### PR TITLE
fix: enhance usage metrics processing and state management

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsChecker.java
@@ -12,7 +12,6 @@ import static java.util.Optional.ofNullable;
 import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
 import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
-import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService.ScheduledTask;
 import io.camunda.zeebe.stream.api.scheduling.Task;
@@ -59,8 +58,7 @@ public class UsageMetricsChecker implements Task {
     LOG.trace("UsageMetricsChecker running...");
 
     taskResultBuilder.appendCommandRecord(
-        UsageMetricIntent.EXPORT,
-        new UsageMetricRecord().setIntervalType(IntervalType.ACTIVE).setEventType(EventType.NONE));
+        UsageMetricIntent.EXPORT, new UsageMetricRecord().setEventType(EventType.NONE));
 
     if (shouldReschedule) {
       schedule(false);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessor.java
@@ -55,8 +55,8 @@ public class UsageMetricsExportProcessor implements TypedRecordProcessor<UsageMe
       bucket = new PersistedUsageMetrics();
     }
 
-    // Copy and update the bucket fromTime as we are exporting it now.
-    // Additionally, ensure the toTime is set. This can happen if metrics were recorded before the
+    // Copy and update the bucket toTime as we are exporting it now.
+    // Additionally, ensure the fromTime is set. This can happen if metrics were recorded before the
     // first applier.
     final PersistedUsageMetrics finalBucket = bucket.close(now);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsProcessors.java
