### PR TITLE
ci: Update project labels in workflow with regards to renaming spring-sdk

### DIFF
--- a/.github/opened_issue_labeler.yml
+++ b/.github/opened_issue_labeler.yml
@@ -18,8 +18,8 @@ component/operate:
   '(Operate-)'
 component/optimize:
   '(Optimize-)'
-component/spring-sdk:
-  '(Spring SDK-)'
+component/spring-boot-starter:
+  '(Spring Boot Starter-)'
 component/tasklist:
   '(Tasklist-)'
 component/zeebe:

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -98,7 +98,7 @@ jobs:
           project-url: https://github.com/orgs/camunda/projects/182
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           # any of the following labels:
-          labeled: component/clients, component/spring-sdk, component/camunda-process-test, component/c8-api
+          labeled: component/clients, component/spring-boot-starter, component/camunda-process-test, component/c8-api
       - id: add-bug-to-quality-board
         name: Add issue to Quality Board
         uses: camunda/infra-global-github-actions/add-bug-to-quality-board@main


### PR DESCRIPTION
## Description

I changed the label `components/spring-sdk` to `components-spring-boot-starter` to align with the renaming done with #37465


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #37465
