### PR TITLE
fix: OpenSearch ISM policy min_index_age is not updated after configuration change

### DIFF
--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -383,6 +383,21 @@ public class SchemaManagerIT {
         .asInstanceOf(type(JsonNode.class))
         .extracting(this::retentionMinAge)
         .isEqualTo("100d");
+
+    // when: update the retention configuration with new values and restart the schema manager
+    retention.setMinimumAge("18d");
+    retention.setUsageMetricsMinimumAge("10d");
+    schemaManager.startup();
+
+    // then: verify that all configured retention policies were updated with new custom values
+    assertThat(searchClientAdapter.getPolicyAsNode("custom-retention-policy"))
+        .asInstanceOf(type(JsonNode.class)) // switch from IterableAssert -> ObjectAssert<JsonNode>
+        .extracting(this::retentionMinAge)
+        .isEqualTo("18d");
+    assertThat(searchClientAdapter.getPolicyAsNode("custom-metrics-retention-policy"))
+        .asInstanceOf(type(JsonNode.class))
+        .extracting(this::retentionMinAge)
+        .isEqualTo("10d");
   }
 
   @TestTemplate


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37361 
