### PR TITLE
[Backport release-8.8.0-alpha8] feat: support handling get requests with empty responses in the java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/ApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/ApiEntityConsumer.java
@@ -64,10 +64,12 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
 
   @Override
   protected void streamStart(final ContentType contentType) throws IOException {
-    if (ContentType.APPLICATION_JSON.isSameMimeType(contentType)) {
-      entityConsumer = new JsonApiEntityConsumer<>(json, type, true);
-    } else if (ContentType.APPLICATION_PROBLEM_JSON.isSameMimeType(contentType)) {
+    if (ContentType.APPLICATION_PROBLEM_JSON.isSameMimeType(contentType)) {
       entityConsumer = new JsonApiEntityConsumer<>(json, type, false);
+    } else if (Void.class.equals(type)) {
+      entityConsumer = new RawApiEntityConsumer<>(true, chunkSize);
+    } else if (ContentType.APPLICATION_JSON.isSameMimeType(contentType)) {
+      entityConsumer = new JsonApiEntityConsumer<>(json, type, true);
     } else {
       final boolean isResponse =
           String.class.equals(type)

--- a/clients/java/src/main/java/io/camunda/client/impl/http/JsonResponseAndStatusCodeTransformer.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/JsonResponseAndStatusCodeTransformer.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.http;
+
+@FunctionalInterface
+public interface JsonResponseAndStatusCodeTransformer<HttpT, RespT> {
+  RespT transform(final HttpT entity, final int statusCode) throws Exception;
+}


### PR DESCRIPTION
# Description
Backport of #37244 to `release-8.8.0-alpha8`.

relates to #37243 #20921