### PR TITLE
Trigger workflow only for branches: release-X.Y.Z and release-X.Y.Z-alphaK

### DIFF
--- a/.github/workflows/release-branch-notifications.yml
+++ b/.github/workflows/release-branch-notifications.yml
@@ -14,25 +14,56 @@ on:
     branches: ['release-*']
 
 jobs:
+  validate-event:
+    name: Validate GitHub event for release branch activity
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    outputs:
+      valid: ${{ steps.validate-event.outputs.valid }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Validate event
+        id: validate-event
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_ACTION: ${{ github.event.action }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_LABEL: ${{ github.event.label.name }}
+        run: |
+          set -euo pipefail
+
+          VALID="false"
+
+          # Regex for release branches: release-X.Y.Z or release-X.Y.Z-alphaK
+          RELEASE_REGEX="^release-[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+)?$"
+
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "pull_request_target" ]]; then
+            if [[ "$PR_BASE_REF" =~ $RELEASE_REGEX ]]; then
+              if [[ "$GITHUB_EVENT_ACTION" == "closed" && "$PR_MERGED" == "true" ]]; then
+                VALID="true"
+              elif [[ "$GITHUB_EVENT_ACTION" == "labeled" && "$PR_LABEL" == "backport/release" ]]; then
+                VALID="true"
+              fi
+            fi
+          elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            if [[ "$GITHUB_REF_NAME" =~ $RELEASE_REGEX ]]; then
+              VALID="true"
+            fi
+          fi
+
+          echo "valid=$VALID" >> "$GITHUB_OUTPUT"
   notify-release-activity:
     name: Send Slack notification for release branch activity
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
-    if: >
-      (
-        (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
-        github.event.action == 'closed' &&
-        github.event.pull_request.merged == true &&
-        startsWith(github.event.pull_request.base.ref, 'release-')
-      ) || (
-        (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
-        github.event.action == 'labeled' &&
-        startsWith(github.event.label.name, 'release-') 
-      ) || (
-        github.event_name == 'push' &&
-        startsWith(github.ref_name, 'release-') 
-      ) 
+    needs: validate-event
+    if: needs.validate-event.outputs.valid == 'true'
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Description

Send messages for branches `release-8.6.0` and `release-8.6.0-alpha1`
<img width="635" height="421" alt="image" src="https://github.com/user-attachments/assets/8c065104-e9e0-4263-b551-200725aaa8d8" />

Do not send messages for branches `release-something/somethin-else-release-8.6.0` and `release-something-8.6.0`

Motivated by [this](https://camunda.slack.com/archives/C06UWQNCU7M/p1756835985989289?thread_ts=1756835707.654149&cid=C06UWQNCU7M) discussion.

## Related issues

closes #
