### PR TITLE
feat: usage metrics record dividing before appending

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessor.java
@@ -7,11 +7,15 @@
  */
 package io.camunda.zeebe.engine.processing.metrics;
 
-import static java.util.Optional.*;
+import static io.camunda.zeebe.util.StreamProcessingConstants.*;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.metrics.PersistedUsageMetrics;
 import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
@@ -19,10 +23,17 @@ import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
 import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
+import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,8 +44,10 @@ public class UsageMetricsExportProcessor implements TypedRecordProcessor<UsageMe
   private static final Logger LOG = LoggerFactory.getLogger(UsageMetricsExportProcessor.class);
 
   private final MutableUsageMetricState usageMetricState;
-  private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
+  private final SideEffectWriter sideEffectWriter;
+  private final TypedCommandWriter typedCommandWriter;
 
   public UsageMetricsExportProcessor(
       final MutableUsageMetricState usageMetricState,
@@ -43,10 +56,18 @@ public class UsageMetricsExportProcessor implements TypedRecordProcessor<UsageMe
     this.usageMetricState = usageMetricState;
     stateWriter = writers.state();
     this.keyGenerator = keyGenerator;
+    sideEffectWriter = writers.sideEffect();
+    typedCommandWriter = writers.command();
   }
 
   @Override
   public void processRecord(final TypedRecord<UsageMetricRecord> usageMetricRecord) {
+
+    final var usageMetricRecordValue = usageMetricRecord.getValue();
+    if (EventType.NONE != usageMetricRecord.getValue().getEventType()) {
+      appendFollowUpEvent(usageMetricRecordValue);
+      return;
+    }
 
     final UsageMetricRecord eventRecord =
         new UsageMetricRecord()
@@ -116,7 +137,7 @@ public class UsageMetricsExportProcessor implements TypedRecordProcessor<UsageMe
         .setEventType(eventType)
         .setStartTime(bucket.getFromTime())
         .setEndTime(bucket.getToTime());
-    if (eventType == EventType.TU) {
+    if (EventType.TU == eventType) {
       usageMetricRecord.setSetValues(valuesBuffer);
     } else {
       usageMetricRecord.setCounterValues(valuesBuffer);
@@ -124,11 +145,322 @@ public class UsageMetricsExportProcessor implements TypedRecordProcessor<UsageMe
   }
 
   private void appendFollowUpEvent(final UsageMetricRecord eventRecord) {
-    LOG.debug(
-        "Creating usage metric EXPORTED event for {} {}",
-        eventRecord.getStartTime(),
-        eventRecord.getEventType());
-    stateWriter.appendFollowUpEvent(
-        keyGenerator.nextKey(), UsageMetricIntent.EXPORTED, eventRecord);
+    if (stateWriter.canWriteEventOfLength(eventRecord.getLength())) {
+      stateWriter.appendFollowUpEvent(
+          keyGenerator.nextKey(), UsageMetricIntent.EXPORTED, eventRecord);
+    } else {
+      LOG.warn("Usage metric event exceeds batch size limit, splitting into smaller records.");
+      splitAndAppendRecordHybrid(eventRecord);
+    }
   }
+
+  /**
+   * Splits a large usage metric record using a hybrid approach. Appends chunks that fit within
+   * batch limits as follow-up events and defers remaining chunks as side effects.
+   */
+  private void splitAndAppendRecordHybrid(final UsageMetricRecord eventRecord) {
+    if (!isRecordEligibleForSplitting(eventRecord)) {
+      return;
+    }
+
+    final var chunkingStrategy = calculateChunkingStrategy(eventRecord);
+    final var chunks =
+        createChunks(eventRecord.getSetValues(), chunkingStrategy.targetEntriesPerChunk());
+
+    LOG.debug(
+        "Splitting record: total entries: {}, target chunk size: {}, estimated bytes per entry: {}, chunks created: {}",
+        chunkingStrategy.totalEntries(),
+        chunkingStrategy.targetEntriesPerChunk(),
+        chunkingStrategy.estimatedBytesPerEntry(),
+        chunks.size());
+
+    final var categorizedChunks = categorizeChunks(eventRecord, chunks);
+
+    // Process immediate chunks and handle failures by moving them to deferred
+    appendImmediateChunks(categorizedChunks.immediate(), categorizedChunks.deferred());
+    deferRemainingChunks(categorizedChunks.deferred());
+  }
+
+  /** Calculates the optimal chunking strategy for the given record. */
+  private ChunkingStrategy calculateChunkingStrategy(final UsageMetricRecord eventRecord) {
+    final var originalSetValues = eventRecord.getSetValues();
+    final int baseRecordOverhead = calculateBaseRecordOverhead(eventRecord);
+    final int availableSpace = CONSERVATIVE_FRAGMENT_SIZE_LIMIT - baseRecordOverhead;
+    final int totalEntries = calculateTotalEntries(originalSetValues);
+    final int estimatedBytesPerEntry =
+        estimateAverageBytesPerEntry(originalSetValues, baseRecordOverhead);
+    final int targetEntriesPerChunk =
+        calculateOptimalChunkSize(availableSpace, estimatedBytesPerEntry, totalEntries);
+
+    return new ChunkingStrategy(
+        CONSERVATIVE_FRAGMENT_SIZE_LIMIT,
+        baseRecordOverhead,
+        availableSpace,
+        totalEntries,
+        estimatedBytesPerEntry,
+        targetEntriesPerChunk);
+  }
+
+  /** Calculates the total number of entries across all tenants. */
+  private int calculateTotalEntries(final Map<String, Set<Long>> setValues) {
+    return setValues.values().stream().mapToInt(Set::size).sum();
+  }
+
+  /** Calculates optimal chunk size based on available space and entry size. */
+  private int calculateOptimalChunkSize(
+      final int availableSpace, final int estimatedBytesPerEntry, final int totalEntries) {
+    final int baseTargetSize = Math.max(1, availableSpace / estimatedBytesPerEntry);
+    final int maxChunkSize = Math.max(MIN_CHUNK_SIZE, totalEntries / CHUNK_SIZE_DIVISOR);
+    return Math.min(baseTargetSize, maxChunkSize);
+  }
+
+  /** Creates chunks from the set values using the specified target size. */
+  private List<Map<String, Set<Long>>> createChunks(
+      final Map<String, Set<Long>> setValues, final int targetEntriesPerChunk) {
+    final var tenantEntries = new ArrayList<>(setValues.entrySet());
+    return createOptimizedChunks(tenantEntries, targetEntriesPerChunk);
+  }
+
+  /** Categorizes chunks into immediate and deferred based on size constraints. */
+  private CategorizedChunks categorizeChunks(
+      final UsageMetricRecord eventRecord, final List<Map<String, Set<Long>>> chunks) {
+    final var immediateChunks = new ArrayList<UsageMetricRecord>();
+    final var deferredChunks = new ArrayList<UsageMetricRecord>();
+
+    for (final var chunk : chunks) {
+      final var chunkRecord = createChunkRecord(eventRecord, chunk);
+      if (stateWriter.canWriteEventOfLength(chunkRecord.getLength())) {
+        immediateChunks.add(chunkRecord);
+      } else {
+        processOversizedChunk(eventRecord, chunk, immediateChunks, deferredChunks);
+      }
+    }
+
+    LOG.debug(
+        "Categorized chunks: {} immediate, {} deferred",
+        immediateChunks.size(),
+        deferredChunks.size());
+    return new CategorizedChunks(immediateChunks, deferredChunks);
+  }
+
+  /** Processes oversized chunks by creating micro-chunks. */
+  private void processOversizedChunk(
+      final UsageMetricRecord eventRecord,
+      final Map<String, Set<Long>> chunk,
+      final List<UsageMetricRecord> immediateChunks,
+      final List<UsageMetricRecord> deferredChunks) {
+
+    final var microChunks = createMicroChunks(eventRecord, chunk);
+    for (final var microChunk : microChunks) {
+      if (stateWriter.canWriteEventOfLength(microChunk.getLength())) {
+        immediateChunks.add(microChunk);
+      } else {
+        deferredChunks.add(microChunk);
+      }
+    }
+  }
+
+  /**
+   * Appends immediate chunks as follow-up events and moves failed chunks to deferred processing.
+   */
+  private void appendImmediateChunks(
+      final List<UsageMetricRecord> immediateChunks, final List<UsageMetricRecord> deferredChunks) {
+    for (int i = 0; i < immediateChunks.size(); i++) {
+      final var chunkRecord = immediateChunks.get(i);
+
+      try {
+        stateWriter.appendFollowUpEvent(
+            keyGenerator.nextKey(), UsageMetricIntent.EXPORTED, chunkRecord);
+      } catch (final ExceededBatchRecordSizeException e) {
+        LOG.warn(
+            "Failed to append immediate chunk {}, moving to deferred processing: {}",
+            i,
+            e.getMessage());
+        deferredChunks.add(chunkRecord);
+      }
+    }
+  }
+
+  /** Defers remaining chunks as side effects. */
+  private void deferRemainingChunks(final List<UsageMetricRecord> deferredChunks) {
+    if (deferredChunks.isEmpty()) {
+      return;
+    }
+
+    sideEffectWriter.appendSideEffect(
+        () -> {
+          for (int i = 0; i < deferredChunks.size(); i++) {
+            final var deferredChunk = deferredChunks.get(i);
+
+            if (typedCommandWriter.canWriteCommandOfLength(deferredChunk.getLength())) {
+              typedCommandWriter.appendFollowUpCommand(
+                  keyGenerator.nextKey(), UsageMetricIntent.EXPORT, deferredChunk);
+            } else {
+              LOG.error("Deferred chunk {} still exceeds size limit even for commands", i);
+            }
+          }
+          return true;
+        });
+  }
+
+  /** Creates micro chunks from an oversized chunk. */
+  private List<UsageMetricRecord> createMicroChunks(
+      final UsageMetricRecord originalRecord, final Map<String, Set<Long>> oversizedChunk) {
+
+    final var microChunks = new ArrayList<UsageMetricRecord>();
+
+    oversizedChunk.forEach(
+        (tenantId, assigneeSet) ->
+            assigneeSet.forEach(
+                assignee -> {
+                  final var singleEntryMap = Map.of(tenantId, Set.of(assignee));
+                  microChunks.add(createChunkRecord(originalRecord, singleEntryMap));
+                }));
+
+    LOG.debug("Created {} micro-chunks for oversized chunk", microChunks.size());
+    return microChunks;
+  }
+
+  /** Creates optimized chunks with improved algorithm. */
+  private List<Map<String, Set<Long>>> createOptimizedChunks(
+      final List<Map.Entry<String, Set<Long>>> tenantEntries, final int targetEntriesPerChunk) {
+
+    final var chunks = new ArrayList<Map<String, Set<Long>>>();
+    var currentChunk = new HashMap<String, Set<Long>>();
+    var currentSize = 0;
+
+    for (final var entry : tenantEntries) {
+      final var assigneeSet = entry.getValue();
+      final var entrySize = assigneeSet.size();
+
+      if (entrySize > targetEntriesPerChunk) {
+        addCurrentChunkIfNotEmpty(chunks, currentChunk);
+        currentChunk = new HashMap<>();
+        currentSize = 0;
+        addLargeEntryAsMultipleChunks(chunks, entry, targetEntriesPerChunk);
+      } else if (currentSize + entrySize > targetEntriesPerChunk && !currentChunk.isEmpty()) {
+        addCurrentChunkIfNotEmpty(chunks, currentChunk);
+        currentChunk = new HashMap<>();
+        currentChunk.put(entry.getKey(), assigneeSet);
+        currentSize = entrySize;
+      } else {
+        currentChunk.put(entry.getKey(), assigneeSet);
+        currentSize += entrySize;
+      }
+    }
+
+    addCurrentChunkIfNotEmpty(chunks, currentChunk);
+    return chunks;
+  }
+
+  /** Adds current chunk to the list if it's not empty. */
+  private void addCurrentChunkIfNotEmpty(
+      final List<Map<String, Set<Long>>> chunks, final Map<String, Set<Long>> currentChunk) {
+    if (!currentChunk.isEmpty()) {
+      chunks.add(new HashMap<>(currentChunk));
+    }
+  }
+
+  /** Splits a large entry into multiple chunks. */
+  private void addLargeEntryAsMultipleChunks(
+      final List<Map<String, Set<Long>>> chunks,
+      final Map.Entry<String, Set<Long>> entry,
+      final int targetEntriesPerChunk) {
+
+    final var assigneeList = new ArrayList<>(entry.getValue());
+    for (int i = 0; i < assigneeList.size(); i += targetEntriesPerChunk) {
+      final var endIndex = Math.min(i + targetEntriesPerChunk, assigneeList.size());
+      final var subSet = new HashSet<>(assigneeList.subList(i, endIndex));
+      chunks.add(Map.of(entry.getKey(), subSet));
+    }
+  }
+
+  /** Creates a new record for a chunk with the same metadata as the original. */
+  private UsageMetricRecord createChunkRecord(
+      final UsageMetricRecord originalRecord, final Map<String, Set<Long>> chunkData) {
+
+    final var chunkRecord =
+        new UsageMetricRecord()
+            .setEventType(originalRecord.getEventType())
+            .setIntervalType(originalRecord.getIntervalType())
+            .setResetTime(originalRecord.getResetTime())
+            .setStartTime(originalRecord.getStartTime())
+            .setEndTime(originalRecord.getEndTime());
+
+    final var chunkBuffer =
+        BufferUtil.wrapArray(
+            io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter.convertToMsgPack(chunkData));
+    chunkRecord.setSetValues(chunkBuffer);
+
+    return chunkRecord;
+  }
+
+  /** Estimates the average bytes per entry using sampling. */
+  private int estimateAverageBytesPerEntry(
+      final Map<String, Set<Long>> setValues, final int baseRecordOverhead) {
+
+    var totalBytes = 0;
+    var totalEntries = 0;
+    var sampledEntries = 0;
+    final int maxSamples = setValues.size() / 2 + 1;
+
+    for (final var entry : setValues.entrySet()) {
+      if (sampledEntries >= maxSamples) {
+        break;
+      }
+
+      final var tenantIdBytes = entry.getKey().getBytes().length;
+      final var assigneeSetSize = entry.getValue().size();
+      final var entryBytes =
+          baseRecordOverhead + tenantIdBytes + (assigneeSetSize * BYTES_PER_LONG);
+
+      totalBytes += entryBytes;
+      totalEntries += assigneeSetSize;
+      sampledEntries++;
+    }
+
+    return sampledEntries > 0 ? totalBytes / totalEntries : DEFAULT_BYTES_PER_ENTRY;
+  }
+
+  /** Calculates the base overhead of a record without the set values data. */
+  private int calculateBaseRecordOverhead(final UsageMetricRecord originalRecord) {
+    final var testRecord =
+        new UsageMetricRecord()
+            .setEventType(originalRecord.getEventType())
+            .setIntervalType(originalRecord.getIntervalType())
+            .setResetTime(originalRecord.getResetTime())
+            .setStartTime(originalRecord.getStartTime())
+            .setEndTime(originalRecord.getEndTime())
+            .setSetValues(BufferUtil.wrapArray(new byte[0]));
+
+    return testRecord.getLength();
+  }
+
+  /**
+   * Validates if the event record is eligible for splitting.
+   *
+   * @param eventRecord the usage metric record to validate
+   * @return true if the record can be split, false otherwise
+   */
+  private boolean isRecordEligibleForSplitting(final UsageMetricRecord eventRecord) {
+    if (EventType.TU != eventRecord.getEventType()) {
+      return false;
+    }
+
+    final var originalSetValues = eventRecord.getSetValues();
+    return originalSetValues != null && !originalSetValues.isEmpty();
+  }
+
+  /** Strategy for chunking records based on size constraints. */
+  private record ChunkingStrategy(
+      int maxRecordLength,
+      int baseRecordOverhead,
+      int availableSpace,
+      int totalEntries,
+      int estimatedBytesPerEntry,
+      int targetEntriesPerChunk) {}
+
+  /** Categorized chunks for processing. */
+  private record CategorizedChunks(
+      List<UsageMetricRecord> immediate, List<UsageMetricRecord> deferred) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsRecordDivideTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsRecordDivideTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.metrics;
+
+import static io.camunda.zeebe.logstreams.impl.serializer.DataFrameDescriptor.FRAME_ALIGNMENT;
+import static io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType.TU;
+import static io.camunda.zeebe.util.StreamProcessingConstants.DEFAULT_MAX_FRAGMENT_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.appliers.EventAppliers;
+import io.camunda.zeebe.engine.state.metrics.DbUsageMetricState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.engine.util.stream.TestBufferedProcessingResultBuilder;
+import io.camunda.zeebe.logstreams.impl.serializer.DataFrameDescriptor;
+import io.camunda.zeebe.logstreams.log.LogAppendEntry;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.WriteContext;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
+import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.HashUtil;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+class UsageMetricsRecordDivideTest {
+
+  private static final String TENANT_ID = "tenant";
+
+  private UsageMetricsExportProcessor processor;
+  private Method appendFollowUpEventMethod;
+  private Method splitAndAppendRecordHybridMethod;
+  private ZeebeDb<ZbColumnFamilies> zeebeDb;
+  private TransactionContext transactionContext;
+  private TestBufferedProcessingResultBuilder<UsageMetricRecord> bufferedProcessingResultBuilder;
+  private MutableUsageMetricState state;
+  private MutableProcessingState processingState;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    // Initialize the mock log stream writer
+    final LogStreamWriter logStreamWriter =
+        new LogStreamWriter() {
+          @Override
+          public boolean canWriteEvents(final int eventCount, final int batchSize) {
+            final int framedMessageLength =
+                batchSize
+                    + eventCount * (DataFrameDescriptor.HEADER_LENGTH + FRAME_ALIGNMENT)
+                    + FRAME_ALIGNMENT;
+            return framedMessageLength <= DEFAULT_MAX_FRAGMENT_SIZE;
+          }
+
+          @Override
+          public Either<WriteFailure, Long> tryWrite(
+              final WriteContext context,
+              final List<LogAppendEntry> appendEntries,
+              final long sourcePosition) {
+            return Either.right(1L);
+          }
+        };
+
+    state = new DbUsageMetricState(zeebeDb, transactionContext, Duration.ofSeconds(1));
+    state.resetActiveBucket(1L);
+    final var keyGenerator =
+        new DbKeyGenerator(Protocol.DEPLOYMENT_PARTITION, zeebeDb, transactionContext);
+    final var eventAppliers = new EventAppliers().registerEventAppliers(processingState);
+
+    // Initialize the fake processing result builder
+    bufferedProcessingResultBuilder =
+        new TestBufferedProcessingResultBuilder<>(logStreamWriter::canWriteEvents);
+
+    final Writers writers = new Writers(() -> bufferedProcessingResultBuilder, eventAppliers);
+    processor = new UsageMetricsExportProcessor(state, writers, keyGenerator);
+
+    // Use reflection to access the private method
+    appendFollowUpEventMethod =
+        UsageMetricsExportProcessor.class.getDeclaredMethod(
+            "appendFollowUpEvent", UsageMetricRecord.class);
+    appendFollowUpEventMethod.setAccessible(true);
+    splitAndAppendRecordHybridMethod =
+        UsageMetricsExportProcessor.class.getDeclaredMethod(
+            "splitAndAppendRecordHybrid", UsageMetricRecord.class);
+    splitAndAppendRecordHybridMethod.setAccessible(true);
+  }
+
+  @Test
+  void shouldAppendOneFollowUpEventWithManyAssignees() throws Exception {
+    // given
+    final UsageMetricRecord eventRecord = createLargeSetValueRecord(1, 465_000);
+
+    // when
+    appendFollowUpEventMethod.invoke(processor, eventRecord);
+
+    // then
+    assertThat(bufferedProcessingResultBuilder.getFollowupEventRecords()).hasSize(1);
+    assertThat(bufferedProcessingResultBuilder.getFollowupCommandRecords()).isEmpty();
+
+    final var recordedEvent = bufferedProcessingResultBuilder.getFollowupEventRecords().getFirst();
+    assertThat(recordedEvent.getIntent()).isEqualTo(UsageMetricIntent.EXPORTED);
+    assertThat(recordedEvent.getValue()).isInstanceOf(UsageMetricRecord.class);
+
+    final UsageMetricRecord capturedRecord = recordedEvent.getValue();
+    assertThat(capturedRecord.getEventType()).isEqualTo(EventType.TU);
+    assertThat(capturedRecord.getIntervalType()).isEqualTo(IntervalType.ACTIVE);
+    assertThat(capturedRecord.getResetTime()).isEqualTo(123L);
+    assertThat(capturedRecord.getStartTime()).isEqualTo(100L);
+    assertThat(capturedRecord.getEndTime()).isEqualTo(200L);
+    assertThat(capturedRecord.getSetValues().get(TENANT_ID)).size().isEqualTo(465_000);
+  }
+
+  @Test
+  void shouldAppendOneFollowUpEventWithManyTenants() throws Exception {
+    // given
+    final UsageMetricRecord eventRecord = createLargeSetValueRecord(20, 20_000);
+
+    // when
+    appendFollowUpEventMethod.invoke(processor, eventRecord);
+
+    // then
+    assertThat(bufferedProcessingResultBuilder.getFollowupEventRecords()).hasSize(1);
+    assertThat(bufferedProcessingResultBuilder.getFollowupCommandRecords()).isEmpty();
+
+    final var recordedEvent = bufferedProcessingResultBuilder.getFollowupEventRecords().getFirst();
+    assertThat(recordedEvent.getIntent()).isEqualTo(UsageMetricIntent.EXPORTED);
+    assertThat(recordedEvent.getValue()).isInstanceOf(UsageMetricRecord.class);
+
+    final UsageMetricRecord capturedRecord = recordedEvent.getValue();
+    assertThat(capturedRecord.getEventType()).isEqualTo(EventType.TU);
+    assertThat(capturedRecord.getIntervalType()).isEqualTo(IntervalType.ACTIVE);
+    assertThat(capturedRecord.getResetTime()).isEqualTo(123L);
+    assertThat(capturedRecord.getStartTime()).isEqualTo(100L);
+    assertThat(capturedRecord.getEndTime()).isEqualTo(200L);
+    assertThat(capturedRecord.getSetValues()).size().isEqualTo(20);
+  }
+
+  @Test
+  void shouldAppendFollowUpEventsManyAssignees() throws Exception {
+    // given
+    final UsageMetricRecord eventRecord = createLargeSetValueRecord(1, 470_000);
+
+    // when
+    splitAndAppendRecordHybridMethod.invoke(processor, eventRecord);
+
+    // then
+    assertThat(bufferedProcessingResultBuilder.getFollowupEventRecords()).hasSize(4);
+    assertThat(bufferedProcessingResultBuilder.getFollowupCommandRecords()).hasSize(1);
+  }
+
+  @Test
+  void shouldAppendFollowUpEventsManyTenants() throws Exception {
+    // given
+    final UsageMetricRecord eventRecord = createLargeSetValueRecord(20, 23_500);
+
+    // when
+    splitAndAppendRecordHybridMethod.invoke(processor, eventRecord);
+
+    // then
+    assertThat(bufferedProcessingResultBuilder.getFollowupEventRecords()).hasSize(4);
+    assertThat(bufferedProcessingResultBuilder.getFollowupCommandRecords()).hasSize(1);
+  }
+
+  @Test
+  void shouldAppendFollowUpEventsAndFollowUpCommandsManyAssignees() throws Exception {
+    // given
+    final UsageMetricRecord eventRecord = createLargeSetValueRecord(1, 600_000);
+
+    // when
+    splitAndAppendRecordHybridMethod.invoke(processor, eventRecord);
+
+    // then
+    assertThat(bufferedProcessingResultBuilder.getFollowupEventRecords()).hasSize(3);
+    assertThat(bufferedProcessingResultBuilder.getFollowupCommandRecords()).hasSize(1);
+  }
+
+  @Test
+  void shouldAppendFollowUpEventsAndFollowUpCommandsManyTenants() throws Exception {
+    // given
+    final UsageMetricRecord eventRecord = createLargeSetValueRecord(20, 40_000);
+
+    // when
+    splitAndAppendRecordHybridMethod.invoke(processor, eventRecord);
+
+    // then
+    assertThat(bufferedProcessingResultBuilder.getFollowupEventRecords()).hasSize(2);
+    assertThat(bufferedProcessingResultBuilder.getFollowupCommandRecords()).hasSize(1);
+  }
+
+  private UsageMetricRecord createLargeSetValueRecord(
+      final int tenantsSize, final int assigneeSize) {
+    return new UsageMetricRecord()
+        .setEventType(TU)
+        .setIntervalType(IntervalType.ACTIVE)
+        .setResetTime(123L)
+        .setStartTime(100L)
+        .setEndTime(200L)
+        .setSetValues(
+            BufferUtil.wrapArray(
+                MsgPackConverter.convertToMsgPack(generateLargeSetMap(tenantsSize, assigneeSize))));
+  }
+
+  private static Map<String, Set<Long>> generateLargeSetMap(
+      final int tenantsSize, final int assigneeSize) {
+    final var map = new HashMap<String, Set<Long>>();
+    final var set = new HashSet<Long>();
+    if (tenantsSize > 1) {
+      for (int i = 0; i < assigneeSize; i++) {
+        set.add(HashUtil.getStringHashValue(String.valueOf(i)));
+      }
+      for (int i = 0; i < tenantsSize; i++) {
+        map.put(TENANT_ID + i, set);
+      }
+
+    } else {
+      for (int i = 0; i < assigneeSize; i++) {
+        set.add(HashUtil.getStringHashValue(String.valueOf(i)));
+      }
+      map.put(TENANT_ID, set);
+    }
+    return map;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/stream/BufferedResult.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/stream/BufferedResult.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.stream;
+
+import io.camunda.zeebe.engine.util.stream.TestBufferedProcessingResultBuilder.ProcessingResponseImpl;
+import io.camunda.zeebe.stream.api.PostCommitTask;
+import io.camunda.zeebe.stream.api.ProcessingResponse;
+import io.camunda.zeebe.stream.api.ProcessingResult;
+import io.camunda.zeebe.stream.api.records.ImmutableRecordBatch;
+import io.camunda.zeebe.stream.api.scheduling.TaskResult;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Implementation of {@link ProcessingResult} and {@link TaskResult} that buffers the processing and
+ * taks results, which will then be written to logstream or send as response.
+ */
+final class BufferedResult implements ProcessingResult, TaskResult {
+
+  private final List<PostCommitTask> postCommitTasks;
+  private final ImmutableRecordBatch immutableRecordBatch;
+  private final ProcessingResponseImpl processingResponse;
+  private final boolean processInASeparateBatch;
+
+  BufferedResult(
+      final ImmutableRecordBatch immutableRecordBatch,
+      final ProcessingResponseImpl processingResponse,
+      final List<PostCommitTask> postCommitTasks,
+      final boolean processInASeparateBatch) {
+    this.postCommitTasks = new ArrayList<>(postCommitTasks);
+    this.processingResponse = processingResponse;
+    this.immutableRecordBatch = immutableRecordBatch;
+    this.processInASeparateBatch = processInASeparateBatch;
+  }
+
+  @Override
+  public ImmutableRecordBatch getRecordBatch() {
+    return immutableRecordBatch;
+  }
+
+  @Override
+  public Optional<ProcessingResponse> getProcessingResponse() {
+    return Optional.ofNullable(processingResponse);
+  }
+
+  @Override
+  public boolean executePostCommitTasks() {
+    boolean aggregatedResult = true;
+
+    for (final PostCommitTask task : postCommitTasks) {
+      try {
+        aggregatedResult = aggregatedResult && task.flush();
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    return aggregatedResult;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return getProcessingResponse().isEmpty()
+        && getRecordBatch().isEmpty()
+        && postCommitTasks.isEmpty();
+  }
+
+  @Override
+  public boolean shouldProcessInASeparateBatch() {
+    return processInASeparateBatch;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/stream/TestBufferedProcessingResultBuilder.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/stream/TestBufferedProcessingResultBuilder.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.stream;
+
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationReferenceNullValue;
+
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.CopiedRecord;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.stream.api.PostCommitTask;
+import io.camunda.zeebe.stream.api.ProcessingResponse;
+import io.camunda.zeebe.stream.api.ProcessingResult;
+import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.stream.api.records.RecordBatchSizePredicate;
+import io.camunda.zeebe.stream.impl.TypedEventRegistry;
+import io.camunda.zeebe.stream.impl.records.RecordBatch;
+import io.camunda.zeebe.stream.impl.records.RecordBatchEntry;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.StringUtil;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestBufferedProcessingResultBuilder<V extends UnifiedRecordValue>
+    implements ProcessingResultBuilder {
+
+  private final List<Record<V>> followupEventRecords = new ArrayList<>();
+  private final List<PostCommitTask> postCommitTasks = new ArrayList<>();
+
+  private final RecordBatch mutableRecordBatch;
+  private ProcessingResponseImpl processingResponse;
+  private final long operationReference;
+  private boolean processInASeparateBatch = false;
+  private final long batchOperationReference;
+
+  public TestBufferedProcessingResultBuilder(final RecordBatchSizePredicate predicate) {
+    this(predicate, operationReferenceNullValue(), batchOperationReferenceNullValue());
+  }
+
+  TestBufferedProcessingResultBuilder(
+      final RecordBatchSizePredicate predicate,
+      final long operationReference,
+      final long batchOperationReference) {
+    mutableRecordBatch = new RecordBatch(predicate);
+    this.operationReference = operationReference;
+    this.batchOperationReference = batchOperationReference;
+  }
+
+  public List<Record<V>> getFollowupEventRecords() {
+    return followupEventRecords;
+  }
+
+  public List<PostCommitTask> getFollowupCommandRecords() {
+    return postCommitTasks;
+  }
+
+  @Override
+  public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
+      final long key, final RecordValue value, final RecordMetadata metadata) {
+
+    // `operationReference` from `metadata` should have a higher precedence
+    if (metadata.getOperationReference() == operationReferenceNullValue()) {
+      if (operationReference != operationReferenceNullValue()) {
+        metadata.operationReference(operationReference);
+      }
+    }
+
+    if (batchOperationReference != batchOperationReferenceNullValue()) {
+      metadata.batchOperationReference(batchOperationReference);
+    }
+
+    final ValueType valueType = TypedEventRegistry.TYPE_REGISTRY.get(value.getClass());
+    if (valueType == null) {
+      // usually happens when the record is not registered at the TypedStreamEnvironment
+      throw new IllegalStateException("Missing value type mapping for record: " + value.getClass());
+    }
+
+    if (value instanceof final UnifiedRecordValue unifiedRecordValue) {
+      final var metadataWithValueType = metadata.valueType(valueType);
+      final var either =
+          mutableRecordBatch.appendRecord(key, metadataWithValueType, -1, unifiedRecordValue);
+      if (either.isLeft()) {
+        return Either.left(either.getLeft());
+      }
+    } else {
+      throw new IllegalStateException(
+          String.format(
+              "The record value %s is not a UnifiedRecordValue",
+              StringUtil.limitString(value.toString(), 1024)));
+    }
+    final int partitionId = Protocol.decodePartitionId(key);
+    final var copiedRecord = new CopiedRecord<>((V) value, metadata, key, partitionId, -1, -1, -1);
+    followupEventRecords.add(copiedRecord.copyOf());
+
+    return Either.right(this);
+  }
+
+  @Override
+  public ProcessingResultBuilder withResponse(
+      final RecordType recordType,
+      final long key,
+      final Intent intent,
+      final UnpackedObject value,
+      final ValueType valueType,
+      final RejectionType rejectionType,
+      final String rejectionReason,
+      final long requestId,
+      final int requestStreamId) {
+    if (requestId == RecordMetadataEncoder.requestIdNullValue()) {
+      return this;
+    }
+    final var metadata =
+        new RecordMetadata()
+            .recordType(recordType)
+            .intent(intent)
+            .rejectionType(rejectionType)
+            .rejectionReason(rejectionReason)
+            .valueType(valueType)
+            .operationReference(operationReference)
+            .batchOperationReference(batchOperationReference);
+    final var entry = RecordBatchEntry.createEntry(key, metadata, -1, value);
+    processingResponse = new ProcessingResponseImpl(entry, requestId, requestStreamId);
+    return this;
+  }
+
+  @Override
+  public ProcessingResultBuilder appendPostCommitTask(final PostCommitTask task) {
+    postCommitTasks.add(task);
+    return this;
+  }
+
+  @Override
+  public ProcessingResultBuilder resetPostCommitTasks() {
+    postCommitTasks.clear();
+    return this;
+  }
+
+  @Override
+  public ProcessingResultBuilder withProcessInASeparateBatch() {
+    processInASeparateBatch = true;
+    return this;
+  }
+
+  @Override
+  public ProcessingResult build() {
+    return new BufferedResult(
+        mutableRecordBatch, processingResponse, postCommitTasks, processInASeparateBatch);
+  }
+
+  @Override
+  public boolean canWriteEventOfLength(final int eventLength) {
+    return mutableRecordBatch.canAppendRecordOfLength(eventLength);
+  }
+
+  record ProcessingResponseImpl(RecordBatchEntry responseValue, long requestId, int requestStreamId)
+      implements ProcessingResponse {}
+}

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.logstreams.impl.log;
 
+import static io.camunda.zeebe.util.StreamProcessingConstants.DEFAULT_MAX_FRAGMENT_SIZE;
+import static io.camunda.zeebe.util.StreamProcessingConstants.MINIMUM_FRAGMENT_SIZE;
+
 import com.netflix.concurrency.limits.Limit;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.RateLimit;
 import io.camunda.zeebe.logstreams.log.LogStream;
@@ -17,8 +20,7 @@ import java.time.InstantSource;
 import java.util.Objects;
 
 public final class LogStreamBuilderImpl implements LogStreamBuilder {
-  private static final int MINIMUM_FRAGMENT_SIZE = 4 * 1024;
-  private int maxFragmentSize = 1024 * 1024 * 4;
+  private int maxFragmentSize = DEFAULT_MAX_FRAGMENT_SIZE;
   private int partitionId = -1;
   private LogStorage logStorage;
   private String logName;

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/StreamProcessingConstants.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/StreamProcessingConstants.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+/** This class provides constant values for logstreams and engine. */
+public final class StreamProcessingConstants {
+
+  // Fragment size constants
+  /** Minimum fragment size in bytes (4KB) */
+  public static final int MINIMUM_FRAGMENT_SIZE = 1024 * 4;
+
+  /** Default maximum fragment size in bytes (4MB) */
+  public static final int DEFAULT_MAX_FRAGMENT_SIZE = 1024 * 1024 * 4;
+
+  /** Conservative fragment size limit for metrics export (3MB) */
+  public static final int CONSERVATIVE_FRAGMENT_SIZE_LIMIT = 1024 * 1024 * 3;
+
+  // Record processing constants for chunking
+  /** Default estimated bytes per entry when calculating chunk sizes */
+  public static final int DEFAULT_BYTES_PER_ENTRY = 100;
+
+  /** Number of bytes per long value */
+  public static final int BYTES_PER_LONG = 8;
+
+  /** Minimum chunk size for record splitting */
+  public static final int MIN_CHUNK_SIZE = 1000;
+
+  /**
+   * Chunk size divisor to decide how many follow-ups we want at most for record dividing in chunks
+   */
+  public static final int CHUNK_SIZE_DIVISOR = 5;
+}


### PR DESCRIPTION
## Description
DRAFT—this is currently considered an edge case and may not be necessary. 
See the ongoing discussion [here](https://camunda.slack.com/archives/C08MRKHJ0CD/p1756121929577529).

The `UsageMetricsExporterProcessor` sends follow-up events, with a current frequency of every 5 minutes. 
In rare situations, appending a `UsageMetricRecord` as a follow-up event can cause the batch record size to exceed the maximum limit, resulting in an `ExceededBatchRecordSizeException`.

### Proposed Approach
If adding new event records would surpass the maximum batch size, then:

1. Add as many follow-up events as will fit within the current batch.
2. Attach any remaining event records as side-effect follow-up commands, so they can be collected by a subsequent batch, preventing the exception.

## Related issues

closes #36762
