### PR TITLE
Send a slack message to #zeebe-ci if the medic benchmark creation fails

### DIFF
--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -14,6 +14,9 @@ on:
     # Runs at 1am every monday https://crontab.guru/#0_1_*_*_1
     - cron: 0 1 * * 1
 
+permissions:
+  contents: read
+
 jobs:
   delete-old-benchmarks:
     runs-on: ubuntu-latest
@@ -124,3 +127,35 @@ jobs:
       benchmark-load: >
         --set starter.rate=1
         --set workers.benchmark.replicas=1
+
+  notify:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    needs: [ delete-old-benchmarks, setup-normal-benchmark, setup-mixed-benchmark, setup-latency-benchmark ]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v4
+      - id: slack-notify
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: *Medic benchmark creation failed:*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "@zeebe-medic Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The mixed benchmark creation was broken for a few weeks and somehow went unnoticed. Adding a notification if the workflow fails makes it more visible when this happens.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

N/A
