### PR TITLE
feat: add internal-api to unified configuration

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -77,6 +77,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/configuration/src/main/java/io/camunda/configuration/InternalApi.java
+++ b/configuration/src/main/java/io/camunda/configuration/InternalApi.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import io.camunda.zeebe.broker.system.configuration.NetworkCfg;
+import io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults;
+import java.util.Map;
+import java.util.Set;
+
+public class InternalApi {
+  private static final String PREFIX = "camunda.cluster.network.internal-api";
+
+  private static final Map<String, String> LEGACY_GATEWAY_NETWORK_INTERNAL_API_PROPERTIES =
+      // "host" and "advertisedHost" are intentionally empty because the legacy values are not
+      // resolved here. They are considered when accessing Network.getHost() and
+      // Network.getAdvertisedHost() in GatewayBasePropertiesOverride.
+      Map.of(
+          "host", "",
+          "port", "zeebe.gateway.cluster.port",
+          "advertisedHost", "",
+          "advertisedPort", "zeebe.gateway.cluster.advertisedPort");
+
+  private static final Map<String, String> LEGACY_BROKER_NETWORK_INTERNAL_API_PROPERTIES =
+      Map.of(
+          "host", "zeebe.broker.network.internalApi.host",
+          "port", "zeebe.broker.network.internalApi.port",
+          "advertisedHost", "zeebe.broker.network.internalApi.advertisedHost",
+          "advertisedPort", "zeebe.broker.network.internalApi.advertisedPort");
+
+  private Map<String, String> legacyPropertiesMap = LEGACY_BROKER_NETWORK_INTERNAL_API_PROPERTIES;
+
+  /** Overrides the host used for internal broker-to-broker communication */
+  private String host;
+
+  /** Sets the port used for internal broker-to-broker communication */
+  private Integer port;
+
+  /**
+   * Controls the advertised host. This is particularly useful if your broker stands behind a proxy.
+   *
+   * <p>If omitted, defaults to:
+   *
+   * <ul>
+   *   <li>If zeebe.broker.network.internalApi.host was set, use this.
+   *   <li>Use the resolved value of zeebe.broker.network.advertisedHost
+   * </ul>
+   */
+  private String advertisedHost;
+
+  /**
+   * Controls the advertised port; if omitted defaults to the port. This is particularly useful if
+   * your broker stands behind a proxy.
+   */
+  private Integer advertisedPort;
+
+  public String getHost() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".host",
+        host,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("host")));
+  }
+
+  public void setHost(final String host) {
+    this.host = host;
+  }
+
+  public Integer getPort() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".port",
+        port,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("port")));
+  }
+
+  public void setPort(final Integer port) {
+    this.port = port;
+  }
+
+  public String getAdvertisedHost() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".advertised-host",
+        advertisedHost,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("advertisedHost")));
+  }
+
+  public void setAdvertisedHost(final String advertisedHost) {
+    this.advertisedHost = advertisedHost;
+  }
+
+  public Integer getAdvertisedPort() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".advertised-port",
+        advertisedPort,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(legacyPropertiesMap.get("advertisedPort")));
+  }
+
+  public void setAdvertisedPort(final Integer advertisedPort) {
+    this.advertisedPort = advertisedPort;
+  }
+
+  @Override
+  public InternalApi clone() {
+    final InternalApi copy = new InternalApi();
+    copy.host = host;
+    copy.port = port;
+    copy.advertisedHost = advertisedHost;
+    copy.advertisedPort = advertisedPort;
+
+    return copy;
+  }
+
+  public InternalApi withBrokerInternalApiProperties() {
+    final var copy = clone();
+    copy.legacyPropertiesMap = LEGACY_BROKER_NETWORK_INTERNAL_API_PROPERTIES;
+    copy.port = copy.port == null ? NetworkCfg.DEFAULT_INTERNAL_API_PORT : copy.port;
+    return copy;
+  }
+
+  public InternalApi withGatewayInternalApiProperties() {
+    final var copy = clone();
+    copy.legacyPropertiesMap = LEGACY_GATEWAY_NETWORK_INTERNAL_API_PROPERTIES;
+    copy.port = copy.port == null ? ConfigurationDefaults.DEFAULT_CLUSTER_PORT : copy.port;
+    return copy;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Network.java
+++ b/configuration/src/main/java/io/camunda/configuration/Network.java
@@ -85,6 +85,9 @@ public class Network {
    */
   private Duration heartbeatInterval = Duration.ofSeconds(5);
 
+  /** Sets the internal api configuration */
+  private InternalApi internalApi = new InternalApi();
+
   public String getHost() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         PREFIX + ".host",
@@ -189,6 +192,14 @@ public class Network {
     this.heartbeatInterval = heartbeatInterval;
   }
 
+  public InternalApi getInternalApi() {
+    return internalApi;
+  }
+
+  public void setInternalApi(final InternalApi internalApi) {
+    this.internalApi = internalApi;
+  }
+
   @Override
   public Network clone() {
     final Network copy = new Network();
@@ -200,6 +211,7 @@ public class Network {
     copy.socketReceiveBuffer = socketReceiveBuffer;
     copy.heartbeatTimeout = heartbeatTimeout;
     copy.heartbeatInterval = heartbeatInterval;
+    copy.internalApi = internalApi;
 
     return copy;
   }

--- a/configuration/src/test/java/io/camunda/configuration/BrokerInternalApiTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/BrokerInternalApiTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.NetworkCfg;
+import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class BrokerInternalApiTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.network.internal-api.host=hostNew",
+        "camunda.cluster.network.internal-api.port=10",
+        "camunda.cluster.network.internal-api.advertised-host=advertisedHostNew",
+        "camunda.cluster.network.internal-api.advertised-port=30",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFromNew() {
+      assertThat(brokerCfg.getNetwork().getInternalApi())
+          .returns("hostNew", SocketBindingCfg::getHost)
+          .returns(10, SocketBindingCfg::getPort)
+          .returns("advertisedHostNew", SocketBindingCfg::getAdvertisedHost)
+          .returns(30, SocketBindingCfg::getAdvertisedPort);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.gateway.cluster.host=hostLegacyGateway",
+        "zeebe.gateway.cluster.port=20",
+        "zeebe.gateway.cluster.advertisedHost=advertisedHostLegacyGateway",
+        "zeebe.gateway.cluster.advertisedPort=40"
+      })
+  class WithOnlyLegacyGatewayPropertiesSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacyGatewayPropertiesSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldNotSetFromLegacyGateway() {
+      assertThat(brokerCfg.getNetwork().getInternalApi())
+          .returns(null, SocketBindingCfg::getHost)
+          .returns(NetworkCfg.DEFAULT_INTERNAL_API_PORT, SocketBindingCfg::getPort)
+          .returns(null, SocketBindingCfg::getAdvertisedHost);
+
+      // We expect a NullPointerException here because advertisedPort is unset.
+      // This confirms that no advertisedPort has been configured.
+      try {
+        brokerCfg.getNetwork().getInternalApi().getAdvertisedPort();
+      } catch (final NullPointerException e) {
+        assertThat(e).isInstanceOf(NullPointerException.class);
+      }
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.network.internalApi.host=hostLegacyBroker",
+        "zeebe.broker.network.internalApi.port=30",
+        "zeebe.broker.network.internalApi.advertisedHost=advertisedHostLegacyBroker",
+        "zeebe.broker.network.internalApi.advertisedPort=50"
+      })
+  class WithOnlyLegacyBrokerSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacyBrokerSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFromLegacyBroker() {
+      assertThat(brokerCfg.getNetwork().getInternalApi())
+          .returns("hostLegacyBroker", SocketBindingCfg::getHost)
+          .returns(30, SocketBindingCfg::getPort)
+          .returns("advertisedHostLegacyBroker", SocketBindingCfg::getAdvertisedHost)
+          .returns(50, SocketBindingCfg::getAdvertisedPort);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.cluster.network.internal-api.host=hostNew",
+        "camunda.cluster.network.internal-api.port=10",
+        "camunda.cluster.network.internal-api.advertised-host=advertisedHostNew",
+        "camunda.cluster.network.internal-api.advertised-port=30",
+        // legacy gateway
+        "zeebe.gateway.cluster.host=hostLegacyGateway",
+        "zeebe.gateway.cluster.port=20",
+        "zeebe.gateway.cluster.advertisedHost=advertisedHostLegacyGateway",
+        "zeebe.gateway.cluster.advertisedPort=40",
+        // legacy broker
+        "zeebe.broker.network.internalApi.host=hostLegacyBroker",
+        "zeebe.broker.network.internalApi.port=30",
+        "zeebe.broker.network.internalApi.advertisedHost=advertisedHostLegacyBroker",
+        "zeebe.broker.network.internalApi.advertisedPort=50"
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFromNew() {
+      assertThat(brokerCfg.getNetwork().getInternalApi())
+          .returns("hostNew", SocketBindingCfg::getHost)
+          .returns(10, SocketBindingCfg::getPort)
+          .returns("advertisedHostNew", SocketBindingCfg::getAdvertisedHost)
+          .returns(30, SocketBindingCfg::getAdvertisedPort);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/GatewayInternalApiTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/GatewayInternalApiTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CLUSTER_HOST;
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CLUSTER_PORT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.utils.net.Address;
+import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
+import io.camunda.configuration.beans.GatewayBasedProperties;
+import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  GatewayBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+public class GatewayInternalApiTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.network.internal-api.host=hostNew",
+        "camunda.cluster.network.internal-api.port=10",
+        "camunda.cluster.network.internal-api.advertised-host=advertisedHostNew",
+        "camunda.cluster.network.internal-api.advertised-port=30",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetFromNew() {
+      assertThat(gatewayCfg.getCluster())
+          .returns("hostNew", ClusterCfg::getHost)
+          .returns(10, ClusterCfg::getPort)
+          .returns("advertisedHostNew", ClusterCfg::getAdvertisedHost)
+          .returns(30, ClusterCfg::getAdvertisedPort);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.network.internalApi.host=hostLegacyBroker",
+        "zeebe.broker.network.internalApi.port=30",
+        "zeebe.broker.network.internalApi.advertisedHost=advertisedHostLegacyBroker",
+        "zeebe.broker.network.internalApi.advertisedPort=50"
+      })
+  class WithOnlyLegacyBrokerSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyLegacyBrokerSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldNotSetFromLegacyBroker() {
+      assertThat(gatewayCfg.getCluster())
+          .returns(DEFAULT_CLUSTER_HOST, ClusterCfg::getHost)
+          .returns(DEFAULT_CLUSTER_PORT, ClusterCfg::getPort)
+          .returns(Address.defaultAdvertisedHost().getHostAddress(), ClusterCfg::getAdvertisedHost)
+          .returns(DEFAULT_CLUSTER_PORT, ClusterCfg::getAdvertisedPort);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.gateway.cluster.host=hostLegacyGateway",
+        "zeebe.gateway.cluster.port=20",
+        "zeebe.gateway.cluster.advertisedHost=advertisedHostLegacyGateway",
+        "zeebe.gateway.cluster.advertisedPort=40"
+      })
+  class WithOnlyLegacyGatewayPropertiesSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyLegacyGatewayPropertiesSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetFromLegacyGateway() {
+      assertThat(gatewayCfg.getCluster())
+          .returns("hostLegacyGateway", ClusterCfg::getHost)
+          .returns(20, ClusterCfg::getPort)
+          .returns("advertisedHostLegacyGateway", ClusterCfg::getAdvertisedHost)
+          .returns(40, ClusterCfg::getAdvertisedPort);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.gateway.cluster.host=hostLegacyGateway",
+        "zeebe.gateway.cluster.port=20",
+      })
+  class WithOnlyLegacyGatewayHostAndPortSet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithOnlyLegacyGatewayHostAndPortSet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetAdvertisedHostAndGatewayFromLegacyGatewayIfNotSpecified() {
+      assertThat(gatewayCfg.getCluster())
+          .returns("hostLegacyGateway", ClusterCfg::getAdvertisedHost)
+          .returns(20, ClusterCfg::getAdvertisedPort);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.cluster.network.internal-api.host=hostNew",
+        "camunda.cluster.network.internal-api.port=10",
+        "camunda.cluster.network.internal-api.advertised-host=advertisedHostNew",
+        "camunda.cluster.network.internal-api.advertised-port=30",
+        // legacy broker
+        "zeebe.broker.network.internalApi.host=hostLegacyBroker",
+        "zeebe.broker.network.internalApi.port=30",
+        "zeebe.broker.network.internalApi.advertisedHost=advertisedHostLegacyBroker",
+        "zeebe.broker.network.internalApi.advertisedPort=50",
+        // legacy gateway
+        "zeebe.gateway.cluster.host=hostLegacyGateway",
+        "zeebe.gateway.cluster.port=20",
+        "zeebe.gateway.cluster.advertisedHost=advertisedHostLegacyGateway",
+        "zeebe.gateway.cluster.advertisedPort=40"
+      })
+  class WithNewAndLegacySet {
+    final GatewayBasedProperties gatewayCfg;
+
+    WithNewAndLegacySet(@Autowired final GatewayBasedProperties gatewayCfg) {
+      this.gatewayCfg = gatewayCfg;
+    }
+
+    @Test
+    void shouldSetFromNew() {
+      assertThat(gatewayCfg.getCluster())
+          .returns("hostNew", ClusterCfg::getHost)
+          .returns(10, ClusterCfg::getPort)
+          .returns("advertisedHostNew", ClusterCfg::getAdvertisedHost)
+          .returns(30, ClusterCfg::getAdvertisedPort);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.cluster.network.internal-api in unified config.

The legacy properties are:
zeebe.gateway.cluster.host
zeebe.gateway.cluster.port
zeebe.gateway.cluster.advertisedHost
zeebe.gateway.cluster.advertisedPort
zeebe.broker.network.internalApi.host
zeebe.broker.network.internalApi.port
zeebe.broker.network.internalApi.advertisedHost
zeebe.broker.network.internalApi.advertisedPort

The new properties are:

camunda.cluster.network.internal-api.host
camunda.cluster.network.internal-api.port
camunda.cluster.network.internal-api.advertised-host
camunda.cluster.network.internal-api.advertised-port

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34906 