### PR TITLE
fix: add missing placeholder in backup failure log message

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/LoggingBackupStore.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/LoggingBackupStore.java
@@ -64,7 +64,7 @@ public class LoggingBackupStore implements BackupStore {
   @Override
   public CompletableFuture<BackupStatusCode> markFailed(
       final BackupIdentifier id, final String failureReason) {
-    logger.atLevel(level).log("Marking {} as failed", id, failureReason);
+    logger.atLevel(level).log("Marking {} as failed: {}", id, failureReason);
     return store.markFailed(id, failureReason);
   }
 


### PR DESCRIPTION
## Description

log message had a mismatch between placeholders and arguments
fixes a logging statement in `LoggingBackupStore` 
message "Marking {} as failed" was called with two arguments (id and failureReason) but only had one placeholder, which caused warning messages during execution
added second placeholder to show both the backup ID and the failure reason.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
