### PR TITLE
[Backport release-8.8.0-alpha8] test: stabilize flaky role migration acceptance tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -225,6 +225,11 @@ public class KeycloakIdentityMigrationIT {
               assertThat(roles.items())
                   .extracting(Role::getRoleId)
                   .contains("operate", "tasklist", "zeebe", "identity");
+
+              final var authorizations = client.newAuthorizationSearchRequest().send().join();
+              assertThat(authorizations.items())
+                  .extracting(Authorization::getOwnerId)
+                  .contains("operate", "tasklist", "zeebe", "identity");
             });
 
     // then

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
@@ -192,6 +192,11 @@ public class OidcIdentityMigrationIT {
               assertThat(roles.items())
                   .extracting(Role::getRoleId)
                   .contains("operate", "tasklist", "zeebe", "identity");
+
+              final var authorizations = client.newAuthorizationSearchRequest().send().join();
+              assertThat(authorizations.items())
+                  .extracting(Authorization::getOwnerId)
+                  .contains("operate", "tasklist", "zeebe", "identity");
             });
 
     // then


### PR DESCRIPTION
# Description
Backport of #37397 to `release-8.8.0-alpha8`.

relates to 