### PR TITLE
[Backport stable/8.7] Add exporter state to identify exporters whose configuration is removed

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -264,6 +264,7 @@ final class ClusterApiUtils {
     return switch (state) {
       case DISABLED -> ExporterStateCode.DISABLED;
       case ENABLED -> ExporterStateCode.ENABLED;
+      case CONFIG_NOT_FOUND -> ExporterStateCode.CONFIG_NOT_FOUND;
     };
   }
 
@@ -484,6 +485,10 @@ final class ClusterApiUtils {
           new ExporterStatus().exporterId(exporterId).status(ExporterStatus.StatusEnum.ENABLED);
       case DISABLED ->
           new ExporterStatus().exporterId(exporterId).status(ExporterStatus.StatusEnum.DISABLED);
+      case CONFIG_NOT_FOUND ->
+          new ExporterStatus()
+              .exporterId(exporterId)
+              .status(ExporterStatus.StatusEnum.CONFIG_NOT_FOUND);
     };
   }
 }

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -364,6 +364,7 @@ schemas:
       - UNKNOWN
       - ENABLED
       - DISABLED
+      - CONFIG_NOT_FOUND
 
   PartitionStateCode:
     title: PartitionStateCode

--- a/dist/src/main/resources/api/cluster/exporter-api.yaml
+++ b/dist/src/main/resources/api/cluster/exporter-api.yaml
@@ -110,6 +110,7 @@ components:
             - DISABLING
             - DISABLED
             - UNKNOWN
+            - CONFIG_NOT_FOUND
           description: Status of the exporter
           example: "ENABLED"
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
@@ -7,24 +7,33 @@
  */
 package io.camunda.zeebe.dynamic.config;
 
+import static org.slf4j.LoggerFactory.*;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.List;
+import java.util.Map.Entry;
 import java.util.Set;
