### PR TITLE
feat: migrate root cause decision data to v2 API usage

### DIFF
--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -19,7 +19,7 @@
         "@tanstack/eslint-plugin-query": "5.81.2",
         "@tanstack/react-query": "5.83.0",
         "@tanstack/react-query-devtools": "5.83.0",
-        "@vzeta/camunda-api-zod-schemas": "2.0.11",
+        "@vzeta/camunda-api-zod-schemas": "2.0.12",
         "bpmn-js": "18.6.2",
         "bpmn-moddle": "9.0.2",
         "date-fns": "4.1.0",
@@ -4298,9 +4298,9 @@
       }
     },
     "node_modules/@vzeta/camunda-api-zod-schemas": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@vzeta/camunda-api-zod-schemas/-/camunda-api-zod-schemas-2.0.11.tgz",
-      "integrity": "sha512-noom7UBDV0SgGW6/2DOXCmG/pWodpQb1jX+qFfd+K9ogsTp/RJkLTvh3sRBHSnW2su8+NkC/xleO3K6WHjsMnQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@vzeta/camunda-api-zod-schemas/-/camunda-api-zod-schemas-2.0.12.tgz",
+      "integrity": "sha512-dsZqjhs1iMlTg9rb5YncyRlFoQ3YmJ7iTPNClbSVzLfJzpSb63rFy04Ap1mn9lPowmkyUEtkhOqVSCbo9Vo3Vw==",
       "license": "MIT",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -15,7 +15,7 @@
     "@tanstack/eslint-plugin-query": "5.81.2",
     "@tanstack/react-query": "5.83.0",
     "@tanstack/react-query-devtools": "5.83.0",
-    "@vzeta/camunda-api-zod-schemas": "2.0.11",
+    "@vzeta/camunda-api-zod-schemas": "2.0.12",
     "bpmn-js": "18.6.2",
     "bpmn-moddle": "9.0.2",
     "date-fns": "4.1.0",

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Incident/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Incident/index.tsx
@@ -11,13 +11,17 @@ import {Link} from 'modules/components/Link';
 import {Paths} from 'modules/Routes';
 import {type MetaDataDto} from 'modules/api/processInstances/fetchFlowNodeMetaData';
 import {Header} from '../../Header';
-import type {Incident as IncidentDto} from '@vzeta/camunda-api-zod-schemas/8.8';
-import {SummaryDataKey, SummaryDataValue} from '../../styled.tsx';
+import type {
+  Incident as IncidentDto,
+  DecisionInstance,
+} from '@vzeta/camunda-api-zod-schemas/8.8';
+import {SummaryDataKey, SummaryDataValue} from '../../styled';
 import {resolveIncidentErrorType} from './resolveIncidentErrorType';
 
 type Props = {
   incidentV2: IncidentDto;
   incident: MetaDataDto['incident'];
+  rootCauseDecisionInstance: DecisionInstance | null;
   processInstanceId?: string;
   onButtonClick: () => void;
 };
