### PR TITLE
test: stabilize flaky role migration acceptance tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -225,6 +225,11 @@ public class KeycloakIdentityMigrationIT {
               assertThat(roles.items())
                   .extracting(Role::getRoleId)
                   .contains("operate", "tasklist", "zeebe", "identity");
+
+              final var authorizations = client.newAuthorizationSearchRequest().send().join();
+              assertThat(authorizations.items())
+                  .extracting(Authorization::getOwnerId)
+                  .contains("operate", "tasklist", "zeebe", "identity");
             });
 
     // then

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
@@ -192,6 +192,11 @@ public class OidcIdentityMigrationIT {
               assertThat(roles.items())
                   .extracting(Role::getRoleId)
                   .contains("operate", "tasklist", "zeebe", "identity");
+
+              final var authorizations = client.newAuthorizationSearchRequest().send().join();
+              assertThat(authorizations.items())
+                  .extracting(Authorization::getOwnerId)
+                  .contains("operate", "tasklist", "zeebe", "identity");
             });
 
     // then


### PR DESCRIPTION
## Description

Await presence of authorizations for all role ids.

All recent observed flakes showed an absence of zeebe role authorizations, I could reproduce it locally and adding a sleep after the migration app completion resolved it. Thus we seem to be troubled by a race-condition here.

This adds an assertion on the presence of authorizations for all roles to the await step. That still leaves a chance for particular authorizations missing but that should be way lower. 🙏 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
