### PR TITLE
Camunda User Task with an incident cannot be migrated

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -245,7 +245,11 @@ public class ProcessInstanceMigrationMigrateProcessor
     requireSameElementType(
         targetProcessDefinition, targetElementId, elementInstance, processInstanceKey);
     requireSameUserTaskImplementation(
-        targetProcessDefinition, targetElementId, elementInstance, processInstanceKey);
+        sourceProcessDefinition,
+        targetProcessDefinition,
+        targetElementId,
+        elementInstance,
+        processInstanceKey);
     requireUnchangedFlowScope(
         elementInstanceState, elementInstanceRecord, targetProcessDefinition, targetElementId);
     requireNoEventSubprocessInSource(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -567,12 +567,14 @@ public final class ProcessInstanceMigrationPreconditions {
    * need to check whether the given element instance and target element has the same user task
    * type. Throws an exception if they have different types.
    *
+   * @param sourceProcessDefinition source process definition to retrieve the source element type
    * @param targetProcessDefinition target process definition to retrieve the target element type
    * @param targetElementId target element id
    * @param elementInstance element instance to do the check
    * @param processInstanceKey process instance key to be logged
    */
   public static void requireSameUserTaskImplementation(
+      final DeployedProcess sourceProcessDefinition,
       final DeployedProcess targetProcessDefinition,
       final String targetElementId,
       final ElementInstance elementInstance,
@@ -597,8 +599,13 @@ public final class ProcessInstanceMigrationPreconditions {
         targetUserTask.getUserTaskProperties() != null
             ? ZEEBE_USER_TASK_IMPLEMENTATION
             : JOB_WORKER_IMPLEMENTATION;
+
+    final ExecutableUserTask sourceUserTask =
+        sourceProcessDefinition
+            .getProcess()
+            .getElementById(elementInstanceRecord.getElementId(), ExecutableUserTask.class);
     final String sourceUserTaskType =
-        elementInstance.getUserTaskKey() > 0
+        sourceUserTask.getUserTaskProperties() != null
             ? ZEEBE_USER_TASK_IMPLEMENTATION
             : JOB_WORKER_IMPLEMENTATION;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Previously, the implementation was based on the user task instance's `userTaskKey`. However, `userTaskKey` is created after the activation of
 the Camunda User Task. If an incident is created during activation,
 user task will not have a key, so no `userTaskKey` is set.

 Precondition is updated to check the user task implementation
 correctly from the definition.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37190

