### PR TITLE
ci: upgrade Helm chart used for preview to 13.0.0-alpha7

### DIFF
--- a/.ci/preview-environments/charts/c8sm/Chart.lock
+++ b/.ci/preview-environments/charts/c8sm/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.6.6
 - name: camunda-platform
   repository: https://helm.camunda.io
-  version: 13.0.0-alpha6
-digest: sha256:00482c6062d5a9e9c3bb669c4f8bb13d6cd246fab3fff848bdfeb25113393c27
-generated: "2025-07-17T22:41:46.008856+02:00"
+  version: 13.0.0-alpha7
+digest: sha256:7d17dcf8502e7069e4bad8e28a7d317003779362269c3135b20bf8bd134aa581
+generated: "2025-09-01T15:45:26.294223+02:00"

--- a/.ci/preview-environments/charts/c8sm/Chart.yaml
+++ b/.ci/preview-environments/charts/c8sm/Chart.yaml
@@ -14,4 +14,4 @@ dependencies:
   version: 1.6.6
 - name: camunda-platform
   repository: https://helm.camunda.io
-  version: 13.0.0-alpha6
+  version: 13.0.0-alpha7

--- a/.ci/preview-environments/charts/c8sm/templates/ingress.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/ingress.yml
@@ -31,7 +31,7 @@ spec:
         pathType: Prefix
       - backend:
           service:
-            name: {{ template "core.fullname" $camundaPlatform }}
+            name: {{ template "core.fullname" $camundaPlatform }}-gateway
             port:
               number: {{ .Values.camundaPlatform.core.service.httpPort }}
         path: {{ .Values.camundaPlatform.core.contextPath }}


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/camunda/issues/24482.

Upgrade the Helm Chart used for preview environment to the latest version: 13.0.0-alpha7 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
