### PR TITLE
test: Add test case for isLatestVersion

### DIFF
--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -12,7 +12,8 @@
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery">
     SELECT COUNT(*)
-    FROM ${prefix}PROCESS_DEFINITION pi
+    FROM ${prefix}PROCESS_DEFINITION t
+    <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.maxVersionFilter"/>
     <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.searchFilter"/>
   </select>
 
@@ -31,13 +32,13 @@
     FROM ${prefix}PROCESS_DEFINITION
     <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.searchFilter"/>
     ) t
-    <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.join"/>
+    <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.maxVersionFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>
 
-  <sql id="join">
+  <sql id="maxVersionFilter">
     <if test="filter.isLatestVersion != null and filter.isLatestVersion == true">
       JOIN (
         SELECT pd.process_definition_id AS pd_id, pd.tenant_id AS t_id, MAX(version) AS max_version

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSpecificFilterIT.java
@@ -90,7 +90,7 @@ public class ProcessDefinitionSpecificFilterIT {
                     .name("Sorting Test Process")
                     .resourceName("sorting-test-process.bpmn")
                     .versionTag("Version 1337")
-                    .version(4711)
+                    .version(1)
                     .tenantId("sorting-tenant1")));
 
     createAndSaveProcessDefinition(
@@ -102,7 +102,7 @@ public class ProcessDefinitionSpecificFilterIT {
                     .name("Sorting Test Process")
                     .resourceName("sorting-test-process.bpmn")
                     .versionTag("Version 1337")
-                    .version(4712)
+                    .version(2)
                     .tenantId("sorting-tenant1")));
 
     final var searchResult =
@@ -117,8 +117,9 @@ public class ProcessDefinitionSpecificFilterIT {
 
     assertThat(searchResult.total()).isEqualTo(1);
     assertThat(searchResult.items()).hasSize(1);
-    assertThat(searchResult.items().getFirst().processDefinitionKey()).isEqualTo(4712L);
-    assertThat(searchResult.items().getFirst().version()).isEqualTo(4712L);
+    assertThat(searchResult.items().getFirst().processDefinitionId())
+        .isEqualTo("sorting-test-process");
+    assertThat(searchResult.items().getFirst().version()).isEqualTo(2L);
   }
 
   static List<ProcessDefinitionFilter> shouldFindProcessDefinitionWithSpecificFilterParameters() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSpecificFilterIT.java
@@ -24,6 +24,7 @@ import io.camunda.search.sort.ProcessDefinitionSort;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,6 +77,48 @@ public class ProcessDefinitionSpecificFilterIT {
     assertThat(searchResult.total()).isEqualTo(1);
     assertThat(searchResult.items()).hasSize(1);
     assertThat(searchResult.items().getFirst().processDefinitionKey()).isEqualTo(1337L);
+  }
+
+  @Test
+  public void shouldFindProcessDefinitionWithLatestVersion() {
+    createAndSaveProcessDefinition(
+        rdbmsWriter,
+        ProcessDefinitionFixtures.createRandomized(
+            b ->
+                b.processDefinitionKey(4711L)
+                    .processDefinitionId("sorting-test-process")
+                    .name("Sorting Test Process")
+                    .resourceName("sorting-test-process.bpmn")
+                    .versionTag("Version 1337")
+                    .version(4711)
+                    .tenantId("sorting-tenant1")));
+
+    createAndSaveProcessDefinition(
+        rdbmsWriter,
+        ProcessDefinitionFixtures.createRandomized(
+            b ->
+                b.processDefinitionKey(4712L)
+                    .processDefinitionId("sorting-test-process")
+                    .name("Sorting Test Process")
+                    .resourceName("sorting-test-process.bpmn")
+                    .versionTag("Version 1337")
+                    .version(4712)
+                    .tenantId("sorting-tenant1")));
+
+    final var searchResult =
+        processDefinitionReader.search(
+            new ProcessDefinitionQuery(
+                new ProcessDefinitionFilter.Builder()
+                    .processDefinitionIds("sorting-test-process")
+                    .isLatestVersion(true)
+                    .build(),
+                ProcessDefinitionSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().processDefinitionKey()).isEqualTo(4712L);
+    assertThat(searchResult.items().getFirst().version()).isEqualTo(4712L);
   }
 
   static List<ProcessDefinitionFilter> shouldFindProcessDefinitionWithSpecificFilterParameters() {


### PR DESCRIPTION
## Description

Adds a missing test for `isLatestVersion` filter for process definitions.

## Related issues

closes #36585
