### PR TITLE
feat: mapping API tests for v2

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMappingRulesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMappingRulesPage.ts
@@ -8,6 +8,7 @@
 
 import {Page, Locator, expect} from '@playwright/test';
 import {relativizePath, Paths} from 'utils/relativizePath';
+import {defaultAssertionOptions} from '../utils/constants';
 
 export class IdentityMappingRulesPage {
   private page: Page;
@@ -193,7 +194,12 @@ export class IdentityMappingRulesPage {
   }
 
   async deleteMappingRule(mappingRuleName: string) {
-    await this.deleteMappingRuleButton(mappingRuleName).click();
+    await expect(this.deleteMappingRuleButton(mappingRuleName)).toBeVisible({
+      timeout: 20000,
+    });
+    await expect(async () => {
+      await this.deleteMappingRuleButton(mappingRuleName).click();
+    }).toPass(defaultAssertionOptions);
     await expect(this.deleteMappingRuleModal).toBeVisible();
     await this.deleteMappingRuleModalDeleteButton.click();
     await expect(this.deleteMappingRuleModal).toBeHidden();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
@@ -25,7 +25,7 @@ import {
   assignMappingToGroup,
   createGroupAndStoreResponseFields,
   createMappingRule,
-  mappingRuleFromState,
+  groupMappingRuleFromState,
 } from '../../../../utils/requestHelpers';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 
@@ -61,7 +61,7 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
   }) => {
     const stateParams: Record<string, string> = {
       groupId: state['groupId2'] as string,
-      mappingRuleId: mappingRuleFromState('groupId2', state) as string,
+      mappingRuleId: groupMappingRuleFromState('groupId2', state) as string,
     };
 
     await expect(async () => {
@@ -137,7 +137,7 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
     await test.step('Unassign Mapping Rule', async () => {
       const p = {
         groupId: state['groupId3'] as string,
-        mappingRuleId: mappingRuleFromState('groupId3', state) as string,
+        mappingRuleId: groupMappingRuleFromState('groupId3', state) as string,
       };
 
       await expect(async () => {
@@ -172,7 +172,7 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
   test('Unassign Mapping Rule From Group Unauthorized', async ({request}) => {
     const p = {
       groupId: state['groupId2'] as string,
-      mappingRuleId: mappingRuleFromState('groupId2', state) as string,
+      mappingRuleId: groupMappingRuleFromState('groupId2', state) as string,
     };
     const res = await request.delete(
       buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),
@@ -186,7 +186,7 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
   test('Unassign Mapping Rule From Group Not Found', async ({request}) => {
     const p = {
       groupId: 'invalidGroupId',
-      mappingRuleId: mappingRuleFromState('groupId2', state) as string,
+      mappingRuleId: groupMappingRuleFromState('groupId2', state) as string,
     };
     const res = await request.delete(
       buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
@@ -1,0 +1,500 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertRequiredFields,
+  assertUnauthorizedRequest,
+  paginatedResponseFields,
+  assertNotFoundRequest,
+  assertEqualsForKeys,
+  assertBadRequest,
+  assertConflictRequest,
+  assertPaginatedRequest,
+} from '../../../utils/http';
+import {defaultAssertionOptions} from '../../../utils/constants';
+import {
+  CREATE_NEW_MAPPING_RULE,
+  mappingRuleBundle,
+  mappingRuleRequiredFields,
+} from '../../../utils/beans/requestBeans';
+
+test.describe.parallel('Mapping Rules API Tests', () => {
+  const state: Record<string, unknown> = {};
+  let mappingRule1: Record<string, unknown>;
+  let mappingRule2: Record<string, unknown>;
+  let mappingRule3: Record<string, unknown>;
+  let mappingRule4: Record<string, unknown>;
+
+  test.beforeAll(async ({request}) => {
+    mappingRule1 = await mappingRuleBundle(request, state);
+    mappingRule2 = await mappingRuleBundle(request, state);
+    mappingRule3 = await mappingRuleBundle(request, state);
+    mappingRule4 = await mappingRuleBundle(request, state);
+  });
+
+  test('Create Mapping Rule', async ({request}) => {
+    await expect(async () => {
+      const requestBody = CREATE_NEW_MAPPING_RULE();
+      const res = await request.post(buildUrl('/mapping-rules'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+
+      expect(res.status()).toBe(201);
+      const json = await res.json();
+      assertRequiredFields(json, mappingRuleRequiredFields);
+      assertEqualsForKeys(json, requestBody, mappingRuleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Mapping Rule Unauthorized', async ({request}) => {
+    const requestBody = CREATE_NEW_MAPPING_RULE();
+
+    const res = await request.post(buildUrl('/mapping-rules'), {
+      headers: {},
+      data: requestBody,
+    });
+
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Create Mapping Rule With Only Claim Name Invalid Body 400', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/mapping-rules'), {
+      headers: jsonHeaders(),
+      data: {claimName: 'claimName'},
+    });
+
+    await assertBadRequest(
+      res,
+      /.*\b(mappingRuleId|name|claimValue)\b.*/,
+      'INVALID_ARGUMENT',
+    );
+  });
+
+  test('Create Mapping Rule With Only Claim Value Invalid Body 400', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/mapping-rules'), {
+      headers: jsonHeaders(),
+      data: {claimValue: 'claimValue'},
+    });
+
+    await assertBadRequest(
+      res,
+      /.*\b(mappingRuleId|name|claimName)\b.*/,
+      'INVALID_ARGUMENT',
+    );
+  });
+
+  test('Create Mapping Rule With Only Name Invalid Body 400', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/mapping-rules'), {
+      headers: jsonHeaders(),
+      data: {name: 'name'},
+    });
+
+    await assertBadRequest(
+      res,
+      /.*\b(mappingRuleId|claimValue|claimName)\b.*/,
+      'INVALID_ARGUMENT',
+    );
+  });
+
+  test('Create Mapping Rule With Only Mapping Rule Id Invalid Body 400', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/mapping-rules'), {
+      headers: jsonHeaders(),
+      data: {mappingRuleId: 'mappingRuleId'},
+    });
+
+    await assertBadRequest(
+      res,
+      /.*\b(name|claimValue|claimName)\b.*/,
+      'INVALID_ARGUMENT',
+    );
+  });
+
+  test('Create Mapping Rule With Same Id Conflict', async ({request}) => {
+    const requestBody = {
+      ...CREATE_NEW_MAPPING_RULE(),
+      mappingRuleId: mappingRule1.mappingRuleId,
+    };
+
+    const res = await request.post(buildUrl('/mapping-rules'), {
+      headers: jsonHeaders(),
+      data: requestBody,
+    });
+    await assertConflictRequest(res);
+  });
+
+  test('Get Mapping Rule', async ({request}) => {
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl('/mapping-rules/{mappingRuleId}', {
+          mappingRuleId: mappingRule1.mappingRuleId as string,
+        }),
+        {headers: jsonHeaders()},
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json,
+        mappingRule1.responseBody as Record<string, unknown>,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Mapping Rule Not Found', async ({request}) => {
+    const p = {mappingRuleId: 'does-not-exist'};
+    const res = await request.get(
+      buildUrl('/mapping-rules/{mappingRuleId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Mapping Rule with id '${p.mappingRuleId}' not found`,
+    );
+  });
+
+  test('Get Mapping Rule Unauthorized', async ({request}) => {
+    const p = {
+      mappingRuleId: mappingRule1.mappingRuleId as string,
+    };
+
+    const res = await request.get(
+      buildUrl('/mapping-rules/{mappingRuleId}', p),
+      {headers: {}},
+    );
+
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Mapping Rules', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+        headers: jsonHeaders(),
+        data: {},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemLengthGreaterThan: 2,
+        totalItemGreaterThan: 2,
+      });
+      const json = await res.json();
+
+      const matchingItem1 = json.items.find(
+        (it: {mappingRuleId: string}) =>
+          it.mappingRuleId === mappingRule1.mappingRuleId,
+      );
+      expect(matchingItem1).toBeDefined();
+      assertRequiredFields(matchingItem1, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        matchingItem1,
+        mappingRule1.responseBody as Record<string, unknown>,
+        mappingRuleRequiredFields,
+      );
+
+      const matchingItem2 = json.items.find(
+        (it: {mappingRuleId: string}) =>
+          it.mappingRuleId === mappingRule2.mappingRuleId,
+      );
+      expect(matchingItem2).toBeDefined();
+      assertRequiredFields(matchingItem2, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        matchingItem2,
+        mappingRule2.responseBody as Record<string, unknown>,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules By Id', async ({request}) => {
+    const body = {
+      filter: {
+        mappingRuleId: mappingRule2.mappingRuleId,
+      },
+    };
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      assertRequiredFields(json.items[0], mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json.items[0],
+        mappingRule2.responseBody as Record<string, unknown>,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules By Name', async ({request}) => {
+    const mappingRule = mappingRule1.responseBody as Record<string, unknown>;
+    const body = {
+      filter: {
+        claimName: mappingRule.claimName as string,
+      },
+    };
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRequiredFields(json.items[0], mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json.items[0],
+        mappingRule,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules By Claim Value', async ({request}) => {
+    const mappingRule = mappingRule2.responseBody as Record<string, unknown>;
+    const body = {
+      filter: {
+        claimValue: mappingRule.claimValue as string,
+      },
+    };
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRequiredFields(json.items[0], mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json.items[0],
+        mappingRule,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules By Claim Name', async ({request}) => {
+    const mappingRule = mappingRule2.responseBody as Record<string, unknown>;
+    const body = {
+      filter: {
+        mappingRuleId: mappingRule.mappingRuleId as string,
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRequiredFields(json.items[0], mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json.items[0],
+        mappingRule,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules No Matching Item', async ({request}) => {
+    const body = {
+      filter: {
+        mappingRuleId: 'invalidMappingRule',
+      },
+    };
+
+    const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+
+  test('Search Mapping Rules By Multiple Fields', async ({request}) => {
+    const mappingRule = mappingRule2.responseBody as Record<string, unknown>;
+    const body = {
+      filter: {
+        mappingRuleId: mappingRule2.mappingRuleId as string,
+        claimName: mappingRule.claimName as string,
+        claimValue: mappingRule.claimValue as string,
+        name: mappingRule.name as string,
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRequiredFields(json.items[0], mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json.items[0],
+        mappingRule,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules Unauthorized', async ({request}) => {
+    const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+      headers: {},
+      data: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Update Mapping Rule', async ({request}) => {
+    const p = {mappingRuleId: mappingRule3.mappingRuleId as string};
+    const mappingRule = mappingRule3.responseBody as Record<string, unknown>;
+    const updateBody = {
+      claimName: `${mappingRule.claimName}-updated`,
+      claimValue: `${mappingRule.claimValue}-updated`,
+      name: `${mappingRule.name}-updated`,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+          data: updateBody,
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, mappingRuleRequiredFields);
+      expect(json.claimName).toBe(updateBody.claimName);
+      expect(json.name).toBe(updateBody.name);
+      expect(json.claimValue).toBe(updateBody.claimValue);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Mapping Rule Not Found', async ({request}) => {
+    const p = {mappingRuleId: 'missing-id'};
+    const res = await request.put(
+      buildUrl('/mapping-rules/{mappingRuleId}', p),
+      {
+        headers: jsonHeaders(),
+        data: {
+          claimName: 'new-value',
+          claimValue: 'new-value',
+          name: 'new-value',
+        },
+      },
+    );
+
+    await assertNotFoundRequest(
+      res,
+      `Command 'UPDATE' rejected with code 'NOT_FOUND`,
+    );
+  });
+
+  test('Update Mapping Rule Unauthorized', async ({request}) => {
+    const p = {mappingRuleId: mappingRule3.mappingRuleId as string};
+    const res = await request.put(
+      buildUrl('/mapping-rules/{mappingRuleId}', p),
+      {
+        headers: {},
+        data: {
+          claimName: 'new-value',
+          claimValue: 'new-value',
+          name: 'new-value',
+        },
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Delete Mapping Rule', async ({request}) => {
+    const p = {mappingRuleId: mappingRule4.mappingRuleId as string};
+
+    await test.step('Delete Mapping Rule', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/mapping-rules/{mappingRuleId}', p),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Get Mapping Rule After Deletion', async () => {
+      await expect(async () => {
+        const resGet = await request.get(
+          buildUrl('/mapping-rules/{mappingRuleId}', p),
+          {headers: jsonHeaders()},
+        );
+        await assertNotFoundRequest(
+          resGet,
+          `Mapping Rule with id '${p.mappingRuleId}' not found`,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Delete Mapping Rule Not Found', async ({request}) => {
+    const p = {mappingRuleId: 'non-existent-rule'};
+    const res = await request.delete(
+      buildUrl('/mapping-rules/{mappingRuleId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'DELETE' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Delete Mapping Rule Unauthorized', async ({request}) => {
+    const p = {mappingRuleId: state['mappingRuleId1'] as string};
+    const res = await request.delete(
+      buildUrl('/mapping-rules/{mappingRuleId}', p),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
@@ -254,7 +254,7 @@ test.describe.parallel('Mapping Rules API Tests', () => {
     const mappingRule = mappingRule1.responseBody as Record<string, unknown>;
     const body = {
       filter: {
-        claimName: mappingRule.claimName as string,
+        name: mappingRule.name as string,
       },
     };
     await expect(async () => {
@@ -308,7 +308,7 @@ test.describe.parallel('Mapping Rules API Tests', () => {
     const mappingRule = mappingRule2.responseBody as Record<string, unknown>;
     const body = {
       filter: {
-        mappingRuleId: mappingRule.mappingRuleId as string,
+        claimName: mappingRule.claimName as string,
       },
     };
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
@@ -414,6 +414,83 @@ test.describe.parallel('Mapping Rules API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
+  test('Update Mapping Rule With Only Claim Name Invalid Body 400', async ({
+    request,
+  }) => {
+    const p = {mappingRuleId: mappingRule3.mappingRuleId as string};
+    const mappingRule = mappingRule3.responseBody as Record<string, unknown>;
+    const updateBody = {
+      claimName: `${mappingRule.claimName}-updated`,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+          data: updateBody,
+        },
+      );
+
+      await assertBadRequest(
+        res,
+        /.*\b(mappingRuleId|name|claimValue)\b.*/,
+        'INVALID_ARGUMENT',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Mapping Rule With Only Claim Value Invalid Body 400', async ({
+    request,
+  }) => {
+    const p = {mappingRuleId: mappingRule3.mappingRuleId as string};
+    const mappingRule = mappingRule3.responseBody as Record<string, unknown>;
+    const updateBody = {
+      claimValue: `${mappingRule.claimValue}-updated`,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+          data: updateBody,
+        },
+      );
+      await assertBadRequest(
+        res,
+        /.*\b(mappingRuleId|name|claimName)\b.*/,
+        'INVALID_ARGUMENT',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Mapping Rule With Only Name Invalid Body 400', async ({
+    request,
+  }) => {
+    const p = {mappingRuleId: mappingRule3.mappingRuleId as string};
+    const mappingRule = mappingRule3.responseBody as Record<string, unknown>;
+    const updateBody = {
+      name: `${mappingRule.name}-updated`,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+          data: updateBody,
+        },
+      );
+
+      await assertBadRequest(
+        res,
+        /.*\b(mappingRuleId|claimValue|claimName)\b.*/,
+        'INVALID_ARGUMENT',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
   test('Update Mapping Rule Not Found', async ({request}) => {
     const p = {mappingRuleId: 'missing-id'};
     const res = await request.put(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules.spec.ts
@@ -12,7 +12,10 @@ import {relativizePath, Paths} from 'utils/relativizePath';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {LOGIN_CREDENTIALS, createTestData} from 'utils/constants';
-import {waitForItemInList} from 'utils/waitForItemInList';
+import {
+  findLocatorInPaginatedList,
+  waitForItemInList,
+} from 'utils/waitForItemInList';
 import {mockOIDCModeUI} from 'utils/mockOIDCModeUI';
 
 test.describe.serial('mapping rules CRUD', () => {
@@ -60,16 +63,17 @@ test.describe.serial('mapping rules CRUD', () => {
     );
 
     await waitForItemInList(page, item, {
-      emptyStateLocator: identityMappingRulesPage.emptyState,
+      clickNext: true,
+      timeout: 30000,
     });
-
-    await expect(item).toBeVisible();
   });
 
   test('edits a mapping rule', async ({page, identityMappingRulesPage}) => {
-    await expect(
-      identityMappingRulesPage.mappingRuleCell(NEW_MAPPING_RULE.name),
-    ).toBeVisible();
+    const mappingRule = identityMappingRulesPage.mappingRuleCell(
+      NEW_MAPPING_RULE.name,
+    );
+    expect(await findLocatorInPaginatedList(page, mappingRule)).toBe(true);
+    await expect(mappingRule).toBeVisible();
 
     await identityMappingRulesPage.editMappingRule(
       NEW_MAPPING_RULE.name,
@@ -82,13 +86,15 @@ test.describe.serial('mapping rules CRUD', () => {
       EDITED_MAPPING_RULE.name,
     );
 
-    await waitForItemInList(page, item);
+    await waitForItemInList(page, item, {timeout: 60000, clickNext: true});
   });
 
   test('deletes a mapping rule', async ({page, identityMappingRulesPage}) => {
-    await expect(
-      identityMappingRulesPage.mappingRuleCell(EDITED_MAPPING_RULE.name),
-    ).toBeVisible();
+    const mappingRule = identityMappingRulesPage.mappingRuleCell(
+      EDITED_MAPPING_RULE.name,
+    );
+    expect(await findLocatorInPaginatedList(page, mappingRule)).toBe(true);
+    await expect(mappingRule).toBeVisible();
 
     await identityMappingRulesPage.deleteMappingRule(EDITED_MAPPING_RULE.name);
 
@@ -98,7 +104,8 @@ test.describe.serial('mapping rules CRUD', () => {
 
     await waitForItemInList(page, item, {
       shouldBeVisible: false,
-      emptyStateLocator: identityMappingRulesPage.emptyState,
+      clickNext: true,
+      timeout: 60000,
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -8,6 +8,8 @@
 
 import {generateUniqueId} from '../constants';
 import * as fs from 'node:fs';
+import {createMappingRule, mappingRuleIdFromState} from '../requestHelpers';
+import {APIRequestContext} from 'playwright-core';
 
 export const groupRequiredFields: string[] = ['groupId', 'name', 'description'];
 export const mappingRuleRequiredFields: string[] = [
@@ -228,6 +230,18 @@ export function CREATE_MAPPING_EXPECTED_BODY_USING_GROUP(
   };
 }
 
+export function CREATE_MAPPING_EXPECTED_BODY(
+  key: string,
+  state: Record<string, unknown>,
+) {
+  return {
+    claimName: state[`claimName${key}`] as string,
+    claimValue: state[`claimValue${key}`] as string,
+    name: state[`name${key}`] as string,
+    mappingRuleId: state[`mappingRuleId${key}`] as string,
+  };
+}
+
 export function CREATE_GROUP_ROLE_EXPECTED_BODY_USING_GROUP(
   groupId: string,
   state: Record<string, unknown>,
@@ -247,5 +261,18 @@ export function CREATE_GROUP_USERS_EXPECTED_BODY_USING_GROUP(
 ) {
   return {
     username: state[`${groupId}user${nth}`] as string,
+  };
+}
+
+export async function mappingRuleBundle(
+  request: APIRequestContext,
+  state: Record<string, unknown>,
+) {
+  const mappingRuleKey = 'mappingRuleId' + generateUniqueId();
+  await createMappingRule(request, state, mappingRuleKey);
+  return {
+    mappingRuleKey: 'mappingRuleId' + generateUniqueId(),
+    mappingRuleId: mappingRuleIdFromState(mappingRuleKey, state),
+    responseBody: CREATE_MAPPING_EXPECTED_BODY(mappingRuleKey, state),
   };
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -271,7 +271,7 @@ export async function mappingRuleBundle(
   const mappingRuleKey = 'mappingRuleId' + generateUniqueId();
   await createMappingRule(request, state, mappingRuleKey);
   return {
-    mappingRuleKey: 'mappingRuleId' + generateUniqueId(),
+    mappingRuleKey: mappingRuleKey,
     mappingRuleId: mappingRuleIdFromState(mappingRuleKey, state),
     responseBody: CREATE_MAPPING_EXPECTED_BODY(mappingRuleKey, state),
   };

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -90,14 +90,10 @@ export async function assertPaginatedRequest(
     );
   }
   if (options.totalItemsEqualTo !== undefined) {
-    expect(json.page.totalItems).toBe(
-        options.totalItemsEqualTo as number,
-    );
+    expect(json.page.totalItems).toBe(options.totalItemsEqualTo as number);
   }
   if (options.itemsLengthEqualTo !== undefined) {
-    expect(json.items.length).toBe(
-        options.itemsLengthEqualTo as number,
-    );
+    expect(json.items.length).toBe(options.itemsLengthEqualTo as number);
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -57,14 +57,48 @@ export async function assertUnsupportedMediaTypeRequest(response: APIResponse) {
 
 export async function assertBadRequest(
   response: APIResponse,
-  detail: string,
+  detail: string | RegExp,
   title = 'Bad Request',
 ) {
   expect(response.status()).toBe(400);
   const json = await response.json();
   assertRequiredFields(json, ['detail', 'title']);
   expect(json.title).toBe(title);
-  expect(json.detail).toContain(detail);
+  expect(json.detail).toMatch(detail);
+}
+
+export async function assertPaginatedRequest(
+  response: APIResponse,
+  options: {
+    totalItemGreaterThan?: number;
+    itemLengthGreaterThan?: number;
+    totalItemsEqualTo?: number;
+    itemsLengthEqualTo?: number;
+  },
+) {
+  expect(response.status()).toBe(200);
+  const json = await response.json();
+  assertRequiredFields(json, paginatedResponseFields);
+  if (options.itemLengthGreaterThan !== undefined) {
+    expect(json.page.totalItems).toBeGreaterThan(
+      options.totalItemGreaterThan as number,
+    );
+  }
+  if (options.itemLengthGreaterThan !== undefined) {
+    expect(json.items.length).toBeGreaterThan(
+      options.itemLengthGreaterThan as number,
+    );
+  }
+  if (options.totalItemsEqualTo !== undefined) {
+    expect(json.page.totalItems).toBe(
+        options.totalItemsEqualTo as number,
+    );
+  }
+  if (options.itemsLengthEqualTo !== undefined) {
+    expect(json.items.length).toBe(
+        options.itemsLengthEqualTo as number,
+    );
+  }
 }
 
 export async function assertForbiddenRequest(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -79,7 +79,7 @@ export async function assertPaginatedRequest(
   expect(response.status()).toBe(200);
   const json = await response.json();
   assertRequiredFields(json, paginatedResponseFields);
-  if (options.itemLengthGreaterThan !== undefined) {
+  if (options.totalItemGreaterThan !== undefined) {
     expect(json.page.totalItems).toBeGreaterThan(
       options.totalItemGreaterThan as number,
     );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers.ts
@@ -137,7 +137,11 @@ export async function assignUsersToGroup(
   }
 }
 
-export async function createMappingRule(request: APIRequestContext) {
+export async function createMappingRule(
+  request: APIRequestContext,
+  state?: Record<string, unknown>,
+  key?: string,
+) {
   const body = CREATE_NEW_MAPPING_RULE();
   await expect(async () => {
     const res = await request.post(buildUrl('/mapping-rules'), {
@@ -145,6 +149,13 @@ export async function createMappingRule(request: APIRequestContext) {
       data: body,
     });
     expect(res.status()).toBe(201);
+    if (state && key) {
+      const json = await res.json();
+      state[`mappingRuleId${key}`] = json.mappingRuleId;
+      state[`claimName${key}`] = json.claimName;
+      state[`claimValue${key}`] = json.claimValue;
+      state[`name${key}`] = json.name;
+    }
   }).toPass(defaultAssertionOptions);
   return body;
 }
@@ -161,7 +172,7 @@ export async function createRole(request: APIRequestContext) {
   return body;
 }
 
-export function mappingRuleFromState(
+export function groupMappingRuleFromState(
   group: string,
   state: Record<string, unknown>,
   nth: number = 1,
@@ -191,4 +202,11 @@ export function clientIdFromState(
   nth: number = 1,
 ): string {
   return state[`${state[group]}clientId${nth}`] as string;
+}
+
+export function mappingRuleIdFromState(
+  key: string,
+  state: Record<string, unknown>,
+): string {
+  return state[`mappingRuleId${key}`] as string;
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Run: https://github.com/camunda/camunda/actions/runs/17379732910

Here is the summary of `mapping-rule-api-tests.spec.ts`. Tests run in parallel.

### Endpoints & Scenarios

- **POST /mapping-rules**  
  Create mapping rule.  
  Scenarios:  
  - 201 success (valid body, all required fields asserted)  
  - 401 unauthorized (missing auth header)  
  - 400 invalid bodies (each single-field payload: claimName only, claimValue only, name only, mappingRuleId only) -> expects INVALID_ARGUMENT with missing field hints  
  - 409 conflict when reusing existing mappingRuleId  

- **GET /mapping-rules/{mappingRuleId}**  
  Retrieve single mapping rule.  
  Scenarios:  
  - 200 success (all required fields, equality vs creation payload)  
  - 404 not found (nonexistent id)  
  - 401 unauthorized  

- **POST /mapping-rules/search**  
  Search (paginated) mapping rules.  
  Base assertions: paginated response structure \(`page`, `items`\) and required item fields.  
  Scenarios:  
  - Unfiltered list (expects >2 items, verifies two known created rules)  
  - Filter by mappingRuleId (single exact match)  
  - Filter by claimName (single exact match)  
  - Filter by claimValue (single exact match)  
  - Filter by name (single match)  
  - Multiple field composite filter (all fields provided -> single match)  
  - No match (invalid id -> 0 items)  
  - 401 unauthorized  

- **PUT /mapping-rules/{mappingRuleId}**  
  Update existing mapping rule.  
  Scenarios:  
  - 200 success (claimName, claimValue, name updated)  
  -  400 invalid bodies (each single-field payload: claimName only, claimValue only, name only) -> expects INVALID_ARGUMENT with missing field hints  
  - 404 not found (nonexistent id, expects NOT_FOUND)  
  - 401 unauthorized  

- **DELETE /mapping-rules/{mappingRuleId}**  
  Delete mapping rule.  
  Scenarios:  
  - 204 success then follow-up GET returns 404  
  - 404 not found (nonexistent id)  
  - 401 unauthorized  


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
