### PR TITLE
[Backport stable/8.7] 28529 introduce release process dry run

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -28,6 +28,10 @@ on:
         description: 'Whether to perform a dry release where no changes or artifacts are pushed, defaults to true.'
         type: boolean
         default: true
+      releaseProcessDryRun:
+        description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       releaseBranch:
@@ -52,7 +56,10 @@ on:
         description: 'Whether to perform a dry release where no changes or artifacts are pushed, defaults to true.'
         type: boolean
         default: true
-
+      releaseProcessDryRun:
+        description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
+        type: boolean
+        default: false
 defaults:
   run:
     shell: bash
@@ -60,6 +67,7 @@ defaults:
 env:
   RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
   RELEASE_VERSION: ${{ inputs.releaseVersion }}
+  RELEASE_TAG: ${{ inputs.releaseProcessDryRun && format('dryrun-{0}', inputs.releaseVersion) || inputs.releaseVersion }}
   GH_TOKEN: ${{ github.token }} # needs to be available for the gh CLI tool
   GITHUB_TOKEN_USR: ${{ github.token }} # needs to be available for the SCM URL in pom.xml
 jobs:
@@ -71,7 +79,7 @@ jobs:
       releaseBranch: ${{ env.RELEASE_BRANCH }}
     env:
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
-      PUSH_CHANGES: ${{ inputs.dryRun == false }}
+      PUSH_CHANGES: ${{ !inputs.dryRun }}
     steps:
       - name: Output Inputs
         run: echo "${{ toJSON(github.event.inputs) }}"
@@ -161,11 +169,11 @@ jobs:
           #   This is the reason why we have to set it at least as empty string.
           ./mvnw release:prepare -B \
             -Dresume=false \
-            -Dtag=${RELEASE_VERSION} \
-            -DreleaseVersion=${RELEASE_VERSION} \
-            -DdevelopmentVersion=${DEVELOPMENT_VERSION} \
-            -DpushChanges=${PUSH_CHANGES} \
-            -DremoteTagging=${PUSH_CHANGES} \
+            -Dtag="${RELEASE_TAG}" \
+            -DreleaseVersion="${RELEASE_VERSION}" \
+            -DdevelopmentVersion="${DEVELOPMENT_VERSION}" \
+            -DpushChanges="${PUSH_CHANGES}" \
+            -DremoteTagging="${PUSH_CHANGES}" \
             -DcompletionGoals="spotless:apply" \
             -P-autoFormat \
             -DpreparationGoals="" \
@@ -174,7 +182,8 @@ jobs:
       - name: Maven Perform Release
         id: maven-perform-release
         env:
-          SKIP_REPO_DEPLOY: ${{ inputs.dryRun }}
+          SKIP_CENTRAL_RELEASE: ${{ inputs.dryRun }}
+          SKIP_CAMUNDA_RELEASE: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
         run: |
           # Perform a maven release
           # https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html
@@ -188,7 +197,7 @@ jobs:
             -DlocalCheckout=${{ inputs.dryRun }} \
             -DskipQaBuild=true \
             -P-autoFormat \
-            -Darguments='-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
+            -Darguments='-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
@@ -231,7 +240,7 @@ jobs:
             fi
           done
       - name: Push Changes to Release branch
-        if: ${{ inputs.dryRun == false }}
+        if: ${{ !inputs.dryRun }}
         run: git push origin "${RELEASE_BRANCH}"
       - name: Cleanup Maven Central GPG Key
         # make sure we always remove the imported signing key to avoid it leaking on runners
@@ -351,17 +360,17 @@ jobs:
           echo "result=${PRE_RELEASE}" >> $GITHUB_OUTPUT
       - name: Create Github release
         uses: ncipollo/release-action@v1
-        if: ${{ inputs.dryRun == false }}
+        if: ${{ !inputs.dryRun }}
         with:
-          name: ${{ inputs.releaseVersion }}
+          name: ${{ env.RELEASE_TAG }}
           artifacts: "release-artifacts/*"
           artifactErrorsFailBuild: true
-          draft: ${{ steps.gen-changelog.outputs.isDraftRelease }}
+          draft: ${{ inputs.releaseProcessDryRun || steps.gen-changelog.outputs.isDraftRelease }}
           makeLatest: ${{ inputs.isLatest }}
           body: ${{ steps.gen-changelog.outputs.changelog }}
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ steps.pre-release.outputs.result }}
-          tag: ${{ inputs.releaseVersion }}
+          tag: ${{ env.RELEASE_TAG }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -434,7 +443,7 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
       - name: Sync Docker Image to DockerHub
         id: push-docker
-        if: ${{ inputs.dryRun == false }}
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
         run: |
           docker buildx imagetools create \
@@ -516,7 +525,7 @@ jobs:
           goldenfile: operate-docker-labels.golden.json
       - name: Sync Operate Docker Image to DockerHub
         id: push-docker
-        if: ${{ inputs.dryRun == false }}
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
         run: |
           docker buildx imagetools create \
@@ -598,7 +607,7 @@ jobs:
           goldenfile: tasklist-docker-labels.golden.json
       - name: Sync Tasklist Docker Image to DockerHub
         id: push-docker
-        if: ${{ inputs.dryRun == false }}
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
         run: |
           docker buildx imagetools create \
@@ -680,7 +689,7 @@ jobs:
           goldenfile: camunda-docker-labels.golden.json
       - name: Sync Camunda Docker Image to DockerHub
         id: push-docker
-        if: ${{ inputs.dryRun == false }}
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
         run: |
           docker buildx imagetools create \
@@ -712,10 +721,10 @@ jobs:
       version: ${{ inputs.releaseVersion }}
       useMinorVersion: true
       # test instead of monitor during dry-runs
-      monitor: ${{ !inputs.dryRun }}
+      monitor: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
       # the docker image will not be pushed during a dry-run, so we need to build it locally
-      build: ${{ inputs.dryRun }}
-      dockerImage: ${{ inputs.dryRun && '' || format('camunda/zeebe:{0}', inputs.releaseVersion) }}
+      build: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
+      dockerImage: ${{ (inputs.dryRun || inputs.releaseProcessDryRun) && '' || format('camunda/zeebe:{0}', inputs.releaseVersion) }}
     secrets: inherit
 
   notify-on-success:
@@ -732,7 +741,7 @@ jobs:
       needs.tasklist-docker.result == 'success' &&
       needs.camunda-docker.result == 'success' &&
       needs.snyk.result == 'success'
-      ) && inputs.dryRun == false }}
+      ) && !inputs.dryRun && !inputs.releaseProcessDryRun }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
@@ -781,7 +790,7 @@ jobs:
         needs.tasklist-docker.result == 'failure' ||
         needs.camunda-docker.result == 'failure' ||
         needs.snyk.result == 'failure'
-        ) && inputs.dryRun == false }}
+        ) && !inputs.dryRun && !inputs.releaseProcessDryRun }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:


### PR DESCRIPTION
# Description
Backport of #37238 to `stable/8.7`.

relates to camunda/camunda#28529

# Test evidence

## Workflow

https://github.com/camunda/camunda/actions/runs/17307977602

## Maven Central deployment

<img width="1673" height="866" alt="image" src="https://github.com/user-attachments/assets/4d555020-6b50-4470-a3c8-c18fb94a0509" />

## GitHub release

<img width="1183" height="375" alt="image" src="https://github.com/user-attachments/assets/a7c6f329-6bf0-4d86-ae1f-e8ef771478d6" />

## Tag

<img width="1148" height="328" alt="image" src="https://github.com/user-attachments/assets/3cbbf25a-5475-4945-9046-dc6072dbd288" />
