### PR TITLE
fix: move `filter` criteria of v2 batch endpoints under a new filter root level request attribute

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
@@ -36,6 +36,8 @@ import io.camunda.client.impl.response.CreateBatchOperationResponseImpl;
 import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
 import io.camunda.client.protocol.rest.MigrateProcessInstanceMappingInstruction;
+import io.camunda.client.protocol.rest.ProcessInstanceCancellationBatchOperationRequest;
+import io.camunda.client.protocol.rest.ProcessInstanceIncidentResolutionBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationPlan;
 import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceModificationBatchOperationRequest;
@@ -142,16 +144,23 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
   }
 
   private Object getBody() {
-    if (type == BatchOperationTypeEnum.MIGRATE_PROCESS_INSTANCE) {
-      return new ProcessInstanceMigrationBatchOperationRequest()
-          .filter(provideSearchRequestProperty(filter))
-          .migrationPlan(migrationPlan);
-    } else if (type == BatchOperationTypeEnum.MODIFY_PROCESS_INSTANCE) {
-      return new ProcessInstanceModificationBatchOperationRequest()
-          .filter(provideSearchRequestProperty(filter))
-          .moveInstructions(moveInstructions);
-    } else {
-      return provideSearchRequestProperty(filter);
+    switch (type) {
+      case MIGRATE_PROCESS_INSTANCE:
+        return new ProcessInstanceMigrationBatchOperationRequest()
+            .filter(provideSearchRequestProperty(filter))
+            .migrationPlan(migrationPlan);
+      case MODIFY_PROCESS_INSTANCE:
+        return new ProcessInstanceModificationBatchOperationRequest()
+            .filter(provideSearchRequestProperty(filter))
+            .moveInstructions(moveInstructions);
+      case CANCEL_PROCESS_INSTANCE:
+        return new ProcessInstanceCancellationBatchOperationRequest()
+            .filter(provideSearchRequestProperty(filter));
+      case RESOLVE_INCIDENT:
+        return new ProcessInstanceIncidentResolutionBatchOperationRequest()
+            .filter(provideSearchRequestProperty(filter));
+      default:
+        throw new IllegalArgumentException("Unsupported batch operation type: " + type);
     }
   }
 

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -53,6 +53,8 @@ public class RestGatewayPaths {
   private static final String URL_PROCESS_INSTANCES = REST_API_PATH + "/process-instances";
   private static final String URL_PROCESS_INSTANCES_CANCELLATION =
       REST_API_PATH + "/process-instances/cancellation";
+  private static final String URL_PROCESS_INSTANCES_INCIDENT_RESOLUTION =
+      REST_API_PATH + "/process-instances/incident-resolution";
   private static final String URL_PROCESS_INSTANCES_MIGRATION =
       REST_API_PATH + "/process-instances/migration";
   private static final String URL_PROCESS_INSTANCES_MODIFICATION =
@@ -237,6 +239,10 @@ public class RestGatewayPaths {
 
   public static String getProcessInstancesCancelUrl() {
     return URL_PROCESS_INSTANCES_CANCELLATION;
+  }
+
+  public static String getProcessInstancesIncidentResolutionUrl() {
+    return URL_PROCESS_INSTANCES_INCIDENT_RESOLUTION;
   }
 
   public static String getProcessInstancesMigrateUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -247,6 +247,10 @@ public class RestGatewayService {
     registerPost(RestGatewayPaths.getProcessInstancesCancelUrl(), response);
   }
 
+  public void onResolveIncidentsRequest(final BatchOperationCreatedResult response) {
+    registerPost(RestGatewayPaths.getProcessInstancesIncidentResolutionUrl(), response);
+  }
+
   public void onMigrateProcessInstancesRequest(final BatchOperationCreatedResult response) {
     registerPost(RestGatewayPaths.getProcessInstancesMigrateUrl(), response);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
@@ -308,7 +308,7 @@ class BatchOperationAuthorizationIT {
             camundaClient
                 .newCreateBatchOperationCommand()
                 .processInstanceCancel()
-                .filter(b -> {})
+                .filter(f -> f.processInstanceKey(serviceTaskV1Key))
                 .send()
                 .join();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterMultiplePartitionsBatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterMultiplePartitionsBatchOperationIT.java
@@ -106,7 +106,7 @@ public class ClusterMultiplePartitionsBatchOperationIT {
         camundaClient
             .newCreateBatchOperationCommand()
             .processInstanceCancel()
-            .filter(new ProcessInstanceFilterImpl())
+            .filter(new ProcessInstanceFilterImpl().processDefinitionId("service_tasks_v1"))
             .send()
             .join();
     final var batchOperationKey = result.getBatchOperationKey();

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2000,11 +2000,11 @@ paths:
         parentProcessInstanceKey are ignored and overridden during this batch operation.
         This is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProcessInstanceFilter"
+              $ref: "#/components/schemas/ProcessInstanceCancellationBatchOperationRequest"
       responses:
         "200":
           description: The batch operation request was created.
@@ -2039,11 +2039,11 @@ paths:
         filters for state are ignored and overridden during this batch operation.
         This is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProcessInstanceFilter"
+              $ref: "#/components/schemas/ProcessInstanceIncidentResolutionBatchOperationRequest"
       responses:
         "200":
           description: The batch operation request was created.
@@ -10869,6 +10869,24 @@ components:
         errorMessage:
           description: the error message from the engine in case of a failed operation.
           type: string
+    ProcessInstanceCancellationBatchOperationRequest:
+      type: object
+      description: |
+        The process instance filter that defines which process instances should be canceled.
+      properties:
+        filter:
+          $ref: "#/components/schemas/ProcessInstanceFilter"
+      required:
+        - filter
+    ProcessInstanceIncidentResolutionBatchOperationRequest:
+      type: object
+      description: |
+        The process instance filter that defines which process instances should have their incidents resolved.
+      properties:
+        filter:
+          $ref: "#/components/schemas/ProcessInstanceFilter"
+      required:
+        - filter
     ProcessInstanceModificationBatchOperationRequest:
       type: object
       description: |

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -111,6 +111,9 @@ public final class SearchQueryRequestMapper {
   public static final AdvancedStringFilter EMPTY_ADVANCED_STRING_FILTER =
       new AdvancedStringFilter();
   public static final BasicStringFilter EMPTY_BASIC_STRING_FILTER = new BasicStringFilter();
+  public static final io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilter
+      EMPTY_PROCESS_INSTANCE_FILTER =
+          new io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilter();
 
   private SearchQueryRequestMapper() {}
 
@@ -955,6 +958,17 @@ public final class SearchQueryRequestMapper {
 
   private static OffsetDateTime toOffsetDateTime(final String text) {
     return StringUtils.isEmpty(text) ? null : OffsetDateTime.parse(text);
+  }
+
+  public static Either<List<String>, ProcessInstanceFilter> toRequiredProcessInstanceFilter(
+      final io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilter filter) {
+    if (filter == null) {
+      return Either.left(List.of(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter")));
+    }
+    if (filter.equals(EMPTY_PROCESS_INSTANCE_FILTER)) {
+      return Either.left(List.of(ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted("filter criteria")));
+    }
+    return toProcessInstanceFilter(filter);
   }
 
   public static Either<List<String>, ProcessInstanceFilter> toProcessInstanceFilter(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -22,8 +22,9 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOper
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
 import io.camunda.zeebe.gateway.protocol.rest.CancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.rest.IncidentSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceCancellationBatchOperationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceCreationInstruction;
-import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilter;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceIncidentResolutionBatchOperationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceIncidentSearchQuery;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceMigrationBatchOperationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceMigrationInstruction;
@@ -39,7 +40,6 @@ import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
-import io.camunda.zeebe.gateway.rest.validator.RequestValidator;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -171,27 +171,17 @@ public class ProcessInstanceController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/cancellation")
   public CompletableFuture<ResponseEntity<Object>> cancelProcessInstancesBatchOperation(
-      @RequestBody(required = false) final ProcessInstanceFilter filter) {
-
-    return SearchQueryRequestMapper.toProcessInstanceFilter(filter)
-        .fold(
-            (errors) ->
-                RestErrorMapper.mapProblemToCompletedResponse(
-                    RequestValidator.createProblemDetail(errors).get()),
-            this::batchOperationCancellation);
+      @RequestBody final ProcessInstanceCancellationBatchOperationRequest request) {
+    return RequestMapper.toRequiredProcessInstanceFilter(request.getFilter())
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::batchOperationCancellation);
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/incident-resolution")
   public CompletableFuture<ResponseEntity<Object>> resolveIncidentsBatchOperation(
-      @RequestBody(required = false) final ProcessInstanceFilter filter) {
-
-    return SearchQueryRequestMapper.toProcessInstanceFilter(filter)
-        .fold(
-            (errors) ->
-                RestErrorMapper.mapProblemToCompletedResponse(
-                    RequestValidator.createProblemDetail(errors).get()),
-            this::batchOperationResolveIncidents);
+      @RequestBody final ProcessInstanceIncidentResolutionBatchOperationRequest request) {
+    return RequestMapper.toRequiredProcessInstanceFilter(request.getFilter())
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::batchOperationResolveIncidents);
   }
 
   @RequiresSecondaryStorage
@@ -199,7 +189,7 @@ public class ProcessInstanceController {
   public CompletableFuture<ResponseEntity<Object>> migrateProcessInstancesBatchOperation(
       @RequestBody final ProcessInstanceMigrationBatchOperationRequest request) {
     return RequestMapper.toProcessInstanceMigrationBatchOperationRequest(request)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::batchOperationModify);
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::batchOperationMigrate);
   }
 
   @RequiresSecondaryStorage
@@ -268,7 +258,7 @@ public class ProcessInstanceController {
         ResponseMapper::toBatchOperationCreatedWithResultResponse);
   }
 
-  private CompletableFuture<ResponseEntity<Object>> batchOperationModify(
+  private CompletableFuture<ResponseEntity<Object>> batchOperationMigrate(
       final ProcessInstanceMigrateBatchOperationRequest request) {
     return RequestMapper.executeServiceMethod(
         () ->

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
+import io.camunda.zeebe.gateway.protocol.rest.AdvancedStringFilter;
 import io.camunda.zeebe.gateway.protocol.rest.MigrateProcessInstanceMappingInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilter;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceMigrationBatchOperationPlan;
@@ -37,6 +38,7 @@ class RequestMapperTest {
     final var batchOperationInstruction = new ProcessInstanceMigrationBatchOperationRequest();
     batchOperationInstruction.setMigrationPlan(migrationPlan);
     final var filter = new ProcessInstanceFilter();
+    filter.setProcessDefinitionId(new AdvancedStringFilter().$like("process"));
     batchOperationInstruction.setFilter(filter);
 
     // when
@@ -90,10 +92,13 @@ class RequestMapperTest {
         new ProcessInstanceModificationMoveBatchOperationInstruction()
             .sourceElementId("source1")
             .targetElementId("target1");
+    final var filter = new ProcessInstanceFilter();
+    filter.setProcessDefinitionId(new AdvancedStringFilter().$like("process"));
 
     final var modificationRequest =
         new ProcessInstanceModificationBatchOperationRequest()
             .addMoveInstructionsItem(moveInstruction);
+    modificationRequest.setFilter(filter);
 
     // when
     final Either<ProblemDetail, ProcessInstanceModifyBatchOperationRequest> result =
@@ -117,10 +122,13 @@ class RequestMapperTest {
     // given
     final var moveInstruction =
         new ProcessInstanceModificationMoveBatchOperationInstruction().sourceElementId("source1");
+    final var filter = new ProcessInstanceFilter();
+    filter.setProcessDefinitionId(new AdvancedStringFilter().$like("process"));
 
     final var modificationRequest =
         new ProcessInstanceModificationBatchOperationRequest()
             .addMoveInstructionsItem(moveInstruction);
+    modificationRequest.setFilter(filter);
 
     // when
     final Either<ProblemDetail, ProcessInstanceModifyBatchOperationRequest> result =

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -1329,7 +1329,10 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     final var request =
         """
             {
-              "processDefinitionId": "test-process-definition-id"
+              "filter":
+               {
+                  "processDefinitionId": "test-process-definition-id"
+                }
             }""";
 
     // when / then
@@ -1455,7 +1458,10 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     final var request =
         """
             {
-              "processDefinitionId": "test-process-definition-id"
+              "filter":
+               {
+                  "processDefinitionId": "test-process-definition-id"
+                }
             }""";
 
     // when / then
@@ -1637,5 +1643,527 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).searchIncidents(processInstanceKey, query);
+  }
+
+  @Test
+  void shouldRejectCancelProcessInstanceBatchOperationWithNoRequestBody() {
+    // given
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"Bad Request",
+                "status":400,
+                "detail":"Required request body is missing",
+                "instance":"/v2/process-instances/cancellation"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/cancellation")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectCancelProcessInstanceBatchOperationWithEmptyRequestBody() {
+    // given
+    final var request = "{}";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"No filter provided.",
+                "instance":"/v2/process-instances/cancellation"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/cancellation")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectCancelProcessInstanceBatchOperationWithEmptyFilter() {
+    // given
+    final var request =
+        """
+        {
+          "filter": {}
+        }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"At least one of filter criteria is required.",
+                "instance":"/v2/process-instances/cancellation"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/cancellation")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectResolveIncidentsBatchOperationWithNoRequestBody() {
+    // given
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"Bad Request",
+                "status":400,
+                "detail":"Required request body is missing",
+                "instance":"/v2/process-instances/incident-resolution"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/incident-resolution")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectResolveIncidentsBatchOperationWithEmptyRequestBody() {
+    // given
+    final var request = "{}";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"No filter provided.",
+                "instance":"/v2/process-instances/incident-resolution"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/incident-resolution")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectResolveIncidentsBatchOperationWithEmptyFilter() {
+    // given
+    final var request =
+        """
+        {
+          "filter": {}
+        }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"At least one of filter criteria is required.",
+                "instance":"/v2/process-instances/incident-resolution"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/incident-resolution")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectMigrateProcessInstancesBatchOperationWithNoFilter() {
+    // given
+    final var request =
+        """
+        {
+          "migrationPlan": {
+            "targetProcessDefinitionKey": "123",
+            "mappingInstructions": [
+              {
+                "sourceElementId": "a",
+                "targetElementId": "b"
+              }
+            ]
+          }
+        }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"No filter provided.",
+                "instance":"/v2/process-instances/migration"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/migration")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectMigrateProcessInstancesBatchOperationWithEmptyFilter() {
+    // given
+    final var request =
+        """
+        {
+          "filter": {},
+          "migrationPlan": {
+            "targetProcessDefinitionKey": "123",
+            "mappingInstructions": [
+              {
+                "sourceElementId": "a",
+                "targetElementId": "b"
+              }
+            ]
+          }
+        }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"At least one of filter criteria is required.",
+                "instance":"/v2/process-instances/migration"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/migration")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectMigrateProcessInstancesBatchOperationWithNoMigrationPlan() {
+    // given
+    final var record = new BatchOperationCreationRecord();
+    record.setBatchOperationKey(123L);
+    record.setBatchOperationType(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
+
+    when(processInstanceServices.migrateProcessInstancesBatchOperation(
+            any(ProcessInstanceMigrateBatchOperationRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    final var request =
+        """
+           {
+            "filter": {
+              "processDefinitionId": "test-process-definition-id"
+            }
+           }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"No migrationPlan provided.",
+                "instance":"/v2/process-instances/migration"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/migration")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectMigrateProcessInstancesBatchOperationWithEmptyMigrationPlan() {
+    // given
+    final var record = new BatchOperationCreationRecord();
+    record.setBatchOperationKey(123L);
+    record.setBatchOperationType(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
+
+    when(processInstanceServices.migrateProcessInstancesBatchOperation(
+            any(ProcessInstanceMigrateBatchOperationRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    final var request =
+        """
+           {
+            "filter": {
+              "processDefinitionId": "test-process-definition-id"
+            },
+            "migrationPlan": {}
+           }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"No targetProcessDefinitionKey provided. No mappingInstructions provided.",
+                "instance":"/v2/process-instances/migration"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/migration")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectModifyProcessInstancesBatchOperationWithNoFilter() {
+    // given
+    final var request =
+        """
+        {
+          "moveInstructions": [
+            {
+              "sourceElementId": "source1",
+              "targetElementId": "target1"
+            }
+          ]
+        }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"No filter provided.",
+                "instance":"/v2/process-instances/modification"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/modification")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectModifyProcessInstancesBatchOperationWithEmptyFilter() {
+    // given
+    final var request =
+        """
+        {
+          "filter": {},
+          "moveInstructions": [
+            {
+              "sourceElementId": "source1",
+              "targetElementId": "target1"
+            }
+          ]
+        }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"At least one of filter criteria is required.",
+                "instance":"/v2/process-instances/modification"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/modification")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectModifyProcessInstancesBatchOperationWithNoMoveInstructions() {
+    // given
+    final var request =
+        """
+        {
+          "filter": {
+              "processDefinitionId": "test-process-definition-id"
+            }
+        }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"No moveInstructions provided.",
+                "instance":"/v2/process-instances/modification"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/modification")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectModifyProcessInstancesBatchOperationWithEmptyMoveInstructions() {
+    // given
+    final var request =
+        """
+        {
+          "filter": {
+              "processDefinitionId": "test-process-definition-id"
+            },
+          "moveInstructions": []
+        }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"No moveInstructions provided.",
+                "instance":"/v2/process-instances/modification"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/process-instances/modification")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validator/ProcessInstanceRequestValidatorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validator/ProcessInstanceRequestValidatorTest.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.gateway.rest.validator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceCreationInstruction;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilter;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceMigrationBatchOperationPlan;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceMigrationBatchOperationRequest;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
@@ -146,9 +148,14 @@ class ProcessInstanceRequestValidatorTest {
   @Test
   @DisplayName("Should accept valid targetProcessDefinitionKey format in migration request")
   void shouldAcceptValidTargetProcessDefinitionKey() {
-    final var request = new ProcessInstanceMigrationBatchOperationPlan();
-    request.setTargetProcessDefinitionKey("987654321");
-    request.setMappingInstructions(java.util.List.of());
+
+    final var migrationPlan = new ProcessInstanceMigrationBatchOperationPlan();
+    migrationPlan.setTargetProcessDefinitionKey("987654321");
+    migrationPlan.setMappingInstructions(java.util.List.of());
+
+    final var request = new ProcessInstanceMigrationBatchOperationRequest();
+    request.setFilter(new ProcessInstanceFilter());
+    request.setMigrationPlan(migrationPlan);
 
     final Optional<ProblemDetail> result =
         ProcessInstanceRequestValidator.validateMigrateProcessInstanceBatchOperationRequest(
@@ -166,9 +173,13 @@ class ProcessInstanceRequestValidatorTest {
   @ValueSource(strings = {"xyz", "99.99", "99xyz", "", " "})
   @DisplayName("Should reject invalid targetProcessDefinitionKey formats in migration request")
   void shouldRejectInvalidTargetProcessDefinitionKey(final String invalidKey) {
-    final var request = new ProcessInstanceMigrationBatchOperationPlan();
-    request.setTargetProcessDefinitionKey(invalidKey);
-    request.setMappingInstructions(java.util.List.of());
+    final var migrationPlan = new ProcessInstanceMigrationBatchOperationPlan();
+    migrationPlan.setTargetProcessDefinitionKey(invalidKey);
+    migrationPlan.setMappingInstructions(java.util.List.of());
+
+    final var request = new ProcessInstanceMigrationBatchOperationRequest();
+    request.setFilter(new ProcessInstanceFilter());
+    request.setMigrationPlan(migrationPlan);
 
     final Optional<ProblemDetail> result =
         ProcessInstanceRequestValidator.validateMigrateProcessInstanceBatchOperationRequest(


### PR DESCRIPTION
## Description

This PR restructures the v2 batch operation endpoints to move filter criteria under a new "filter" root-level request attribute, ensuring API consistency across all batch operation endpoints. The change affects process instance cancellation and incident resolution endpoints to match the existing pattern used by migration and modification operations.

- Updates REST API schema to use dedicated request objects with nested filter attributes
- Modifies Java client implementation to construct proper request bodies with the new structure
- Enhances validation logic to handle the restructured request format
- **Ensures a valid filter object is required by all batch endpoints with at least one criteria filled**

## Related issues

closes #37332
