### PR TITLE
fix: map batch operation states correctly

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
@@ -53,7 +53,7 @@ public class BatchOperationImpl implements BatchOperation {
   public BatchOperationImpl(final BatchOperationResponse item) {
     batchOperationKey = item.getBatchOperationKey();
     type = EnumUtil.convert(item.getBatchOperationType(), BatchOperationType.class);
-    status = item.getState() != null ? BatchOperationState.valueOf(item.getState().name()) : null;
+    status = EnumUtil.convert(item.getState(), BatchOperationState.class);
     startDate = item.getStartDate();
     endDate = item.getEndDate();
     operationsTotalCount = item.getOperationsTotalCount();

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.protocol.rest.*;
+import io.camunda.client.protocol.rest.BatchOperationResponse.StateEnum;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import java.util.*;
@@ -33,7 +34,10 @@ public class QueryBatchOperationTest extends ClientRestTest {
     // given
     final String batchOperationKey = "123";
     gatewayService.onBatchOperationRequest(
-        batchOperationKey, Instancio.create(BatchOperationResponse.class));
+        batchOperationKey,
+        Instancio.create(BatchOperationResponse.class)
+            .state(StateEnum.UNKNOWN_DEFAULT_OPEN_API)
+            .batchOperationType(BatchOperationTypeEnum.UNKNOWN_DEFAULT_OPEN_API));
 
     // when
     client.newBatchOperationGetRequest(batchOperationKey).send().join();


### PR DESCRIPTION
## Description

The batch operation state in Java client responses must be transformed considering unsupported values. The EnumUtil provided by the client takes care of this automatically.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37289 
