### PR TITLE
fix: fix unassigned and tenant filters on Tasklist v2

### DIFF
--- a/tasklist/client/src/common/multitenancy/MultitenancySelect.tsx
+++ b/tasklist/client/src/common/multitenancy/MultitenancySelect.tsx
@@ -13,15 +13,10 @@ type Props = React.ComponentProps<typeof Select>;
 
 const MultitenancySelect: React.FC<Props> = (props) => {
   const {data: currentUser} = useCurrentUser();
-  const defaultTenant = currentUser?.tenants[0];
   const tenants = currentUser?.tenants ?? [];
 
   return (
-    <Select
-      {...props}
-      defaultValue={defaultTenant}
-      disabled={props.disabled || currentUser === undefined}
-    >
+    <Select {...props} disabled={props.disabled || currentUser === undefined}>
       {tenants.map(({tenantId, name}) => (
         <SelectItem key={tenantId} value={tenantId} text={name} />
       ))}

--- a/tasklist/client/src/common/tasks/filters/prepareCustomFiltersParams.ts
+++ b/tasklist/client/src/common/tasks/filters/prepareCustomFiltersParams.ts
@@ -26,6 +26,7 @@ function prepareCustomFiltersParams(
     taskId,
   } = body;
   const params: Record<string, string> = {};
+  const {clientMode} = getClientConfig();
 
   if (body === undefined) {
     return params;
@@ -63,7 +64,11 @@ function prepareCustomFiltersParams(
   }
 
   if (tenant !== undefined) {
-    params.tenantIds = JSON.stringify([tenant]);
+    if (clientMode === 'v1') {
+      params.tenantIds = JSON.stringify([tenant]);
+    } else {
+      params.tenantId = tenant;
+    }
   }
 
   if (dueDateFrom !== undefined) {
@@ -83,7 +88,7 @@ function prepareCustomFiltersParams(
   }
 
   if (taskId !== undefined) {
-    if (getClientConfig().clientMode === 'v1') {
+    if (clientMode === 'v1') {
       params.taskDefinitionId = taskId;
     } else {
       params.elementId = taskId;

--- a/tasklist/client/src/v2/api/getQueryVariables.tsx
+++ b/tasklist/client/src/v2/api/getQueryVariables.tsx
@@ -125,6 +125,7 @@ function convertFiltersToQueryVariables(
     dueDateTo,
     followUpDateFrom,
     followUpDateTo,
+    assigned,
     ...restFilters
   } = filters;
   const numberFilters =
@@ -167,6 +168,12 @@ function convertFiltersToQueryVariables(
     updatedFilters.followUpDate = {
       $gte: followUpDateFrom.toISOString(),
       $lte: followUpDateTo.toISOString(),
+    };
+  }
+
+  if (assigned !== undefined && !assigned) {
+    updatedFilters.assignee = {
+      $exists: false,
     };
   }
 

--- a/tasklist/client/src/v2/features/tasks/filters/useTaskFilters.ts
+++ b/tasklist/client/src/v2/features/tasks/filters/useTaskFilters.ts
@@ -45,6 +45,10 @@ const filtersSchema = z.object({
   dueDateTo: z.coerce.date().optional(),
   followUpDateFrom: z.coerce.date().optional(),
   followUpDateTo: z.coerce.date().optional(),
+  assigned: z
+    .string()
+    .transform((value) => value === 'true')
+    .optional(),
   ...apiFiltersSchema.shape,
 });
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Some of the Tasklist custom filters on V2 were still using the V1 format. This PR fixes that

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37296, #37294
