### PR TITLE
Exclude 8.6 fields from being serialized for 8.5 records

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -190,6 +190,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -11,12 +11,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import io.camunda.zeebe.exporter.BulkIndexRequest.BulkOperation;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableDeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableDecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableFormMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableProcessMetadataValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.camunda.zeebe.util.VersionUtil;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -24,19 +35,28 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @Execution(ExecutionMode.CONCURRENT)
 final class BulkIndexRequestTest {
 
   private static final ObjectMapper MAPPER =
-      new ObjectMapper().registerModule(new ZeebeProtocolModule());
+      new ObjectMapper()
+          .registerModule(new ZeebeProtocolModule())
+          .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
 
   private static final int PARTITION_ID = 1;
 
@@ -49,7 +69,11 @@ final class BulkIndexRequestTest {
   @Test
   void shouldReturnMemoryUsageAsLengthOfAllSerializedRecords() throws IOException {
     // given
-    final var records = recordFactory.generateRecords().limit(2).toList();
+    final var records =
+        recordFactory
+            .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+            .limit(2)
+            .toList();
     final var actions =
         List.of(
             new BulkIndexAction("index", "id", "routing"),
@@ -83,7 +107,11 @@ final class BulkIndexRequestTest {
   @Test
   void shouldClear() {
     // given
-    final var records = recordFactory.generateRecords().limit(2).toList();
+    final var records =
+        recordFactory
+            .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+            .limit(2)
+            .toList();
     final var actions =
         List.of(
             new BulkIndexAction("index", "id", "routing"),
@@ -107,7 +135,11 @@ final class BulkIndexRequestTest {
     @Test
     void shouldNotIndexWithIdenticalMetadata() {
       // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var records =
+          recordFactory
+              .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+              .limit(2)
+              .toList();
       final var action = new BulkIndexAction("index", "id", "routing");
 
       // when - doesn't matter what the records are, if the metadata is the same we skip it
@@ -125,7 +157,11 @@ final class BulkIndexRequestTest {
     @Test
     void shouldIndexWithDifferentMetadata() {
       // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var records =
+          recordFactory
+              .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+              .limit(2)
+              .toList();
       final var actions =
           List.of(
               new BulkIndexAction("index", "id", "routing"),
@@ -146,10 +182,12 @@ final class BulkIndexRequestTest {
 
   @Nested
   final class SerializationTest {
+
     @Test
     void shouldIndexRecordSerialized() {
       // given
-      final var record = recordFactory.generateRecord();
+      final var record =
+          recordFactory.generateRecord(b -> b.withBrokerVersion(VersionUtil.getVersion()));
       final var action = new BulkIndexAction("index", "id", "routing");
 
       // when
@@ -166,7 +204,11 @@ final class BulkIndexRequestTest {
     @Test
     void shouldWriteOperationsAsNDJson() throws IOException {
       // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var records =
+          recordFactory
+              .generateRecords(b -> b.withBrokerVersion(VersionUtil.getVersion()))
+              .limit(2)
+              .toList();
       final var actions =
           List.of(
               new BulkIndexAction("index", "id", "routing"),
@@ -197,10 +239,12 @@ final class BulkIndexRequestTest {
               Tuple.tuple(actions.get(1), records.get(1)));
     }
 
-    @Test
-    void shouldIndexRecordWithSequence() {
+    @ParameterizedTest
+    @MethodSource("versionProvider")
+    void shouldIndexRecordWithSequence(final String brokerVersion) {
       // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var records =
+          recordFactory.generateRecords(r -> r.withBrokerVersion(brokerVersion)).limit(2).toList();
 
       final var actions =
           List.of(
@@ -221,6 +265,585 @@ final class BulkIndexRequestTest {
           .extracting(source -> source.get("sequence"))
           .describedAs("Expect that the records are serialized with the sequences")
           .containsExactly(recordSequences.get(0).sequence(), recordSequences.get(1).sequence());
+    }
+
+    static Stream<Arguments> versionProvider() {
+      return Stream.of(Arguments.of(VersionUtil.getVersion()), Arguments.of("8.5.0"));
+    }
+
+    @Test
+    void shouldIndexRecordForPreviousVersionWithoutOperationReference() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r -> r.withBrokerVersion("8.5.0").withOperationReference(123L));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("operationReference"))
+          .describedAs("Expect that the records are NOT serialized with operationReference")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexRecordWithOperationReference() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withOperationReference(123L));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("operationReference"))
+          .describedAs("Expect that the records are serialized with operationReference")
+          .containsExactly(123);
+    }
+
+    @Test
+    void shouldIndexCommandDistributionRecordForPreviousVersionWithoutQueueId() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          ImmutableCommandDistributionRecordValue.builder()
+                              .withQueueId("test-queue-id")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("queueId"))
+          .describedAs("Expect that the records are NOT serialized with queueId")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexCommandDistributionRecordWithQueueId() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableCommandDistributionRecordValue.builder()
+                              .withQueueId("test-queue-id")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("queueId"))
+          .describedAs("Expect that the records are serialized with queueId")
+          .containsExactly("test-queue-id");
+    }
+
+    @Test
+    void shouldIndexDecisionRecordForPreviousVersionWithoutDeploymentKeyAndVersionTag() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          ImmutableDecisionRecordValue.builder()
+                              .withDeploymentKey(456L)
+                              .withVersionTag("v1.0")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are NOT serialized with deploymentKey")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("versionTag"))
+          .describedAs("Expect that the records are NOT serialized with versionTag")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexDecisionRecordWithDeploymentKeyAndVersionTag() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableDecisionRecordValue.builder()
+                              .withDeploymentKey(456L)
+                              .withVersionTag("v1.0")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are serialized with deploymentKey")
+          .containsExactly(456);
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("versionTag"))
+          .describedAs("Expect that the records are serialized with versionTag")
+          .containsExactly("v1.0");
+    }
+
+    @Test
+    void shouldIndexDeploymentRecordForPreviousVersionWithoutDeploymentKey() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          ImmutableDeploymentRecordValue.builder()
+                              .withDeploymentKey(789L)
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are NOT serialized with deploymentKey")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexDeploymentRecordWithDeploymentKey() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableDeploymentRecordValue.builder()
+                              .withDeploymentKey(789L)
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are serialized with deploymentKey")
+          .containsExactly(789);
+    }
+
+    @Test
+    void shouldIndexFormMetadataRecordForPreviousVersionWithoutDeploymentKeyAndVersionTag() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          ImmutableFormMetadataValue.builder()
+                              .withDeploymentKey(321L)
+                              .withVersionTag("v2.0")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are NOT serialized with deploymentKey")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("versionTag"))
+          .describedAs("Expect that the records are NOT serialized with versionTag")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexFormMetadataRecordWithDeploymentKeyAndVersionTag() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableFormMetadataValue.builder()
+                              .withDeploymentKey(321L)
+                              .withVersionTag("v2.0")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are serialized with deploymentKey")
+          .containsExactly(321);
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("versionTag"))
+          .describedAs("Expect that the records are serialized with versionTag")
+          .containsExactly("v2.0");
+    }
+
+    @Test
+    void shouldIndexProcessMetadataRecordForPreviousVersionWithoutDeploymentKeyAndVersionTag() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          ImmutableProcessMetadataValue.builder()
+                              .withDeploymentKey(654L)
+                              .withVersionTag("v3.0")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are NOT serialized with deploymentKey")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("versionTag"))
+          .describedAs("Expect that the records are NOT serialized with versionTag")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexProcessMetadataRecordWithDeploymentKeyAndVersionTag() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableProcessMetadataValue.builder()
+                              .withDeploymentKey(654L)
+                              .withVersionTag("v3.0")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are serialized with deploymentKey")
+          .containsExactly(654);
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("versionTag"))
+          .describedAs("Expect that the records are serialized with versionTag")
+          .containsExactly("v3.0");
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordForPreviousVersionWithoutPriority() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r -> r.withBrokerVersion("8.5.0").withValue(new UserTaskRecord().setPriority(50)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("priority"))
+          .describedAs("Expect that the records are NOT serialized with priority")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithPriority() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new UserTaskRecord().setPriority(50)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("priority"))
+          .describedAs("Expect that the records are serialized with priority")
+          .containsExactly(50);
+    }
+
+    @Test
+    void
+        shouldIndexIncidentRecordForPreviousVersionWithoutElementInstancePathProcessDefinitionPathAndCallingElementPath() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          ImmutableIncidentRecordValue.builder()
+                              .withElementInstancePath(List.of(List.of(1L, 2L, 3L)))
+                              .withProcessDefinitionPath(List.of(1L, 2L, 3L))
+                              .withCallingElementPath(List.of(3, 4, 5))
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("elementInstancePath"))
+          .describedAs("Expect that the records are NOT serialized with elementInstancePath")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionPath"))
+          .describedAs("Expect that the records are NOT serialized with processDefinitionPath")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("callingElementPath"))
+          .describedAs("Expect that the records are NOT serialized with callingElementPath")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void
+        shouldIndexIncidentRecordWithElementInstancePathProcessDefinitionPathAndCallingElementPath() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableIncidentRecordValue.builder()
+                              .withElementInstancePath(List.of(List.of(1L, 2L, 3L)))
+                              .withProcessDefinitionPath(List.of(1L, 2L, 3L))
+                              .withCallingElementPath(List.of(3, 4, 5))
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("elementInstancePath"))
+          .describedAs("Expect that the records are serialized with elementInstancePath")
+          .containsExactly(List.of(List.of(1, 2, 3)));
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionPath"))
+          .describedAs("Expect that the records are serialized with processDefinitionPath")
+          .containsExactly(List.of(1, 2, 3));
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("callingElementPath"))
+          .describedAs("Expect that the records are serialized with callingElementPath")
+          .containsExactly(List.of(3, 4, 5));
+    }
+
+    @Test
+    void shouldIndexJobRecordForPreviousVersionWithoutJobListenerEventTypeAndChangedAttributes() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          new JobRecord()
+                              .setChangedAttributes(Set.of("attr1", "attr2"))
+                              .setListenerEventType(JobListenerEventType.START)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("jobListenerEventType"))
+          .describedAs("Expect that the records are NOT serialized with jobListenerEventType")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("changedAttributes"))
+          .describedAs("Expect that the records are NOT serialized with changedAttributes")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobRecordWithJobListenerEventTypeAndChangedAttributes() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new JobRecord()
+                              .setChangedAttributes(Set.of("attr1", "attr2"))
+                              .setListenerEventType(JobListenerEventType.START)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("jobListenerEventType"))
+          .describedAs("Expect that the records are serialized with jobListenerEventType")
+          .containsExactly(JobListenerEventType.START.toString());
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("changedAttributes"))
+          .flatMap(source -> new HashSet<>((Collection) source))
+          .describedAs("Expect that the records are serialized with changedAttributes")
+          .containsExactlyInAnyOrder("attr1", "attr2");
     }
 
     private Record<?> deserializeSource(final BulkOperation operation) {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
@@ -158,8 +158,12 @@ final class ElasticsearchClientTest {
     @Test
     void shouldFlushOnMemoryLimit() {
       // given
-      final var firstRecord = factory.generateRecord(ValueType.DECISION);
-      final var secondRecord = factory.generateRecord(ValueType.VARIABLE);
+      final var firstRecord =
+          factory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValueType(ValueType.DECISION));
+      final var secondRecord =
+          factory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValueType(ValueType.VARIABLE));
 
       // when - index a single record, then set the memory limit specifically to be its size + 1
       // this decouples the test from whatever is used to serialize the record
@@ -176,8 +180,10 @@ final class ElasticsearchClientTest {
     void shouldFlushOnSizeLimit() {
       // given
       config.bulk.size = 2;
-      final var firstRecord = factory.generateRecord();
-      final var secondRecord = factory.generateRecord();
+      final var firstRecord =
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
+      final var secondRecord =
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
 
       // when
       client.index(firstRecord, new RecordSequence(PARTITION_ID, 1));
@@ -207,7 +213,9 @@ final class ElasticsearchClientTest {
           mockClientResponse(new BulkIndexResponse(false, List.of()));
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       client.flush();
 
       // then
@@ -227,7 +235,9 @@ final class ElasticsearchClientTest {
       mockClientResponse(new BulkIndexResponse(false, List.of()));
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       client.flush();
 
       // then
@@ -242,7 +252,9 @@ final class ElasticsearchClientTest {
       doThrow(failure).when(restClient).performRequest(any());
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       assertThatCode(client::flush).isEqualTo(failure);
 
       // then

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -204,6 +204,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -7,11 +7,22 @@
  */
 package io.camunda.zeebe.exporter.opensearch;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import io.camunda.zeebe.util.SemanticVersion;
+import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -30,11 +41,33 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(Record.class, RecordSequenceMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
+  private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
+      new ObjectMapper()
+          .addMixIn(Record.class, Record85Mixin.class)
+          .addMixIn(CommandDistributionRecordValue.class, CommandDistribution85Mixin.class)
+          .addMixIn(DecisionRecordValue.class, Decision85Mixin.class)
+          .addMixIn(DeploymentRecordValue.class, Deployment85Mixin.class)
+          .addMixIn(FormMetadataValue.class, FormMetadata85Mixin.class)
+          .addMixIn(ProcessMetadataValue.class, ProcessMeta85Mixin.class)
+          .addMixIn(UserTaskRecordValue.class, UserTask85Mixin.class)
+          .addMixIn(IncidentRecordValue.class, Incident85Mixin.class)
+          .addMixIn(JobRecordValue.class, Job85Mixin.class)
+          .enable(Feature.ALLOW_SINGLE_QUOTES);
+
   // The property of the ES record template to store the sequence of the record.
   private static final String RECORD_SEQUENCE_PROPERTY = "sequence";
+  private static final String RECORD_OPERATION_REFERENCE_PROPERTY = "operationReference";
+  private static final String QUEUE_ID_PROPERTY = "queueId";
+  private static final String DEPLOYMENT_KEY_PROPERTY = "deploymentKey";
+  private static final String VERSION_TAG_PROPERTY = "versionTag";
+  private static final String PRIORITY_PROPERTY = "priority";
+  private static final String ELEMENT_INSTANCE_PATH_PROPERTY = "elementInstancePath";
+  private static final String PROCESS_DEFINITION_PATH_PROPERTY = "processDefinitionPath";
+  private static final String CALLING_ELEMENT_PATH_PROPERTY = "callingElementPath";
+  private static final String JOB_LISTENER_EVENT_TYPE_PROPERTY = "jobListenerEventType";
+  private static final String CHANGED_ATTRIBUTES_PROPERTY = "changedAttributes";
 
   private final List<BulkOperation> operations = new ArrayList<>();
-
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
 
@@ -75,7 +108,9 @@ final class BulkIndexRequest implements ContentProducer {
 
   private static byte[] serializeRecord(final Record<?> record, final RecordSequence recordSequence)
       throws IOException {
-    return MAPPER
+    final var mapper =
+        isPreviousVersionRecord(record.getBrokerVersion()) ? PREVIOUS_VERSION_MAPPER : MAPPER;
+    return mapper
         .writer()
         // Enhance the serialized record by its sequence number. The sequence number is not a part
         // of the record itself but a special property for Opensearch. It can be used to limit
@@ -131,8 +166,76 @@ final class BulkIndexRequest implements ContentProducer {
     }
   }
 
+  private static boolean isPreviousVersionRecord(final String brokerVersion) {
+    final SemanticVersion semanticVersion =
+        SemanticVersion.parse(brokerVersion)
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Expected to parse valid semantic version, but got [%s]"
+                            .formatted(brokerVersion)));
+    final int currentMinorVersion =
+        VersionUtil.getSemanticVersion()
+            .map(SemanticVersion::minor)
+            .orElseThrow(
+                () -> new IllegalStateException("Expected to have a valid semantic version"));
+    return semanticVersion.minor() < currentMinorVersion;
+  }
+
   record BulkOperation(BulkIndexAction metadata, byte[] source) {}
 
   @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
   private static final class RecordSequenceMixin {}
+
+  @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
+  @JsonIgnoreProperties({
+    RECORD_OPERATION_REFERENCE_PROPERTY,
+  })
+  private static final class Record85Mixin {}
+
+  @JsonIgnoreProperties({
+    QUEUE_ID_PROPERTY,
+  })
+  private static final class CommandDistribution85Mixin {}
+
+  @JsonIgnoreProperties({
+    DEPLOYMENT_KEY_PROPERTY,
+    VERSION_TAG_PROPERTY,
+  })
+  private static final class Decision85Mixin {}
+
+  @JsonIgnoreProperties({
+    DEPLOYMENT_KEY_PROPERTY,
+  })
+  private static final class Deployment85Mixin {}
+
+  @JsonIgnoreProperties({
+    DEPLOYMENT_KEY_PROPERTY,
+    VERSION_TAG_PROPERTY,
+  })
+  private static final class FormMetadata85Mixin {}
+
+  @JsonIgnoreProperties({
+    DEPLOYMENT_KEY_PROPERTY,
+    VERSION_TAG_PROPERTY,
+  })
+  private static final class ProcessMeta85Mixin {}
+
+  @JsonIgnoreProperties({
+    PRIORITY_PROPERTY,
+  })
+  private static final class UserTask85Mixin {}
+
+  @JsonIgnoreProperties({
+    ELEMENT_INSTANCE_PATH_PROPERTY,
+    PROCESS_DEFINITION_PATH_PROPERTY,
+    CALLING_ELEMENT_PATH_PROPERTY,
+  })
+  private static final class Incident85Mixin {}
+
+  @JsonIgnoreProperties({
+    JOB_LISTENER_EVENT_TYPE_PROPERTY,
+    CHANGED_ATTRIBUTES_PROPERTY,
+  })
+  private static final class Job85Mixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -11,12 +11,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import io.camunda.zeebe.exporter.opensearch.BulkIndexRequest.BulkOperation;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableDeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableDecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableFormMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableProcessMetadataValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.camunda.zeebe.util.VersionUtil;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -24,19 +35,28 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @Execution(ExecutionMode.CONCURRENT)
 final class BulkIndexRequestTest {
 
   private static final ObjectMapper MAPPER =
-      new ObjectMapper().registerModule(new ZeebeProtocolModule());
+      new ObjectMapper()
+          .registerModule(new ZeebeProtocolModule())
+          .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
 
   private static final int PARTITION_ID = 1;
 
@@ -49,7 +69,11 @@ final class BulkIndexRequestTest {
   @Test
   void shouldReturnMemoryUsageAsLengthOfAllSerializedRecords() throws IOException {
     // given
-    final var records = recordFactory.generateRecords().limit(2).toList();
+    final var records =
+        recordFactory
+            .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+            .limit(2)
+            .toList();
     final var actions =
         List.of(
             new BulkIndexAction("index", "id", "routing"),
@@ -83,7 +107,11 @@ final class BulkIndexRequestTest {
   @Test
   void shouldClear() {
     // given
-    final var records = recordFactory.generateRecords().limit(2).toList();
+    final var records =
+        recordFactory
+            .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+            .limit(2)
+            .toList();
     final var actions =
         List.of(
             new BulkIndexAction("index", "id", "routing"),
@@ -107,7 +135,11 @@ final class BulkIndexRequestTest {
     @Test
     void shouldNotIndexWithIdenticalMetadata() {
       // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var records =
+          recordFactory
+              .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+              .limit(2)
+              .toList();
       final var action = new BulkIndexAction("index", "id", "routing");
 
       // when - doesn't matter what the records are, if the metadata is the same we skip it
@@ -125,7 +157,11 @@ final class BulkIndexRequestTest {
     @Test
     void shouldIndexWithDifferentMetadata() {
       // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var records =
+          recordFactory
+              .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+              .limit(2)
+              .toList();
       final var actions =
           List.of(
               new BulkIndexAction("index", "id", "routing"),
@@ -146,10 +182,12 @@ final class BulkIndexRequestTest {
 
   @Nested
   final class SerializationTest {
+
     @Test
     void shouldIndexRecordSerialized() {
       // given
-      final var record = recordFactory.generateRecord();
+      final var record =
+          recordFactory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
       final var action = new BulkIndexAction("index", "id", "routing");
 
       // when
@@ -166,7 +204,11 @@ final class BulkIndexRequestTest {
     @Test
     void shouldWriteOperationsAsNDJson() throws IOException {
       // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var records =
+          recordFactory
+              .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+              .limit(2)
+              .toList();
       final var actions =
           List.of(
               new BulkIndexAction("index", "id", "routing"),
@@ -197,10 +239,15 @@ final class BulkIndexRequestTest {
               Tuple.tuple(actions.get(1), records.get(1)));
     }
 
-    @Test
-    void shouldIndexRecordWithSequence() {
+    @ParameterizedTest
+    @MethodSource("versionProvider")
+    void shouldIndexRecordWithSequence(final String brokerVersion) {
       // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var records =
+          recordFactory
+              .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+              .limit(2)
+              .toList();
 
       final var actions =
           List.of(
@@ -221,6 +268,585 @@ final class BulkIndexRequestTest {
           .extracting(source -> source.get("sequence"))
           .describedAs("Expect that the records are serialized with the sequences")
           .containsExactly(recordSequences.get(0).sequence(), recordSequences.get(1).sequence());
+    }
+
+    static Stream<Arguments> versionProvider() {
+      return Stream.of(Arguments.of(VersionUtil.getVersion()), Arguments.of("8.5.0"));
+    }
+
+    @Test
+    void shouldIndexRecordForPreviousVersionWithoutOperationReference() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r -> r.withBrokerVersion("8.5.0").withOperationReference(123L));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("operationReference"))
+          .describedAs("Expect that the records are NOT serialized with operationReference")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexRecordWithOperationReference() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withOperationReference(123L));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("operationReference"))
+          .describedAs("Expect that the records are serialized with operationReference")
+          .containsExactly(123);
+    }
+
+    @Test
+    void shouldIndexCommandDistributionRecordForPreviousVersionWithoutQueueId() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          ImmutableCommandDistributionRecordValue.builder()
+                              .withQueueId("test-queue-id")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("queueId"))
+          .describedAs("Expect that the records are NOT serialized with queueId")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexCommandDistributionRecordWithQueueId() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableCommandDistributionRecordValue.builder()
+                              .withQueueId("test-queue-id")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("queueId"))
+          .describedAs("Expect that the records are serialized with queueId")
+          .containsExactly("test-queue-id");
+    }
+
+    @Test
+    void shouldIndexDecisionRecordForPreviousVersionWithoutDeploymentKeyAndVersionTag() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          ImmutableDecisionRecordValue.builder()
+                              .withDeploymentKey(456L)
+                              .withVersionTag("v1.0")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are NOT serialized with deploymentKey")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("versionTag"))
+          .describedAs("Expect that the records are NOT serialized with versionTag")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexDecisionRecordWithDeploymentKeyAndVersionTag() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableDecisionRecordValue.builder()
+                              .withDeploymentKey(456L)
+                              .withVersionTag("v1.0")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are serialized with deploymentKey")
+          .containsExactly(456);
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("versionTag"))
+          .describedAs("Expect that the records are serialized with versionTag")
+          .containsExactly("v1.0");
+    }
+
+    @Test
+    void shouldIndexDeploymentRecordForPreviousVersionWithoutDeploymentKey() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          ImmutableDeploymentRecordValue.builder()
+                              .withDeploymentKey(789L)
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are NOT serialized with deploymentKey")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexDeploymentRecordWithDeploymentKey() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableDeploymentRecordValue.builder()
+                              .withDeploymentKey(789L)
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are serialized with deploymentKey")
+          .containsExactly(789);
+    }
+
+    @Test
+    void shouldIndexFormMetadataRecordForPreviousVersionWithoutDeploymentKeyAndVersionTag() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          ImmutableFormMetadataValue.builder()
+                              .withDeploymentKey(321L)
+                              .withVersionTag("v2.0")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are NOT serialized with deploymentKey")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("versionTag"))
+          .describedAs("Expect that the records are NOT serialized with versionTag")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexFormMetadataRecordWithDeploymentKeyAndVersionTag() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableFormMetadataValue.builder()
+                              .withDeploymentKey(321L)
+                              .withVersionTag("v2.0")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are serialized with deploymentKey")
+          .containsExactly(321);
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("versionTag"))
+          .describedAs("Expect that the records are serialized with versionTag")
+          .containsExactly("v2.0");
+    }
+
+    @Test
+    void shouldIndexProcessMetadataRecordForPreviousVersionWithoutDeploymentKeyAndVersionTag() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          ImmutableProcessMetadataValue.builder()
+                              .withDeploymentKey(654L)
+                              .withVersionTag("v3.0")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are NOT serialized with deploymentKey")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("versionTag"))
+          .describedAs("Expect that the records are NOT serialized with versionTag")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexProcessMetadataRecordWithDeploymentKeyAndVersionTag() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableProcessMetadataValue.builder()
+                              .withDeploymentKey(654L)
+                              .withVersionTag("v3.0")
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deploymentKey"))
+          .describedAs("Expect that the records are serialized with deploymentKey")
+          .containsExactly(654);
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("versionTag"))
+          .describedAs("Expect that the records are serialized with versionTag")
+          .containsExactly("v3.0");
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordForPreviousVersionWithoutPriority() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r -> r.withBrokerVersion("8.5.0").withValue(new UserTaskRecord().setPriority(50)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("priority"))
+          .describedAs("Expect that the records are NOT serialized with priority")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexUserTaskRecordWithPriority() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new UserTaskRecord().setPriority(50)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("priority"))
+          .describedAs("Expect that the records are serialized with priority")
+          .containsExactly(50);
+    }
+
+    @Test
+    void
+        shouldIndexIncidentRecordForPreviousVersionWithoutElementInstancePathProcessDefinitionPathAndCallingElementPath() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          ImmutableIncidentRecordValue.builder()
+                              .withElementInstancePath(List.of(List.of(1L, 2L, 3L)))
+                              .withProcessDefinitionPath(List.of(1L, 2L, 3L))
+                              .withCallingElementPath(List.of(3, 4, 5))
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("elementInstancePath"))
+          .describedAs("Expect that the records are NOT serialized with elementInstancePath")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionPath"))
+          .describedAs("Expect that the records are NOT serialized with processDefinitionPath")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("callingElementPath"))
+          .describedAs("Expect that the records are NOT serialized with callingElementPath")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void
+        shouldIndexIncidentRecordWithElementInstancePathProcessDefinitionPathAndCallingElementPath() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableIncidentRecordValue.builder()
+                              .withElementInstancePath(List.of(List.of(1L, 2L, 3L)))
+                              .withProcessDefinitionPath(List.of(1L, 2L, 3L))
+                              .withCallingElementPath(List.of(3, 4, 5))
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("elementInstancePath"))
+          .describedAs("Expect that the records are serialized with elementInstancePath")
+          .containsExactly(List.of(List.of(1, 2, 3)));
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionPath"))
+          .describedAs("Expect that the records are serialized with processDefinitionPath")
+          .containsExactly(List.of(1, 2, 3));
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("callingElementPath"))
+          .describedAs("Expect that the records are serialized with callingElementPath")
+          .containsExactly(List.of(3, 4, 5));
+    }
+
+    @Test
+    void shouldIndexJobRecordForPreviousVersionWithoutJobListenerEventTypeAndChangedAttributes() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion("8.5.0")
+                      .withValue(
+                          new JobRecord()
+                              .setChangedAttributes(Set.of("attr1", "attr2"))
+                              .setListenerEventType(JobListenerEventType.START)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("jobListenerEventType"))
+          .describedAs("Expect that the records are NOT serialized with jobListenerEventType")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("changedAttributes"))
+          .describedAs("Expect that the records are NOT serialized with changedAttributes")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobRecordWithJobListenerEventTypeAndChangedAttributes() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new JobRecord()
+                              .setChangedAttributes(Set.of("attr1", "attr2"))
+                              .setListenerEventType(JobListenerEventType.START)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("jobListenerEventType"))
+          .describedAs("Expect that the records are serialized with jobListenerEventType")
+          .containsExactly(JobListenerEventType.START.toString());
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("changedAttributes"))
+          .flatMap(source -> new HashSet<>((Collection) source))
+          .describedAs("Expect that the records are serialized with changedAttributes")
+          .containsExactlyInAnyOrder("attr1", "attr2");
     }
 
     private Record<?> deserializeSource(final BulkOperation operation) {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientTest.java
@@ -130,8 +130,12 @@ final class OpensearchClientTest {
     @Test
     void shouldFlushOnMemoryLimit() {
       // given
-      final var firstRecord = factory.generateRecord(ValueType.DECISION);
-      final var secondRecord = factory.generateRecord(ValueType.VARIABLE);
+      final var firstRecord =
+          factory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValueType(ValueType.DECISION));
+      final var secondRecord =
+          factory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValueType(ValueType.VARIABLE));
 
       // when - index a single record, then set the memory limit specifically to be its size + 1
       // this decouples the test from whatever is used to serialize the record
@@ -148,8 +152,10 @@ final class OpensearchClientTest {
     void shouldFlushOnSizeLimit() {
       // given
       config.bulk.size = 2;
-      final var firstRecord = factory.generateRecord();
-      final var secondRecord = factory.generateRecord();
+      final var firstRecord =
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
+      final var secondRecord =
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
 
       // when
       client.index(firstRecord, new RecordSequence(PARTITION_ID, 1));
@@ -179,7 +185,9 @@ final class OpensearchClientTest {
           mockClientResponse(new BulkIndexResponse(false, List.of()));
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       client.flush();
 
       // then
@@ -199,7 +207,9 @@ final class OpensearchClientTest {
       mockClientResponse(new BulkIndexResponse(false, List.of()));
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       client.flush();
 
       // then
@@ -214,7 +224,9 @@ final class OpensearchClientTest {
       doThrow(failure).when(restClient).performRequest(any());
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       assertThatCode(client::flush).isEqualTo(failure);
 
       // then

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -17,13 +17,25 @@ import io.camunda.zeebe.exporter.opensearch.TestClient.IndexTemplatesDto.IndexTe
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableDeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableDecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableForm;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableProcess;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
@@ -306,6 +318,136 @@ final class OpensearchExporterIT {
         .isInstanceOf(UncheckedIOException.class)
         .hasCauseInstanceOf(ResponseException.class)
         .hasMessageContaining("Policy not found");
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("io.camunda.zeebe.exporter.opensearch.TestSupport#provideValueTypes")
+  void shouldExportRecordsOnPreviousVersion(final ValueType valueType) {
+    // given
+    exporter.configure(exporterTestContext);
+    exporter.open(controller);
+
+    final var record = factory.generateRecord(valueType, r -> r.withBrokerVersion("8.5.0"));
+
+    // when
+    export(record);
+
+    // then
+    final var response = testClient.getExportedDocumentFor(record);
+    assertThat(response)
+        .extracting(GetResponse::index, GetResponse::id, GetResponse::routing, GetResponse::source)
+        .containsExactly(
+            indexRouter.indexFor(record),
+            indexRouter.idFor(record),
+            String.valueOf(record.getPartitionId()),
+            modifyExpectedRecordForPreviousVersion(valueType, record));
+  }
+
+  private Record modifyExpectedRecordForPreviousVersion(
+      final ValueType valueType, final Record record) {
+    // For 8.5.0 version, we need to remove fields that are not serialized due to Jackson mixins
+    final var copyFactory = new ProtocolFactory(factory.getSeed());
+    final var recordValue =
+        modifyExpectedRecordValueForPreviousVersion(valueType, record.getValue());
+
+    // Also remove operationReference from the record itself for 8.5.0
+    return ImmutableRecord.builder()
+        .from(record)
+        .withValue(recordValue)
+        .withOperationReference(0L)
+        .build();
+  }
+
+  private static <T extends RecordValue> T modifyExpectedRecordValueForPreviousVersion(
+      final ValueType valueType, final T value) {
+    final T recordValue =
+        (T)
+            switch (valueType) {
+              case DEPLOYMENT ->
+                  ImmutableDeploymentRecordValue.builder()
+                      .from(((ImmutableDeploymentRecordValue) value))
+                      .withDecisionsMetadata(
+                          ((ImmutableDeploymentRecordValue) value)
+                              .getDecisionsMetadata().stream()
+                                  .map(
+                                      decisionRecordValue ->
+                                          modifyExpectedRecordValueForPreviousVersion(
+                                              ValueType.DECISION, decisionRecordValue))
+                                  .toList())
+                      .withFormMetadata(
+                          ((ImmutableDeploymentRecordValue) value)
+                              .getFormMetadata().stream()
+                                  .map(
+                                      formMetadataValue ->
+                                          modifyExpectedRecordValueForPreviousVersion(
+                                              ValueType.FORM, formMetadataValue))
+                                  .toList())
+                      .withProcessesMetadata(
+                          ((ImmutableDeploymentRecordValue) value)
+                              .getProcessesMetadata().stream()
+                                  .map(
+                                      processMetadataValue ->
+                                          modifyExpectedRecordValueForPreviousVersion(
+                                              ValueType.PROCESS, processMetadataValue))
+                                  .toList())
+                      .withDeploymentKey(0L)
+                      .build();
+              case DECISION ->
+                  ImmutableDecisionRecordValue.builder()
+                      .from(((DecisionRecordValue) value))
+                      .withDeploymentKey(0L)
+                      .withVersionTag(null)
+                      .build();
+              case FORM ->
+                  ImmutableForm.builder()
+                      .from(((FormMetadataValue) value))
+                      .withDeploymentKey(0L)
+                      .withVersionTag(null)
+                      .build();
+              case PROCESS ->
+                  ImmutableProcess.builder()
+                      .from(((ProcessMetadataValue) value))
+                      .withDeploymentKey(0L)
+                      .withVersionTag(null)
+                      .build();
+              case COMMAND_DISTRIBUTION ->
+                  ImmutableCommandDistributionRecordValue.builder()
+                      .from(((ImmutableCommandDistributionRecordValue) value))
+                      .withQueueId(null)
+                      .build();
+              case USER_TASK ->
+                  ImmutableUserTaskRecordValue.builder()
+                      .from(((ImmutableUserTaskRecordValue) value))
+                      .withPriority(0)
+                      .build();
+              case INCIDENT ->
+                  ImmutableIncidentRecordValue.builder()
+                      .from(((IncidentRecordValue) value))
+                      .withElementInstancePath(List.of())
+                      .withProcessDefinitionPath(List.of())
+                      .withCallingElementPath(List.of())
+                      .build();
+              case JOB ->
+                  ImmutableJobRecordValue.builder()
+                      .from(((JobRecordValue) value))
+                      .withJobListenerEventType(null)
+                      .withChangedAttributes(List.of())
+                      .build();
+              case JOB_BATCH ->
+                  ImmutableJobBatchRecordValue.builder()
+                      .from((JobBatchRecordValue) value)
+                      .withJobs(
+                          ((JobBatchRecordValue) value)
+                              .getJobs().stream()
+                                  .map(
+                                      jobRecordValue ->
+                                          modifyExpectedRecordValueForPreviousVersion(
+                                              ValueType.JOB, jobRecordValue))
+                                  .toList())
+                      .build();
+              default -> value;
+            };
+    return recordValue;
   }
 
   private boolean export(final Record<?> record) {


### PR DESCRIPTION
# Description
Backport of #37346 to `stable/8.6`.

closes https://github.com/camunda/camunda/issues/37283
relates to #37343

8.5 vs 8.6 diffs:
```
diff -r zeebe/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json zeebe3/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
25,27d24
<             "queueId": {
<               "type": "keyword"
<             },
diff -r zeebe/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-template.json zeebe3/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-template.json
45,50d44
<             },
<             "deploymentKey": {
<               "type": "long"
<             },
<             "versionTag": {
<               "type": "keyword"
diff -r zeebe/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json zeebe3/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
46,51d45
<                 },
<                 "deploymentKey": {
<                   "type": "long"
<                 },
<                 "versionTag": {
<                   "type": "keyword"
121,126d114
<                 },
<                 "deploymentKey": {
<                   "type": "long"
<                 },
<                 "versionTag": {
<                   "type": "keyword"
152,157d139
<                 },
<                 "deploymentKey": {
<                   "type": "long"
<                 },
<                 "versionTag": {
<                   "type": "keyword"
163,165d144
<             },
<             "deploymentKey": {
<               "type": "long"
diff -r zeebe/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-form-template.json zeebe3/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-form-template.json
47,52d46
<             },
<             "deploymentKey": {
<               "type": "long"
<             },
<             "versionTag": {
<               "type": "keyword"
diff -r zeebe/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json zeebe3/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
51,59d50
<             },
<             "elementInstancePath": {
<               "enabled": false
<             },
<             "processDefinitionPath": {
<               "enabled": false
<             },
<             "callingElementPath": {
<               "enabled": false
diff -r zeebe/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json zeebe3/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
97,102d96
<                 },
<                 "jobListenerEventType": {
<                   "type": "keyword"
<                 },
<                 "changedAttributes": {
<                   "type": "text"
diff -r zeebe/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json zeebe3/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
78,83d77
<             },
<             "jobListenerEventType": {
<               "type": "keyword"
<             },
<             "changedAttributes": {
<               "type": "text"
diff -r zeebe/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json zeebe3/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
45,50d44
<             },
<             "deploymentKey": {
<               "type": "long"
<             },
<             "versionTag": {
<               "type": "keyword"
diff -r zeebe/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json zeebe3/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
53,55d52
<         },
<         "operationReference": {
<           "type": "long"
diff -r zeebe/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json zeebe3/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
81,83d80
<             },
<             "priority": {
<               "type": "integer"
```