### PR TITLE
test: 8.8 - v2 API testing for documents endpoints

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/helloworld.txt
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/helloworld.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
@@ -18,7 +18,7 @@ import {
   assertBadRequest,
   assertNotFoundRequest,
   assertForbiddenRequest,
-} from '../../../../utils/http';
+} from '../../../utils/http';
 import {
   CREATE_DOC_INVALID_REQUEST,
   CREATE_DOCUMENT_LINK_REQUEST,
@@ -29,11 +29,11 @@ import {
   CREATE_TXT_DOCUMENT_REQUEST,
   documentRequiredFields,
   multipleDocumentsRequiredFields,
-} from '../../../../utils/beans/requestBeans';
+} from '../../../utils/beans/requestBeans';
 import {
   defaultAssertionOptions,
   generateUniqueId,
-} from '../../../../utils/constants';
+} from '../../../utils/constants';
 import {Serializable} from 'playwright-core/types/structs';
 
 test.describe.parallel('Document API Tests', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
@@ -170,9 +170,9 @@ test.describe.parallel('Document API Tests', () => {
         buildUrl(
           '/documents/{documentId}',
           {
-            documentId: state.documentId1 as number,
+            documentId: state.documentId1 as string,
           },
-          {contentHash: state.contentHash1 as number},
+          {contentHash: state.contentHash1 as string},
         ),
         {headers: defaultHeaders()},
       );
@@ -186,7 +186,7 @@ test.describe.parallel('Document API Tests', () => {
     await expect(async () => {
       const res = await request.get(
         buildUrl('/documents/{documentId}', {
-          documentId: state.documentId1 as number,
+          documentId: state.documentId1 as string,
         }),
         {headers: defaultHeaders()},
       );
@@ -346,9 +346,9 @@ test.describe.parallel('Document API Tests', () => {
         buildUrl(
           '/documents/{documentId}/links',
           {
-            documentId: state.documentId1 as number,
+            documentId: state.documentId1 as string,
           },
-          {contentHash: state.contentHash1 as number},
+          {contentHash: state.contentHash1 as string},
         ),
         {
           headers: jsonHeaders(),
@@ -366,7 +366,7 @@ test.describe.parallel('Document API Tests', () => {
     await expect(async () => {
       const res = await request.post(
         buildUrl('/documents/{documentId}/links', {
-          documentId: state.documentId1 as number,
+          documentId: state.documentId1 as string,
         }),
         {
           headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document/document-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document/document-api-tests.spec.ts
@@ -1,0 +1,371 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertRequiredFields,
+  defaultHeaders,
+  assertEqualsForKeys,
+  assertUnauthorizedRequest,
+  assertUnsupportedMediaTypeRequest,
+  assertBadRequest,
+  assertNotFoundRequest,
+  assertForbiddenRequest,
+} from '../../../../utils/http';
+import {
+  CREATE_DOC_INVALID_REQUEST,
+  CREATE_DOCUMENT_LINK_REQUEST,
+  CREATE_ON_FLY_DOCUMENT_REQUEST_BODY_WITH_METADATA,
+  CREATE_ON_FLY_MULTIPLE_DOCUMENTS_REQUEST_BODY,
+  CREATE_TXT_DOC_RESPONSE_BODY,
+  CREATE_TXT_DOC_RESPONSE_WITH_METADATA,
+  CREATE_TXT_DOCUMENT_REQUEST,
+  documentRequiredFields,
+  multipleDocumentsRequiredFields,
+} from '../../../../utils/beans/requestBeans';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+import {Serializable} from 'playwright-core/types/structs';
+
+test.describe.parallel('Document API Tests', () => {
+  const state: Record<string, unknown> = {};
+  const nonexistentId = 'nonExistingDocumentId';
+  const resposeKeys: string[] = [
+    'camunda.document.type',
+    'storeId',
+    'metadata',
+  ];
+
+  test.beforeAll(async ({request}) => {
+    async function createDocumentAndStoreIds(nth: number) {
+      const name = generateUniqueId();
+      const payload = CREATE_ON_FLY_DOCUMENT_REQUEST_BODY_WITH_METADATA(name);
+      const res = await request.post(buildUrl('/documents'), {
+        headers: defaultHeaders(),
+        multipart: payload,
+      });
+
+      expect(res.status()).toBe(201);
+      const json = await res.json();
+      assertRequiredFields(json, documentRequiredFields);
+      state[`documentId${nth}`] = json.documentId;
+      state[`contentHash${nth}`] = json.contentHash;
+      state[`storeId${nth}`] = json.storeId;
+      state[`name${nth}`] = name;
+    }
+
+    await createDocumentAndStoreIds(1);
+    await createDocumentAndStoreIds(2);
+  });
+
+  test('Create Document Unauthorized 401', async ({request}) => {
+    const res = await request.post(buildUrl('/documents'), {
+      headers: {},
+      data: CREATE_TXT_DOCUMENT_REQUEST(),
+    });
+
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Create Document Invalid Header 415', async ({request}) => {
+    const res = await request.post(buildUrl('/documents'), {
+      headers: jsonHeaders(),
+      multipart: CREATE_TXT_DOCUMENT_REQUEST(),
+    });
+
+    await assertUnsupportedMediaTypeRequest(res);
+  });
+
+  test('Create Document Invalid Body 400', async ({request}) => {
+    const res = await request.post(buildUrl('/documents'), {
+      headers: defaultHeaders(),
+      multipart: CREATE_DOC_INVALID_REQUEST(),
+    });
+
+    await assertBadRequest(res, "Required part 'file' is not present.");
+  });
+
+  test('Create Document', async ({request}) => {
+    const payload = CREATE_TXT_DOCUMENT_REQUEST();
+    const expectedPostBody = CREATE_TXT_DOC_RESPONSE_BODY('helloworld', 12);
+
+    const res = await request.post(buildUrl('/documents'), {
+      headers: defaultHeaders(),
+      multipart: payload,
+    });
+
+    expect(res.status()).toBe(201);
+    const json = await res.json();
+    assertRequiredFields(json, documentRequiredFields);
+    assertEqualsForKeys(json, expectedPostBody, resposeKeys);
+  });
+
+  test('Create Document With Metadata', async ({request}) => {
+    const name = generateUniqueId();
+    const payload = CREATE_ON_FLY_DOCUMENT_REQUEST_BODY_WITH_METADATA(name);
+    const expectedPostBody = CREATE_TXT_DOC_RESPONSE_WITH_METADATA(name, 21);
+
+    const res = await request.post(buildUrl('/documents'), {
+      headers: defaultHeaders(),
+      multipart: payload,
+    });
+
+    expect(res.status()).toBe(201);
+    const json = await res.json();
+    assertRequiredFields(json, documentRequiredFields);
+    assertEqualsForKeys(json, expectedPostBody, resposeKeys);
+  });
+
+  test('Get Document', async ({request}) => {
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl(
+          '/documents/{documentId}',
+          {
+            documentId: state.documentId1 as number,
+          },
+          {contentHash: state.contentHash1 as number},
+        ),
+        {headers: defaultHeaders()},
+      );
+      expect(res.status()).toBe(200);
+      const text = await res.text();
+      expect(text).toBe(`Hello World ${state['name1']}!`);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Document Without Hash 400', async ({request}) => {
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl('/documents/{documentId}', {
+          documentId: state.documentId1 as number,
+        }),
+        {headers: defaultHeaders()},
+      );
+      await assertBadRequest(
+        res,
+        'No document hash provided for document',
+        'INVALID_ARGUMENT',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Document Not Found 404', async ({request}) => {
+    const res = await request.get(
+      buildUrl('/documents/{documentId}', {documentId: nonexistentId}),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Document with id '${nonexistentId}' not found`,
+    );
+  });
+
+  test('Get Document Unauthorized 401', async ({request}) => {
+    const res = await request.get(
+      buildUrl('/documents/{documentId}', {
+        documentId: state.documentId1 as string,
+      }),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Delete Document Unauthorized 401', async ({request}) => {
+    const res = await request.delete(
+      buildUrl('/documents/{documentId}', {
+        documentId: state.documentId2 as string,
+      }),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Delete Document Not Found 404', async ({request}) => {
+    const res = await request.delete(
+      buildUrl('/documents/{documentId}', {
+        documentId: nonexistentId,
+      }),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Document with id '${nonexistentId}' not found`,
+    );
+  });
+
+  test('Delete Document', async ({request}) => {
+    await test.step('Delete Document 204', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/documents/{documentId}', {
+            documentId: state.documentId2 as string,
+          }),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Get Deleted Document 404', async () => {
+      await expect(async () => {
+        const res = await request.get(
+          buildUrl('/documents/{documentId}', {
+            documentId: state.documentId2 as string,
+          }),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(404);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Create Multiple Documents', async ({request}) => {
+    const name = generateUniqueId();
+    const payload = CREATE_ON_FLY_MULTIPLE_DOCUMENTS_REQUEST_BODY(name, 2);
+    const expectedFile1 = CREATE_TXT_DOC_RESPONSE_BODY(`${name}1`, 22);
+    const expectedFile2 = CREATE_TXT_DOC_RESPONSE_BODY(`${name}2`, 22);
+    let json: Serializable = {};
+
+    await test.step('Create Multiple Documents 201', async () => {
+      const res = await request.post(buildUrl('/documents/batch'), {
+        headers: defaultHeaders(),
+        multipart: payload,
+      });
+
+      expect(res.status()).toBe(201);
+      json = await res.json();
+      assertRequiredFields(json, multipleDocumentsRequiredFields);
+      expect(json['createdDocuments']).toHaveLength(2);
+      expect(json['failedDocuments']).toHaveLength(0);
+    });
+
+    await test.step('Assert First File Fields', async () => {
+      const actualFile1 = json.createdDocuments.find(
+        (it: {metadata: {fileName: string}}) =>
+          it.metadata.fileName === expectedFile1.metadata.fileName,
+      );
+      expect(actualFile1).toBeDefined();
+      assertEqualsForKeys(actualFile1, expectedFile1, resposeKeys);
+    });
+
+    await test.step('Assert Second File Fields', async () => {
+      const actualFile2 = json.createdDocuments.find(
+        (it: {metadata: {fileName: string}}) =>
+          it.metadata.fileName === expectedFile2.metadata.fileName,
+      );
+      expect(actualFile2).toBeDefined();
+      assertEqualsForKeys(actualFile2, expectedFile2, resposeKeys);
+    });
+  });
+
+  test('Create Multiple Documents Unauthorized 401', async ({request}) => {
+    const name = generateUniqueId();
+    const payload = CREATE_ON_FLY_MULTIPLE_DOCUMENTS_REQUEST_BODY(name, 2);
+
+    const res = await request.post(buildUrl('/documents/batch'), {
+      headers: {},
+      data: payload,
+    });
+
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Create Multiple Documents Invalid Header 415', async ({request}) => {
+    const name = generateUniqueId();
+    const payload = CREATE_ON_FLY_MULTIPLE_DOCUMENTS_REQUEST_BODY(name, 2);
+
+    const res = await request.post(buildUrl('/documents/batch'), {
+      headers: jsonHeaders(),
+      multipart: payload,
+    });
+
+    await assertUnsupportedMediaTypeRequest(res);
+  });
+
+  test('Create Multiple Documents Invalid Body 400', async ({request}) => {
+    const res = await request.post(buildUrl('/documents/batch'), {
+      headers: defaultHeaders(),
+      multipart: CREATE_DOC_INVALID_REQUEST(),
+    });
+
+    await assertBadRequest(res, "Required part 'files' is not present.");
+  });
+
+  test('Create Document Link 403 For In-Memory Storage', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          '/documents/{documentId}/links',
+          {
+            documentId: state.documentId1 as number,
+          },
+          {contentHash: state.contentHash1 as number},
+        ),
+        {
+          headers: jsonHeaders(),
+          data: CREATE_DOCUMENT_LINK_REQUEST,
+        },
+      );
+      await assertForbiddenRequest(
+        res,
+        'The in-memory document store does not support creating links',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Document Link Without Hash 400', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/documents/{documentId}/links', {
+          documentId: state.documentId1 as number,
+        }),
+        {
+          headers: jsonHeaders(),
+          data: CREATE_DOCUMENT_LINK_REQUEST,
+        },
+      );
+      await assertBadRequest(
+        res,
+        'No document hash provided for document',
+        'INVALID_ARGUMENT',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Document Link Not Found 404', async ({request}) => {
+    const res = await request.post(
+      buildUrl('/documents/{documentId}/links', {documentId: nonexistentId}),
+      {
+        headers: jsonHeaders(),
+        data: CREATE_DOCUMENT_LINK_REQUEST,
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Document with id '${nonexistentId}' not found`,
+    );
+  });
+
+  test('Create Document Link Unauthorized 401', async ({request}) => {
+    const res = await request.post(
+      buildUrl('/documents/{documentId}/links', {
+        documentId: state.documentId1 as string,
+      }),
+      {
+        headers: {},
+        data: CREATE_DOCUMENT_LINK_REQUEST,
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
@@ -18,7 +18,7 @@ import {
 import {
   CREATE_NEW_GROUP,
   groupRequiredFields,
-} from '../../../../utils/beans/request-beans';
+} from '../../../../utils/beans/requestBeans';
 import {sleep} from '../../../../utils/sleep';
 
 test.describe('Groups API Tests', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
@@ -17,7 +17,7 @@ import {
 import {
   CREATE_NEW_GROUP,
   groupRequiredFields,
-} from '../../../../utils/beans/request-beans';
+} from '../../../../utils/beans/requestBeans';
 import {sleep} from '../../../../utils/sleep';
 
 test.describe('Groups Clients API Tests', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
@@ -19,9 +19,9 @@ import {
   CREATE_NEW_GROUP,
   groupRequiredFields,
   mappingRuleRequiredFields,
-} from '../../../../utils/beans/request-beans';
+} from '../../../../utils/beans/requestBeans';
 import {sleep} from '../../../../utils/sleep';
-import {CREATE_NEW_MAPPING_RULE} from '../../../../utils/beans/request-beans';
+import {CREATE_NEW_MAPPING_RULE} from '../../../../utils/beans/requestBeans';
 
 test.describe('Group Mapping Rules API Tests', () => {
   const state: Record<string, unknown> = {};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
@@ -20,7 +20,7 @@ import {
   CREATE_NEW_ROLE,
   groupRequiredFields,
   roleRequiredFields,
-} from '../../../../utils/beans/request-beans';
+} from '../../../../utils/beans/requestBeans';
 import {sleep} from '../../../../utils/sleep';
 
 test.describe('Group Roles API Tests', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
@@ -18,7 +18,7 @@ import {
 import {
   CREATE_NEW_GROUP,
   groupRequiredFields,
-} from '../../../../utils/beans/request-beans';
+} from '../../../../utils/beans/requestBeans';
 import {sleep} from '../../../../utils/sleep';
 
 test.describe('Group Users API Tests', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/license-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/license-api-tests.spec.ts
@@ -8,9 +8,9 @@
 
 import {test, expect} from '@playwright/test';
 import {buildUrl, jsonHeaders, assertRequiredFields} from '../../../utils/http';
-import {licenseRequiredFields} from '../../../utils/beans/request-beans';
+import {licenseRequiredFields} from '../../../utils/beans/requestBeans';
 
-test.describe('License API Tests', () => {
+test.describe.parallel('License API Tests', () => {
   test('Get License', async ({request}) => {
     await test.step('Get License', async () => {
       const res = await request.get(buildUrl('/license'), {
@@ -23,16 +23,16 @@ test.describe('License API Tests', () => {
       expect(json.licenseType).toBe('unknown');
       expect(json.isCommercial).toBeFalsy();
     });
+  });
 
-    await test.step('Get License Unauthorized', async () => {
-      const res = await request.get(buildUrl('/license'), {headers: {}});
+  test('Get License Unauthorized', async ({request}) => {
+    const res = await request.get(buildUrl('/license'), {headers: {}});
 
-      expect(res.status()).toBe(200);
-      const json = await res.json();
-      assertRequiredFields(json, licenseRequiredFields);
-      expect(json.validLicense).toBeFalsy();
-      expect(json.licenseType).toBe('unknown');
-      expect(json.isCommercial).toBeFalsy();
-    });
+    expect(res.status()).toBe(200);
+    const json = await res.json();
+    assertRequiredFields(json, licenseRequiredFields);
+    expect(json.validLicense).toBeFalsy();
+    expect(json.licenseType).toBe('unknown');
+    expect(json.isCommercial).toBeFalsy();
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-api-tests.spec.ts
@@ -17,8 +17,9 @@ import {
 import {
   CORRELATE_MESSAGE,
   correlateMessageRequiredFields,
-} from '../../../../utils/beans/request-beans';
+} from '../../../../utils/beans/requestBeans';
 import {createInstances, deploy} from '../../../../utils/zeebeClient';
+import {defaultAssertionOptions} from '../../../../utils/constants';
 
 test.describe('Correlate Message API Tests', () => {
   const state: Record<string, unknown> = {};
@@ -44,10 +45,7 @@ test.describe('Correlate Message API Tests', () => {
       );
       expect(matchingItem).toBeDefined();
       state['processInstanceKey'] = matchingItem['processInstanceKey'];
-    }).toPass({
-      intervals: [5_000, 10_000, 15_000],
-      timeout: 30_000,
-    });
+    }).toPass(defaultAssertionOptions);
   });
 
   test('Correlate Message Unauthorized', async ({request}) => {
@@ -139,10 +137,7 @@ test.describe('Correlate Message API Tests', () => {
         const json = await res.json();
         assertRequiredFields(json, paginatedResponseFields);
         expect(json.page.totalItems).toBe(0);
-      }).toPass({
-        intervals: [5_000, 10_000, 15_000],
-        timeout: 30_000,
-      });
+      }).toPass(defaultAssertionOptions);
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/publish-message-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/publish-message-api-tests.spec.ts
@@ -13,9 +13,9 @@ import {
   assertRequiredFields,
   assertEqualsForKeys,
 } from '../../../../utils/http';
-import {PUBLISH_NEW_MESSAGE} from '../../../../utils/beans/request-beans';
+import {PUBLISH_NEW_MESSAGE} from '../../../../utils/beans/requestBeans';
 
-test.describe('Publish Message API Tests', () => {
+test.describe.parallel('Publish Message API Tests', () => {
   test('Publish Message', async ({request}) => {
     const requestBody = PUBLISH_NEW_MESSAGE();
     const res = await request.post(buildUrl('/messages/publication'), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-message-subscription-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-message-subscription-api-tests.spec.ts
@@ -18,7 +18,7 @@ import {
   expectedMessageSubscription1,
   expectedMessageSubscription2,
   messageSubscriptionRequiredFields,
-} from '../../../../utils/beans/request-beans';
+} from '../../../../utils/beans/requestBeans';
 import {createInstances, deploy} from '../../../../utils/zeebeClient';
 
 test.beforeAll(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -7,6 +7,7 @@
  */
 
 import {generateUniqueId} from '../constants';
+import * as fs from 'node:fs';
 
 export const groupRequiredFields: string[] = ['groupId', 'name', 'description'];
 export const mappingRuleRequiredFields: string[] = [
@@ -33,6 +34,17 @@ export const messageSubscriptionRequiredFields = [
   'messageName',
   'correlationKey',
   'tenantId',
+];
+export const documentRequiredFields = [
+  'camunda.document.type',
+  'storeId',
+  'documentId',
+  'contentHash',
+  'metadata',
+];
+export const multipleDocumentsRequiredFields = [
+  'createdDocuments',
+  'failedDocuments',
 ];
 export const correlateMessageRequiredFields: string[] = [
   'tenantId',
@@ -102,4 +114,103 @@ export const CORRELATE_MESSAGE = {
   name: expectedMessageSubscription3.messageName,
   correlationKey: expectedMessageSubscription3.correlationKey,
   variables: {foo: 'bar'},
+};
+
+export function CREATE_TXT_DOCUMENT_REQUEST() {
+  const form = new FormData();
+  form.append(
+    'file',
+    new Blob([fs.readFileSync('./resources/helloworld.txt')], {
+      type: 'text/plain',
+    }),
+    'helloworld.txt',
+  );
+  return form;
+}
+
+export function CREATE_DOC_INVALID_REQUEST() {
+  const form = new FormData();
+  form.append('metadata', '{}');
+  return form;
+}
+
+export function CREATE_TXT_DOC_RESPONSE_BODY(name: string, size: number) {
+  return {
+    'camunda.document.type': 'camunda',
+    storeId: 'in-memory',
+    metadata: {
+      contentType: 'text/plain',
+      fileName: `${name}.txt`,
+      size: size,
+      customProperties: {},
+    },
+  };
+}
+
+export function CREATE_TXT_DOC_RESPONSE_WITH_METADATA(
+  name: string,
+  size: number,
+) {
+  return {
+    'camunda.document.type': 'camunda',
+    storeId: 'in-memory',
+    metadata: {
+      contentType: 'text/plain',
+      fileName: `${name}.txt`,
+      size: size,
+      processDefinitionId: name,
+      processInstanceKey: '123456',
+      customProperties: {foo: 'bar'},
+    },
+  };
+}
+
+export function CREATE_ON_FLY_DOCUMENT_REQUEST_BODY_WITH_METADATA(
+  name: string,
+) {
+  const form = new FormData();
+  form.append(
+    'file',
+    new File([`Hello World ${name}!`], `${name}.txt`, {
+      type: 'text/ plain',
+    }),
+  );
+  form.append(
+    'metadata',
+    new Blob(
+      [
+        JSON.stringify({
+          contentType: 'text/plain',
+          fileName: `${name}.txt`,
+          processDefinitionId: name,
+          processInstanceKey: '123456',
+          customProperties: {foo: 'bar'},
+        }),
+      ],
+      {
+        type: 'application/json',
+      },
+    ),
+  );
+  return form;
+}
+
+export function CREATE_ON_FLY_MULTIPLE_DOCUMENTS_REQUEST_BODY(
+  name: string,
+  numberOfDocs: number = 1,
+) {
+  const form = new FormData();
+  for (let i = 1; i <= numberOfDocs; i++) {
+    form.append(
+      'files',
+      new File([`Hello World ${name + i}!`], `${name}${i}.txt`, {
+        type: 'text/plain',
+      }),
+    );
+  }
+  return form;
+}
+
+export const CREATE_DOCUMENT_LINK_REQUEST = {
+  timeToLive: 60000,
 };

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -24,6 +24,11 @@ export const createUniqueUser = (customId?: string) => {
   };
 };
 
+export const defaultAssertionOptions = {
+  intervals: [5_000, 10_000, 15_000],
+  timeout: 30_000,
+};
+
 // Create unique auth role with optional custom ID
 export const createUniqueAuthRole = (customId?: string) => {
   const id = customId || generateUniqueId();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -41,6 +41,54 @@ export function assertRequiredFields(obj: unknown, required: string[]): void {
   }
 }
 
+export async function assertUnauthorizedRequest(response: APIResponse) {
+  expect(response.status()).toBe(401);
+  const json = await response.json();
+  assertRequiredFields(json, ['detail', 'title']);
+  expect(json.title).toBe('Unauthorized');
+}
+
+export async function assertUnsupportedMediaTypeRequest(response: APIResponse) {
+  expect(response.status()).toBe(415);
+  const json = await response.json();
+  assertRequiredFields(json, ['error']);
+  expect(json.error).toContain('Unsupported Media Type');
+}
+
+export async function assertBadRequest(
+  response: APIResponse,
+  detail: string,
+  title = 'Bad Request',
+) {
+  expect(response.status()).toBe(400);
+  const json = await response.json();
+  assertRequiredFields(json, ['detail', 'title']);
+  expect(json.title).toBe(title);
+  expect(json.detail).toContain(detail);
+}
+
+export async function assertForbiddenRequest(
+  response: APIResponse,
+  detail: string,
+) {
+  expect(response.status()).toBe(403);
+  const json = await response.json();
+  assertRequiredFields(json, ['detail', 'title']);
+  expect(json.title).toBe('FORBIDDEN');
+  expect(json.detail).toContain(detail);
+}
+
+export async function assertNotFoundRequest(
+  response: APIResponse,
+  detail: string,
+) {
+  expect(response.status()).toBe(404);
+  const json = await response.json();
+  assertRequiredFields(json, ['detail', 'title']);
+  expect(json.title).toBe('NOT_FOUND');
+  expect(json.detail).toContain(detail);
+}
+
 export function assertEqualsForKeys(
   obj: unknown,
   expected: Record<string, unknown>,
@@ -92,6 +140,13 @@ export function assertEqualsForKeys(
 export function jsonHeaders(): Record<string, string> {
   return {
     'Content-Type': 'application/json',
+    ...authHeaders(credentials.accessToken),
+  };
+}
+
+export function defaultHeaders(): Record<string, string> {
+  return {
+    Accept: 'application/json',
     ...authHeaders(credentials.accessToken),
   };
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Test run: https://github.com/camunda/camunda/actions/runs/17278556349

- Renamed `request-beans` to `requestBeans` since we don't use kebab case in that directory.
- Added the following endpoints and respective flows:

#### Document Creation (POST /documents)
- Unauthorized request (401) → Missing headers.
- Invalid header (415) → Wrong content type.
- Invalid body (400) → Required file part missing.
- Invalid store ID (400) → Nonexistent store passed via ?storeId.
- Valid document creation (201) → Asserts required fields and response keys.
- With query params (201) → ?documentId and ?storeId verified.
- With metadata (201) → Metadata correctly saved and validated.

#### Document Retrieval (GET /documents/{documentId}?contentHash=...)

- Valid retrieval (200) → Document text matches expected content.
- Without content hash (400) → Error for missing contentHash query param.
- Nonexistent document (404) → Proper error returned.
- Unauthorized retrieval (401) → Missing headers.


#### Document Deletion (DELETE /documents/{documentId})

- Unauthorized delete (401) → Missing headers.
- Nonexistent delete (404) → Proper error returned.
- Successful delete (204) → Followed by verify deleted (404) (GET /documents/{documentId}).


#### Multiple Document Creation (Batch) (POST /documents/batch)

- Valid batch create (201) → Two documents created, fields validated.
- Unauthorized (401) → Missing headers.
- Invalid header (415) → Wrong content type.
- Invalid body (400) → Required files part missing.


#### Document Link Creation (POST /documents/{documentId}/links?contentHash=...)

- Forbidden (403) → In-memory storage doesn’t support links.
- Without content hash (400) → Hash required error.
- Nonexistent document (404) → Proper error returned.
- Unauthorized (401) → Missing headers.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
