### PR TITLE
ci: workflow for running OC tests on 8.6 releases

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -1,0 +1,210 @@
+# description: Runs End to End tests on the C8 Orchestration Cluster (ie, Tasklist, Operate) for release validation
+# test location: /qa/c8-orchestration-cluster-e2e-test-suite
+# type: CI
+# owner: @camunda/qa-engineering
+---
+name: C8 Orchestration Cluster E2E Tests - Release Validation
+
+on:
+  push:
+    branches:
+      - "release**"
+  pull_request:
+    branches:
+      - "release**"
+
+permissions:
+  contents: read
+
+jobs:
+  release-e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Determine Image Tag
+        id: image-tag
+        run: |
+          # Extract version from branch name patterns:
+          # - release-8.6.1
+          # - origin/release-8.6.2
+          # - origin/custom-release-8.6.0-rc1
+          # - custom-release-8.6.5-alpha1
+          BRANCH_NAME="${{ github.ref_name }}"
+          echo "Analyzing branch name: $BRANCH_NAME"
+
+          if [[ "$BRANCH_NAME" =~ ^(origin/)?.*release-(8\.6\.[0-9]+(-[a-zA-Z0-9]+)?)$ ]]; then
+            IMAGE_TAG="${BASH_REMATCH[2]}"
+            echo "Extracted 8.6 version from branch name: $IMAGE_TAG"
+          elif [[ "$BRANCH_NAME" =~ ^(origin/)?release-(.+)$ ]]; then
+            IMAGE_TAG="${BASH_REMATCH[2]}"
+            echo "Extracted version from simple release branch: $IMAGE_TAG"
+          else
+            echo "Error: Could not extract version from branch name: $BRANCH_NAME"
+            echo "Expected patterns: release-8.6.x, origin/release-8.6.x, custom-release-8.6.x-suffix"
+            exit 1
+          fi
+
+          echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "Final image tag: $IMAGE_TAG"
+
+      - name: Update Docker Compose with Release Image
+        if: steps.image-tag.outcome == 'success'
+        run: |
+          IMAGE_TAG="${{ steps.image-tag.outputs.image-tag }}"
+          echo "Using separate services configuration for version: $IMAGE_TAG"
+
+          # Update individual service images - replace any existing tag with the extracted one
+          sed -i -E "s|image: camunda/zeebe:[^[:space:]]*|image: camunda/zeebe:$IMAGE_TAG|g" \
+            qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+          sed -i -E "s|image: camunda/tasklist:[^[:space:]]*|image: camunda/tasklist:$IMAGE_TAG|g" \
+            qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+          sed -i -E "s|image: camunda/operate:[^[:space:]]*|image: camunda/operate:$IMAGE_TAG|g" \
+            qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+
+          echo "Updated individual services to use version: $IMAGE_TAG"
+
+          # Verify the changes
+          echo "Zeebe image:"
+          grep "image: camunda/zeebe:" qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml || echo "No zeebe image found"
+          echo "Tasklist image:"
+          grep "image: camunda/tasklist:" qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml || echo "No tasklist image found"
+          echo "Operate image:"
+          grep "image: camunda/operate:" qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml || echo "No operate image found"
+
+      - name: Start Camunda
+        if: steps.image-tag.outcome == 'success'
+        run: |
+          echo "Starting Camunda with image tag: ${{ steps.image-tag.outputs.image-tag }}"
+          export DATABASE=elasticsearch
+          DATABASE=elasticsearch docker compose up -d zeebe operate tasklist
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+        env:
+          DATABASE: elasticsearch
+
+      - name: List running Docker containers
+        if: steps.image-tag.outcome == 'success'
+        run: docker ps -a
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Wait for services to be ready
+        if: steps.image-tag.outcome == 'success'
+        id: wait-for-services
+        run: |
+          echo "Checking if services are up..."
+          ready=false
+          for i in {1..90}; do
+            zeebe_status=$(curl -s -m 5 http://localhost:8080/actuator/health || echo "Failed")
+            tasklist_status=$(curl -s -m 5 http://localhost:8080/tasklist || echo "Failed")
+            operate_status=$(curl -s -m 5 http://localhost:8081/operate || echo "Failed")
+
+            if [[ "$tasklist_status" != "Failed" && "$operate_status" != "Failed" && "$zeebe_status" != "Failed" ]]; then
+              echo "Services are ready!"
+              ready=true
+              break
+            fi
+
+            echo "Waiting for services... ($i/90)"
+            echo "Response from Zeebe: $zeebe_status"
+            echo "Response from Tasklist: $tasklist_status"
+            echo "Response from Operate: $operate_status"
+            sleep 10
+          done
+
+          if [ "$ready" = true ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Services failed to start in time."
+            exit 1
+          fi
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Print Docker logs before failing
+        if: failure()
+        run: |
+          echo "=== Zeebe logs ==="
+          docker compose logs zeebe || true
+          echo "=== Tasklist logs ==="
+          docker compose logs tasklist || true
+          echo "=== Operate logs ==="
+          docker compose logs operate || true
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Setup Node.js
+        if: steps.image-tag.outcome == 'success'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+
+      - name: Clean install dependencies
+        if: steps.image-tag.outcome == 'success'
+        shell: bash
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@2c5827061f1ad91ca97897d6257ebe638e033699
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_EMAIL;
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
+
+      - name: Install Playwright Browsers
+        if: steps.image-tag.outcome == 'success'
+        shell: bash
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Run E2E Tests
+        if: steps.image-tag.outcome == 'success'
+        shell: bash
+        env:
+          LOCAL_TEST: "false"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          CORE_APPLICATION_TASKLIST_URL: http://localhost:8080
+          CORE_APPLICATION_OPERATE_URL: http://localhost:8081
+          ZEEBE_REST_ADDRESS: "http://localhost:8089"
+          RELEASE_VERSION: ${{ steps.image-tag.outputs.image-tag }}
+        run: |
+          echo "Running E2E tests against Camunda release version: $RELEASE_VERSION"
+          npm run test -- --project=chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Publish test results to TestRail
+        if: always()
+        shell: bash
+        env:
+          TESTRAIL_HOST: "https://camunda.testrail.com/"
+          TESTRAIL_USERNAME: ${{ steps.secrets.outputs.TESTRAIL_QA_EMAIL }} # Use the imported secret
+          TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }} # Use the imported secret
+          JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
+        run: |
+          pip install trcli
+          trcli -y -h "$TESTRAIL_HOST" \
+            --project 'C8' \
+            --username "$TESTRAIL_USERNAME" \
+            --key "$TESTRAIL_KEY" \
+            parse_junit --suite-id 17050 \
+            --title "${{ steps.image-tag.outputs.image-tag }}-Release OC test results" \
+            --close-run \
+            -f "$JUNIT_RESULTS_FILE"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ${{ steps.image-tag.outputs.image-tag }}-Release OC test results
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
+          retention-days: 10

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "main"
       - "stable/**"
-      - "release**"
     paths:
       - ".ci/**"
       - ".github/actions/**"

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "main"
       - "stable/**"
-      - "release**"
     paths:
       - ".github/actions/**"
       - ".github/workflows/tasklist-*"


### PR DESCRIPTION
## Description
Adds automated E2E testing workflow for C8 Orchestration Cluster release validation with support for automatic triggering on release branches.

### Key Features
- **Multi-trigger Support**: Runs on release branch pushes/PRs
- **Smart Version Detection**: Auto-extracts version from release branch names
- **Docker Integration**: Updates docker-compose with release-specific images and starts separate services


### Technical Details
- **Test Location**: `qa/c8-orchestration-cluster-e2e-test-suite`
- **Browser**: Chromium via Playwright
- **Services**: Zeebe (8080), Tasklist (8080/tasklist), Operate (8081/operate)
- **Authentication**: Basic auth with demo credentials

### Usage
- **Automatic**: Push to any `release**` branch triggers tests with extracted version

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
