### PR TITLE
ci: allow SNAPSHOT upload on future stable branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1355,7 +1355,7 @@ jobs:
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 25
     permissions: { }  # GITHUB_TOKEN unused in this job
-    if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
     concurrency:
       group: ${{ needs.utils-get-concurrency-group-for-maven-snapshot.outputs.concurrency_group_name }}
       cancel-in-progress: false


### PR DESCRIPTION
## Description

Since we will be forking future `stable/*` branches from `main`, those will inherit the CI code from `main` as well.

We want to run the `deploy-snapshots` Unified CI job on `main` and all `stable/*` branches to ensure [delivery of promised SNAPSHOT artifacts](https://github.com/camunda/camunda/wiki/CI-&-Automation#available-snapshot-artifacts) - similar as the `deploy-camunda-docker-snapshot` job already does.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to #37374
