### PR TITLE
[Backport release-8.8.0-alpha8] fix: map batch operation states correctly

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
@@ -53,7 +53,7 @@ public class BatchOperationImpl implements BatchOperation {
   public BatchOperationImpl(final BatchOperationResponse item) {
     batchOperationKey = item.getBatchOperationKey();
     type = EnumUtil.convert(item.getBatchOperationType(), BatchOperationType.class);
-    status = item.getState() != null ? BatchOperationState.valueOf(item.getState().name()) : null;
+    status = EnumUtil.convert(item.getState(), BatchOperationState.class);
     startDate = item.getStartDate();
     endDate = item.getEndDate();
     operationsTotalCount = item.getOperationsTotalCount();

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.protocol.rest.*;
+import io.camunda.client.protocol.rest.BatchOperationResponse.StateEnum;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import java.util.*;
@@ -33,7 +34,10 @@ public class QueryBatchOperationTest extends ClientRestTest {
     // given
     final String batchOperationKey = "123";
     gatewayService.onBatchOperationRequest(
-        batchOperationKey, Instancio.create(BatchOperationResponse.class));
+        batchOperationKey,
+        Instancio.create(BatchOperationResponse.class)
+            .state(StateEnum.UNKNOWN_DEFAULT_OPEN_API)
+            .batchOperationType(BatchOperationTypeEnum.UNKNOWN_DEFAULT_OPEN_API));
 
     // when
     client.newBatchOperationGetRequest(batchOperationKey).send().join();


### PR DESCRIPTION
# Description
Backport of #37392 to `release-8.8.0-alpha8`.

relates to #37289