@@ -30,7 +30,7 @@ public class UsageMetricsProcessors {
             ValueType.USAGE_METRIC,
             UsageMetricIntent.EXPORT,
             new UsageMetricsExportProcessor(
-                processingState.getUsageMetricState(), writers, keyGenerator))
+                processingState.getUsageMetricState(), writers, keyGenerator, clock))
         .withListener(new UsageMetricsCheckerScheduler(config, clock));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -186,8 +186,7 @@ public class ProcessingDbState implements MutableProcessingState {
     mappingRuleState = new DbMappingRuleState(zeebeDb, transactionContext);
     batchOperationState = new DbBatchOperationState(zeebeDb, transactionContext);
     membershipState = new DbMembershipState(zeebeDb, transactionContext);
-    usageMetricState =
-        new DbUsageMetricState(zeebeDb, transactionContext, config.getUsageMetricsExportInterval());
+    usageMetricState = new DbUsageMetricState(zeebeDb, transactionContext);
     multiInstanceState = new DbMultiInstanceState(zeebeDb, transactionContext);
     asyncRequestState = new DbAsyncRequestState(zeebeDb, transactionContext);
     this.transientProcessMessageSubscriptionState = transientProcessMessageSubscriptionState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplier.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
 import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
 import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,15 +29,7 @@ public class UsageMetricsExportedApplier
 
   @Override
   public void applyState(final long key, final UsageMetricRecord record) {
-    final var activeBucket = usageMetricState.getActiveBucket();
-
-    // uninitialized bucket created on-demand
-    if (activeBucket != null && !activeBucket.isInitialized()) {
-      LOG.debug("Update active bucket time {}", record.getResetTime());
-      usageMetricState.updateActiveBucketTime(record.getResetTime());
-    }
-    // regular export interval
-    else if (activeBucket == null || activeBucket.getFromTime() != record.getResetTime()) {
+    if (record.getEventType() == EventType.NONE) {
       LOG.debug("Reset active bucket {}", record.getResetTime());
       usageMetricState.resetActiveBucket(record.getResetTime());
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UsageMetricState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UsageMetricState.java
@@ -12,6 +12,4 @@ import io.camunda.zeebe.engine.state.metrics.PersistedUsageMetrics;
 public interface UsageMetricState {
 
   PersistedUsageMetrics getActiveBucket();
-
-  PersistedUsageMetrics getOrCreateActiveBucket();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricState.java
@@ -48,20 +48,6 @@ public class DbUsageMetricState implements MutableUsageMetricState {
     return metricsBucketColumnFamily.get(metricsBucketKey);
   }
 
-  @Override
-  public PersistedUsageMetrics getOrCreateActiveBucket() {
-    setActiveBucketKeys();
-
-    final var existingBucket = metricsBucketColumnFamily.get(metricsBucketKey);
-    if (existingBucket != null) {
-      return existingBucket;
-    }
-
-    final var bucket = new PersistedUsageMetrics();
-    metricsBucketColumnFamily.insert(metricsBucketKey, bucket);
-    return bucket;
-  }
-
   public void updateActiveBucket(final PersistedUsageMetrics bucket) {
     setActiveBucketKeys();
     metricsBucketColumnFamily.update(metricsBucketKey, bucket);
@@ -91,21 +77,22 @@ public class DbUsageMetricState implements MutableUsageMetricState {
   public void resetActiveBucket(final long resetTime) {
     setActiveBucketKeys();
     metricsBucketColumnFamily.deleteIfExists(metricsBucketKey);
-    final var bucket =
-        new PersistedUsageMetrics()
-            .setFromTime(resetTime)
-            .setToTime(resetTime + exportInterval.toMillis());
+    final var bucket = new PersistedUsageMetrics().setFromTime(resetTime);
 
     metricsBucketColumnFamily.insert(metricsBucketKey, bucket);
   }
 
   @Override
-  public void updateActiveBucketTime(final long resetTime) {
+  public PersistedUsageMetrics getOrCreateActiveBucket() {
     setActiveBucketKeys();
-    final var bucket =
-        getOrCreateActiveBucket()
-            .setFromTime(resetTime)
-            .setToTime(resetTime + exportInterval.toMillis());
-    metricsBucketColumnFamily.update(metricsBucketKey, bucket);
+
+    final var existingBucket = metricsBucketColumnFamily.get(metricsBucketKey);
+    if (existingBucket != null) {
+      return existingBucket;
+    }
+
+    final var bucket = new PersistedUsageMetrics();
+    metricsBucketColumnFamily.insert(metricsBucketKey, bucket);
+    return bucket;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricState.java
@@ -16,22 +16,15 @@ import io.camunda.zeebe.db.impl.DbEnumValue;
 import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
-import java.time.Duration;
 
 public class DbUsageMetricState implements MutableUsageMetricState {
-
-  private final Duration exportInterval;
 
   private final ColumnFamily<DbEnumValue<IntervalType>, PersistedUsageMetrics>
       metricsBucketColumnFamily;
   private final DbEnumValue<IntervalType> metricsBucketKey;
 
   public DbUsageMetricState(
-      final ZeebeDb<ZbColumnFamilies> zeebeDb,
-      final TransactionContext transactionContext,
-      final Duration exportInterval) {
-
-    this.exportInterval = exportInterval;
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
 
     metricsBucketKey = new DbEnumValue<>(IntervalType.class);
     metricsBucketColumnFamily =
@@ -82,7 +75,6 @@ public class DbUsageMetricState implements MutableUsageMetricState {
     metricsBucketColumnFamily.insert(metricsBucketKey, bucket);
   }
 
-  @Override
   public PersistedUsageMetrics getOrCreateActiveBucket() {
     setActiveBucketKeys();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
@@ -37,10 +37,6 @@ public class PersistedUsageMetrics extends UnpackedObject implements DbValue {
         .declareProperty(tenantTUMapProp);
   }
 
-  public boolean isInitialized() {
-    return fromTimeProp.getValue() != TIME_NOT_SET && toTimeProp.getValue() != TIME_NOT_SET;
-  }
-
   public long getFromTime() {
     return fromTimeProp.getValue();
   }
@@ -121,5 +117,14 @@ public class PersistedUsageMetrics extends UnpackedObject implements DbValue {
       setTenantTUMap(tenantTUMap);
     }
     return this;
+  }
+
+  public PersistedUsageMetrics close(final long time) {
+    if (getFromTime() == TIME_NOT_SET) {
+      // initialize fromTime in case metrics were recorded before the first checker run
+      setFromTime(time);
+    }
+    setToTime(time);
+    return this; // return copy
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
@@ -120,11 +120,13 @@ public class PersistedUsageMetrics extends UnpackedObject implements DbValue {
   }
 
   public PersistedUsageMetrics close(final long time) {
+    final var bucket = new PersistedUsageMetrics();
+    bucket.copyFrom(this);
+    // Ensure the toTime is set. This can happen if metrics were recorded before the first applier.
     if (getFromTime() == TIME_NOT_SET) {
-      // initialize fromTime in case metrics were recorded before the first checker run
-      setFromTime(time);
+      bucket.setFromTime(time);
     }
-    setToTime(time);
-    return this; // return copy
+    bucket.setToTime(time);
+    return bucket;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/metrics/PersistedUsageMetrics.java
@@ -122,7 +122,8 @@ public class PersistedUsageMetrics extends UnpackedObject implements DbValue {
   public PersistedUsageMetrics close(final long time) {
     final var bucket = new PersistedUsageMetrics();
     bucket.copyFrom(this);
-    // Ensure the toTime is set. This can happen if metrics were recorded before the first applier.
+    // Ensure the fromTime is set. This can happen if metrics were recorded before the first
+    // applier.
     if (getFromTime() == TIME_NOT_SET) {
       bucket.setFromTime(time);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUsageMetricState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUsageMetricState.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.state.mutable;
 
 import io.camunda.zeebe.engine.state.immutable.UsageMetricState;
-import io.camunda.zeebe.engine.state.metrics.PersistedUsageMetrics;
 
 public interface MutableUsageMetricState extends UsageMetricState {
 
@@ -19,6 +18,4 @@ public interface MutableUsageMetricState extends UsageMetricState {
   void recordTUMetric(final String tenantId, final String assignee);
 
   void resetActiveBucket(final long fromTime);
-
-  PersistedUsageMetrics getOrCreateActiveBucket();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUsageMetricState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUsageMetricState.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.mutable;
 
 import io.camunda.zeebe.engine.state.immutable.UsageMetricState;
+import io.camunda.zeebe.engine.state.metrics.PersistedUsageMetrics;
 
 public interface MutableUsageMetricState extends UsageMetricState {
 
@@ -19,5 +20,5 @@ public interface MutableUsageMetricState extends UsageMetricState {
 
   void resetActiveBucket(final long fromTime);
 
-  void updateActiveBucketTime(long resetTime);
+  PersistedUsageMetrics getOrCreateActiveBucket();
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricStateTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
-import java.time.Duration;
 import java.time.InstantSource;
 import java.util.Map;
 import java.util.Set;
@@ -40,7 +39,7 @@ public class DbUsageMetricStateTest {
   @BeforeEach
   void beforeEach() {
     mockClock = mock(InstantSource.class);
-    state = new DbUsageMetricState(zeebeDb, transactionContext, Duration.ofSeconds(1));
+    state = new DbUsageMetricState(zeebeDb, transactionContext);
     state.resetActiveBucket(1L);
   }
 
@@ -54,7 +53,7 @@ public class DbUsageMetricStateTest {
     state.resetActiveBucket(1L);
 
     // then
-    final var actual = state.getOrCreateActiveBucket();
+    final var actual = state.getActiveBucket();
     assertThat(actual.getFromTime()).isEqualTo(1L);
     assertThat(actual.getToTime()).isEqualTo(-1L);
     assertThat(actual.getTenantRPIMap()).isEmpty();
@@ -78,7 +77,7 @@ public class DbUsageMetricStateTest {
     state.recordRPIMetric("tenant2");
 
     // then
-    final var actual = state.getOrCreateActiveBucket();
+    final var actual = state.getActiveBucket();
     assertThat(actual.getFromTime()).isEqualTo(1L);
     assertThat(actual.getToTime()).isEqualTo(-1L);
     assertThat(actual.getTenantRPIMap())
@@ -102,7 +101,7 @@ public class DbUsageMetricStateTest {
     state.recordEDIMetric("tenant2");
 
     // then
-    final var actual = state.getOrCreateActiveBucket();
+    final var actual = state.getActiveBucket();
     assertThat(actual.getFromTime()).isEqualTo(1L);
     assertThat(actual.getToTime()).isEqualTo(-1L);
     assertThat(actual.getTenantEDIMap())
@@ -127,7 +126,7 @@ public class DbUsageMetricStateTest {
     state.recordTUMetric("tenant2", "assignee1");
 
     // then
-    final var actual = state.getOrCreateActiveBucket();
+    final var actual = state.getActiveBucket();
     assertThat(actual.getFromTime()).isEqualTo(1L);
     assertThat(actual.getToTime()).isEqualTo(-1L);
     assertThat(actual.getTenantTUMap())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricStateTest.java
@@ -56,7 +56,7 @@ public class DbUsageMetricStateTest {
     // then
     final var actual = state.getOrCreateActiveBucket();
     assertThat(actual.getFromTime()).isEqualTo(1L);
-    assertThat(actual.getToTime()).isEqualTo(1001L);
+    assertThat(actual.getToTime()).isEqualTo(-1L);
     assertThat(actual.getTenantRPIMap()).isEmpty();
     assertThat(actual.getTenantEDIMap()).isEmpty();
     assertThat(actual.getTenantTUMap()).isEmpty();
@@ -80,7 +80,7 @@ public class DbUsageMetricStateTest {
     // then
     final var actual = state.getOrCreateActiveBucket();
     assertThat(actual.getFromTime()).isEqualTo(1L);
-    assertThat(actual.getToTime()).isEqualTo(1001L);
+    assertThat(actual.getToTime()).isEqualTo(-1L);
     assertThat(actual.getTenantRPIMap())
         .containsExactlyInAnyOrderEntriesOf(
             Map.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 2L, "tenant1", 3L, "tenant2", 1L));
@@ -104,7 +104,7 @@ public class DbUsageMetricStateTest {
     // then
     final var actual = state.getOrCreateActiveBucket();
     assertThat(actual.getFromTime()).isEqualTo(1L);
-    assertThat(actual.getToTime()).isEqualTo(1001L);
+    assertThat(actual.getToTime()).isEqualTo(-1L);
     assertThat(actual.getTenantEDIMap())
         .containsExactlyInAnyOrderEntriesOf(
             Map.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 2L, "tenant1", 3L, "tenant2", 1L));
@@ -129,7 +129,7 @@ public class DbUsageMetricStateTest {
     // then
     final var actual = state.getOrCreateActiveBucket();
     assertThat(actual.getFromTime()).isEqualTo(1L);
-    assertThat(actual.getToTime()).isEqualTo(1001L);
+    assertThat(actual.getToTime()).isEqualTo(-1L);
     assertThat(actual.getTenantTUMap())
         .containsExactlyInAnyOrderEntriesOf(
             Map.of(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -184,7 +184,7 @@ public final class EngineRule extends ExternalResource {
   }
 
   public void start() {
-    start(StreamProcessorMode.PROCESSING, true);
+    start(environmentRule.getStreamProcessorMode(), true);
   }
 
   public void start(final StreamProcessorMode mode, final boolean awaitOpening) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -201,6 +201,10 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
     return streamProcessingComposite.getProcessingState(getLogName(partitionId));
   }
 
+  public StreamProcessorMode getStreamProcessorMode() {
+    return streamProcessorMode;
+  }
+
   public RecordStream events() {
     return new RecordStream(streams.events(getLogName(startPartitionId)));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -290,6 +290,8 @@ public final class TestStreams {
             Tags.of(
                 PartitionKeyNames.PARTITION.asString(), String.valueOf(stream.getPartitionId())));
 
+    final boolean isReplay = streamProcessorMode == StreamProcessorMode.REPLAY;
+
     final var builder =
         StreamProcessor.builder()
             .logStream(stream)
@@ -303,7 +305,7 @@ public final class TestStreams {
                         wrappedFactory, new EngineConfiguration(), new SecurityConfiguration())))
             .streamProcessorMode(streamProcessorMode)
             .maxCommandsInBatch(maxCommandsInBatch)
-            .partitionCommandSender(mock(InterPartitionCommandSender.class))
+            .partitionCommandSender(isReplay ? null : mock(InterPartitionCommandSender.class))
             .meterRegistry(meterRegistry)
             .clock(StreamClock.controllable(clock));
 

--- a/zeebe/engine/src/test/resources/state/appliers/golden/UsageMetric_EXPORTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/UsageMetric_EXPORTED_v1.golden
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
 import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
 import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,15 +29,7 @@ public class UsageMetricsExportedApplier
 
   @Override
   public void applyState(final long key, final UsageMetricRecord record) {
-    final var activeBucket = usageMetricState.getActiveBucket();
-
-    // uninitialized bucket created on-demand
-    if (activeBucket != null && !activeBucket.isInitialized()) {
-      LOG.debug("Update active bucket time {}", record.getResetTime());
-      usageMetricState.updateActiveBucketTime(record.getResetTime());
-    }
-    // regular export interval
-    else if (activeBucket == null || activeBucket.getFromTime() != record.getResetTime()) {
+    if (record.getEventType() == EventType.NONE) {
       LOG.debug("Reset active bucket {}", record.getResetTime());
       usageMetricState.resetActiveBucket(record.getResetTime());
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UsageMetricHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UsageMetricHandler.java
@@ -78,7 +78,7 @@ public record UsageMetricHandler(String indexName, String tuIndexName)
 
     final var recordKey = record.getKey();
     final var partitionId = record.getPartitionId();
-    final var timestamp = DateUtil.toOffsetDateTime(record.getTimestamp());
+    final var endTime = DateUtil.toOffsetDateTime(recordValue.getEndTime());
     final var collection = usageMetricsBatch.variables();
     final var tuCollection = usageMetricsBatch.tuVariables();
 
@@ -88,7 +88,7 @@ public record UsageMetricHandler(String indexName, String tuIndexName)
             (tenantId, counter) ->
                 collection.add(
                     createUsageMetricEntity(
-                        recordKey, partitionId, timestamp, tenantId, eventType, counter)));
+                        recordKey, partitionId, endTime, tenantId, eventType, counter)));
 
     recordValue
         .getSetValues()
@@ -98,7 +98,7 @@ public record UsageMetricHandler(String indexName, String tuIndexName)
                     .map(
                         setValue ->
                             createUsageMetricTUEntity(
-                                recordKey, partitionId, timestamp, tenantId, setValue))
+                                recordKey, partitionId, endTime, tenantId, setValue))
                     .forEach(tuCollection::add));
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/metrics/UsageMetricRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/metrics/UsageMetricRecord.java
@@ -139,4 +139,8 @@ public class UsageMetricRecord extends UnifiedRecordValue implements UsageMetric
   public DirectBuffer getSetValueBuffer() {
     return setValuesProp.getValue();
   }
+
+  public boolean hasData() {
+    return !(getCounterValues().isEmpty() && getSetValues().isEmpty());
+  }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/metrics/UsageMetricRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/metrics/UsageMetricRecord.java
@@ -51,15 +51,6 @@ public class UsageMetricRecord extends UnifiedRecordValue implements UsageMetric
         .declareProperty(setValuesProp);
   }
 
-  public static UsageMetricRecord copyWithoutValues(final UsageMetricRecord usageMetricRecord) {
-    return new UsageMetricRecord()
-        .setEventType(usageMetricRecord.getEventType())
-        .setIntervalType(usageMetricRecord.getIntervalType())
-        .setResetTime(usageMetricRecord.getResetTime())
-        .setStartTime(usageMetricRecord.getStartTime())
-        .setEndTime(usageMetricRecord.getEndTime());
-  }
-
   @Override
   public IntervalType getIntervalType() {
     return intervalTypeProp.getValue();

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -1401,6 +1401,9 @@ public class CompactRecordLogger {
   }
 
   private String formatTime(final String name, final long time) {
+    if (time == -1) {
+      return "%s[%s]".formatted(name, -1);
+    }
     final var dateTime = Instant.ofEpochMilli(time).atZone(ZoneOffset.UTC);
     return "%s[%s]".formatted(name, shortenDateTime(dateTime));
   }


### PR DESCRIPTION
## Description

- Update usage metric handlers to use endTime instead of timestamp
- Enhance usage metrics processing and state management
- Adjust usage metric processor tests
- Adjust usage metric applier tests

## Related issues

closes https://github.com/camunda/camunda/issues/37390
