### PR TITLE
feat: support multiple OIDC providers

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/ClientAwareOAuth2AuthorizationRequestResolver.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ClientAwareOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest.Builder;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+/**
+ * An implementation of {@link OAuth2AuthorizationRequestResolver} that is aware of individual OIDC
+ * client configurations and dynamically resolves authorization requests based on the registration
+ * ID extracted from the request URI.
+ *
+ * <p>This resolver supports customization of the authorization request per client, such as
+ * including additional parameters defined in {@link OidcAuthenticationConfiguration}.
+ *
+ * <p>Expected request pattern: {@code /oauth2/authorization/{registrationId}}
+ *
+ * <p>Example usage:
+ *
+ * <pre>
+ * http://localhost:8080/oauth2/authorization/foo
+ * </pre>
+ *
+ * <p>Resolvers are cached per client registration ID.
+ */
+public class ClientAwareOAuth2AuthorizationRequestResolver
+    implements OAuth2AuthorizationRequestResolver {
+
+  private static final String ERROR_INVALID_CLIENT_REGISTRATION_ID =
+      "Invalid Client Registration with ID '%s'";
+  private static final String AUTHORIZATION_REQUEST_BASE_URI = "/oauth2/authorization";
+  private static final String REGISTRATION_ID = "registrationId";
+  private final ClientRegistrationRepository clientRegistrationRepository;
+  private final OidcAuthenticationConfigurationRepository oidcProviderRepository;
+  private final Map<String, OAuth2AuthorizationRequestResolver> authorizationRequestResolvers;
+  private final RequestMatcher authorizationRequestMatcher;
+
+  public ClientAwareOAuth2AuthorizationRequestResolver(
+      final ClientRegistrationRepository clientRegistrationRepository,
+      final OidcAuthenticationConfigurationRepository oidcProviderRepository) {
+    this.clientRegistrationRepository = clientRegistrationRepository;
+    this.oidcProviderRepository = oidcProviderRepository;
+    authorizationRequestResolvers = new ConcurrentHashMap<>();
+    authorizationRequestMatcher =
+        PathPatternRequestMatcher.withDefaults()
+            .matcher("%s/{%s}".formatted(AUTHORIZATION_REQUEST_BASE_URI, REGISTRATION_ID));
+  }
+
+  /**
+   * Attempts to resolve an {@link OAuth2AuthorizationRequest} from the given HTTP request. Extracts
+   * the client registration ID from the path and delegates to the appropriate resolver.
+   *
+   * @param request the incoming HTTP request
+   * @return the resolved {@code OAuth2AuthorizationRequest}, or {@code null} if not applicable
+   */
+  @Override
+  public OAuth2AuthorizationRequest resolve(final HttpServletRequest request) {
+    final var clientRegistrationId = resolveRegistrationId(request);
+    return resolve(clientRegistrationId, r -> r.resolve(request));
+  }
+
+  /**
+   * Attempts to resolve an {@link OAuth2AuthorizationRequest} using a known registration ID.
+   *
+   * @param request the incoming HTTP request
+   * @param clientRegistrationId the registration ID of the client
+   * @return the resolved {@code OAuth2AuthorizationRequest}, or {@code null} if not applicable
+   */
+  @Override
+  public OAuth2AuthorizationRequest resolve(
+      final HttpServletRequest request, final String clientRegistrationId) {
+    return resolve(clientRegistrationId, r -> r.resolve(request, clientRegistrationId));
+  }
+
+  /**
+   * Resolves the {@link OAuth2AuthorizationRequest} using the given registration ID and a resolver
+   * function, after verifying the client exists.
+   *
+   * @param clientRegistrationId the client registration ID
+   * @param requestSupplier a function that resolves the authorization request
+   * @return the resolved {@code OAuth2AuthorizationRequest}, or {@code null} if resolution fails
+   * @throws IllegalArgumentException if the client registration ID is invalid
+   */
+  protected OAuth2AuthorizationRequest resolve(
+      final String clientRegistrationId,
+      final Function<OAuth2AuthorizationRequestResolver, OAuth2AuthorizationRequest>
+          requestSupplier) {
+    if (clientRegistrationId == null || clientRegistrationId.isBlank()) {
+      return null;
+    }
+
+    ensureClientRegistrationExistsOrThrow(clientRegistrationId);
+    return Optional.of(getOrCreateAuthorizationRequestResolver(clientRegistrationId))
+        .map(requestSupplier)
+        .orElse(null);
+  }
+
+  protected void ensureClientRegistrationExistsOrThrow(final String clientRegistrationId) {
+    final var clientRegistration =
+        clientRegistrationRepository.findByRegistrationId(clientRegistrationId);
+    if (clientRegistration == null) {
+      throw new IllegalArgumentException(
+          ERROR_INVALID_CLIENT_REGISTRATION_ID.formatted(clientRegistrationId));
+    }
+  }
+
+  /**
+   * Retrieves an existing or creates a new {@link OAuth2AuthorizationRequestResolver} for the given
+   * client registration ID.
+   *
+   * @param clientRegistrationId the registration ID of the client
+   * @return a resolver configured for the given client
+   */
+  protected OAuth2AuthorizationRequestResolver getOrCreateAuthorizationRequestResolver(
+      final String clientRegistrationId) {
+    return authorizationRequestResolvers.computeIfAbsent(
+        clientRegistrationId, this::createAuthorizationRequestResolver);
+  }
+
+  /**
+   * Creates a new {@link OAuth2AuthorizationRequestResolver} instance for the given client
+   * registration ID, applying any additional parameters configured in the OIDC provider settings.
+   *
+   * @param clientRegistrationId the registration ID of the client
+   * @return a configured authorization request resolver
+   */
+  protected OAuth2AuthorizationRequestResolver createAuthorizationRequestResolver(
+      final String clientRegistrationId) {
+    final var resolver =
+        new DefaultOAuth2AuthorizationRequestResolver(
+            clientRegistrationRepository, AUTHORIZATION_REQUEST_BASE_URI);
+    final var oidcProvider =
+        oidcProviderRepository.getOidcAuthenticationConfigurationById(clientRegistrationId);
+    final var customizer = createAuthorizationRequestCustomizer(oidcProvider);
+    resolver.setAuthorizationRequestCustomizer(customizer);
+    return resolver;
+  }
+
+  protected Consumer<Builder> createAuthorizationRequestCustomizer(
+      final OidcAuthenticationConfiguration oidcProvider) {
+    return customizer -> {
+      final var additionalParameters = oidcProvider.getAuthorizeRequest().getAdditionalParameters();
+      if (additionalParameters != null && !additionalParameters.isEmpty()) {
+        customizer.additionalParameters(additionalParameters);
+      }
+
+      final var resource = oidcProvider.getResource();
+      if (resource != null && !resource.isEmpty()) {
+        // add `resource` parameter to authorization request
+        customizer.additionalParameters(Map.of(OAuth2ParameterNames.RESOURCE, resource));
+      }
+    };
+  }
+
+  /**
+   * Resolves the client registration ID from the HTTP request path if it matches the expected
+   * pattern.
+   *
+   * @param request the incoming HTTP request
+   * @return the registration ID, or {@code null} if no match is found
+   */
+  protected String resolveRegistrationId(final HttpServletRequest request) {
+    if (!authorizationRequestMatcher.matches(request)) {
+      return null;
+    }
+    return authorizationRequestMatcher.matcher(request).getVariables().get(REGISTRATION_ID);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/ClientRegistrationFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ClientRegistrationFactory.java
@@ -16,21 +16,24 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 
-public final class OidcClientRegistration {
-  public static final String REGISTRATION_ID = "oidc";
+public final class ClientRegistrationFactory {
 
-  private OidcClientRegistration() {}
+  private ClientRegistrationFactory() {}
 
-  public static ClientRegistration create(final OidcAuthenticationConfiguration configuration) {
+  public static ClientRegistration createClientRegistration(
+      final String registrationId, final OidcAuthenticationConfiguration configuration) {
     final Builder builder;
     if (configuration.getIssuerUri() != null) {
       builder =
           ClientRegistrations.fromIssuerLocation(configuration.getIssuerUri())
-              .registrationId(REGISTRATION_ID);
+              .registrationId(registrationId);
     } else {
-      builder = ClientRegistration.withRegistrationId(REGISTRATION_ID);
+      builder = ClientRegistration.withRegistrationId(registrationId);
     }
 
+    if (configuration.getClientName() != null) {
+      builder.clientName(configuration.getClientName());
+    }
     if (configuration.getClientId() != null) {
       builder.clientId(configuration.getClientId());
     }

--- a/authentication/src/main/java/io/camunda/authentication/config/IssuerAwareJWSKeySelector.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/IssuerAwareJWSKeySelector.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.JWTClaimsSetAwareJWSKeySelector;
+import java.security.Key;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+
+/**
+ * A {@link JWSKeySelector} implementation that dynamically selects the appropriate key selector
+ * based on the {@code iss} (issuer) claim in a JWT.
+ *
+ * <p>This is used to support multi-tenant setups where each identity provider (issuer) may have its
+ * own JWK Set URI for verifying token signatures.
+ */
+public class IssuerAwareJWSKeySelector implements JWTClaimsSetAwareJWSKeySelector<SecurityContext> {
+
+  private static final String ERROR_UNKNOWN_ISSUER =
+      "Unknown issuer '%s'. No matching client registration found.";
+  private static final String ERROR_MISSING_ISSUER =
+      "Missing or empty 'iss' (issuer) claim in JWT.";
+
+  private final List<ClientRegistration> clientRegistrations;
+  private final JWSKeySelectorFactory jwsKeySelectorFactory;
+  private final Map<String, JWSKeySelector<SecurityContext>> selectors;
+
+  public IssuerAwareJWSKeySelector(
+      final List<ClientRegistration> clientRegistrations,
+      final JWSKeySelectorFactory jwsKeySelectorFactory) {
+    this.clientRegistrations = List.copyOf(clientRegistrations);
+    this.jwsKeySelectorFactory = jwsKeySelectorFactory;
+    selectors = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public List<? extends Key> selectKeys(
+      final JWSHeader jwsHeader,
+      final JWTClaimsSet jwtClaimsSet,
+      final SecurityContext securityContext)
+      throws KeySourceException {
+    final var issuer = jwtClaimsSet.getIssuer();
+
+    if (issuer == null || issuer.isBlank()) {
+      throw new KeySourceException(ERROR_MISSING_ISSUER);
+    }
+
+    return selectors
+        .computeIfAbsent(issuer, this::createJWSKeySelector)
+        .selectJWSKeys(jwsHeader, securityContext);
+  }
+
+  /**
+   * Finds the {@link ClientRegistration} that matches the given issuer URI.
+   *
+   * @param issuer the issuer URI from the JWT claims
+   * @return the matching client registration, or {@code null} if not found
+   */
+  private ClientRegistration getClientRegistrationByIssuer(final String issuer) {
+    return clientRegistrations.stream()
+        .filter(c -> issuer.equals(c.getProviderDetails().getIssuerUri()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(ERROR_UNKNOWN_ISSUER.formatted(issuer)));
+  }
+
+  /**
+   * Lazily creates a {@link JWSKeySelector} for the given issuer.
+   *
+   * @param issuer the issuer URI
+   * @return a key selector for the issuer
+   */
+  private JWSKeySelector<SecurityContext> createJWSKeySelector(final String issuer) {
+    final var clientRegistration = getClientRegistrationByIssuer(issuer);
+    final var providerDetails = clientRegistration.getProviderDetails();
+    final var jwkSetUri = providerDetails.getJwkSetUri();
+    return jwsKeySelectorFactory.createJWSKeySelector(jwkSetUri);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/IssuerAwareTokenValidator.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/IssuerAwareTokenValidator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * A custom {@link OAuth2TokenValidator} implementation that validates a {@link Jwt} based on the
+ * token's issuer claim ({@code iss}). This validator ensures that the token was issued by a trusted
+ * issuer registered by the list of {@link ClientRegistration}s.
+ *
+ * <p>If a trusted client registration is found for the token's issuer, a corresponding validator is
+ * obtained (or created) via a {@link TokenValidatorFactory}, and used to validate the token.
+ *
+ * <p>If the issuer is not recognized, the validation fails with an {@code invalid_token} error.
+ *
+ * <p>This allows support for multiple issuers in multi-tenant OIDC setups.
+ */
+public class IssuerAwareTokenValidator implements OAuth2TokenValidator<Jwt> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IssuerAwareTokenValidator.class);
+  private static final String CLAIM_ISSUER = "iss";
+  private static final String OAUTH2_ERROR_DESCRIPTION = "Token issuer '%s' is not trusted";
+
+  private final List<ClientRegistration> clientRegistrations;
+  private final TokenValidatorFactory tokenValidatorFactory;
+  private final Map<String, OAuth2TokenValidator<Jwt>> validators;
+
+  public IssuerAwareTokenValidator(
+      final List<ClientRegistration> clientRegistrations,
+      final TokenValidatorFactory tokenValidatorFactory) {
+    this.clientRegistrations = clientRegistrations;
+    this.tokenValidatorFactory = tokenValidatorFactory;
+    validators = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public OAuth2TokenValidatorResult validate(final Jwt token) {
+    final var issuer = token.getClaimAsString(CLAIM_ISSUER);
+    final var registration = getClientRegistrationByIssuer(issuer);
+
+    if (registration == null) {
+      return OAuth2TokenValidatorResult.failure(
+          new OAuth2Error(
+              OAuth2ErrorCodes.INVALID_TOKEN, OAUTH2_ERROR_DESCRIPTION.formatted(issuer), null));
+    }
+
+    return getOrCreateTokenValidator(registration).validate(token);
+  }
+
+  protected OAuth2TokenValidator<Jwt> getOrCreateTokenValidator(
+      final ClientRegistration clientRegistration) {
+    final var issuer = clientRegistration.getProviderDetails().getIssuerUri();
+    return validators.computeIfAbsent(
+        issuer, k -> tokenValidatorFactory.createTokenValidator(clientRegistration));
+  }
+
+  protected ClientRegistration getClientRegistrationByIssuer(final String issuer) {
+    return clientRegistrations.stream()
+        .filter(c -> issuer.equals(c.getProviderDetails().getIssuerUri()))
+        .findFirst()
+        .orElseGet(
+            () -> {
+              LOG.debug("No matching client registration found for issuer uri {}", issuer);
+              return null;
+            });
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/JWSKeySelectorFactory.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Set;
+
+/**
+ * Factory for creating {@link JWSKeySelector} instances based on a configured set of allowed {@link
+ * JWSAlgorithm} values and a JWK Set URI.
+ *
+ * <p>This class provides a default set of secure algorithms (RSA and EC families).
+ */
+public class JWSKeySelectorFactory {
+
+  private static final String ERROR_MISSING_JWK_SET_URI = "Missing or empty 'jwkSetUri'";
+  private static final String ERROR_INVALID_JWK_SET_URI =
+      "Invalid 'jwkSetUri' provided: '%s'. It could not be converted to a valid URL. Cause: %s";
+
+  private static final Set<JWSAlgorithm> DEFAULT_JWS_ALGORITHMS =
+      Set.of(
+          // JWS Algorithm Family: RSA
+          JWSAlgorithm.RS256,
+          JWSAlgorithm.RS384,
+          JWSAlgorithm.RS512,
+          // JWS Algorithm Family: EC
+          JWSAlgorithm.ES256,
+          JWSAlgorithm.ES384,
+          JWSAlgorithm.ES512);
+
+  private final Set<JWSAlgorithm> jwsAlgorithms;
+
+  public JWSKeySelectorFactory() {
+    this(DEFAULT_JWS_ALGORITHMS);
+  }
+
+  public JWSKeySelectorFactory(final Set<JWSAlgorithm> jwsAlgorithms) {
+    this.jwsAlgorithms = Set.copyOf(jwsAlgorithms);
+  }
+
+  /**
+   * Creates a {@link JWSKeySelector} for the given JWK Set URI.
+   *
+   * @param jwkSetUri the URI of the JWK Set used to verify token signatures
+   * @return a {@link JWSVerificationKeySelector} configured with the allowed algorithms
+   * @throws IllegalArgumentException if the URI is malformed
+   */
+  public JWSKeySelector<SecurityContext> createJWSKeySelector(final String jwkSetUri) {
+    if (jwkSetUri == null || jwkSetUri.isBlank()) {
+      throw new IllegalArgumentException(ERROR_MISSING_JWK_SET_URI);
+    }
+
+    final var url = toURL(jwkSetUri);
+    final var jwkSource = createJWKSource(url);
+    final var jwsAlgorithms = getJWSAlgorithms();
+    return new JWSVerificationKeySelector<>(jwsAlgorithms, jwkSource);
+  }
+
+  /**
+   * Converts a JWK Set URI to a {@link URL}, with validation.
+   *
+   * @param jwkSetUri the URI as a string
+   * @return the corresponding {@link URL}
+   * @throws IllegalArgumentException if the URI is not a valid URL
+   */
+  protected URL toURL(final String jwkSetUri) {
+    try {
+      return URI.create(jwkSetUri).toURL();
+    } catch (final MalformedURLException ex) {
+      throw new IllegalArgumentException(
+          ERROR_INVALID_JWK_SET_URI.formatted(jwkSetUri, ex.getMessage()), ex);
+    }
+  }
+
+  /**
+   * Creates a {@link JWKSource} for the given JWK Set URL.
+   *
+   * @see org.springframework.security.oauth2.jwt.NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder
+   * @param jwkSetUri the JWK Set URI
+   * @return a {@link JWKSource} for use in verifying JWT signatures
+   */
+  protected JWKSource<SecurityContext> createJWKSource(final URL jwkSetUri) {
+    return JWKSourceBuilder.create(jwkSetUri)
+        .refreshAheadCache(false)
+        .rateLimited(false)
+        .cache(true)
+        .build();
+  }
+
+  /**
+   * Returns the set of supported JWS algorithms.
+   *
+   * @return the configured set of allowed {@link JWSAlgorithm} values
+   */
+  public Set<JWSAlgorithm> getJWSAlgorithms() {
+    return jwsAlgorithms;
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcAccessTokenDecoderFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcAccessTokenDecoderFactory.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static com.nimbusds.jose.JOSEObjectType.JWT;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
+import com.nimbusds.jose.proc.JOSEObjectTypeVerifier;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import com.nimbusds.jwt.proc.JWTProcessor;
+import java.util.List;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+/**
+ * Factory for creating {@link JwtDecoder} instances tailored for decoding access tokens issued by
+ * OpenID Connect (OIDC) Identity Providers.
+ *
+ * <p>This factory supports both single-issuer and multi-issuer (issuer-aware) setups, and enforces
+ * proper configuration of issuer URIs and JWK Set URIs.
+ */
+public class OidcAccessTokenDecoderFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OidcAccessTokenDecoderFactory.class);
+  private static final String ERROR_MISSING_ISSUER =
+      "The following OIDC Providers are missing 'issuerUri': %s";
+  private static final String ERROR_MISSING_JWK =
+      "OIDC Provider '%s' is missing a valid 'jwk-set-uri'. Issuer URI: %s";
+
+  // We explicitly support the "at+jwt" JWT 'typ' header defined in
+  // https://datatracker.ietf.org/doc/html/rfc9068#name-header
+  private static final JOSEObjectType AT_JWT = new JOSEObjectType("at+jwt");
+  private final JWSKeySelectorFactory jwsKeySelectorFactory;
+  private final TokenValidatorFactory tokenValidatorFactory;
+
+  public OidcAccessTokenDecoderFactory(
+      final JWSKeySelectorFactory jwsKeySelectorFactory,
+      final TokenValidatorFactory tokenValidatorFactory) {
+    this.jwsKeySelectorFactory = jwsKeySelectorFactory;
+    this.tokenValidatorFactory = tokenValidatorFactory;
+  }
+
+  /**
+   * Creates a {@link JwtDecoder} that supports multiple OIDC Providers by resolving issuer-specific
+   * keys and validation logic at runtime.
+   *
+   * @param clientRegistrations the list of client registrations to support
+   * @return a {@link JwtDecoder} capable of handling multiple issuers
+   * @throws IllegalArgumentException if any registration is missing an issuer URI
+   */
+  public JwtDecoder createIssuerAwareAccessTokenDecoder(
+      final List<ClientRegistration> clientRegistrations) {
+    LOG.debug(
+        "Creating an Issuer Aware JwtDecoder for multiple OIDC Providers: {}",
+        clientRegistrations.size());
+    validateClientRegistrationsHaveIssuer(clientRegistrations);
+    final var jwtProcessor = createIssuerAwareJwtProcessor(clientRegistrations);
+    final var jwtValidator = createIssuerAwareJwtValidator(clientRegistrations);
+    return createNimbusJwtDecoder(jwtProcessor, jwtValidator);
+  }
+
+  /**
+   * Validates that all provided {@link ClientRegistration} entries have a configured issuer URI.
+   *
+   * @param clientRegistrations the list of client registrations to validate
+   * @throws IllegalArgumentException if any registration is missing a valid issuer URI
+   */
+  protected void validateClientRegistrationsHaveIssuer(
+      final List<ClientRegistration> clientRegistrations) {
+    final var invalidProviders =
+        clientRegistrations.stream()
+            .filter(
+                r -> {
+                  final var issuerUri = r.getProviderDetails().getIssuerUri();
+                  return issuerUri == null || issuerUri.isBlank();
+                })
+            .map(ClientRegistration::getRegistrationId)
+            .toList();
+
+    if (!invalidProviders.isEmpty()) {
+      throw new IllegalArgumentException(
+          ERROR_MISSING_ISSUER.formatted(String.join(", ", invalidProviders)));
+    }
+  }
+
+  /**
+   * Creates a {@link JwtDecoder} for a single OIDC Identity Provider.
+   *
+   * @param clientRegistration the client registration to use
+   * @return a {@link JwtDecoder} for that client
+   * @throws IllegalArgumentException if the registration is missing a JWK Set URI
+   */
+  public JwtDecoder createAccessTokenDecoder(final ClientRegistration clientRegistration) {
+    LOG.debug("Creating JwtDecoder for OIDC Provider {}", clientRegistration.getRegistrationId());
+    final var jwtProcessor = createJwtProcessor(clientRegistration);
+    final var jwtValidator = createJwtValidator(clientRegistration);
+    return createNimbusJwtDecoder(jwtProcessor, jwtValidator);
+  }
+
+  /**
+   * Extracts the JWK Set URI from the given client registration.
+   *
+   * @param clientRegistration the client registration
+   * @return the JWK Set URI
+   * @throws IllegalArgumentException if the URI is missing or blank
+   */
+  protected String getJWKSetUri(final ClientRegistration clientRegistration) {
+    final var providerDetails = clientRegistration.getProviderDetails();
+    final var jwkSetUri = providerDetails.getJwkSetUri();
+    if (jwkSetUri == null || jwkSetUri.isBlank()) {
+      throw new IllegalArgumentException(
+          ERROR_MISSING_JWK.formatted(
+              clientRegistration.getRegistrationId(), providerDetails.getIssuerUri()));
+    }
+    return jwkSetUri;
+  }
+
+  /**
+   * Creates a {@link NimbusJwtDecoder} using the given processor and validator.
+   *
+   * @param jwtProcessor the JWT processor
+   * @param tokenValidator the token validator
+   * @return a configured {@link NimbusJwtDecoder}
+   */
+  protected NimbusJwtDecoder createNimbusJwtDecoder(
+      final JWTProcessor<SecurityContext> jwtProcessor,
+      final OAuth2TokenValidator<Jwt> tokenValidator) {
+    final var decoder = new NimbusJwtDecoder(jwtProcessor);
+    decoder.setJwtValidator(tokenValidator);
+    return decoder;
+  }
+
+  /**
+   * Creates a {@link ConfigurableJWTProcessor} that is aware of multiple issuers.
+   *
+   * @param clientRegistrations the list of client registrations
+   * @return a configured JWT processor
+   */
+  protected ConfigurableJWTProcessor<SecurityContext> createIssuerAwareJwtProcessor(
+      final List<ClientRegistration> clientRegistrations) {
+    final var jwsKeySelector =
+        new IssuerAwareJWSKeySelector(clientRegistrations, jwsKeySelectorFactory);
+    return createAndCustomizeJwtProcessor(
+        processor -> processor.setJWTClaimsSetAwareJWSKeySelector(jwsKeySelector));
+  }
+
+  /**
+   * Creates a {@link ConfigurableJWTProcessor} for a single issuer using its JWK Set URI.
+   *
+   * @param clientRegistration the client registration
+   * @return a configured JWT processor
+   */
+  protected ConfigurableJWTProcessor<SecurityContext> createJwtProcessor(
+      final ClientRegistration clientRegistration) {
+    final var jwkSetUri = getJWKSetUri(clientRegistration);
+    final var jwsKeySelector = jwsKeySelectorFactory.createJWSKeySelector(jwkSetUri);
+    return createAndCustomizeJwtProcessor(processor -> processor.setJWSKeySelector(jwsKeySelector));
+  }
+
+  /**
+   * Creates and customizes a {@link ConfigurableJWTProcessor} with a standard JOSE header type
+   * verifier.
+   *
+   * @param customizer a lambda for applying processor-specific customization
+   * @return a configured JWT processor
+   */
+  protected ConfigurableJWTProcessor<SecurityContext> createAndCustomizeJwtProcessor(
+      final Consumer<ConfigurableJWTProcessor<SecurityContext>> customizer) {
+    final var jwtProcessor = new DefaultJWTProcessor<>();
+    final var jwsTypeVerifier = createJOSEObjectTypeVerifier();
+    jwtProcessor.setJWSTypeVerifier(jwsTypeVerifier);
+    customizer.accept(jwtProcessor);
+    return jwtProcessor;
+  }
+
+  /**
+   * Creates a {@link Jwt} validator that supports multiple issuers.
+   *
+   * @param clientRegistrations the list of client registrations
+   * @return a token validator aware of multiple issuers
+   */
+  protected OAuth2TokenValidator<Jwt> createIssuerAwareJwtValidator(
+      final List<ClientRegistration> clientRegistrations) {
+    return new IssuerAwareTokenValidator(clientRegistrations, tokenValidatorFactory);
+  }
+
+  /**
+   * Creates a token validator for a single OIDC Identity Provider.
+   *
+   * @param clientRegistration the client registration
+   * @return a token validator for the issuer
+   */
+  protected OAuth2TokenValidator<Jwt> createJwtValidator(
+      final ClientRegistration clientRegistration) {
+    return tokenValidatorFactory.createTokenValidator(clientRegistration);
+  }
+
+  /**
+   * Creates a {@link JOSEObjectTypeVerifier} that accepts standard JWT types.
+   *
+   * @return a JOSE object type verifier
+   */
+  protected JOSEObjectTypeVerifier<SecurityContext> createJOSEObjectTypeVerifier() {
+    return new DefaultJOSEObjectTypeVerifier<>(JWT, AT_JWT, null);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcAuthenticationConfigurationRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcAuthenticationConfigurationRepository.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.ProvidersConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class OidcAuthenticationConfigurationRepository {
+
+  private static final String REGISTRATION_ID = "oidc";
+  private final Map<String, OidcAuthenticationConfiguration> providers;
+
+  public OidcAuthenticationConfigurationRepository(
+      final SecurityConfiguration securityConfiguration) {
+    providers = initializeProviders(securityConfiguration);
+  }
+
+  protected Map<String, OidcAuthenticationConfiguration> initializeProviders(
+      final SecurityConfiguration securityConfiguration) {
+    final var providers = new HashMap<String, OidcAuthenticationConfiguration>();
+    final var authenticationConfiguration = securityConfiguration.getAuthentication();
+
+    Optional.ofNullable(authenticationConfiguration.getOidc())
+        .filter(c -> Objects.nonNull(c.getClientId()) && !c.getClientId().isBlank())
+        .ifPresent(c -> providers.put(REGISTRATION_ID, c));
+
+    Optional.ofNullable(authenticationConfiguration.getProviders())
+        .map(ProvidersConfiguration::getOidc)
+        .ifPresent(providers::putAll);
+
+    return providers;
+  }
+
+  public OidcAuthenticationConfiguration getOidcAuthenticationConfigurationById(
+      final String registrationId) {
+    return providers.get(registrationId);
+  }
+
+  public Map<String, OidcAuthenticationConfiguration> getOidcAuthenticationConfigurations() {
+    return providers;
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/TokenValidatorFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/TokenValidatorFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import io.camunda.security.configuration.SecurityConfiguration;
+import java.util.LinkedList;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+
+/**
+ * A factory for creating {@link OAuth2TokenValidator} instances for validating {@link Jwt} tokens.
+ *
+ * <p>This factory uses configuration data from:
+ *
+ * <ul>
+ *   <li>{@link OidcAuthenticationConfigurationRepository} – for client-specific validation settings
+ *   <li>{@link SecurityConfiguration} – for global security settings such as SaaS
+ *       organization/cluster
+ * </ul>
+ *
+ * <p>The resulting validator may include:
+ *
+ * <ul>
+ *   <li>{@link AudienceValidator} – if the client is configured with expected audiences
+ *   <li>{@link OrganizationValidator} – if SaaS configuration is present
+ *   <li>{@link ClusterValidator} – if SaaS configuration is present
+ * </ul>
+ *
+ * <p>If no additional validators are required, the default validator from {@link
+ * JwtValidators#createDefault()} is used.
+ */
+public class TokenValidatorFactory {
+
+  private final SecurityConfiguration securityConfiguration;
+  private final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository;
+
+  public TokenValidatorFactory(
+      final SecurityConfiguration securityConfiguration,
+      final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository) {
+    this.securityConfiguration = securityConfiguration;
+    this.oidcAuthenticationConfigurationRepository = oidcAuthenticationConfigurationRepository;
+  }
+
+  /**
+   * Creates a new {@link OAuth2TokenValidator} for the given {@link ClientRegistration}. The
+   * resulting validator may include one or more of:
+   *
+   * <ul>
+   *   <li>{@link AudienceValidator} – if audience validation is configured for the client
+   *   <li>{@link OrganizationValidator} and {@link ClusterValidator} – if SaaS configuration is
+   *       present
+   * </ul>
+   *
+   * @param clientRegistration the client registration associated with the JWT issuer
+   * @return a composed {@code OAuth2TokenValidator} instance
+   */
+  public OAuth2TokenValidator<Jwt> createTokenValidator(
+      final ClientRegistration clientRegistration) {
+    final var registrationId = clientRegistration.getRegistrationId();
+    final var oidcAuthenticationConfiguration =
+        oidcAuthenticationConfigurationRepository.getOidcAuthenticationConfigurationById(
+            registrationId);
+    final var validators = new LinkedList<OAuth2TokenValidator<Jwt>>();
+
+    final var validAudiences = oidcAuthenticationConfiguration.getAudiences();
+    if (validAudiences != null) {
+      validators.add(new AudienceValidator(validAudiences));
+    }
+
+    if (securityConfiguration.getSaas().isConfigured()) {
+      validators.add(
+          new OrganizationValidator(securityConfiguration.getSaas().getOrganizationId()));
+      validators.add(new ClusterValidator(securityConfiguration.getSaas().getClusterId()));
+    }
+
+    if (!validators.isEmpty()) {
+      return JwtValidators.createDefaultWithValidators(validators);
+    }
+    return JwtValidators.createDefault();
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -7,18 +7,10 @@
  */
 package io.camunda.authentication.config;
 
-import static com.nimbusds.jose.JOSEObjectType.JWT;
 import static io.camunda.security.configuration.headers.ContentSecurityPolicyConfig.DEFAULT_SAAS_SECURITY_POLICY;
 import static io.camunda.security.configuration.headers.ContentSecurityPolicyConfig.DEFAULT_SM_SECURITY_POLICY;
-import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.ES256;
-import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.ES384;
-import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.ES512;
-import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS256;
-import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS384;
-import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS512;
 
 import com.nimbusds.jose.JOSEObjectType;
-import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
 import io.camunda.authentication.CamundaUserDetailsService;
 import io.camunda.authentication.ConditionalOnAuthenticationMethod;
 import io.camunda.authentication.ConditionalOnProtectedApi;
@@ -37,8 +29,10 @@ import io.camunda.authentication.handler.AuthFailureHandler;
 import io.camunda.authentication.service.MembershipService;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.auth.OidcGroupsLoader;
+import io.camunda.security.configuration.AuthenticationConfiguration;
 import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.ProvidersConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.configuration.headers.HeaderConfiguration;
 import io.camunda.security.configuration.headers.values.FrameOptionMode;
@@ -56,11 +50,12 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
@@ -90,18 +85,12 @@ import org.springframework.security.oauth2.client.oidc.authentication.OidcIdToke
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
-import org.springframework.security.oauth2.core.OAuth2TokenValidator;
-import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest.Builder;
-import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
-import org.springframework.security.oauth2.jwt.JwtValidators;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.SupplierJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -133,26 +122,6 @@ public class WebSecurityConfig {
           "/v2/status",
           // deprecated Tasklist v1 Public Endpoints
           "/v1/external/process/**");
-  public static final Set<String> WEBAPP_PATHS =
-      Set.of(
-          "/login/**",
-          "/logout",
-          "/identity/**",
-          "/operate/**",
-          "/tasklist/**",
-          "/",
-          "/sso-callback/**",
-          "/oauth2/authorization/**",
-          // old Tasklist and Operate webapps routes
-          "/processes",
-          "/processes/*",
-          "/{regex:[\\d]+}", // user task id
-          "/processes/*/start",
-          "/new/*",
-          "/decisions",
-          "/decisions/*",
-          "/instances",
-          "/instances/*");
   public static final Set<String> UNPROTECTED_PATHS =
       Set.of(
           // endpoint for failure forwarding
@@ -173,6 +142,28 @@ public class WebSecurityConfig {
   // We explicitly support the "at+jwt" JWT 'typ' header defined in
   // https://datatracker.ietf.org/doc/html/rfc9068#name-header
   static final JOSEObjectType AT_JWT = new JOSEObjectType("at+jwt");
+  private static final String SPRING_DEFAULT_UI_CSS = "/default-ui.css";
+  public static final Set<String> WEBAPP_PATHS =
+      Set.of(
+          "/login/**",
+          "/logout",
+          "/identity/**",
+          "/operate/**",
+          "/tasklist/**",
+          "/",
+          "/sso-callback/**",
+          "/oauth2/authorization/**",
+          // old Tasklist and Operate webapps routes
+          "/processes",
+          "/processes/*",
+          "/{regex:[\\d]+}", // user task id
+          "/processes/*/start",
+          "/new/*",
+          "/decisions",
+          "/decisions/*",
+          "/instances",
+          "/instances/*",
+          SPRING_DEFAULT_UI_CSS);
   private static final Logger LOG = LoggerFactory.getLogger(WebSecurityConfig.class);
   // Used for chains that grant unauthenticated access, always comes first.
   private static final int ORDER_UNPROTECTED = 0;
@@ -428,11 +419,25 @@ public class WebSecurityConfig {
 
     @PostConstruct
     public void verifyBasicConfiguration() {
-      if (securityConfiguration.getAuthentication().getOidc() != null
-          && securityConfiguration.getAuthentication().getOidc().isSet()) {
+      if (isOidcConfigurationEnabled(securityConfiguration)) {
         throw new IllegalStateException(
             "Oidc configuration is not supported with `BASIC` authentication method");
       }
+    }
+
+    protected boolean isOidcConfigurationEnabled(
+        final SecurityConfiguration securityConfiguration) {
+      if (securityConfiguration.getAuthentication().getOidc() != null
+          && securityConfiguration.getAuthentication().getOidc().isSet()) {
+        return true;
+      }
+
+      return Optional.ofNullable(securityConfiguration.getAuthentication())
+          .map(AuthenticationConfiguration::getProviders)
+          .map(ProvidersConfiguration::getOidc)
+          .map(Map::values)
+          .map(values -> values.stream().anyMatch(OidcAuthenticationConfiguration::isSet))
+          .orElse(false);
     }
 
     @Bean
@@ -601,21 +606,35 @@ public class WebSecurityConfig {
     @Bean
     public CamundaAuthenticationConverter<Authentication> oidcUserAuthenticationConverter(
         final OAuth2AuthorizedClientRepository authorizedClientRepository,
-        final JwtDecoder jwtDecoder,
+        final OidcAccessTokenDecoderFactory oidcAccessTokenDecoderFactory,
         final TokenClaimsConverter tokenClaimsConverter,
         final HttpServletRequest request) {
       return new OidcUserAuthenticationConverter(
-          authorizedClientRepository, jwtDecoder, tokenClaimsConverter, request);
+          authorizedClientRepository, oidcAccessTokenDecoderFactory, tokenClaimsConverter, request);
+    }
+
+    @Bean
+    public OidcAuthenticationConfigurationRepository oidcProviderRepository(
+        final SecurityConfiguration securityConfiguration) {
+      return new OidcAuthenticationConfigurationRepository(securityConfiguration);
     }
 
     @Bean
     public ClientRegistrationRepository clientRegistrationRepository(
-        final SecurityConfiguration securityConfiguration) {
+        final OidcAuthenticationConfigurationRepository oidcProviderRepository) {
+      final var clientRegistrations =
+          oidcProviderRepository.getOidcAuthenticationConfigurations().entrySet().stream()
+              .map(e -> createClientRegistration(e.getKey(), e.getValue()))
+              .toList();
+      return new InMemoryClientRegistrationRepository(clientRegistrations);
+    }
+
+    private ClientRegistration createClientRegistration(
+        final String registrationId, final OidcAuthenticationConfiguration configuration) {
       try {
-        return new InMemoryClientRegistrationRepository(
-            OidcClientRegistration.create(securityConfiguration.getAuthentication().getOidc()));
+        return ClientRegistrationFactory.createClientRegistration(registrationId, configuration);
       } catch (final Exception e) {
-        final String issuerUri = securityConfiguration.getAuthentication().getOidc().getIssuerUri();
+        final String issuerUri = configuration.getIssuerUri();
         throw new IllegalStateException(
             "Unable to connect to the Identity Provider endpoint `"
                 + issuerUri
@@ -626,64 +645,59 @@ public class WebSecurityConfig {
     }
 
     @Bean
-    public OidcGroupsLoader oidcGroupsLoader(final SecurityConfiguration securityConfiguration) {
-      final String groupsClaim =
-          securityConfiguration.getAuthentication().getOidc().getGroupsClaim();
-      return new OidcGroupsLoader(groupsClaim);
+    public TokenValidatorFactory tokenValidatorFactory(
+        final SecurityConfiguration securityConfiguration,
+        final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository) {
+      return new TokenValidatorFactory(
+          securityConfiguration, oidcAuthenticationConfigurationRepository);
     }
 
     @Bean
     public JwtDecoderFactory<ClientRegistration> idTokenDecoderFactory(
-        final SecurityConfiguration securityConfiguration) {
+        final TokenValidatorFactory tokenValidatorFactory) {
       final var decoderFactory = new OidcIdTokenDecoderFactory();
-      decoderFactory.setJwtValidatorFactory(
-          registration -> getTokenValidator(securityConfiguration));
+      decoderFactory.setJwtValidatorFactory(tokenValidatorFactory::createTokenValidator);
       return decoderFactory;
     }
 
     @Bean
-    public JwtDecoder jwtDecoder(
-        final SecurityConfiguration securityConfiguration,
-        final ClientRegistrationRepository clientRegistrationRepository) {
-      // Do not rely on the configured uri, the client registration can automatically discover it
-      // based on the issuer uri.
-      final var jwkSetUri =
-          clientRegistrationRepository
-              .findByRegistrationId(OidcClientRegistration.REGISTRATION_ID)
-              .getProviderDetails()
-              .getJwkSetUri();
-
-      final var decoder =
-          NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
-              .jwsAlgorithms(
-                  algorithms ->
-                      algorithms.addAll(List.of(RS256, RS384, RS512, ES256, ES384, ES512)))
-              .jwtProcessorCustomizer(
-                  // the default implementation supports only JOSEObjectType.JWT and null
-                  processor ->
-                      processor.setJWSTypeVerifier(
-                          new DefaultJOSEObjectTypeVerifier<>(JWT, AT_JWT, null)))
-              .build();
-      decoder.setJwtValidator(getTokenValidator(securityConfiguration));
-      return decoder;
+    public JWSKeySelectorFactory jwsKeySelectorFactory() {
+      return new JWSKeySelectorFactory();
     }
 
-    private static OAuth2TokenValidator<Jwt> getTokenValidator(
-        final SecurityConfiguration configuration) {
-      final var validAudiences = configuration.getAuthentication().getOidc().getAudiences();
-      final var validators = new LinkedList<OAuth2TokenValidator<Jwt>>();
-      if (validAudiences != null) {
-        validators.add(new AudienceValidator(validAudiences));
-      }
-      if (configuration.getSaas().isConfigured()) {
-        validators.add(new OrganizationValidator(configuration.getSaas().getOrganizationId()));
-        validators.add(new ClusterValidator(configuration.getSaas().getClusterId()));
-      }
+    @Bean
+    public OidcAccessTokenDecoderFactory accessTokenDecoderFactory(
+        final JWSKeySelectorFactory jwsKeySelectorFactory,
+        final TokenValidatorFactory tokenValidatorFactory) {
+      return new OidcAccessTokenDecoderFactory(jwsKeySelectorFactory, tokenValidatorFactory);
+    }
 
-      if (!validators.isEmpty()) {
-        return JwtValidators.createDefaultWithValidators(validators);
+    @Bean
+    public JwtDecoder jwtDecoder(
+        final OidcAccessTokenDecoderFactory oidcAccessTokenDecoderFactory,
+        final ClientRegistrationRepository clientRegistrationRepository) {
+      final var repository = (Iterable<ClientRegistration>) clientRegistrationRepository;
+      final var clientRegistrations =
+          StreamSupport.stream(repository.spliterator(), false).toList();
+
+      if (clientRegistrations.size() == 1) {
+        final var clientRegistration = clientRegistrations.getFirst();
+        LOG.info(
+            "Create Access Token JWT Decoder for OIDC Provider: {}",
+            clientRegistration.getRegistrationId());
+        return new SupplierJwtDecoder(
+            () -> oidcAccessTokenDecoderFactory.createAccessTokenDecoder(clientRegistration));
+      } else {
+        LOG.info(
+            "Create Issuer Aware JWT Decoder for multiple OIDC Providers: [{}]",
+            clientRegistrations.stream()
+                .map(ClientRegistration::getRegistrationId)
+                .collect(Collectors.joining(", ")));
+        return new SupplierJwtDecoder(
+            () ->
+                oidcAccessTokenDecoderFactory.createIssuerAwareAccessTokenDecoder(
+                    clientRegistrations));
       }
-      return JwtValidators.createDefault();
     }
 
     @Bean
@@ -693,8 +707,8 @@ public class WebSecurityConfig {
 
     @Bean
     public OidcTokenEndpointCustomizer oidcTokenEndpointCustomizer(
-        final SecurityConfiguration securityConfiguration) {
-      return new OidcTokenEndpointCustomizer(securityConfiguration);
+        final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository) {
+      return new OidcTokenEndpointCustomizer(oidcAuthenticationConfigurationRepository);
     }
 
     @Bean
@@ -750,6 +764,7 @@ public class WebSecurityConfig {
         final HttpSecurity httpSecurity,
         final AuthFailureHandler authFailureHandler,
         final ClientRegistrationRepository clientRegistrationRepository,
+        final OidcAuthenticationConfigurationRepository oidcProviderRepository,
         final JwtDecoder jwtDecoder,
         final SecurityConfiguration securityConfiguration,
         final CamundaAuthenticationProvider authenticationProvider,
@@ -763,7 +778,12 @@ public class WebSecurityConfig {
           httpSecurity
               .securityMatcher(WEBAPP_PATHS.toArray(new String[0]))
               .authorizeHttpRequests(
-                  (authorizeHttpRequests) -> authorizeHttpRequests.anyRequest().authenticated())
+                  (authorizeHttpRequests) ->
+                      authorizeHttpRequests
+                          .requestMatchers(SPRING_DEFAULT_UI_CSS)
+                          .permitAll()
+                          .anyRequest()
+                          .authenticated())
               .headers(
                   headers ->
                       setupSecureHeaders(
@@ -778,19 +798,20 @@ public class WebSecurityConfig {
               .oauth2ResourceServer(
                   oauth2 -> oauth2.jwt(jwtConfigurer -> jwtConfigurer.decoder(jwtDecoder)))
               .oauth2Login(
-                  oauthLoginConfigurer ->
-                      oauthLoginConfigurer
-                          .clientRegistrationRepository(clientRegistrationRepository)
-                          .authorizedClientRepository(authorizedClientRepository)
-                          .redirectionEndpoint(
-                              redirectionEndpointConfig ->
-                                  redirectionEndpointConfig.baseUri("/sso-callback"))
-                          .authorizationEndpoint(
-                              authorization ->
-                                  authorization.authorizationRequestResolver(
-                                      authorizationRequestResolver(
-                                          clientRegistrationRepository, securityConfiguration)))
-                          .tokenEndpoint(tokenEndpointCustomizer))
+                  oauthLoginConfigurer -> {
+                    oauthLoginConfigurer
+                        .clientRegistrationRepository(clientRegistrationRepository)
+                        .authorizedClientRepository(authorizedClientRepository)
+                        .redirectionEndpoint(
+                            redirectionEndpointConfig ->
+                                redirectionEndpointConfig.baseUri("/sso-callback"))
+                        .authorizationEndpoint(
+                            authorization ->
+                                authorization.authorizationRequestResolver(
+                                    authorizationRequestResolver(
+                                        clientRegistrationRepository, oidcProviderRepository)))
+                        .tokenEndpoint(tokenEndpointCustomizer);
+                  })
               .oidcLogout(httpSecurityOidcLogoutConfigurer -> {})
               .logout(
                   (logout) ->
@@ -816,37 +837,9 @@ public class WebSecurityConfig {
 
     private OAuth2AuthorizationRequestResolver authorizationRequestResolver(
         final ClientRegistrationRepository clientRegistrationRepository,
-        final SecurityConfiguration securityConfiguration) {
-
-      final var authorizationRequestResolver =
-          new DefaultOAuth2AuthorizationRequestResolver(
-              clientRegistrationRepository, "/oauth2/authorization");
-      authorizationRequestResolver.setAuthorizationRequestCustomizer(
-          authorizationRequestCustomizer(securityConfiguration));
-
-      return authorizationRequestResolver;
-    }
-
-    private Consumer<Builder> authorizationRequestCustomizer(
-        final SecurityConfiguration securityConfiguration) {
-      return customizer -> {
-        final var additionalParameters =
-            securityConfiguration
-                .getAuthentication()
-                .getOidc()
-                .getAuthorizeRequest()
-                .getAdditionalParameters();
-
-        if (additionalParameters != null && !additionalParameters.isEmpty()) {
-          customizer.additionalParameters(additionalParameters);
-        }
-        final List<String> resource =
-            securityConfiguration.getAuthentication().getOidc().getResource();
-        if (resource != null && !resource.isEmpty()) {
-          // add `resource` parameter to authorization request
-          customizer.additionalParameters(Map.of(OAuth2ParameterNames.RESOURCE, resource));
-        }
-      };
+        final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository) {
+      return new ClientAwareOAuth2AuthorizationRequestResolver(
+          clientRegistrationRepository, oidcAuthenticationConfigurationRepository);
     }
 
     // refresh token filter has to be registered after the ExceptionTranslationFilter

--- a/authentication/src/test/java/io/camunda/authentication/MultipleOidcProviderFlowTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/MultipleOidcProviderFlowTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import static io.camunda.authentication.config.controllers.TestApiController.*;
+import static io.camunda.authentication.config.controllers.TestApiController.DUMMY_UNPROTECTED_ENDPOINT;
+import static io.camunda.authentication.config.controllers.TestApiController.DUMMY_V2_API_ENDPOINT;
+import static java.net.http.HttpClient.newHttpClient;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.authentication.config.controllers.OidcFlowTestContext;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SuppressWarnings({"SpringBootApplicationProperties", "WrongPropertyKeyValueDelimiter"})
+@AutoConfigureMockMvc
+@AutoConfigureWebMvc
+@SpringBootTest(
+    classes = {
+      OidcFlowTestContext.class,
+      WebSecurityConfig.class,
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+
+      // OIDC provider/realm: camunda-foo
+      "camunda.security.authentication.providers.oidc.foo.client-id="
+          + MultipleOidcProviderFlowTest.REALM_FOO_CLIENT_ID,
+      "camunda.security.authentication.providers.oidc.foo.client-secret="
+          + MultipleOidcProviderFlowTest.REALM_FOO_CLIENT_SECRET,
+      "camunda.security.authentication.providers.oidc.foo.redirect-uri=http://localhost/sso-callback",
+      "camunda.security.authentication.providers.oidc.foo.audiences=camunda-foo",
+
+      // OIDC provider/realm: camunda-bar
+      "camunda.security.authentication.providers.oidc.bar.client-id="
+          + MultipleOidcProviderFlowTest.REALM_BAR_CLIENT_ID,
+      "camunda.security.authentication.providers.oidc.bar.client-secret="
+          + MultipleOidcProviderFlowTest.REALM_BAR_CLIENT_SECRET,
+      "camunda.security.authentication.providers.oidc.bar.redirect-uri=http://localhost/sso-callback"
+    })
+@ActiveProfiles("consolidated-auth")
+@Testcontainers
+class MultipleOidcProviderFlowTest {
+
+  static final String REALM_FOO_CLIENT_ID = "camunda-foo";
+  static final String REALM_FOO_CLIENT_SECRET = "pW7IzLnbYMpPk785irfwoQjBQ3VSQnT3";
+  static final String REALM_FOO = "camunda-foo";
+
+  static final String REALM_BAR_CLIENT_ID = "camunda-bar";
+  static final String REALM_BAR_CLIENT_SECRET = "kCgndC3n3apTVJ8j76X3Y6hpqbxR7Kvf";
+  static final String REALM_BAR = "camunda-bar";
+
+  // used to test that access to not configured providers is denied
+  static final String REALM_IDENTITY_TEST_CLIENT_ID = "camunda-test";
+  static final String REALM_IDENTITY_TEST_CLIENT_SECRET = "yI2oAlOzx2A9AXmiUO0fqT4qNb8l3HBP";
+  static final String REALM_IDENTITY_TEST = "camunda-identity-test";
+
+  @Container
+  static KeycloakContainer keycloak =
+      new KeycloakContainer()
+          .withRealmImportFiles(
+              "/camunda-foo-realm.json",
+              "/camunda-bar-realm.json",
+              "/camunda-identity-test-realm.json");
+
+  @Autowired MockMvcTester mockMvcTester;
+
+  @DynamicPropertySource
+  static void properties(final DynamicPropertyRegistry registry) {
+    registry.add(
+        "camunda.security.authentication.providers.oidc.foo.issuer-uri",
+        () -> keycloak.getAuthServerUrl() + "/realms/" + REALM_FOO);
+    registry.add(
+        "camunda.security.authentication.providers.oidc.bar.issuer-uri",
+        () -> keycloak.getAuthServerUrl() + "/realms/" + REALM_BAR);
+  }
+
+  @Nested
+  class ClientFlow {
+    @Test
+    public void shouldReturnUnauthorizedWhenClientUnauthenticated() {
+      // Given an unauthenticated client
+      // When the client accesses a protected API endpoint
+      final MvcTestResult result =
+          mockMvcTester.get().uri("/api/dummy").accept(MediaType.APPLICATION_JSON).exchange();
+
+      // Then the client receives the http response code 401
+      assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    public void shouldDenyAccessWithInvalidClientCredentialsToken() {
+      // Given an invalid token
+      final String invalidToken = "invalid-token";
+      final MvcTestResult result =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_V2_API_ENDPOINT)
+              .accept(MediaType.APPLICATION_JSON)
+              .header("Authorization", "Bearer " + invalidToken)
+              .exchange();
+      assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    public void shouldObtainTokenUsingRealmFoo() throws Exception {
+      // Given valid client credentials
+      final String accessToken =
+          getClientAccessToken(REALM_FOO, REALM_FOO_CLIENT_ID, REALM_FOO_CLIENT_SECRET);
+
+      // When using the token to access a protected endpoint
+      final MvcTestResult apiResult =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_V2_API_ENDPOINT)
+              .accept(MediaType.APPLICATION_JSON)
+              .header("Authorization", "Bearer " + accessToken)
+              .exchange();
+      // Then access is granted
+      assertThat(apiResult).hasStatus(HttpStatus.OK).hasBodyTextEqualTo(DEFAULT_RESPONSE);
+    }
+
+    @Test
+    public void shouldObtainTokenUsingRealmBar() throws Exception {
+      // Given valid client credentials
+      final String accessToken =
+          getClientAccessToken(REALM_BAR, REALM_BAR_CLIENT_ID, REALM_BAR_CLIENT_SECRET);
+
+      // When using the token to access a protected endpoint
+      final MvcTestResult apiResult =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_V2_API_ENDPOINT)
+              .accept(MediaType.APPLICATION_JSON)
+              .header("Authorization", "Bearer " + accessToken)
+              .exchange();
+      // Then access is granted
+      assertThat(apiResult).hasStatus(HttpStatus.OK).hasBodyTextEqualTo(DEFAULT_RESPONSE);
+    }
+
+    @Test
+    public void shouldDenyAccessToUnknownIssuer() throws Exception {
+      // Given valid client credentials
+      final String accessToken =
+          getClientAccessToken(
+              REALM_IDENTITY_TEST,
+              REALM_IDENTITY_TEST_CLIENT_ID,
+              REALM_IDENTITY_TEST_CLIENT_SECRET);
+
+      // When using the token to access a protected endpoint
+      final MvcTestResult apiResult =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_V2_API_ENDPOINT)
+              .accept(MediaType.APPLICATION_JSON)
+              .header("Authorization", "Bearer " + accessToken)
+              .exchange();
+      // Then access is granted
+      assertThat(apiResult).hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    private static String getClientAccessToken(
+        final String realm, final String clientId, final String clientSecret)
+        throws IOException, InterruptedException {
+      final String tokenEndpoint =
+          keycloak.getAuthServerUrl() + "/realms/" + realm + "/protocol/openid-connect/token";
+      final String requestBody =
+          "grant_type=client_credentials&client_id=" + clientId + "&client_secret=" + clientSecret;
+      final HttpResponse<String> response;
+      try (final HttpClient httpClient = newHttpClient()) {
+        final HttpRequest request =
+            HttpRequest.newBuilder()
+                .uri(URI.create(tokenEndpoint))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+
+        response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+      }
+      return new ObjectMapper().readTree(response.body()).get("access_token").asText();
+    }
+  }
+
+  @Nested
+  class UserFlow {
+    @Test
+    public void shouldAllowUnauthenticatedRequestsToUnprotectedApi() {
+      final MvcTestResult result =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_UNPROTECTED_ENDPOINT)
+              .accept(MediaType.TEXT_HTML)
+              .exchange();
+      assertThat(result).hasStatus(HttpStatus.OK);
+    }
+
+    @Test
+    public void shouldRedirectToLoginPageWhenUserUnauthenticated() {
+      // Given an unauthenticated user
+      // When the user accesses a protected webapp endpoint...
+      // (The Accept header is essential here - Spring filters use text/html to match the request to
+      // a redirection flow, rather than just returning 401)
+      final MvcTestResult result =
+          mockMvcTester.get().uri("/").accept(MediaType.TEXT_HTML).exchange();
+
+      // Then the user is redirected to the Login Page listing the OIDC providers
+      assertThat(result)
+          .hasStatus(HttpStatus.FOUND)
+          .hasHeader("Location", "http://localhost/login");
+    }
+
+    @Test
+    public void shouldRedirectToRealmFoo() {
+      // When a user requests Spring's local authorization endpoint
+      final MvcTestResult result =
+          mockMvcTester
+              .get()
+              .uri("/oauth2/authorization/foo")
+              .accept(MediaType.TEXT_HTML)
+              .exchange();
+
+      // Then the response should be a redirect to the OIDC provider's authentication endpoint
+      assertThat(result).hasStatus(HttpStatus.FOUND).containsHeader("Location");
+      final var locationHeader = result.getResponse().getHeader("Location");
+      assertThat(locationHeader)
+          .startsWith(
+              keycloak.getAuthServerUrl()
+                  + "/realms/"
+                  + REALM_FOO
+                  + "/protocol/openid-connect/auth")
+          .contains("client_id=" + REALM_FOO_CLIENT_ID)
+          .contains("response_type=code")
+          .contains("scope=openid%20profile");
+    }
+
+    @Test
+    public void shouldRedirectToRealmBar() {
+      // When a user requests Spring's local authorization endpoint
+      final MvcTestResult result =
+          mockMvcTester
+              .get()
+              .uri("/oauth2/authorization/bar")
+              .accept(MediaType.TEXT_HTML)
+              .exchange();
+
+      // Then the response should be a redirect to the OIDC provider's authentication endpoint
+      assertThat(result).hasStatus(HttpStatus.FOUND).containsHeader("Location");
+      final var locationHeader = result.getResponse().getHeader("Location");
+      assertThat(locationHeader)
+          .startsWith(
+              keycloak.getAuthServerUrl()
+                  + "/realms/"
+                  + REALM_BAR
+                  + "/protocol/openid-connect/auth")
+          .contains("client_id=" + REALM_BAR_CLIENT_ID)
+          .contains("response_type=code")
+          .contains("scope=openid%20profile");
+    }
+
+    @Test
+    public void shouldDenyWithUnknownRealm() {
+      // When a user requests Spring's local authorization endpoint
+      final MvcTestResult result =
+          mockMvcTester
+              .get()
+              .uri("/oauth2/authorization/unknown")
+              .accept(MediaType.TEXT_HTML)
+              .exchange();
+
+      // Spring returns 500 in such cases
+      assertThat(result).hasStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/IssuerAwareTokenValidatorTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/IssuerAwareTokenValidatorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistration.ProviderDetails;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class IssuerAwareTokenValidatorTest {
+
+  @Test
+  public void shouldThrowExceptionWhenIssuerUnknown() {
+    // given
+    final var validator = new IssuerAwareTokenValidator(List.of(), new NoopTokenValidatorFactory());
+    final var jwt = createJwtWithIssuer("unknown-issuer");
+
+    // when // then
+    final var result = validator.validate(jwt);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+
+    final var errors = result.getErrors();
+    assertThat(errors).hasSize(1);
+
+    final var error = errors.iterator().next();
+    assertThat(error.getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_TOKEN);
+    assertThat(error.getDescription()).isEqualTo("Token issuer 'unknown-issuer' is not trusted");
+  }
+
+  @Test
+  public void shouldAcceptJwtWithKnownIssuer() {
+    // given
+    final var providerDetails = mock(ProviderDetails.class);
+    when(providerDetails.getIssuerUri()).thenReturn("known-issuer");
+    final var clientRegistration = mock(ClientRegistration.class);
+    when(clientRegistration.getProviderDetails()).thenReturn(providerDetails);
+
+    final var validator =
+        new IssuerAwareTokenValidator(List.of(clientRegistration), new NoopTokenValidatorFactory());
+    final var jwt = createJwtWithIssuer("known-issuer");
+
+    // when // then
+    final var result = validator.validate(jwt);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  private static Jwt createJwtWithIssuer(final String issuer) {
+    return new Jwt(
+        "token-value",
+        Instant.now(),
+        Instant.now().plusSeconds(60),
+        Map.of("alg", "RS256"),
+        Map.of("iss", issuer));
+  }
+
+  private static class NoopTokenValidatorFactory extends TokenValidatorFactory {
+
+    public NoopTokenValidatorFactory() {
+      super(null, null);
+    }
+
+    @Override
+    public OAuth2TokenValidator<Jwt> createTokenValidator(
+        final ClientRegistration clientRegistration) {
+      return token -> OAuth2TokenValidatorResult.success();
+    }
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/JwtDecoderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JwtDecoderTest.java
@@ -37,6 +37,8 @@ import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext
 import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
 import java.util.Date;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -47,6 +49,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 
 @SuppressWarnings("SpringBootApplicationProperties")
 @SpringBootTest(
@@ -54,150 +57,215 @@ import org.springframework.test.context.DynamicPropertySource;
       WebSecurityConfigTestContext.class,
       WebSecurityOidcTestContext.class,
       WebSecurityConfig.class
-    },
-    properties = {
-      "camunda.security.authentication.unprotected-api=false",
-      "camunda.security.authentication.method=oidc",
-      "camunda.security.authentication.oidc.client-id=example",
-      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
-      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
-      "camunda.security.authentication.oidc.token-uri=token.example.com",
     })
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class JwtDecoderTest extends AbstractWebSecurityConfigTest {
 
-  @RegisterExtension
-  static WireMockExtension wireMock =
-      WireMockExtension.newInstance().configureStaticDsl(true).build();
+  abstract static class DecoderTest {
+    @RegisterExtension
+    static WireMockExtension wireMock =
+        WireMockExtension.newInstance().configureStaticDsl(true).build();
 
-  @Autowired private JwtDecoder decoder;
+    @Autowired private JwtDecoder decoder;
 
-  @DynamicPropertySource
-  static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
-    registry.add(
-        "camunda.security.authentication.oidc.jwk-set-uri",
-        () -> "http://localhost:" + wireMock.getPort() + "/protocol/openid-connect/certs");
-  }
+    @ParameterizedTest
+    @MethodSource("basicAlgTestParameters")
+    public void testDecodeJwtWithNoAlgFieldInJwkResponse(
+        final JWSAlgorithm algorithm, final Curve curve) throws JOSEException {
+      final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, JWT);
 
-  @ParameterizedTest
-  @MethodSource("basicAlgTestParameters")
-  public void testDecodeJwtWithNoAlgFieldInJwkResponse(
-      final JWSAlgorithm algorithm, final Curve curve) throws JOSEException {
-    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, JWT);
+      // remove alg field from mocked server response and assert it was removed to cover this use
+      // case
+      final String withoutAlg = jwtKeys.publicKey.replaceFirst(",\"alg\":\"[^\"]*\"", "");
+      final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
+      assertThat(authServerResponseBody).doesNotContain("alg\":");
+      mockAuthServerResponse(authServerResponseBody);
 
-    // remove alg field from mocked server response and assert it was removed to cover this use case
-    final String withoutAlg = jwtKeys.publicKey.replaceFirst(",\"alg\":\"[^\"]*\"", "");
-    final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
-    assertThat(authServerResponseBody).doesNotContain("alg\":");
-    mockAuthServerResponse(authServerResponseBody);
-
-    assertThatCode(() -> decoder.decode(jwtKeys.serializedJwt)).doesNotThrowAnyException();
-    wireMock.getRuntimeInfo().getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
-  }
-
-  private static Stream<Arguments> basicAlgTestParameters() {
-    return Stream.of(
-        Arguments.of(JWSAlgorithm.RS256, null), Arguments.of(JWSAlgorithm.ES256, Curve.P_256));
-  }
-
-  @ParameterizedTest
-  @MethodSource("supportedJwsAlgorithms")
-  public void testDecodeJwtsWithNoTypeHeader(final JWSAlgorithm algorithm, final Curve curve)
-      throws JOSEException {
-    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, null);
-    final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
-    mockAuthServerResponse(authServerResponseBody);
-
-    assertThatCode(() -> decoder.decode(jwtKeys.serializedJwt)).doesNotThrowAnyException();
-    wireMock.getRuntimeInfo().getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
-  }
-
-  @ParameterizedTest
-  @MethodSource("supportedJwsAlgorithms")
-  public void testDecodeJwtsWithAtJwkTypeHeader(final JWSAlgorithm algorithm, final Curve curve)
-      throws JOSEException {
-    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, AT_JWT);
-    final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
-    mockAuthServerResponse(authServerResponseBody);
-
-    assertThatCode(() -> decoder.decode(jwtKeys.serializedJwt)).doesNotThrowAnyException();
-    wireMock.getRuntimeInfo().getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
-  }
-
-  @ParameterizedTest
-  @MethodSource("supportedJwsAlgorithms")
-  public void testDecodeJwtWithJwtTypeHeader(final JWSAlgorithm algorithm, final Curve curve)
-      throws JOSEException {
-    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, JWT);
-    final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
-    mockAuthServerResponse(authServerResponseBody);
-
-    assertThatCode(() -> decoder.decode(jwtKeys.serializedJwt)).doesNotThrowAnyException();
-    wireMock.getRuntimeInfo().getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
-  }
-
-  private static Stream<Arguments> supportedJwsAlgorithms() {
-    return Stream.of(
-        Arguments.of(JWSAlgorithm.RS256, null),
-        Arguments.of(JWSAlgorithm.RS384, null),
-        Arguments.of(JWSAlgorithm.RS512, null),
-        Arguments.of(JWSAlgorithm.ES256, Curve.P_256),
-        Arguments.of(JWSAlgorithm.ES384, Curve.P_384),
-        Arguments.of(JWSAlgorithm.ES512, Curve.P_521));
-  }
-
-  private void mockAuthServerResponse(final String authServerResponseBody) {
-    wireMock
-        .getRuntimeInfo()
-        .getWireMock()
-        .register(
-            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
-                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
-  }
-
-  private static class JwtKeys {
-    JWK jwk;
-    String serializedJwt;
-    String publicKey;
-    JWSSigner jwsSigner;
-
-    JwtKeys(final JWSAlgorithm algorithm, final Curve curve, final JOSEObjectType type)
-        throws JOSEException {
-      if (Family.RSA.contains(algorithm)) {
-        jwk =
-            new RSAKeyGenerator(2048)
-                .algorithm(algorithm)
-                .keyID("123")
-                .keyUse(KeyUse.SIGNATURE)
-                .generate();
-        jwsSigner = new RSASSASigner((RSAKey) jwk);
-      } else if (Family.EC.contains(algorithm)) {
-        jwk =
-            new ECKeyGenerator(curve)
-                .algorithm(algorithm)
-                .keyID("345")
-                .keyUse(KeyUse.SIGNATURE)
-                .generate();
-        jwsSigner = new ECDSASigner((ECKey) jwk);
-      } else {
-        fail("unsupported algorithm type '%s'", algorithm);
-        throw new IllegalStateException("Unreachable");
-      }
-      serializedJwt = signAndSerialize(jwk, algorithm, type);
-      publicKey = jwk.toPublicJWK().toJSONString();
+      assertThatCode(() -> decoder.decode(jwtKeys.serializedJwt)).doesNotThrowAnyException();
+      wireMock.getRuntimeInfo().getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
     }
 
-    private String signAndSerialize(
-        final JWK jwk, final JWSAlgorithm alg, final JOSEObjectType type) throws JOSEException {
-      final SignedJWT jwt =
-          new SignedJWT(
-              new JWSHeader.Builder(alg).type(type).keyID(jwk.getKeyID()).build(),
-              new Builder()
-                  .subject("alice")
-                  .issuer("http://localhost")
-                  .expirationTime(new Date(new Date().getTime() + 60 * 1000))
-                  .build());
-      jwt.sign(jwsSigner);
-      return jwt.serialize();
+    private static Stream<Arguments> basicAlgTestParameters() {
+      return Stream.of(
+          Arguments.of(JWSAlgorithm.RS256, null), Arguments.of(JWSAlgorithm.ES256, Curve.P_256));
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedJwsAlgorithms")
+    public void testDecodeJwtsWithNoTypeHeader(final JWSAlgorithm algorithm, final Curve curve)
+        throws JOSEException {
+      final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, null);
+      final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
+      mockAuthServerResponse(authServerResponseBody);
+
+      assertThatCode(() -> decoder.decode(jwtKeys.serializedJwt)).doesNotThrowAnyException();
+      wireMock.getRuntimeInfo().getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedJwsAlgorithms")
+    public void testDecodeJwtsWithAtJwkTypeHeader(final JWSAlgorithm algorithm, final Curve curve)
+        throws JOSEException {
+      final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, AT_JWT);
+      final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
+      mockAuthServerResponse(authServerResponseBody);
+
+      assertThatCode(() -> decoder.decode(jwtKeys.serializedJwt)).doesNotThrowAnyException();
+      wireMock.getRuntimeInfo().getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedJwsAlgorithms")
+    public void testDecodeJwtWithJwtTypeHeader(final JWSAlgorithm algorithm, final Curve curve)
+        throws JOSEException {
+      final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, JWT);
+      final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
+      mockAuthServerResponse(authServerResponseBody);
+
+      assertThatCode(() -> decoder.decode(jwtKeys.serializedJwt)).doesNotThrowAnyException();
+      wireMock.getRuntimeInfo().getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+    }
+
+    private static Stream<Arguments> supportedJwsAlgorithms() {
+      return Stream.of(
+          Arguments.of(JWSAlgorithm.RS256, null),
+          Arguments.of(JWSAlgorithm.RS384, null),
+          Arguments.of(JWSAlgorithm.RS512, null),
+          Arguments.of(JWSAlgorithm.ES256, Curve.P_256),
+          Arguments.of(JWSAlgorithm.ES384, Curve.P_384),
+          Arguments.of(JWSAlgorithm.ES512, Curve.P_521));
+    }
+
+    private void mockAuthServerResponse(final String authServerResponseBody) {
+      wireMock
+          .getRuntimeInfo()
+          .getWireMock()
+          .register(
+              WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                  .willReturn(
+                      WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+    }
+
+    private static class JwtKeys {
+      JWK jwk;
+      String serializedJwt;
+      String publicKey;
+      JWSSigner jwsSigner;
+
+      JwtKeys(final JWSAlgorithm algorithm, final Curve curve, final JOSEObjectType type)
+          throws JOSEException {
+        if (Family.RSA.contains(algorithm)) {
+          jwk =
+              new RSAKeyGenerator(2048)
+                  .algorithm(algorithm)
+                  .keyID("123")
+                  .keyUse(KeyUse.SIGNATURE)
+                  .generate();
+          jwsSigner = new RSASSASigner((RSAKey) jwk);
+        } else if (Family.EC.contains(algorithm)) {
+          jwk =
+              new ECKeyGenerator(curve)
+                  .algorithm(algorithm)
+                  .keyID("345")
+                  .keyUse(KeyUse.SIGNATURE)
+                  .generate();
+          jwsSigner = new ECDSASigner((ECKey) jwk);
+        } else {
+          fail("unsupported algorithm type '%s'", algorithm);
+          throw new IllegalStateException("Unreachable");
+        }
+        serializedJwt = signAndSerialize(jwk, algorithm, type);
+        publicKey = jwk.toPublicJWK().toJSONString();
+      }
+
+      private String signAndSerialize(
+          final JWK jwk, final JWSAlgorithm alg, final JOSEObjectType type) throws JOSEException {
+        final SignedJWT jwt =
+            new SignedJWT(
+                new JWSHeader.Builder(alg).type(type).keyID(jwk.getKeyID()).build(),
+                new Builder()
+                    .subject("alice")
+                    .issuer("http://localhost:" + wireMock.getPort() + "/foo")
+                    .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+                    .build());
+        jwt.sign(jwsSigner);
+        return jwt.serialize();
+      }
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.security.authentication.unprotected-api=false",
+        "camunda.security.authentication.method=oidc",
+        "camunda.security.authentication.oidc.client-id=example",
+        "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+        "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+        "camunda.security.authentication.oidc.token-uri=token.example.com",
+      })
+  class SingleOidcProviderConfiguration extends DecoderTest {
+
+    @DynamicPropertySource
+    static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+      registry.add(
+          "camunda.security.authentication.oidc.jwk-set-uri",
+          () -> "http://localhost:" + wireMock.getPort() + "/protocol/openid-connect/certs");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.security.authentication.unprotected-api=false",
+        "camunda.security.authentication.method=oidc",
+        "camunda.security.authentication.providers.oidc.foo.client-id=foo",
+        "camunda.security.authentication.providers.oidc.foo.redirect-uri=redirect.foo.com",
+        "camunda.security.authentication.providers.oidc.foo.authorization-uri=authorization.foo.com",
+        "camunda.security.authentication.providers.oidc.foo.token-uri=token.foo.com",
+        "camunda.security.authentication.providers.oidc.bar.client-id=bar",
+        "camunda.security.authentication.providers.oidc.bar.redirect-uri=redirect.bar.com",
+        "camunda.security.authentication.providers.oidc.bar.authorization-uri=authorization.bar.com",
+        "camunda.security.authentication.providers.oidc.bar.token-uri=token.bar.com",
+      })
+  class MultipleOidcProviderConfiguration extends DecoderTest {
+
+    static final String REALM_FOO = "foo";
+    static final String REALM_BAR = "bar";
+    static final String OPENID_CONFIGURATION =
+        "{\"issuer\": \"http://localhost:%s/%s\","
+            + "\"token_endpoint\": \"token.%s.com\","
+            + "\"jwks_uri\": \"http://localhost:%s/realms/%s/protocol/openid-connect/certs\","
+            + "\"subject_types_supported\": [\"public\"]"
+            + "}";
+
+    @DynamicPropertySource
+    static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+      registry.add(
+          "camunda.security.authentication.providers.oidc.foo.issuer-uri",
+          () -> "http://localhost:" + wireMock.getPort() + "/" + REALM_FOO);
+      final var realmFooConfiguration =
+          OPENID_CONFIGURATION.formatted(
+              wireMock.getPort(), REALM_FOO, REALM_FOO, wireMock.getPort(), REALM_FOO);
+      mockOpenidConfigurationResponse(REALM_FOO, realmFooConfiguration);
+
+      registry.add(
+          "camunda.security.authentication.providers.oidc.bar.issuer-uri",
+          () -> "http://localhost:" + wireMock.getPort() + "/" + REALM_BAR);
+      final var realmBarConfiguration =
+          OPENID_CONFIGURATION.formatted(
+              wireMock.getPort(), REALM_BAR, REALM_BAR, wireMock.getPort(), REALM_BAR);
+      mockOpenidConfigurationResponse(REALM_BAR, realmBarConfiguration);
+    }
+
+    static void mockOpenidConfigurationResponse(final String realm, final String response) {
+      wireMock
+          .getRuntimeInfo()
+          .getWireMock()
+          .register(
+              WireMock.get(
+                      WireMock.urlMatching(".*/" + realm + "/.well-known/openid-configuration"))
+                  .willReturn(WireMock.jsonResponse(response, HttpStatus.OK.value())));
     }
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcClientRegistrationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcClientRegistrationTest.java
@@ -23,7 +23,7 @@ class OidcClientRegistrationTest {
     config.setTokenUri("tokenUri");
     config.setClientAuthenticationMethod("client_secret_basic");
 
-    Assertions.assertThat(OidcClientRegistration.create(config))
+    Assertions.assertThat(ClientRegistrationFactory.createClientRegistration("foo", config))
         .isInstanceOf(ClientRegistration.class);
   }
 
@@ -36,7 +36,8 @@ class OidcClientRegistrationTest {
     config.setTokenUri("tokenUri");
     config.setClientAuthenticationMethod("does_not_exist");
 
-    Assertions.assertThatThrownBy(() -> OidcClientRegistration.create(config))
+    Assertions.assertThatThrownBy(
+            () -> ClientRegistrationFactory.createClientRegistration("foo", config))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("unsupported client authentication method: does_not_exist");
   }

--- a/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.authentication.config.OidcAccessTokenDecoderFactory;
 import io.camunda.security.auth.CamundaAuthentication;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
@@ -25,6 +26,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -39,11 +41,13 @@ public class OidcUserAuthenticationConverterTest {
   @Mock private JwtDecoder jwtDecoder;
   @Mock private TokenClaimsConverter tokenClaimsConverter;
   @Mock private HttpServletRequest request;
+  @Mock private OidcAccessTokenDecoderFactory oidcAccessTokenDecoderFactory;
   @InjectMocks private OidcUserAuthenticationConverter authenticationConverter;
 
   @BeforeEach
   void setup() throws Exception {
     MockitoAnnotations.openMocks(this).close();
+    when(oidcAccessTokenDecoderFactory.createAccessTokenDecoder(any())).thenReturn(jwtDecoder);
   }
 
   @Test
@@ -85,10 +89,14 @@ public class OidcUserAuthenticationConverterTest {
     final var accessToken = mock(OAuth2AccessToken.class);
     when(accessToken.getTokenValue()).thenReturn(accessTokenValue);
 
+    final var clientRegistration = mock(ClientRegistration.class);
+    when(clientRegistration.getRegistrationId()).thenReturn("bar");
+
     final var authorizedClient = mock(OAuth2AuthorizedClient.class);
     when(authorizedClient.getAccessToken()).thenReturn(accessToken);
     when(authorizedClientRepository.loadAuthorizedClient(any(), any(), any()))
         .thenReturn(authorizedClient);
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
 
     final Map<String, Object> accessTokenClaims =
         Map.of("access_token", "test-access-token", "token_type", "Bearer", "expires_in", 3600);
@@ -146,10 +154,14 @@ public class OidcUserAuthenticationConverterTest {
     final var accessToken = mock(OAuth2AccessToken.class);
     when(accessToken.getTokenValue()).thenReturn(accessTokenValue);
 
+    final var clientRegistration = mock(ClientRegistration.class);
+    when(clientRegistration.getRegistrationId()).thenReturn("bar");
+
     final var authorizedClient = mock(OAuth2AuthorizedClient.class);
     when(authorizedClient.getAccessToken()).thenReturn(accessToken);
     when(authorizedClientRepository.loadAuthorizedClient(any(), any(), any()))
         .thenReturn(authorizedClient);
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
 
     when(jwtDecoder.decode(eq(accessTokenValue))).thenThrow(new JwtException("Failed to decode"));
 

--- a/authentication/src/test/resources/camunda-bar-realm.json
+++ b/authentication/src/test/resources/camunda-bar-realm.json
@@ -1,0 +1,2538 @@
+{
+  "id": "7f73c7bf-5c45-48d5-8029-5ac607a7030c",
+  "realm": "camunda-bar",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "bruteForceStrategy": "MULTIPLE",
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "346b742a-db8c-464b-bc6c-2820ce445ef6",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "7f73c7bf-5c45-48d5-8029-5ac607a7030c",
+        "attributes": {}
+      },
+      {
+        "id": "efbf96be-512b-4946-93a8-9b5eb0cd8bbc",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "7f73c7bf-5c45-48d5-8029-5ac607a7030c",
+        "attributes": {}
+      },
+      {
+        "id": "55a64744-aaf1-47d8-9285-2ad6d2ce9032",
+        "name": "default-roles-camunda-bar",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "view-profile",
+              "manage-account"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "7f73c7bf-5c45-48d5-8029-5ac607a7030c",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "realm-management": [
+        {
+          "id": "30b84814-d6d3-4e0b-8ab5-5db8d306cdf4",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "685755ed-d158-4a76-b47e-696ce7c20aa8",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "64336ffd-ee19-4fa1-804b-c288aa2d01a3",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "12d5869d-3d11-498a-a7b7-21ca02b06639",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "dfde8dc8-f8ff-4601-a4eb-191c8f33159b",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "07025d37-4cf7-41ec-9672-4971fd3eab92",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "fc3c2d70-8387-45f2-b1d2-32cf17e359b0",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "df6edee9-6331-40a7-bedd-19380fd9c9fe",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "fd71ff3e-bf45-4525-ba54-a6f90889b0ca",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "ecbe0ebb-81b6-4177-b9c7-bea3adc22076",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "7798ba41-1469-4e22-9967-22817e35698e",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "76e18046-70f3-42cb-b695-94b1a4594d1a",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "manage-identity-providers",
+                "query-realms",
+                "view-events",
+                "query-users",
+                "query-clients",
+                "view-authorization",
+                "create-client",
+                "manage-users",
+                "manage-events",
+                "manage-authorization",
+                "query-groups",
+                "view-users",
+                "manage-realm",
+                "impersonation",
+                "view-realm",
+                "view-identity-providers",
+                "view-clients",
+                "manage-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "082442be-f1f7-47c5-a7a9-9acef75a8657",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-users",
+                "query-groups"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "b49828ac-2746-42a8-a449-674f3010defa",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "842ba117-fe25-4c8c-a71b-d535da8892bf",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "e712ee47-28ef-4a6f-9f96-643f942bb482",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "3bfcfcc4-a0c6-4012-bde6-3804833d3994",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "4a1cbfd3-7c82-436e-a6c4-8c5766149f25",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        },
+        {
+          "id": "0b365f06-4755-44b6-97ae-ad4e4df92086",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "aba36471-76f2-4b38-9183-74fd023ee238",
+          "attributes": {}
+        }
+      ],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "camunda-bar": [],
+      "broker": [
+        {
+          "id": "84667ebb-410b-491f-9de7-ce6b7142208e",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "116b4e04-be98-4b0b-84db-1fa277921dae",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "9c330a1f-bc78-4234-a087-71273a9e0a50",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "9cb5930c-c1dc-4eed-a7ed-98afba7126ad",
+          "attributes": {}
+        },
+        {
+          "id": "8ecca6a6-a782-4727-8720-5464f9eb8660",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "9cb5930c-c1dc-4eed-a7ed-98afba7126ad",
+          "attributes": {}
+        },
+        {
+          "id": "85e81f36-8318-4fe7-a2fa-87b132f5b54d",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "9cb5930c-c1dc-4eed-a7ed-98afba7126ad",
+          "attributes": {}
+        },
+        {
+          "id": "5963a5db-7a8f-4444-9d74-3beb35d0a592",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "9cb5930c-c1dc-4eed-a7ed-98afba7126ad",
+          "attributes": {}
+        },
+        {
+          "id": "7ca987c3-14c6-432d-b1d2-4ff1eb07bd61",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "9cb5930c-c1dc-4eed-a7ed-98afba7126ad",
+          "attributes": {}
+        },
+        {
+          "id": "8b0ebf42-4d20-427d-8f78-8a98915c180b",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "9cb5930c-c1dc-4eed-a7ed-98afba7126ad",
+          "attributes": {}
+        },
+        {
+          "id": "04049d72-109f-41c6-bd9b-2755f7fff3cc",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "9cb5930c-c1dc-4eed-a7ed-98afba7126ad",
+          "attributes": {}
+        },
+        {
+          "id": "6a9e3228-0c03-43f3-a0e7-9286657406fb",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "9cb5930c-c1dc-4eed-a7ed-98afba7126ad",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "55a64744-aaf1-47d8-9285-2ad6d2ce9032",
+    "name": "default-roles-camunda-bar",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "7f73c7bf-5c45-48d5-8029-5ac607a7030c"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "users": [
+    {
+      "id": "bd952f11-7178-45fa-99e8-c49aa258b635",
+      "username": "service-account-camunda-bar",
+      "emailVerified": false,
+      "enabled": true,
+      "createdTimestamp": 1756999989773,
+      "totp": false,
+      "serviceAccountClientId": "camunda-bar",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-camunda-bar"
+      ],
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account",
+          "view-groups"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "9cb5930c-c1dc-4eed-a7ed-98afba7126ad",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/camunda-bar/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/camunda-bar/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "bf5647d7-8a29-432d-80bd-17d68b21d06d",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/camunda-bar/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/camunda-bar/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "62015abc-3c0a-44ee-b2b4-0128e7706a44",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "deb7af71-5cbf-4c88-8b60-cbc5d6d1cadc",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "116b4e04-be98-4b0b-84db-1fa277921dae",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "58bc7fca-529f-44e0-94ff-9fa5909c6b94",
+      "clientId": "camunda-bar",
+      "name": "",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kCgndC3n3apTVJ8j76X3Y6hpqbxR7Kvf",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1756999989",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "service_account",
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "aba36471-76f2-4b38-9183-74fd023ee238",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "205dfe05-ba8a-466e-add2-35dba6d3a68a",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/camunda-bar/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/camunda-bar/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "87788578-fcbf-4224-a6ce-ca05f030a79b",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "ed985d00-a082-4ac9-a117-c4719c344242",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "4ddd6859-b2ee-40f9-949e-85727751af75",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "ed89912c-a042-4b03-ba82-822fb6e7644a",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "a4ce957e-c4b3-4ed5-830f-a6454ee61ff5",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "d4522042-b920-41f6-94ca-58467e88b838",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "4fdb64d6-26bd-4b95-b428-71269183e18c",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7e2a18db-613f-46f8-a849-1e3f1c28c5af",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "78d42e7b-c836-4c7d-8036-dcf87ce9fae9",
+      "name": "service_account",
+      "description": "Specific scope for a client enabled for service accounts",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "9706261d-2f5a-487d-a3ee-8cb104b5b441",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5dcf1602-461d-418a-b1ae-47a838b8606d",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a0b5a4be-afef-4896-8231-748c2ba30802",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "867ce84c-c65e-49d2-8a70-6444d16426dc",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "4c539cf0-806d-4238-8f3b-350802756e98",
+      "name": "saml_organization",
+      "description": "Organization Membership",
+      "protocol": "saml",
+      "attributes": {
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "34d77b85-cdd8-43d1-9f50-0125c68ad736",
+          "name": "organization",
+          "protocol": "saml",
+          "protocolMapper": "saml-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "6388feed-7c56-40e9-a302-932275f031f1",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${phoneScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "ea104e31-4908-412e-9343-1961fc084b0f",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "02fdade5-5f03-4fc6-a011-0211fe0d1cb8",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "76bcb974-33f8-44b9-bb75-770d52b89e6d",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${profileScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "d8885200-30e6-4e00-971f-1ed998ab42a3",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cf507562-92bc-47a3-9319-4dd766971f7e",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "8090dce7-8681-4d64-862a-c11c61b98ab1",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "c261029f-4763-4605-920f-6da3c919ebee",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "f815e174-d522-40af-9a1d-a9de22a2da0b",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "20a95ced-21ae-47e1-a17f-0dd9487c4eb8",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e88927ff-b569-4ac2-8b96-c8d96c83f6ba",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "103d4edc-3464-4a21-895e-f66d9c28c322",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5ca680d4-efb3-400e-933e-301a48222010",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "ac6aa0c9-ff22-4419-a695-55f821db948f",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "018e929b-7ad6-413d-9399-ad4e0978bf4a",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e217b65e-9d64-43c0-946b-2273155c8515",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4f649c5f-50f1-4893-8f29-51af66b3e310",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d2240d08-6adc-481c-a482-19807ba8a517",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "3213e6bd-c55f-4c71-8d0b-5e7685b8574c",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${emailScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "38f04697-a7d8-4d20-b859-e6e4f12d71ef",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3b93a660-4a69-4a6a-b5e7-60e0d5e20d06",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "f13edbb7-d94d-4aa9-90a1-a5d2945a965f",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${addressScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "2c3664ca-af32-4a46-820c-47d9bcc46a0d",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "introspection.token.claim": "true",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "df43df37-bd1a-4ea3-a1de-fbcb39d639b1",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "${rolesScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "5616bbbc-146e-4677-8c7a-3efc05dd1efe",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "id": "12d9611f-157f-4b01-a1a4-049dfee59376",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "aec16389-db66-4e9c-aadc-df1475ae7a57",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "1db03916-429a-4f18-b131-2ac933e7ac51",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "6cab0842-9228-4ce1-aa79-ddbff4f64ca5",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "6eeb8784-5cbf-4301-a6d6-3fcb4a228743",
+      "name": "organization",
+      "description": "Additional claims about the organization a subject belongs to",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${organizationScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "63f831a1-d80d-484a-9423-8a1012d9d43e",
+          "name": "organization",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "organization",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "13e31244-5364-432b-86ce-3727f93d1a9f",
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "44e75a4e-a3ee-45fd-b185-fcd689bb820b",
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "934269f3-eaf9-4ad8-8580-5a8ca62bafbb",
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "saml_organization",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr",
+    "basic"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt",
+    "organization"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "78d0a05e-016a-4eed-b1e6-1ee56f36f5f1",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-full-name-mapper",
+            "saml-user-attribute-mapper",
+            "saml-user-property-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-address-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-attribute-mapper"
+          ]
+        }
+      },
+      {
+        "id": "dbc20b4e-71e4-4892-8eec-641879942757",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "c30b258d-63d9-4f8d-9bb1-6b8ded26fa0d",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-attribute-mapper",
+            "saml-role-list-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-full-name-mapper",
+            "saml-user-property-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-address-mapper"
+          ]
+        }
+      },
+      {
+        "id": "8c3beab0-4f40-4947-b0d0-7d0bc5548c82",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "e89b8960-8b1a-47fc-9b24-5314fd833c29",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "df46df1e-5931-4437-b7fa-652fb9af40b1",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "97748f8f-e29e-4dbb-a347-510baf158891",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "5a9e66bc-dd49-4d10-839e-c82b082bc008",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "2f291cf0-b03c-4d9f-8abf-20beb0114f28",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS512"
+          ]
+        }
+      },
+      {
+        "id": "103708af-c556-468d-bea4-551a30e30995",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "fd41cedf-8f98-4bae-9c6e-5e49ff407bb2",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "RSA-OAEP"
+          ]
+        }
+      },
+      {
+        "id": "d90f4640-d1b8-4f4f-b907-f49adddf7588",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "authenticationFlows": [
+    {
+      "id": "59c878de-7107-4545-8b75-b4141844a60a",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "68ce08ae-8675-44bf-8338-0f19e9cedabd",
+      "alias": "Browser - Conditional 2FA",
+      "description": "Flow to determine if any 2FA is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "webauthn-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-recovery-authn-code-form",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "1ac6d68e-255f-472c-bf52-bea219ddb762",
+      "alias": "Browser - Conditional Organization",
+      "description": "Flow to determine if the organization identity-first login is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "organization",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a2287b6b-59ae-432f-81ee-6ee6b0be6896",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "46cdff66-1432-4a39-8594-fcfdbe75ce8b",
+      "alias": "First Broker Login - Conditional Organization",
+      "description": "Flow to determine if the authenticator that adds organization members is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "idp-add-organization-member",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "7167b4a0-1606-442f-b4cc-c76ab047ae69",
+      "alias": "First broker login - Conditional 2FA",
+      "description": "Flow to determine if any 2FA is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "webauthn-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-recovery-authn-code-form",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "fb2f3fb5-6d7c-4d77-8517-95a12701e15a",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "bd87b69f-5052-4b69-8a37-90d843168a5b",
+      "alias": "Organization",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "67ad8306-9e72-4b39-9e5d-631656340f8c",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "88c5cb3c-117c-498f-85b5-ba9bbcb7a273",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "54798241-c6fb-4344-9ca6-81336319dabe",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional 2FA",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "8c6a876e-1e78-4507-94ae-56ee4ee14ab6",
+      "alias": "browser",
+      "description": "Browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 26,
+          "autheticatorFlow": true,
+          "flowAlias": "Organization",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "d3410d62-85b3-42bb-9290-defa5b1dde8f",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "44a42df4-7781-495b-bb0e-bab5c600d004",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "68397549-57db-4676-8684-0e4e4e412ae1",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "4faeed46-f9ac-4082-8978-54bd40008399",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 50,
+          "autheticatorFlow": true,
+          "flowAlias": "First Broker Login - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0e521918-3892-42d8-8984-f6e5793fcb99",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional 2FA",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "48b49d4a-672f-4f3a-acee-ff45553b7e8a",
+      "alias": "registration",
+      "description": "Registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "d95b8a96-8d6a-4cfd-9796-126231af1e17",
+      "alias": "registration form",
+      "description": "Registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e1e05dda-0200-480b-9457-caf31177b324",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "3b3ae0dc-2cea-430e-bb4e-65913f7d95c6",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "f2364a48-5350-45d5-9bef-69c590cb5959",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "5073bbd6-5b06-449c-93f7-2852339cd485",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 90,
+      "config": {}
+    },
+    {
+      "alias": "delete_credential",
+      "name": "Delete Credential",
+      "providerId": "delete_credential",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 100,
+      "config": {}
+    },
+    {
+      "alias": "idp_link",
+      "name": "Linking Identity Provider",
+      "providerId": "idp_link",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 110,
+      "config": {}
+    },
+    {
+      "alias": "CONFIGURE_RECOVERY_AUTHN_CODES",
+      "name": "Recovery Authentication Codes",
+      "providerId": "CONFIGURE_RECOVERY_AUTHN_CODES",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 120,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaExpiresIn": "120",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DeviceCodeLifespan": "600",
+    "oauth2DevicePollingInterval": "5",
+    "parRequestUriLifespan": "60",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false"
+  },
+  "keycloakVersion": "26.3.2",
+  "userManagedAccessAllowed": false,
+  "organizationsEnabled": false,
+  "verifiableCredentialsEnabled": false,
+  "adminPermissionsEnabled": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}

--- a/authentication/src/test/resources/camunda-foo-realm.json
+++ b/authentication/src/test/resources/camunda-foo-realm.json
@@ -1,0 +1,2567 @@
+{
+  "id": "3cc7893c-d66b-496d-a6bd-33252bce2a00",
+  "realm": "camunda-foo",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "bruteForceStrategy": "MULTIPLE",
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "85aeade8-01e2-4c80-aa80-f341ff4a2e56",
+        "name": "default-roles-camunda-foo",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "manage-account",
+              "view-profile"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "3cc7893c-d66b-496d-a6bd-33252bce2a00",
+        "attributes": {}
+      },
+      {
+        "id": "41de43c6-8fc4-4243-92ad-67b643e1ec84",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "3cc7893c-d66b-496d-a6bd-33252bce2a00",
+        "attributes": {}
+      },
+      {
+        "id": "2864791e-2efa-44ea-b28b-1a7f63d95ee6",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "3cc7893c-d66b-496d-a6bd-33252bce2a00",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "realm-management": [
+        {
+          "id": "b3b98202-a521-44db-9779-3dafcf16fefe",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "5b772415-e674-42a2-915f-d569ea4d0f73",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "88eb855a-6172-40f8-9974-db600833f4d0",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients",
+                "impersonation",
+                "view-realm",
+                "view-clients",
+                "manage-users",
+                "manage-identity-providers",
+                "view-identity-providers",
+                "view-authorization",
+                "manage-realm",
+                "view-events",
+                "query-groups",
+                "manage-events",
+                "create-client",
+                "query-users",
+                "query-realms",
+                "manage-authorization",
+                "view-users",
+                "manage-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "a2c3cceb-3f49-450b-8c5e-16e29362ff68",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "48091f3b-4137-47f9-92af-e78172ec0c05",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "8ca42489-6b6a-4d95-8cd8-99879cb1fdb7",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "96d6a24d-7a29-43e3-b2c8-eeda3773021c",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "1e407989-0d7f-471f-a6b1-70fe0f90c6fa",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "80e66813-1029-47ff-b681-010b16a0a067",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "496f00d7-bff0-484c-8cd8-f7608e8b33e8",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "baf45085-f098-4501-899a-750d49eb470b",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "35985770-280c-4523-a257-bd85d4a2e208",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "cfc67c15-e332-4b7d-9821-8733d1b0bb7a",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "16e4021b-4734-4b9d-919a-b7c17bac8601",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "a1d5b9ae-8de6-486a-ba18-b5824f4e731b",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "e1bb1648-b9fd-431c-9b04-72d54081de02",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "f7f7d6b5-8f38-4cb5-9a2b-e800fa6ed402",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "85bf3dcf-def0-4f88-8f8f-d13f1aa68147",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-users",
+                "query-groups"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        },
+        {
+          "id": "016ac713-838e-421a-a377-60d8aefa49bd",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b169733-896b-4582-9196-3387e16e2323",
+          "attributes": {}
+        }
+      ],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "98472609-832c-41ec-92dc-bc6b8e5f662e",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d09c139e-de34-49cf-99b0-35ff2b41fec9",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "7a0c54bb-ae14-4dd0-894d-342800b509c8",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "4b332f27-9783-4150-8a32-dae23a06a286",
+          "attributes": {}
+        },
+        {
+          "id": "a246323b-493a-47d8-986a-f5f4047c0b25",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "4b332f27-9783-4150-8a32-dae23a06a286",
+          "attributes": {}
+        },
+        {
+          "id": "74d53012-be8e-4908-aca0-5ad72b253265",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "4b332f27-9783-4150-8a32-dae23a06a286",
+          "attributes": {}
+        },
+        {
+          "id": "377130ee-0235-4339-8a0f-e9eee64aac86",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "4b332f27-9783-4150-8a32-dae23a06a286",
+          "attributes": {}
+        },
+        {
+          "id": "8a7e73a8-7f45-41ac-8f5c-71dfcaa22d40",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "4b332f27-9783-4150-8a32-dae23a06a286",
+          "attributes": {}
+        },
+        {
+          "id": "e77a51c7-0038-4fd2-80c1-d9ad76e83d54",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "4b332f27-9783-4150-8a32-dae23a06a286",
+          "attributes": {}
+        },
+        {
+          "id": "d57c04ab-8abb-49f3-986f-6db3af8ecded",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "4b332f27-9783-4150-8a32-dae23a06a286",
+          "attributes": {}
+        },
+        {
+          "id": "02261e55-da01-414a-86ad-0037a56eed80",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "4b332f27-9783-4150-8a32-dae23a06a286",
+          "attributes": {}
+        }
+      ],
+      "camunda-foo": []
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "85aeade8-01e2-4c80-aa80-f341ff4a2e56",
+    "name": "default-roles-camunda-foo",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "3cc7893c-d66b-496d-a6bd-33252bce2a00"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "users": [
+    {
+      "id": "9e32bdbc-cbe5-42ee-89ed-872d352ffe64",
+      "username": "service-account-camunda-foo",
+      "emailVerified": false,
+      "enabled": true,
+      "createdTimestamp": 1756997545550,
+      "totp": false,
+      "serviceAccountClientId": "camunda-foo",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-camunda-foo"
+      ],
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account",
+          "view-groups"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "4b332f27-9783-4150-8a32-dae23a06a286",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/camunda-foo/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/camunda-foo/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "ffc8ddaf-900d-425b-b996-d248c043e2a5",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/camunda-foo/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/camunda-foo/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "f1fb61f0-b22f-414c-9742-40850e4c09b9",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "c09cec24-c6fc-4b00-bb99-c3baecb10075",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "d09c139e-de34-49cf-99b0-35ff2b41fec9",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "5888f1bf-e435-46e5-8bf5-cb3b31405650",
+      "clientId": "camunda-foo",
+      "name": "",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "pW7IzLnbYMpPk785irfwoQjBQ3VSQnT3",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1756997545",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "service_account",
+        "web-origins",
+        "acr",
+        "Audience",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "1b169733-896b-4582-9196-3387e16e2323",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "c9faff69-3223-41e4-9695-7a70b8cbb363",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/camunda-foo/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/camunda-foo/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "bcac37e4-567e-4c5c-ad26-2bd9742b3604",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "1bf27ec4-e95f-4a47-897b-82116b68bac7",
+      "name": "saml_organization",
+      "description": "Organization Membership",
+      "protocol": "saml",
+      "attributes": {
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "5db91c95-7ef2-4e7f-ab88-a5ced088f5c4",
+          "name": "organization",
+          "protocol": "saml",
+          "protocolMapper": "saml-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "6a97def3-fe5b-4a03-8237-b8679c860453",
+      "name": "organization",
+      "description": "Additional claims about the organization a subject belongs to",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${organizationScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "eef47f8c-97b4-46c3-aa9b-0b40a58ab9b4",
+          "name": "organization",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "organization",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "abb824f1-bf1b-44f9-aef1-0d4f197444ee",
+      "name": "Audience",
+      "description": "",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "gui.order": "",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "53307643-0f02-4410-a524-7a520ff4ac24",
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true",
+            "included.custom.audience": "camunda-foo"
+          }
+        }
+      ]
+    },
+    {
+      "id": "8b047b2a-b345-4546-b521-2f1305b2a3da",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${addressScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "613feef2-78cd-4b63-b20a-1b1563697e4f",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "introspection.token.claim": "true",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "8d444714-e054-4041-b610-17cb3bc9065f",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "3cf15bd5-26e1-4c97-b27a-0554a958a95a",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "54d8cdb8-eb1b-4e77-bc4f-4edf076f2ffb",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${phoneScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "8f6828b3-903d-4238-9132-de3890d2cbfb",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3c379263-f7b5-4e78-b639-a6508fd91bb0",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "99cd9205-1846-4d3b-953f-3ce3f6b83ef0",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${profileScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "05bda12f-39ec-4422-8451-d132ae3acd51",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ca83bd11-21cb-4712-a6ac-ed552e9304c6",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "835072a8-0f5d-42bc-8398-610b758c6a84",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "43516837-2ce8-4298-85cb-c397c854f4bb",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c180fe76-f550-4046-b063-d577e5194cca",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ad5b9cbe-d89e-4d38-be4a-e1c5d96244fc",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d41c30dd-708b-40ba-b02d-10aea9e20d8a",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "19d26c3e-d694-408a-9c03-6f029fd80e5a",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "26f8c7dc-d4c8-4dd6-a355-ae1a66367bbe",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a85a49d9-ff6a-4f35-b0de-f5e1b3c9d7a6",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "d2a0532f-0a29-4326-bdd1-64cce934b1df",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a0415454-4a5e-4518-84ed-b59202ed168b",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "f969260b-d8de-4dfd-a5e5-18ee98c31a34",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "2b7de736-3b79-4673-a181-7c5973181b27",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "59cf8396-6d9b-4ef4-967a-d2dfc40999f9",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "${rolesScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "faaedbdb-b99e-4540-849d-79f2c1140999",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "id": "6030efd3-911a-4f9b-9c51-ed01c7d8818e",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "8aa70d94-b065-4eeb-8c87-5027e0984fe2",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "bc4fb455-f18b-4773-9353-901c8afa1696",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "fdedd210-be47-4814-bd35-2b950aab58ae",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "10621057-1f3a-454d-831f-689a751ff1ee",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "9da8ce8f-ff9b-4909-951b-ec2f1d101943",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "7c21910d-36b0-4b9d-b4dd-8b31e3627d39",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "36fba146-2a90-4675-9b88-1b7542917778",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "62d48674-405b-4c63-9d51-50f17985ff5c",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "59d338ef-e6f4-47b7-bfee-39ea389352f4",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "1517f238-8430-4d00-9228-9ec31f50cb79",
+      "name": "service_account",
+      "description": "Specific scope for a client enabled for service accounts",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "0966f725-2e98-4016-a975-0edd8402f8b4",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "46d041ba-4a58-4ade-9e22-e2cc90adbf30",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3adec576-8867-4952-98a9-5b362da1b6fd",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "d9e46d1c-5846-4fe2-a3d6-d76560855b66",
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "426cc67d-f73a-4a3f-b352-284b786fa71e",
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "id": "9d867577-03c4-4359-af17-0113e1ab4a25",
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        }
+      ]
+    },
+    {
+      "id": "c95b824c-de0c-4e68-ab24-88cd32938e3d",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${emailScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "1894f148-8f11-4781-8030-2a288c18bbd7",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "76993312-4e51-46c2-acb0-d6c51e86dc10",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "saml_organization",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr",
+    "basic"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt",
+    "organization"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "e4c77471-e570-4ef5-bc66-a6f0f4acb968",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "bc15d40f-41ee-43bb-af29-a34ebfcf1839",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "99fe03d0-7a38-4691-a473-3f682b962284",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "a4e7f252-32ae-4213-8ae6-5a5db26830b3",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "b4221474-4bbd-4d30-97d0-b19f2fb6f6fc",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "df61401e-8fbd-4d3c-9d19-927eead66adc",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "e8bbe62d-381d-40e5-ba7d-3fd7c474ac28",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-address-mapper",
+            "oidc-full-name-mapper",
+            "saml-user-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-role-list-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-property-mapper"
+          ]
+        }
+      },
+      {
+        "id": "2db45a79-9964-45fd-a862-82fa7c5c203c",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-property-mapper",
+            "oidc-address-mapper",
+            "saml-user-property-mapper",
+            "saml-role-list-mapper",
+            "oidc-full-name-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "855d2c17-14cd-49dc-8774-ab119255c3ab",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "RSA-OAEP"
+          ]
+        }
+      },
+      {
+        "id": "8791da56-3af9-49b4-928e-efdb6164d8ff",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "4b3230c0-26de-4a43-bd5b-39c8aea65365",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS512"
+          ]
+        }
+      },
+      {
+        "id": "e3c2f8f0-1a87-4dc5-955d-8ce78696aeae",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "authenticationFlows": [
+    {
+      "id": "9aac063a-6227-4c59-8b22-b03a55367198",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "ec576af6-c878-466b-9b17-46589d1b10f2",
+      "alias": "Browser - Conditional 2FA",
+      "description": "Flow to determine if any 2FA is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "webauthn-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-recovery-authn-code-form",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "d8bebec1-2edb-4c23-812e-b6554668edec",
+      "alias": "Browser - Conditional Organization",
+      "description": "Flow to determine if the organization identity-first login is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "organization",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "8d1b4769-3c44-46b3-b0c8-7600a4b35617",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "ee21cc1f-4534-4352-a7d9-9181c96164e6",
+      "alias": "First Broker Login - Conditional Organization",
+      "description": "Flow to determine if the authenticator that adds organization members is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "idp-add-organization-member",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "4f980c81-07b7-43b1-bd75-8ff94b4023e4",
+      "alias": "First broker login - Conditional 2FA",
+      "description": "Flow to determine if any 2FA is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "webauthn-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-recovery-authn-code-form",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "6d1b83f0-85c9-4f2f-8c7e-87f1660c1abc",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0dc24cd8-5a6d-40c2-90aa-60fb1de91207",
+      "alias": "Organization",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "71ef7bd2-e9c8-4202-a813-ce7f7c083867",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "225adb4b-86d7-440c-a4dd-886aae8fffda",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "84ed0461-e0bf-45b8-8a3c-7d041b724663",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional 2FA",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "df35ca8b-752f-4564-9247-a1d3256e662f",
+      "alias": "browser",
+      "description": "Browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 26,
+          "autheticatorFlow": true,
+          "flowAlias": "Organization",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "371d9fce-11e5-4e0f-81c6-bfb76554d34c",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0ea6dfeb-0722-49ce-b49a-19b74e4acc43",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "30100770-ce1d-4c82-8cbd-007a291c000f",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "8281b794-1df3-452b-96ea-80412f2b8f31",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 50,
+          "autheticatorFlow": true,
+          "flowAlias": "First Broker Login - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "dfc1c75f-5bf1-4f92-bda7-8de1aba1580c",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional 2FA",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "2638b3bc-3880-4107-b0e6-07c72db30efc",
+      "alias": "registration",
+      "description": "Registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "f9fa92f0-aafd-4f86-bc48-5c870779e6e3",
+      "alias": "registration form",
+      "description": "Registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "2fdeb4fe-7d3f-4dfb-8e47-504baf7632d7",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "4e67f619-73b0-40da-91fa-be127df21b4f",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "224b05a9-1f36-4f16-a90e-f5d155bc80c9",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "6a4a437e-fa58-4a28-bb6c-bf6056637488",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 90,
+      "config": {}
+    },
+    {
+      "alias": "delete_credential",
+      "name": "Delete Credential",
+      "providerId": "delete_credential",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 100,
+      "config": {}
+    },
+    {
+      "alias": "idp_link",
+      "name": "Linking Identity Provider",
+      "providerId": "idp_link",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 110,
+      "config": {}
+    },
+    {
+      "alias": "CONFIGURE_RECOVERY_AUTHN_CODES",
+      "name": "Recovery Authentication Codes",
+      "providerId": "CONFIGURE_RECOVERY_AUTHN_CODES",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 120,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaExpiresIn": "120",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DeviceCodeLifespan": "600",
+    "oauth2DevicePollingInterval": "5",
+    "parRequestUriLifespan": "60",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false"
+  },
+  "keycloakVersion": "26.3.2",
+  "userManagedAccessAllowed": false,
+  "organizationsEnabled": false,
+  "verifiableCredentialsEnabled": false,
+  "adminPermissionsEnabled": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
@@ -19,6 +19,8 @@ public class AuthenticationConfiguration {
       new OidcAuthenticationConfiguration();
   private boolean unprotectedApi = DEFAULT_UNPROTECTED_API;
 
+  private ProvidersConfiguration providers;
+
   public boolean getUnprotectedApi() {
     return unprotectedApi;
   }
@@ -49,5 +51,13 @@ public class AuthenticationConfiguration {
 
   public void setOidc(final OidcAuthenticationConfiguration configuration) {
     oidcAuthenticationConfiguration = configuration;
+  }
+
+  public ProvidersConfiguration getProviders() {
+    return providers;
+  }
+
+  public void setProviders(final ProvidersConfiguration providers) {
+    this.providers = providers;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -25,6 +25,7 @@ public class OidcAuthenticationConfiguration {
           CLIENT_AUTHENTICATION_METHOD_PRIVATE_KEY_JWT);
 
   private String issuerUri;
+  private String clientName;
   private String clientId;
   private String clientSecret;
   private String grantType = "authorization_code";
@@ -59,6 +60,14 @@ public class OidcAuthenticationConfiguration {
 
   public void setIssuerUri(final String issuerUri) {
     this.issuerUri = issuerUri;
+  }
+
+  public String getClientName() {
+    return clientName;
+  }
+
+  public void setClientName(final String clientName) {
+    this.clientName = clientName;
   }
 
   public String getClientId() {
@@ -228,6 +237,7 @@ public class OidcAuthenticationConfiguration {
   public static class Builder {
     private String issuerUri;
     private String clientId;
+    private String clientName;
     private String clientSecret;
     private String grantType = "authorization_code";
     private String redirectUri;
@@ -253,6 +263,11 @@ public class OidcAuthenticationConfiguration {
 
     public Builder clientId(final String clientId) {
       this.clientId = clientId;
+      return this;
+    }
+
+    public Builder clientName(final String clientName) {
+      this.clientName = clientName;
       return this;
     }
 
@@ -338,6 +353,7 @@ public class OidcAuthenticationConfiguration {
       final OidcAuthenticationConfiguration config = new OidcAuthenticationConfiguration();
       config.setIssuerUri(issuerUri);
       config.setClientId(clientId);
+      config.setClientName(clientName);
       config.setClientSecret(clientSecret);
       config.setGrantType(grantType);
       config.setRedirectUri(redirectUri);

--- a/security/security-core/src/main/java/io/camunda/security/configuration/ProvidersConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ProvidersConfiguration.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+import java.util.Map;
+
+public class ProvidersConfiguration {
+
+  private Map<String, OidcAuthenticationConfiguration> oidc;
+
+  public Map<String, OidcAuthenticationConfiguration> getOidc() {
+    return oidc;
+  }
+
+  public void setOidc(final Map<String, OidcAuthenticationConfiguration> oidc) {
+    this.oidc = oidc;
+  }
+}


### PR DESCRIPTION
## Description

* Adds support to configure multiple OIDC providers
* When an unauthenticated user accesses the C8 Webapps, they get redirected to a Login Page that lists all available OIDC providers
* When an access token is passed while calling the API, it is accepted when the issuer is known (as configured in the OIDC provider configuration).
* With a single OIDC provider configuration, nothing changes.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37676
