### PR TITLE
Multi-partition Zeebe update tests

### DIFF
--- a/zeebe/qa/update-tests/pom.xml
+++ b/zeebe/qa/update-tests/pom.xml
@@ -140,6 +140,11 @@
       <artifactId>resilience4j-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.test.testcontainers.RemoteDebugger;
 import io.camunda.zeebe.util.VersionUtil;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.ZeebeGatewayContainer;
+import io.zeebe.containers.ZeebeTopologyWaitStrategy;
 import io.zeebe.containers.ZeebeVolume;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -37,6 +38,7 @@ import org.testcontainers.utility.DockerImageName;
 
 final class ContainerState implements AutoCloseable {
 
+  public static final int PARTITION_COUNT = 2;
   private static final RetryPolicy<Void> CONTAINER_START_RETRY_POLICY =
       new RetryPolicy<Void>().withMaxRetries(5).withBackoff(3, 30, ChronoUnit.SECONDS);
   private static final Pattern DOUBLE_NEWLINE = Pattern.compile("\n\n");
@@ -139,9 +141,12 @@ final class ContainerState implements AutoCloseable {
             .withEnv("ZEEBE_BROKER_DATA_LOGSEGMENTSIZE", "64MB")
             .withEnv("ZEEBE_BROKER_DATA_SNAPSHOTPERIOD", "1m")
             .withEnv("ZEEBE_BROKER_DATA_LOGINDEXDENSITY", "1")
+            .withEnv("ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT", String.valueOf(PARTITION_COUNT))
+            .withEnv("ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYLIMIT", "32MB")
             .withEnv(CREATE_SCHEMA_ENV_VAR, "false")
             .withEnv(UNPROTECTED_API_ENV_VAR, "true")
             .withEnv(AUTHORIZATION_CHECKS_ENV_VAR, "false")
+            .withTopologyCheck(new ZeebeTopologyWaitStrategy(1, 1, PARTITION_COUNT))
             .withZeebeData(volume)
             .withNetwork(network);
     this.withRemoteDebugging = withRemoteDebugging;

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/SnapshotTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/SnapshotTest.java
@@ -10,8 +10,14 @@ package io.camunda.zeebe.test;
 import static io.camunda.zeebe.test.ContainerStateAssert.assertThat;
 import static io.camunda.zeebe.test.UpdateTestCaseProvider.PROCESS_ID;
 
+import io.camunda.zeebe.protocol.Protocol;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -64,25 +70,54 @@ final class SnapshotTest {
   void takesSnapshotAfterUpdate(final ContainerState state) {
     // given - we take an initial snapshot on the old version
     state.withNetwork(network).withOldBroker().start(true);
-    state
-        .client()
-        .newPublishMessageCommand()
-        .messageName("test")
-        .correlationKey("key")
-        .send()
-        .join();
+    activateAllPartitions(state);
     state.getPartitionsActuator().takeSnapshot();
-    assertThat(state).eventuallyHasSnapshotAvailable(1);
-    final var oldSnapshotId = state.getPartitionsActuator().query().get(1).snapshotId();
+
+    for (int i = 1; i <= ContainerState.PARTITION_COUNT; i++) {
+      assertThat(state).eventuallyHasSnapshotAvailable(i);
+    }
+    final Map<Integer, String> oldSnapshotIds = getPartitionSnapshotIds(state);
 
     // when - we update to the new version without any new processing
     state.close();
     state.withNewBroker().start(true);
 
     // then - the new version takes a new snapshot to persist migrations and version marker
-    Awaitility.await()
+    for (int i = 1; i <= ContainerState.PARTITION_COUNT; i++) {
+      assertThat(state).eventuallyHasNewSnapshotAvailable(i, oldSnapshotIds.get(i));
+    }
+  }
+
+  private void activateAllPartitions(final ContainerState state) {
+    final var partitionIdsActivated = new HashSet<>();
+    final AtomicInteger correlationKey = new AtomicInteger(0);
+    Awaitility.await("Await all partitions to be activated")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .pollInterval(Duration.ofSeconds(1))
         .until(
-            () -> state.getPartitionsActuator().query().get(1).snapshotId(),
-            newSnapshotId -> !newSnapshotId.equals(oldSnapshotId));
+            () -> {
+              final var messageKey =
+                  state
+                      .client()
+                      .newPublishMessageCommand()
+                      .messageName("test")
+                      .correlationKey(String.valueOf(correlationKey.incrementAndGet()))
+                      .send()
+                      .join()
+                      .getMessageKey();
+              partitionIdsActivated.add(Protocol.decodePartitionId(messageKey));
+              return partitionIdsActivated;
+            },
+            (partitionsActivated) -> partitionsActivated.size() == ContainerState.PARTITION_COUNT);
+  }
+
+  private Map<Integer, String> getPartitionSnapshotIds(final ContainerState state) {
+    final var partitionStatuses = state.getPartitionsActuator().query();
+    return partitionStatuses.keySet().stream()
+        .collect(
+            HashMap::new,
+            (m, partitionId) -> m.put(partitionId, partitionStatuses.get(partitionId).snapshotId()),
+            HashMap::putAll);
   }
 }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/UpdateTestCase.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/UpdateTestCase.java
@@ -118,6 +118,11 @@ final class UpdateTestCase implements Arguments {
       return this;
     }
 
+    TestCaseBuilder afterUpgrade(final Consumer<ContainerState> func) {
+      after = (state, ignoredProcessKey, ignoredProcessInstanceKey) -> func.accept(state);
+      return this;
+    }
+
     UpdateTestCase done() {
       return new UpdateTestCase(this);
     }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/UpdateTestCaseProvider.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/UpdateTestCaseProvider.java
@@ -12,10 +12,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.api.response.ActivateJobsResponse;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.test.UpdateTestCase.TestCaseBuilder;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.time.Duration;
 import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;
@@ -225,6 +227,15 @@ public class UpdateTestCaseProvider implements ArgumentsProvider {
             .createInstance(Map.of("activateElements", List.of(TASK)))
             .beforeUpgrade(this::activateJob)
             .afterUpgrade(this::completeJob)
+            .done(),
+        scenario()
+            .name("resource distribution")
+            .beforeUpgrade(
+                state -> {
+                  publishMessage(state, -1L, -1L);
+                  return -1;
+                })
+            .afterUpgrade(this::awaitAllPartitionsToBeActivated)
             .done());
   }
 
