### PR TITLE
fix: map batch operation types correctly

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.response.BatchOperation;
 import io.camunda.client.api.search.response.BatchOperationError;
+import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.client.protocol.rest.BatchOperationResponse;
 import java.util.ArrayList;
@@ -40,10 +41,7 @@ public class BatchOperationImpl implements BatchOperation {
 
   public BatchOperationImpl(final BatchOperationCreatedResult item) {
     batchOperationKey = item.getBatchOperationKey();
-    type =
-        item.getBatchOperationType() != null
-            ? BatchOperationType.valueOf(item.getBatchOperationType().name())
-            : null;
+    type = EnumUtil.convert(item.getBatchOperationType(), BatchOperationType.class);
     status = null;
     startDate = null;
     endDate = null;
@@ -54,10 +52,7 @@ public class BatchOperationImpl implements BatchOperation {
 
   public BatchOperationImpl(final BatchOperationResponse item) {
     batchOperationKey = item.getBatchOperationKey();
-    type =
-        item.getBatchOperationType() != null
-            ? BatchOperationType.valueOf(item.getBatchOperationType().name())
-            : null;
+    type = EnumUtil.convert(item.getBatchOperationType(), BatchOperationType.class);
     status = item.getState() != null ? BatchOperationState.valueOf(item.getState().name()) : null;
     startDate = item.getStartDate();
     endDate = item.getEndDate();


### PR DESCRIPTION
## Description

The batch operation type in Java client responses must be transformed considering unsupported values. The EnumUtil provided by the client takes care of this automatically.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37289 
