### PR TITLE
fix: re-install MigrationSnapshotDirector on each role transition

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotAfterMigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotAfterMigrationTransitionStep.java
@@ -22,7 +22,7 @@ public class SnapshotAfterMigrationTransitionStep implements PartitionTransition
   @Override
   public ActorFuture<Void> prepareTransition(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
-    if (targetRole == Role.INACTIVE & migrationSnapshotDirector != null) {
+    if (migrationSnapshotDirector != null) {
       migrationSnapshotDirector.close();
       migrationSnapshotDirector = null;
     }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotMigrationTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotMigrationTransitionStepTest.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 
 public class SnapshotMigrationTransitionStepTest {
   @AutoClose
-  private static final ActorScheduler scheduler = ActorScheduler.newActorScheduler().build();
+  private static final ActorScheduler SCHEDULER = ActorScheduler.newActorScheduler().build();
 
   private static final Logger LOG =
       LoggerFactory.getLogger(SnapshotMigrationTransitionStepTest.class);
@@ -76,13 +76,13 @@ public class SnapshotMigrationTransitionStepTest {
 
   @BeforeAll
   static void setupAll() {
-    scheduler.start();
+    SCHEDULER.start();
   }
 
   @BeforeEach
   void setup() {
     actor.setMonitor(healthMonitor);
-    scheduler.submitActor(actor).join();
+    SCHEDULER.submitActor(actor).join();
     transitionContext.setConcurrencyControl(actor);
     transitionContext.setSnapshotDirector(snapshotDirector);
     transitionContext.setConcurrencyControl(concurrencyControl);


### PR DESCRIPTION
## Description

`MigrationSnapshotDirector` needs to be re-installed on role changes, because otherwise it might be using an already closed `AsyncSnapshotDirector`.  This leads to the partition remain in unhealthy state as the migration snapshot director cannot take a snapshot anymore.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37234 
