### PR TITLE
fix: Monaco error on dev mode

### DIFF
--- a/tasklist/client/vite.config.ts
+++ b/tasklist/client/vite.config.ts
@@ -70,6 +70,9 @@ export default defineConfig(({mode}) => ({
       src: path.resolve(__dirname, './src'),
     },
   },
+  optimizeDeps: {
+    exclude: ['monaco-editor'],
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Due to some Vite optimizations in dev mode pages which loaded Monaco would fail in dev with the errors below
<img width="1369" height="385" alt="image" src="https://github.com/user-attachments/assets/aeea1d53-7cc9-450e-8691-6199f80b4bc3" />
<img width="1720" height="1100" alt="image" src="https://github.com/user-attachments/assets/8d483ad4-e7f8-49a1-b7e3-2ba91af8d015" />
