### PR TITLE
ci: add OC workflow for 8.8 releases

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -1,0 +1,227 @@
+# description: Runs End to End tests on the C8 Orchestration Cluster (ie, Tasklist, Operate) for release validation
+# test location: /qa/c8-orchestration-cluster-e2e-test-suite
+# type: CI
+# owner: @camunda/qa-engineering
+---
+name: C8 Orchestration Cluster E2E Tests - Release Validation
+
+on:
+  push:
+    branches:
+      - "release**"
+  pull_request:
+    branches:
+      - "release**"
+
+permissions: {}
+
+jobs:
+  release-e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions: {}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Determine Image Tag
+        id: image-tag
+        shell: bash
+        run: |
+          # Extract version from 8.8+ release branch patterns:
+          # - release-8.8.0, release-8.9.1, release-9.0.0
+          # - origin/release-8.8.2
+          # - custom-release-8.8.0-rc3, custom-release-9.0.0-beta1
+          BRANCH_NAME="${{ github.ref_name }}"
+          echo "Analyzing branch name: $BRANCH_NAME"
+
+          if [[ "$BRANCH_NAME" =~ ^(origin/)?.*release-([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?)$ ]]; then
+            VERSION="${BASH_REMATCH[2]}"
+            
+            # Extract major and minor version numbers
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            
+            # Check if version is 8.8 or greater (consolidated architecture)
+            if [[ "$MAJOR" -eq 8 && "$MINOR" -ge 8 ]] || [[ "$MAJOR" -gt 8 ]]; then
+              IMAGE_TAG="$VERSION"
+              echo "Extracted version $IMAGE_TAG from branch name (8.8+ supported)"
+            else
+              echo "Error: Version $VERSION is not supported"
+              echo "This workflow only supports 8.8+ releases (consolidated architecture)"
+              echo "Found version: $VERSION (requires 8.8+)"
+              exit 1
+            fi
+          else
+            echo "Error: Could not extract version from branch name: $BRANCH_NAME"
+            echo "Expected patterns: release-X.Y.Z where X.Y >= 8.8"
+            echo "Examples: release-8.8.0, release-8.9.1, release-9.0.0"
+            exit 1
+          fi
+
+          echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "Final image tag: $IMAGE_TAG"
+
+      - name: Update Docker Compose with Release Image
+        if: steps.image-tag.outcome == 'success'
+        shell: bash
+        run: |
+          IMAGE_TAG="${{ steps.image-tag.outputs.image-tag }}"
+          echo "Updating Docker Compose configuration for version: $IMAGE_TAG"
+
+          # Update consolidated image for all versions
+          sed -i -E "s|image: camunda/camunda:[^[:space:]]*|image: camunda/camunda:$IMAGE_TAG|g" \
+            qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+
+          echo "Updated docker-compose.yml to use image: camunda/camunda:$IMAGE_TAG"
+
+          # Verify the change
+          echo "Updated image configuration:"
+          grep "image: camunda/camunda:" qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml || echo "No consolidated image found"
+
+      - name: Start Camunda
+        if: steps.image-tag.outcome == 'success'
+        shell: bash
+        run: |
+          echo "Starting Camunda with image tag: ${{ steps.image-tag.outputs.image-tag }}"
+          export DATABASE=elasticsearch
+          DATABASE=elasticsearch docker compose up -d camunda
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+        env:
+          DATABASE: elasticsearch
+
+      - name: List running Docker containers
+        if: steps.image-tag.outcome == 'success'
+        shell: bash
+        run: docker ps -a
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Wait for services to be ready
+        if: steps.image-tag.outcome == 'success'
+        id: wait-for-services
+        shell: bash
+        run: |
+          echo "Checking if services are up..."
+          ready=false
+          for i in {1..90}; do
+            tasklist_status=$(curl -s -m 5 http://localhost:8080/tasklist || echo "Failed")
+            operate_status=$(curl -s -m 5 http://localhost:8080/operate || echo "Failed")
+            identity_status=$(curl -s -m 5 http://localhost:8080/identity || echo "Failed")
+
+            if [[ "$tasklist_status" != "Failed" && "$operate_status" != "Failed" && "$identity_status" != "Failed" ]]; then
+              echo "Services are ready!"
+              ready=true
+              break
+            fi
+
+            echo "Waiting for services... ($i/90)"
+            echo "Response from Tasklist: $tasklist_status"
+            echo "Response from Operate: $operate_status"
+            echo "Response from Identity: $identity_status"
+            sleep 10
+          done
+
+          if [ "$ready" = true ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Services failed to start in time."
+            exit 1
+          fi
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Setup Node.js
+        if: steps.image-tag.outcome == 'success'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+
+      - name: Clean install dependencies
+        if: steps.image-tag.outcome == 'success'
+        shell: bash
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Import Secrets
+        if: steps.image-tag.outcome == 'success'
+        id: secrets
+        uses: hashicorp/vault-action@2c5827061f1ad91ca97897d6257ebe638e033699
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_EMAIL;
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
+
+      - name: Install Playwright Browsers
+        if: steps.image-tag.outcome == 'success'
+        shell: bash
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Run E2E Tests
+        if: steps.image-tag.outcome == 'success'
+        shell: bash
+        env:
+          LOCAL_TEST: "false"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          CORE_APPLICATION_URL: "http://localhost:8080"
+          ZEEBE_REST_ADDRESS: "http://localhost:8080"
+          RELEASE_VERSION: ${{ steps.image-tag.outputs.image-tag }}
+        run: |
+          echo "Running E2E tests against Camunda release version: $RELEASE_VERSION"
+          npm run test -- --project=chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Publish test results to TestRail
+        if: always() && steps.image-tag.outcome == 'success'
+        shell: bash
+        env:
+          TESTRAIL_HOST: "https://camunda.testrail.com/"
+          TESTRAIL_USERNAME: ${{ steps.secrets.outputs.TESTRAIL_QA_EMAIL }}
+          TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }}
+          JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
+        run: |
+          pip install trcli
+          trcli -y -h "$TESTRAIL_HOST" \
+            --project 'C8' \
+            --username "$TESTRAIL_USERNAME" \
+            --key "$TESTRAIL_KEY" \
+            parse_junit --suite-id 17050 \
+            --title "${{ steps.image-tag.outputs.image-tag }}-Release OC test" \
+            --close-run \
+            -f "$JUNIT_RESULTS_FILE"
+
+      - name: Upload test results
+        if: always() && steps.image-tag.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.image-tag.outputs.image-tag }}-Release OC test
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
+          retention-days: 10
+
+      - name: Print Docker logs before failing
+        if: failure()
+        shell: bash
+        run: |
+          echo "=== Camunda logs ==="
+          docker compose logs camunda || true
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/identity-e2e-tests.yml
+++ b/.github/workflows/identity-e2e-tests.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - "main"
       - "stable/**"
-      - "release**"
     paths:
       - ".ci/**"
       - ".github/actions/**"

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - "main"
       - "stable/**"
-      - "release**"
     paths:
       - ".ci/**"
       - ".github/actions/**"

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - "main"
       - "stable/**"
-      - "release**"
   pull_request:
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs


### PR DESCRIPTION
## Description
Adds automated E2E testing workflow for C8 Orchestration Cluster release validation with support for automatic triggering on release branches.

### Key Features
- **Multi-trigger Support**: Runs on release branch pushes/PRs
- **Smart Version Detection**: Auto-extracts version from release branch names
- **Docker Integration**: Updates docker-compose with release-specific images and starts separate services
- **TestRail Integration**: Automatically publishes test results to TestRail with run closure
- **Artifact Upload**: Creates HTML reports and test artifacts for debugging


### Technical Details
- **Test Location**: `qa/c8-orchestration-cluster-e2e-test-suite`
- **Browser**: Chromium via Playwright
- **Services**: Camunda standalone
- **Authentication**: Basic auth with demo credentials

### Usage
- **Automatic**: Push to any `release**` branch triggers tests with extracted version

(https://github.com/camunda/camunda/actions/runs/17428068687/job/49479727381?pr=37535) is where it was triggered
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
