### PR TITLE
feat: add elasticsearch/opensearch security group to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
@@ -18,6 +18,8 @@ public abstract class SecondaryStorageDatabase {
   /** Name of the cluster */
   private String clusterName = databaseName().toLowerCase();
 
+  private Security security = new Security(databaseName());
+
   public String getUrl() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         prefix() + ".url",
@@ -27,8 +29,16 @@ public abstract class SecondaryStorageDatabase {
         legacyUrlProperties());
   }
 
-  public void setUrl(String url) {
+  public void setUrl(final String url) {
     this.url = url;
+  }
+
+  public Security getSecurity() {
+    return security;
+  }
+
+  public void setSecurity(final Security security) {
+    this.security = security;
   }
 
   public String getClusterName() {

--- a/configuration/src/main/java/io/camunda/configuration/Security.java
+++ b/configuration/src/main/java/io/camunda/configuration/Security.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+
+public class Security {
+
+  private final String databaseName;
+
+  /** Enable security */
+  private boolean enabled = false;
+
+  /** Path to certificate used by Elasticsearch or Opensearch */
+  private String certificatePath;
+
+  /** Should the hostname be validated */
+  private boolean verifyHostname = true;
+
+  /** Certificate was self-signed */
+  private boolean selfSigned = false;
+
+  public Security(final String databaseName) {
+    this.databaseName = databaseName.toLowerCase();
+  }
+
+  public boolean isEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".enabled",
+        enabled,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyEnabledProperties());
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getCertificatePath() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".certificate-path",
+        certificatePath,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyCertificatePathProperties());
+  }
+
+  public void setCertificatePath(final String certificatePath) {
+    this.certificatePath = certificatePath;
+  }
+
+  public boolean isVerifyHostname() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".verify-hostname",
+        verifyHostname,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyVerifyHostnameProperties());
+  }
+
+  public void setVerifyHostname(final boolean verifyHostname) {
+    this.verifyHostname = verifyHostname;
+  }
+
+  public boolean isSelfSigned() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".self-signed",
+        selfSigned,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacySelfSignedProperties());
+  }
+
+  public void setSelfSigned(final boolean selfSigned) {
+    this.selfSigned = selfSigned;
+  }
+
+  private String prefix() {
+    return "camunda.data.secondary-storage." + databaseName + ".security";
+  }
+
+  private Set<String> legacyEnabledProperties() {
+    return Set.of(
+        "camunda.database.security.enabled",
+        "zeebe.broker.exporters.camundaexporter.args.connect.security.enabled");
+  }
+
+  private Set<String> legacyCertificatePathProperties() {
+    return Set.of(
+        "camunda.database.security.certificatePath",
+        "camunda.tasklist." + databaseName + ".ssl.certificatePath",
+        "camunda.operate." + databaseName + ".ssl.certificatePath",
+        "zeebe.broker.exporters.camundaexporter.args.connect.security.certificatePath");
+  }
+
+  private Set<String> legacyVerifyHostnameProperties() {
+    return Set.of(
+        "camunda.database.security.verifyHostname",
+        "camunda.tasklist." + databaseName + ".ssl.verifyHostname",
+        "camunda.operate." + databaseName + ".ssl.verifyHostname",
+        "zeebe.broker.exporters.camundaexporter.args.connect.security.verifyHostname");
+  }
+
+  private Set<String> legacySelfSignedProperties() {
+    return Set.of(
+        "camunda.database.security.selfSigned",
+        "camunda.tasklist." + databaseName + ".ssl.selfSigned",
+        "camunda.operate." + databaseName + ".ssl.selfSigned",
+        "zeebe.broker.exporters.camundaexporter.args.connect.security.selfSigned");
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -458,6 +458,14 @@ public class BrokerBasedPropertiesOverride {
     setArg(args, "connect.type", secondaryStorage.getType().name());
     setArg(args, "connect.url", database.getUrl());
     setArg(args, "connect.clusterName", database.getClusterName());
+
+    // Add security configuration mapping
+    if (database.getSecurity() != null) {
+      setArg(args, "connect.security.enabled", database.getSecurity().isEnabled());
+      setArg(args, "connect.security.certificatePath", database.getSecurity().getCertificatePath());
+      setArg(args, "connect.security.verifyHostname", database.getSecurity().isVerifyHostname());
+      setArg(args, "connect.security.selfSigned", database.getSecurity().isSelfSigned());
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -10,10 +10,15 @@ package io.camunda.configuration.beanoverrides;
 import io.camunda.configuration.Backup;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.Security;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.operate.conditions.DatabaseType;
 import io.camunda.operate.property.BackupProperties;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.property.SslProperties;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -50,19 +55,12 @@ public class OperatePropertiesOverride {
         unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
 
     if (SecondaryStorageType.elasticsearch.equals(database.getType())) {
-      override.setDatabase(DatabaseType.Elasticsearch);
-      override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
-      override.getZeebeElasticsearch().setUrl(database.getElasticsearch().getUrl());
+      populateFromElasticsearch(override, database);
       override.getElasticsearch().setClusterName(database.getElasticsearch().getClusterName());
     } else if (SecondaryStorageType.opensearch == database.getType()) {
-      override.setDatabase(DatabaseType.Opensearch);
-      override.getOpensearch().setUrl(database.getOpensearch().getUrl());
-      override.getZeebeOpensearch().setUrl(database.getOpensearch().getUrl());
+      populateFromOpensearch(override, database);
       override.getOpensearch().setClusterName(database.getOpensearch().getClusterName());
     }
-
-    // TODO: Populate the rest of the bean using unifiedConfiguration
-    //  override.setSampleField(unifiedConfiguration.getSampleField());
 
     return override;
   }
@@ -75,5 +73,40 @@ public class OperatePropertiesOverride {
     backupProperties.setSnapshotTimeout(operateBackup.getSnapshotTimeout());
     backupProperties.setIncompleteCheckTimeoutInSeconds(
         operateBackup.getIncompleteCheckTimeout().getSeconds());
+  }
+
+  private void populateFromElasticsearch(
+      final OperateProperties override, final SecondaryStorage database) {
+    override.setDatabase(DatabaseType.Elasticsearch);
+    override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
+    override.getZeebeElasticsearch().setUrl(database.getElasticsearch().getUrl());
+
+    populateFromSecurity(
+        database.getElasticsearch().getSecurity(),
+        override.getElasticsearch()::getSsl,
+        override.getElasticsearch()::setSsl);
+  }
+
+  private void populateFromOpensearch(
+      final OperateProperties override, final SecondaryStorage database) {
+    override.setDatabase(DatabaseType.Opensearch);
+    override.getOpensearch().setUrl(database.getOpensearch().getUrl());
+    override.getZeebeOpensearch().setUrl(database.getOpensearch().getUrl());
+
+    populateFromSecurity(
+        database.getOpensearch().getSecurity(),
+        override.getOpensearch()::getSsl,
+        override.getOpensearch()::setSsl);
+  }
+
+  private void populateFromSecurity(
+      final Security security,
+      final Supplier<SslProperties> getSsl,
+      final Consumer<SslProperties> setSsl) {
+    final SslProperties sslProps = Objects.requireNonNullElseGet(getSsl.get(), SslProperties::new);
+    sslProps.setCertificatePath(security.getCertificatePath());
+    sslProps.setVerifyHostname(security.isVerifyHostname());
+    sslProps.setSelfSigned(security.isSelfSigned());
+    setSsl.accept(sslProps);
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -11,9 +11,14 @@ package io.camunda.configuration.beanoverrides;
 import io.camunda.configuration.Backup;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.Security;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.tasklist.property.BackupProperties;
+import io.camunda.tasklist.property.SslProperties;
 import io.camunda.tasklist.property.TasklistProperties;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -50,19 +55,12 @@ public class TasklistPropertiesOverride {
         unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
 
     if (SecondaryStorageType.elasticsearch == database.getType()) {
-      override.setDatabase("elasticsearch");
-      override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
-      override.getZeebeElasticsearch().setUrl(database.getElasticsearch().getUrl());
+      populateFromElasticsearch(override, database);
       override.getElasticsearch().setClusterName(database.getElasticsearch().getClusterName());
     } else if (SecondaryStorageType.opensearch == database.getType()) {
-      override.setDatabase("opensearch");
-      override.getOpenSearch().setUrl(database.getOpensearch().getUrl());
-      override.getZeebeOpenSearch().setUrl(database.getOpensearch().getUrl());
+      populateFromOpensearch(override, database);
       override.getOpenSearch().setClusterName(database.getOpensearch().getClusterName());
     }
-
-    // TODO: Populate the rest of the bean using unifiedConfiguration
-    //  override.setSampleField(unifiedConfiguration.getSampleField());
 
     return override;
   }
@@ -72,5 +70,40 @@ public class TasklistPropertiesOverride {
         unifiedConfiguration.getCamunda().getData().getBackup().withTasklistBackupProperties();
     final BackupProperties backupProperties = override.getBackup();
     backupProperties.setRepositoryName(backup.getRepositoryName());
+  }
+
+  private void populateFromElasticsearch(
+      final TasklistProperties override, final SecondaryStorage database) {
+    override.setDatabase("elasticsearch");
+    override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
+    override.getZeebeElasticsearch().setUrl(database.getElasticsearch().getUrl());
+
+    populateFromSecurity(
+        database.getElasticsearch().getSecurity(),
+        override.getElasticsearch()::getSsl,
+        override.getElasticsearch()::setSsl);
+  }
+
+  private void populateFromOpensearch(
+      final TasklistProperties override, final SecondaryStorage database) {
+    override.setDatabase("opensearch");
+    override.getOpenSearch().setUrl(database.getOpensearch().getUrl());
+    override.getZeebeOpenSearch().setUrl(database.getOpensearch().getUrl());
+
+    populateFromSecurity(
+        database.getOpensearch().getSecurity(),
+        override.getOpenSearch()::getSsl,
+        override.getOpenSearch()::setSsl);
+  }
+
+  private void populateFromSecurity(
+      final Security security,
+      final Supplier<SslProperties> getSsl,
+      final Consumer<SslProperties> setSsl) {
+    final SslProperties sslProps = Objects.requireNonNullElseGet(getSsl.get(), SslProperties::new);
+    sslProps.setCertificatePath(security.getCertificatePath());
+    sslProps.setVerifyHostname(security.isVerifyHostname());
+    sslProps.setSelfSigned(security.isSelfSigned());
+    setSsl.accept(sslProps);
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/SecurityElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecurityElasticsearchTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
+import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.search.connect.configuration.SecurityConfiguration;
+import io.camunda.tasklist.property.SslProperties;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@ActiveProfiles({"broker"})
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  SearchEngineConnectPropertiesOverride.class,
+  BrokerBasedPropertiesOverride.class,
+  TasklistPropertiesOverride.class,
+  OperatePropertiesOverride.class,
+})
+public class SecurityElasticsearchTest {
+
+  private ExporterConfiguration getExporterConfiguration(
+      final BrokerBasedProperties brokerBasedProperties) {
+
+    final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+    assertThat(camundaExporter).isNotNull();
+
+    final Map<String, Object> args = camundaExporter.getArgs();
+    assertThat(args).isNotNull();
+
+    return UnifiedConfigurationHelper.argsToExporterConfiguration(args);
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.secondary-storage.elasticsearch.security.enabled=true",
+        "camunda.data.secondary-storage.elasticsearch.security.certificate-path=certificatePath",
+        "camunda.data.secondary-storage.elasticsearch.security.verify-hostname=false",
+        "camunda.data.secondary-storage.elasticsearch.security.self-signed=true"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+    final TasklistProperties tasklistProperties;
+    final OperateProperties operateProperties;
+
+    WithOnlyUnifiedConfigSet(
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final OperateProperties operateProperties) {
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.tasklistProperties = tasklistProperties;
+      this.operateProperties = operateProperties;
+    }
+
+    @Test
+    void testCamundaSearchEngineConnectProperties() {
+      assertThat(searchEngineConnectProperties.getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaExporterProperties() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getConnect().getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaTasklistProperties() {
+      assertThat(tasklistProperties.getElasticsearch().getSsl())
+          .returns("certificatePath", SslProperties::getCertificatePath)
+          .returns(false, SslProperties::isVerifyHostname)
+          .returns(true, SslProperties::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaOperateProperties() {
+      assertThat(operateProperties.getElasticsearch().getSsl())
+          .returns("certificatePath", io.camunda.operate.property.SslProperties::getCertificatePath)
+          .returns(false, io.camunda.operate.property.SslProperties::isVerifyHostname)
+          .returns(true, io.camunda.operate.property.SslProperties::isSelfSigned);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        // enabled
+        "camunda.data.secondary-storage.elasticsearch.security.enabled=true",
+        "camunda.database.security.enabled=true",
+        // certificate path
+        "camunda.data.secondary-storage.elasticsearch.security.certificate-path=certificatePath",
+        "camunda.database.security.certificatePath=certificatePath",
+        "camunda.tasklist.elasticsearch.ssl.certificatePath=certificatePath",
+        "camunda.operate.elasticsearch.ssl.certificatePath=certificatePath",
+        // verify hostname
+        "camunda.data.secondary-storage.elasticsearch.security.verify-hostname=false",
+        "camunda.database.security.verifyHostname=false",
+        "camunda.tasklist.elasticsearch.ssl.verifyHostname=false",
+        "camunda.operate.elasticsearch.ssl.verifyHostname=false",
+        // self signed
+        "camunda.data.secondary-storage.elasticsearch.security.self-signed=true",
+        "camunda.database.security.selfSigned=true",
+        "camunda.tasklist.elasticsearch.ssl.selfSigned=true",
+        "camunda.operate.elasticsearch.ssl.selfSigned=true"
+      })
+  class WithNewAndLegacySet {
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+    final TasklistProperties tasklistProperties;
+    final OperateProperties operateProperties;
+
+    WithNewAndLegacySet(
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final OperateProperties operateProperties) {
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.tasklistProperties = tasklistProperties;
+      this.operateProperties = operateProperties;
+    }
+
+    @Test
+    void testCamundaSearchEngineConnectProperties() {
+      assertThat(searchEngineConnectProperties.getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaExporterProperties() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getConnect().getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaTasklistProperties() {
+      assertThat(tasklistProperties.getElasticsearch().getSsl())
+          .returns("certificatePath", SslProperties::getCertificatePath)
+          .returns(false, SslProperties::isVerifyHostname)
+          .returns(true, SslProperties::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaOperateProperties() {
+      assertThat(operateProperties.getElasticsearch().getSsl())
+          .returns("certificatePath", io.camunda.operate.property.SslProperties::getCertificatePath)
+          .returns(false, io.camunda.operate.property.SslProperties::isVerifyHostname)
+          .returns(true, io.camunda.operate.property.SslProperties::isSelfSigned);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/SecurityOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecurityOpensearchTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
+import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.search.connect.configuration.SecurityConfiguration;
+import io.camunda.tasklist.property.SslProperties;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@ActiveProfiles({"broker"})
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  SearchEngineConnectPropertiesOverride.class,
+  BrokerBasedPropertiesOverride.class,
+  TasklistPropertiesOverride.class,
+  OperatePropertiesOverride.class,
+})
+public class SecurityOpensearchTest {
+
+  private ExporterConfiguration getExporterConfiguration(
+      final BrokerBasedProperties brokerBasedProperties) {
+
+    final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+    assertThat(camundaExporter).isNotNull();
+
+    final Map<String, Object> args = camundaExporter.getArgs();
+    assertThat(args).isNotNull();
+
+    return UnifiedConfigurationHelper.argsToExporterConfiguration(args);
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=opensearch",
+        "camunda.data.secondary-storage.opensearch.security.enabled=true",
+        "camunda.data.secondary-storage.opensearch.security.certificate-path=certificatePath",
+        "camunda.data.secondary-storage.opensearch.security.verify-hostname=false",
+        "camunda.data.secondary-storage.opensearch.security.self-signed=true"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+    final TasklistProperties tasklistProperties;
+    final OperateProperties operateProperties;
+
+    WithOnlyUnifiedConfigSet(
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final OperateProperties operateProperties) {
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.tasklistProperties = tasklistProperties;
+      this.operateProperties = operateProperties;
+    }
+
+    @Test
+    void testCamundaSearchEngineConnectProperties() {
+      assertThat(searchEngineConnectProperties.getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaExporterProperties() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getConnect().getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaTasklistProperties() {
+      assertThat(tasklistProperties.getOpenSearch().getSsl())
+          .returns("certificatePath", SslProperties::getCertificatePath)
+          .returns(false, SslProperties::isVerifyHostname)
+          .returns(true, SslProperties::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaOperateProperties() {
+      assertThat(operateProperties.getOpensearch().getSsl())
+          .returns("certificatePath", io.camunda.operate.property.SslProperties::getCertificatePath)
+          .returns(false, io.camunda.operate.property.SslProperties::isVerifyHostname)
+          .returns(true, io.camunda.operate.property.SslProperties::isSelfSigned);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=opensearch",
+        // enabled
+        "camunda.data.secondary-storage.opensearch.security.enabled=true",
+        "camunda.database.security.enabled=true",
+        // certificate path
+        "camunda.data.secondary-storage.opensearch.security.certificate-path=certificatePath",
+        "camunda.database.security.certificatePath=certificatePath",
+        "camunda.tasklist.opensearch.ssl.certificatePath=certificatePath",
+        "camunda.operate.opensearch.ssl.certificatePath=certificatePath",
+        // verify hostname
+        "camunda.data.secondary-storage.opensearch.security.verify-hostname=false",
+        "camunda.database.security.verifyHostname=false",
+        "camunda.tasklist.opensearch.ssl.verifyHostname=false",
+        "camunda.operate.opensearch.ssl.verifyHostname=false",
+        // self signed
+        "camunda.data.secondary-storage.opensearch.security.self-signed=true",
+        "camunda.database.security.selfSigned=true",
+        "camunda.tasklist.opensearch.ssl.selfSigned=true",
+        "camunda.operate.opensearch.ssl.selfSigned=true"
+      })
+  class WithNewAndLegacySet {
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+    final TasklistProperties tasklistProperties;
+    final OperateProperties operateProperties;
+
+    WithNewAndLegacySet(
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final OperateProperties operateProperties) {
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.tasklistProperties = tasklistProperties;
+      this.operateProperties = operateProperties;
+    }
+
+    @Test
+    void testCamundaSearchEngineConnectProperties() {
+      assertThat(searchEngineConnectProperties.getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaExporterProperties() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getConnect().getSecurity())
+          .returns(true, SecurityConfiguration::isEnabled)
+          .returns("certificatePath", SecurityConfiguration::getCertificatePath)
+          .returns(false, SecurityConfiguration::isVerifyHostname)
+          .returns(true, SecurityConfiguration::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaTasklistProperties() {
+      assertThat(tasklistProperties.getOpenSearch().getSsl())
+          .returns("certificatePath", SslProperties::getCertificatePath)
+          .returns(false, SslProperties::isVerifyHostname)
+          .returns(true, SslProperties::isSelfSigned);
+    }
+
+    @Test
+    void testCamundaOperateProperties() {
+      assertThat(operateProperties.getOpensearch().getSsl())
+          .returns("certificatePath", io.camunda.operate.property.SslProperties::getCertificatePath)
+          .returns(false, io.camunda.operate.property.SslProperties::isVerifyHostname)
+          .returns(true, io.camunda.operate.property.SslProperties::isSelfSigned);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.data.secondary-storage.elasticsearch and camunda.data.secondary-storage.opensearch in unified config.

The legacy properties are:

tbd

The new properties are:

tbd

Backwards compatibility is SUPPORTED_ONLY_IF_VALUES_MATCH.

## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34902 