### PR TITLE
chore: update preview-env external-secret apiVersion for eso upgrade on infra clusters

### DIFF
--- a/.ci/preview-environments/charts/c8sm/templates/secrets.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/secrets.yml
@@ -23,7 +23,7 @@ data:
   {{- if .Values.camundaPlatform.identityKeycloak.auth.existingSecret }}
   # Identity Keycloak login.
   {{ .Values.camundaPlatform.identityKeycloak.auth.passwordSecretKey }}: "{{ .Values.camundaPlatform.identityKeycloak.auth.adminUser | b64enc }}"
-  {{- end }}  
+  {{- end }}
   {{- if .Values.camundaPlatform.identityKeycloak.postgresql.auth.existingSecret }}
   # Identity Keycloak PostgreSQL.
   {{ .Values.camundaPlatform.identityKeycloak.postgresql.auth.secretKeys.adminPasswordKey  }}: "{{ "postgresql" | b64enc }}"
@@ -59,7 +59,7 @@ data:
   # Set to an empty JSON to comply with kubernetes.io/dockerconfigjson requirements
   .dockerconfigjson: "e30="
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: registry-camunda-cloud


### PR DESCRIPTION
## Description

This pull request updates the Kubernetes manifest for the `registry-camunda-cloud` secret to use a newer version of the ExternalSecrets API.

Kubernetes manifest update:

* Changed the `apiVersion` in `.ci/preview-environments/charts/c8sm/templates/secrets.yml` from `external-secrets.io/v1beta1` to `external-secrets.io/v1` to use the stable API version for ExternalSecrets - necessary to upgrade ESO from v0.16.2 -> 0.17.x and above

## Checklist

- [ ] Backporting to stable branches

## Related issues

- https://github.com/camunda/team-infrastructure/issues/883

