### PR TITLE
Fix Flaky Test - Interaction between diagram and filters

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -174,6 +174,7 @@ test.describe('Process Instances Filters', () => {
   test('Interaction between diagram and filters', async ({
     operateProcessesPage,
     operateFiltersPanelPage,
+    page
   }) => {
     await test.step('Filter by Process Name and assert version value', async () => {
       await operateFiltersPanelPage.selectProcess(
@@ -189,9 +190,14 @@ test.describe('Process Instances Filters', () => {
       await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue('');
 
       await operateFiltersPanelPage.selectFlowNode('StartEvent_1');
-      await expect(operateProcessesPage.noMatchingInstancesMessage).toBeVisible(
-        {timeout: 60000},
-      );
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateProcessesPage.noMatchingInstancesMessage).toBeVisible({timeout: 60000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
     });
 
     await test.step('Select another flow node from the diagram', async () => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The `Interaction between diagram and filters `test needs a more robust assertion as it is proving to be flaky.

Test run can be seen [here](https://github.com/camunda/camunda/actions/runs/17259694255/job/48978288434). The two failed tests are due to a know [variable bug](https://github.com/camunda/camunda/issues/36368).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
