### PR TITLE
fix: update request filters calculation logic

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/v2/index.tsx
@@ -33,7 +33,8 @@ const MigrateAction: React.FC = observer(() => {
   const {
     selectedProcessInstanceIds,
     hasSelectedRunningInstances,
-    state: {isAllChecked},
+    excludedProcessInstanceIds,
+    state: {selectionMode},
   } = processInstancesSelectionStore;
 
   const isVersionSelected = version !== undefined && version !== 'all';
@@ -73,8 +74,8 @@ const MigrateAction: React.FC = observer(() => {
 
     const requestFilterParameters = {
       ...getProcessInstancesRequestFilters(),
-      ids: isAllChecked ? [] : selectedProcessInstanceIds,
-      excludeIds: isAllChecked ? selectedProcessInstanceIds : [],
+      ids: selectionMode === 'INCLUDE' ? selectedProcessInstanceIds : [],
+      excludeIds: selectionMode === 'EXCLUDE' ? excludedProcessInstanceIds : [],
     };
 
     processInstanceMigrationStore.setSelectedInstancesCount(


### PR DESCRIPTION
## Description

Updates the way in which excluded and included elements are calculated for the `requestFilterParameters`

Assumed root cause: 
After “Select all” and deselecting some elements the selection store switches to `EXCLUDE` mode. The submit handler was building the payload using `isAllChecked` and the include-mode getter `selectedProcessInstanceIds` (which returns [] in `EXCLUDE`), resulting in `ids: [] and excludeIds: []`. The backend interpreted this as “migrate all filtered instances,” so unselected items are migrated too.

## Related issues

closes #32201 
