### PR TITLE
feat: v2 API testing license and message endpoints

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/messageCatchEvent1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/messageCatchEvent1.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="ed62e54" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="messageCatchEvent1" name="messageCatchEvent1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0dddo2u</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0dddo2u" sourceRef="StartEvent_1" targetRef="Event_1idbbd5" />
+    <bpmn:intermediateCatchEvent id="Event_1idbbd5">
+      <bpmn:incoming>Flow_0dddo2u</bpmn:incoming>
+      <bpmn:outgoing>Flow_12lbnru</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0pp94vl" messageRef="Message_143t419" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="Event_0k92tl4">
+      <bpmn:incoming>Flow_12lbnru</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_12lbnru" sourceRef="Event_1idbbd5" targetRef="Event_0k92tl4" />
+  </bpmn:process>
+  <bpmn:message id="Message_35st2mb" name="Message_35st2mb" />
+  <bpmn:message id="Message_143t419" name="Message_143t419">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=143419" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="messageCatchEvent1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0b13uxf_di" bpmnElement="Event_1idbbd5">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0k92tl4_di" bpmnElement="Event_0k92tl4">
+        <dc:Bounds x="342" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0dddo2u_di" bpmnElement="Flow_0dddo2u">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12lbnru_di" bpmnElement="Flow_12lbnru">
+        <di:waypoint x="278" y="118" />
+        <di:waypoint x="342" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/messageCatchEvent2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/messageCatchEvent2.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="ec2f99c" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="messageCatchEvent2" name="messageCatchEvent2" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1y67rmv</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="Event_1aspkyg">
+      <bpmn:incoming>Flow_1y67rmv</bpmn:incoming>
+      <bpmn:outgoing>Flow_1uipbl2</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0ycbjf1" messageRef="Message_3p6krla" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1y67rmv" sourceRef="StartEvent_1" targetRef="Event_1aspkyg" />
+    <bpmn:endEvent id="Event_07mpz7s">
+      <bpmn:incoming>Flow_1uipbl2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1uipbl2" sourceRef="Event_1aspkyg" targetRef="Event_07mpz7s" />
+  </bpmn:process>
+  <bpmn:message id="Message_3p6krla" name="Message_3p6krla">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=3234432" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="messageCatchEvent2">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1aspkyg_di" bpmnElement="Event_1aspkyg">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07mpz7s_di" bpmnElement="Event_07mpz7s">
+        <dc:Bounds x="342" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1y67rmv_di" bpmnElement="Flow_1y67rmv">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1uipbl2_di" bpmnElement="Flow_1uipbl2">
+        <di:waypoint x="278" y="118" />
+        <di:waypoint x="342" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/messageCatchEvent3.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/messageCatchEvent3.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="ec2f99c" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="messageCatchEvent3" name="messageCatchEvent3" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_11bwijd</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="Event_17u9bac">
+      <bpmn:incoming>Flow_11bwijd</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ayeh51</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_19hzxeu" messageRef="Message_3tvi9o8" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_11bwijd" sourceRef="StartEvent_1" targetRef="Event_17u9bac" />
+    <bpmn:endEvent id="Event_10h7qm4">
+      <bpmn:incoming>Flow_0ayeh51</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ayeh51" sourceRef="Event_17u9bac" targetRef="Event_10h7qm4" />
+  </bpmn:process>
+  <bpmn:message id="Message_3tvi9o8" name="Message_3tvi9o8">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=3838383" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="messageCatchEvent3">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_17u9bac_di" bpmnElement="Event_17u9bac">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10h7qm4_di" bpmnElement="Event_10h7qm4">
+        <dc:Bounds x="342" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_11bwijd_di" bpmnElement="Flow_11bwijd">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ayeh51_di" bpmnElement="Flow_0ayeh51">
+        <di:waypoint x="278" y="118" />
+        <di:waypoint x="342" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/licence-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/licence-api-tests.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {buildUrl, jsonHeaders, assertRequiredFields} from '../../../utils/http';
+import {licenseRequiredFields} from '../../../utils/beans/request-beans';
+
+test.describe('License API Tests', () => {
+  test('Get License', async ({request}) => {
+    await test.step('Get License', async () => {
+      const res = await request.get(buildUrl('/license'), {
+        headers: jsonHeaders(),
+      });
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, licenseRequiredFields);
+      expect(json.validLicense).toBeFalsy();
+      expect(json.licenseType).toBe('unknown');
+      expect(json.isCommercial).toBeFalsy();
+    });
+
+    await test.step('Get License Unauthorized', async () => {
+      const res = await request.get(buildUrl('/license'), {headers: {}});
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, licenseRequiredFields);
+      expect(json.validLicense).toBeFalsy();
+      expect(json.licenseType).toBe('unknown');
+      expect(json.isCommercial).toBeFalsy();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-api-tests.spec.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertRequiredFields,
+  assertEqualsForKeys,
+  paginatedResponseFields,
+} from '../../../../utils/http';
+import {
+  CORRELATE_MESSAGE,
+  correlateMessageRequiredFields,
+} from '../../../../utils/beans/request-beans';
+import {createInstances, deploy} from '../../../../utils/zeebeClient';
+
+test.describe('Correlate Message API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await deploy(['./resources/messageCatchEvent3.bpmn']);
+    await createInstances('messageCatchEvent3', 1, 1);
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThan(1);
+      const matchingItem = json.items.find(
+        (it: {processDefinitionId: string}) =>
+          it.processDefinitionId === 'messageCatchEvent3',
+      );
+      expect(matchingItem).toBeDefined();
+      state['processInstanceKey'] = matchingItem['processInstanceKey'];
+    }).toPass({
+      intervals: [5_000, 10_000, 15_000],
+      timeout: 30_000,
+    });
+  });
+
+  test('Correlate Message Unauthorized', async ({request}) => {
+    const res = await request.post(buildUrl('/messages/correlation'), {
+      headers: {},
+      data: CORRELATE_MESSAGE,
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test('Correlate Message Bad Request', async ({request}) => {
+    const res = await request.post(buildUrl('/messages/correlation'), {
+      headers: jsonHeaders(),
+      data: {correlationKey: 'correlationKey'},
+    });
+    expect(res.status()).toBe(400);
+    const json = await res.json();
+    assertRequiredFields(json, ['detail', 'title']);
+    expect(json.title).toBe('INVALID_ARGUMENT');
+    expect(json.detail).toBe('No messageName provided.');
+  });
+
+  test('Correlate Message Not found', async ({request}) => {
+    const res = await request.post(buildUrl('/messages/correlation'), {
+      headers: jsonHeaders(),
+      data: {
+        name: 'invalidMessageName',
+        correlationKey: 'invalidKey',
+        variables: {foo: 'bar'},
+      },
+    });
+    expect(res.status()).toBe(404);
+    const json = await res.json();
+    assertRequiredFields(json, ['detail', 'title']);
+    expect(json.title).toBe('NOT_FOUND');
+  });
+
+  test('Correlate Message Invalid Tenant', async ({request}) => {
+    const updatedBody = {
+      ...CORRELATE_MESSAGE,
+      tenantId: 'invaliTenant',
+    };
+    const res = await request.post(buildUrl('/messages/correlation'), {
+      headers: jsonHeaders(),
+      data: updatedBody,
+    });
+    expect(res.status()).toBe(400);
+    const json = await res.json();
+    assertRequiredFields(json, ['detail', 'title']);
+    expect(json.title).toBe('INVALID_ARGUMENT');
+    expect(json.detail).toContain(
+      'Expected to handle request Correlate Message with tenant identifier',
+    );
+  });
+
+  test('Correlate Message Flow', async ({request}) => {
+    await test.step('Correlate Message', async () => {
+      const res = await request.post(buildUrl('/messages/correlation'), {
+        headers: jsonHeaders(),
+        data: CORRELATE_MESSAGE,
+      });
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, correlateMessageRequiredFields);
+      assertEqualsForKeys(
+        json,
+        {
+          tenantId: '<default>',
+          processInstanceKey: state.processInstanceKey,
+        },
+        ['tenantId', 'processInstanceKey'],
+      );
+    });
+
+    await test.step('Search Message Subscriptions After Correlating Message', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/message-subscriptions/search'),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                processInstanceKey: state.processInstanceKey,
+              },
+            },
+          },
+        );
+        expect(res.status()).toBe(200);
+        const json = await res.json();
+        assertRequiredFields(json, paginatedResponseFields);
+        expect(json.page.totalItems).toBe(0);
+      }).toPass({
+        intervals: [5_000, 10_000, 15_000],
+        timeout: 30_000,
+      });
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/publish-message-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/publish-message-api-tests.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertRequiredFields,
+  assertEqualsForKeys,
+} from '../../../../utils/http';
+import {PUBLISH_NEW_MESSAGE} from '../../../../utils/beans/request-beans';
+
+test.describe('Publish Message API Tests', () => {
+  test('Publish Message', async ({request}) => {
+    const requestBody = PUBLISH_NEW_MESSAGE();
+    const res = await request.post(buildUrl('/messages/publication'), {
+      headers: jsonHeaders(),
+      data: requestBody,
+    });
+    expect(res.status()).toBe(200);
+    const json = await res.json();
+    assertRequiredFields(json, ['tenantId', 'messageKey']);
+    assertEqualsForKeys(json, {tenantId: '<default>'}, ['tenantId']);
+  });
+
+  test('Publish Message Unauthorized', async ({request}) => {
+    const requestBody = PUBLISH_NEW_MESSAGE();
+
+    const res = await request.post(buildUrl('/messages/publication'), {
+      headers: {},
+      data: requestBody,
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test('Publish Message Bad Request', async ({request}) => {
+    const res = await request.post(buildUrl('/messages/publication'), {
+      headers: jsonHeaders(),
+      data: {correlationKey: 'correlationKey'},
+    });
+    expect(res.status()).toBe(400);
+    const json = await res.json();
+    assertRequiredFields(json, ['detail', 'title']);
+    expect(json.title).toBe('INVALID_ARGUMENT');
+    expect(json.detail).toBe('No name provided.');
+  });
+
+  test('Publish Message Invalid Tenant', async ({request}) => {
+    const updatedBody = {
+      ...PUBLISH_NEW_MESSAGE(),
+      tenantId: 'invaliTenant',
+    };
+    const res = await request.post(buildUrl('/messages/publication'), {
+      headers: jsonHeaders(),
+      data: updatedBody,
+    });
+    expect(res.status()).toBe(400);
+    const json = await res.json();
+    assertRequiredFields(json, ['detail', 'title']);
+    expect(json.title).toBe('INVALID_ARGUMENT');
+    expect(json.detail).toContain(
+      'Expected to handle request Publish Message with tenant identifier',
+    );
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-message-subscription-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-message-subscription-api-tests.spec.ts
@@ -1,0 +1,402 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertRequiredFields,
+  assertEqualsForKeys,
+  paginatedResponseFields,
+} from '../../../../utils/http';
+import {
+  expectedMessageSubscription1,
+  expectedMessageSubscription2,
+  messageSubscriptionRequiredFields,
+} from '../../../../utils/beans/request-beans';
+import {createInstances, deploy} from '../../../../utils/zeebeClient';
+
+test.beforeAll(async () => {
+  await deploy(['./resources/messageCatchEvent1.bpmn']);
+  await deploy(['./resources/messageCatchEvent2.bpmn']);
+  await createInstances('messageCatchEvent1', 1, 1);
+  await createInstances('messageCatchEvent2', 1, 1);
+});
+
+test.describe('Search Message Subscription API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test('Search Message Subscriptions By Invalid Name', async ({request}) => {
+    const res = await request.post(buildUrl('/message-subscriptions/search'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          messageName: 'invalid-message-name',
+        },
+      },
+    });
+    expect(res.status()).toBe(200);
+    const json = await res.json();
+    assertRequiredFields(json, paginatedResponseFields);
+    expect(json.page.totalItems).toBe(0);
+    expect(json.items.length).toBe(0);
+  });
+
+  test('Search Subscriptions Unauthorized', async ({request}) => {
+    const res = await request.post(buildUrl(`/message-subscriptions/search`), {
+      headers: {},
+      data: {filter: {name: state.name}},
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test('Search Message Flow', async ({request}) => {
+    await test.step('Search Message Subscriptions', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/message-subscriptions/search'),
+          {
+            headers: jsonHeaders(),
+            data: {},
+          },
+        );
+
+        expect(res.status()).toBe(200);
+        const json = await res.json();
+        assertRequiredFields(json, paginatedResponseFields);
+        expect(json.page.totalItems).toBeGreaterThan(1);
+        const matchingItem1 = json.items.find(
+          (it: {processDefinitionId: string}) =>
+            it.processDefinitionId === 'messageCatchEvent1',
+        );
+        const matchingItem2 = json.items.find(
+          (it: {processDefinitionId: string}) =>
+            it.processDefinitionId === 'messageCatchEvent2',
+        );
+        assertRequiredFields(matchingItem1, messageSubscriptionRequiredFields);
+        assertRequiredFields(matchingItem2, messageSubscriptionRequiredFields);
+        assertEqualsForKeys(matchingItem1, expectedMessageSubscription1, [
+          'correlationKey',
+          'tenantId',
+          'elementId',
+          'messageName',
+        ]);
+        assertEqualsForKeys(matchingItem2, expectedMessageSubscription2, [
+          'correlationKey',
+          'tenantId',
+          'elementId',
+          'messageName',
+        ]);
+        state['processDefinitionKey'] = matchingItem1['processDefinitionKey'];
+        state['processInstanceKey'] = matchingItem1['processInstanceKey'];
+        state['elementInstanceKey'] = matchingItem2['elementInstanceKey'];
+      }).toPass({
+        intervals: [5_000, 10_000, 15_000],
+        timeout: 30_000,
+      });
+    });
+
+    await test.step('Search Message Subscriptions By Process Definition Id', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processDefinitionId:
+                expectedMessageSubscription1.processDefinitionId,
+            },
+          },
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+      json.items.forEach((it: object) => {
+        assertRequiredFields(it, messageSubscriptionRequiredFields);
+        assertEqualsForKeys(it, expectedMessageSubscription1, [
+          'correlationKey',
+          'tenantId',
+          'elementId',
+          'messageName',
+        ]);
+      });
+    });
+
+    await test.step('Search Message Subscriptions By Correlation Key', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              correlationKey: expectedMessageSubscription1.correlationKey,
+            },
+          },
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+      json.items.forEach((it: object) => {
+        assertRequiredFields(it, messageSubscriptionRequiredFields);
+        assertEqualsForKeys(it, expectedMessageSubscription1, [
+          'correlationKey',
+          'tenantId',
+          'elementId',
+          'messageName',
+        ]);
+      });
+    });
+
+    await test.step('Search Message Subscriptions By Tenant Id', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              tenantId: expectedMessageSubscription1.tenantId,
+            },
+          },
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      const matchingItem1 = json.items.find(
+        (it: {processDefinitionId: string}) =>
+          it.processDefinitionId === 'messageCatchEvent1',
+      );
+      const matchingItem2 = json.items.find(
+        (it: {processDefinitionId: string}) =>
+          it.processDefinitionId === 'messageCatchEvent2',
+      );
+      assertRequiredFields(matchingItem1, messageSubscriptionRequiredFields);
+      assertRequiredFields(matchingItem2, messageSubscriptionRequiredFields);
+      assertEqualsForKeys(matchingItem1, expectedMessageSubscription1, [
+        'correlationKey',
+        'tenantId',
+        'elementId',
+        'messageName',
+      ]);
+      assertEqualsForKeys(matchingItem2, expectedMessageSubscription2, [
+        'correlationKey',
+        'tenantId',
+        'elementId',
+        'messageName',
+      ]);
+    });
+
+    await test.step('Search Message Subscriptions By Message Subscription Type', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              messageSubscriptionType: 'CREATED',
+            },
+          },
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThan(1);
+      const matchingItem1 = json.items.find(
+        (it: {processDefinitionId: string}) =>
+          it.processDefinitionId === 'messageCatchEvent1',
+      );
+      const matchingItem2 = json.items.find(
+        (it: {processDefinitionId: string}) =>
+          it.processDefinitionId === 'messageCatchEvent2',
+      );
+      assertRequiredFields(matchingItem1, messageSubscriptionRequiredFields);
+      assertRequiredFields(matchingItem2, messageSubscriptionRequiredFields);
+      assertEqualsForKeys(matchingItem1, expectedMessageSubscription1, [
+        'correlationKey',
+        'tenantId',
+        'elementId',
+        'messageName',
+      ]);
+      assertEqualsForKeys(matchingItem2, expectedMessageSubscription2, [
+        'correlationKey',
+        'tenantId',
+        'elementId',
+        'messageName',
+      ]);
+    });
+
+    await test.step('Search Message Subscriptions By Element Id', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              elementId: expectedMessageSubscription2.elementId,
+            },
+          },
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+      json.items.forEach((it: object) => {
+        assertRequiredFields(it, messageSubscriptionRequiredFields);
+        assertEqualsForKeys(it, expectedMessageSubscription2, [
+          'correlationKey',
+          'tenantId',
+          'elementId',
+          'messageName',
+        ]);
+      });
+    });
+
+    await test.step('Search Message Subscriptions By Message Name', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              messageName: expectedMessageSubscription2.messageName,
+            },
+          },
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+      json.items.forEach((it: object) => {
+        assertRequiredFields(it, messageSubscriptionRequiredFields);
+        assertEqualsForKeys(it, expectedMessageSubscription2, [
+          'correlationKey',
+          'tenantId',
+          'elementId',
+          'messageName',
+        ]);
+      });
+    });
+
+    await test.step('Search Message Subscriptions By Process Definition Key', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: state.processInstanceKey,
+            },
+          },
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+      json.items.forEach((it: object) => {
+        assertRequiredFields(it, messageSubscriptionRequiredFields);
+        assertEqualsForKeys(it, expectedMessageSubscription1, [
+          'correlationKey',
+          'tenantId',
+          'elementId',
+          'messageName',
+        ]);
+      });
+    });
+
+    await test.step('Search Message Subscriptions By Process Instance Key', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: state.processInstanceKey,
+            },
+          },
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+      json.items.forEach((it: object) => {
+        assertRequiredFields(it, messageSubscriptionRequiredFields);
+        assertEqualsForKeys(it, expectedMessageSubscription1, [
+          'correlationKey',
+          'tenantId',
+          'elementId',
+          'messageName',
+        ]);
+      });
+    });
+
+    await test.step('Search Message Subscriptions By Element Instance Key', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              elementInstanceKey: state.elementInstanceKey,
+            },
+          },
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+      json.items.forEach((it: object) => {
+        assertRequiredFields(it, messageSubscriptionRequiredFields);
+        assertEqualsForKeys(it, expectedMessageSubscription2, [
+          'correlationKey',
+          'tenantId',
+          'elementId',
+          'messageName',
+        ]);
+      });
+    });
+
+    await test.step('Search Message Subscriptions By Multiple Fields', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              elementInstanceKey: state.elementInstanceKey,
+              tenantId: expectedMessageSubscription2.tenantId,
+              messageName: expectedMessageSubscription2.messageName,
+              elementId: expectedMessageSubscription2.elementId,
+            },
+          },
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+      json.items.forEach((it: object) => {
+        assertRequiredFields(it, messageSubscriptionRequiredFields);
+        assertEqualsForKeys(it, expectedMessageSubscription2, [
+          'correlationKey',
+          'tenantId',
+          'elementId',
+          'messageName',
+        ]);
+      });
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/request-beans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/request-beans.ts
@@ -16,6 +16,50 @@ export const mappingRuleRequiredFields: string[] = [
   'mappingRuleId',
 ];
 export const roleRequiredFields: string[] = ['roleId', 'name', 'description'];
