### PR TITLE
[Backport stable/8.6] fix: add missing placeholder in backup failure log message

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/LoggingBackupStore.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/LoggingBackupStore.java
@@ -64,7 +64,7 @@ public class LoggingBackupStore implements BackupStore {
   @Override
   public CompletableFuture<BackupStatusCode> markFailed(
       final BackupIdentifier id, final String failureReason) {
-    logger.atLevel(level).log("Marking {} as failed", id, failureReason);
+    logger.atLevel(level).log("Marking {} as failed: {}", id, failureReason);
     return store.markFailed(id, failureReason);
   }
 


### PR DESCRIPTION
# Description
Backport of #37518 to `stable/8.6`.

relates to 