### PR TITLE
feat: migrate business rule task to v2 api usage

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.11
+
+### 🚀 Enhancements
+
+- add root rootDecisionDefinitionKey to decision instance ([#37363](https://github.com/camunda/camunda/pull/37363))
+
+### ❤️ Contributors
+
+- Yuliia Saienko ([@juliasaienko](https://github.com/juliasaienko))
+
 ## v0.0.10
 
 ### 🩹 Fixes

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/decision-instance.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/decision-instance.ts
@@ -39,6 +39,7 @@ const decisionInstanceSchema = z.object({
 	processInstanceKey: z.string(),
 	decisionDefinitionKey: z.string(),
 	elementInstanceKey: z.string(),
+	rootDecisionDefinitionKey: z.string(),
 });
 type DecisionInstance = z.infer<typeof decisionInstanceSchema>;
 
@@ -59,6 +60,7 @@ const queryDecisionInstancesRequestBodySchema = getQueryRequestBodySchema({
 		'decisionDefinitionType',
 		'tenantId',
 		'elementInstanceKey',
+		'rootDecisionDefinitionKey',
 	] as const,
 	filter: z
 		.object({
@@ -77,6 +79,7 @@ const queryDecisionInstancesRequestBodySchema = getQueryRequestBodySchema({
 				processDefinitionKey: true,
 				processInstanceKey: true,
 				elementInstanceKey: true,
+				rootDecisionDefinitionKey: true,
 			}).shape,
 		})
 		.partial(),

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/operate/client/e2e-playwright/mocks/decisionInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/decisionInstance.mocks.ts
@@ -16,6 +16,7 @@ import type {
 const mockEvaluatedDecisionInstance: GetDecisionInstanceResponseBody = {
   decisionEvaluationInstanceKey: '2251799813830820-1',
   decisionEvaluationKey: '2251799813830820',
+  rootDecisionDefinitionKey: '2251799813687886',
   tenantId: '<default>',
   decisionDefinitionKey: '2251799813687886',
   decisionDefinitionId: 'invoiceClassification',
@@ -88,6 +89,7 @@ const mockEvaluatedDecisionInstanceWithoutPanels: GetDecisionInstanceResponseBod
     decisionEvaluationKey: '2251799813830820',
     tenantId: '<default>',
     decisionDefinitionKey: '2251799813687887',
+    rootDecisionDefinitionKey: '2251799813687887',
     decisionDefinitionId: 'amountToString',
     state: 'EVALUATED',
     decisionDefinitionName: 'Convert amount to string',
@@ -134,6 +136,7 @@ const mockFailedDecisionInstance: GetDecisionInstanceResponseBody = {
   decisionEvaluationKey: '6755399441062312',
   tenantId: '<default>',
   decisionDefinitionKey: '2251799813687886',
+  rootDecisionDefinitionKey: '2251799813687886',
   decisionDefinitionId: 'invoiceClassification',
   state: 'FAILED',
   decisionDefinitionName: 'Invoice Classification',

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.10.2",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.9",
+        "@camunda/camunda-api-zod-schemas": "0.0.11",
         "@camunda/camunda-composite-components": "0.19.1",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.57.0",
@@ -558,9 +558,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.9.tgz",
-      "integrity": "sha512-jyvd9Li5C+8ClKHwK3MLVVtLlPj/tNMmSn/ODJIwSjAiiYGa/juOklA6iWRqgf6AFeNaIvEsvP+btDEaebi+Jw==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.11.tgz",
+      "integrity": "sha512-U8N5v6W5PCD3tooIKu46ngE8YSrkEPSPuStlTwtDUa/nZxkuFxvPtaQyvi/OMra4WQtq0KBrZ+feO0S7lHzdjQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -186,6 +186,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -739,6 +740,7 @@
       "integrity": "sha512-NjK9hgwJ8sdvUwYPcb33kTgSJ1uTLh1N5ebzEYwNxckgUePtaiv8fOBUxyLJ1hqohenVhw3/x4DiG3pzgVJi7Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@carbon/feature-flags": "^0.20.0",
@@ -1008,6 +1010,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1031,6 +1034,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3134,6 +3138,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.0.tgz",
       "integrity": "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.83.0"
       },
@@ -3195,6 +3200,7 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3648,6 +3654,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3658,6 +3665,7 @@
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3761,6 +3769,7 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -3991,6 +4000,7 @@
       "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -4273,6 +4283,7 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -4343,6 +4354,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4641,6 +4653,7 @@
       "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.6.2.tgz",
       "integrity": "sha512-3C+ktypiJKTco5U6GmZ3FTqcy2o7KwWY0W1KlNon39tW3RInPqJ3W48impd8cFkZ/9QmvITN99NoZjSBu4JFgw==",
       "license": "SEE LICENSE IN LICENSE",
+      "peer": true,
       "dependencies": {
         "bpmn-moddle": "^9.0.1",
         "diagram-js": "^15.3.0",
@@ -4716,6 +4729,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -5761,6 +5775,7 @@
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.3.0.tgz",
       "integrity": "sha512-Fjq+C8Bee2DhX9N3jpIUIhbqvSbP6oMD75n+y5UChcr34buApZFO+fXsv8a/SlW+tci+6nvc71vf17TBY/RJVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.0",
@@ -6234,6 +6249,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6295,6 +6311,7 @@
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6840,6 +6857,7 @@
       "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.20.10.tgz",
       "integrity": "sha512-TL48Pi1oNHeMOHrKv1bCJUrWZDcD3DIG6AGYVNOnyZPr7Bd/pStN0pL+lfzF5BNoj/FclaoiaLenk4XUIFVYng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.0"
       },
@@ -6856,6 +6874,7 @@
       "resolved": "https://registry.npmjs.org/final-form-arrays/-/final-form-arrays-3.1.0.tgz",
       "integrity": "sha512-TWBvun+AopgBLw9zfTFHBllnKMVNEwCEyDawphPuBGGqNsuhGzhT7yewHys64KFFwzIs6KEteGLpKOwvTQEscQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "final-form": "^4.20.8"
       }
@@ -7420,6 +7439,7 @@
       "integrity": "sha512-2m7bEo/6D+pbxFkFKY/2QOVdknxxXyrXyDdVFobJcQyvfv3985MY+VVwyRZoVJylQG+mzPY5/uDNuXygp8jObA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inferno-shared": "5.6.3",
         "inferno-vnode-flags": "5.6.3",
@@ -8891,6 +8911,7 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.13.7.tgz",
       "integrity": "sha512-aChaVU/DO5aRPmk1GX8L+whocagUUpBQqoPtJk+cm7UOXUk87J4PeWCh6nNmTTIfEhiR9DI/+FnA8dln/hTK7g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -8951,6 +8972,7 @@
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.0.0.tgz",
       "integrity": "sha512-Hpte2hfKDwoZWPvDngsEHjloPnO+sKMUVkAPc0r9PrpnVLqsyPUTV0ZQU8CAp87YmRZ9QzeQMJxdKbaP9vEIKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "min-dash": "^4.2.1"
       }
@@ -8985,7 +9007,8 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -9509,6 +9532,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9635,6 +9659,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9877,6 +9902,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9889,6 +9915,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9914,6 +9941,7 @@
       "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-6.5.9.tgz",
       "integrity": "sha512-x3XYvozolECp3nIjly+4QqxdjSSWfcnpGEL5K8OBT6xmGrq5kBqbA6+/tOqoom9NwqIPPbxPNsOViFlbKgowbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4"
       },
@@ -10228,6 +10256,7 @@
       "integrity": "sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10433,6 +10462,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
       "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -11135,6 +11165,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
       "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",
@@ -11521,6 +11552,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11861,6 +11893,7 @@
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -12160,6 +12193,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -12318,6 +12352,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -12888,6 +12923,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
       "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.10.2",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.9",
+    "@camunda/camunda-api-zod-schemas": "0.0.11",
     "@camunda/camunda-composite-components": "0.19.1",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.57.0",

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/buildMetadata.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/buildMetadata.ts
@@ -6,10 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type V2MetaDataDto} from '../types';
+import {type V2InstanceMetadata} from '../types';
 
 export const buildMetadata = (
-  metadata: V2MetaDataDto['instanceMetadata'] | null,
+  metadata: V2InstanceMetadata | null,
   incident: {
     errorType: {id: string; name: string};
     errorMessage: string;
@@ -19,18 +19,13 @@ export const buildMetadata = (
     return '';
   }
 
-  const {
-    flowNodeInstanceId,
-    calledProcessInstanceId,
-    calledDecisionInstanceId,
-    ...metadataSubset
-  } = metadata;
+  const {calledProcessInstanceId, calledDecisionInstanceId, ...metadataSubset} =
+    metadata;
 
   return JSON.stringify({
     ...metadataSubset,
     incidentErrorType: incident?.errorType.name || null,
     incidentErrorMessage: incident?.errorMessage || null,
-    flowNodeInstanceKey: flowNodeInstanceId,
     calledProcessInstanceKey: calledProcessInstanceId,
     calledDecisionInstanceKey: calledDecisionInstanceId,
   });

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
@@ -108,6 +108,7 @@ const mockDecisionInstance: DecisionInstance = {
   evaluationFailure: '',
   tenantId: '<default>',
   result: '',
+  rootDecisionDefinitionKey: '123',
 };
 
 describe('MetadataPopover', () => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
@@ -13,6 +13,8 @@ import type {
   Job,
   UserTask,
   MessageSubscription,
+  DecisionDefinition,
+  DecisionInstance,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 
 // V2 Element Instance Metadata - extends the old structure but with v2 element instance fields will be removed after other components migration
@@ -80,6 +82,8 @@ function createV2InstanceMetadata(
   job?: Job,
   calledProcess?: ProcessInstance,
   messageSubscription?: MessageSubscription,
+  calledDecisionDefinition?: DecisionDefinition,
+  calledDecisionInstance?: DecisionInstance,
   userTask: Partial<UserTaskSubset> | null = {},
 ): V2InstanceMetadata {
   const {
@@ -103,9 +107,12 @@ function createV2InstanceMetadata(
   return {
     calledProcessInstanceId: calledProcess?.processInstanceKey ?? null,
     calledProcessDefinitionName: calledProcess?.processDefinitionName ?? null,
-    calledDecisionInstanceId: oldMetadata?.calledDecisionInstanceId ?? null,
+    calledDecisionInstanceId:
+      calledDecisionInstance?.decisionEvaluationInstanceKey ?? null,
     calledDecisionDefinitionName:
-      oldMetadata?.calledDecisionDefinitionName ?? null,
+      calledDecisionInstance?.decisionDefinitionName ||
+      calledDecisionDefinition?.name ||
+      null,
     jobRetries: job?.retries ?? null,
     jobDeadline: job?.deadline ?? null,
     jobKey: job?.jobKey ?? null,
@@ -148,6 +155,6 @@ function createV2InstanceMetadata(
   };
 }
 
-export type {V2MetaDataDto};
+export type {V2MetaDataDto, V2InstanceMetadata};
 
 export {createV2InstanceMetadata};

--- a/operate/client/src/modules/api/v2/decisionDefinitions/fetchDecisionDefinition.ts
+++ b/operate/client/src/modules/api/v2/decisionDefinitions/fetchDecisionDefinition.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  type DecisionDefinition,
+  endpoints,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import {requestWithThrow} from 'modules/request';
+
+const fetchDecisionDefinition = async (
+  payload: Pick<DecisionDefinition, 'decisionDefinitionKey'>,
+) => {
+  return requestWithThrow<DecisionDefinition>({
+    url: endpoints.getDecisionDefinition.getUrl(payload),
+    method: endpoints.getDecisionDefinition.method,
+  });
+};
+
+export {fetchDecisionDefinition};

--- a/operate/client/src/modules/mocks/api/v2/decisionDefinitions/fetchDecisionDefinition.ts
+++ b/operate/client/src/modules/mocks/api/v2/decisionDefinitions/fetchDecisionDefinition.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockGetRequest} from '../../mockRequest';
+import {
+  endpoints,
+  type DecisionDefinition,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+
+const mockFetchDecisionDefinition = (decisionDefinitionKey: string) =>
+  mockGetRequest<DecisionDefinition>(
+    endpoints.getDecisionDefinition.getUrl({decisionDefinitionKey}),
+  );
+
+export {mockFetchDecisionDefinition};

--- a/operate/client/src/modules/mocks/metadata.ts
+++ b/operate/client/src/modules/mocks/metadata.ts
@@ -247,6 +247,25 @@ const jobMetadata: Job = {
   deniedReason: '',
 };
 
+const calledDecisionInstanceMetadata = {
+  decisionEvaluationKey: '9876543210',
+  decisionEvaluationInstanceKey: '9876543210',
+  decisionDefinitionName: 'Approval Rules',
+  decisionDefinitionId: 'approval-decision',
+  decisionDefinitionKey: '123456',
+  decisionDefinitionVersion: 1,
+  decisionDefinitionType: 'DECISION_TABLE' as const,
+  processDefinitionKey: '2',
+  processInstanceKey: PROCESS_INSTANCE_ID,
+  elementInstanceKey: '2251799813699889',
+  state: 'EVALUATED' as const,
+  evaluationDate: '2023-01-15T10:05:00.000Z',
+  evaluationFailure: '',
+  tenantId: '<default>',
+  result: '',
+  rootDecisionDefinitionKey: '123456',
+};
+
 export {
   baseMetadata as singleInstanceMetadata,
   incidentFlowNodeMetaData,
@@ -262,6 +281,7 @@ export {
   incidentsByProcessKeyMetadata,
   processDefinitionMetadata,
   jobMetadata,
+  calledDecisionInstanceMetadata,
   PROCESS_INSTANCE_ID,
   CALL_ACTIVITY_FLOW_NODE_ID,
   FLOW_NODE_ID,

--- a/operate/client/src/modules/mocks/mockDecisionInstance.ts
+++ b/operate/client/src/modules/mocks/mockDecisionInstance.ts
@@ -22,6 +22,7 @@ const invoiceClassification: GetDecisionInstanceResponseBody = {
   processDefinitionKey: '666',
   elementInstanceKey: '37423847',
   evaluationFailure: '',
+  rootDecisionDefinitionKey: '111',
   evaluatedInputs: [
     {inputId: '0', inputName: 'Age', inputValue: '16'},
     {inputId: '1', inputName: 'Stateless Person', inputValue: 'false'},
@@ -122,6 +123,7 @@ const assignApproverGroup: GetDecisionInstanceResponseBody = {
   processDefinitionKey: '777',
   elementInstanceKey: '2347238947239',
   evaluationFailure: 'An error occurred',
+  rootDecisionDefinitionKey: '111',
   evaluatedInputs: [
     {
       inputId: '0',
@@ -166,6 +168,7 @@ const literalExpression: GetDecisionInstanceResponseBody = {
   processDefinitionKey: '42',
   elementInstanceKey: '623426348231',
   evaluationFailure: '',
+  rootDecisionDefinitionKey: '111',
   evaluatedInputs: [],
   matchedRules: [],
   decisionDefinitionType: 'LITERAL_EXPRESSION',

--- a/operate/client/src/modules/queries/decisionDefinitions/useDecisionDefinition.ts
+++ b/operate/client/src/modules/queries/decisionDefinitions/useDecisionDefinition.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {skipToken, useQuery} from '@tanstack/react-query';
+import {fetchDecisionDefinition} from 'modules/api/v2/decisionDefinitions/fetchDecisionDefinition.ts';
+
+const DECISION_DEFINITION_QUERY_KEY = 'decisionDefinition';
+
+const useDecisionDefinition = (
+  decisionDefinitionKey: string,
+  options?: {
+    enabled?: boolean;
+  },
+) => {
+  return useQuery({
+    queryKey: [DECISION_DEFINITION_QUERY_KEY, decisionDefinitionKey],
+    queryFn: decisionDefinitionKey
+      ? async () => {
+          const {response, error} = await fetchDecisionDefinition({
+            decisionDefinitionKey,
+          });
+          if (response !== null) {
+            return response;
+          }
+          throw error;
+        }
+      : skipToken,
+    enabled: options?.enabled,
+  });
+};
+
+export {useDecisionDefinition};

--- a/operate/client/src/modules/queries/decisionDefinitions/useDecisionDefinition.ts
+++ b/operate/client/src/modules/queries/decisionDefinitions/useDecisionDefinition.ts
@@ -6,18 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-/*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
- */
-
 import {skipToken, useQuery} from '@tanstack/react-query';
 import {fetchDecisionDefinition} from 'modules/api/v2/decisionDefinitions/fetchDecisionDefinition.ts';
-
-const DECISION_DEFINITION_QUERY_KEY = 'decisionDefinition';
+import {queryKeys} from 'modules/queries/queryKeys';
 
 const useDecisionDefinition = (
   decisionDefinitionKey: string,
@@ -26,7 +17,7 @@ const useDecisionDefinition = (
   },
 ) => {
   return useQuery({
-    queryKey: [DECISION_DEFINITION_QUERY_KEY, decisionDefinitionKey],
+    queryKey: queryKeys.decisionDefinitions.get(decisionDefinitionKey),
     queryFn: decisionDefinitionKey
       ? async () => {
           const {response, error} = await fetchDecisionDefinition({

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -31,6 +31,12 @@ const queryKeys = {
       decisionEvaluationKey,
     ],
   },
+  decisionDefinitions: {
+    get: (decisionDefinitionKey: string) => [
+      'decisionDefinition',
+      decisionDefinitionKey,
+    ],
+  },
   processDefinitionXml: {
     get: (processDefinitionKey?: string) => [
       'processDefinitionXml',

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.16.0",
         "@bpmn-io/form-js-viewer": "1.16.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.9",
+        "@camunda/camunda-api-zod-schemas": "0.0.11",
         "@camunda/camunda-composite-components": "0.20.2",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.87.1",
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.9.tgz",
-      "integrity": "sha512-jyvd9Li5C+8ClKHwK3MLVVtLlPj/tNMmSn/ODJIwSjAiiYGa/juOklA6iWRqgf6AFeNaIvEsvP+btDEaebi+Jw==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.11.tgz",
+      "integrity": "sha512-U8N5v6W5PCD3tooIKu46ngE8YSrkEPSPuStlTwtDUa/nZxkuFxvPtaQyvi/OMra4WQtq0KBrZ+feO0S7lHzdjQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.16.0",
     "@bpmn-io/form-js-viewer": "1.16.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.9",
+    "@camunda/camunda-api-zod-schemas": "0.0.11",
     "@camunda/camunda-composite-components": "0.20.2",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.87.1",


### PR DESCRIPTION
## Description

This PR migrates business rule task data of MetadataPopover.

- Migrates MetadataPopover to use v2 endpoints to get business rule task data:
    - query all related to an element decision instances using
    - define root(called) definition
    - fetch dpecific definition(if needed)
- Extends DecisionInstance schema in `@camunda/camunda-api-zod-schemas` with `rootDecisionDefinitionKey`

**Note:** The test case for the UNSPECIFIED decision was skipped and partially commented out, as work is currently in progress to remove non-existent decision states(#39658). Since the current schema supports only "EVALUATED" and "FAILED" states, it seems this test will soon become redundant

## Related issues

closes #33217 
