### PR TITLE
test: fix failing Tasklist OS backup restore test

### DIFF
--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -7,13 +7,11 @@
  */
 package io.camunda.tasklist.qa.backup;
 
-import static io.camunda.tasklist.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
 import static io.camunda.tasklist.util.CollectionUtil.asMap;
 
 import io.camunda.tasklist.CommonUtils;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.qa.backup.generator.BackupRestoreDataGenerator;
-import io.camunda.tasklist.qa.util.ContainerVersionsUtil;
 import io.camunda.tasklist.qa.util.TestContainerUtil;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.webapps.backup.TakeBackupResponseDto;
@@ -162,8 +160,7 @@ public class BackupRestoreTest {
     testContext.setOsClient(osClient);
     createOsSnapshotRepository(testContext);
 
-    testContainerUtil.startZeebe(
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME), testContext);
+    testContainerUtil.startZeebe(IMAGE_REPO, VERSION, testContext);
     createZeebeClient(testContext.getExternalZeebeContactPoint());
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
https://github.com/camunda/camunda/pull/37023 changed the zeebe image that is used in the test to use the one built by the CI, but this was only done for Elasticsearch and not Opensearch

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
