### PR TITLE
Implement parent list for process definition statistics endpoint

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionInstanceStatisticsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionInstanceStatisticsDbReader.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.sql.columns.SearchColumn;
+import io.camunda.search.clients.reader.ProcessDefinitionInstanceStatisticsReader;
+import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
+import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+
+public class ProcessDefinitionInstanceStatisticsDbReader
+    extends AbstractEntityReader<ProcessDefinitionInstanceStatisticsEntity>
+    implements ProcessDefinitionInstanceStatisticsReader {
+
+  public ProcessDefinitionInstanceStatisticsDbReader() {
+    super(new SearchColumn[] {});
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity> aggregate(
+      final ProcessDefinitionInstanceStatisticsQuery query,
+      final ResourceAccessChecks resourceAccessChecks) {
+    // Not implemented yet
+    return SearchQueryResult.empty();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -27,6 +27,7 @@ import io.camunda.db.rdbms.read.service.JobDbReader;
 import io.camunda.db.rdbms.read.service.MappingRuleDbReader;
 import io.camunda.db.rdbms.read.service.MessageSubscriptionDbReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionInstanceStatisticsDbReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionStatisticsDbReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceStatisticsDbReader;
@@ -67,6 +68,7 @@ import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
+import io.camunda.search.clients.reader.ProcessDefinitionInstanceStatisticsReader;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -235,6 +237,11 @@ public class RdbmsConfiguration {
   @Bean
   public UsageMetricTUDbReader usageMetricTUReader(final UsageMetricTUMapper usageMetricTUMapper) {
     return new UsageMetricTUDbReader(usageMetricTUMapper);
+  }
+
+  @Bean
+  public ProcessDefinitionInstanceStatisticsReader processDefinitionInstanceStatisticsReader() {
+    return new ProcessDefinitionInstanceStatisticsDbReader();
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -27,6 +27,7 @@ import io.camunda.search.clients.reader.IncidentReader;
 import io.camunda.search.clients.reader.JobReader;
 import io.camunda.search.clients.reader.MappingRuleReader;
 import io.camunda.search.clients.reader.MessageSubscriptionReader;
+import io.camunda.search.clients.reader.ProcessDefinitionInstanceStatisticsReader;
 import io.camunda.search.clients.reader.ProcessDefinitionReader;
 import io.camunda.search.clients.reader.ProcessDefinitionStatisticsReader;
 import io.camunda.search.clients.reader.ProcessInstanceReader;
@@ -117,6 +118,7 @@ public class SearchClientDatabaseConfiguration {
       final MappingRuleReader mappingRuleReader,
       final MessageSubscriptionReader messageSubscriptionReader,
       final ProcessDefinitionReader processDefinitionReader,
+      final ProcessDefinitionInstanceStatisticsReader processDefinitionInstanceStatisticsReader,
       final ProcessDefinitionStatisticsReader processDefinitionFlowNodeStatisticsReader,
       final ProcessInstanceReader processInstanceReader,
       final ProcessInstanceStatisticsReader processInstanceFlowNodeStatisticsReader,
@@ -149,6 +151,7 @@ public class SearchClientDatabaseConfiguration {
         processDefinitionReader,
         processDefinitionFlowNodeStatisticsReader,
         processInstanceReader,
+        processDefinitionInstanceStatisticsReader,
         processInstanceFlowNodeStatisticsReader,
         roleReader,
         roleMemberReader,

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
@@ -42,6 +42,8 @@ import io.camunda.search.clients.reader.MappingRuleReader;
 import io.camunda.search.clients.reader.MessageSubscriptionDocumentReader;
 import io.camunda.search.clients.reader.MessageSubscriptionReader;
 import io.camunda.search.clients.reader.ProcessDefinitionDocumentReader;
+import io.camunda.search.clients.reader.ProcessDefinitionInstanceStatisticsDocumentReader;
+import io.camunda.search.clients.reader.ProcessDefinitionInstanceStatisticsReader;
 import io.camunda.search.clients.reader.ProcessDefinitionReader;
 import io.camunda.search.clients.reader.ProcessDefinitionStatisticsDocumentReader;
 import io.camunda.search.clients.reader.ProcessDefinitionStatisticsReader;
@@ -69,6 +71,7 @@ import io.camunda.search.clients.reader.UserTaskDocumentReader;
 import io.camunda.search.clients.reader.UserTaskReader;
 import io.camunda.search.clients.reader.VariableDocumentReader;
 import io.camunda.search.clients.reader.VariableReader;
+import io.camunda.search.clients.reader.utils.IncidentErrorHashCodeNormalizer;
 import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
@@ -124,6 +127,12 @@ public class SearchClientReaderConfiguration {
   public AuthorizationReader authorizationReader(
       final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
     return new AuthorizationDocumentReader(executor, descriptors.get(AuthorizationIndex.class));
+  }
+
+  @Bean
+  public IncidentErrorHashCodeNormalizer incidentErrorHashCodeNormalizer(
+      final IncidentReader incidentReader) {
+    return new IncidentErrorHashCodeNormalizer((IncidentDocumentReader) incidentReader);
   }
 
   @Bean
@@ -241,18 +250,27 @@ public class SearchClientReaderConfiguration {
   public ProcessDefinitionStatisticsReader processDefinitionStatisticsReader(
       final SearchClientBasedQueryExecutor executor,
       final IndexDescriptors descriptors,
-      final IncidentReader incidentReader) {
+      final IncidentErrorHashCodeNormalizer normalizer) {
     return new ProcessDefinitionStatisticsDocumentReader(
-        executor, descriptors.get(ListViewTemplate.class), (IncidentDocumentReader) incidentReader);
+        executor, descriptors.get(ListViewTemplate.class), normalizer);
+  }
+
+  @Bean
+  public ProcessDefinitionInstanceStatisticsReader processDefinitionInstanceStatisticsReader(
+      final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptors descriptors,
+      final IncidentErrorHashCodeNormalizer normalizer) {
+    return new ProcessDefinitionInstanceStatisticsDocumentReader(
+        executor, descriptors.get(ListViewTemplate.class), normalizer) {};
   }
 
   @Bean
   public ProcessInstanceReader processInstanceReader(
       final SearchClientBasedQueryExecutor executor,
       final IndexDescriptors descriptors,
-      final IncidentReader incidentReader) {
+      final IncidentErrorHashCodeNormalizer normalizer) {
     return new ProcessInstanceDocumentReader(
-        executor, descriptors.get(ListViewTemplate.class), (IncidentDocumentReader) incidentReader);
+        executor, descriptors.get(ListViewTemplate.class), normalizer);
   }
 
   @Bean

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
@@ -710,7 +710,8 @@ public class ProcessDefinitionStatisticsTest {
             .getProcesses()
             .getFirst()
             .getProcessDefinitionKey();
-    TestHelper.startProcessInstance(camundaClient, "service_tasks_v2", "{\"path\":222}");
+    final Map<String, Object> variables = Map.of("path", 222);
+    TestHelper.startProcessInstance(camundaClient, "service_tasks_v2", variables);
 
     try (final JobWorker ignored =
         camundaClient
@@ -719,7 +720,7 @@ public class ProcessDefinitionStatisticsTest {
             .handler((client, job) -> client.newFailCommand(job).retries(1).send().join())
             .open()) {
 
-      waitUntilJobWorkerHasFailedJob(camundaClient, 1);
+      waitUntilJobWorkerHasFailedJob(camundaClient, variables, 1);
 
       // when
       final var actual =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchTest.java
@@ -1172,13 +1172,15 @@ public class ProcessInstanceSearchTest {
             .handler((client, job) -> client.newFailCommand(job).retries(1).send().join())
             .open()) {
 
-      waitUntilJobWorkerHasFailedJob(camundaClient, 1);
+      final Map<String, Object> variables = Map.of("path", 222);
+
+      waitUntilJobWorkerHasFailedJob(camundaClient, variables, 1);
 
       // when
       final var result =
           camundaClient
               .newProcessInstanceSearchRequest()
-              .filter(f -> f.hasRetriesLeft(true))
+              .filter(f -> f.hasRetriesLeft(true).variables(variables))
               .send()
               .join();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -206,6 +206,18 @@ public final class TestHelper {
     return createProcessInstanceCommandStep3.send().join();
   }
 
+  public static ProcessInstanceEvent startProcessInstance(
+      final CamundaClient camundaClient,
+      final String bpmnProcessId,
+      final Map<String, Object> variables) {
+    final CreateProcessInstanceCommandStep1.CreateProcessInstanceCommandStep3 cmd =
+        camundaClient.newCreateInstanceCommand().bpmnProcessId(bpmnProcessId).latestVersion();
+    if (variables != null && !variables.isEmpty()) {
+      cmd.variables(variables);
+    }
+    return cmd.send().join();
+  }
+
   public static void waitForProcessInstancesToStart(
       final CamundaClient camundaClient, final int expectedProcessInstances) {
     waitForProcessInstancesToStart(camundaClient, f -> {}, expectedProcessInstances);
@@ -895,7 +907,9 @@ public final class TestHelper {
   }
 
   public static void waitUntilJobWorkerHasFailedJob(
-      final CamundaClient camundaClient, final int expectedProcesses) {
+      final CamundaClient camundaClient,
+      final Map<String, Object> variables,
+      final int expectedProcesses) {
     await("should wait until the process instance has been updated to reflect retries left.")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
@@ -903,7 +917,7 @@ public final class TestHelper {
               final var result =
                   camundaClient
                       .newProcessInstanceSearchRequest()
-                      .filter(f -> f.hasRetriesLeft(true))
+                      .filter(f -> f.hasRetriesLeft(true).variables(variables))
                       .send()
                       .join();
               assertThat(result.items().size()).isEqualTo(expectedProcesses);

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
@@ -8,6 +8,8 @@
 package io.camunda.search.es.transformers;
 
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import io.camunda.search.clients.aggregator.SearchBucketSortAggregator;
+import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
 import io.camunda.search.clients.aggregator.SearchChildrenAggregator;
 import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
 import io.camunda.search.clients.aggregator.SearchFilterAggregator;
@@ -44,6 +46,8 @@ import io.camunda.search.clients.source.SearchSourceConfig;
 import io.camunda.search.clients.source.SearchSourceFilter;
 import io.camunda.search.clients.transformers.SearchTransfomer;
 import io.camunda.search.clients.types.TypedValue;
+import io.camunda.search.es.transformers.aggregator.SearchBucketSortAggregationTransformer;
+import io.camunda.search.es.transformers.aggregator.SearchCardinalityAggregationTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchChildrenAggregatorTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchCompositeAggregatorTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchFilterAggregatorTransformer;
@@ -150,6 +154,10 @@ public final class ElasticsearchTransformers {
     mappers.put(SearchChildrenAggregator.class, new SearchChildrenAggregatorTransformer(mappers));
     mappers.put(SearchParentAggregator.class, new SearchParentAggregatorTransformer(mappers));
     mappers.put(SearchSumAggregator.class, new SearchSumAggregatorTransformer(mappers));
+    mappers.put(
+        SearchBucketSortAggregator.class, new SearchBucketSortAggregationTransformer(mappers));
+    mappers.put(
+        SearchCardinalityAggregator.class, new SearchCardinalityAggregationTransformer(mappers));
 
     // sort
     mappers.put(SearchSortOptions.class, new SortOptionsTransformer(mappers));

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.search.es.transformers.aggregator;
 
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.CardinalityAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket;
 import co.elastic.clients.elasticsearch._types.aggregations.LongTermsAggregate;
@@ -113,6 +114,10 @@ public class SearchAggregationResultTransformer<T>
     return new Builder().hits(toSearchQueryHits(hits, topHitAggregator.documentClass())).build();
   }
 
+  private AggregationResult transformCardinalityAggregate(final CardinalityAggregate aggregate) {
+    return new Builder().docCount(aggregate.value()).build();
+  }
+
   private <B extends MultiBucketBase> AggregationResult transformMultiBucketAggregate(
       final MultiBucketAggregateBase<B> aggregate) {
     final var map = new LinkedHashMap<String, AggregationResult>();
@@ -190,6 +195,7 @@ public class SearchAggregationResultTransformer<T>
             case Composite -> res = transformMultiBucketAggregate(aggregate.composite());
             case TopHits -> res = transformTopHitsAggregate(key, aggregate.topHits());
             case Sum -> res = transformSingleMetricAggregate(aggregate.sum());
+            case Cardinality -> res = transformCardinalityAggregate(aggregate.cardinality());
             default ->
                 throw new IllegalStateException(
                     "Unsupported aggregation type: " + aggregate._kind());

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchBucketSortAggregationTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchBucketSortAggregationTransformer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregator;
+
+import co.elastic.clients.elasticsearch._types.SortOptions;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.AggregationBuilders;
+import co.elastic.clients.elasticsearch._types.aggregations.BucketSortAggregation;
+import io.camunda.search.clients.aggregator.SearchBucketSortAggregator;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import java.util.List;
+import java.util.Optional;
+
+public final class SearchBucketSortAggregationTransformer
+    extends AggregatorTransformer<SearchBucketSortAggregator, Aggregation> {
+
+  public SearchBucketSortAggregationTransformer(final ElasticsearchTransformers transformers) {
+    super(transformers);
+  }
+
+  @Override
+  public Aggregation apply(final SearchBucketSortAggregator value) {
+    // Create the BucketSortAggregation
+    final BucketSortAggregation.Builder bucketSortBuilder = AggregationBuilders.bucketSort();
+    Optional.ofNullable(value.sorting())
+        .ifPresent(sorting -> bucketSortBuilder.sort(toSort(sorting)));
+    Optional.ofNullable(value.from()).ifPresent(bucketSortBuilder::from);
+    Optional.ofNullable(value.size()).ifPresent(bucketSortBuilder::size);
+    final var builder = new Aggregation.Builder().bucketSort(bucketSortBuilder.build());
+    applySubAggregations(builder, value);
+    return builder.build();
+  }
+
+  private List<SortOptions> toSort(final List<FieldSorting> requestedSort) {
+    return requestedSort.stream()
+        .map(
+            fieldSort ->
+                SortOptions.of(
+                    s ->
+                        s.field(f -> f.field(fieldSort.field()).order(toOrder(fieldSort.order())))))
+        .toList();
+  }
+
+  private SortOrder toOrder(final io.camunda.search.sort.SortOrder order) {
+    return order == io.camunda.search.sort.SortOrder.ASC ? SortOrder.Asc : SortOrder.Desc;
+  }
+}

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchCardinalityAggregationTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchCardinalityAggregationTransformer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregator;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.AggregationBuilders;
+import co.elastic.clients.elasticsearch._types.aggregations.CardinalityAggregation;
+import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import java.util.Optional;
+
+public final class SearchCardinalityAggregationTransformer
+    extends AggregatorTransformer<SearchCardinalityAggregator, Aggregation> {
+
+  public SearchCardinalityAggregationTransformer(final ElasticsearchTransformers transformers) {
+    super(transformers);
+  }
+
+  @Override
+  public Aggregation apply(final SearchCardinalityAggregator value) {
+    // Create the CardinalityAggregation
+    final CardinalityAggregation.Builder cardinalityBuilder = AggregationBuilders.cardinality();
+    Optional.ofNullable(value.field()).ifPresent(cardinalityBuilder::field);
+    final var builder = new Aggregation.Builder().cardinality(cardinalityBuilder.build());
+    applySubAggregations(builder, value);
+    return builder.build();
+  }
+}

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregator/SearchBucketSortAggregationTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregator/SearchBucketSortAggregationTransformerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import io.camunda.search.clients.aggregator.SearchAggregatorBuilders;
+import io.camunda.search.clients.aggregator.SearchBucketSortAggregator;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SearchBucketSortAggregationTransformerTest {
+
+  private SearchBucketSortAggregationTransformer transformer;
+
+  @BeforeEach
+  public void setUp() {
+    transformer = new SearchBucketSortAggregationTransformer(new ElasticsearchTransformers());
+  }
+
+  @Test
+  public void shouldTransformWithSortingFromAndSize() {
+    final SearchBucketSortAggregator aggregator =
+        SearchAggregatorBuilders.bucketSort()
+            .name("foo")
+            .sorting(List.of(new FieldSorting("name", SortOrder.ASC)))
+            .from(5)
+            .size(10)
+            .build();
+
+    final Aggregation aggregation = transformer.apply(aggregator);
+    assertThat(aggregation.bucketSort()).isNotNull();
+    assertThat(aggregation.bucketSort().sort()).hasSize(1);
+    assertThat(aggregation.bucketSort().from()).isEqualTo(5);
+    assertThat(aggregation.bucketSort().size()).isEqualTo(10);
+    assertThat(aggregation.bucketSort().sort().getFirst().field().field()).isEqualTo("name");
+    assertThat(
+            Objects.requireNonNull(aggregation.bucketSort().sort().getFirst().field().order())
+                .jsonValue())
+        .isEqualTo("asc");
+  }
+
+  @Test
+  public void shouldTransformWithNoSorting() {
+    final SearchBucketSortAggregator aggregator =
+        SearchAggregatorBuilders.bucketSort().name("foo").from(0).size(20).build();
+
+    final Aggregation aggregation = transformer.apply(aggregator);
+    assertThat(aggregation.bucketSort()).isNotNull();
+    assertThat(aggregation.bucketSort().sort()).isEmpty();
+    assertThat(aggregation.bucketSort().from()).isEqualTo(0);
+    assertThat(aggregation.bucketSort().size()).isEqualTo(20);
+  }
+
+  @Test
+  public void shouldTransformWithMultipleSortFields() {
+    final SearchBucketSortAggregator aggregator =
+        SearchAggregatorBuilders.bucketSort()
+            .name("foo")
+            .sorting(
+                List.of(
+                    new FieldSorting("name", SortOrder.ASC),
+                    new FieldSorting("date", SortOrder.DESC)))
+            .size(15)
+            .build();
+
+    final Aggregation aggregation = transformer.apply(aggregator);
+    assertThat(aggregation.bucketSort()).isNotNull();
+    assertThat(aggregation.bucketSort().sort()).hasSize(2);
+    assertThat(aggregation.bucketSort().sort().get(0).field().field()).isEqualTo("name");
+    assertThat(
+            Objects.requireNonNull(aggregation.bucketSort().sort().get(0).field().order())
+                .jsonValue())
+        .isEqualTo("asc");
+    assertThat(aggregation.bucketSort().sort().get(1).field().field()).isEqualTo("date");
+    assertThat(
+            Objects.requireNonNull(aggregation.bucketSort().sort().get(1).field().order())
+                .jsonValue())
+        .isEqualTo("desc");
+    assertThat(aggregation.bucketSort().size()).isEqualTo(15);
+  }
+
+  @Test
+  public void shouldThrowErrorOnInvalidSize() {
+    assertThatThrownBy(
+            () ->
+                SearchAggregatorBuilders.bucketSort()
+                    .name("foo")
+                    .sorting(List.of())
+                    .size(-1)
+                    .build())
+        .hasMessageContaining("Size must be greater than or equal to 0.")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregator/SearchCardinalityAggregationTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregator/SearchCardinalityAggregationTransformerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import io.camunda.search.clients.aggregator.SearchAggregatorBuilders;
+import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SearchCardinalityAggregationTransformerTest {
+
+  private SearchCardinalityAggregationTransformer transformer;
+
+  @BeforeEach
+  public void setUp() {
+    transformer = new SearchCardinalityAggregationTransformer(new ElasticsearchTransformers());
+  }
+
+  @Test
+  public void shouldTransformWithField() {
+    final SearchCardinalityAggregator aggregator =
+        SearchAggregatorBuilders.cardinality().name("cardinalityAgg").field("myField").build();
+
+    final Aggregation aggregation = transformer.apply(aggregator);
+    assertThat(aggregation.cardinality()).isNotNull();
+    assertThat(aggregation.cardinality().field()).isEqualTo("myField");
+  }
+
+  @Test
+  public void shouldTransformWithoutField() {
+    final SearchCardinalityAggregator aggregator =
+        SearchAggregatorBuilders.cardinality().name("cardinalityAgg").build();
+
+    final Aggregation aggregation = transformer.apply(aggregator);
+    assertThat(aggregation.cardinality()).isNotNull();
+    assertThat(aggregation.cardinality().field()).isNull();
+  }
+}

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.search.os.transformers;
 
+import io.camunda.search.clients.aggregator.SearchBucketSortAggregator;
+import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
 import io.camunda.search.clients.aggregator.SearchChildrenAggregator;
 import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
 import io.camunda.search.clients.aggregator.SearchFilterAggregator;
@@ -43,6 +45,8 @@ import io.camunda.search.clients.source.SearchSourceConfig;
 import io.camunda.search.clients.source.SearchSourceFilter;
 import io.camunda.search.clients.transformers.SearchTransfomer;
 import io.camunda.search.clients.types.TypedValue;
+import io.camunda.search.os.transformers.aggregator.SearchBucketSortAggregationTransformer;
+import io.camunda.search.os.transformers.aggregator.SearchCardinalityAggregationTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchChildrenAggregatorTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchCompositeAggregatorTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchFilterAggregatorTransformer;
@@ -150,6 +154,10 @@ public final class OpensearchTransformers {
     mappers.put(SearchChildrenAggregator.class, new SearchChildrenAggregatorTransformer(mappers));
     mappers.put(SearchParentAggregator.class, new SearchParentAggregatorTransformer(mappers));
     mappers.put(SearchSumAggregator.class, new SearchSumAggregatorTransformer(mappers));
+    mappers.put(
+        SearchBucketSortAggregator.class, new SearchBucketSortAggregationTransformer(mappers));
+    mappers.put(
+        SearchCardinalityAggregator.class, new SearchCardinalityAggregationTransformer(mappers));
 
     // sort
     mappers.put(SearchSortOptions.class, new SortOptionsTransformer(mappers));

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.CardinalityAggregate;
 import org.opensearch.client.opensearch._types.aggregations.CompositeAggregate;
 import org.opensearch.client.opensearch._types.aggregations.CompositeBucket;
 import org.opensearch.client.opensearch._types.aggregations.LongTermsAggregate;
@@ -112,6 +113,10 @@ public class SearchAggregationResultTransformer<T>
     return new Builder().hits(toSearchQueryHits(hits, topHitAggregator.documentClass())).build();
   }
 
+  private AggregationResult transformCardinalityAggregate(final CardinalityAggregate aggregate) {
+    return new Builder().docCount(aggregate.value()).build();
+  }
+
   private <B extends MultiBucketBase> AggregationResult transformMultiBucketAggregate(
       final MultiBucketAggregateBase<B> aggregate) {
     final var map = new LinkedHashMap<String, AggregationResult>();
@@ -190,6 +195,7 @@ public class SearchAggregationResultTransformer<T>
             case Composite -> res = transformMultiBucketAggregate(aggregate.composite());
             case TopHits -> res = transformTopHitsAggregate(key, aggregate.topHits());
             case Sum -> res = transformSingleMetricAggregate(aggregate.sum());
+            case Cardinality -> res = transformCardinalityAggregate(aggregate.cardinality());
             default ->
                 throw new IllegalStateException(
                     "Unsupported aggregation type: " + aggregate._kind());

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchBucketSortAggregationTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchBucketSortAggregationTransformer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.aggregator;
+
+import io.camunda.search.clients.aggregator.SearchBucketSortAggregator;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
+import org.opensearch.client.opensearch._types.aggregations.BucketSortAggregation;
+
+public final class SearchBucketSortAggregationTransformer
+    extends AggregatorTransformer<SearchBucketSortAggregator, Aggregation> {
+
+  public SearchBucketSortAggregationTransformer(final OpensearchTransformers transformers) {
+    super(transformers);
+  }
+
+  @Override
+  public Aggregation apply(final SearchBucketSortAggregator value) {
+    // Create the BucketSortAggregation
+    final BucketSortAggregation.Builder bucketSortBuilder = AggregationBuilders.bucketSort();
+    Optional.ofNullable(value.sorting())
+        .ifPresent(sorting -> bucketSortBuilder.sort(toSort(sorting)));
+    Optional.ofNullable(value.from()).ifPresent(bucketSortBuilder::from);
+    Optional.ofNullable(value.size()).ifPresent(bucketSortBuilder::size);
+    final var builder = new Aggregation.Builder().bucketSort(bucketSortBuilder.build());
+    applySubAggregations(builder, value);
+    return builder.build();
+  }
+
+  private List<SortOptions> toSort(final List<FieldSorting> requestedSort) {
+    final List<SortOptions> result = new ArrayList<>();
+
+    for (final FieldSorting fieldSort : requestedSort) {
+      result.add(
+          SortOptions.of(
+              s -> s.field(f -> f.field(fieldSort.field()).order(toOrder(fieldSort.order())))));
+    }
+    return result;
+  }
+
+  private SortOrder toOrder(final io.camunda.search.sort.SortOrder order) {
+    return order == io.camunda.search.sort.SortOrder.ASC ? SortOrder.Asc : SortOrder.Desc;
+  }
+}

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchCardinalityAggregationTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchCardinalityAggregationTransformer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.aggregator;
+
+import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import java.util.Optional;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
+import org.opensearch.client.opensearch._types.aggregations.CardinalityAggregation;
+
+public final class SearchCardinalityAggregationTransformer
+    extends AggregatorTransformer<SearchCardinalityAggregator, Aggregation> {
+
+  public SearchCardinalityAggregationTransformer(final OpensearchTransformers transformers) {
+    super(transformers);
+  }
+
+  @Override
+  public Aggregation apply(final SearchCardinalityAggregator value) {
+    // Create the CardinalityAggregation
+    final CardinalityAggregation.Builder cardinalityBuilder = AggregationBuilders.cardinality();
+    Optional.ofNullable(value.field()).ifPresent(cardinalityBuilder::field);
+    final var builder = new Aggregation.Builder().cardinality(cardinalityBuilder.build());
+    applySubAggregations(builder, value);
+    return builder.build();
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/SearchBucketSortAggregationTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/SearchBucketSortAggregationTransformerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.aggregator.SearchAggregatorBuilders;
+import io.camunda.search.clients.aggregator.SearchBucketSortAggregator;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+
+public class SearchBucketSortAggregationTransformerTest {
+
+  private SearchBucketSortAggregationTransformer transformer;
+
+  @BeforeEach
+  public void setUp() {
+    transformer = new SearchBucketSortAggregationTransformer(new OpensearchTransformers());
+  }
+
+  @Test
+  public void shouldTransformWithSortingFromAndSize() {
+    final SearchBucketSortAggregator aggregator =
+        SearchAggregatorBuilders.bucketSort()
+            .name("foo")
+            .sorting(List.of(new FieldSorting("name", SortOrder.ASC)))
+            .from(5)
+            .size(10)
+            .build();
+
+    final Aggregation aggregation = transformer.apply(aggregator);
+    assertThat(aggregation.bucketSort()).isNotNull();
+    assertThat(aggregation.bucketSort().sort()).hasSize(1);
+    assertThat(aggregation.bucketSort().from()).isEqualTo(5);
+    assertThat(aggregation.bucketSort().size()).isEqualTo(10);
+    assertThat(aggregation.bucketSort().sort().getFirst().field().field()).isEqualTo("name");
+    assertThat(
+            Objects.requireNonNull(aggregation.bucketSort().sort().getFirst().field().order())
+                .jsonValue())
+        .isEqualTo("asc");
+  }
+
+  @Test
+  public void shouldTransformWithNoSorting() {
+    final SearchBucketSortAggregator aggregator =
+        SearchAggregatorBuilders.bucketSort().name("foo").from(0).size(20).build();
+
+    final Aggregation aggregation = transformer.apply(aggregator);
+    assertThat(aggregation.bucketSort()).isNotNull();
+    assertThat(aggregation.bucketSort().sort()).isEmpty();
+    assertThat(aggregation.bucketSort().from()).isEqualTo(0);
+    assertThat(aggregation.bucketSort().size()).isEqualTo(20);
+  }
+
+  @Test
+  public void shouldTransformWithMultipleSortFields() {
+    final SearchBucketSortAggregator aggregator =
+        SearchAggregatorBuilders.bucketSort()
+            .name("foo")
+            .sorting(
+                List.of(
+                    new FieldSorting("name", SortOrder.ASC),
+                    new FieldSorting("date", SortOrder.DESC)))
+            .size(15)
+            .build();
+
+    final Aggregation aggregation = transformer.apply(aggregator);
+    assertThat(aggregation.bucketSort()).isNotNull();
+    assertThat(aggregation.bucketSort().sort()).hasSize(2);
+    assertThat(aggregation.bucketSort().sort().get(0).field().field()).isEqualTo("name");
+    assertThat(
+            Objects.requireNonNull(aggregation.bucketSort().sort().get(0).field().order())
+                .jsonValue())
+        .isEqualTo("asc");
+    assertThat(aggregation.bucketSort().sort().get(1).field().field()).isEqualTo("date");
+    assertThat(
+            Objects.requireNonNull(aggregation.bucketSort().sort().get(1).field().order())
+                .jsonValue())
+        .isEqualTo("desc");
+    assertThat(aggregation.bucketSort().size()).isEqualTo(15);
+  }
+
+  @Test
+  public void shouldThrowErrorOnInvalidSize() {
+    assertThatThrownBy(
+            () ->
+                SearchAggregatorBuilders.bucketSort()
+                    .name("foo")
+                    .sorting(List.of())
+                    .size(-1)
+                    .build())
+        .hasMessageContaining("Size must be greater than or equal to 0.")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/SearchCardinalityAggregationTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/SearchCardinalityAggregationTransformerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.aggregator.SearchAggregatorBuilders;
+import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+
+public class SearchCardinalityAggregationTransformerTest {
+
+  private SearchCardinalityAggregationTransformer transformer;
+
+  @BeforeEach
+  public void setUp() {
+    transformer = new SearchCardinalityAggregationTransformer(new OpensearchTransformers());
+  }
+
+  @Test
+  public void shouldTransformWithField() {
+    final SearchCardinalityAggregator aggregator =
+        SearchAggregatorBuilders.cardinality().name("cardinalityAgg").field("myField").build();
+
+    final Aggregation aggregation = transformer.apply(aggregator);
+    assertThat(aggregation.cardinality()).isNotNull();
+    assertThat(aggregation.cardinality().field()).isEqualTo("myField");
+  }
+
+  @Test
+  public void shouldTransformWithoutField() {
+    final SearchCardinalityAggregator aggregator =
+        SearchAggregatorBuilders.cardinality().name("cardinalityAgg").build();
+
+    final Aggregation aggregation = transformer.apply(aggregator);
+    assertThat(aggregation.cardinality()).isNotNull();
+    assertThat(aggregation.cardinality().field()).isNull();
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchAggregatorBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchAggregatorBuilders.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.aggregator;
 
 import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.sort.SortOption.FieldSorting;
 import java.util.List;
 
 public final class SearchAggregatorBuilders {
@@ -74,5 +75,25 @@ public final class SearchAggregatorBuilders {
 
   public static SearchFiltersAggregator.Builder filters() {
     return new SearchFiltersAggregator.Builder();
+  }
+
+  public static SearchBucketSortAggregator.Builder bucketSort() {
+    return new SearchBucketSortAggregator.Builder();
+  }
+
+  public static SearchBucketSortAggregator bucketSort(
+      final String name,
+      final List<FieldSorting> sortings,
+      final Integer from,
+      final Integer size) {
+    return bucketSort().name(name).sorting(sortings).from(from).size(size).build();
+  }
+
+  public static SearchCardinalityAggregator.Builder cardinality() {
+    return new SearchCardinalityAggregator.Builder();
+  }
+
+  public static SearchCardinalityAggregator cardinality(final String name, final String field) {
+    return cardinality().name(name).field(field).build();
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchBucketSortAggregator.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchBucketSortAggregator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregator;
+
+import io.camunda.search.sort.SortOption.FieldSorting;
+import java.util.List;
+import java.util.Objects;
+
+public record SearchBucketSortAggregator(
+    String name,
+    List<FieldSorting> sorting,
+    Integer from,
+    Integer size,
+    List<SearchAggregator> aggregations)
+    implements SearchAggregator {
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public List<SearchAggregator> getAggregations() {
+    return aggregations;
+  }
+
+  public static final class Builder extends SearchAggregator.AbstractBuilder<Builder> {
+
+    private List<FieldSorting> sorting;
+    private Integer from;
+    private Integer size;
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    public Builder sorting(final List<FieldSorting> value) {
+      sorting = value;
+      return this;
+    }
+
+    public Builder from(final Integer value) {
+      if (value != null && value < 0) {
+        throw new IllegalArgumentException("From must be greater than or equal to 0.");
+      }
+      from = value;
+      return this;
+    }
+
+    public Builder size(final Integer value) {
+      if (value != null && value < 0) {
+        throw new IllegalArgumentException("Size must be greater than or equal to 0.");
+      }
+      size = value;
+      return this;
+    }
+
+    public SearchBucketSortAggregator build() {
+      return new SearchBucketSortAggregator(
+          Objects.requireNonNull(name, "Expected non-null field for name."),
+          sorting,
+          from,
+          size,
+          aggregations);
+    }
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchCardinalityAggregator.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchCardinalityAggregator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregator;
+
+import java.util.List;
+import java.util.Objects;
+
+public record SearchCardinalityAggregator(
+    String name, String field, List<SearchAggregator> aggregations) implements SearchAggregator {
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public List<SearchAggregator> getAggregations() {
+    return aggregations;
+  }
+
+  public static final class Builder extends SearchAggregator.AbstractBuilder<Builder> {
+    private String field;
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    public Builder field(final String value) {
+      field = value;
+      return this;
+    }
+
+    public SearchCardinalityAggregator build() {
+      return new SearchCardinalityAggregator(
+          Objects.requireNonNull(name, "Expected non-null field for name."), field, aggregations);
+    }
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/core/AggregationResult.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/core/AggregationResult.java
@@ -17,6 +17,9 @@ public record AggregationResult(
     List<SearchQueryHit> hits,
     String endCursor) {
 
+  public static final AggregationResult EMPTY =
+      new AggregationResult(0L, Map.of(), List.of(), null);
+
   public AggregationResult(final Long docCount, final Map<String, AggregationResult> aggregations) {
     this(docCount, aggregations, List.of(), null);
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionInstanceStatisticsDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionInstanceStatisticsDocumentReader.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_FIELD_KEY;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_FIELD_PROCESS_DEFINITION_ID;
+
+import io.camunda.search.aggregation.result.ProcessDefinitionInstanceStatisticsAggregationResult;
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.clients.reader.utils.IncidentErrorHashCodeNormalizer;
+import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
+import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class ProcessDefinitionInstanceStatisticsDocumentReader extends DocumentBasedReader
+    implements ProcessDefinitionInstanceStatisticsReader {
+
+  private final IncidentErrorHashCodeNormalizer normalizer;
+
+  public ProcessDefinitionInstanceStatisticsDocumentReader(
+      final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptor indexDescriptor,
+      final IncidentErrorHashCodeNormalizer normalizer) {
+    super(executor, indexDescriptor);
+    this.normalizer = normalizer;
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity> aggregate(
+      final ProcessDefinitionInstanceStatisticsQuery query,
+      final ResourceAccessChecks resourceAccessChecks) {
+
+    final var filter =
+        normalizer.normalizeAndValidateProcessInstanceFilter(query.filter(), resourceAccessChecks);
+    if (filter.isEmpty()) {
+      return SearchQueryResult.empty();
+    }
+
+    // Update the query to use the normalized filter
+    final var normalizedQuery =
+        new ProcessDefinitionInstanceStatisticsQuery(filter.get(), query.sort(), query.page());
+
+    // Convert sorting field if needed
+    final var updatedQuery =
+        normalizedQuery.withConvertedSortingField(
+            AGGREGATION_FIELD_PROCESS_DEFINITION_ID, AGGREGATION_FIELD_KEY);
+
+    // Run a single paginated query; total count is provided by the cardinality aggregation
+    final var paginatedResult =
+        getSearchExecutor()
+            .aggregateWithQueryResult(
+                updatedQuery,
+                ProcessDefinitionInstanceStatisticsAggregationResult.class,
+                resourceAccessChecks,
+                ProcessDefinitionInstanceStatisticsAggregationResult::items);
+
+    // Return paginated items and total from the single query result
+    return new SearchQueryResult<>(
+        paginatedResult.total(),
+        paginatedResult.hasMoreTotalItems(),
+        paginatedResult.items(),
+        paginatedResult.startCursor(),
+        paginatedResult.endCursor());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionStatisticsDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionStatisticsDocumentReader.java
@@ -9,26 +9,24 @@ package io.camunda.search.clients.reader;
 
 import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResult;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.clients.reader.utils.IncidentErrorHashCodeNormalizer;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
-import io.camunda.search.filter.Operation;
-import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
-import java.util.ArrayList;
 import java.util.List;
 
 public class ProcessDefinitionStatisticsDocumentReader extends DocumentBasedReader
     implements ProcessDefinitionStatisticsReader {
 
-  private final IncidentDocumentReader incidentReader;
+  private final IncidentErrorHashCodeNormalizer normalizer;
 
   public ProcessDefinitionStatisticsDocumentReader(
       final SearchClientBasedQueryExecutor executor,
       final IndexDescriptor indexDescriptor,
-      final IncidentDocumentReader incidentReader) {
+      final IncidentErrorHashCodeNormalizer normalizer) {
     super(executor, indexDescriptor);
-    this.incidentReader = incidentReader;
+    this.normalizer = normalizer;
   }
 
   @Override
@@ -36,29 +34,15 @@ public class ProcessDefinitionStatisticsDocumentReader extends DocumentBasedRead
       final ProcessDefinitionFlowNodeStatisticsQuery query,
       final ResourceAccessChecks resourceAccessChecks) {
 
-    var filter = query.filter();
-    if (filter.incidentErrorHashCodeOperations() != null
-        && !filter.incidentErrorHashCodeOperations().isEmpty()) {
-      filter = normalizePDTopLevelIncidentHashCodes(filter, resourceAccessChecks);
-      if (filter.incidentErrorHashCodeOperations() == null
-          || filter.errorMessageOperations().isEmpty()) {
-        // If the incidentErrorHashCodes were resolved to null, we can return an empty result
-        return List.of();
-      }
-    }
-
-    if (filter.orFilters() != null && !filter.orFilters().isEmpty()) {
-      final var normalizedOr =
-          normalizePDOrFilterErrorHashCodes(filter.orFilters(), resourceAccessChecks);
-      if (normalizedOr.isEmpty()) {
-        // If all OR filters was not resolved, we can return an empty result
-        return List.of();
-      }
-      filter = filter.toBuilder().orFilters(normalizedOr).build();
+    final var filter =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(
+            query.filter(), resourceAccessChecks);
+    if (filter.isEmpty()) {
+      return List.of();
     }
 
     return executeAggregate(
-        new ProcessDefinitionFlowNodeStatisticsQuery(filter), resourceAccessChecks);
+        new ProcessDefinitionFlowNodeStatisticsQuery(filter.get()), resourceAccessChecks);
   }
 
   private List<ProcessFlowNodeStatisticsEntity> executeAggregate(
@@ -68,71 +52,5 @@ public class ProcessDefinitionStatisticsDocumentReader extends DocumentBasedRead
         .aggregate(
             query, ProcessDefinitionFlowNodeStatisticsAggregationResult.class, resourceAccessChecks)
         .items();
-  }
-
-  private ProcessDefinitionStatisticsFilter normalizePDTopLevelIncidentHashCodes(
-      final ProcessDefinitionStatisticsFilter filter,
-      final ResourceAccessChecks resourceAccessChecks) {
-    if (filter.incidentErrorHashCodeOperations() == null
-        || filter.incidentErrorHashCodeOperations().isEmpty()) {
-      return filter;
-    }
-
-    final var resolvedErrorMessage =
-        incidentReader.findErrorMessageByErrorHashCodes(
-            filter.incidentErrorHashCodeOperations(), resourceAccessChecks);
-
-    if (resolvedErrorMessage == null || resolvedErrorMessage.isEmpty()) {
-      return filter.toBuilder().incidentErrorHashCodeOperations(List.of()).build();
-    }
-    final var existingOps =
-        filter.errorMessageOperations() != null
-            ? new ArrayList<>(filter.errorMessageOperations())
-            : new ArrayList<Operation<String>>();
-
-    existingOps.add(Operation.eq(resolvedErrorMessage));
-
-    return filter.toBuilder()
-        .incidentErrorHashCodeOperations(null)
-        .replaceErrorMessageOperations(existingOps)
-        .build();
-  }
-
-  private List<ProcessDefinitionStatisticsFilter> normalizePDOrFilterErrorHashCodes(
-      final List<ProcessDefinitionStatisticsFilter> orFilters,
-      final ResourceAccessChecks resourceAccessChecks) {
-
-    final List<ProcessDefinitionStatisticsFilter> normalized = new ArrayList<>();
-    for (final var subFilter : orFilters) {
-      if (subFilter.incidentErrorHashCodeOperations() == null
-          || subFilter.incidentErrorHashCodeOperations().isEmpty()) {
-        normalized.add(subFilter);
-        continue;
-      }
-
-      final var resolvedErrorMessage =
-          incidentReader.findErrorMessageByErrorHashCodes(
-              subFilter.incidentErrorHashCodeOperations(), resourceAccessChecks);
-
-      if (resolvedErrorMessage == null || resolvedErrorMessage.isBlank()) {
-        continue;
-      }
-
-      final var existingOps =
-          subFilter.errorMessageOperations() != null
-              ? new ArrayList<>(subFilter.errorMessageOperations())
-              : new ArrayList<Operation<String>>();
-
-      existingOps.add(Operation.eq(resolvedErrorMessage));
-
-      final var updatedSubFilter =
-          subFilter.toBuilder()
-              .incidentErrorHashCodeOperations(null)
-              .replaceErrorMessageOperations(existingOps)
-              .build();
-
-      normalized.add(updatedSubFilter);
-    }
-    return normalized;
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessInstanceDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessInstanceDocumentReader.java
@@ -8,28 +8,25 @@
 package io.camunda.search.clients.reader;
 
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.clients.reader.utils.IncidentErrorHashCodeNormalizer;
 import io.camunda.search.entities.ProcessInstanceEntity;
-import io.camunda.search.filter.Operation;
-import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
-import java.util.ArrayList;
-import java.util.List;
 
 public class ProcessInstanceDocumentReader extends DocumentBasedReader
     implements ProcessInstanceReader {
 
-  private final IncidentDocumentReader incidentReader;
+  private final IncidentErrorHashCodeNormalizer normalizer;
 
   public ProcessInstanceDocumentReader(
       final SearchClientBasedQueryExecutor executor,
       final IndexDescriptor indexDescriptor,
-      final IncidentDocumentReader incidentReader) {
+      final IncidentErrorHashCodeNormalizer normalizer) {
     super(executor, indexDescriptor);
-    this.incidentReader = incidentReader;
+    this.normalizer = normalizer;
   }
 
   @Override
@@ -45,33 +42,16 @@ public class ProcessInstanceDocumentReader extends DocumentBasedReader
   public SearchQueryResult<ProcessInstanceEntity> search(
       final ProcessInstanceQuery query, final ResourceAccessChecks resourceAccessChecks) {
 
-    var filter = query.filter();
-
-    if (filter.incidentErrorHashCodeOperations() != null
-        && !filter.incidentErrorHashCodeOperations().isEmpty()) {
-      filter = normalizePITopLevelIncidentHashCodes(filter, resourceAccessChecks);
-      if (filter.incidentErrorHashCodeOperations().isEmpty()
-          || filter.errorMessageOperations().isEmpty()) {
-        // If the incidentErrorHashCode was resolved to empty, we can return an empty result
-        return SearchQueryResult.empty();
-      }
+    final var filter =
+        normalizer.normalizeAndValidateProcessInstanceFilter(query.filter(), resourceAccessChecks);
+    if (filter.isEmpty()) {
+      return SearchQueryResult.empty();
     }
 
-    if (filter.orFilters() != null && !filter.orFilters().isEmpty()) {
-      final var normalizedOr =
-          normalizePIOrFilterErrorHashCodes(filter.orFilters(), resourceAccessChecks);
-      if (normalizedOr.isEmpty()) {
-        // If all OR filters was not resolved, we can return an empty result
-        return SearchQueryResult.empty();
-      }
-      filter = filter.toBuilder().orFilters(normalizedOr).build();
-    }
-
-    final ProcessInstanceFilter finalFilter = filter;
     final var updatedQuery =
         ProcessInstanceQuery.of(
             q ->
-                q.filter(finalFilter)
+                q.filter(filter.get())
                     .sort(query.sort())
                     .page(query.page())
                     .resultConfig(query.resultConfig()));
@@ -83,83 +63,5 @@ public class ProcessInstanceDocumentReader extends DocumentBasedReader
       final ProcessInstanceQuery query, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()
         .search(query, ProcessInstanceForListViewEntity.class, resourceAccessChecks);
-  }
-
-  /**
-   * Normalizes a top-level incidentErrorHashCode by resolving it to a full errorMessage, and always
-   * adds it as an additional errorMessageOperation (AND), regardless of existing ones. This
-   * reflects the fact that a process instance can have multiple incidents, and all error messages
-   * can be valid under AND semantics.
-   */
-  private ProcessInstanceFilter normalizePITopLevelIncidentHashCodes(
-      final ProcessInstanceFilter filter, final ResourceAccessChecks resourceAccessChecks) {
-    if (filter.incidentErrorHashCodeOperations() == null
-        || filter.incidentErrorHashCodeOperations().isEmpty()) {
-      return filter;
-    }
-
-    final var resolvedErrorMessage =
-        incidentReader.findErrorMessageByErrorHashCodes(
-            filter.incidentErrorHashCodeOperations(), resourceAccessChecks);
-
-    if (resolvedErrorMessage == null || resolvedErrorMessage.isBlank()) {
-      return filter.toBuilder().incidentErrorHashCode(null).build();
-    }
-
-    final var existingOps =
-        filter.errorMessageOperations() != null
-            ? new ArrayList<>(filter.errorMessageOperations())
-            : new ArrayList<Operation<String>>();
-
-    existingOps.add(Operation.eq(resolvedErrorMessage));
-
-    return filter.toBuilder()
-        .incidentErrorHashCode(null)
-        .replaceErrorMessageOperations(existingOps)
-        .build();
-  }
-
-  /**
-   * Given a list of OR filters, normalize any sub-filter that uses incidentErrorHashCode by
-   * resolving it to a full errorMessage equals operation, and adding it to any existing
-   * errorMessage filters, using AND semantics within the subfilter. If the hash code cannot be
-   * resolved, skip that clause.
-   */
-  private List<ProcessInstanceFilter> normalizePIOrFilterErrorHashCodes(
-      final List<ProcessInstanceFilter> orFilters,
-      final ResourceAccessChecks resourceAccessChecks) {
-
-    final List<ProcessInstanceFilter> normalized = new ArrayList<>();
-    for (final var subFilter : orFilters) {
-      if (subFilter.incidentErrorHashCodeOperations() == null
-          || subFilter.incidentErrorHashCodeOperations().isEmpty()) {
-        normalized.add(subFilter);
-        continue;
-      }
-
-      final var resolvedErrorMessage =
-          incidentReader.findErrorMessageByErrorHashCodes(
-              subFilter.incidentErrorHashCodeOperations(), resourceAccessChecks);
-
-      if (resolvedErrorMessage == null || resolvedErrorMessage.isBlank()) {
-        continue;
-      }
-
-      final var existingOps =
-          subFilter.errorMessageOperations() != null
-              ? new ArrayList<>(subFilter.errorMessageOperations())
-              : new ArrayList<Operation<String>>();
-
-      existingOps.add(Operation.eq(resolvedErrorMessage));
-
-      final var updatedSubFilter =
-          subFilter.toBuilder()
-              .incidentErrorHashCode(null)
-              .replaceErrorMessageOperations(existingOps)
-              .build();
-
-      normalized.add(updatedSubFilter);
-    }
-    return normalized;
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/utils/IncidentErrorHashCodeNormalizer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/utils/IncidentErrorHashCodeNormalizer.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader.utils;
+
+import static java.util.stream.Collectors.toMap;
+
+import io.camunda.search.clients.reader.IncidentDocumentReader;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.Operator;
+import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper that normalizes incident error hash code operations into error message operations by
+ * resolving the hash codes via the IncidentDocumentReader.
+ */
+public class IncidentErrorHashCodeNormalizer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IncidentErrorHashCodeNormalizer.class);
+
+  private final IncidentDocumentReader incidentReader;
+
+  public IncidentErrorHashCodeNormalizer(final IncidentDocumentReader incidentReader) {
+    this.incidentReader = incidentReader;
+  }
+
+  public Optional<ProcessInstanceFilter> normalizeAndValidateProcessInstanceFilter(
+      final ProcessInstanceFilter filter, final ResourceAccessChecks resourceAccessChecks) {
+    return normalizeProcessInstanceFilter(filter, resourceAccessChecks, new HashSet<>());
+  }
+
+  public Optional<ProcessDefinitionStatisticsFilter> normalizeAndValidateProcessDefinitionFilter(
+      final ProcessDefinitionStatisticsFilter filter,
+      final ResourceAccessChecks resourceAccessChecks) {
+    return normalizeProcessDefinitionFilter(filter, resourceAccessChecks, new HashSet<>());
+  }
+
+  private Optional<ProcessInstanceFilter> normalizeProcessInstanceFilter(
+      final ProcessInstanceFilter filter,
+      final ResourceAccessChecks resourceAccessChecks,
+      final Set<ProcessInstanceFilter> visited) {
+    if (filter == null) {
+      logDropReason("process instance filter", "filter is null");
+      return Optional.empty();
+    }
+    if (!visited.add(filter)) {
+      logDropReason(
+          "process instance filter", "cycle detected (filter already visited)", filter, visited);
+      return Optional.empty();
+    }
+
+    final var hashOps = filter.incidentErrorHashCodeOperations();
+    final var msgOps = filter.errorMessageOperations();
+    final boolean hasHash = hashOps != null && !hashOps.isEmpty();
+    final boolean hasMsg = msgOps != null && !msgOps.isEmpty();
+
+    if (hasHash && hasMsg) {
+      final boolean hasLike =
+          msgOps.stream().anyMatch(op -> op != null && op.operator() == Operator.LIKE);
+      if (hasLike) {
+        if (hasInvalidErrorMessages(msgOps)) {
+          logDropReason("process instance filter", "invalid error message operations", msgOps);
+          return Optional.empty();
+        }
+        return normalizeOrFilters(
+            filter.toBuilder().replaceErrorMessageOperations(dedupeErrorMessages(msgOps)).build(),
+            resourceAccessChecks,
+            visited);
+      }
+      final var inOp = msgOps.stream().filter(op -> op.operator() == Operator.IN).findFirst();
+      if (inOp.isPresent()) {
+        final var resolvedOpt = resolveErrorMessage(hashOps, resourceAccessChecks);
+        if (resolvedOpt.isEmpty()) {
+          logDropReason(
+              "process instance filter",
+              "could not resolve error message from hashOps for IN op",
+              hashOps,
+              msgOps);
+          return Optional.empty();
+        }
+        final String resolved = resolvedOpt.get();
+        final List<String> values = new ArrayList<>(inOp.get().values());
+        if (!values.contains(resolved)) {
+          values.add(resolved);
+        }
+        return normalizeOrFilters(
+            filter.toBuilder().replaceErrorMessageOperations(List.of(Operation.in(values))).build(),
+            resourceAccessChecks,
+            visited);
+      }
+      final var resolvedOpt = resolveErrorMessage(hashOps, resourceAccessChecks);
+      if (resolvedOpt.isEmpty()) {
+        logDropReason(
+            "process instance filter", "could not resolve error message from hashOps", hashOps);
+        return Optional.empty();
+      }
+      if (anyOpDoesNotMatch(msgOps, resolvedOpt.get())) {
+        logDropReason(
+            "process instance filter",
+            "resolved error message does not match msgOps",
+            msgOps,
+            resolvedOpt.get());
+        return Optional.empty();
+      }
+      return normalizeOrFilters(
+          filter.toBuilder()
+              .replaceErrorMessageOperations(List.of(Operation.eq(resolvedOpt.get())))
+              .build(),
+          resourceAccessChecks,
+          visited);
+    }
+    if (hasHash) {
+      final var resolvedOpt = resolveErrorMessage(hashOps, resourceAccessChecks);
+      if (resolvedOpt.isEmpty()) {
+        logDropReason(
+            "process instance filter", "could not resolve error message from hashOps", hashOps);
+        return Optional.empty();
+      }
+      return normalizeOrFilters(
+          filter.toBuilder()
+              .replaceErrorMessageOperations(List.of(Operation.eq(resolvedOpt.get())))
+              .build(),
+          resourceAccessChecks,
+          visited);
+    }
+    if (hasMsg) {
+      if (hasInvalidErrorMessages(msgOps)) {
+        logDropReason("process instance filter", "invalid error message operations", msgOps);
+        return Optional.empty();
+      }
+      return normalizeOrFilters(
+          filter.toBuilder().replaceErrorMessageOperations(dedupeErrorMessages(msgOps)).build(),
+          resourceAccessChecks,
+          visited);
+    }
+    return normalizeOrFilters(filter, resourceAccessChecks, visited);
+  }
+
+  private Optional<ProcessInstanceFilter> normalizeOrFilters(
+      final ProcessInstanceFilter filter,
+      final ResourceAccessChecks resourceAccessChecks,
+      final Set<ProcessInstanceFilter> visited) {
+    final var orFilters = filter.orFilters();
+    if (orFilters == null || orFilters.isEmpty()) {
+      return Optional.of(filter);
+    }
+    final List<ProcessInstanceFilter> normalized = new ArrayList<>();
+    for (final var sub : orFilters) {
+      final var norm = normalizeProcessInstanceFilter(sub, resourceAccessChecks, visited);
+      norm.ifPresent(normalized::add);
+    }
+    if (normalized.isEmpty()) {
+      logDropReason(
+          "process instance filter",
+          "all orFilters were dropped after normalization",
+          filter,
+          orFilters);
+      return Optional.empty();
+    }
+    return Optional.of(filter.toBuilder().orFilters(normalized).build());
+  }
+
+  private Optional<ProcessDefinitionStatisticsFilter> normalizeProcessDefinitionFilter(
+      final ProcessDefinitionStatisticsFilter filter,
+      final ResourceAccessChecks resourceAccessChecks,
+      final Set<ProcessDefinitionStatisticsFilter> visited) {
+    if (filter == null) {
+      logDropReason("process definition filter", "filter is null");
+      return Optional.empty();
+    }
+    if (!visited.add(filter)) {
+      logDropReason(
+          "process definition filter", "cycle detected (filter already visited)", filter, visited);
+      return Optional.empty();
+    }
+
+    final var hashOps = filter.incidentErrorHashCodeOperations();
+    final var msgOps = filter.errorMessageOperations();
+    final boolean hasHash = hashOps != null && !hashOps.isEmpty();
+    final boolean hasMsg = msgOps != null && !msgOps.isEmpty();
+
+    if (hasHash && hasMsg) {
+      final boolean hasLike =
+          msgOps.stream().anyMatch(op -> op != null && op.operator() == Operator.LIKE);
+      if (hasLike) {
+        if (hasInvalidErrorMessages(msgOps)) {
+          logDropReason("process definition filter", "invalid error message operations", msgOps);
+          return Optional.empty();
+        }
+        return normalizeOrFilters(
+            filter.toBuilder().replaceErrorMessageOperations(dedupeErrorMessages(msgOps)).build(),
+            resourceAccessChecks,
+            visited);
+      }
+      final var inOp = msgOps.stream().filter(op -> op.operator() == Operator.IN).findFirst();
+      if (inOp.isPresent()) {
+        final var resolvedOpt = resolveErrorMessage(hashOps, resourceAccessChecks);
+        if (resolvedOpt.isEmpty()) {
+          logDropReason(
+              "process definition filter",
+              "could not resolve error message from hashOps for IN op",
+              hashOps,
+              msgOps);
+          return Optional.empty();
+        }
+        final String resolved = resolvedOpt.get();
+        final List<String> values = new ArrayList<>(inOp.get().values());
+        if (!values.contains(resolved)) {
+          values.add(resolved);
+        }
+        return normalizeOrFilters(
+            filter.toBuilder().replaceErrorMessageOperations(List.of(Operation.in(values))).build(),
+            resourceAccessChecks,
+            visited);
+      }
+      final var resolvedOpt = resolveErrorMessage(hashOps, resourceAccessChecks);
+      if (resolvedOpt.isEmpty()) {
+        logDropReason(
+            "process definition filter", "could not resolve error message from hashOps", hashOps);
+        return Optional.empty();
+      }
+      if (anyOpDoesNotMatch(msgOps, resolvedOpt.get())) {
+        logDropReason(
+            "process definition filter",
+            "resolved error message does not match msgOps",
+            msgOps,
+            resolvedOpt.get());
+        return Optional.empty();
+      }
+      return normalizeOrFilters(
+          filter.toBuilder()
+              .replaceErrorMessageOperations(List.of(Operation.eq(resolvedOpt.get())))
+              .build(),
+          resourceAccessChecks,
+          visited);
+    }
+    if (hasHash) {
+      final var resolvedOpt = resolveErrorMessage(hashOps, resourceAccessChecks);
+      if (resolvedOpt.isEmpty()) {
+        logDropReason(
+            "process definition filter", "could not resolve error message from hashOps", hashOps);
+        return Optional.empty();
+      }
+      return normalizeOrFilters(
+          filter.toBuilder()
+              .replaceErrorMessageOperations(List.of(Operation.eq(resolvedOpt.get())))
+              .build(),
+          resourceAccessChecks,
+          visited);
+    }
+    if (hasMsg) {
+      if (hasInvalidErrorMessages(msgOps)) {
+        logDropReason("process definition filter", "invalid error message operations", msgOps);
+        return Optional.empty();
+      }
+      return normalizeOrFilters(
+          filter.toBuilder().replaceErrorMessageOperations(dedupeErrorMessages(msgOps)).build(),
+          resourceAccessChecks,
+          visited);
+    }
+    return normalizeOrFilters(filter, resourceAccessChecks, visited);
+  }
+
+  private Optional<ProcessDefinitionStatisticsFilter> normalizeOrFilters(
+      final ProcessDefinitionStatisticsFilter filter,
+      final ResourceAccessChecks resourceAccessChecks,
+      final Set<ProcessDefinitionStatisticsFilter> visited) {
+    final var orFilters = filter.orFilters();
+    if (orFilters == null || orFilters.isEmpty()) {
+      return Optional.of(filter);
+    }
+    final List<ProcessDefinitionStatisticsFilter> normalized = new ArrayList<>();
+    for (final var sub : orFilters) {
+      final var norm = normalizeProcessDefinitionFilter(sub, resourceAccessChecks, visited);
+      norm.ifPresent(normalized::add);
+    }
+    if (normalized.isEmpty()) {
+      logDropReason(
+          "process definition filter",
+          "all orFilters were dropped after normalization",
+          filter,
+          orFilters);
+      return Optional.empty();
+    }
+    return Optional.of(filter.toBuilder().orFilters(normalized).build());
+  }
+
+  private Optional<String> resolveErrorMessage(
+      final List<Operation<Integer>> hashCodeOps, final ResourceAccessChecks resourceAccessChecks) {
+    if (hashCodeOps == null || hashCodeOps.isEmpty()) {
+      logDropReason("error message resolution", "hashCodeOps is null or empty", hashCodeOps);
+      return Optional.empty();
+    }
+    final var resolved =
+        incidentReader.findErrorMessageByErrorHashCodes(hashCodeOps, resourceAccessChecks);
+    if (resolved == null || resolved.isBlank()) {
+      logDropReason(
+          "error message resolution",
+          "resolved error message is null or blank",
+          hashCodeOps,
+          resolved);
+      return Optional.empty();
+    }
+    return Optional.of(resolved);
+  }
+
+  private boolean anyOpDoesNotMatch(final List<Operation<String>> ops, final String value) {
+    if (ops == null || ops.isEmpty()) {
+      return true;
+    }
+    for (final var op : ops) {
+      if (op == null || op.value() == null || !value.equals(op.value())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean hasInvalidErrorMessages(final List<Operation<String>> ops) {
+    if (ops == null || ops.isEmpty()) {
+      return true;
+    }
+    for (final var op : ops) {
+      if ((op.operator() != Operator.EXISTS && op.operator() != Operator.NOT_EXISTS)
+          && (op.value() == null || op.value().isBlank())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void logDropReason(
+      final String filterType, final String reason, final Object... context) {
+    if (context != null && context.length > 0) {
+      LOG.warn("Dropping {}: {} Context: {}", filterType, reason, context);
+    } else {
+      LOG.warn("Dropping {}: {}", filterType, reason);
+    }
+  }
+
+  private List<Operation<String>> dedupeErrorMessages(final List<Operation<String>> ops) {
+    if (ops == null || ops.isEmpty()) {
+      return List.of();
+    }
+    return ops.stream()
+        .filter(Objects::nonNull)
+        .collect(toMap(Operation::value, op -> op, (op1, op2) -> op1, LinkedHashMap::new))
+        .values()
+        .stream()
+        .toList();
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -9,12 +9,14 @@ package io.camunda.search.clients.transformers;
 
 import io.camunda.search.aggregation.AggregationBase;
 import io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation;
+import io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation;
 import io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation;
 import io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation;
 import io.camunda.search.aggregation.UsageMetricsAggregation;
 import io.camunda.search.aggregation.UsageMetricsTUAggregation;
 import io.camunda.search.aggregation.result.AggregationResultBase;
 import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResult;
+import io.camunda.search.aggregation.result.ProcessDefinitionInstanceStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionLatestVersionAggregationResult;
 import io.camunda.search.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.UsageMetricsAggregationResult;
@@ -25,12 +27,14 @@ import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.transformers.aggregation.AggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionFlowNodeStatisticsAggregationTransformer;
+import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionInstanceStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionLatestVersionAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessInstanceFlowNodeStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.UsageMetricsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.UsageMetricsTUAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.AggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer;
+import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionInstanceStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionLatestVersionAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsAggregationResultTransformer;
@@ -160,6 +164,7 @@ import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
+import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceFlowNodeStatisticsQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
@@ -330,6 +335,7 @@ public final class ServiceTransformers {
             MessageSubscriptionQuery.class,
             ProcessDefinitionQuery.class,
             ProcessDefinitionFlowNodeStatisticsQuery.class,
+            ProcessDefinitionInstanceStatisticsQuery.class,
             ProcessInstanceQuery.class,
             ProcessInstanceFlowNodeStatisticsQuery.class,
             RoleQuery.class,
@@ -498,6 +504,9 @@ public final class ServiceTransformers {
         new ProcessDefinitionLatestVersionAggregationTransformer());
     mappers.put(UsageMetricsAggregation.class, new UsageMetricsAggregationTransformer());
     mappers.put(UsageMetricsTUAggregation.class, new UsageMetricsTUAggregationTransformer());
+    mappers.put(
+        ProcessDefinitionInstanceStatisticsAggregation.class,
+        new ProcessDefinitionInstanceStatisticsAggregationTransformer());
 
     // aggregation result
     mappers.put(
@@ -513,5 +522,8 @@ public final class ServiceTransformers {
         UsageMetricsAggregationResult.class, new UsageMetricsAggregationResultTransformer());
     mappers.put(
         UsageMetricsTUAggregationResult.class, new UsageMetricsTUAggregationResultTransformer());
+    mappers.put(
+        ProcessDefinitionInstanceStatisticsAggregationResult.class,
+        new ProcessDefinitionInstanceStatisticsAggregationResultTransformer());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessDefinitionInstanceStatisticsAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessDefinitionInstanceStatisticsAggregationTransformer.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_FIELD_KEY;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_NAME_LATEST_PROCESS_DEFINITION;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_NAME_PAGE;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_NAME_VERSION_COUNT;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_TERMS_SIZE;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.bucketSort;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.cardinality;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.filter;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.topHits;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.INCIDENT;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PROCESS_VERSION;
+
+import io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchTopHitsAggregator;
+import io.camunda.search.clients.aggregator.SearchTopHitsAggregator.Builder;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+
+public class ProcessDefinitionInstanceStatisticsAggregationTransformer
+    implements AggregationTransformer<ProcessDefinitionInstanceStatisticsAggregation> {
+
+  @Override
+  public List<SearchAggregator> apply(
+      final Tuple<ProcessDefinitionInstanceStatisticsAggregation, ServiceTransformers> value) {
+    final var aggregation = value.getLeft();
+    final Builder<ProcessInstanceForListViewEntity> topHits = topHits();
+
+    final SearchTopHitsAggregator<ProcessInstanceForListViewEntity> latestProcessDefinitionAgg =
+        topHits
+            .name(AGGREGATION_NAME_LATEST_PROCESS_DEFINITION)
+            .field(PROCESS_VERSION)
+            .size(1)
+            .documentClass(ProcessInstanceForListViewEntity.class)
+            .build();
+
+    final var versionCountAgg =
+        cardinality().name(AGGREGATION_NAME_VERSION_COUNT).field(PROCESS_VERSION).build();
+
+    final var totalWithIncidentsAgg =
+        filter()
+            .name(
+                ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_NAME_TOTAL_WITH_INCIDENT)
+            .query(term(INCIDENT, true))
+            .build();
+
+    final var totalWithoutIncidentsAgg =
+        filter()
+            .name(
+                ProcessDefinitionInstanceStatisticsAggregation
+                    .AGGREGATION_NAME_TOTAL_WITHOUT_INCIDENT)
+            .query(term(INCIDENT, false))
+            .build();
+
+    final var byProcessDefinitionIdAggBuilder =
+        terms()
+            .name(ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_NAME_BY_PROCESS_ID)
+            .field(BPMN_PROCESS_ID)
+            .size(AGGREGATION_TERMS_SIZE)
+            .sorting(
+                List.of(
+                    new FieldSorting(AGGREGATION_FIELD_KEY, io.camunda.search.sort.SortOrder.ASC)));
+
+    final var bucketSort =
+        bucketSort()
+            .name(AGGREGATION_NAME_PAGE)
+            .sorting(getCountSuffixSortings(aggregation))
+            .from(aggregation.page() != null ? aggregation.page().from() : null)
+            .size(aggregation.page() != null ? aggregation.page().size() : null)
+            .build();
+
+    final var byProcessDefinitionIdAgg =
+        byProcessDefinitionIdAggBuilder
+            .aggregations(
+                latestProcessDefinitionAgg,
+                versionCountAgg,
+                totalWithIncidentsAgg,
+                totalWithoutIncidentsAgg,
+                bucketSort)
+            .build();
+
+    // Add a cardinality aggregation to estimate the total number of unique process definition keys
+    // (buckets)
+    final var processDefinitionKeyCardinalityAgg =
+        cardinality()
+            .name(
+                ProcessDefinitionInstanceStatisticsAggregation
+                    .AGGREGATION_NAME_PROCESS_DEFINITION_KEY_CARDINALITY)
+            .field(BPMN_PROCESS_ID)
+            .build();
+
+    return List.of(byProcessDefinitionIdAgg, processDefinitionKeyCardinalityAgg);
+  }
+
+  private static List<FieldSorting> getCountSuffixSortings(
+      final ProcessDefinitionInstanceStatisticsAggregation aggregation) {
+    return aggregation.sort().getFieldSortings().stream()
+        .map(ordering -> new FieldSorting(ordering.field() + "._count", ordering.order()))
+        .toList();
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/ProcessDefinitionInstanceStatisticsAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/ProcessDefinitionInstanceStatisticsAggregationResultTransformer.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_NAME_BY_PROCESS_ID;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_NAME_LATEST_PROCESS_DEFINITION;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_NAME_TOTAL_WITHOUT_INCIDENT;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_NAME_TOTAL_WITH_INCIDENT;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_NAME_VERSION_COUNT;
+
+import io.camunda.search.aggregation.result.ProcessDefinitionInstanceStatisticsAggregationResult;
+import io.camunda.search.clients.core.AggregationResult;
+import io.camunda.search.clients.core.SearchQueryHit;
+import io.camunda.search.clients.transformers.entity.ProcessInstanceEntityTransformer;
+import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import java.util.List;
+import java.util.Map;
+
+public class ProcessDefinitionInstanceStatisticsAggregationResultTransformer
+    implements AggregationResultTransformer<ProcessDefinitionInstanceStatisticsAggregationResult> {
+
+  @Override
+  public ProcessDefinitionInstanceStatisticsAggregationResult apply(
+      final Map<String, AggregationResult> value) {
+
+    final AggregationResult byProcessIdAgg = value.get(AGGREGATION_NAME_BY_PROCESS_ID);
+    final Map<String, AggregationResult> perProcessAggregations = byProcessIdAgg.aggregations();
+
+    // Use the cardinality aggregation for totalItems, which may be an estimate (see ES docs)
+    final AggregationResult cardinalityAgg =
+        value.get(
+            io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation
+                .AGGREGATION_NAME_PROCESS_DEFINITION_KEY_CARDINALITY);
+    final int totalItems =
+        cardinalityAgg != null
+            ? Math.toIntExact(cardinalityAgg.docCount())
+            : perProcessAggregations.size();
+
+    final List<ProcessDefinitionInstanceStatisticsEntity> items =
+        perProcessAggregations.entrySet().stream()
+            .map(
+                entry -> {
+                  final String processId = entry.getKey();
+                  final AggregationResult agg = entry.getValue();
+                  final long withIncidents =
+                      agg.aggregations()
+                          .getOrDefault(
+                              AGGREGATION_NAME_TOTAL_WITH_INCIDENT, AggregationResult.EMPTY)
+                          .docCount();
+                  final long withoutIncidents =
+                      agg.aggregations()
+                          .getOrDefault(
+                              AGGREGATION_NAME_TOTAL_WITHOUT_INCIDENT, AggregationResult.EMPTY)
+                          .docCount();
+
+                  final String latestProcessDefinitionName =
+                      entry
+                          .getValue()
+                          .aggregations()
+                          .get(AGGREGATION_NAME_LATEST_PROCESS_DEFINITION)
+                          .hits()
+                          .stream()
+                          .map(SearchQueryHit::source)
+                          .filter(ProcessInstanceForListViewEntity.class::isInstance)
+                          .map(ProcessInstanceForListViewEntity.class::cast)
+                          .map(new ProcessInstanceEntityTransformer()::apply)
+                          .map(ProcessInstanceEntity::processDefinitionName)
+                          .findFirst()
+                          .orElse(null);
+
+                  final boolean hasMultipleVersions =
+                      agg.aggregations().get(AGGREGATION_NAME_VERSION_COUNT).docCount() > 1;
+
+                  return new ProcessDefinitionInstanceStatisticsEntity(
+                      processId,
+                      latestProcessDefinitionName,
+                      hasMultipleVersions,
+                      withoutIncidents,
+                      withIncidents);
+                })
+            .toList();
+    return new ProcessDefinitionInstanceStatisticsAggregationResult(items, totalItems);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/reader/utils/IncidentErrorHashCodeNormalizerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/reader/utils/IncidentErrorHashCodeNormalizerTest.java
@@ -1,0 +1,561 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.search.clients.reader.IncidentDocumentReader;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class IncidentErrorHashCodeNormalizerTest {
+
+  private IncidentDocumentReader incidentReader;
+  private IncidentErrorHashCodeNormalizer normalizer;
+  private ResourceAccessChecks resourceAccessChecks;
+
+  @BeforeEach
+  void setUp() {
+    incidentReader = mock(IncidentDocumentReader.class);
+    normalizer = new IncidentErrorHashCodeNormalizer(incidentReader);
+    resourceAccessChecks = mock(ResourceAccessChecks.class);
+  }
+
+  @Test
+  void shouldResolveErrorHashCodeForProcessInstance() {
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("ResolvedError");
+
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().errorMessageOperations()).hasSize(1);
+    assertThat(result.get().errorMessageOperations().getFirst().value()).isEqualTo("ResolvedError");
+  }
+
+  @Test
+  void shouldReturnEmptyIfUnresolvedHashCodeForProcessInstance() {
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldHandleOrFiltersForProcessInstance() {
+    final var subFilter1 =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .build();
+    final var subFilter2 =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1111)))
+            .build();
+    final var filter =
+        new ProcessInstanceFilter.Builder().orFilters(List.of(subFilter1, subFilter2)).build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("Error1");
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1111))), any()))
+        .thenReturn("");
+
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().orFilters()).hasSize(1);
+    assertThat(result.get().orFilters().getFirst().errorMessageOperations().getFirst().value())
+        .isEqualTo("Error1");
+  }
+
+  @Test
+  void shouldResolveErrorHashCodeForProcessDefinition() {
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(22012345678900L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("ResolvedError");
+
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().errorMessageOperations()).hasSize(1);
+    assertThat(result.get().errorMessageOperations().getFirst().value()).isEqualTo("ResolvedError");
+  }
+
+  @Test
+  void shouldReturnEmptyIfUnresolvedHashCodeForProcessDefinition() {
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(22012345678900L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1111)))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1111))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldHandleOrFiltersForProcessDefinition() {
+    final var subFilter1 =
+        new ProcessDefinitionStatisticsFilter.Builder(22012345678900L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .build();
+    final var subFilter2 =
+        new ProcessDefinitionStatisticsFilter.Builder(22012345678900L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1111)))
+            .build();
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(22012345678900L)
+            .orFilters(List.of(subFilter1, subFilter2))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("Error1");
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1111))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().orFilters()).hasSize(1);
+    assertThat(result.get().orFilters().getFirst().errorMessageOperations().getFirst().value())
+        .isEqualTo("Error1");
+  }
+
+  @Test
+  void shouldNormalizeToResolvedErrorMessageWhenHashSuppliedAndResolves() {
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("Resolved");
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+    assertThat(result).isPresent();
+    assertThat(result.get().errorMessageOperations()).containsExactly(Operation.eq("Resolved"));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenHashSuppliedAndDoesNotResolveAndNoErrorMessage() {
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldNormalizeToDedupeErrorMessageWhenHashAndMatchingErrorMessageSupplied() {
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .errorMessageOperations(List.of(Operation.eq("Resolved")))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("Resolved");
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+    assertThat(result).isPresent();
+    assertThat(result.get().errorMessageOperations()).containsExactly(Operation.eq("Resolved"));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenHashAndErrorMessageSuppliedButNotEqual() {
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .errorMessageOperations(List.of(Operation.eq("Other")))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("Resolved");
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenHashResolvesButErrorMessageIsInvalid() {
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .errorMessageOperations(List.of(Operation.eq(" "))) // blank
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("Resolved");
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenHashDoesNotResolveAndErrorMessageSupplied() {
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .errorMessageOperations(List.of(Operation.eq("Resolved")))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldNormalizeToErrorMessageWhenOnlyErrorMessageSupplied() {
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .errorMessageOperations(List.of(Operation.eq("Resolved")))
+            .build();
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+    assertThat(result).isPresent();
+    assertThat(result.get().errorMessageOperations()).containsExactly(Operation.eq("Resolved"));
+  }
+
+  @Test
+  void shouldReturnEmptyFilterWhenNoHashAndNoErrorMessageSupplied() {
+    final var filter = new ProcessInstanceFilter.Builder().build();
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+    assertThat(result).isPresent();
+    assertThat(result.get().errorMessageOperations()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenHashDoesNotResolveAndErrorMessageIsInvalid() {
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .errorMessageOperations(List.of(Operation.eq(" ")))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyIfAllOrFiltersInvalid() {
+    final var invalid1 =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1111)))
+            .build();
+    final var invalid2 =
+        new ProcessInstanceFilter.Builder()
+            .errorMessageOperations(List.of(Operation.eq(" ")))
+            .build();
+    final var filter =
+        new ProcessInstanceFilter.Builder().orFilters(List.of(invalid1, invalid2)).build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1111))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnOnlyValidOrFilters() {
+    final var valid =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .build();
+    final var invalid =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1111)))
+            .build();
+    final var filter =
+        new ProcessInstanceFilter.Builder().orFilters(List.of(valid, invalid)).build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(
+            argThat(
+                ops ->
+                    ops != null
+                        && !ops.isEmpty()
+                        && ops.getFirst().value() != null
+                        && Objects.equals(ops.getFirst().value(), 1234)),
+            any()))
+        .thenReturn("Resolved");
+    when(incidentReader.findErrorMessageByErrorHashCodes(
+            argThat(
+                ops ->
+                    ops != null
+                        && !ops.isEmpty()
+                        && ops.getFirst().value() != null
+                        && Objects.equals(ops.getFirst().value(), 1111)),
+            any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
+    assertThat(result).isPresent();
+    assertThat(result.get().orFilters()).hasSize(1);
+    assertThat(result.get().orFilters().getFirst().errorMessageOperations().getFirst().value())
+        .isEqualTo("Resolved");
+  }
+
+  @Test
+  void shouldReturnEmptyIfTopLevelInvalidEvenIfOrValid() {
+    final var valid =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .build();
+    final var topLevel =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1111)))
+            .orFilters(List.of(valid))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1111))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(topLevel, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnValidIfTopLevelValidAndOrInvalid() {
+    final var invalid =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1111)))
+            .build();
+    final var topLevel =
+        new ProcessInstanceFilter.Builder()
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .orFilters(List.of(invalid))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(
+            argThat(
+                ops ->
+                    ops != null
+                        && !ops.isEmpty()
+                        && ops.getFirst().value() != null
+                        && Objects.equals(ops.getFirst().value(), 1234)),
+            any()))
+        .thenReturn("Resolved");
+
+    when(incidentReader.findErrorMessageByErrorHashCodes(
+            argThat(
+                ops ->
+                    ops != null
+                        && !ops.isEmpty()
+                        && ops.getFirst().value() != null
+                        && Objects.equals(ops.getFirst().value(), 1111)),
+            any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessInstanceFilter(topLevel, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  // --- ProcessDefinitionStatisticsFilter: Truth Table & ORs ---
+
+  @Test
+  void shouldNormalizeToResolvedErrorMessageWhenHashSuppliedAndResolvesDefStat() {
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("Resolved");
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+    assertThat(result).isPresent();
+    assertThat(result.get().errorMessageOperations()).containsExactly(Operation.eq("Resolved"));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenHashSuppliedAndDoesNotResolveAndNoErrorMessageDefStat() {
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldNormalizeToDedupeErrorMessageWhenHashAndMatchingErrorMessageSuppliedDefStat() {
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .errorMessageOperations(List.of(Operation.eq("Resolved")))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("Resolved");
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+    assertThat(result).isPresent();
+    assertThat(result.get().errorMessageOperations()).containsExactly(Operation.eq("Resolved"));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenHashAndErrorMessageSuppliedButNotEqualDefStat() {
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .errorMessageOperations(List.of(Operation.eq("Other")))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("Resolved");
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenHashResolvesButErrorMessageIsInvalidDefStat() {
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .errorMessageOperations(List.of(Operation.eq(" ")))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenHashDoesNotResolveAndErrorMessageSuppliedDefStat() {
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .errorMessageOperations(List.of(Operation.eq("Resolved")))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldNormalizeToErrorMessageWhenOnlyErrorMessageSuppliedDefStat() {
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .errorMessageOperations(List.of(Operation.eq("Resolved")))
+            .build();
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+    assertThat(result).isPresent();
+    assertThat(result.get().errorMessageOperations()).containsExactly(Operation.eq("Resolved"));
+  }
+
+  @Test
+  void shouldReturnEmptyFilterWhenNoHashAndNoErrorMessageSuppliedDefStat() {
+    final var filter = new ProcessDefinitionStatisticsFilter.Builder(1L).build();
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+    assertThat(result).isPresent();
+    assertThat(result.get().errorMessageOperations()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenHashDoesNotResolveAndErrorMessageIsInvalidDefStat() {
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .errorMessageOperations(List.of(Operation.eq(" ")))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyIfAllOrFiltersInvalidDefStat() {
+    final var invalid1 =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1111)))
+            .build();
+    final var invalid2 =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .errorMessageOperations(List.of(Operation.eq(" ")))
+            .build();
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .orFilters(List.of(invalid1, invalid2))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1111))), any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnOnlyValidOrFiltersDefStat() {
+    final var valid =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
+            .build();
+    final var invalid =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .incidentErrorHashCodeOperations(List.of(Operation.eq(1111)))
+            .build();
+    final var filter =
+        new ProcessDefinitionStatisticsFilter.Builder(1L)
+            .orFilters(List.of(valid, invalid))
+            .build();
+    when(incidentReader.findErrorMessageByErrorHashCodes(
+            argThat(
+                ops ->
+                    ops != null
+                        && !ops.isEmpty()
+                        && ops.getFirst().value() != null
+                        && Objects.equals(ops.getFirst().value(), 1234)),
+            any()))
+        .thenReturn("Resolved");
+    when(incidentReader.findErrorMessageByErrorHashCodes(
+            argThat(
+                ops ->
+                    ops != null
+                        && !ops.isEmpty()
+                        && ops.getFirst().value() != null
+                        && Objects.equals(ops.getFirst().value(), 1111)),
+            any()))
+        .thenReturn("");
+    final var result =
+        normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
+    assertThat(result).isPresent();
+    assertThat(result.get().orFilters()).hasSize(1);
+    assertThat(result.get().orFilters().getFirst().errorMessageOperations().getFirst().value())
+        .isEqualTo("Resolved");
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionInstanceStatisticsReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionInstanceStatisticsReader.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
+import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
+
+public interface ProcessDefinitionInstanceStatisticsReader
+    extends SearchQueryStatisticsReader<
+        ProcessDefinitionInstanceStatisticsEntity, ProcessDefinitionInstanceStatisticsQuery> {}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -26,6 +26,7 @@ public record SearchClientReaders(
     ProcessDefinitionReader processDefinitionReader,
     ProcessDefinitionStatisticsReader processDefinitionStatisticsReader,
     ProcessInstanceReader processInstanceReader,
+    ProcessDefinitionInstanceStatisticsReader processDefinitionInstanceStatisticsReader,
     ProcessInstanceStatisticsReader processInstanceStatisticsReader,
     RoleReader roleReader,
     RoleMemberReader roleMemberReader,

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchQueryStatisticsReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchQueryStatisticsReader.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.TypedSearchAggregationQuery;
+import io.camunda.security.reader.ResourceAccessChecks;
+
+public interface SearchQueryStatisticsReader<T, A extends TypedSearchAggregationQuery<?, ?, ?>>
+    extends SearchClientReader {
+  SearchQueryResult<T> aggregate(final A query, final ResourceAccessChecks resourceAccessChecks);
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchStatisticsReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchStatisticsReader.java
@@ -11,8 +11,7 @@ import io.camunda.search.query.TypedSearchAggregationQuery;
 import io.camunda.security.reader.ResourceAccessChecks;
 import java.util.List;
 
-public interface SearchStatisticsReader<T, A extends TypedSearchAggregationQuery<?, ?>>
+public interface SearchStatisticsReader<T, A extends TypedSearchAggregationQuery<?, ?, ?>>
     extends SearchClientReader {
-
   List<T> aggregate(final A query, final ResourceAccessChecks resourceAccessChecks);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/ProcessDefinitionSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/ProcessDefinitionSearchClient.java
@@ -8,8 +8,10 @@
 package io.camunda.search.clients;
 
 import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
@@ -26,4 +28,7 @@ public interface ProcessDefinitionSearchClient {
       final ProcessDefinitionStatisticsFilter filter);
 
   ProcessDefinitionSearchClient withSecurityContext(SecurityContext securityContext);
+
+  SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity> processDefinitionInstanceStatistics(
+      final ProcessDefinitionInstanceStatisticsQuery query);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -24,6 +24,7 @@ import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
@@ -52,6 +53,7 @@ import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
+import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.RoleQuery;
@@ -201,6 +203,12 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   @Override
   public List<ProcessFlowNodeStatisticsEntity> processDefinitionFlowNodeStatistics(
       final ProcessDefinitionStatisticsFilter filter) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity>
+      processDefinitionInstanceStatistics(final ProcessDefinitionInstanceStatisticsQuery query) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -26,6 +26,7 @@ import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
@@ -53,6 +54,7 @@ import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
+import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.RoleQuery;
@@ -204,6 +206,12 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   public List<ProcessFlowNodeStatisticsEntity> processDefinitionFlowNodeStatistics(
       final ProcessDefinitionStatisticsFilter filter) {
     return emptyList();
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity>
+      processDefinitionInstanceStatistics(final ProcessDefinitionInstanceStatisticsQuery query) {
+    return SearchQueryResult.empty();
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/ProcessDefinitionInstanceStatisticsAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/ProcessDefinitionInstanceStatisticsAggregation.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation;
+
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AggregationPaginated;
+import io.camunda.search.sort.ProcessDefinitionInstanceStatisticsSort;
+
+public record ProcessDefinitionInstanceStatisticsAggregation(
+    ProcessInstanceFilter filter,
+    ProcessDefinitionInstanceStatisticsSort sort,
+    SearchQueryPage page)
+    implements AggregationBase, AggregationPaginated {
+
+  public static final int AGGREGATION_TERMS_SIZE = 10000;
+  public static final String AGGREGATION_NAME_BY_PROCESS_ID = "by_process_id";
+  public static final String AGGREGATION_NAME_PAGE = "page";
+  public static final String AGGREGATION_NAME_TOTAL_WITH_INCIDENT = "activeInstancesWithIncident";
+  public static final String AGGREGATION_NAME_TOTAL_WITHOUT_INCIDENT =
+      "activeInstancesWithoutIncident";
+  public static final String AGGREGATION_NAME_LATEST_PROCESS_DEFINITION = "latestProcessDefinition";
+  public static final String AGGREGATION_NAME_VERSION_COUNT = "versionCount";
+  public static final String AGGREGATION_FIELD_KEY = "_key";
+  public static final String AGGREGATION_FIELD_PROCESS_DEFINITION_ID = "processDefinitionId";
+  public static final String AGGREGATION_NAME_PROCESS_DEFINITION_KEY_CARDINALITY =
+      "processDefinitionKeyCardinality";
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/HasTotalItems.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/HasTotalItems.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation.result;
+
+public interface HasTotalItems {
+  int totalItems();
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/ProcessDefinitionInstanceStatisticsAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/ProcessDefinitionInstanceStatisticsAggregationResult.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation.result;
+
+import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
+import java.util.List;
+
+public record ProcessDefinitionInstanceStatisticsAggregationResult(
+    List<ProcessDefinitionInstanceStatisticsEntity> items, int totalItems)
+    implements AggregationResultBase, HasTotalItems {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionInstanceStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionInstanceStatisticsEntity.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.util.ObjectBuilder;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ProcessDefinitionInstanceStatisticsEntity(
+    String processDefinitionId,
+    String latestProcessDefinitionName,
+    Boolean hasMultipleVersions,
+    Long activeInstancesWithoutIncidentCount,
+    Long activeInstancesWithIncidentCount) {
+
+  public static class Builder implements ObjectBuilder<ProcessDefinitionInstanceStatisticsEntity> {
+    private String processDefinitionId;
+    private String latestProcessDefinitionName;
+    private Boolean hasMultipleVersions;
+    private Long activeInstancesWithoutIncidentCount;
+    private Long activeInstancesWithIncidentCount;
+
+    public Builder processDefinitionId(final String processDefinitionId) {
+      this.processDefinitionId = processDefinitionId;
+      return this;
+    }
+
+    public Builder latestProcessDefinitionName(final String latestProcessDefinitionName) {
+      this.latestProcessDefinitionName = latestProcessDefinitionName;
+      return this;
+    }
+
+    public Builder hasMultipleVersions(final Boolean hasMultipleVersions) {
+      this.hasMultipleVersions = hasMultipleVersions;
+      return this;
+    }
+
+    public Builder activeInstancesWithoutIncidentCount(final Long count) {
+      activeInstancesWithoutIncidentCount = count;
+      return this;
+    }
+
+    public Builder activeInstancesWithIncidentCount(final Long count) {
+      activeInstancesWithIncidentCount = count;
+      return this;
+    }
+
+    @Override
+    public ProcessDefinitionInstanceStatisticsEntity build() {
+      return new ProcessDefinitionInstanceStatisticsEntity(
+          processDefinitionId,
+          latestProcessDefinitionName,
+          hasMultipleVersions,
+          activeInstancesWithoutIncidentCount,
+          activeInstancesWithIncidentCount);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionStatisticsFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionStatisticsFilter.java
@@ -49,7 +49,14 @@ public record ProcessDefinitionStatisticsFilter(
         .hasIncident(hasIncident)
         .tenantIdOperations(tenantIdOperations)
         .variables(variableFilters)
-        .batchOperationIdOperations(batchOperationIdOperations);
+        .errorMessageOperations(errorMessageOperations)
+        .batchOperationIdOperations(batchOperationIdOperations)
+        .hasRetriesLeft(hasRetriesLeft)
+        .flowNodeIdOperations(flowNodeIdOperations)
+        .hasFlowNodeInstanceIncident(hasFlowNodeInstanceIncident)
+        .flowNodeInstanceStateOperations(flowNodeInstanceStateOperations)
+        .incidentErrorHashCodeOperations(incidentErrorHashCodeOperations)
+        .orFilters(orFilters);
   }
 
   public static final class Builder implements ObjectBuilder<ProcessDefinitionStatisticsFilter> {

--- a/search/search-domain/src/main/java/io/camunda/search/query/ProcessDefinitionFlowNodeStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/ProcessDefinitionFlowNodeStatisticsQuery.java
@@ -9,13 +9,28 @@ package io.camunda.search.query;
 
 import io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.NoSort;
+import io.camunda.search.sort.SortOption;
 
 public record ProcessDefinitionFlowNodeStatisticsQuery(ProcessDefinitionStatisticsFilter filter)
     implements TypedSearchAggregationQuery<
-        ProcessDefinitionStatisticsFilter, ProcessDefinitionFlowNodeStatisticsAggregation> {
+        ProcessDefinitionStatisticsFilter,
+        SortOption,
+        ProcessDefinitionFlowNodeStatisticsAggregation> {
+
+  @Override
+  public SortOption sort() {
+    return NoSort.NO_SORT;
+  }
 
   @Override
   public ProcessDefinitionFlowNodeStatisticsAggregation aggregation() {
     return new ProcessDefinitionFlowNodeStatisticsAggregation(filter);
+  }
+
+  @Override
+  public SearchQueryPage page() {
+    return SearchQueryPage.NO_ENTITIES_QUERY;
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/ProcessDefinitionInstanceStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/ProcessDefinitionInstanceStatisticsQuery.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_TERMS_SIZE;
+
+import io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.ProcessDefinitionInstanceStatisticsSort;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record ProcessDefinitionInstanceStatisticsQuery(
+    ProcessInstanceFilter filter,
+    ProcessDefinitionInstanceStatisticsSort sort,
+    SearchQueryPage page)
+    implements TypedSearchAggregationQuery<
+        ProcessInstanceFilter,
+        ProcessDefinitionInstanceStatisticsSort,
+        ProcessDefinitionInstanceStatisticsAggregation> {
+
+  public static ProcessDefinitionInstanceStatisticsQuery of(
+      final Function<Builder, ObjectBuilder<ProcessDefinitionInstanceStatisticsQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  @Override
+  public ProcessDefinitionInstanceStatisticsAggregation aggregation() {
+    return new ProcessDefinitionInstanceStatisticsAggregation(filter, sort, page);
+  }
+
+  public ProcessDefinitionInstanceStatisticsQuery withConvertedSortingField(
+      final String originalField, final String convertedField) {
+    if (sort != null && sort.orderings() != null) {
+      final var updatedOrderings =
+          sort.orderings().stream()
+              .map(
+                  ordering ->
+                      ordering.field().equals(originalField)
+                          ? new FieldSorting(convertedField, ordering.order())
+                          : ordering)
+              .toList();
+      final var newSort = new ProcessDefinitionInstanceStatisticsSort(updatedOrderings);
+      return new ProcessDefinitionInstanceStatisticsQuery(filter, newSort, page);
+    }
+    return this;
+  }
+
+  public ProcessDefinitionInstanceStatisticsQuery withUnlimitedPage() {
+    return ProcessDefinitionInstanceStatisticsQuery.of(
+        b ->
+            b.filter(filter)
+                .sort(sort)
+                .page(p -> p.size(AGGREGATION_TERMS_SIZE).from(0).after(null).before(null)));
+  }
+
+  public static final class Builder
+      extends SearchQueryBase.AbstractQueryBuilder<ProcessDefinitionInstanceStatisticsQuery.Builder>
+      implements TypedSearchQueryBuilder<
+          ProcessDefinitionInstanceStatisticsQuery,
+          ProcessDefinitionInstanceStatisticsQuery.Builder,
+          ProcessInstanceFilter,
+          ProcessDefinitionInstanceStatisticsSort> {
+
+    private static final ProcessInstanceFilter EMPTY_FILTER =
+        FilterBuilders.processInstance().build();
+    private static final ProcessDefinitionInstanceStatisticsSort EMPTY_SORT =
+        SortOptionBuilders.processDefinitionInstanceStatistics().build();
+
+    private ProcessInstanceFilter filter;
+    private ProcessDefinitionInstanceStatisticsSort sort;
+
+    @Override
+    public Builder filter(final ProcessInstanceFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final ProcessDefinitionInstanceStatisticsSort value) {
+      sort = value;
+      return this;
+    }
+
+    public ProcessDefinitionInstanceStatisticsQuery.Builder filter(
+        final Function<ProcessInstanceFilter.Builder, ObjectBuilder<ProcessInstanceFilter>> fn) {
+      return filter(FilterBuilders.processInstance(fn));
+    }
+
+    public ProcessDefinitionInstanceStatisticsQuery.Builder sort(
+        final Function<
+                ProcessDefinitionInstanceStatisticsSort.Builder,
+                ObjectBuilder<ProcessDefinitionInstanceStatisticsSort>>
+            fn) {
+      return sort(SortOptionBuilders.processDefinitionInstanceStatistics(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public ProcessDefinitionInstanceStatisticsQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new ProcessDefinitionInstanceStatisticsQuery(filter, sort, page());
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/ProcessInstanceFlowNodeStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/ProcessInstanceFlowNodeStatisticsQuery.java
@@ -9,13 +9,26 @@ package io.camunda.search.query;
 
 import io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation;
 import io.camunda.search.filter.ProcessInstanceStatisticsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.NoSort;
+import io.camunda.search.sort.SortOption;
 
 public record ProcessInstanceFlowNodeStatisticsQuery(ProcessInstanceStatisticsFilter filter)
     implements TypedSearchAggregationQuery<
-        ProcessInstanceStatisticsFilter, ProcessInstanceFlowNodeStatisticsAggregation> {
+        ProcessInstanceStatisticsFilter, SortOption, ProcessInstanceFlowNodeStatisticsAggregation> {
+
+  @Override
+  public SortOption sort() {
+    return NoSort.NO_SORT;
+  }
 
   @Override
   public ProcessInstanceFlowNodeStatisticsAggregation aggregation() {
     return new ProcessInstanceFlowNodeStatisticsAggregation();
+  }
+
+  @Override
+  public SearchQueryPage page() {
+    return SearchQueryPage.NO_ENTITIES_QUERY;
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -211,4 +211,9 @@ public final class SearchQueryBuilders {
           fn) {
     return fn.apply(correlatedMessageSubscriptionSearchQuery()).build();
   }
+
+  public static ProcessDefinitionInstanceStatisticsQuery.Builder
+      processDefinitionInstanceStatisticsQuery() {
+    return new ProcessDefinitionInstanceStatisticsQuery.Builder();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/TypedSearchAggregationQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/TypedSearchAggregationQuery.java
@@ -9,19 +9,8 @@ package io.camunda.search.query;
 
 import io.camunda.search.aggregation.AggregationBase;
 import io.camunda.search.filter.FilterBase;
-import io.camunda.search.page.SearchQueryPage;
-import io.camunda.search.sort.NoSort;
+import io.camunda.search.sort.SortOption;
 
-public interface TypedSearchAggregationQuery<F extends FilterBase, A extends AggregationBase>
-    extends TypedSearchQuery<F, NoSort> {
-
-  @Override
-  default NoSort sort() {
-    return NoSort.NO_SORT;
-  }
-
-  @Override
-  default SearchQueryPage page() {
-    return SearchQueryPage.NO_ENTITIES_QUERY;
-  }
-}
+public interface TypedSearchAggregationQuery<
+        F extends FilterBase, S extends SortOption, A extends AggregationBase>
+    extends TypedSearchQuery<F, S> {}

--- a/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsQuery.java
@@ -10,20 +10,34 @@ package io.camunda.search.query;
 import io.camunda.search.aggregation.UsageMetricsAggregation;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.UsageMetricsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.NoSort;
+import io.camunda.search.sort.SortOption;
 import io.camunda.util.ObjectBuilder;
 import java.util.Objects;
 import java.util.function.Function;
 
 public record UsageMetricsQuery(UsageMetricsFilter filter)
-    implements TypedSearchAggregationQuery<UsageMetricsFilter, UsageMetricsAggregation> {
+    implements TypedSearchAggregationQuery<
+        UsageMetricsFilter, SortOption, UsageMetricsAggregation> {
 
   public static UsageMetricsQuery of(final Function<Builder, ObjectBuilder<UsageMetricsQuery>> fn) {
     return fn.apply(new Builder()).build();
   }
 
   @Override
+  public SortOption sort() {
+    return NoSort.NO_SORT;
+  }
+
+  @Override
   public UsageMetricsAggregation aggregation() {
     return new UsageMetricsAggregation(filter);
+  }
+
+  @Override
+  public SearchQueryPage page() {
+    return SearchQueryPage.NO_ENTITIES_QUERY;
   }
 
   public static final class Builder implements ObjectBuilder<UsageMetricsQuery> {

--- a/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsTUQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsTUQuery.java
@@ -10,12 +10,16 @@ package io.camunda.search.query;
 import io.camunda.search.aggregation.UsageMetricsTUAggregation;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.UsageMetricsTUFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.NoSort;
+import io.camunda.search.sort.SortOption;
 import io.camunda.util.ObjectBuilder;
 import java.util.Objects;
 import java.util.function.Function;
 
 public record UsageMetricsTUQuery(UsageMetricsTUFilter filter)
-    implements TypedSearchAggregationQuery<UsageMetricsTUFilter, UsageMetricsTUAggregation> {
+    implements TypedSearchAggregationQuery<
+        UsageMetricsTUFilter, SortOption, UsageMetricsTUAggregation> {
 
   public static UsageMetricsTUQuery of(
       final Function<Builder, ObjectBuilder<UsageMetricsTUQuery>> fn) {
@@ -23,8 +27,18 @@ public record UsageMetricsTUQuery(UsageMetricsTUFilter filter)
   }
 
   @Override
+  public SortOption sort() {
+    return NoSort.NO_SORT;
+  }
+
+  @Override
   public UsageMetricsTUAggregation aggregation() {
     return new UsageMetricsTUAggregation(filter);
+  }
+
+  @Override
+  public SearchQueryPage page() {
+    return SearchQueryPage.NO_ENTITIES_QUERY;
   }
 
   public static final class Builder implements ObjectBuilder<UsageMetricsTUQuery> {

--- a/search/search-domain/src/main/java/io/camunda/search/sort/ProcessDefinitionInstanceStatisticsSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/ProcessDefinitionInstanceStatisticsSort.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record ProcessDefinitionInstanceStatisticsSort(List<FieldSorting> orderings)
+    implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static ProcessDefinitionInstanceStatisticsSort of(
+      final Function<Builder, ObjectBuilder<ProcessDefinitionInstanceStatisticsSort>> fn) {
+    return SortOptionBuilders.processDefinitionInstanceStatistics(fn);
+  }
+
+  public static final class Builder
+      extends SortOption.AbstractBuilder<ProcessDefinitionInstanceStatisticsSort.Builder>
+      implements ObjectBuilder<ProcessDefinitionInstanceStatisticsSort> {
+
+    public Builder processDefinitionId() {
+      currentOrdering = new FieldSorting("processDefinitionId", null);
+      return this;
+    }
+
+    public Builder activeInstancesWithIncident() {
+      currentOrdering = new FieldSorting("activeInstancesWithIncident", null);
+      return this;
+    }
+
+    public Builder activeInstancesWithoutIncident() {
+      currentOrdering = new FieldSorting("activeInstancesWithoutIncident", null);
+      return this;
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public ProcessDefinitionInstanceStatisticsSort build() {
+      return new ProcessDefinitionInstanceStatisticsSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -210,4 +210,17 @@ public final class SortOptionBuilders {
           fn) {
     return fn.apply(correlatedMessageSubscription()).build();
   }
+
+  public static ProcessDefinitionInstanceStatisticsSort.Builder
+      processDefinitionInstanceStatistics() {
+    return new ProcessDefinitionInstanceStatisticsSort.Builder();
+  }
+
+  public static ProcessDefinitionInstanceStatisticsSort processDefinitionInstanceStatistics(
+      final Function<
+              ProcessDefinitionInstanceStatisticsSort.Builder,
+              ObjectBuilder<ProcessDefinitionInstanceStatisticsSort>>
+          fn) {
+    return fn.apply(processDefinitionInstanceStatistics()).build();
+  }
 }

--- a/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
@@ -9,12 +9,15 @@ package io.camunda.service;
 
 import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.PROCESS_DEFINITION_READ_AUTHORIZATION;
+import static io.camunda.service.authorization.Authorizations.PROCESS_INSTANCE_READ_AUTHORIZATION;
 
 import io.camunda.search.clients.ProcessDefinitionSearchClient;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -95,6 +98,17 @@ public class ProcessDefinitionServices
                             PROCESS_DEFINITION_READ_AUTHORIZATION,
                             ProcessDefinitionEntity::processDefinitionId)))
                 .getProcessDefinition(processDefinitionKey));
+  }
+
+  public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity>
+      getProcessDefinitionInstanceStatistics(final ProcessDefinitionInstanceStatisticsQuery query) {
+    return executeSearchRequest(
+        () ->
+            processDefinitionSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
+                .processDefinitionInstanceStatistics(query));
   }
 
   public Optional<FormEntity> getProcessDefinitionStartForm(final long processDefinitionKey) {

--- a/service/src/test/java/io/camunda/service/ProcessDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessDefinitionServiceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.ProcessDefinitionSearchClient;
+import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
+import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ProcessDefinitionServiceTest {
+
+  private ProcessDefinitionServices services;
+  private ProcessDefinitionSearchClient processDefinitionSearchClient;
+  private SecurityContextProvider securityContextProvider;
+  private CamundaAuthentication authentication;
+  private BrokerClient brokerClient;
+  private FormServices formServices;
+  private ApiServicesExecutorProvider executorProvider;
+  private BrokerRequestAuthorizationConverter authorizationConverter;
+
+  @BeforeEach
+  public void before() {
+    processDefinitionSearchClient = mock(ProcessDefinitionSearchClient.class);
+    when(processDefinitionSearchClient.withSecurityContext(any()))
+        .thenReturn(processDefinitionSearchClient);
+    securityContextProvider = mock(SecurityContextProvider.class);
+    authentication = CamundaAuthentication.none();
+    brokerClient = mock(BrokerClient.class);
+    formServices = mock(FormServices.class);
+    executorProvider = mock(ApiServicesExecutorProvider.class);
+    authorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
+
+    services =
+        new ProcessDefinitionServices(
+            brokerClient,
+            securityContextProvider,
+            processDefinitionSearchClient,
+            formServices,
+            authentication,
+            executorProvider,
+            authorizationConverter);
+  }
+
+  @Test
+  public void shouldReturnProcessDefinitionInstanceStatistics() {
+    // given
+    final var statsEntity =
+        new ProcessDefinitionInstanceStatisticsEntity(
+            "complexProcess", "Complex process", true, 5L, 10L);
+    final var statsResult =
+        new SearchQueryResult.Builder<ProcessDefinitionInstanceStatisticsEntity>()
+            .total(1L)
+            .items(List.of(statsEntity))
+            .startCursor(null)
+            .endCursor(null)
+            .build();
+    when(processDefinitionSearchClient.processDefinitionInstanceStatistics(any()))
+        .thenReturn(statsResult);
+
+    final var query = new ProcessDefinitionInstanceStatisticsQuery.Builder().build();
+
+    // when
+    final var result = services.getProcessDefinitionInstanceStatistics(query);
+
+    // then
+    assertThat(result).isEqualTo(statsResult);
+    verify(processDefinitionSearchClient).processDefinitionInstanceStatistics(query);
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1724,6 +1724,39 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /process-definitions/statistics/process-instances:
+    post:
+      tags:
+        - Process definition
+      operationId: getProcessDefinitionInstanceStatistics
+      summary: Get statistics for process instances by process definition
+      description: |
+        Get statistics about process instances, grouped by process definition. For each process
+        definition, the response includes the latest deployed instance name, total counts of active
+        instances without incident, total counts of active instances with incident and whether the
+        instance has more than one version.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProcessDefinitionInstanceStatisticsQuery"
+      responses:
+        "200":
+          description: The process definition instance statistic result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessDefinitionInstanceStatisticsQueryResult"
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /process-instances:
     post:
       tags:
@@ -6746,6 +6779,101 @@ components:
           description: The total number of completed instances of the element.
           type: integer
           format: int64
+    ProcessDefinitionInstanceStatisticsQuery:
+      type: object
+      properties:
+        page:
+          description: Pagination criteria.
+          allOf:
+            - $ref: "#/components/schemas/ProcessDefinitionInstanceStatisticsPageRequest"
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: "#/components/schemas/ProcessDefinitionInstanceStatisticsQuerySortRequest"
+        filter:
+          description: The process definition instance statistics filters.
+          allOf:
+            - $ref: "#/components/schemas/ProcessInstanceFilter"
+
+    ProcessDefinitionInstanceStatisticsQueryResult:
+      type: object
+      description: Process definition instance statistics query response.
+      properties:
+        items:
+          description: The process definition instance statistics result.
+          type: array
+          items:
+            $ref: "#/components/schemas/ProcessDefinitionInstanceStatisticsResult"
+        page:
+          description: Pagination information about the search results.
+          allOf:
+            - $ref: "#/components/schemas/ProcessDefinitionInstanceStatisticsPageResponse"
+
+
+    ProcessDefinitionInstanceStatisticsResult:
+      description: Process definition instance statistics response.
+      type: object
+      properties:
+        processDefinitionId:
+          description: Unique identifier for the process definition.
+          type: string
+        latestProcessDefinitionName:
+          description: Name of the latest deployed process definition instance version.
+          type: string
+        hasMultipleVersions:
+          description: Indicates whether multiple versions of this process definition instance are deployed.
+          type: boolean
+        activeInstancesWithoutIncidentCount:
+          description: Total number of currently active process instances of this definition that do not have incidents.
+          type: integer
+          format: int64
+        activeInstancesWithIncidentCount:
+          description: Total number of currently active process instances of this definition that have at least one incident.
+          type: integer
+          format: int64
+
+    ProcessDefinitionInstanceStatisticsQuerySortRequest:
+      type: object
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - processDefinitionId
+            - activeInstancesWithIncident
+            - activeInstancesWithoutIncident
+        order:
+          $ref: "#/components/schemas/SortOrderEnum"
+      required:
+        - field
+
+    ProcessDefinitionInstanceStatisticsPageRequest:
+      type: object
+      properties:
+        from:
+          description: The index of items to start searching from.
+          type: integer
+          format: int32
+        limit:
+          description: The maximum number of items to return in one request.
+          type: integer
+          format: int32
+          default: 100
+
+    ProcessDefinitionInstanceStatisticsPageResponse:
+      description: Pagination information about the search results.
+      type: object
+      properties:
+        totalItems:
+          description: Total items matching the criteria.
+          type: integer
+          format: int64
+        hasMoreTotalItems:
+          description: |
+            Indicates if more results exist beyond the reported totalItems value. Due to system limitations, the totalItems value can be capped.
+          type: boolean
+
     CancelProcessInstanceRequest:
       type: object
       nullable: true

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
@@ -17,6 +17,8 @@ import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.zeebe.gateway.protocol.rest.FormResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionElementStatisticsQuery;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionElementStatisticsQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionInstanceStatisticsQuery;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionInstanceStatisticsQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionSearchQuery;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionSearchQueryResult;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
@@ -132,6 +134,13 @@ public class ProcessDefinitionController {
         .fold(RestErrorMapper::mapProblemToResponse, this::elementStatistics);
   }
 
+  @CamundaPostMapping(path = "/statistics/process-instances")
+  public ResponseEntity<ProcessDefinitionInstanceStatisticsQueryResult> processInstanceStatistics(
+      @RequestBody(required = false) final ProcessDefinitionInstanceStatisticsQuery query) {
+    return SearchQueryRequestMapper.toProcessDefinitionInstanceStatisticsQuery(query)
+        .fold(RestErrorMapper::mapProblemToResponse, this::getProcessDefinitionInstanceStatistics);
+  }
+
   private ResponseEntity<ProcessDefinitionElementStatisticsQueryResult> elementStatistics(
       final ProcessDefinitionStatisticsFilter filter) {
     try {
@@ -141,6 +150,21 @@ public class ProcessDefinitionController {
               .elementStatistics(filter);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toProcessDefinitionElementStatisticsResult(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  private ResponseEntity<ProcessDefinitionInstanceStatisticsQueryResult>
+      getProcessDefinitionInstanceStatistics(
+          final io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery query) {
+    try {
+      final var result =
+          processDefinitionServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .getProcessDefinitionInstanceStatistics(query);
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toProcessInstanceStatisticsQueryResult(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest.mapper.search;
 
 import static io.camunda.zeebe.gateway.rest.mapper.RequestMapper.getResult;
+import static io.camunda.zeebe.gateway.rest.mapper.search.SearchQueryFilterMapper.toProcessInstanceFilter;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.*;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validateDate;
@@ -142,7 +143,7 @@ public final class SearchQueryRequestMapper {
                 request.getSort()),
             SortOptionBuilders::processInstance,
             SearchQuerySortRequestMapper::applyProcessInstanceSortField);
-    final var filter = SearchQueryFilterMapper.toProcessInstanceFilter(request.getFilter());
+    final var filter = toProcessInstanceFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::processInstanceSearchQuery);
   }
 
@@ -586,6 +587,26 @@ public final class SearchQueryRequestMapper {
         filter, sort, page, SearchQueryBuilders::correlatedMessageSubscriptionSearchQuery);
   }
 
+  public static Either<
+          ProblemDetail, io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery>
+      toProcessDefinitionInstanceStatisticsQuery(
+          final ProcessDefinitionInstanceStatisticsQuery request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.processDefinitionInstanceStatisticsQuery().build());
+    }
+
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        SearchQuerySortRequestMapper.toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromProcessDefinitionInstanceStatisticsQuerySortRequest(
+                request.getSort()),
+            SortOptionBuilders::processDefinitionInstanceStatistics,
+            SearchQuerySortRequestMapper::applyProcessDefinitionInstanceStatisticsSortField);
+    final var filter = toProcessInstanceFilter(request.getFilter());
+    return buildSearchQuery(
+        filter, sort, page, SearchQueryBuilders::processDefinitionInstanceStatisticsQuery);
+  }
+
   private static Either<List<String>, SearchQueryPage> toSearchQueryPage(
       final SearchQueryPageRequest requestedPage) {
     if (requestedPage == null) {
@@ -607,6 +628,16 @@ public final class SearchQueryRequestMapper {
                     .from(requestedPage.getFrom())
                     .after(requestedPage.getAfter())
                     .before(requestedPage.getBefore())));
+  }
+
+  private static Either<List<String>, SearchQueryPage> toSearchQueryPage(
+      final ProcessDefinitionInstanceStatisticsPageRequest requestedPage) {
+    if (requestedPage == null) {
+      return Either.right(null);
+    }
+
+    return Either.right(
+        SearchQueryPage.of((p) -> p.size(requestedPage.getLimit()).from(requestedPage.getFrom())));
   }
 
   private static <

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -34,6 +34,7 @@ import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
@@ -99,6 +100,9 @@ import io.camunda.zeebe.gateway.protocol.rest.MessageSubscriptionStateEnum;
 import io.camunda.zeebe.gateway.protocol.rest.OwnerTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.PermissionTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionElementStatisticsQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionInstanceStatisticsPageResponse;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionInstanceStatisticsQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionInstanceStatisticsResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessElementStatisticsResult;
@@ -231,6 +235,28 @@ public final class SearchQueryResponseMapper {
         .canceled(result.canceled())
         .incidents(result.incidents())
         .completed(result.completed());
+  }
+
+  public static ProcessDefinitionInstanceStatisticsQueryResult
+      toProcessInstanceStatisticsQueryResult(
+          final SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity> result) {
+    final var page = toProcessDefinitionInstanceStatisticsPageResponse(result);
+    return new ProcessDefinitionInstanceStatisticsQueryResult()
+        .page(page)
+        .items(
+            result.items().stream()
+                .map(SearchQueryResponseMapper::toProcessInstanceStatisticsResult)
+                .toList());
+  }
+
+  private static ProcessDefinitionInstanceStatisticsResult toProcessInstanceStatisticsResult(
+      final ProcessDefinitionInstanceStatisticsEntity result) {
+    return new ProcessDefinitionInstanceStatisticsResult()
+        .processDefinitionId(result.processDefinitionId())
+        .latestProcessDefinitionName(result.latestProcessDefinitionName())
+        .hasMultipleVersions(result.hasMultipleVersions())
+        .activeInstancesWithIncidentCount(result.activeInstancesWithIncidentCount())
+        .activeInstancesWithoutIncidentCount(result.activeInstancesWithoutIncidentCount());
   }
 
   public static ProcessInstanceSequenceFlowsQueryResult toSequenceFlowsResult(
@@ -528,6 +554,14 @@ public final class SearchQueryResponseMapper {
         .hasMoreTotalItems(result.hasMoreTotalItems())
         .startCursor(result.startCursor())
         .endCursor(result.endCursor());
+  }
+
+  private static ProcessDefinitionInstanceStatisticsPageResponse
+      toProcessDefinitionInstanceStatisticsPageResponse(final SearchQueryResult<?> result) {
+
+    return new ProcessDefinitionInstanceStatisticsPageResponse()
+        .totalItems(result.total())
+        .hasMoreTotalItems(result.hasMoreTotalItems());
   }
 
   private static List<ProcessDefinitionResult> toProcessDefinitions(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
@@ -22,6 +22,7 @@ import io.camunda.search.sort.IncidentSort;
 import io.camunda.search.sort.JobSort;
 import io.camunda.search.sort.MappingRuleSort;
 import io.camunda.search.sort.MessageSubscriptionSort;
+import io.camunda.search.sort.ProcessDefinitionInstanceStatisticsSort;
 import io.camunda.search.sort.ProcessDefinitionSort;
 import io.camunda.search.sort.ProcessInstanceSort;
 import io.camunda.search.sort.RoleSort;
@@ -200,6 +201,13 @@ public class SearchQuerySortRequestMapper {
   static List<SearchQuerySortRequest<CorrelatedMessageSubscriptionSearchQuerySortRequest.FieldEnum>>
       fromCorrelatedMessageSubscriptionSearchQuerySortRequest(
           final List<CorrelatedMessageSubscriptionSearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
+  public static List<
+          SearchQuerySortRequest<ProcessDefinitionInstanceStatisticsQuerySortRequest.FieldEnum>>
+      fromProcessDefinitionInstanceStatisticsQuerySortRequest(
+          final List<ProcessDefinitionInstanceStatisticsQuerySortRequest> requests) {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
@@ -731,6 +739,23 @@ public class SearchQuerySortRequestMapper {
         case PROCESS_INSTANCE_KEY -> builder.processInstanceKey();
         case SUBSCRIPTION_KEY -> builder.subscriptionKey();
         case TENANT_ID -> builder.tenantId();
+        default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
+      }
+    }
+    return validationErrors;
+  }
+
+  public static List<String> applyProcessDefinitionInstanceStatisticsSortField(
+      final ProcessDefinitionInstanceStatisticsQuerySortRequest.FieldEnum field,
+      final ProcessDefinitionInstanceStatisticsSort.Builder builder) {
+    final List<String> validationErrors = new ArrayList<>();
+    if (field == null) {
+      validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+    } else {
+      switch (field) {
+        case PROCESS_DEFINITION_ID -> builder.processDefinitionId();
+        case ACTIVE_INSTANCES_WITH_INCIDENT -> builder.activeInstancesWithIncident();
+        case ACTIVE_INSTANCES_WITHOUT_INCIDENT -> builder.activeInstancesWithoutIncident();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR implements the first part of the `/v2/process-definitions/statistics` endpoint in the document-based data layer.

Specifically, it covers the **"parent list"**, which returns:
- The latest deployed name of each process definition
- Totals of active instances with and without incidents
- Whether the process definition has multiple versions

The full design and expected behavior are documented in the parent GitHub issue:
🔗 [Finalised API Design – Parent List section](https://github.com/camunda/camunda/issues/21720#issuecomment-3248165941)*

Remaining parts of the endpoint will be handled in follow-up PRs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