@@ -25,15 +29,16 @@ type Props = {
 const Incident: React.FC<Props> = ({
   incidentV2,
   incident,
+  rootCauseDecisionInstance,
   processInstanceId,
   onButtonClick,
 }) => {
-  if (incident === null) {
+  if (!incident || !incidentV2) {
     return null;
   }
 
-  //TODO will be handled separately in #35528 and #35529
-  const {rootCauseDecision, rootCauseInstance} = incident;
+  //TODO will be handled separately in #35529
+  const {rootCauseInstance} = incident;
 
   const errorType = resolveIncidentErrorType(incidentV2.errorType);
 
@@ -61,35 +66,35 @@ const Incident: React.FC<Props> = ({
             </SummaryDataValue>
           </Stack>
         )}
-        {incidentV2 !== null &&
-          rootCauseInstance !== null &&
-          rootCauseDecision === null && (
-            <Stack gap={3} as="dl">
-              <SummaryDataKey>Root Cause Process Instance</SummaryDataKey>
-              <SummaryDataValue>
-                {rootCauseInstance.instanceId === processInstanceId ? (
-                  'Current Instance'
-                ) : (
-                  <Link
-                    to={Paths.processInstance(rootCauseInstance.instanceId)}
-                    title={`View root cause instance ${rootCauseInstance.processDefinitionName} - ${rootCauseInstance.instanceId}`}
-                  >
-                    {`${rootCauseInstance.processDefinitionName} - ${rootCauseInstance.instanceId}`}
-                  </Link>
-                )}
-              </SummaryDataValue>
-            </Stack>
-          )}
-        {rootCauseDecision !== null && (
+        {!!rootCauseInstance && !rootCauseDecisionInstance && (
+          <Stack gap={3} as="dl">
+            <SummaryDataKey>Root Cause Process Instance</SummaryDataKey>
+            <SummaryDataValue>
+              {rootCauseInstance.instanceId === processInstanceId ? (
+                'Current Instance'
+              ) : (
+                <Link
+                  to={Paths.processInstance(rootCauseInstance.instanceId)}
+                  title={`View root cause instance ${rootCauseInstance.processDefinitionName} - ${rootCauseInstance.instanceId}`}
+                >
+                  {`${rootCauseInstance.processDefinitionName} - ${rootCauseInstance.instanceId}`}
+                </Link>
+              )}
+            </SummaryDataValue>
+          </Stack>
+        )}
+        {rootCauseDecisionInstance !== null && (
           <Stack gap={3} as="dl">
             <SummaryDataKey>Root Cause Decision Instance</SummaryDataKey>
             <SummaryDataValue>
               <Link
-                to={Paths.decisionInstance(rootCauseDecision.instanceId)}
-                title={`View root cause decision ${rootCauseDecision.decisionName} - ${rootCauseDecision.instanceId}`}
-                aria-label={`View root cause decision ${rootCauseDecision.decisionName} - ${rootCauseDecision.instanceId}`}
+                to={Paths.decisionInstance(
+                  rootCauseDecisionInstance.decisionInstanceKey,
+                )}
+                title={`View root cause decision ${rootCauseDecisionInstance.decisionDefinitionName} - ${rootCauseDecisionInstance.decisionInstanceKey}`}
+                aria-label={`View root cause decision ${rootCauseDecisionInstance.decisionDefinitionName} - ${rootCauseDecisionInstance.decisionInstanceKey}`}
               >
-                {`${rootCauseDecision.decisionName} - ${rootCauseDecision.instanceId}`}
+                {`${rootCauseDecisionInstance.decisionDefinitionName} - ${rootCauseDecisionInstance.decisionInstanceKey}`}
               </Link>
             </SummaryDataValue>
           </Stack>

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/calledDecisions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/calledDecisions.test.tsx
@@ -21,7 +21,7 @@ import {
   PROCESS_INSTANCE_ID,
   FLOW_NODE_ID,
   USER_TASK_FLOW_NODE_ID,
-  BUSSINESS_RULE_FLOW_NODE_ID,
+  BUSINESS_RULE_FLOW_NODE_ID,
 } from 'modules/mocks/metadata';
 import {metadataDemoProcess} from 'modules/mocks/metadataDemoProcess';
 import {
@@ -51,7 +51,7 @@ const MOCK_EXECUTION_DATE = '21 seconds';
 
 const mockElementInstance: ElementInstance = {
   elementInstanceKey: '2251799813699889',
-  elementId: BUSSINESS_RULE_FLOW_NODE_ID,
+  elementId: BUSINESS_RULE_FLOW_NODE_ID,
   elementName: 'Service Task',
   type: 'SERVICE_TASK',
   state: 'COMPLETED',
@@ -217,7 +217,7 @@ describe('MetadataPopover', () => {
     selectFlowNode(
       {},
       {
-        flowNodeId: BUSSINESS_RULE_FLOW_NODE_ID,
+        flowNodeId: BUSINESS_RULE_FLOW_NODE_ID,
         flowNodeInstanceId: '2251799813699889',
       },
     );
@@ -273,7 +273,7 @@ describe('MetadataPopover', () => {
     selectFlowNode(
       {},
       {
-        flowNodeId: BUSSINESS_RULE_FLOW_NODE_ID,
+        flowNodeId: BUSINESS_RULE_FLOW_NODE_ID,
         flowNodeInstanceId: '2251799813699889',
       },
     );
@@ -334,7 +334,7 @@ describe('MetadataPopover', () => {
     selectFlowNode(
       {},
       {
-        flowNodeId: BUSSINESS_RULE_FLOW_NODE_ID,
+        flowNodeId: BUSINESS_RULE_FLOW_NODE_ID,
         flowNodeInstanceId: '2251799813699889',
       },
     );

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
@@ -185,6 +185,11 @@ describe('MetadataPopover', () => {
   });
 
   it('should not show unrelated data', async () => {
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
     flowNodeMetaDataStore.setMetaData(singleInstanceMetadata);
 
@@ -312,6 +317,11 @@ describe('MetadataPopover', () => {
         },
       ],
       page: {totalItems: 1},
+    });
+
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
+      items: [],
+      page: {totalItems: 0},
     });
 
     mockSearchJobs().withSuccess({
@@ -494,6 +504,12 @@ describe('MetadataPopover', () => {
   it('should not render called instances for multi instance call activities', async () => {
     mockFetchFlowNodeMetadata().withSuccess(multiInstanceCallActivityMetadata);
     mockFetchFlowNodeMetadata().withSuccess(multiInstanceCallActivityMetadata);
+
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+
     flowNodeMetaDataStore.setMetaData(multiInstanceCallActivityMetadata);
 
     processInstanceDetailsStore.setProcessInstance(
@@ -561,6 +577,12 @@ describe('MetadataPopover', () => {
 
     mockFetchFlowNodeMetadata().withSuccess(userTaskFlowNodeMetaData);
     mockFetchFlowNodeMetadata().withSuccess(userTaskFlowNodeMetaData);
+
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+
     flowNodeMetaDataStore.setMetaData(userTaskFlowNodeMetaData);
 
     processInstanceDetailsStore.setProcessInstance(
@@ -592,6 +614,12 @@ describe('MetadataPopover', () => {
   it('should render retries left', async () => {
     mockFetchFlowNodeMetadata().withSuccess(retriesLeftFlowNodeMetaData);
     mockFetchFlowNodeMetadata().withSuccess(retriesLeftFlowNodeMetaData);
+
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+
     flowNodeMetaDataStore.setMetaData(retriesLeftFlowNodeMetaData);
 
     processInstanceDetailsStore.setProcessInstance(
@@ -628,6 +656,11 @@ describe('MetadataPopover', () => {
       mockElementInstance,
     );
 
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+
     processInstanceDetailsStore.setProcessInstance(
       createInstance({
         id: PROCESS_INSTANCE_ID,
@@ -652,6 +685,11 @@ describe('MetadataPopover', () => {
   });
 
   it('should search for single element instance when count is 1', async () => {
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [
@@ -667,6 +705,11 @@ describe('MetadataPopover', () => {
     mockSearchElementInstances().withSuccess({
       items: [mockElementInstance],
       page: {totalItems: 1},
+    });
+
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
+      items: [],
+      page: {totalItems: 0},
     });
 
     processInstanceDetailsStore.setProcessInstance(
@@ -687,6 +730,10 @@ describe('MetadataPopover', () => {
   });
 
   it('should handle failed element instance search gracefully', async () => {
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
     mockSearchElementInstances().withNetworkError();
 
@@ -707,6 +754,10 @@ describe('MetadataPopover', () => {
   });
 
   it('should handle failed single element instance fetch gracefully', async () => {
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
     mockFetchElementInstance('invalid-key').withNetworkError();
 
@@ -733,6 +784,10 @@ describe('MetadataPopover', () => {
   });
 
   it('should render root cause decision instance link when decision instance exists', async () => {
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
     mockFetchFlowNodeMetadata().withSuccess(incidentFlowNodeMetaData);
     mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess(
       incidentsByProcessKeyMetadata,

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
@@ -31,6 +31,7 @@ import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefi
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import {convertBpmnJsTypeToAPIType} from './convertBpmnJsTypeToAPIType';
 import {useJobs} from 'modules/queries/jobs/useJobs';
+import {useDecisionInstancesSearch} from 'modules/queries/decisionInstances/useDecisionInstancesSearch';
 
 type Props = {
   selectedFlowNodeRef?: SVGGraphicsElement | null;
@@ -169,6 +170,20 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
     select: (data) => data.pages?.flatMap((page) => page.items),
   });
 
+  const {
+    data: decisionInstanceSearchResult,
+    isLoading: isSearchingDecisionInstance,
+  } = useDecisionInstancesSearch(
+    {
+      filter: {
+        elementInstanceKey: elementInstanceMetadata?.elementInstanceKey ?? '',
+      },
+    },
+    {
+      enabled: !!elementInstanceMetadata?.elementInstanceKey,
+    },
+  );
+
   if (
     elementId === undefined ||
     metaData === null ||
@@ -176,7 +191,8 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
     (!!elementInstanceId && isFetchingInstance) ||
     isSearchingUserTasks ||
     isSearchingProcessInstances ||
-    isSearchingJob
+    isSearchingJob ||
+    isSearchingDecisionInstance
   ) {
     return null;
   }
@@ -242,6 +258,9 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
               processInstanceId={processInstance?.processInstanceKey}
               incidentV2={singleIncident}
               incident={incident}
+              rootCauseDecisionInstance={
+                decisionInstanceSearchResult?.items?.[0] || null
+              }
               onButtonClick={() => {
                 incidentsStore.clearSelection();
                 incidentsStore.toggleFlowNodeSelection(elementId);

--- a/operate/client/src/modules/mocks/metadata.ts
+++ b/operate/client/src/modules/mocks/metadata.ts
@@ -14,7 +14,7 @@ const CALL_ACTIVITY_FLOW_NODE_ID = 'Activity_0zqism7'; // this need to match the
 const USER_TASK_FLOW_NODE_ID = 'UserTask';
 const FLOW_NODE_INSTANCE_ID = '2251799813699889';
 const PROCESS_INSTANCE_ID = '2251799813685591';
-const BUSSINESS_RULE_FLOW_NODE_ID = 'BusinessRuleTask';
+const BUSINESS_RULE_FLOW_NODE_ID = 'BusinessRuleTask';
 
 const baseInstanceMetadata: MetaDataDto['instanceMetadata'] = {
   flowNodeId: FLOW_NODE_ID,
@@ -266,6 +266,6 @@ export {
   CALL_ACTIVITY_FLOW_NODE_ID,
   FLOW_NODE_ID,
   USER_TASK_FLOW_NODE_ID,
-  BUSSINESS_RULE_FLOW_NODE_ID,
+  BUSINESS_RULE_FLOW_NODE_ID,
   FLOW_NODE_INSTANCE_ID,
 };


### PR DESCRIPTION
## Description

This PR migrates root cause decision data of MetadataPopover and Incident components.

- Migrates MetadataPopover to use v2  decision instance search endpoint  to get root cause decision instance data
- Updates `@vzeta/camunda-api-zod-schemas` version to support decision instance search filtering by `elementInstanceKey`

## Related issues

closes #35528 
