### PR TITLE
fix: enhance v2 tasklist api with processName

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapper.java
@@ -19,6 +19,7 @@ public class UserTaskEntityMapper {
         dbModel.elementId(),
         dbModel.name(),
         dbModel.processDefinitionId(),
+        null, // filled later from ProcessCache in UserTaskService
         dbModel.creationDate(),
         dbModel.completionDate(),
         dbModel.assignee(),

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapperTest.java
@@ -55,7 +55,12 @@ public class UserTaskEntityMapperTest {
     assertThat(entity)
         .usingRecursiveComparison()
         .ignoringFields(
-            "customHeaders", "creationDate", "completionDate", "dueDate", "followUpDate")
+            "customHeaders",
+            "creationDate",
+            "completionDate",
+            "dueDate",
+            "followUpDate",
+            "processName")
         .isEqualTo(dbModel);
 
     assertThat(entity.customHeaders()).isEqualTo(Map.of("key", "value"));
@@ -103,7 +108,12 @@ public class UserTaskEntityMapperTest {
     assertThat(entity)
         .usingRecursiveComparison()
         .ignoringFields(
-            "customHeaders", "creationDate", "completionDate", "dueDate", "followUpDate")
+            "customHeaders",
+            "creationDate",
+            "completionDate",
+            "dueDate",
+            "followUpDate",
+            "processName")
         .isEqualTo(dbModel);
 
     assertThat(entity.customHeaders()).isEqualTo(Map.of("key", "value"));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
@@ -646,6 +646,7 @@ public class UserTaskIT {
             "dueDate",
             "followUpDate",
             "candidateUsers",
+            "processName",
             "candidateGroups")
         .isEqualTo(userTask);
     assertThat(instance.creationDate())

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/UserTaskEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/UserTaskEntityTransformer.java
@@ -23,6 +23,7 @@ public class UserTaskEntityTransformer implements ServiceTransformer<TaskEntity,
         source.getFlowNodeBpmnId(),
         source.getName(),
         source.getBpmnProcessId(),
+        null, // filled later from ProcessCache in UserTaskService
         source.getCreationTime(),
         source.getCompletionTime(),
         source.getAssignee(),

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UserTaskEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UserTaskEntity.java
@@ -18,6 +18,7 @@ public record UserTaskEntity(
     String elementId,
     String name,
     String processDefinitionId,
+    String processName,
     OffsetDateTime creationDate,
     OffsetDateTime completionDate,
     String assignee,
@@ -43,6 +44,33 @@ public record UserTaskEntity(
         elementId,
         newName,
         processDefinitionId,
+        processName,
+        creationDate,
+        completionDate,
+        assignee,
+        state,
+        formKey,
+        processDefinitionKey,
+        processInstanceKey,
+        elementInstanceKey,
+        tenantId,
+        dueDate,
+        followUpDate,
+        candidateGroups,
+        candidateUsers,
+        externalFormReference,
+        processDefinitionVersion,
+        customHeaders,
+        priority);
+  }
+
+  public UserTaskEntity withProcessName(final String newProcessName) {
+    return new UserTaskEntity(
+        userTaskKey,
+        elementId,
+        name,
+        processDefinitionId,
+        newProcessName,
         creationDate,
         completionDate,
         assignee,
@@ -64,6 +92,10 @@ public record UserTaskEntity(
 
   public boolean hasName() {
     return name != null && !name.isBlank();
+  }
+
+  public boolean hasProcessName() {
+    return processName != null && !processName.isBlank();
   }
 
   public enum UserTaskState {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UserTaskEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UserTaskEntity.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record UserTaskEntity(
@@ -95,7 +96,7 @@ public record UserTaskEntity(
   }
 
   public boolean hasProcessName() {
-    return processName != null && !processName.isBlank();
+    return !StringUtils.isBlank(processName);
   }
 
   public enum UserTaskState {

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -103,7 +103,7 @@ public final class UserTaskServices
 
     final var processDefinitionKeys =
         result.items().stream()
-            .filter(u -> !u.hasName())
+            .filter(u -> !u.hasName() || !u.hasProcessName())
             .map(UserTaskEntity::processDefinitionKey)
             .collect(Collectors.toSet());
 
@@ -123,8 +123,16 @@ public final class UserTaskServices
   }
 
   private UserTaskEntity toCacheEnrichedUserTaskEntity(
-      final UserTaskEntity item, final ProcessCacheItem cachedItem) {
-    return item.hasName() ? item : item.withName(cachedItem.getElementName(item.elementId()));
+      UserTaskEntity item, final ProcessCacheItem cachedItem) {
+
+    if (!item.hasName()) {
+      item = item.withName(cachedItem.getElementName(item.elementId()));
+    }
+    if (!item.hasProcessName()) {
+      item = item.withProcessName(cachedItem.getProcessName());
+    }
+
+    return item;
   }
 
   public SearchQueryResult<UserTaskEntity> search(

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -40,10 +40,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public final class UserTaskServices
     extends SearchQueryService<UserTaskServices, UserTaskQuery, UserTaskEntity> {
+
+  private static final Predicate<UserTaskEntity> NEEDS_CACHE_ENRICHMENT =
+      u -> !u.hasName() || !u.hasProcessName();
 
   private final UserTaskSearchClient userTaskSearchClient;
   private final FormServices formServices;
@@ -103,7 +107,7 @@ public final class UserTaskServices
 
     final var processDefinitionKeys =
         result.items().stream()
-            .filter(u -> !u.hasName() || !u.hasProcessName())
+            .filter(NEEDS_CACHE_ENRICHMENT)
             .map(UserTaskEntity::processDefinitionKey)
             .collect(Collectors.toSet());
 

--- a/service/src/main/java/io/camunda/service/cache/ProcessCache.java
+++ b/service/src/main/java/io/camunda/service/cache/ProcessCache.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -83,8 +82,7 @@ public class ProcessCache {
     @Override
     public ProcessCacheItem load(final Long processDefinitionKey) {
       final var processData = processDefinitionProvider.extractProcessData(processDefinitionKey);
-      return new ProcessCacheItem(
-          processData.processName(), Collections.unmodifiableMap(processData.elementIdNameMap()));
+      return ProcessCacheItem.from(processData);
     }
 
     @Override
@@ -94,11 +92,7 @@ public class ProcessCache {
       return processDataMap.entrySet().stream()
           .collect(
               Collectors.toMap(
-                  Map.Entry::getKey,
-                  entry ->
-                      new ProcessCacheItem(
-                          entry.getValue().processName(),
-                          Collections.unmodifiableMap(entry.getValue().elementIdNameMap()))));
+                  Map.Entry::getKey, entry -> ProcessCacheItem.from(entry.getValue())));
     }
   }
 

--- a/service/src/main/java/io/camunda/service/cache/ProcessCacheItem.java
+++ b/service/src/main/java/io/camunda/service/cache/ProcessCacheItem.java
@@ -10,9 +10,13 @@ package io.camunda.service.cache;
 import java.util.Collections;
 import java.util.Map;
 
-public record ProcessCacheItem(Map<String, String> elementIdNameMap) {
+public record ProcessCacheItem(String processName, Map<String, String> elementIdNameMap) {
 
-  public static final ProcessCacheItem EMPTY = new ProcessCacheItem(Collections.emptyMap());
+  public static final ProcessCacheItem EMPTY = new ProcessCacheItem(null, Collections.emptyMap());
+
+  public String getProcessName() {
+    return processName;
+  }
 
   public String getElementName(final String elementId) {
     return elementIdNameMap.getOrDefault(elementId, elementId);

--- a/service/src/main/java/io/camunda/service/cache/ProcessCacheItem.java
+++ b/service/src/main/java/io/camunda/service/cache/ProcessCacheItem.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service.cache;
 
+import io.camunda.service.cache.ProcessDefinitionProvider.ProcessCacheData;
 import java.util.Collections;
 import java.util.Map;
 
@@ -20,5 +21,11 @@ public record ProcessCacheItem(String processName, Map<String, String> elementId
 
   public String getElementName(final String elementId) {
     return elementIdNameMap.getOrDefault(elementId, elementId);
+  }
+
+  public static ProcessCacheItem from(ProcessCacheData processCacheData) {
+    return new ProcessCacheItem(
+        processCacheData.processName(),
+        Collections.unmodifiableMap(processCacheData.elementIdNameMap()));
   }
 }

--- a/service/src/main/java/io/camunda/service/cache/ProcessCacheResult.java
+++ b/service/src/main/java/io/camunda/service/cache/ProcessCacheResult.java
@@ -24,7 +24,7 @@ public record ProcessCacheResult(Map<Long, ProcessCacheItem> cachedProcesses) {
 
   public static ProcessCacheResult of(
       final Long processDefinitionKey,
-      String processName,
+      final String processName,
       final String elementId,
       final String cachedName) {
     return new ProcessCacheResult(

--- a/service/src/main/java/io/camunda/service/cache/ProcessCacheResult.java
+++ b/service/src/main/java/io/camunda/service/cache/ProcessCacheResult.java
@@ -23,9 +23,14 @@ public record ProcessCacheResult(Map<Long, ProcessCacheItem> cachedProcesses) {
   }
 
   public static ProcessCacheResult of(
-      final Long processDefinitionKey, final String elementId, final String cachedName) {
+      final Long processDefinitionKey,
+      String processName,
+      final String elementId,
+      final String cachedName) {
     return new ProcessCacheResult(
-        Map.of(processDefinitionKey, new ProcessCacheItem(Map.of(elementId, cachedName))));
+        Map.of(
+            processDefinitionKey,
+            new ProcessCacheItem(processName, Map.of(elementId, cachedName))));
   }
 
   public boolean isEmpty() {

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -85,7 +85,10 @@ public final class ElementInstanceServiceTest {
       when(processCache.getCacheItems(Set.of(entity.processDefinitionKey())))
           .thenReturn(
               ProcessCacheResult.of(
-                  entity.processDefinitionKey(), null, entity.flowNodeId(), "cached name"));
+                  entity.processDefinitionKey(),
+                  "ProcessName",
+                  entity.flowNodeId(),
+                  "cached name"));
 
       final var searchQueryResult = services.search(FlowNodeInstanceQuery.of(q -> q));
 
@@ -155,7 +158,8 @@ public final class ElementInstanceServiceTest {
 
       when(client.getFlowNodeInstance(any(Long.class))).thenReturn(entity);
       when(processCache.getCacheItem(entity.processDefinitionKey()))
-          .thenReturn(new ProcessCacheItem(null, Map.of(entity.flowNodeId(), "cached name")));
+          .thenReturn(
+              new ProcessCacheItem("ProcessName", Map.of(entity.flowNodeId(), "cached name")));
 
       // when
       final var foundEntity = services.getByKey(entity.flowNodeInstanceKey());
@@ -174,7 +178,7 @@ public final class ElementInstanceServiceTest {
 
       when(client.getFlowNodeInstance(any(Long.class))).thenReturn(entity);
       when(processCache.getCacheItem(entity.processDefinitionKey()))
-          .thenReturn(new ProcessCacheItem(null, Map.of("unknown-id", "cached name")));
+          .thenReturn(new ProcessCacheItem("ProcessName", Map.of("unknown-id", "cached name")));
 
       // when
       final var foundEntity = services.getByKey(entity.flowNodeInstanceKey());

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -85,7 +85,7 @@ public final class ElementInstanceServiceTest {
       when(processCache.getCacheItems(Set.of(entity.processDefinitionKey())))
           .thenReturn(
               ProcessCacheResult.of(
-                  entity.processDefinitionKey(), entity.flowNodeId(), "cached name"));
+                  entity.processDefinitionKey(), null, entity.flowNodeId(), "cached name"));
 
       final var searchQueryResult = services.search(FlowNodeInstanceQuery.of(q -> q));
 
@@ -155,7 +155,7 @@ public final class ElementInstanceServiceTest {
 
       when(client.getFlowNodeInstance(any(Long.class))).thenReturn(entity);
       when(processCache.getCacheItem(entity.processDefinitionKey()))
-          .thenReturn(new ProcessCacheItem(Map.of(entity.flowNodeId(), "cached name")));
+          .thenReturn(new ProcessCacheItem(null, Map.of(entity.flowNodeId(), "cached name")));
 
       // when
       final var foundEntity = services.getByKey(entity.flowNodeInstanceKey());
@@ -174,7 +174,7 @@ public final class ElementInstanceServiceTest {
 
       when(client.getFlowNodeInstance(any(Long.class))).thenReturn(entity);
       when(processCache.getCacheItem(entity.processDefinitionKey()))
-          .thenReturn(new ProcessCacheItem(Map.of("unknown-id", "cached name")));
+          .thenReturn(new ProcessCacheItem(null, Map.of("unknown-id", "cached name")));
 
       // when
       final var foundEntity = services.getByKey(entity.flowNodeInstanceKey());

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -187,15 +187,34 @@ public class UserTaskServiceTest {
     @Test
     void shouldReturnUserTaskWithCachedName() {
       final var entity =
-          Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::name), null).create();
+          Instancio.of(UserTaskEntity.class)
+              .set(field(UserTaskEntity::name), null)
+              .set(field(UserTaskEntity::processName), null)
+              .create();
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(processCache.getCacheItem(entity.processDefinitionKey()))
-          .thenReturn(new ProcessCacheItem(null, Map.of(entity.elementId(), "cached name")));
+          .thenReturn(
+              new ProcessCacheItem("ProcessName", Map.of(entity.elementId(), "cached name")));
 
       final var foundEntity = services.getByKey(entity.userTaskKey());
 
       assertThat(foundEntity.name()).isEqualTo("cached name");
+    }
+
+    @Test
+    void shouldReturnUserTaskWithProcessName() {
+      final var entity =
+          Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::processName), null).create();
+
+      when(client.getUserTask(any(Long.class))).thenReturn(entity);
+      when(processCache.getCacheItem(entity.processDefinitionKey()))
+          .thenReturn(
+              new ProcessCacheItem("ProcessName", Map.of(entity.elementId(), "cached name")));
+
+      final var foundEntity = services.getByKey(entity.userTaskKey());
+
+      assertThat(foundEntity.processName()).isEqualTo("ProcessName");
     }
 
     @Test
@@ -205,11 +224,12 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(processCache.getCacheItem(entity.processDefinitionKey()))
-          .thenReturn(new ProcessCacheItem(null, Map.of("unknown-id", "cached name")));
+          .thenReturn(new ProcessCacheItem("ProcessName", Map.of("unknown-id", "cached name")));
 
       final var foundEntity = services.getByKey(entity.userTaskKey());
 
       assertThat(foundEntity.name()).isEqualTo(entity.elementId());
+      assertThat(foundEntity.processName()).isEqualTo(entity.processName());
     }
 
     @Test
@@ -251,11 +271,26 @@ public class UserTaskServiceTest {
       when(processCache.getCacheItems(Set.of(entity.processDefinitionKey())))
           .thenReturn(
               ProcessCacheResult.of(
-                  entity.processDefinitionKey(), null, entity.elementId(), "cached name"));
+                  entity.processDefinitionKey(), "ProcessName", entity.elementId(), "cached name"));
 
       final var searchQueryResult = services.search(UserTaskQuery.of(q -> q));
 
       assertThat(searchQueryResult.items()).contains(entity.withName("cached name"));
+    }
+
+    @Test
+    void shouldReturnUserTaskWithProcessName() {
+      final var entity =
+          Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::processName), null).create();
+      when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
+      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey())))
+          .thenReturn(
+              ProcessCacheResult.of(
+                  entity.processDefinitionKey(), "ProcessName", entity.elementId(), "cached name"));
+
+      final var searchQueryResult = services.search(UserTaskQuery.of(q -> q));
+
+      assertThat(searchQueryResult.items()).contains(entity.withProcessName("ProcessName"));
     }
 
     @Test

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -191,7 +191,7 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(processCache.getCacheItem(entity.processDefinitionKey()))
-          .thenReturn(new ProcessCacheItem(Map.of(entity.elementId(), "cached name")));
+          .thenReturn(new ProcessCacheItem(null, Map.of(entity.elementId(), "cached name")));
 
       final var foundEntity = services.getByKey(entity.userTaskKey());
 
@@ -205,7 +205,7 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(processCache.getCacheItem(entity.processDefinitionKey()))
-          .thenReturn(new ProcessCacheItem(Map.of("unknown-id", "cached name")));
+          .thenReturn(new ProcessCacheItem(null, Map.of("unknown-id", "cached name")));
 
       final var foundEntity = services.getByKey(entity.userTaskKey());
 
@@ -251,7 +251,7 @@ public class UserTaskServiceTest {
       when(processCache.getCacheItems(Set.of(entity.processDefinitionKey())))
           .thenReturn(
               ProcessCacheResult.of(
-                  entity.processDefinitionKey(), entity.elementId(), "cached name"));
+                  entity.processDefinitionKey(), null, entity.elementId(), "cached name"));
 
       final var searchQueryResult = services.search(UserTaskQuery.of(q -> q));
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5830,6 +5830,9 @@ components:
         elementInstanceKey:
           type: string
           description: The key of the element instance.
+        processName:
+          type: string
+          description: The name of the process definition.
         processDefinitionKey:
           type: string
           description: The key of the process definition.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -873,6 +873,7 @@ public final class SearchQueryResponseMapper {
         .processDefinitionKey(KeyUtil.keyToString(t.processDefinitionKey()))
         .elementInstanceKey(KeyUtil.keyToString(t.elementInstanceKey()))
         .processDefinitionId(t.processDefinitionId())
+        .processName(t.processName())
         .state(UserTaskStateEnum.fromValue(t.state().name()))
         .assignee(t.assignee())
         .candidateUsers(t.candidateUsers())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -63,6 +63,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                       "userTaskKey": "0",
                       "processInstanceKey": "1",
                       "processDefinitionKey": "2",
+                      "processName": "ProcessName",
                       "elementInstanceKey": "3",
                       "processDefinitionId": "b",
                       "state": "CREATED",
@@ -129,6 +130,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                       "userTaskKey": "0",
                       "processInstanceKey": "1",
                       "processDefinitionKey": "2",
+                      "processName": "ProcessName",
                       "elementInstanceKey": "3",
                       "processDefinitionId": "b",
                       "state": "CREATED",
@@ -172,6 +174,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                       "e", // elementBpmnId
                       "name",
                       "b", // bpmnProcessId
+                      "ProcessName",
                       OffsetDateTime.parse("2020-11-11T00:00:00.000Z"), // creationTime
                       OffsetDateTime.parse("2020-11-11T00:00:00.000Z"), // completionTime
                       "a", // assignee
@@ -224,6 +227,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 "e",
                 "name",
                 "b",
+                "ProcessName",
                 OffsetDateTime.parse("2020-11-11T00:00:00.000Z"),
                 OffsetDateTime.parse("2020-11-11T00:00:00.000Z"),
                 "a",


### PR DESCRIPTION
## Description

#### Issue
`/v2/user-tasks/search` endpoint did not return field `processName` in the response like `v1/tasks/search` did.

Tasklist UI -> Tasks -> All open tasks
The information retrieved by v2 displayed the `processId` rather than the `processName`.

#### Fix
Use existing following chain and enhance with processName
UserTaskServices -> ProcessCache -> ProcessDefinitionProvider -> ProcessDefinitionServices.search

BEFORE fix
<img width="1315" height="142" alt="image" src="https://github.com/user-attachments/assets/f618c60d-4224-436c-af0e-6124cc4fbebc" />

AFTER fix
<img width="1399" height="193" alt="image" src="https://github.com/user-attachments/assets/86a41caa-de15-443c-bb5e-dbf343759492" />

## Related issues

closes #34961
