### PR TITLE
deps: bump jetty version

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -45,7 +45,7 @@
     <previous.optimize.opensearch.version>2.9.0</previous.optimize.opensearch.version>
     <awssdk.version>2.28.13</awssdk.version>
 
-    <jetty.version>12.0.22</jetty.version>
+    <jetty.version>12.0.25</jetty.version>
     <jackson.version>2.18.1</jackson.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <apache.http5-client.version>5.4</apache.http5-client.version>
@@ -174,6 +174,81 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-ee</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-http</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-io</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-alpn-client</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-security</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-session</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-xml</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-plus</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-client</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-proxy</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-webapp</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+        <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+        <artifactId>jetty-ee10-websocket-jakarta-client</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-annotations</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-plus</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <!-- override wrong tomcat embed version coming from spring-boot-dependencies BOM -->


### PR DESCRIPTION
## Description

This aligns the version across all jetty dependencies.

Before
```
[INFO] --- dependency:3.8.0:tree (default-cli) @ camunda-optimize ---
[INFO] io.camunda.optimize:camunda-optimize:pom:8.7.9-SNAPSHOT
[INFO] \- io.camunda.optimize:optimize-backend:jar:8.7.9-SNAPSHOT:compile
[INFO]    +- org.eclipse.jetty:jetty-server:jar:12.0.22:compile
[INFO]    |  +- org.eclipse.jetty:jetty-http:jar:12.0.22:compile
[INFO]    |  \- org.eclipse.jetty:jetty-io:jar:12.0.22:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-java-client:jar:12.0.22:compile
[INFO]    |  \- org.eclipse.jetty:jetty-alpn-client:jar:12.0.22:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-java-server:jar:12.0.22:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-server:jar:12.0.22:compile
[INFO]    +- org.eclipse.jetty.ee10:jetty-ee10-servlet:jar:12.0.22:compile
[INFO]    |  +- org.eclipse.jetty:jetty-security:jar:12.0.22:compile
[INFO]    |  \- org.eclipse.jetty:jetty-session:jar:12.0.22:compile
[INFO]    +- org.eclipse.jetty:jetty-rewrite:jar:12.0.22:compile
[INFO]    +- org.eclipse.jetty:jetty-util:jar:12.0.22:compile
[INFO]    \- org.springframework.boot:spring-boot-starter-jetty:jar:3.3.13:compile
[INFO]       +- org.eclipse.jetty.ee10:jetty-ee10-webapp:jar:12.0.22:compile
[INFO]       |  +- org.eclipse.jetty:jetty-ee:jar:12.0.22:compile
[INFO]       |  \- org.eclipse.jetty:jetty-xml:jar:12.0.22:compile
[INFO]       \- org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jakarta-server:jar:12.0.22:compile
[INFO]          +- org.eclipse.jetty.ee10:jetty-ee10-annotations:jar:12.0.22:compile
[INFO]          |  \- org.eclipse.jetty.ee10:jetty-ee10-plus:jar:12.0.22:compile
[INFO]          |     \- org.eclipse.jetty:jetty-plus:jar:12.0.22:compile
[INFO]          \- org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jakarta-client:jar:12.0.22:compile
[INFO]             \- org.eclipse.jetty:jetty-client:jar:12.0.22:compile
```

After
```
[INFO] --- dependency:3.8.0:tree (default-cli) @ camunda-optimize ---
[INFO] io.camunda.optimize:camunda-optimize:pom:8.7.9-SNAPSHOT
[INFO] \- io.camunda.optimize:optimize-backend:jar:8.7.9-SNAPSHOT:compile
[INFO]    +- org.eclipse.jetty:jetty-server:jar:12.0.25:compile
[INFO]    |  +- org.eclipse.jetty:jetty-http:jar:12.0.25:compile
[INFO]    |  \- org.eclipse.jetty:jetty-io:jar:12.0.25:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-java-client:jar:12.0.25:compile
[INFO]    |  \- org.eclipse.jetty:jetty-alpn-client:jar:12.0.25:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-java-server:jar:12.0.25:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-server:jar:12.0.25:compile
[INFO]    +- org.eclipse.jetty.ee10:jetty-ee10-servlet:jar:12.0.25:compile
[INFO]    |  +- org.eclipse.jetty:jetty-security:jar:12.0.25:compile
[INFO]    |  \- org.eclipse.jetty:jetty-session:jar:12.0.25:compile
[INFO]    +- org.eclipse.jetty:jetty-rewrite:jar:12.0.25:compile
[INFO]    +- org.eclipse.jetty:jetty-util:jar:12.0.25:compile
[INFO]    \- org.springframework.boot:spring-boot-starter-jetty:jar:3.3.13:compile
[INFO]       +- org.eclipse.jetty.ee10:jetty-ee10-webapp:jar:12.0.25:compile
[INFO]       |  +- org.eclipse.jetty:jetty-ee:jar:12.0.25:compile
[INFO]       |  \- org.eclipse.jetty:jetty-xml:jar:12.0.25:compile
[INFO]       \- org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jakarta-server:jar:12.0.25:compile
[INFO]          +- org.eclipse.jetty.ee10:jetty-ee10-annotations:jar:12.0.25:compile
[INFO]          |  \- org.eclipse.jetty.ee10:jetty-ee10-plus:jar:12.0.25:compile
[INFO]          |     \- org.eclipse.jetty:jetty-plus:jar:12.0.25:compile
[INFO]          \- org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jakarta-client:jar:12.0.25:compile
[INFO]             \- org.eclipse.jetty:jetty-client:jar:12.0.25:compile
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37216 
