### PR TITLE
Add Quality Board Shared Action

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -99,10 +99,17 @@ jobs:
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           # any of the following labels:
           labeled: component/clients, component/spring-sdk, component/camunda-process-test, component/c8-api
-      - id: add-to-qualityboard
-        name: Add to Quality Board project
-        uses: actions/add-to-project@v1.0.2
+      - id: add-bug-to-quality-board
+        name: Add issue to Quality Board
+        uses: camunda/infra-global-github-actions/add-bug-to-quality-board@main
         with:
-          project-url: https://github.com/orgs/camunda/projects/187
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
-          labeled: kind/bug
+          project-number: "187"
+        if: >
+          contains(github.event.issue.labels.*.name, 'kind/bug') &&
+          (
+              github.event.action == 'opened' ||
+              github.event.action == 'reopened' ||
+              github.event.action == 'transferred' ||
+              (github.event.action == 'labeled' && github.event.label.name == 'kind/bug')
+          )


### PR DESCRIPTION
Change in the add-to-project workflow. To handle the assignment to the quality board project via shared action. 
Furthermore, the action will extract component and severity label to use this as a custom field in the project.
