### PR TITLE
ci: enable deploy of Optimize 8.8-SNAPSHOT Docker image

### DIFF
--- a/.github/optimize/scripts/build-docker-image.sh
+++ b/.github/optimize/scripts/build-docker-image.sh
@@ -12,6 +12,10 @@ if [ "${IS_MAIN}" = "true" ]; then
     tags+=("${DOCKER_IMAGE_DOCKER_HUB}:8-SNAPSHOT")
 fi
 
+if [ "${IS_STABLE_88}" = "true" ]; then
+    tags+=("${DOCKER_IMAGE_DOCKER_HUB}:8.8-SNAPSHOT")
+fi
+
 printf -v tag_arguments -- "-t %s " "${tags[@]}"
 docker buildx create --use
 

--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -41,6 +41,7 @@ jobs:
           echo "VERSION=${{ steps.pom-info.outputs.project_version }}"
           echo "PUSH_LATEST_TAG=${{ steps.define-values.outputs.is_main_or_stable_branch }}"
           echo "IS_MAIN=${{ steps.define-values.outputs.is_main_branch }}"
+          echo "IS_STABLE_88=${{ github.ref == 'refs/heads/stable/8.8' }}"
           echo "REVISION=${{ steps.define-values.outputs.git_commit_hash }}"
         } >> "$GITHUB_ENV"
     # Generating a production build


### PR DESCRIPTION
## Description

One-off adjustment to unlock Optimize 8.8-SNAPSHOT Docker image builds.

Mid-term when aligning the Optimize release process, we should harmonize this into version-agnostic reusable logic that detects stable branches 🤔

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to #37374
