### PR TITLE
feat: add parent process instance selector

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceSelectors.java
@@ -41,6 +41,17 @@ public class ProcessInstanceSelectors {
     return new ProcessDefinitionIdSelector(processDefinitionId);
   }
 
+  /**
+   * Select the process instance by its parent process instance key
+   *
+   * @param parentProcessInstanceKey the key of the parent instance
+   * @return the selector
+   */
+  public static ProcessInstanceSelector byParentProcesInstanceKey(
+      final long parentProcessInstanceKey) {
+    return new ParentProcessInstanceKeySelector(parentProcessInstanceKey);
+  }
+
   private static final class ProcessInstanceKeySelector implements ProcessInstanceSelector {
 
     private final long processInstanceKey;
@@ -62,6 +73,30 @@ public class ProcessInstanceSelectors {
     @Override
     public void applyFilter(final ProcessInstanceFilter filter) {
       filter.processInstanceKey(processInstanceKey);
+    }
+  }
+
+  private static final class ParentProcessInstanceKeySelector implements ProcessInstanceSelector {
+
+    private final long parentProcessInstanceKey;
+
+    private ParentProcessInstanceKeySelector(final long parentProcessInstanceKey) {
+      this.parentProcessInstanceKey = parentProcessInstanceKey;
+    }
+
+    @Override
+    public boolean test(final ProcessInstance processInstance) {
+      return processInstance.getParentProcessInstanceKey().equals(parentProcessInstanceKey);
+    }
+
+    @Override
+    public String describe() {
+      return String.format("parent key: %s", parentProcessInstanceKey);
+    }
+
+    @Override
+    public void applyFilter(final ProcessInstanceFilter filter) {
+      filter.parentProcessInstanceKey(parentProcessInstanceKey);
     }
   }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/ProcessInstanceBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/ProcessInstanceBuilder.java
@@ -186,6 +186,27 @@ public class ProcessInstanceBuilder implements ProcessInstance {
     return this;
   }
 
+  public static ProcessInstanceBuilder newActiveChildProcessInstance(
+      final long processInstanceKey, final long parentElementInstanceKey) {
+
+    return newActiveProcessInstance(processInstanceKey)
+        .setParentProcessInstanceKey(parentElementInstanceKey);
+  }
+
+  public static ProcessInstanceBuilder newCompletedChildProcessInstance(
+      final long processInstanceKey, final long parentElementInstanceKey) {
+
+    return newCompletedProcessInstance(processInstanceKey)
+        .setParentProcessInstanceKey(parentElementInstanceKey);
+  }
+
+  public static ProcessInstanceBuilder newTerminatedChildProcessInstance(
+      final long processInstanceKey, final long parentElementInstanceKey) {
+
+    return newTerminatedProcessInstance(processInstanceKey)
+        .setParentProcessInstanceKey(parentElementInstanceKey);
+  }
+
   public static ProcessInstanceBuilder newActiveProcessInstance(final long processInstanceKey) {
     return new ProcessInstanceBuilder()
         .setProcessInstanceKey(processInstanceKey)


### PR DESCRIPTION
## Description

Adds a new process instance selector, `byParentProcesInstanceKey` that filters for the first valid child process instance.

## Related issues

closes #36410 
