### PR TITLE
ci: trigger action on all label changes

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -105,11 +105,4 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           project-number: "187"
-        if: >
-          contains(github.event.issue.labels.*.name, 'kind/bug') &&
-          (
-              github.event.action == 'opened' ||
-              github.event.action == 'reopened' ||
-              github.event.action == 'transferred' ||
-              (github.event.action == 'labeled' && github.event.label.name == 'kind/bug')
-          )
+        if: contains(github.event.issue.labels.*.name, 'kind/bug')


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Modified the `if` condition for the add-bug-to-quality-board step so that it executes whenever an issue has the 'kind/bug' label, even if component or severity labels are added later. This ensures that the Component and Severity fields are always updated for bug issues, regardless of the order in which labels are applied.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- tested functionality in the sandbox repository https://github.com/camunda/qa-sandbox/blob/main/.github/workflows/add-to-project.yml
- test run: https://github.com/camunda/qa-sandbox/actions/runs/17409541437/job/49422947214

## Related issues

closes #
