### PR TITLE
feat: filter runtime backups by prefix

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -92,7 +92,7 @@ public final class BackupEndpoint {
       return new WebEndpointResponse<>(
           new Error()
               .message(
-                  "Id '%s' was neither an number nor a prefix ending with '*'"
+                  "Expected a backup ID or prefix ending with '*', but got '%s'."
                       .formatted(prefixOrId)),
           400);
     }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -76,7 +76,40 @@ public final class BackupEndpoint {
   }
 
   @ReadOperation
-  public WebEndpointResponse<?> status(@Selector @NonNull final long id) {
+  public WebEndpointResponse<?> listAll() {
+    return listPrefix(BackupApi.WILDCARD);
+  }
+
+  @ReadOperation
+  public WebEndpointResponse<?> query(@Selector final String prefixOrId) {
+    if (prefixOrId.endsWith(BackupApi.WILDCARD)) {
+      return listPrefix(prefixOrId);
+    }
+    final long id;
+    try {
+      id = Long.parseLong(prefixOrId);
+    } catch (final NumberFormatException e) {
+      return new WebEndpointResponse<>(
+          new Error()
+              .message(
+                  "Id '%s' was neither an number nor a prefix ending with '*'"
+                      .formatted(prefixOrId)),
+          400);
+    }
+    return status(id);
+  }
+
+  @DeleteOperation
+  public WebEndpointResponse<?> delete(@Selector @NonNull final long id) {
+    try {
+      api.deleteBackup(id).toCompletableFuture().join();
+      return new WebEndpointResponse<>(WebEndpointResponse.STATUS_NO_CONTENT);
+    } catch (final Exception e) {
+      return mapErrorResponse(e);
+    }
+  }
+
+  private WebEndpointResponse<?> status(final long id) {
     try {
       final BackupStatus status = api.getStatus(id).toCompletableFuture().join();
       if (status.status() == State.DOES_NOT_EXIST) {
@@ -89,22 +122,11 @@ public final class BackupEndpoint {
     }
   }
 
-  @ReadOperation
-  public WebEndpointResponse<?> list() {
+  private WebEndpointResponse<?> listPrefix(final String prefix) {
     try {
-      final var backups = api.listBackups().toCompletableFuture().join();
+      final var backups = api.listBackups(prefix).toCompletableFuture().join();
       final var response = backups.stream().map(this::getBackupInfoFromBackupStatus).toList();
       return new WebEndpointResponse<>(response);
-    } catch (final Exception e) {
-      return mapErrorResponse(e);
-    }
-  }
-
-  @DeleteOperation
-  public WebEndpointResponse<?> delete(@Selector @NonNull final long id) {
-    try {
-      api.deleteBackup(id).toCompletableFuture().join();
-      return new WebEndpointResponse<>(WebEndpointResponse.STATUS_NO_CONTENT);
     } catch (final Exception e) {
       return mapErrorResponse(e);
     }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
@@ -15,7 +15,6 @@ import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
 import org.springframework.lang.NonNull;
-import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,7 +33,12 @@ public final class BackupEndpointStandalone {
   }
 
   @ReadOperation
-  public WebEndpointResponse<?> query(@Selector @Nullable final String prefixOrId) {
+  public WebEndpointResponse<?> listAll() {
+    return backupEndpoint.listAll();
+  }
+
+  @ReadOperation
+  public WebEndpointResponse<?> query(@Selector final String prefixOrId) {
     return backupEndpoint.query(prefixOrId);
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
@@ -15,6 +15,7 @@ import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
 import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -33,13 +34,8 @@ public final class BackupEndpointStandalone {
   }
 
   @ReadOperation
-  public WebEndpointResponse<?> status(@Selector @NonNull final long id) {
-    return backupEndpoint.status(id);
-  }
-
-  @ReadOperation
-  public WebEndpointResponse<?> list() {
-    return backupEndpoint.list();
+  public WebEndpointResponse<?> query(@Selector @Nullable final String prefixOrId) {
+    return backupEndpoint.query(prefixOrId);
   }
 
   @DeleteOperation

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -179,7 +179,7 @@ paths:
       responses:
         '200':
           description: OK
-          $ref: '#/components/responses/HistoryBackupInfo'
+          $ref: '#/components/responses/HistoryBackupDetail'
         '404':
           description: Backup with given ID does not exist.
           $ref: '#/components/responses/Error'

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -67,16 +67,15 @@ paths:
         '504':
           description: Request from gateway to broker timed out
           $ref: '#/components/responses/Error'
-  /backupRuntime/{backupId}:
+  /backupRuntime/{backupIdOrPrefix}:
     get:
       summary: Get information of a runtime backup
       description: A detailed information of the backup with the give backup id.
       parameters:
-        - $ref: '#/components/parameters/BackupId'
+        - $ref: '#/components/parameters/BackupIdOrPrefix'
       responses:
         '200':
-          description: OK
-          $ref: '#/components/responses/BackupInfo'
+          $ref: '#/components/responses/BackupStatusOrList'
         '400':
           description: Backup is not enabled or configured on the brokers
           $ref: '#/components/responses/Error'
@@ -216,6 +215,15 @@ components:
       description: Id of the backup
       schema:
         $ref: '#/components/schemas/BackupId'
+    BackupIdOrPrefix:
+      name: backupIdOrPrefix
+      required: true
+      in: path
+      description: A prefix of ids ending with '*', or a full backup id. Defaults to '*', matching all backup ids.
+      schema:
+        oneOf:
+          - $ref: '#/components/schemas/BackupId'
+          - $ref: '#/components/schemas/BackupIdPrefix'
 
   responses:
     Error:
@@ -224,7 +232,15 @@ components:
         application/json:
           schema:
             "$ref": "#/components/schemas/Error"
-
+    BackupStatusOrList:
+      description: |
+        Status of a single backup or list of statuses when querying for multiple backups
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/BackupList'
+              - $ref: '#/components/schemas/BackupInfo'
     BackupList:
       description: |
        List of all available backups.
@@ -288,6 +304,15 @@ components:
       format: int64
       example: 1
       minimum: 0
+
+    BackupIdPrefix:
+      title: Backup ID Prefix
+      description: |
+        Prefix of a backup id, followed by an '*' as wildcard to match any backups with a backup ID
+        starting with the given prefix.
+      type: string
+      pattern: "^\\d*\\*$"
+      example: "17567*"
 
     PartitionId:
       title: Partition ID

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
@@ -25,25 +25,37 @@ public abstract class BackupEndpointStandaloneTest {
 
   @Test
   public void shouldCallTakeWhenIsStandalone() {
+    // when
     backupEndpointStandalone.take(11L);
+
+    // then
     verify(backupEndpoint).take(11L);
   }
 
   @Test
   public void shouldCallListWhenIsStandalone() {
+    // when
     backupEndpointStandalone.query(null);
+
+    // then
     verify(backupEndpoint).query(null);
   }
 
   @Test
   public void shouldCallGetWhenIsStandalone() {
+    // when
     backupEndpointStandalone.query("11");
+
+    // then
     verify(backupEndpoint).query("11");
   }
 
   @Test
   public void shouldCallDeleteWhenIsStandalone() {
+    // when
     backupEndpointStandalone.delete(11L);
+
+    // then
     verify(backupEndpoint).delete(11L);
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
@@ -31,14 +31,14 @@ public abstract class BackupEndpointStandaloneTest {
 
   @Test
   public void shouldCallListWhenIsStandalone() {
-    backupEndpointStandalone.list();
-    verify(backupEndpoint).list();
+    backupEndpointStandalone.query(null);
+    verify(backupEndpoint).query(null);
   }
 
   @Test
   public void shouldCallGetWhenIsStandalone() {
-    backupEndpointStandalone.status(11L);
-    verify(backupEndpoint).status(11L);
+    backupEndpointStandalone.query("11");
+    verify(backupEndpoint).query("11");
   }
 
   @Test

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -147,7 +147,7 @@ final class BackupEndpointTest {
       doThrow(failure).when(api).getStatus(anyLong());
 
       // when
-      final WebEndpointResponse<?> response = endpoint.status(1);
+      final WebEndpointResponse<?> response = endpoint.query("1");
 
       // then
       assertThat(response.getBody())
@@ -165,7 +165,7 @@ final class BackupEndpointTest {
       doReturn(CompletableFuture.completedFuture(backupStatus)).when(api).getStatus(anyLong());
 
       // when
-      final WebEndpointResponse<?> response = endpoint.status(1);
+      final WebEndpointResponse<?> response = endpoint.query("1");
 
       // then
       assertThat(response.getStatus()).isEqualTo(404);
@@ -183,7 +183,7 @@ final class BackupEndpointTest {
       doReturn(CompletableFuture.failedFuture(error)).when(api).getStatus(anyLong());
 
       // when
-      final var response = endpoint.status(1);
+      final var response = endpoint.query("1");
 
       // then
       assertThat(response.getStatus()).isEqualTo(expectedCode);
@@ -236,7 +236,7 @@ final class BackupEndpointTest {
       final BackupInfo expectedResponse = mapper.readValue(expectedJson, BackupInfo.class);
 
       // when
-      final WebEndpointResponse<?> response = endpoint.status(1);
+      final WebEndpointResponse<?> response = endpoint.query("1");
 
       // then
       assertThat(response.getBody())
@@ -282,7 +282,7 @@ final class BackupEndpointTest {
       final BackupInfo expectedResponse = mapper.readValue(expectedJson, BackupInfo.class);
 
       // when
-      final WebEndpointResponse<?> response = endpoint.status(1);
+      final WebEndpointResponse<?> response = endpoint.query("1");
 
       // then
       assertThat(response.getBody())
@@ -342,10 +342,10 @@ final class BackupEndpointTest {
       final var api = mock(BackupApi.class);
       final var endpoint = new BackupEndpoint(api);
       final var failure = new RuntimeException("failure");
-      doThrow(failure).when(api).listBackups();
+      doThrow(failure).when(api).listBackups("*");
 
       // when
-      final WebEndpointResponse<?> response = endpoint.list();
+      final WebEndpointResponse<?> response = endpoint.listAll();
 
       // then
       assertThat(response.getBody())
@@ -359,10 +359,10 @@ final class BackupEndpointTest {
       // given
       final var api = mock(BackupApi.class);
       final var endpoint = new BackupEndpoint(api);
-      doReturn(CompletableFuture.failedFuture(error)).when(api).listBackups();
+      doReturn(CompletableFuture.failedFuture(error)).when(api).listBackups("*");
 
       // when
-      final var response = endpoint.list();
+      final var response = endpoint.listAll();
 
       // then
       assertThat(response.getStatus()).isEqualTo(expectedCode);
@@ -392,7 +392,7 @@ final class BackupEndpointTest {
               List.of(createPartialPartitionStatus(BackupStatusCode.IN_PROGRESS)));
       doReturn(CompletableFuture.completedFuture(List.of(backup1, backup2)))
           .when(api)
-          .listBackups();
+          .listBackups("*");
 
       final String expectedJson =
           """
@@ -431,7 +431,7 @@ final class BackupEndpointTest {
               mapper.getTypeFactory().constructCollectionType(List.class, BackupInfo.class));
 
       // when
-      final WebEndpointResponse<?> response = endpoint.list();
+      final WebEndpointResponse<?> response = endpoint.listAll();
 
       // then
       assertThat(response.getBody())
@@ -444,10 +444,10 @@ final class BackupEndpointTest {
       // given
       final var api = mock(BackupApi.class);
       final var endpoint = new BackupEndpoint(api);
-      doReturn(CompletableFuture.completedFuture(List.of())).when(api).listBackups();
+      doReturn(CompletableFuture.completedFuture(List.of())).when(api).listBackups("*");
 
       // when
-      final WebEndpointResponse<?> response = endpoint.list();
+      final WebEndpointResponse<?> response = endpoint.listAll();
 
       // then
       assertThat(response.getBody())

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
@@ -37,10 +37,7 @@ import io.camunda.zeebe.backup.common.Manifest.StatusCode;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collection;
-import java.util.Optional;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public final class ManifestManager {
   public static final int PRECONDITION_FAILED = 412;
@@ -236,7 +233,7 @@ public final class ManifestManager {
         Pattern.compile(
                 MANIFEST_PATH_FORMAT.formatted(
                     wildcard.partitionId().map(Number::toString).orElse("\\d+"),
-                    wildcard.checkpointId().map(Number::toString).orElse("\\d+"),
+                    wildcard.checkpointPattern().asRegex(),
                     wildcard.nodeId().map(Number::toString).orElse("\\d+")))
             .asMatchPredicate();
     return pattern.test(path);
@@ -248,12 +245,7 @@ public final class ManifestManager {
    * the prefix is empty, the prefix will only contain the first prefix component and so forth.
    */
   private String wildcardPrefix(final BackupIdentifierWildcard wildcard) {
-    //noinspection OptionalGetWithoutIsPresent -- checked by takeWhile
-    return Stream.of(wildcard.partitionId(), wildcard.checkpointId(), wildcard.nodeId())
-        .takeWhile(Optional::isPresent)
-        .map(Optional::get)
-        .map(Number::toString)
-        .collect(Collectors.joining("/", "manifests/", ""));
+    return "manifests/" + BackupIdentifierWildcard.asPrefix(wildcard);
   }
 
   void assureContainerCreated() {

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
@@ -210,7 +210,7 @@ public final class ManifestManager {
                 MANIFEST_PATH_FORMAT.formatted(
                     basePath,
                     wildcard.partitionId().map(Number::toString).orElse("\\d+"),
-                    wildcard.checkpointId().map(Number::toString).orElse("\\d+"),
+                    wildcard.checkpointPattern().asRegex(),
                     wildcard.nodeId().map(Number::toString).orElse("\\d+")))
             .asMatchPredicate();
     return pattern.test(path);

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
@@ -145,16 +146,20 @@ class ManifestManagerTest {
   private static Stream<Arguments> provideWildcardsForListManifests() {
     return Stream.of(
         Arguments.of(
-            new BackupIdentifierWildcardImpl(Optional.empty(), Optional.empty(), Optional.empty()),
+            new BackupIdentifierWildcardImpl(
+                Optional.empty(), Optional.empty(), CheckpointPattern.any()),
             6),
         Arguments.of(
-            new BackupIdentifierWildcardImpl(Optional.of(1337), Optional.empty(), Optional.empty()),
+            new BackupIdentifierWildcardImpl(
+                Optional.of(1337), Optional.empty(), CheckpointPattern.any()),
             4),
         Arguments.of(
-            new BackupIdentifierWildcardImpl(Optional.empty(), Optional.empty(), Optional.of(42L)),
+            new BackupIdentifierWildcardImpl(
+                Optional.empty(), Optional.empty(), CheckpointPattern.of(42L)),
             3),
         Arguments.of(
-            new BackupIdentifierWildcardImpl(Optional.of(1337), Optional.of(0), Optional.of(42L)),
+            new BackupIdentifierWildcardImpl(
+                Optional.of(1337), Optional.of(0), CheckpointPattern.of(42L)),
             1));
   }
 

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -37,8 +37,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -133,12 +131,8 @@ public final class S3BackupStore implements BackupStore {
    * matches.
    */
   private String wildcardPrefix(final BackupIdentifierWildcard wildcard) {
-    //noinspection OptionalGetWithoutIsPresent -- checked by takeWhile
-    return Stream.of(wildcard.partitionId(), wildcard.checkpointId(), wildcard.nodeId())
-        .takeWhile(Optional::isPresent)
-        .map(Optional::get)
-        .map(Number::toString)
-        .collect(Collectors.joining("/", config.basePath().map(base -> base + "/").orElse(""), ""));
+    return config.basePath().map(base -> base + "/").orElse("")
+        + BackupIdentifierWildcard.asPrefix(wildcard);
   }
 
   public String objectPrefix(final BackupIdentifier id) {

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ConnectionErrorTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ConnectionErrorTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.s3;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
@@ -48,7 +49,8 @@ final class ConnectionErrorTest {
     // when
     final var res =
         store.list(
-            new BackupIdentifierWildcardImpl(Optional.empty(), Optional.of(1), Optional.empty()));
+            new BackupIdentifierWildcardImpl(
+                Optional.empty(), Optional.of(1), CheckpointPattern.any()));
 
     // then
     assertThat(res)

--- a/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/support/WildcardBackupProvider.java
+++ b/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/support/WildcardBackupProvider.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.testkit.support;
 
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import java.util.List;
@@ -28,7 +29,7 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                 "Backups of arbitrary nodes",
                 new WildcardTestParameter(
                     new BackupIdentifierWildcardImpl(
-                        Optional.empty(), Optional.of(1), Optional.of(1L)),
+                        Optional.empty(), Optional.of(1), CheckpointPattern.of(1L)),
                     List.of(
                         new BackupIdentifierImpl(1, 1, 1),
                         new BackupIdentifierImpl(2, 1, 1),
@@ -40,7 +41,7 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                 "Backups of arbitrary partitions",
                 new WildcardTestParameter(
                     new BackupIdentifierWildcardImpl(
-                        Optional.of(1), Optional.empty(), Optional.of(1L)),
+                        Optional.of(1), Optional.empty(), CheckpointPattern.of(1L)),
                     List.of(
                         new BackupIdentifierImpl(1, 1, 1),
                         new BackupIdentifierImpl(1, 2, 1),
@@ -52,7 +53,7 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                 "Backups of arbitrary checkpoints",
                 new WildcardTestParameter(
                     new BackupIdentifierWildcardImpl(
-                        Optional.of(1), Optional.of(1), Optional.empty()),
+                        Optional.of(1), Optional.of(1), CheckpointPattern.any()),
                     List.of(
                         new BackupIdentifierImpl(1, 1, 1),
                         new BackupIdentifierImpl(1, 1, 2),
@@ -64,7 +65,7 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                 "Backups of arbitrary partitions and checkpoints",
                 new WildcardTestParameter(
                     new BackupIdentifierWildcardImpl(
-                        Optional.of(1), Optional.empty(), Optional.empty()),
+                        Optional.of(1), Optional.empty(), CheckpointPattern.any()),
                     List.of(
                         new BackupIdentifierImpl(1, 1, 3),
                         new BackupIdentifierImpl(1, 2, 2),
@@ -76,7 +77,7 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                 "Backups of arbitrary nodes and partitions",
                 new WildcardTestParameter(
                     new BackupIdentifierWildcardImpl(
-                        Optional.empty(), Optional.empty(), Optional.of(1L)),
+                        Optional.empty(), Optional.empty(), CheckpointPattern.of(1L)),
                     List.of(
                         new BackupIdentifierImpl(1, 3, 1),
                         new BackupIdentifierImpl(2, 2, 1),
@@ -88,7 +89,7 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                 "Backups of arbitrary nodes and checkpoints",
                 new WildcardTestParameter(
                     new BackupIdentifierWildcardImpl(
-                        Optional.empty(), Optional.of(1), Optional.empty()),
+                        Optional.empty(), Optional.of(1), CheckpointPattern.any()),
                     List.of(
                         new BackupIdentifierImpl(1, 1, 3),
                         new BackupIdentifierImpl(2, 1, 2),
@@ -100,7 +101,7 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                 "All backups",
                 new WildcardTestParameter(
                     new BackupIdentifierWildcardImpl(
-                        Optional.empty(), Optional.empty(), Optional.empty()),
+                        Optional.empty(), Optional.empty(), CheckpointPattern.any()),
                     List.of(
                         new BackupIdentifierImpl(1, 1, 1),
                         new BackupIdentifierImpl(2, 2, 2),

--- a/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/support/WildcardBackupProvider.java
+++ b/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/support/WildcardBackupProvider.java
@@ -62,6 +62,21 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                         new BackupIdentifierImpl(1, 2, 1), new BackupIdentifierImpl(2, 1, 3))))),
         Arguments.of(
             Named.of(
+                "Backups matching checkpoint prefix",
+                new WildcardTestParameter(
+                    new BackupIdentifierWildcardImpl(
+                        Optional.of(1), Optional.of(1), CheckpointPattern.of("10*")),
+                    List.of(
+                        new BackupIdentifierImpl(1, 1, 10),
+                        new BackupIdentifierImpl(1, 1, 100),
+                        new BackupIdentifierImpl(1, 1, 101)),
+                    List.of(
+                        new BackupIdentifierImpl(1, 1, 1),
+                        new BackupIdentifierImpl(1, 1, 20),
+                        new BackupIdentifierImpl(2, 1, 10),
+                        new BackupIdentifierImpl(1, 2, 10))))),
+        Arguments.of(
+            Named.of(
                 "Backups of arbitrary partitions and checkpoints",
                 new WildcardTestParameter(
                     new BackupIdentifierWildcardImpl(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcard.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcard.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern.Any;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern.Exact;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern.Prefix;
 import java.util.Optional;
 
 /**
@@ -27,7 +30,7 @@ public interface BackupIdentifierWildcard {
   /**
    * @return id of the checkpoint included in the backup
    */
-  Optional<Long> checkpointId();
+  CheckpointPattern checkpointPattern();
 
   /**
    * Predicate that tries to match an id to this wildcard.
@@ -35,4 +38,120 @@ public interface BackupIdentifierWildcard {
    * @return true if the given id matches the wildcard, otherwise false.
    */
   boolean matches(BackupIdentifier id);
+
+  /**
+   * Tries to build the longest possible prefix based on the given wildcard. The prefix is
+   * constructed as follows: {@code ${partitionId}/${checkpointId}/${nodeId}}. If a field is not
+   * present or is a non-exact match, all following fields are omitted. For example, if the
+   * checkpoint id should match a {@link CheckpointPattern.Prefix prefix}, the returned prefix is
+   * {@code ${partitionId}/${checkpointPattern.Prefix}}. If none of the fields are present, an empty
+   * string is returned.
+   */
+  static String asPrefix(final BackupIdentifierWildcard wildcard) {
+    final var prefix = new StringBuilder();
+    if (wildcard.partitionId().isEmpty()) {
+      return prefix.toString();
+    }
+    prefix.append(wildcard.partitionId().get());
+    prefix.append("/");
+
+    switch (wildcard.checkpointPattern()) {
+      case Exact(final var checkpointId) -> {
+        prefix.append(checkpointId);
+        prefix.append("/");
+        // Checkpoint pattern is exact so we can include node id if present
+        if (wildcard.nodeId().isPresent()) {
+          prefix.append(wildcard.nodeId().get());
+        }
+      }
+      // Checkpoint pattern is not exact so our prefix ends here, we can't include the node id
+      case Prefix(final var cpPrefix) -> prefix.append(cpPrefix);
+      case Any() -> {}
+    }
+    return prefix.toString();
+  }
+
+  sealed interface CheckpointPattern {
+
+    boolean matches(final long checkpointId);
+
+    String asRegex();
+
+    static CheckpointPattern any() {
+      return new Any();
+    }
+
+    static CheckpointPattern of(final long checkpointId) {
+      return new Exact(checkpointId);
+    }
+
+    static CheckpointPattern of(final String pattern) {
+      if (pattern == null || pattern.isEmpty() || "*".equals(pattern)) {
+        return new Any();
+      } else if (pattern.endsWith("*")) {
+        return new Prefix(pattern.substring(0, pattern.length() - 1));
+      } else {
+        try {
+          final var checkpointId = Long.parseLong(pattern);
+          return new Exact(checkpointId);
+        } catch (final NumberFormatException e) {
+          throw new IllegalArgumentException("Invalid checkpoint id pattern: " + pattern, e);
+        }
+      }
+    }
+
+    record Any() implements CheckpointPattern {
+
+      @Override
+      public boolean matches(final long checkpointId) {
+        return true;
+      }
+
+      @Override
+      public String asRegex() {
+        return "\\d+";
+      }
+    }
+
+    record Prefix(String prefix) implements CheckpointPattern {
+      public Prefix {
+        if (prefix.isEmpty()) {
+          throw new IllegalArgumentException("Prefix must not be empty");
+        }
+        try {
+          Long.valueOf(prefix);
+        } catch (final NumberFormatException e) {
+          throw new IllegalArgumentException("Prefix must be a valid number", e);
+        }
+      }
+
+      @Override
+      public boolean matches(final long checkpointId) {
+        return String.valueOf(checkpointId).startsWith(prefix);
+      }
+
+      @Override
+      public String asRegex() {
+        return prefix + "\\d*";
+      }
+    }
+
+    record Exact(long checkpointId) implements CheckpointPattern {
+      public Exact {
+        if (checkpointId < 0) {
+          throw new IllegalArgumentException("Checkpoint id must be non-negative");
+        }
+      }
+
+      @Override
+      public boolean matches(final long checkpointId) {
+        return checkpointId == this.checkpointId;
+      }
+
+      @Override
+      public String asRegex() {
+        return Long.toString(checkpointId);
+      }
+    }
+  }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
@@ -36,13 +36,17 @@ public interface BackupManager {
    */
   ActorFuture<BackupStatus> getBackupStatus(long checkpointId);
 
+  default ActorFuture<Collection<BackupStatus>> listBackups() {
+    return listBackups(null);
+  }
+
   /**
    * Get all available backups where status is one of {@link BackupStatusCode#COMPLETED}, {@link
    * BackupStatusCode#FAILED}, {@link BackupStatusCode#IN_PROGRESS}
    *
    * @return a collection of backup status
    */
-  ActorFuture<Collection<BackupStatus>> listBackups();
+  ActorFuture<Collection<BackupStatus>> listBackups(final String pattern);
 
   /**
    * Deletes the backup.

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
@@ -36,10 +36,6 @@ public interface BackupManager {
    */
   ActorFuture<BackupStatus> getBackupStatus(long checkpointId);
 
-  default ActorFuture<Collection<BackupStatus>> listBackups() {
-    return listBackups(null);
-  }
-
   /**
    * Get all available backups where status is one of {@link BackupStatusCode#COMPLETED}, {@link
    * BackupStatusCode#FAILED}, {@link BackupStatusCode#IN_PROGRESS}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
@@ -40,7 +40,8 @@ public interface BackupManager {
    * Get all available backups where status is one of {@link BackupStatusCode#COMPLETED}, {@link
    * BackupStatusCode#FAILED}, {@link BackupStatusCode#IN_PROGRESS}
    *
-   * @return a collection of backup status
+   * @param pattern null, empty, a prefix ending in '*' or an exact backup id
+   * @return all backups with ids matching the pattern
    */
   ActorFuture<Collection<BackupStatus>> listBackups(final String pattern);
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupIdentifierWildcardImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupIdentifierWildcardImpl.java
@@ -12,13 +12,13 @@ import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
 import java.util.Optional;
 
 public record BackupIdentifierWildcardImpl(
-    Optional<Integer> nodeId, Optional<Integer> partitionId, Optional<Long> checkpointId)
+    Optional<Integer> nodeId, Optional<Integer> partitionId, CheckpointPattern checkpointPattern)
     implements BackupIdentifierWildcard {
 
   @Override
   public boolean matches(final BackupIdentifier id) {
     return (nodeId.isEmpty() || nodeId.get().equals(id.nodeId()))
         && (partitionId.isEmpty() || partitionId.get().equals(id.partitionId()))
-        && (checkpointId.isEmpty() || checkpointId.get().equals(id.checkpointId()));
+        && checkpointPattern.matches(id.checkpointId());
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -144,9 +144,9 @@ public final class BackupService extends Actor implements BackupManager {
   }
 
   @Override
-  public ActorFuture<Collection<BackupStatus>> listBackups() {
+  public ActorFuture<Collection<BackupStatus>> listBackups(final String pattern) {
     final var operationMetrics = metrics.startListingBackups();
-    final var resultFuture = internalBackupManager.listBackups(partitionId, actor);
+    final var resultFuture = internalBackupManager.listBackups(partitionId, pattern, actor);
     resultFuture.onComplete(operationMetrics::complete);
     resultFuture.onComplete(
         (ignore, error) -> {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.management;
 
 import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
@@ -63,7 +64,7 @@ final class BackupServiceImpl {
             new BackupIdentifierWildcardImpl(
                 Optional.empty(),
                 Optional.of(inProgressBackup.id().partitionId()),
-                Optional.of(inProgressBackup.checkpointId())));
+                CheckpointPattern.of(inProgressBackup.checkpointId())));
 
     final ActorFuture<Void> backupSaved = concurrencyControl.createFuture();
 
@@ -208,7 +209,9 @@ final class BackupServiceImpl {
             backupStore
                 .list(
                     new BackupIdentifierWildcardImpl(
-                        Optional.empty(), Optional.of(partitionId), Optional.of(checkpointId)))
+                        Optional.empty(),
+                        Optional.of(partitionId),
+                        CheckpointPattern.of(checkpointId)))
                 .whenComplete(
                     (backupStatuses, throwable) -> {
                       if (throwable != null) {
@@ -230,7 +233,7 @@ final class BackupServiceImpl {
                       new BackupIdentifierWildcardImpl(
                           Optional.empty(),
                           Optional.of(partitionId),
-                          Optional.of(lastCheckpointId)))
+                          CheckpointPattern.of(lastCheckpointId)))
                   .thenAccept(backups -> backups.forEach(this::failInProgressBackup))
                   .exceptionally(
                       failure -> {
@@ -267,7 +270,9 @@ final class BackupServiceImpl {
             backupStore
                 .list(
                     new BackupIdentifierWildcardImpl(
-                        Optional.empty(), Optional.of(partitionId), Optional.of(checkpointId)))
+                        Optional.empty(),
+                        Optional.of(partitionId),
+                        CheckpointPattern.of(checkpointId)))
                 .thenCompose(
                     backups ->
                         CompletableFuture.allOf(
@@ -303,31 +308,14 @@ final class BackupServiceImpl {
             backupStore
                 .list(
                     new BackupIdentifierWildcardImpl(
-                        Optional.empty(), Optional.of(partitionId), Optional.empty()))
-                .thenAccept(
-                    statuses ->
-                        availableBackupsFuture.complete(
-                            statuses.stream()
-                                .filter(status -> matchPattern(status, pattern))
-                                .toList()))
+                        Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(pattern)))
+                .thenAccept(availableBackupsFuture::complete)
                 .exceptionally(
                     error -> {
                       availableBackupsFuture.completeExceptionally(error);
                       return null;
                     }));
     return availableBackupsFuture;
-  }
-
-  private boolean matchPattern(final BackupStatus status, final String pattern) {
-    if (pattern == null || pattern.isEmpty()) {
-      return true;
-    }
-    if (pattern.endsWith("*")) {
-      final var prefix = pattern.substring(0, pattern.length() - 1);
-      return Long.toString(status.id().checkpointId()).startsWith(prefix);
-    } else {
-      return Long.toString(status.id().checkpointId()).equals(pattern);
-    }
   }
 
   void createFailedBackup(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
@@ -44,7 +44,7 @@ public class NoopBackupManager implements BackupManager {
   }
 
   @Override
-  public ActorFuture<Collection<BackupStatus>> listBackups() {
+  public ActorFuture<Collection<BackupStatus>> listBackups(final String pattern) {
     return CompletableActorFuture.completedExceptionally(
         new UnsupportedOperationException(errorMessage));
   }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcardTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcardTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern.Any;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern.Exact;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern.Prefix;
+import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class BackupIdentifierWildcardTest {
+  @Test
+  void shouldBuildPrefixWithPartitionId() {
+    // given
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(Optional.empty(), Optional.of(1), new Any());
+
+    // when
+    final var prefix = BackupIdentifierWildcard.asPrefix(wildcard);
+
+    // then
+    assertThat(prefix).isEqualTo("1/");
+  }
+
+  @Test
+  void shouldBuildPrefixWithPartitionIdAndExactCheckpoint() {
+    // given
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(Optional.empty(), Optional.of(1), new Exact(100));
+
+    // when
+    final var prefix = BackupIdentifierWildcard.asPrefix(wildcard);
+
+    // then
+    assertThat(prefix).isEqualTo("1/100/");
+  }
+
+  @Test
+  void shouldBuildPrefixWithPartitionIdAndExactCheckpointAndNodeId() {
+    // given
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(Optional.of(1), Optional.of(2), new Exact(100));
+
+    // when
+    final var prefix = BackupIdentifierWildcard.asPrefix(wildcard);
+
+    // then
+    assertThat(prefix).isEqualTo("2/100/1");
+  }
+
+  @Test
+  void shouldBuildPrefixWithPartitionIdAndCheckpointPrefix() {
+    // given
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(Optional.of(1), Optional.of(2), new Prefix("10"));
+
+    // when
+    final var prefix = BackupIdentifierWildcard.asPrefix(wildcard);
+
+    // then
+    assertThat(prefix).isEqualTo("2/10");
+  }
+
+  @Test
+  void shouldReturnEmptyPrefixWhenNoPartitionId() {
+    // given
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(Optional.of(1), Optional.empty(), new Prefix("10"));
+
+    // when
+    final var prefix = BackupIdentifierWildcard.asPrefix(wildcard);
+
+    // then
+    assertThat(prefix).isEmpty();
+  }
+
+  @Test
+  void shouldBuildPrefixWithAnyCheckpoint() {
+    // given
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(Optional.of(1), Optional.of(2), new Any());
+
+    // when
+    final var prefix = BackupIdentifierWildcard.asPrefix(wildcard);
+
+    // then
+    assertThat(prefix).isEqualTo("2/");
+  }
+
+  @Test
+  void checkpointPatternOfShouldReturnAny() {
+    assertThat(CheckpointPattern.of(null)).isInstanceOf(Any.class);
+    assertThat(CheckpointPattern.of("")).isInstanceOf(Any.class);
+    assertThat(CheckpointPattern.of("*")).isInstanceOf(Any.class);
+  }
+
+  @Test
+  void checkpointPatternOfShouldReturnExact() {
+    assertThat(CheckpointPattern.of("123")).isEqualTo(new Exact(123));
+  }
+
+  @Test
+  void checkpointPatternOfShouldReturnPrefix() {
+    assertThat(CheckpointPattern.of("123*")).isEqualTo(new Prefix("123"));
+  }
+
+  @Test
+  void checkpointPatternOfShouldThrowExceptionForInvalidArgument() {
+    assertThatThrownBy(() -> CheckpointPattern.of("invalid"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> CheckpointPattern.of("123a*"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void anyCheckpointPatternShouldMatchAnyId() {
+    // given
+    final var pattern = new Any();
+    // then
+    assertThat(pattern.matches(1L)).isTrue();
+    assertThat(pattern.matches(100L)).isTrue();
+    assertThat(pattern.matches(Long.MAX_VALUE)).isTrue();
+  }
+
+  @Test
+  void anyCheckpointPatternShouldReturnRegex() {
+    assertThat(new Any().asRegex()).isEqualTo("\\d+");
+  }
+
+  @Test
+  void exactCheckpointPatternShouldMatchOnlyExactId() {
+    // given
+    final var pattern = new Exact(100);
+    // then
+    assertThat(pattern.matches(100L)).isTrue();
+    assertThat(pattern.matches(1L)).isFalse();
+    assertThat(pattern.matches(101L)).isFalse();
+  }
+
+  @Test
+  void exactCheckpointPatternShouldReturnRegex() {
+    assertThat(new Exact(123).asRegex()).isEqualTo("123");
+  }
+
+  @Test
+  void exactCheckpointPatternShouldThrowExceptionForNegativeId() {
+    assertThatThrownBy(() -> new Exact(-1)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void prefixCheckpointPatternShouldMatchPrefix() {
+    // given
+    final var pattern = new Prefix("10");
+    // then
+    assertThat(pattern.matches(10L)).isTrue();
+    assertThat(pattern.matches(100L)).isTrue();
+    assertThat(pattern.matches(101L)).isTrue();
+    assertThat(pattern.matches(1L)).isFalse();
+    assertThat(pattern.matches(20L)).isFalse();
+  }
+
+  @Test
+  void prefixCheckpointPatternShouldReturnRegex() {
+    assertThat(new Prefix("123").asRegex()).isEqualTo("123\\d*");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "  "})
+  void prefixCheckpointPatternShouldThrowExceptionForEmptyPrefix(final String prefix) {
+    assertThatThrownBy(() -> new Prefix(prefix)).isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcardTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcardTest.java
@@ -147,6 +147,7 @@ class BackupIdentifierWildcardTest {
     assertThat(pattern.matches(100L)).isTrue();
     assertThat(pattern.matches(1L)).isFalse();
     assertThat(pattern.matches(101L)).isFalse();
+    assertThat(pattern.matches(1000L)).isFalse();
   }
 
   @Test
@@ -169,6 +170,7 @@ class BackupIdentifierWildcardTest {
     assertThat(pattern.matches(101L)).isTrue();
     assertThat(pattern.matches(1L)).isFalse();
     assertThat(pattern.matches(20L)).isFalse();
+    assertThat(pattern.matches(110L)).isFalse();
   }
 
   @Test

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -417,7 +417,49 @@ class BackupServiceImplTest {
         .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2)));
 
     // when
-    final var backups = backupService.listBackups(partitionId, concurrencyControl).join();
+    final var backups = backupService.listBackups(partitionId, null, concurrencyControl).join();
+
+    // then
+    assertThat(backups).containsExactlyInAnyOrder(backup1, backup2);
+  }
+
+  @Test
+  void shouldListAvailableBackupsWithPrefix() {
+    // given
+    final int partitionId = 2;
+    final var backup1 = mock(BackupStatus.class);
+    final var backup2 = mock(BackupStatus.class);
+    when(backup1.id()).thenReturn(new BackupIdentifierImpl(1, partitionId, 11));
+    when(backup2.id()).thenReturn(new BackupIdentifierImpl(1, partitionId, 21));
+
+    when(backupStore.list(
+            new BackupIdentifierWildcardImpl(
+                Optional.empty(), Optional.of(partitionId), Optional.empty())))
+        .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2)));
+
+    // when
+    final var backups = backupService.listBackups(partitionId, "1*", concurrencyControl).join();
+
+    // then
+    assertThat(backups).singleElement().isEqualTo(backup1);
+  }
+
+  @Test
+  void shouldListAllAvailableBackupsWithEmptyPrefix() {
+    // given
+    final int partitionId = 2;
+    final var backup1 = mock(BackupStatus.class);
+    final var backup2 = mock(BackupStatus.class);
+    when(backup1.id()).thenReturn(new BackupIdentifierImpl(1, partitionId, 11));
+    when(backup2.id()).thenReturn(new BackupIdentifierImpl(1, partitionId, 21));
+
+    when(backupStore.list(
+            new BackupIdentifierWildcardImpl(
+                Optional.empty(), Optional.of(partitionId), Optional.empty())))
+        .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2)));
+
+    // when
+    final var backups = backupService.listBackups(partitionId, "*", concurrencyControl).join();
 
     // then
     assertThat(backups).containsExactlyInAnyOrder(backup1, backup2);

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
@@ -77,7 +78,7 @@ class BackupServiceImplTest {
         .when(
             backupStore.list(
                 new BackupIdentifierWildcardImpl(
-                    Optional.empty(), Optional.of(2), Optional.of(3L))))
+                    Optional.empty(), Optional.of(2), CheckpointPattern.of(3L))))
         .thenReturn(CompletableFuture.completedFuture(List.of()));
 
     lenient()
@@ -319,7 +320,7 @@ class BackupServiceImplTest {
             new BackupIdentifierWildcardImpl(
                 Optional.empty(),
                 Optional.of(inProgressBackup.id.partitionId()),
-                Optional.of(inProgressBackup.checkpointId()))))
+                CheckpointPattern.of(inProgressBackup.checkpointId()))))
         .thenReturn(CompletableFuture.completedFuture(List.of(status)));
 
     // when
@@ -365,7 +366,7 @@ class BackupServiceImplTest {
 
     when(backupStore.list(
             new BackupIdentifierWildcardImpl(
-                Optional.empty(), Optional.of(partitionId), Optional.of(checkpointId))))
+                Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(checkpointId))))
         .thenReturn(CompletableFuture.completedFuture(List.of(backupNode1, backupNode2)));
 
     when(backupStore.delete(any())).thenReturn(CompletableFuture.completedFuture(null));
@@ -389,7 +390,7 @@ class BackupServiceImplTest {
 
     when(backupStore.list(
             new BackupIdentifierWildcardImpl(
-                Optional.empty(), Optional.of(partitionId), Optional.of(checkpointId))))
+                Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(checkpointId))))
         .thenReturn(CompletableFuture.completedFuture(List.of(backup)));
 
     when(backupStore.delete(any())).thenReturn(CompletableFuture.completedFuture(null));
@@ -413,53 +414,11 @@ class BackupServiceImplTest {
 
     when(backupStore.list(
             new BackupIdentifierWildcardImpl(
-                Optional.empty(), Optional.of(partitionId), Optional.empty())))
+                Optional.empty(), Optional.of(partitionId), CheckpointPattern.any())))
         .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2)));
 
     // when
     final var backups = backupService.listBackups(partitionId, null, concurrencyControl).join();
-
-    // then
-    assertThat(backups).containsExactlyInAnyOrder(backup1, backup2);
-  }
-
-  @Test
-  void shouldListAvailableBackupsWithPrefix() {
-    // given
-    final int partitionId = 2;
-    final var backup1 = mock(BackupStatus.class);
-    final var backup2 = mock(BackupStatus.class);
-    when(backup1.id()).thenReturn(new BackupIdentifierImpl(1, partitionId, 11));
-    when(backup2.id()).thenReturn(new BackupIdentifierImpl(1, partitionId, 21));
-
-    when(backupStore.list(
-            new BackupIdentifierWildcardImpl(
-                Optional.empty(), Optional.of(partitionId), Optional.empty())))
-        .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2)));
-
-    // when
-    final var backups = backupService.listBackups(partitionId, "1*", concurrencyControl).join();
-
-    // then
-    assertThat(backups).singleElement().isEqualTo(backup1);
-  }
-
-  @Test
-  void shouldListAllAvailableBackupsWithEmptyPrefix() {
-    // given
-    final int partitionId = 2;
-    final var backup1 = mock(BackupStatus.class);
-    final var backup2 = mock(BackupStatus.class);
-    when(backup1.id()).thenReturn(new BackupIdentifierImpl(1, partitionId, 11));
-    when(backup2.id()).thenReturn(new BackupIdentifierImpl(1, partitionId, 21));
-
-    when(backupStore.list(
-            new BackupIdentifierWildcardImpl(
-                Optional.empty(), Optional.of(partitionId), Optional.empty())))
-        .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2)));
-
-    // when
-    final var backups = backupService.listBackups(partitionId, "*", concurrencyControl).join();
 
     // then
     assertThat(backups).containsExactlyInAnyOrder(backup1, backup2);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -90,7 +90,7 @@ public final class BackupApiRequestHandler
               handleTakeBackupRequest(
                   requestStreamId, requestId, requestReader, responseWriter, errorWriter));
       case QUERY_STATUS -> handleQueryStatusRequest(requestReader, responseWriter, errorWriter);
-      case LIST -> handleListBackupRequest(responseWriter, errorWriter);
+      case LIST -> handleListBackupRequest(requestReader, responseWriter, errorWriter);
       case DELETE -> handleDeleteBackupRequest(requestReader, responseWriter, errorWriter);
       default ->
           CompletableActorFuture.completed(unknownRequest(errorWriter, requestReader.type()));
@@ -151,12 +151,15 @@ public final class BackupApiRequestHandler
   }
 
   private ActorFuture<Either<ErrorResponseWriter, BackupApiResponseWriter>> handleListBackupRequest(
-      final BackupApiResponseWriter responseWriter, final ErrorResponseWriter errorWriter) {
+      final BackupApiRequestReader requestReader,
+      final BackupApiResponseWriter responseWriter,
+      final ErrorResponseWriter errorWriter) {
     final ActorFuture<Either<ErrorResponseWriter, BackupApiResponseWriter>> result =
         new CompletableActorFuture<>();
+    final var pattern = requestReader.pattern();
 
     backupManager
-        .listBackups()
+        .listBackups(pattern)
         .onComplete(
             (backups, error) -> {
               if (error == null) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
@@ -32,6 +32,10 @@ public final class BackupApiRequestReader implements RequestReader {
     return messageDecoder.backupId();
   }
 
+  public String pattern() {
+    return messageDecoder.pattern();
+  }
+
   public int partitionId() {
     return messageDecoder.partitionId();
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -295,7 +295,8 @@ final class BackupApiRequestHandlerTest {
             Optional.of(createdAt),
             Optional.of(lastModified));
 
-    when(backupManager.listBackups()).thenReturn(CompletableActorFuture.completed(List.of(status)));
+    when(backupManager.listBackups(""))
+        .thenReturn(CompletableActorFuture.completed(List.of(status)));
 
     // when
     final BackupListResponse listResponse = new BackupListResponse(List.of());
@@ -329,7 +330,7 @@ final class BackupApiRequestHandlerTest {
                             Optional.of(Instant.now())))
             .toList();
 
-    when(backupManager.listBackups()).thenReturn(CompletableActorFuture.completed(statuses));
+    when(backupManager.listBackups("")).thenReturn(CompletableActorFuture.completed(statuses));
 
     // when
     final BackupListResponse listResponse = new BackupListResponse(List.of());
@@ -346,7 +347,7 @@ final class BackupApiRequestHandlerTest {
     // given
     final var request = new BackupRequest().setType(BackupRequestType.LIST).setPartitionId(1);
 
-    when(backupManager.listBackups())
+    when(backupManager.listBackups(""))
         .thenReturn(
             CompletableActorFuture.completedExceptionally(new RuntimeException("list failed")));
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 public interface BackupApi {
+  String WILDCARD = "*";
 
   /**
    * Triggers backup on all partitions. Returned future is completed successfully after all
@@ -39,7 +40,16 @@ public interface BackupApi {
   /**
    * @return a list of available backups
    */
-  CompletionStage<List<BackupStatus>> listBackups();
+  default CompletionStage<List<BackupStatus>> listBackups() {
+    return listBackups(WILDCARD);
+  }
+
+  /**
+   * Returns a list of backups with ids matching the prefix.
+   *
+   * @param prefix A string that backup ids must match. Must end in a single `*`.
+   */
+  CompletionStage<List<BackupStatus>> listBackups(String prefix);
 
   /**
    * Deletes the backup with the given id

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupListRequest.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupListRequest.java
@@ -36,6 +36,14 @@ public class BackupListRequest extends BrokerRequest<BackupListResponse> {
     request.setBackupId(backupId);
   }
 
+  public String getPattern() {
+    return request.getPattern();
+  }
+
+  public void setPattern(final String pattern) {
+    request.setPattern(pattern);
+  }
+
   @Override
   public int getPartitionId() {
     return request.getPartitionId();

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
@@ -114,15 +114,12 @@ public final class BackupRequestHandler implements BackupApi {
 
   @Override
   public CompletionStage<List<BackupStatus>> listBackups(final String prefix) {
-    if (!prefix.equals(BackupApi.WILDCARD)) {
-      throw new UnsupportedOperationException("Filtering by prefix is not yet supported");
-    }
     return checkTopologyComplete()
         .thenCompose(
             topology -> {
               final var backupsReceived =
                   topology.getPartitions().stream()
-                      .map(this::createListRequest)
+                      .map(partitionId -> createListRequest(partitionId, prefix))
                       .map(brokerClient::sendRequestWithRetry)
                       .toList();
 
@@ -308,9 +305,10 @@ public final class BackupRequestHandler implements BackupApi {
     return request;
   }
 
-  private BackupListRequest createListRequest(final Integer partitionId) {
+  private BackupListRequest createListRequest(final Integer partitionId, final String pattern) {
     final var request = new BackupListRequest();
     request.setPartitionId(partitionId);
+    request.setPattern(pattern);
     return request;
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
@@ -113,7 +113,10 @@ public final class BackupRequestHandler implements BackupApi {
   }
 
   @Override
-  public CompletionStage<List<BackupStatus>> listBackups() {
+  public CompletionStage<List<BackupStatus>> listBackups(final String prefix) {
+    if (!prefix.equals(BackupApi.WILDCARD)) {
+      throw new UnsupportedOperationException("Filtering by prefix is not yet supported");
+    }
     return checkTopologyComplete()
         .thenCompose(
             topology -> {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerBackupRequest.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerBackupRequest.java
@@ -117,6 +117,14 @@ public final class BrokerBackupRequest extends BrokerRequest<BackupResponse> {
     request.setBackupId(backupId);
   }
 
+  public String getPattern() {
+    return request.getPattern();
+  }
+
+  public void setPattern(final String pattern) {
+    request.setPattern(pattern);
+  }
+
   @Override
   public int getLength() {
     return request.getLength();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRequest.java
@@ -26,11 +26,13 @@ public class BackupRequest implements BufferReader, BufferWriter {
   private BackupRequestType type;
   private int partitionId;
   private long backupId;
+  private String pattern;
 
   public BackupRequest reset() {
     type = BackupRequestType.NULL_VAL;
     partitionId = BackupRequestEncoder.partitionIdNullValue();
     backupId = BackupRequestEncoder.backupIdNullValue();
+    pattern = null;
     return this;
   }
 
@@ -61,17 +63,30 @@ public class BackupRequest implements BufferReader, BufferWriter {
     return this;
   }
 
+  public String getPattern() {
+    return pattern;
+  }
+
+  public BackupRequest setPattern(final String pattern) {
+    this.pattern = pattern;
+    return this;
+  }
+
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
     partitionId = bodyDecoder.partitionId();
     type = bodyDecoder.type();
     backupId = bodyDecoder.backupId();
+    pattern = bodyDecoder.pattern();
   }
 
   @Override
   public int getLength() {
-    return headerEncoder.encodedLength() + bodyEncoder.sbeBlockLength();
+    return headerEncoder.encodedLength()
+        + bodyEncoder.sbeBlockLength()
+        + BackupRequestEncoder.patternHeaderLength()
+        + (pattern == null ? 0 : pattern.length());
   }
 
   @Override
@@ -80,6 +95,7 @@ public class BackupRequest implements BufferReader, BufferWriter {
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .partitionId(partitionId)
         .type(type)
-        .backupId(backupId);
+        .backupId(backupId)
+        .pattern(pattern);
   }
 }

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -57,6 +57,7 @@
     <field name="partitionId" id="1" type="uint16"/>
     <field name="type" id="2" type="BackupRequestType"/>
     <field name="backupId" id="3" type="int64"/>
+    <data name="pattern" id="4" type="varDataEncoding"/>
   </sbe:message>
 
   <sbe:message name="BackupStatusResponse" id="4">

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupErrorResponseTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupErrorResponseTest.java
@@ -126,7 +126,7 @@ class BackupErrorResponseTest {
     @Test
     void shouldReturn400() {
       // when - then
-      assertThat(backupEndpoint.status(1).getStatus()).isEqualTo(400);
+      assertThat(backupEndpoint.query("1").getStatus()).isEqualTo(400);
     }
   }
 
@@ -154,7 +154,7 @@ class BackupErrorResponseTest {
       clusteringRule.disconnect(clusteringRule.getBroker(0));
 
       // when - then
-      assertThat(backupEndpoint.status(1).getStatus()).isEqualTo(504);
+      assertThat(backupEndpoint.query("1").getStatus()).isEqualTo(504);
     }
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -112,6 +112,10 @@ public interface BackupActuator {
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   List<BackupInfo> list();
 
+  @RequestLine("GET /{prefix}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  List<BackupInfo> list(@Param final String prefix);
+
   @RequestLine("DELETE /{id}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   void delete(@Param final long id);

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.restore;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
@@ -247,7 +248,7 @@ public class PartitionRestoreService {
         backupStore
             .list(
                 new BackupIdentifierWildcardImpl(
-                    Optional.empty(), Optional.of(partitionId), Optional.of(checkpointId)))
+                    Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(checkpointId)))
             .join();
     final var validStatus =
         statuses.stream()


### PR DESCRIPTION
This is the first half of https://github.com/camunda/camunda/issues/36162, adding the option to filter backup statuses by prefix.

`GET actuator/backupRuntime` can now take:
- A full backup id, returning the backup status, as before.
- No extra parameter, listing all backup statuses, as before.
- A backup prefix ending in `*`, listing all backup statuses matching that prefix.

The commits should be rather tidy, reviewing them one by one and reading the commit messages is recommended.