+export const licenseRequiredFields: string[] = [
+  'validLicense',
+  'licenseType',
+  'isCommercial',
+];
+export const messageSubscriptionRequiredFields = [
+  'messageSubscriptionKey',
+  'processDefinitionId',
+  'processDefinitionKey',
+  'processInstanceKey',
+  'elementId',
+  'elementInstanceKey',
+  'messageSubscriptionType',
+  'lastUpdatedDate',
+  'messageName',
+  'correlationKey',
+  'tenantId',
+];
+export const correlateMessageRequiredFields: string[] = [
+  'tenantId',
+  'messageKey',
+  'processInstanceKey',
+];
+export const expectedMessageSubscription1 = {
+  messageName: 'Message_143t419',
+  correlationKey: '143419',
+  tenantId: '<default>',
+  elementId: 'Event_1idbbd5',
+  processDefinitionId: 'messageCatchEvent1',
+};
+export const expectedMessageSubscription2 = {
+  messageName: 'Message_3p6krla',
+  correlationKey: '3234432',
+  tenantId: '<default>',
+  elementId: 'Event_1aspkyg',
+  processDefinitionId: 'messageCatchEvent3',
+};
+export const expectedMessageSubscription3 = {
+  messageName: 'Message_3tvi9o8',
+  correlationKey: '3838383',
+  tenantId: '<default>',
+  elementId: 'Event_17u9bac',
+  processDefinitionId: 'messageCatchEvent1',
+};
 
 export function CREATE_NEW_GROUP() {
   return {
@@ -43,3 +87,19 @@ export function CREATE_NEW_ROLE() {
     description: 'E2E test role',
   };
 }
+
+export function PUBLISH_NEW_MESSAGE() {
+  return {
+    name: `msg-${Date.now()}`,
+    correlationKey: `corr-${Math.random().toString(36).slice(2, 10)}`,
+    messageId: `corr-${Math.random().toString(36).slice(2, 10)}`,
+    timeToLive: 300000,
+    variables: {foo: 'bar'},
+  };
+}
+
+export const CORRELATE_MESSAGE = {
+  name: expectedMessageSubscription3.messageName,
+  correlationKey: expectedMessageSubscription3.correlationKey,
+  variables: {foo: 'bar'},
+};


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Run: https://github.com/camunda/camunda/actions/runs/17248332979

### Summary: Add v2 API Test Coverage (License + Message)

### Full List of API Request URLs Used
- `GET /license`
- `POST /message-subscriptions/search`
- `POST /messages/correlation`

### Categories / Endpoints / Validations

1. License API  
   URL: `GET /license`  
   Validations:  
   - Success `200` 
   - On `200`: required fields `validLicense`, `licenseType`, `isCommercial`, `expiresAt`   
   - `expiresAt` future when `validLicense` is true (if not `null`)  
   - Negative: Unauthorized - still returns 200 with body.

2. Message API \- Publish  
   URL: `POST /messages/publication`  
   Validations:  
   - Success `200` with required fields 
   - Negative: `401` (no headers), `400` invalid request

3. Message API \- Search Subscriptions (paginated)  
   URL: `POST /message-subscriptions/search`  
   Validations:  
   - Base search `200`, paginated shape (`page`, `items`)  
   - Individual filter steps (all `POST /message-subscriptions/search` with single-field `filter`):  
     - By `processDefinitionId`  
     - By `correlationKey`  
     - By `tenantId`  
     - By `elementId`  
     - By `messageName`  
   - Each filter: `200`, non-empty when matching, items assert key field fidelity (`correlationKey`, `tenantId`, `elementId`, `messageName`)  
   - Negative: Invalid filter scenario returns empty list , Unauthorized search: `401`, Invalid Tenant `400`

4. Message API \- Correlate Subscription  
   URL: `POST /messages/correlation`  
   Validations:  
   - Success `200`, Search Message Subscriptions After correlation
   - Negative: Bad request: `400` ,     Unauthorized: `400` , Invalid Tenant `400`



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
