### PR TITLE
[Backport release-8.8.0-alpha8] Exclude 8.8 fields from being serialized for 8.7 records

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -184,6 +184,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -44,11 +44,11 @@ final class BulkIndexRequest implements ContentProducer {
       new ObjectMapper()
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(Record.class, RecordMetadata87Mixin.class)
-          .addMixIn(ProcessInstanceCreationRecordValue.class, ProcessInstanceCreationMixin.class)
-          .addMixIn(ProcessInstanceRecordValue.class, ProcessInstanceMixin.class)
-          .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResultMixin.class)
-          .addMixIn(UserTaskRecordValue.class, UserTaskMixin.class)
-          .addMixIn(JobRecordValue.class, JobMixin.class)
+          .addMixIn(ProcessInstanceCreationRecordValue.class, ProcessInstanceCreation87Mixin.class)
+          .addMixIn(ProcessInstanceRecordValue.class, ProcessInstance87Mixin.class)
+          .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResult87Mixin.class)
+          .addMixIn(UserTaskRecordValue.class, UserTask87Mixin.class)
+          .addMixIn(JobRecordValue.class, Job87Mixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -199,17 +199,17 @@ final class BulkIndexRequest implements ContentProducer {
     PROCESS_DEFINITION_PATH_PROPERTY,
     CALLING_ELEMENT_PATH_PROPERTY,
   })
-  private static final class ProcessInstanceMixin {}
+  private static final class ProcessInstance87Mixin {}
 
   @JsonIgnoreProperties({TAGS_PROPERTY, RUNTIME_INSTRUCTIONS_PROPERTY})
-  private static final class ProcessInstanceCreationMixin {}
+  private static final class ProcessInstanceCreation87Mixin {}
 
   @JsonIgnoreProperties({TAGS_PROPERTY})
-  private static final class ProcessInstanceResultMixin {}
+  private static final class ProcessInstanceResult87Mixin {}
 
   @JsonIgnoreProperties({DENIED_REASON_PROPERTY})
-  private static final class UserTaskMixin {}
+  private static final class UserTask87Mixin {}
 
   @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY})
-  private static final class JobMixin {}
+  private static final class Job87Mixin {}
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.util.SemanticVersion;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -33,11 +34,18 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
+  private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
+      new ObjectMapper()
+          .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
+          .addMixIn(Record.class, BatchOperationReferenceMixin.class)
+          .enable(Feature.ALLOW_SINGLE_QUOTES);
+
   // The property of the ES record template to store the sequence of the record.
   private static final String RECORD_SEQUENCE_PROPERTY = "sequence";
   private static final String RECORD_AUTHORIZATIONS_PROPERTY = "authorizations";
   private static final String RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY =
       "decisionEvaluationInstanceKey";
+  private static final String BATCH_OPERATION_REFERENCE_PROPERTY = "batchOperationReference";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -82,7 +90,15 @@ final class BulkIndexRequest implements ContentProducer {
 
   private static byte[] serializeRecord(final Record<?> record, final RecordSequence recordSequence)
       throws IOException {
-    return MAPPER
+    final SemanticVersion semanticVersion =
+        SemanticVersion.parse(record.getBrokerVersion())
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Expected to parse valid semantic version, but got [%s]"
+                            .formatted(record.getBrokerVersion())));
+    final var mapper = semanticVersion.minor() < 8 ? PREVIOUS_VERSION_MAPPER : MAPPER;
+    return mapper
         .writer()
         // Enhance the serialized record by its sequence number. The sequence number is not a part
         // of the record itself but a special property for Elasticsearch. It can be used to limit
