### PR TITLE
[Backport release-8.8.0-alpha8] fix: add missing metadata name to Maven module

### DIFF
--- a/migration/commons/pom.xml
+++ b/migration/commons/pom.xml
@@ -17,6 +17,7 @@
 
   <groupId>io.camunda.migration</groupId>
   <artifactId>migration-commons</artifactId>
+  <name>Migration Commons</name>
 
   <properties>
     <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
# Description
Backport of #37227 to `release-8.8.0-alpha8`.

relates to 