### PR TITLE
Fix latency benchmark by renaming benchmark to worker

### DIFF
--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -126,7 +126,7 @@ jobs:
       reuse-tag: ${{ inputs.reuse-tag || '' }}
       benchmark-load: >
         --set starter.rate=1
-        --set workers.benchmark.replicas=1
+        --set workers.worker.replicas=1
 
   notify:
     name: Notify on failure


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Benchmark got renamed to worker in the benchmark charts. This needs to be adjusted here as well.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
