### PR TITLE
ci: Change Camunda Process test ownership to CamundaEx

### DIFF
--- a/.ci/scripts/ci/setup-medic-lookup.sh
+++ b/.ci/scripts/ci/setup-medic-lookup.sh
@@ -29,6 +29,11 @@ lookupTeamMedic["team-distributed-systems"]=$distributedSystemsMedic
 lookupTeamMedic["Distributed Systems"]=$distributedSystemsMedic
 lookupTeamMedic["DistributedSystems"]=$distributedSystemsMedic
 
+# @camunda-ex-medic
+camundaExMedic="<!subteam^S064J3N99A5|camunda-ex-medic>"
+lookupTeamMedic["Camunda Ex"]=camundaExMedic
+lookupTeamMedic["CamundaEx"]=camundaExMedic
+
 # failure in QA test
 lookupTeamMedic["QA"]="QA Acceptance Test, requires investigation"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,7 +815,7 @@ jobs:
             runs-on: gcp-perf-core-8-default
             docker-repository: localhost:5000/camunda/camunda
             docker-file: camunda.Dockerfile
-            owner: "Core Features"
+            owner: "CamundaEx"
             module: "Testing"
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
See discussion here: https://camunda.slack.com/archives/C071KP5BTHB/p1756706709202239

Give the Camunda Ex team ownership of the "Camunda Process" tests

- Adds CamundaEx to `setup-medic-lookup.sh` so that the team's medic can be alerted in slack

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