@@ -146,4 +162,8 @@ final class BulkIndexRequest implements ContentProducer {
 
   @JsonIgnoreProperties({RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY})
   private static final class EvaluatedDecisionMixin {}
+
+  @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
+  @JsonIgnoreProperties({BATCH_OPERATION_REFERENCE_PROPERTY, RECORD_AUTHORIZATIONS_PROPERTY})
+  private static final class BatchOperationReferenceMixin {}
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
@@ -158,8 +158,12 @@ final class ElasticsearchClientTest {
     @Test
     void shouldFlushOnMemoryLimit() {
       // given
-      final var firstRecord = factory.generateRecord(ValueType.DECISION);
-      final var secondRecord = factory.generateRecord(ValueType.VARIABLE);
+      final var firstRecord =
+          factory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValueType(ValueType.DECISION));
+      final var secondRecord =
+          factory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValueType(ValueType.VARIABLE));
 
       // when - index a single record, then set the memory limit specifically to be its size + 1
       // this decouples the test from whatever is used to serialize the record
@@ -176,8 +180,10 @@ final class ElasticsearchClientTest {
     void shouldFlushOnSizeLimit() {
       // given
       config.bulk.size = 2;
-      final var firstRecord = factory.generateRecord();
-      final var secondRecord = factory.generateRecord();
+      final var firstRecord =
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
+      final var secondRecord =
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
 
       // when
       client.index(firstRecord, new RecordSequence(PARTITION_ID, 1));
@@ -207,7 +213,9 @@ final class ElasticsearchClientTest {
           mockClientResponse(new BulkIndexResponse(false, List.of()));
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       client.flush();
 
       // then
@@ -227,7 +235,9 @@ final class ElasticsearchClientTest {
       mockClientResponse(new BulkIndexResponse(false, List.of()));
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       client.flush();
 
       // then
@@ -242,7 +252,9 @@ final class ElasticsearchClientTest {
       doThrow(failure).when(restClient).performRequest(any());
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       assertThatCode(client::flush).isEqualTo(failure);
 
       // then

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -275,11 +275,18 @@ final class ElasticsearchExporterIT {
     config.setIncludeEnabledRecords(false);
     exporter.configure(exporterTestContext);
     exporter.open(controller);
-
+    final var copyFactory = new ProtocolFactory(factory.getSeed());
     final var record =
         factory.generateRecord(
             valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion().toLowerCase()));
 
+    final var expectedRecord =
+        copyFactory.generateRecord(
+            valueType,
+            r ->
+                r.withAuthorizations(Map.of())
+                    .withBrokerVersion(VersionUtil.getPreviousVersion().toLowerCase())
+                    .withBatchOperationReference(-1L));
     // when
     export(record);
 
@@ -291,7 +298,7 @@ final class ElasticsearchExporterIT {
             indexRouter.indexFor(record),
             indexRouter.idFor(record),
             String.valueOf(record.getPartitionId()),
-            record);
+            expectedRecord);
   }
 
   private boolean export(final Record<?> record) {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -27,6 +27,8 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
@@ -275,18 +277,11 @@ final class ElasticsearchExporterIT {
     config.setIncludeEnabledRecords(false);
     exporter.configure(exporterTestContext);
     exporter.open(controller);
-    final var copyFactory = new ProtocolFactory(factory.getSeed());
+
     final var record =
         factory.generateRecord(
             valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion().toLowerCase()));
 
-    final var expectedRecord =
-        copyFactory.generateRecord(
-            valueType,
-            r ->
-                r.withAuthorizations(Map.of())
-                    .withBrokerVersion(VersionUtil.getPreviousVersion().toLowerCase())
-                    .withBatchOperationReference(-1L));
     // when
     export(record);
 
@@ -298,7 +293,58 @@ final class ElasticsearchExporterIT {
             indexRouter.indexFor(record),
             indexRouter.idFor(record),
             String.valueOf(record.getPartitionId()),
-            expectedRecord);
+            modifyExpectedRecordForPreviousVersion(valueType, record));
+  }
+
+  private Record modifyExpectedRecordForPreviousVersion(
+      final ValueType valueType, final Record record) {
+    final var copyFactory = new ProtocolFactory(factory.getSeed());
+    final RecordValue recordValue =
+        switch (valueType) {
+          case JOB ->
+              ImmutableJobRecordValue.builder()
+                  .from(((ImmutableJobRecordValue) record.getValue()))
+                  .withTags(List.of())
+                  .resultBuilder(null)
+                  .build();
+          case PROCESS_INSTANCE ->
+              ImmutableProcessInstanceRecordValue.builder()
+                  .from(((ImmutableProcessInstanceRecordValue) record.getValue()))
+                  .withCallingElementPath(List.of())
+                  .withProcessDefinitionPath(List.of())
+                  .withTags(List.of())
+                  .withElementInstancePath(List.of())
+                  .build();
+          case JOB_BATCH ->
+              ImmutableJobBatchRecordValue.builder()
+                  .from(((ImmutableJobBatchRecordValue) record.getValue()))
+                  .withJobs(
+                      ((ImmutableJobBatchRecordValue) record.getValue())
+                          .getJobs().stream()
+                              .map(
+                                  job ->
+                                      ImmutableJobRecordValue.builder()
+                                          .from(job)
+                                          .withTags(List.of())
+                                          .resultBuilder(null)
+                                          .build())
+                              .toList())
+                  .build();
+          case PROCESS_INSTANCE_CREATION ->
+              ImmutableProcessInstanceCreationRecordValue.builder()
+                  .from(((ImmutableProcessInstanceCreationRecordValue) record.getValue()))
+                  .withTags(List.of())
+                  .withRuntimeInstructions(List.of())
+                  .build();
+          default -> record.getValue();
+        };
+    return copyFactory.generateRecord(
+        valueType,
+        r ->
+            r.withValue(recordValue)
+                .withAuthorizations(record.getAuthorizations())
+                .withBrokerVersion(record.getBrokerVersion())
+                .withBatchOperationReference(-1L));
   }
 
   private boolean export(final Record<?> record) {

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -209,6 +209,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -14,6 +14,11 @@ import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -31,6 +36,7 @@ final class BulkIndexRequest implements ContentProducer {
   private static final ObjectMapper MAPPER =
       new ObjectMapper()
           .addMixIn(Record.class, RecordSequenceMixin.class)
+          .addMixIn(UserTaskRecordValue.class, UserTaskMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
@@ -38,6 +44,11 @@ final class BulkIndexRequest implements ContentProducer {
       new ObjectMapper()
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(Record.class, BatchOperationReferenceMixin.class)
+          .addMixIn(ProcessInstanceCreationRecordValue.class, ProcessInstanceCreationMixin.class)
+          .addMixIn(ProcessInstanceRecordValue.class, ProcessInstanceMixin.class)
+          .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResultMixin.class)
+          .addMixIn(UserTaskRecordValue.class, UserTaskMixin.class)
+          .addMixIn(JobRecordValue.class, JobMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -46,6 +57,13 @@ final class BulkIndexRequest implements ContentProducer {
   private static final String RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY =
       "decisionEvaluationInstanceKey";
   private static final String BATCH_OPERATION_REFERENCE_PROPERTY = "batchOperationReference";
+  private static final String TAGS_PROPERTY = "tags";
+  private static final String RESULT_PROPERTY = "result";
+  private static final String DENIED_REASON_PROPERTY = "deniedReason";
+  private static final String RUNTIME_INSTRUCTIONS_PROPERTY = "runtimeInstructions";
+  private static final String ELEMENT_INSTANCE_PATH_PROPERTY = "elementInstancePath";
+  private static final String PROCESS_DEFINITION_PATH_PROPERTY = "processDefinitionPath";
+  private static final String CALLING_ELEMENT_PATH_PROPERTY = "callingElementPath";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -162,9 +180,27 @@ final class BulkIndexRequest implements ContentProducer {
   @JsonIgnoreProperties({RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY})
   private static final class EvaluatedDecisionMixin {}
 
-  /// Include annotations from {@link RecordSequenceMixin} since you can only have one Mixin per
-  /// class in Jackson
   @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
   @JsonIgnoreProperties({BATCH_OPERATION_REFERENCE_PROPERTY, RECORD_AUTHORIZATIONS_PROPERTY})
   private static final class BatchOperationReferenceMixin {}
+
+  @JsonIgnoreProperties({
+    TAGS_PROPERTY,
+    ELEMENT_INSTANCE_PATH_PROPERTY,
+    PROCESS_DEFINITION_PATH_PROPERTY,
+    CALLING_ELEMENT_PATH_PROPERTY,
+  })
+  private static final class ProcessInstanceMixin {}
+
+  @JsonIgnoreProperties({TAGS_PROPERTY, RUNTIME_INSTRUCTIONS_PROPERTY})
+  private static final class ProcessInstanceCreationMixin {}
+
+  @JsonIgnoreProperties({TAGS_PROPERTY})
+  private static final class ProcessInstanceResultMixin {}
+
+  @JsonIgnoreProperties({DENIED_REASON_PROPERTY})
+  private static final class UserTaskMixin {}
+
+  @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY})
+  private static final class JobMixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -43,12 +43,12 @@ final class BulkIndexRequest implements ContentProducer {
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
       new ObjectMapper()
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
-          .addMixIn(Record.class, BatchOperationReferenceMixin.class)
-          .addMixIn(ProcessInstanceCreationRecordValue.class, ProcessInstanceCreationMixin.class)
-          .addMixIn(ProcessInstanceRecordValue.class, ProcessInstanceMixin.class)
-          .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResultMixin.class)
-          .addMixIn(UserTaskRecordValue.class, UserTaskMixin.class)
-          .addMixIn(JobRecordValue.class, JobMixin.class)
+          .addMixIn(Record.class, RecordMetadata87Mixin.class)
+          .addMixIn(ProcessInstanceCreationRecordValue.class, ProcessInstanceCreation87Mixin.class)
+          .addMixIn(ProcessInstanceRecordValue.class, ProcessInstance87Mixin.class)
+          .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResult87Mixin.class)
+          .addMixIn(UserTaskRecordValue.class, UserTask87Mixin.class)
+          .addMixIn(JobRecordValue.class, Job87Mixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -192,7 +192,7 @@ final class BulkIndexRequest implements ContentProducer {
 
   @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
   @JsonIgnoreProperties({BATCH_OPERATION_REFERENCE_PROPERTY, RECORD_AUTHORIZATIONS_PROPERTY})
-  private static final class BatchOperationReferenceMixin {}
+  private static final class RecordMetadata87Mixin {}
 
   @JsonIgnoreProperties({
     TAGS_PROPERTY,
@@ -200,17 +200,17 @@ final class BulkIndexRequest implements ContentProducer {
     PROCESS_DEFINITION_PATH_PROPERTY,
     CALLING_ELEMENT_PATH_PROPERTY,
   })
-  private static final class ProcessInstanceMixin {}
+  private static final class ProcessInstance87Mixin {}
 
   @JsonIgnoreProperties({TAGS_PROPERTY, RUNTIME_INSTRUCTIONS_PROPERTY})
-  private static final class ProcessInstanceCreationMixin {}
+  private static final class ProcessInstanceCreation87Mixin {}
 
   @JsonIgnoreProperties({TAGS_PROPERTY})
-  private static final class ProcessInstanceResultMixin {}
+  private static final class ProcessInstanceResult87Mixin {}
 
   @JsonIgnoreProperties({DENIED_REASON_PROPERTY})
-  private static final class UserTaskMixin {}
+  private static final class UserTask87Mixin {}
 
   @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY})
-  private static final class JobMixin {}
+  private static final class Job87Mixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -13,9 +13,17 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.opensearch.BulkIndexRequest.BulkOperation;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceCreationRuntimeInstructionValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceResultRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.BufferedReader;
@@ -27,11 +35,15 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @Execution(ExecutionMode.CONCURRENT)
 final class BulkIndexRequestTest {
@@ -319,6 +331,276 @@ final class BulkIndexRequestTest {
           .containsExactly(10);
     }
 
+    @ParameterizedTest
+    @MethodSource("deniedReasonRecordVersions")
+    void shouldIndexRecordWithoutDeniedReason(final String version) {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(version)
+                      .withValue(new UserTaskRecord().setDeniedReason("denied")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("deniedReason"))
+          .describedAs("Expect that the records are NOT serialized with deniedReason")
+          .containsExactly(new Object[] {null});
+    }
+
+    @ParameterizedTest
+    @MethodSource("recordsSupportingTags")
+    void shouldIndexRecordWithTags(final Record record) {
+      // given
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("tags"))
+          .describedAs("Expect that the records are serialized with tags")
+          .containsExactly(List.of("t1", "t2"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("recordsSupportingTagsPreviousVersion")
+    void shouldIndexRecordWithoutTags(final Record record) {
+      // given
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("tags"))
+          .describedAs("Expect that the records are NOT serialized with tags")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexRecordWithoutResult() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new JobRecord().setResult(new JobResult().setDeniedReason("denied"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("result"))
+          .describedAs("Expect that the records are NOT serialized with deniedReason")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexRecordWithResult() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new JobRecord().setResult(new JobResult().setDeniedReason("denied"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("result"))
+          .extracting(source -> ((Map<String, Object>) source).get("deniedReason"))
+          .describedAs("Expect that the records are NOT serialized with deniedReason")
+          .containsExactly("denied");
+    }
+
+    @Test
+    void shouldIndexProcessInstanceCreationRecordWithoutRuntimeInstructions() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          ImmutableProcessInstanceCreationRecordValue.builder()
+                              .withRuntimeInstructions(
+                                  List.of(
+                                      ImmutableProcessInstanceCreationRuntimeInstructionValue
+                                          .builder()
+                                          .withAfterElementId("afterElementId")
+                                          .build()))
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("runtimeInstructions"))
+          .describedAs("Expect that the records are NOT serialized with runtimeInstructions")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexProcessInstanceCreationRecordWithRuntimeInstructions() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableProcessInstanceCreationRecordValue.builder()
+                              .withRuntimeInstructions(
+                                  List.of(
+                                      ImmutableProcessInstanceCreationRuntimeInstructionValue
+                                          .builder()
+                                          .withAfterElementId("afterElementId")
+                                          .build()))
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("runtimeInstructions"))
+          .extracting(source -> ((List) source).getFirst())
+          .extracting(source -> ((Map<String, Object>) source).get("afterElementId"))
+          .describedAs("Expect that the records are serialized with runtimeInstructions")
+          .containsExactly("afterElementId");
+    }
+
+    @Test
+    void shouldIndexProcessInstanceRecordWithoutNewFields() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          ImmutableProcessInstanceRecordValue.builder()
+                              .withElementInstancePath(List.of(List.of(1L, 2L, 3L)))
+                              .withProcessDefinitionPath(List.of(1L, 2L, 3L))
+                              .withCallingElementPath(List.of(3, 4, 5))
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("elementInstancePath"))
+          .describedAs("Expect that the records are NOT serialized with elementInstancePath")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionPath"))
+          .describedAs("Expect that the records are NOT serialized with processDefinitionPath")
+          .containsExactly(new Object[] {null});
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("callingElementPath"))
+          .describedAs("Expect that the records are NOT serialized with callingElementPath")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexProcessInstanceRecordWithNewFields() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          ImmutableProcessInstanceRecordValue.builder()
+                              .withElementInstancePath(List.of(List.of(1L, 2L, 3L)))
+                              .withProcessDefinitionPath(List.of(1L, 2L, 3L))
+                              .withCallingElementPath(List.of(3, 4, 5))
+                              .build()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("elementInstancePath"))
+          .describedAs("Expect that the records are serialized with elementInstancePath")
+          .containsExactly(List.of(List.of(1, 2, 3)));
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionPath"))
+          .describedAs("Expect that the records are serialized with processDefinitionPath")
+          .containsExactly(List.of(1, 2, 3));
+
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("callingElementPath"))
+          .describedAs("Expect that the records are serialized with callingElementPath")
+          .containsExactly(List.of(3, 4, 5));
+    }
+
     private Record<?> deserializeSource(final BulkOperation operation) {
       try {
         return MAPPER.readValue(operation.source(), new TypeReference<>() {});
@@ -336,6 +618,56 @@ final class BulkIndexRequestTest {
       } catch (final IOException e) {
         throw new UncheckedIOException(e);
       }
+    }
+
+    static Stream<Arguments> recordsSupportingTagsPreviousVersion() {
+      final var version = VersionUtil.getPreviousVersion();
+      return tagRecordArguments(version);
+    }
+
+    static Stream<Arguments> recordsSupportingTags() {
+      final var version = VersionUtil.getVersion();
+      return tagRecordArguments(version);
+    }
+
+    static Stream<Arguments> tagRecordArguments(final String version) {
+      final ProtocolFactory recordFactory = new ProtocolFactory();
+      final var tags = List.of("t1", "t2");
+      return Stream.of(
+          Arguments.of(
+              recordFactory.generateRecord(
+                  r ->
+                      r.withBrokerVersion(version)
+                          .withValue(
+                              ImmutableProcessInstanceCreationRecordValue.builder()
+                                  .withTags(tags)
+                                  .build()))),
+          Arguments.of(
+              recordFactory.generateRecord(
+                  r ->
+                      r.withBrokerVersion(version)
+                          .withValue(
+                              ImmutableProcessInstanceRecordValue.builder()
+                                  .withTags(tags)
+                                  .build()))),
+          Arguments.of(
+              recordFactory.generateRecord(
+                  r ->
+                      r.withBrokerVersion(version)
+                          .withValue(
+                              ImmutableProcessInstanceResultRecordValue.builder()
+                                  .withTags(tags)
+                                  .build()))),
+          Arguments.of(
+              recordFactory.generateRecord(
+                  r ->
+                      r.withBrokerVersion(version)
+                          .withValue(ImmutableJobRecordValue.builder().withTags(tags).build()))));
+    }
+
+    static Stream<Arguments> deniedReasonRecordVersions() {
+      return Stream.of(
+          Arguments.of(VersionUtil.getVersion()), Arguments.of(VersionUtil.getPreviousVersion()));
     }
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientTest.java
@@ -130,8 +130,12 @@ final class OpensearchClientTest {
     @Test
     void shouldFlushOnMemoryLimit() {
       // given
-      final var firstRecord = factory.generateRecord(ValueType.DECISION);
-      final var secondRecord = factory.generateRecord(ValueType.VARIABLE);
+      final var firstRecord =
+          factory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValueType(ValueType.DECISION));
+      final var secondRecord =
+          factory.generateRecord(
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValueType(ValueType.VARIABLE));
 
       // when - index a single record, then set the memory limit specifically to be its size + 1
       // this decouples the test from whatever is used to serialize the record
@@ -148,8 +152,10 @@ final class OpensearchClientTest {
     void shouldFlushOnSizeLimit() {
       // given
       config.bulk.size = 2;
-      final var firstRecord = factory.generateRecord();
-      final var secondRecord = factory.generateRecord();
+      final var firstRecord =
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
+      final var secondRecord =
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion()));
 
       // when
       client.index(firstRecord, new RecordSequence(PARTITION_ID, 1));
@@ -179,7 +185,9 @@ final class OpensearchClientTest {
           mockClientResponse(new BulkIndexResponse(false, List.of()));
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       client.flush();
 
       // then
@@ -199,7 +207,9 @@ final class OpensearchClientTest {
       mockClientResponse(new BulkIndexResponse(false, List.of()));
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       client.flush();
 
       // then
@@ -214,7 +224,9 @@ final class OpensearchClientTest {
       doThrow(failure).when(restClient).performRequest(any());
 
       // when
-      client.index(factory.generateRecord(), new RecordSequence(PARTITION_ID, 1));
+      client.index(
+          factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersion())),
+          new RecordSequence(PARTITION_ID, 1));
       assertThatCode(client::flush).isEqualTo(failure);
 
       // then

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -351,11 +351,18 @@ final class OpensearchExporterIT {
     config.setIncludeEnabledRecords(false);
     exporter.configure(exporterTestContext);
     exporter.open(controller);
-
+    final var copyFactory = new ProtocolFactory(factory.getSeed());
     final var record =
         factory.generateRecord(
             valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion().toLowerCase()));
 
+    final var expectedRecord =
+        copyFactory.generateRecord(
+            valueType,
+            r ->
+                r.withAuthorizations(Map.of())
+                    .withBrokerVersion(VersionUtil.getPreviousVersion().toLowerCase())
+                    .withBatchOperationReference(-1L));
     // when
     export(record);
 
@@ -367,7 +374,7 @@ final class OpensearchExporterIT {
             indexRouter.indexFor(record),
             indexRouter.idFor(record),
             String.valueOf(record.getPartitionId()),
-            record);
+            expectedRecord);
   }
 
   private boolean export(final Record<?> record) {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
@@ -351,18 +353,11 @@ final class OpensearchExporterIT {
     config.setIncludeEnabledRecords(false);
     exporter.configure(exporterTestContext);
     exporter.open(controller);
-    final var copyFactory = new ProtocolFactory(factory.getSeed());
+
     final var record =
         factory.generateRecord(
             valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion().toLowerCase()));
 
-    final var expectedRecord =
-        copyFactory.generateRecord(
-            valueType,
-            r ->
-                r.withAuthorizations(Map.of())
-                    .withBrokerVersion(VersionUtil.getPreviousVersion().toLowerCase())
-                    .withBatchOperationReference(-1L));
     // when
     export(record);
 
@@ -374,7 +369,59 @@ final class OpensearchExporterIT {
             indexRouter.indexFor(record),
             indexRouter.idFor(record),
             String.valueOf(record.getPartitionId()),
-            expectedRecord);
+            modifyExpectedRecordForPreviousVersion(valueType, record));
+  }
+
+  private Record modifyExpectedRecordForPreviousVersion(
+      final ValueType valueType, final Record record) {
+    final var copyFactory = new ProtocolFactory(factory.getSeed());
+    final RecordValue recordValue =
+        (RecordValue)
+            switch (valueType) {
+              case JOB ->
+                  ImmutableJobRecordValue.builder()
+                      .from(((ImmutableJobRecordValue) record.getValue()))
+                      .withTags(List.of())
+                      .resultBuilder(null)
+                      .build();
+              case PROCESS_INSTANCE ->
+                  ImmutableProcessInstanceRecordValue.builder()
+                      .from(((ImmutableProcessInstanceRecordValue) record.getValue()))
+                      .withCallingElementPath(List.of())
+                      .withProcessDefinitionPath(List.of())
+                      .withTags(List.of())
+                      .withElementInstancePath(List.of())
+                      .build();
+              case JOB_BATCH ->
+                  ImmutableJobBatchRecordValue.builder()
+                      .from(((ImmutableJobBatchRecordValue) record.getValue()))
+                      .withJobs(
+                          ((ImmutableJobBatchRecordValue) record.getValue())
+                              .getJobs().stream()
+                                  .map(
+                                      job ->
+                                          ImmutableJobRecordValue.builder()
+                                              .from(job)
+                                              .withTags(List.of())
+                                              .resultBuilder(null)
+                                              .build())
+                                  .toList())
+                      .build();
+              case PROCESS_INSTANCE_CREATION ->
+                  ImmutableProcessInstanceCreationRecordValue.builder()
+                      .from(((ImmutableProcessInstanceCreationRecordValue) record.getValue()))
+                      .withTags(List.of())
+                      .withRuntimeInstructions(List.of())
+                      .build();
+              default -> record.getValue();
+            };
+    return copyFactory.generateRecord(
+        valueType,
+        r ->
+            r.withValue(recordValue)
+                .withAuthorizations(record.getAuthorizations())
+                .withBrokerVersion(record.getBrokerVersion())
+                .withBatchOperationReference(-1L));
   }
 
   private boolean export(final Record<?> record) {


### PR DESCRIPTION
# Description
Backport of #37346 to `release-8.8.0-alpha8`.

relates to #37343