### PR TITLE
fix: opensearch ism policy min_ingex_age change

### DIFF
--- a/schema-manager/pom.xml
+++ b/schema-manager/pom.xml
@@ -96,6 +96,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## Description

When changing the ISM policies, OpenSearch require us to provide the current policy `seq_no` and the `primary_term`. 

This will first check if a policy with the name exist, and if so read it's current `_seq_no` and `_primary_term` and attach it as a param when updating ISM policy with new min age.

Additionally if the ISM policy already exist with the given value, this will skip applying that policy.


## Related issues

closes #37361
