### PR TITLE
Exclude 8.7 fields from being serialized for 8.6 records

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -190,6 +190,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-msgpack-value</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -7,16 +7,20 @@
  */
 package io.camunda.zeebe.exporter;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import io.camunda.zeebe.exporter.BulkIndexRequest.BulkOperation;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.camunda.zeebe.util.VersionUtil;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -36,7 +40,9 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 final class BulkIndexRequestTest {
 
   private static final ObjectMapper MAPPER =
-      new ObjectMapper().registerModule(new ZeebeProtocolModule());
+      new ObjectMapper()
+          .registerModule(new ZeebeProtocolModule())
+          .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
 
   private static final int PARTITION_ID = 1;
 
@@ -49,7 +55,11 @@ final class BulkIndexRequestTest {
   @Test
   void shouldReturnMemoryUsageAsLengthOfAllSerializedRecords() throws IOException {
     // given
-    final var records = recordFactory.generateRecords().limit(2).toList();
+    final var records =
+        recordFactory
+            .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+            .limit(2)
+            .toList();
     final var actions =
         List.of(
             new BulkIndexAction("index", "id", "routing"),
@@ -83,7 +93,11 @@ final class BulkIndexRequestTest {
   @Test
   void shouldClear() {
     // given
-    final var records = recordFactory.generateRecords().limit(2).toList();
+    final var records =
+        recordFactory
+            .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+            .limit(2)
+            .toList();
     final var actions =
         List.of(
             new BulkIndexAction("index", "id", "routing"),
@@ -107,7 +121,11 @@ final class BulkIndexRequestTest {
     @Test
     void shouldNotIndexWithIdenticalMetadata() {
       // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var records =
+          recordFactory
+              .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+              .limit(2)
+              .toList();
       final var action = new BulkIndexAction("index", "id", "routing");
 
       // when - doesn't matter what the records are, if the metadata is the same we skip it
@@ -125,7 +143,11 @@ final class BulkIndexRequestTest {
     @Test
     void shouldIndexWithDifferentMetadata() {
       // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var records =
+          recordFactory
+              .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+              .limit(2)
+              .toList();
       final var actions =
           List.of(
               new BulkIndexAction("index", "id", "routing"),
@@ -146,10 +168,12 @@ final class BulkIndexRequestTest {
 
   @Nested
   final class SerializationTest {
+
     @Test
     void shouldIndexRecordSerialized() {
       // given
-      final var record = recordFactory.generateRecord();
+      final var record =
+          recordFactory.generateRecord(b -> b.withBrokerVersion(VersionUtil.getVersion()));
       final var action = new BulkIndexAction("index", "id", "routing");
 
       // when
@@ -166,7 +190,11 @@ final class BulkIndexRequestTest {
     @Test
     void shouldWriteOperationsAsNDJson() throws IOException {
       // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var records =
+          recordFactory
+              .generateRecords(b -> b.withBrokerVersion(VersionUtil.getVersion()))
+              .limit(2)
+              .toList();
       final var actions =
           List.of(
               new BulkIndexAction("index", "id", "routing"),
@@ -200,7 +228,11 @@ final class BulkIndexRequestTest {
     @Test
     void shouldIndexRecordWithSequence() {
       // given
-      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var records =
+          recordFactory
+              .generateRecords(r -> r.withBrokerVersion(VersionUtil.getVersion()))
+              .limit(2)
+              .toList();
 
       final var actions =
           List.of(
@@ -221,6 +253,72 @@ final class BulkIndexRequestTest {
           .extracting(source -> source.get("sequence"))
           .describedAs("Expect that the records are serialized with the sequences")
           .containsExactly(recordSequences.get(0).sequence(), recordSequences.get(1).sequence());
+    }
+
+    @Test
+    void shouldIndexDeploymentRecordWithResourceMetadata() {
+      // given
+      final var value = new DeploymentRecord();
+      value
+          .resourceMetadata()
+          .add()
+          .setDeploymentKey(12345L)
+          .setResourceName("resourceName")
+          .setResourceId("resourceId")
+          .setChecksum(wrapString("checksum"))
+          .setResourceKey(1L)
+          .setVersion(1);
+      final var record =
+          recordFactory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValue(value));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("resourceMetadata"))
+          .describedAs("Expect that the records are serialized with resourceMetadata")
+          .map(source -> MAPPER.writeValueAsString(source))
+          .containsExactly(
+              """
+[{"checksum":"Y2hlY2tzdW0=","deploymentKey":12345,"duplicate":false,"resourceId":"resourceId","resourceKey":1,"resourceName":"resourceName","tenantId":"<default>","version":1,"versionTag":""}]""");
+    }
+
+    @Test
+    void shouldIndexDeploymentRecordOnPreviousVersionWithoutResourceMetadata() {
+      // given
+      final var value = new DeploymentRecord();
+      value
+          .resourceMetadata()
+          .add()
+          .setDeploymentKey(12345L)
+          .setResourceName("resourceName")
+          .setResourceId("resourceId")
+          .setChecksum(wrapString("checksum"))
+          .setResourceKey(1L)
+          .setVersion(1);
+      final var record =
+          recordFactory.generateRecord(r -> r.withBrokerVersion("8.6.0").withValue(value));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("resourceMetadata"))
+          .describedAs("Expect that the records are NOT serialized with resourceMetadata")
+          .containsExactly(new Object[] {null});
     }
 
     private Record<?> deserializeSource(final BulkOperation operation) {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
@@ -158,8 +158,12 @@ final class ElasticsearchClientTest {
     @Test
     void shouldFlushOnMemoryLimit() {
       // given
-      final var firstRecord = factory.generateRecord(ValueType.DECISION);
-      final var secondRecord = factory.generateRecord(ValueType.VARIABLE);
+      final var firstRecord =
+          factory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValueType(ValueType.DECISION));
+      final var secondRecord =
+          factory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValueType(ValueType.VARIABLE));
 
       // when - index a single record, then set the memory limit specifically to be its size + 1
       // this decouples the test from whatever is used to serialize the record
@@ -176,8 +180,10 @@ final class ElasticsearchClientTest {
     void shouldFlushOnSizeLimit() {
       // given
       config.bulk.size = 2;
-      final var firstRecord = factory.generateRecord();
-      final var secondRecord = factory.generateRecord();
+      final var firstRecord =
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
+      final var secondRecord =
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
 
       // when
       client.index(firstRecord, new RecordSequence(PARTITION_ID, 1));
@@ -207,7 +213,9 @@ final class ElasticsearchClientTest {
           mockClientResponse(new BulkIndexResponse(false, List.of()));
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       client.flush();
 
       // then
@@ -227,7 +235,9 @@ final class ElasticsearchClientTest {
       mockClientResponse(new BulkIndexResponse(false, List.of()));
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       client.flush();
 
       // then
@@ -242,7 +252,9 @@ final class ElasticsearchClientTest {
       doThrow(failure).when(restClient).performRequest(any());
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       assertThatCode(client::flush).isEqualTo(failure);
 
       // then

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -20,9 +20,11 @@ import io.camunda.zeebe.exporter.TestClient.IndexTemplatesDto.IndexTemplateWrapp
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.ImmutableDeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
@@ -221,6 +223,43 @@ final class ElasticsearchExporterIT {
         .get()
         .extracting(ComponentTemplateWrapper::name)
         .isEqualTo(config.index.prefix + "-" + VersionUtil.getVersionLowerCase());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("io.camunda.zeebe.exporter.TestSupport#provideValueTypes")
+  void shouldExportRecordsOnPreviousVersion(final ValueType valueType) {
+    // given
+    exporter.configure(exporterTestContext);
+    exporter.open(controller);
+
+    final var record = factory.generateRecord(valueType, r -> r.withBrokerVersion("8.6.0"));
+
+    // when
+    export(record);
+
+    // then
+    final var response = testClient.getExportedDocumentFor(record);
+    assertThat(response)
+        .extracting(GetResponse::index, GetResponse::id, GetResponse::routing, GetResponse::source)
+        .containsExactly(
+            indexRouter.indexFor(record),
+            indexRouter.idFor(record),
+            String.valueOf(record.getPartitionId()),
+            modifyExpectedRecordForPreviousVersion(valueType, record));
+  }
+
+  private Record modifyExpectedRecordForPreviousVersion(
+      final ValueType valueType, final Record record) {
+    final RecordValue recordValue =
+        switch (valueType) {
+          case DEPLOYMENT ->
+              ImmutableDeploymentRecordValue.builder()
+                  .from(((ImmutableDeploymentRecordValue) record.getValue()))
+                  .withResourceMetadata(List.of())
+                  .build();
+          default -> record.getValue();
+        };
+    return ImmutableRecord.copyOf(record).withValue(recordValue);
   }
 
   private boolean export(final Record<?> record) {

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -204,6 +204,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-msgpack-value</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -7,11 +7,15 @@
  */
 package io.camunda.zeebe.exporter.opensearch;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.util.SemanticVersion;
+import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -30,11 +34,17 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(Record.class, RecordSequenceMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
+  private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
+      new ObjectMapper()
+          .addMixIn(Record.class, RecordSequenceMixin.class)
+          .addMixIn(DeploymentRecordValue.class, Deployment86Mixin.class)
+          .enable(Feature.ALLOW_SINGLE_QUOTES);
+
   // The property of the ES record template to store the sequence of the record.
   private static final String RECORD_SEQUENCE_PROPERTY = "sequence";
+  private static final String RESOURCE_METADATA_PROPERTY = "resourceMetadata";
 
   private final List<BulkOperation> operations = new ArrayList<>();
-
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
 
@@ -75,10 +85,12 @@ final class BulkIndexRequest implements ContentProducer {
 
   private static byte[] serializeRecord(final Record<?> record, final RecordSequence recordSequence)
       throws IOException {
-    return MAPPER
+    final var mapper =
+        isPreviousVersionRecord(record.getBrokerVersion()) ? PREVIOUS_VERSION_MAPPER : MAPPER;
+    return mapper
         .writer()
         // Enhance the serialized record by its sequence number. The sequence number is not a part
-        // of the record itself but a special property for Opensearch. It can be used to limit
+        // of the record itself but a special property for Elasticsearch. It can be used to limit
         // the number of records when reading from the index, for example, by using a range query.
         // Read https://github.com/camunda/camunda/issues/10568 for details.
         .withAttribute(RECORD_SEQUENCE_PROPERTY, recordSequence.sequence())
@@ -131,8 +143,29 @@ final class BulkIndexRequest implements ContentProducer {
     }
   }
 
+  private static boolean isPreviousVersionRecord(final String brokerVersion) {
+    final SemanticVersion semanticVersion =
+        SemanticVersion.parse(brokerVersion)
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Expected to parse valid semantic version, but got [%s]"
+                            .formatted(brokerVersion)));
+    final int currentMinorVersion =
+        VersionUtil.getSemanticVersion()
+            .map(SemanticVersion::minor)
+            .orElseThrow(
+                () -> new IllegalStateException("Expected to have a valid semantic version"));
+    return semanticVersion.minor() < currentMinorVersion;
+  }
+
   record BulkOperation(BulkIndexAction metadata, byte[] source) {}
 
   @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
   private static final class RecordSequenceMixin {}
+
+  @JsonIgnoreProperties({
+    RESOURCE_METADATA_PROPERTY,
+  })
+  private static final class Deployment86Mixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -90,7 +90,7 @@ final class BulkIndexRequest implements ContentProducer {
     return mapper
         .writer()
         // Enhance the serialized record by its sequence number. The sequence number is not a part
-        // of the record itself but a special property for Elasticsearch. It can be used to limit
+        // of the record itself but a special property for Opensearch. It can be used to limit
         // the number of records when reading from the index, for example, by using a range query.
         // Read https://github.com/camunda/camunda/issues/10568 for details.
         .withAttribute(RECORD_SEQUENCE_PROPERTY, recordSequence.sequence())

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientTest.java
@@ -130,8 +130,12 @@ final class OpensearchClientTest {
     @Test
     void shouldFlushOnMemoryLimit() {
       // given
-      final var firstRecord = factory.generateRecord(ValueType.DECISION);
-      final var secondRecord = factory.generateRecord(ValueType.VARIABLE);
+      final var firstRecord =
+          factory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValueType(ValueType.DECISION));
+      final var secondRecord =
+          factory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValueType(ValueType.VARIABLE));
 
       // when - index a single record, then set the memory limit specifically to be its size + 1
       // this decouples the test from whatever is used to serialize the record
@@ -148,8 +152,10 @@ final class OpensearchClientTest {
     void shouldFlushOnSizeLimit() {
       // given
       config.bulk.size = 2;
-      final var firstRecord = factory.generateRecord();
-      final var secondRecord = factory.generateRecord();
+      final var firstRecord =
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
+      final var secondRecord =
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
 
       // when
       client.index(firstRecord, new RecordSequence(PARTITION_ID, 1));
@@ -179,7 +185,9 @@ final class OpensearchClientTest {
           mockClientResponse(new BulkIndexResponse(false, List.of()));
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       client.flush();
 
       // then
@@ -199,7 +207,9 @@ final class OpensearchClientTest {
       mockClientResponse(new BulkIndexResponse(false, List.of()));
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       client.flush();
 
       // then
@@ -214,7 +224,9 @@ final class OpensearchClientTest {
       doThrow(failure).when(restClient).performRequest(any());
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       assertThatCode(client::flush).isEqualTo(failure);
 
       // then


### PR DESCRIPTION
# Description
Backport of #37346 to `stable/8.7`.

closes https://github.com/camunda/camunda/issues/37283
relates to  #37343

8.6 vs 8.7 diffs show
```
> diff -r 8.7/zeebe/exporters/elasticsearch-exporter/src/main/resources 8.6/zeebe/exporters/elasticsearch-exporter/src/main/resources

diff -r zeebe/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json zeebe3/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
161,191d160
<             "resourceMetadata": {
<               "properties": {
<                 "resourceId": {
<                   "type": "keyword"
<                 },
<                 "version": {
<                   "type": "long"
<                 },
<                 "resourceKey": {
<                   "type": "long"
<                 },
<                 "resourceName": {
<                   "type": "text"
<                 },
<                 "checksum": {
<                   "enabled": false
<                 },
<                 "duplicate": {
<                   "type": "boolean"
<                 },
<                 "tenantId": {
<                   "type": "keyword"
<                 },
<                 "deploymentKey": {
<                   "type": "long"
<                 },
<                 "versionTag": {
<                   "type": "keyword"
<                 }
<               }
<             },
```