### PR TITLE
Disable importers in 8.8

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -21,7 +21,7 @@ public class OperateProperties {
 
   private static final String UNKNOWN_VERSION = "unknown-version";
 
-  private boolean importerEnabled = true;
+  private boolean importerEnabled = false;
   private boolean webappEnabled = true;
 
   private boolean rfc3339ApiDateFormat = false;

--- a/operate/webapp/README.md
+++ b/operate/webapp/README.md
@@ -33,7 +33,7 @@ In case of high load you may need to scale importing of data from Zeebe and arch
 In order to achieve this you can run any of the modules separately: Webapp, Importer and Archiver.
 
 For this you can use following configuration parameters:
-* `camunda.operate.importerEnabled`: when `true` will include the Importer in current run, default: true
+* `camunda.operate.importerEnabled`: when `true` will include the Importer in current run, default: false
 * `camunda.operate.webappEnabled`: when `true` will include the Webapp in current run, default: true
 * `camunda.operate.clusterNode.partitionIds`: array of Zeebe partition ids, this Importer node must be responsible for, default: empty array, meaning all partitions data is loaded
 * `camunda.operate.clusterNode.nodeCount`: total amount of Importer nodes in cluster

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistProperties.java
@@ -20,7 +20,7 @@ public class TasklistProperties {
   public static final String OPEN_SEARCH = "opensearch";
   private static final String UNKNOWN_VERSION = "unknown-version";
 
-  private boolean importerEnabled = true;
+  private boolean importerEnabled = false;
   private boolean webappEnabled = true;
 
   private boolean persistentSessionsEnabled = false;

--- a/tasklist/webapp/README.md
+++ b/tasklist/webapp/README.md
@@ -45,7 +45,7 @@ In case of high load you may need to scale importing of data from Zeebe and arch
 In order to achieve this you can run any of the modules separately: Webapp, Importer and Archiver.
 
 For this you can use following configuration parameters:
-* `camunda.tasklist.importerEnabled`: when `true` will include the Importer in current run, default: true
+* `camunda.tasklist.importerEnabled`: when `true` will include the Importer in current run, default: false
 * `camunda.tasklist.webappEnabled`: when `true` will include the Webapp in current run, default: true
 * `camunda.tasklist.archiverEnabled`: when `true` will include the Archiver in current run, default: true
 * `camunda.tasklist.clusterNode.partitionIds`: array of Zeebe partition ids, this Importer (or Archiver) node must be responsible for, default: empty array, meaning all partitions data is loaded


### PR DESCRIPTION
## Description

Set the default as disabled for Tasklist/Operate importers.

## Checklist

## Related issues

closes #https://github.com/camunda/camunda/issues/37080
