### PR TITLE
Remove explicit permission on weekly medic benchmark workfow

### DIFF
--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -14,9 +14,6 @@ on:
     # Runs at 1am every monday https://crontab.guru/#0_1_*_*_1
     - cron: 0 1 * * 1
 
-permissions:
-  contents: read
-
 jobs:
   delete-old-benchmarks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The required permissions are defined on the job level in the zeebe-benchmark workflow.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
