### PR TITLE
feat: unassignClientFromTenant

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -67,6 +67,7 @@ import io.camunda.client.api.command.SetVariablesCommandStep1;
 import io.camunda.client.api.command.SuspendBatchOperationStep1;
 import io.camunda.client.api.command.TopologyRequestStep1;
 import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1;
+import io.camunda.client.api.command.UnassignClientFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignGroupFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignMappingRuleFromGroupStep1;
 import io.camunda.client.api.command.UnassignRoleFromClientCommandStep1;
@@ -2236,6 +2237,24 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder to configure and send the assign client to tenant command
    */
   AssignClientToTenantCommandStep1 newAssignClientToTenantCommand();
+
+  /**
+   * Command to unassign a client from a tenant.
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newUnassignClientFromTenantCommand()
+   *  .clientId("clientId")
+   *  .tenantId("tenantId")
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   *
+   * @return a builder to configure and send the unassign client from tenant command
+   */
+  UnassignClientFromTenantCommandStep1 newUnassignClientFromTenantCommand();
 
   /**
    * Command to create an authorization

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignClientFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignClientFromTenantCommandStep1.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.UnassignClientFromTenantResponse;
+
+public interface UnassignClientFromTenantCommandStep1 {
+
+  /**
+   * Sets the ID of the client to be unassigned from a tenant.
+   *
+   * @param clientId the ID of the client
+   * @return the builder for this command.
+   */
+  UnassignClientFromTenantCommandStep2 clientId(String clientId);
+
+  interface UnassignClientFromTenantCommandStep2
+      extends FinalCommandStep<UnassignClientFromTenantResponse> {
+
+    /**
+     * Sets the tenant ID.
+     *
+     * @param tenantId the ID of the tenant
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    UnassignClientFromTenantCommandStep2 tenantId(String tenantId);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignClientFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignClientFromTenantCommandStep1.java
@@ -27,8 +27,7 @@ public interface UnassignClientFromTenantCommandStep1 {
    */
   UnassignClientFromTenantCommandStep2 clientId(String clientId);
 
-  interface UnassignClientFromTenantCommandStep2
-      extends FinalCommandStep<UnassignClientFromTenantResponse> {
+  interface UnassignClientFromTenantCommandStep2 {
 
     /**
      * Sets the tenant ID.
@@ -37,6 +36,9 @@ public interface UnassignClientFromTenantCommandStep1 {
      * @return the builder for this command. Call {@link #send()} to complete the command and send
      *     it to the broker.
      */
-    UnassignClientFromTenantCommandStep2 tenantId(String tenantId);
+    UnassignClientFromTenantCommandStep3 tenantId(String tenantId);
   }
+
+  interface UnassignClientFromTenantCommandStep3
+      extends FinalCommandStep<UnassignClientFromTenantResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/UnassignClientFromTenantResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UnassignClientFromTenantResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface UnassignClientFromTenantResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -78,6 +78,7 @@ import io.camunda.client.api.command.SuspendBatchOperationStep1;
 import io.camunda.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.client.api.command.TopologyRequestStep1;
 import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1;
+import io.camunda.client.api.command.UnassignClientFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignGroupFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignMappingRuleFromGroupStep1;
 import io.camunda.client.api.command.UnassignRoleFromClientCommandStep1;
@@ -213,6 +214,7 @@ import io.camunda.client.impl.command.StreamJobsCommandImpl;
 import io.camunda.client.impl.command.SuspendBatchOperationCommandImpl;
 import io.camunda.client.impl.command.TopologyRequestImpl;
 import io.camunda.client.impl.command.UnassignClientFromGroupCommandImpl;
+import io.camunda.client.impl.command.UnassignClientFromTenantCommandImpl;
 import io.camunda.client.impl.command.UnassignGroupFromTenantCommandImpl;
 import io.camunda.client.impl.command.UnassignMappingRuleFromGroupCommandImpl;
 import io.camunda.client.impl.command.UnassignRoleFromClientCommandImpl;
@@ -1185,6 +1187,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public AssignClientToTenantCommandStep1 newAssignClientToTenantCommand() {
     return new AssignClientToTenantCommandImpl(httpClient);
+  }
+
+  @Override
+  public UnassignClientFromTenantCommandStep1 newUnassignClientFromTenantCommand() {
+    return new UnassignClientFromTenantCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignClientFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignClientFromTenantCommandImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.UnassignClientFromTenantCommandStep1;
+import io.camunda.client.api.command.UnassignClientFromTenantCommandStep1.UnassignClientFromTenantCommandStep2;
+import io.camunda.client.api.response.UnassignClientFromTenantResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignClientFromTenantResponseImpl;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class UnassignClientFromTenantCommandImpl
+    implements UnassignClientFromTenantCommandStep1, UnassignClientFromTenantCommandStep2 {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private String clientId;
+  private String tenantId;
+
+  public UnassignClientFromTenantCommandImpl(final HttpClient httpClient) {
+    this.httpClient = httpClient;
+    this.httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public UnassignClientFromTenantCommandStep2 clientId(final String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
+
+  @Override
+  public UnassignClientFromTenantCommandStep2 tenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<UnassignClientFromTenantResponse> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<UnassignClientFromTenantResponse> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("clientId", clientId);
+    ArgumentUtil.ensureNotNullNorEmpty("tenantId", tenantId);
+    final HttpCamundaFuture<UnassignClientFromTenantResponse> result = new HttpCamundaFuture<>();
+    httpClient.delete(
+        "/tenants/" + tenantId + "/clients/" + clientId,
+        null, // No request body needed
+        httpRequestConfig.build(),
+        UnassignClientFromTenantResponseImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignClientFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignClientFromTenantCommandImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignClientFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignClientFromTenantCommandStep1.UnassignClientFromTenantCommandStep2;
+import io.camunda.client.api.command.UnassignClientFromTenantCommandStep1.UnassignClientFromTenantCommandStep3;
 import io.camunda.client.api.response.UnassignClientFromTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class UnassignClientFromTenantCommandImpl
-    implements UnassignClientFromTenantCommandStep1, UnassignClientFromTenantCommandStep2 {
+    implements UnassignClientFromTenantCommandStep1,
+        UnassignClientFromTenantCommandStep2,
+        UnassignClientFromTenantCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class UnassignClientFromTenantCommandImpl
   }
 
   @Override
-  public UnassignClientFromTenantCommandStep2 tenantId(final String tenantId) {
+  public UnassignClientFromTenantCommandStep3 tenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignClientFromTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignClientFromTenantResponseImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.UnassignClientFromTenantResponse;
+
+public class UnassignClientFromTenantResponseImpl implements UnassignClientFromTenantResponse {
+
+  public UnassignClientFromTenantResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/test/java/io/camunda/client/tenant/UnassignClientFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/UnassignClientFromTenantTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.tenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class UnassignClientFromTenantTest extends ClientRestTest {
+
+  public static final String CLIENT_ID = "clientId";
+  public static final String TENANT_ID = "tenantId";
+
+  @Test
+  void shouldUnassignClientFromTenant() {
+    // when
+    client
+        .newUnassignClientFromTenantCommand()
+        .clientId(CLIENT_ID)
+        .tenantId(TENANT_ID)
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl().contains(TENANT_ID + "/clients/" + CLIENT_ID)).isTrue();
+    assertThat(RestGatewayService.getLastRequest().getMethod()).isEqualTo(RequestMethod.DELETE);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullClientIdWhenUnassigningClientFromTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignClientFromTenantCommand()
+                    .clientId(null)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("clientId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyClientIdWhenUnassigningClientFromTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignClientFromTenantCommand()
+                    .clientId("")
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("clientId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullTenantIdWhenUnassigningClientFromTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignClientFromTenantCommand()
+                    .clientId(CLIENT_ID)
+                    .tenantId(null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyTenantIdWhenUnassigningClientFromTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignClientFromTenantCommand()
+                    .clientId(CLIENT_ID)
+                    .tenantId("")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be empty");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/tenant/UnassignClientFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/UnassignClientFromTenantTest.java
@@ -15,11 +15,11 @@
  */
 package io.camunda.client.tenant;
 
+import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import org.junit.jupiter.api.Test;
@@ -40,9 +40,11 @@ public class UnassignClientFromTenantTest extends ClientRestTest {
         .join();
 
     // then
-    final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl().contains(TENANT_ID + "/clients/" + CLIENT_ID)).isTrue();
-    assertThat(RestGatewayService.getLastRequest().getMethod()).isEqualTo(RequestMethod.DELETE);
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    final RequestMethod method = RestGatewayService.getLastRequest().getMethod();
+    assertThat(requestPath)
+        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/clients/" + CLIENT_ID);
+    assertThat(method).isEqualTo(RequestMethod.DELETE);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UnassignClientFromTenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UnassignClientFromTenantIntegrationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.Client;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import java.net.http.HttpClient;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+public class UnassignClientFromTenantIntegrationTest {
+
+  private static CamundaClient camundaClient;
+  private static final String TENANT_ID = Strings.newRandomValidIdentityId();
+
+  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+  @BeforeAll
+  static void setup() {
+    camundaClient.newCreateTenantCommand().tenantId(TENANT_ID).name("tenantName").send().join();
+  }
+
+  @Test
+  void shouldUnassignClientFromTenant() {
+    // given
+    final var clientId = Strings.newRandomValidIdentityId();
+
+    // first assign the client to the tenant
+    camundaClient
+        .newAssignClientToTenantCommand()
+        .clientId(clientId)
+        .tenantId(TENANT_ID)
+        .send()
+        .join();
+
+    // verify client is assigned
+    Awaitility.await("Client is assigned to the tenant")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final SearchResponse<Client> result =
+                  camundaClient.newClientsByTenantSearchRequest(TENANT_ID).send().join();
+              assertThat(result.items()).map(Client::getClientId).contains(clientId);
+            });
+
+    // when - unassign the client from the tenant
+    camundaClient
+        .newUnassignClientFromTenantCommand()
+        .clientId(clientId)
+        .tenantId(TENANT_ID)
+        .send()
+        .join();
+
+    // then - verify client is no longer assigned
+    Awaitility.await("Client is unassigned from the tenant")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final SearchResponse<Client> result =
+                  camundaClient.newClientsByTenantSearchRequest(TENANT_ID).send().join();
+              assertThat(result.items()).map(Client::getClientId).doesNotContain(clientId);
+            });
+  }
+
+  @Test
+  void shouldReturnNotFoundOnUnassigningClientFromTenantIfTenantDoesNotExist() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newUnassignClientFromTenantCommand()
+                    .clientId(Strings.newRandomValidIdentityId())
+                    .tenantId(Strings.newRandomValidIdentityId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining("no tenant with this ID exists.");
+  }
+
+  @Test
+  void shouldReturnNotFoundOnUnassigningClientFromTenantIfClientIsNotAssigned() {
+    // given
+    final var clientId = Strings.newRandomValidIdentityId();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newUnassignClientFromTenantCommand()
+                    .clientId(clientId)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+}


### PR DESCRIPTION
## Description

Adds the missing unassignClientFromTenant command to the Camunda Java Client that exposes the `DELETE /v2/tenants/:tenantId/clients/:clientId` API endpoint.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35768