+import org.slf4j.Logger;
 
 /**
  * Updates the exporter state of the local member in the configuration. If a broker restarts with a
  * changes of exporters in the static configuration, this modifier updates the dynamic config to
  * reflect that. If new exporter are added to the static configuration, they are added to the
  * dynamic config with state ENABLED. If existing exporters are removed, they are marked as
- * disabled. Note that the exporters are not removed from the dynamic config.
+ * CONFIG_NOT_FOUND. Note that the exporters are not removed from the dynamic config.
  */
 public class ExporterStateInitializer implements ClusterConfigurationModifier {
 
+  private static final Logger LOGGER = getLogger(ExporterStateInitializer.class);
   private final Set<String> configuredExporters;
   private final MemberId localMemberId;
   private final ConcurrencyControl executor;
@@ -75,13 +84,48 @@ public class ExporterStateInitializer implements ClusterConfigurationModifier {
 
     final var newlyAddedExporters =
         configuredExporters.stream().filter(id -> !exportersInConfig.containsKey(id)).toList();
-    final var removedExporters =
-        exportersInConfig.keySet().stream()
-            .filter(id -> !configuredExporters.contains(id))
+    final var configRemovedExporters =
+        exportersInConfig.entrySet().stream()
+            // Only mark exporters as CONFIG_NOT_FOUND if they are currently enabled.
+            .filter(entry -> State.ENABLED.equals(entry.getValue().state()))
+            .filter(entry -> !configuredExporters.contains(entry.getKey()))
+            .map(Entry::getKey)
+            .toList();
+
+    if (!configRemovedExporters.isEmpty()) {
+      LOGGER.warn(
+          "Previously configured exporters [{}] are not found in the application properties. "
+              + "They will be paused. Please add the configuration back or remove the exporter using the management api.",
+          configRemovedExporters);
+    }
+    // Re-enable exporters whose configuration is added back to the application properties.
+    final var configReaddedExporters =
+        exportersInConfig.entrySet().stream()
+            .filter(entry -> exportersInConfig.containsKey(entry.getKey()))
+            .filter(entry -> entry.getValue().state().equals(State.CONFIG_NOT_FOUND))
             .toList();
 
     return initializedPartitionState
-        .updateConfig(c -> c.updateExporting(e -> e.disableExporters(removedExporters)))
+        .updateConfig(c -> c.updateExporting(e -> e.withConfigNotFoundFor(configRemovedExporters)))
+        .updateConfig(c -> c.updateExporting(e -> reEnableExporters(e, configReaddedExporters)))
         .updateConfig(c -> c.updateExporting(e -> e.addExporters(newlyAddedExporters)));
+  }
+
+  private ExportersConfig reEnableExporters(
+      final ExportersConfig exportersConfig,
+      final List<Entry<String, ExporterState>> configReaddedExporters) {
+
+    ExportersConfig updating = exportersConfig;
+    for (final var entry : configReaddedExporters) {
+      final var exporterName = entry.getKey();
+      final var exporterState = entry.getValue();
+      // reuse the metadata version and initializedFrom from the existing exporter state
+      updating =
+          updating.enableExporter(
+              exporterName,
+              exporterState.initializedFrom().orElse(null),
+              exporterState.metadataVersion());
+    }
+    return updating;
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -226,6 +226,9 @@ public class ProtoBufSerializer
       case DISABLED ->
           new ExporterState(
               value.getMetadataVersion(), ExporterState.State.DISABLED, initializeFrom);
+      case CONFIG_NOT_FOUND ->
+          new ExporterState(
+              value.getMetadataVersion(), ExporterState.State.CONFIG_NOT_FOUND, initializeFrom);
       case UNRECOGNIZED, ENABLED_DISBALED_UNKNOWN ->
           throw new IllegalStateException("Unknown exporter state " + value.getState());
     };
@@ -281,8 +284,9 @@ public class ProtoBufSerializer
   private Topology.ExporterState encodeExporterState(final ExporterState value) {
     final var state =
         switch (value.state()) {
-          case ENABLED -> Topology.EnabledDisabledState.ENABLED;
-          case DISABLED -> Topology.EnabledDisabledState.DISABLED;
+          case ENABLED -> Topology.ExporterStateEnum.ENABLED;
+          case DISABLED -> Topology.ExporterStateEnum.DISABLED;
+          case CONFIG_NOT_FOUND -> Topology.ExporterStateEnum.CONFIG_NOT_FOUND;
         };
     final var builder =
         Topology.ExporterState.newBuilder()

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExporterState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExporterState.java
@@ -22,7 +22,19 @@ import java.util.Optional;
  */
 public record ExporterState(long metadataVersion, State state, Optional<String> initializedFrom) {
   public enum State {
+    /** The records will be exported to this exporter */
     ENABLED,
-    DISABLED
+    /**
+     * The records are not exported to this exporter. But the ExporterMetadata of this exporter is
+     * persisted in the cluster. When this exporter is re-enabled, it will start exporting new
+     * records and reuse the previous metadata. Note that the records created while this exporter is
+     * disabled may not be available to export to this exporter anymore.
+     */
+    DISABLED,
+    /**
+     * The exporter is still enabled, but unable to export because it has been removed from the
+     * application properties.
+     */
+    CONFIG_NOT_FOUND,
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportersConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportersConfig.java
@@ -90,4 +90,27 @@ public record ExportersConfig(Map<String, ExporterState> exporters) {
         builder.buildKeepingLast(); // choose last one if there are duplicate keys
     return new ExportersConfig(newExporters);
   }
+
+  /**
+   * Updates existing exporters to state {@link ExporterState.State#CONFIG_NOT_FOUND}.
+   *
+   * @param exporterNames the names of exporters for which the state should be updated
+   * @return a new {@link ExportersConfig} with the updated state for the specified exporters
+   */
+  public ExportersConfig withConfigNotFoundFor(final Collection<String> exporterNames) {
+    final var builder = ImmutableMap.<String, ExporterState>builder().putAll(exporters);
+
+    exporterNames.forEach(
+        exporterName ->
+            builder.put(
+                exporterName,
+                new ExporterState(
+                    exporters.get(exporterName).metadataVersion(),
+                    ExporterState.State.CONFIG_NOT_FOUND,
+                    exporters.get(exporterName).initializedFrom())));
+
+    final var newExporters =
+        builder.buildKeepingLast(); // choose last one if there are duplicate keys
+    return new ExportersConfig(newExporters);
+  }
 }

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -55,7 +55,7 @@ message ExportersConfig{
 }
 
 message ExporterState {
-  EnabledDisabledState state = 1;
+  ExporterStateEnum state = 1;
   int64 metadataVersion = 2;
   optional string initializedFrom = 3;
 }
@@ -157,10 +157,11 @@ enum ChangeStatus {
   CANCELLED = 4;
 }
 
-enum EnabledDisabledState {
+enum ExporterStateEnum {
   ENABLED_DISBALED_UNKNOWN = 0;
   ENABLED = 1;
   DISABLED = 2;
+  CONFIG_NOT_FOUND = 3;
 }
 
 


### PR DESCRIPTION
# Description
Backport of #35383 to `stable/8.7`.

BREAKING CHANGE:
This PR renames the enum in ExporterState in dynamic-config/topology.proto. This is not technically a breaking change because the binary representation is not changed. Hence we can safely accept this change.

relates to #35318