@@ -454,5 +465,39 @@ public class UpdateTestCaseProvider implements ArgumentsProvider {
 
   private TestCaseBuilder scenario() {
     return UpdateTestCase.builder();
+  }
+
+  private void deployProcess(final ContainerState state) {
+    state
+        .client()
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done(), "process.bpmn")
+        .send()
+        .join();
+  }
+
+  private void awaitAllPartitionsToBeActivated(final ContainerState containerState) {
+    deployProcess(containerState);
+    final var partitionIdsActivated = new HashSet<>();
+    Awaitility.await("Await all partitions to be activated")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .pollInterval(Duration.ofSeconds(1))
+        .until(
+            () -> {
+              final var processInstanceKey =
+                  containerState
+                      .client()
+                      .newCreateInstanceCommand()
+                      .bpmnProcessId(PROCESS_ID)
+                      .latestVersion()
+                      .send()
+                      .join()
+                      .getProcessInstanceKey();
+              partitionIdsActivated.add(Protocol.decodePartitionId(processInstanceKey));
+              return partitionIdsActivated;
+            },
+            (partitionsActivated) -> partitionsActivated.size() == ContainerState.PARTITION_COUNT);
   }
 }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/UpdateTestCaseProvider.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/UpdateTestCaseProvider.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.test.UpdateTestCase.TestCaseBuilder;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.time.Duration;
-import java.util.List;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;
@@ -235,7 +235,7 @@ public class UpdateTestCaseProvider implements ArgumentsProvider {
                   publishMessage(state, -1L, -1L);
                   return -1;
                 })
-            .afterUpgrade(this::awaitAllPartitionsToBeActivated)
+            .afterUpgrade(this::awaitUntilInstancesCreatedOnAllPartitions)
             .done());
   }
 
@@ -477,7 +477,7 @@ public class UpdateTestCaseProvider implements ArgumentsProvider {
         .join();
   }
 
-  private void awaitAllPartitionsToBeActivated(final ContainerState containerState) {
+  private void awaitUntilInstancesCreatedOnAllPartitions(final ContainerState containerState) {
     deployProcess(containerState);
     final var partitionIdsActivated = new HashSet<>();
     Awaitility.await("Await all partitions to be activated")


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Enable multi-partition  Zeebe update tests
- Include scenario for resource distribution among partitions
- `SnapshotTest.takesSnapshotAfterUpdate` assert on all partitions that a snapshot was taken

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
