### PR TITLE
test: v2 tenant and role endpoints

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -201,7 +201,14 @@ export class IdentityAuthorizationsPage {
 
   async selectAuthorizationOwner(authorization: {ownerId: string}) {
     await this.createAuthorizationOwnerComboBox.click();
-    await this.createAuthorizationOwnerOption(authorization.ownerId).click();
+    try {
+      await this.createAuthorizationOwnerOption(authorization.ownerId).click({
+        timeout: 20000,
+      });
+    } catch (error) {
+      console.log('Error while selecting owner' + error);
+      await this.createAuthorizationOwnerComboBox.fill(authorization.ownerId);
+    }
   }
 
   async assertAuthorizationExists(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
@@ -9,6 +9,7 @@
 import {Page, Locator, expect} from '@playwright/test';
 import {relativizePath, Paths} from 'utils/relativizePath';
 import {sleep} from 'utils/sleep';
+import {defaultAssertionOptions} from '../utils/constants';
 
 export class IdentityGroupsPage {
   private page: Page;
@@ -40,6 +41,7 @@ export class IdentityGroupsPage {
   readonly assignUserButtonModal: Locator;
   readonly selectGroupRow: (name: string) => Locator;
   readonly groupCell: (name: string) => Locator;
+  readonly groupsHeading: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -132,6 +134,7 @@ export class IdentityGroupsPage {
     this.assignUserButtonModal = page
       .getByLabel('Assign user')
       .getByRole('button', {name: 'Assign user'});
+    this.groupsHeading = this.page.getByRole('heading', {name: 'Groups'});
   }
 
   async navigateToGroups() {
@@ -165,7 +168,13 @@ export class IdentityGroupsPage {
   }
 
   async deleteGroup(groupName: string) {
-    await this.deleteGroupButton(groupName).click();
+    await expect(async () => {
+      await expect(this.deleteGroupButton(groupName)).toBeVisible({
+        timeout: 20000,
+      });
+      await this.groupsHeading.click();
+      await this.deleteGroupButton(groupName).click();
+    }).toPass(defaultAssertionOptions);
     await expect(this.deleteGroupModal).toBeVisible();
     await this.deleteGroupModalDeleteButton.click();
     await expect(this.deleteGroupModal).toBeHidden();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
@@ -133,8 +133,10 @@ export class IdentityRolesPage {
   }
 
   async deleteRole(roleName: string) {
-    await expect(this.deleteRoleButton(roleName)).toBeVisible({timeout: 20000});
     await expect(async () => {
+      await expect(this.deleteRoleButton(roleName)).toBeVisible({
+        timeout: 20000,
+      });
       await this.deleteRoleButton(roleName).click({timeout: 20000});
     }).toPass(defaultAssertionOptions);
     await expect(this.deleteRoleModal).toBeVisible();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
@@ -32,6 +32,7 @@ export class IdentityRolesPage {
   readonly deleteRoleModalCancelButton: Locator;
   readonly deleteRoleModalDeleteButton: Locator;
   readonly roleCell: (name: string) => Locator;
+  readonly rolesHeading: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -101,6 +102,7 @@ export class IdentityRolesPage {
     );
     this.roleCell = (roleID: string) =>
       this.rolesList.getByRole('cell', {name: roleID, exact: true});
+    this.rolesHeading = this.page.getByRole('heading', {name: 'Roles'});
   }
 
   async clickCreateRoles() {
@@ -137,6 +139,7 @@ export class IdentityRolesPage {
       await expect(this.deleteRoleButton(roleName)).toBeVisible({
         timeout: 20000,
       });
+      await this.rolesHeading.click();
       await this.deleteRoleButton(roleName).click({timeout: 20000});
     }).toPass(defaultAssertionOptions);
     await expect(this.deleteRoleModal).toBeVisible();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
@@ -8,6 +8,7 @@
 
 import {Page, Locator, expect} from '@playwright/test';
 import {relativizePath, Paths} from 'utils/relativizePath';
+import {defaultAssertionOptions} from '../utils/constants';
 
 export class IdentityTenantsPage {
   private page: Page;
@@ -38,6 +39,7 @@ export class IdentityTenantsPage {
   readonly userRow: (userName: string) => Locator;
   readonly tenantCell: (tenantName: string) => Locator;
   readonly tenantRow: (tenantName: string) => Locator;
+  readonly tenantsHeading: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -123,6 +125,7 @@ export class IdentityTenantsPage {
     this.confirmRemoveUserButton = this.removeUserModal.getByRole('button', {
       name: 'Remove user',
     });
+    this.tenantsHeading = this.page.getByRole('heading', {name: 'Tenants'});
   }
 
   async navigateToTenants() {
@@ -162,7 +165,14 @@ export class IdentityTenantsPage {
   }
 
   async deleteTenant(tenantName: string) {
-    await this.deleteTenantButton(tenantName).click();
+    await expect(async () => {
+      await expect(this.deleteTenantButton(tenantName)).toBeVisible({
+        timeout: 20000,
+      });
+      await this.tenantsHeading.click();
+      await this.deleteTenantButton(tenantName).click();
+    }).toPass(defaultAssertionOptions);
+
     await expect(this.deleteTenantModal).toBeVisible();
     await this.deleteTenantModalDeleteButton.click();
     await expect(this.deleteTenantModal).toBeHidden();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
@@ -18,14 +18,14 @@ import {
   assertConflictRequest,
 } from '../../../../utils/http';
 import {
-  CREATE_MAPPING_EXPECTED_BODY_USING_GROUP,
+  MAPPING_RULE_EXPECTED_BODY_USING_STATE,
   mappingRuleRequiredFields,
 } from '../../../../utils/beans/requestBeans';
 import {
   assignMappingToGroup,
   createGroupAndStoreResponseFields,
   createMappingRule,
-  groupMappingRuleFromState,
+  mappingRuleIdFromState,
 } from '../../../../utils/requestHelpers';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 
@@ -61,7 +61,7 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
   }) => {
     const stateParams: Record<string, string> = {
       groupId: state['groupId2'] as string,
-      mappingRuleId: groupMappingRuleFromState('groupId2', state) as string,
+      mappingRuleId: mappingRuleIdFromState('groupId2', state) as string,
     };
 
     await expect(async () => {
@@ -81,8 +81,6 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
 
   test('Search Mapping Rules For Group', async ({request}) => {
     const groupId: string = state['groupId2'] as string;
-    const expectedBody: Record<string, string> =
-      CREATE_MAPPING_EXPECTED_BODY_USING_GROUP(groupId, state);
 
     await expect(async () => {
       const res = await request.post(
@@ -99,7 +97,7 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
       assertRequiredFields(json.items[0], mappingRuleRequiredFields);
       assertEqualsForKeys(
         json.items[0],
-        expectedBody,
+        MAPPING_RULE_EXPECTED_BODY_USING_STATE('groupId2', state),
         mappingRuleRequiredFields,
       );
     }).toPass(defaultAssertionOptions);
@@ -137,7 +135,7 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
     await test.step('Unassign Mapping Rule', async () => {
       const p = {
         groupId: state['groupId3'] as string,
-        mappingRuleId: groupMappingRuleFromState('groupId3', state) as string,
+        mappingRuleId: mappingRuleIdFromState('groupId3', state) as string,
       };
 
       await expect(async () => {
@@ -172,7 +170,7 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
   test('Unassign Mapping Rule From Group Unauthorized', async ({request}) => {
     const p = {
       groupId: state['groupId2'] as string,
-      mappingRuleId: groupMappingRuleFromState('groupId2', state) as string,
+      mappingRuleId: mappingRuleIdFromState('groupId2', state) as string,
     };
     const res = await request.delete(
       buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),
@@ -186,7 +184,7 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
   test('Unassign Mapping Rule From Group Not Found', async ({request}) => {
     const p = {
       groupId: 'invalidGroupId',
-      mappingRuleId: groupMappingRuleFromState('groupId2', state) as string,
+      mappingRuleId: mappingRuleIdFromState('groupId2', state) as string,
     };
     const res = await request.delete(
       buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
@@ -91,7 +91,7 @@ test.describe.parallel('Group Users API Tests', () => {
   test('Search Users For Group', async ({request}) => {
     const groupId: string = state['groupId2'] as string;
     const expectedBody = CREATE_GROUP_USERS_EXPECTED_BODY_USING_GROUP(
-      groupId,
+      'groupId2',
       state,
     );
     const requiredFields = Object.keys(expectedBody);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
@@ -132,11 +132,13 @@ test.describe.parallel('Mapping Rules API Tests', () => {
       mappingRuleId: mappingRule1.mappingRuleId,
     };
 
-    const res = await request.post(buildUrl('/mapping-rules'), {
-      headers: jsonHeaders(),
-      data: requestBody,
-    });
-    await assertConflictRequest(res);
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
   });
 
   test('Get Mapping Rule', async ({request}) => {
@@ -147,7 +149,6 @@ test.describe.parallel('Mapping Rules API Tests', () => {
         }),
         {headers: jsonHeaders()},
       );
-
       expect(res.status()).toBe(200);
       const json = await res.json();
       assertRequiredFields(json, mappingRuleRequiredFields);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-api-tests.spec.ts
@@ -254,7 +254,7 @@ test.describe.parallel('Roles API Tests', () => {
     });
     await assertNotFoundRequest(
       res,
-      "Command 'DELETE' rejected with code 'NOT_FOUND",
+      "Command 'DELETE' rejected with code 'NOT_FOUND'",
     );
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-api-tests.spec.ts
@@ -1,0 +1,419 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertRequiredFields,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  assertEqualsForKeys,
+  assertBadRequest,
+  assertPaginatedRequest,
+} from '../../../../utils/http';
+import {
+  CREATE_NEW_ROLE,
+  roleRequiredFields,
+  UPDATE_ROLE,
+} from '../../../../utils/beans/requestBeans';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  assertRoleInResponse,
+  createRoleAndStoreResponseFields,
+} from '../../../../utils/requestHelpers';
+
+test.describe.parallel('Roles API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createRoleAndStoreResponseFields(request, 3, state);
+  });
+
+  test('Create Role', async ({request}) => {
+    await expect(async () => {
+      const role = CREATE_NEW_ROLE();
+      const res = await request.post(buildUrl('/roles'), {
+        headers: jsonHeaders(),
+        data: role,
+      });
+
+      expect(res.status()).toBe(201);
+      const json = await res.json();
+      assertRequiredFields(json, roleRequiredFields);
+      assertEqualsForKeys(json, role, roleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Role Unauthorized', async ({request}) => {
+    const res = await request.post(buildUrl('/roles'), {
+      headers: {},
+      data: CREATE_NEW_ROLE(),
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Create Role Missing Name Invalid Body 400', async ({request}) => {
+    const body = {description: 'only description provided'};
+    const res = await request.post(buildUrl('/roles'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, /.*\b(name)\b.*/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Create Role Empty Name Invalid Body 400', async ({request}) => {
+    const body = {name: '', description: 'empty name'};
+    const res = await request.post(buildUrl('/roles'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, /.*\b(name)\b.*/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Create Role Missing Role Id Invalid Body 400', async ({request}) => {
+    const body = {name: 'role name', description: 'only description provided'};
+    const res = await request.post(buildUrl('/roles'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, /.*\b(roleId)\b.*/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Create Role Conflict', async ({request}) => {
+    await expect(async () => {
+      const role = CREATE_NEW_ROLE();
+      role['roleId'] = state['roleId1'] as string;
+      const res = await request.post(buildUrl('/roles'), {
+        headers: jsonHeaders(),
+        data: role,
+      });
+
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Role', async ({request}) => {
+    const p = {roleId: state['roleId1'] as string};
+    const expectedBody = {
+      roleId: state['roleId1'],
+      name: state['roleName1'],
+      description: state['roleDescription1'],
+    };
+
+    await expect(async () => {
+      const res = await request.get(buildUrl('/roles/{roleId}', p), {
+        headers: jsonHeaders(),
+      });
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, roleRequiredFields);
+      assertEqualsForKeys(json, expectedBody, roleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Role Unauthorized', async ({request}) => {
+    const p = {roleId: state['roleId2'] as string};
+    const res = await request.get(buildUrl('/roles/{roleId}', p), {
+      headers: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Get Role Not Found', async ({request}) => {
+    const p = {roleId: 'does-not-exist'};
+    const res = await request.get(buildUrl('/roles/{roleId}', p), {
+      headers: jsonHeaders(),
+    });
+    await assertNotFoundRequest(res, `Role with id '${p.roleId}' not found`);
+  });
+
+  test('Update Role', async ({request}) => {
+    const p = {roleId: state['roleId2'] as string};
+    const requestBody = UPDATE_ROLE();
+    const expectedBody = {
+      ...p,
+      ...requestBody,
+    };
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/roles/{roleId}', p), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, roleRequiredFields);
+      assertEqualsForKeys(json, expectedBody, roleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Role Empty Name Invalid Body 400', async ({request}) => {
+    const p = {roleId: state['roleId1'] as string};
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/roles/{roleId}', p), {
+        headers: jsonHeaders(),
+        data: {name: ''},
+      });
+      await assertBadRequest(res, /.*\b(name)\b.*/i, 'INVALID_ARGUMENT');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Role Missing Name Invalid Body 400', async ({request}) => {
+    const p = {roleId: state['roleId1'] as string};
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/roles/{roleId}', p), {
+        headers: jsonHeaders(),
+        data: {description: 'missing name only description'},
+      });
+      await assertBadRequest(res, /.*\b(name)\b.*/i, 'INVALID_ARGUMENT');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Role Missing Description Invalid Body 400', async ({
+    request,
+  }) => {
+    const p = {roleId: state['roleId1'] as string};
+    await expect(async () => {
+      const res = await request.put(buildUrl('/roles/{roleId}', p), {
+        headers: jsonHeaders(),
+        data: {name: 'missing description'},
+      });
+
+      await assertBadRequest(res, /.*\b(description)\b.*/i, 'INVALID_ARGUMENT');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Role Unauthorized', async ({request}) => {
+    const p = {roleId: state['roleId2'] as string};
+    const requestBody = UPDATE_ROLE();
+
+    const res = await request.put(buildUrl('/roles/{roleId}', p), {
+      headers: {},
+      data: requestBody,
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Update Role Not Found', async ({request}) => {
+    const p = {roleId: 'invalid-role'};
+    const res = await request.put(buildUrl('/roles/{roleId}', p), {
+      headers: jsonHeaders(),
+      data: UPDATE_ROLE(),
+    });
+    await assertNotFoundRequest(
+      res,
+      "Command 'UPDATE' rejected with code 'NOT_FOUND'",
+    );
+  });
+
+  test('Delete Role', async ({request}) => {
+    const p = {roleId: state['roleId3'] as string};
+    await test.step('Delete Role 204', async () => {
+      await expect(async () => {
+        const res = await request.delete(buildUrl('/roles/{roleId}', p), {
+          headers: jsonHeaders(),
+        });
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Get Role After Deletion', async () => {
+      await expect(async () => {
+        const after = await request.get(buildUrl('/roles/{roleId}', p), {
+          headers: jsonHeaders(),
+        });
+        await assertNotFoundRequest(
+          after,
+          `Role with id '${p.roleId}' not found`,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Delete Role Unauthorized', async ({request}) => {
+    const p = {roleId: state['roleId3'] as string};
+    const res = await request.delete(buildUrl('/roles/{roleId}', p), {
+      headers: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Delete Role Not Found', async ({request}) => {
+    const p = {roleId: 'invalid-role'};
+    const res = await request.delete(buildUrl('/roles/{roleId}', p), {
+      headers: jsonHeaders(),
+    });
+    await assertNotFoundRequest(
+      res,
+      "Command 'DELETE' rejected with code 'NOT_FOUND",
+    );
+  });
+
+  test('Search Roles', async ({request}) => {
+    const role1ExpectedBody = {
+      roleId: state['roleId1'],
+      name: state['roleName1'],
+      description: state['roleDescription1'],
+    };
+    const role2ExpectedBody = {
+      roleId: state['roleId2'],
+      name: state['roleName2'],
+      description: state['roleDescription2'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/roles/search'), {
+        headers: jsonHeaders(),
+        data: {},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemLengthGreaterThan: 2,
+        totalItemGreaterThan: 2,
+      });
+      const json = await res.json();
+      assertRoleInResponse(
+        json,
+        role1ExpectedBody,
+        role1ExpectedBody.roleId as string,
+      );
+      assertRoleInResponse(
+        json,
+        role2ExpectedBody,
+        role2ExpectedBody.roleId as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Roles By Name', async ({request}) => {
+    const roleName = state['roleName1'];
+    const body = {
+      filter: {
+        name: roleName,
+      },
+    };
+    const expectedBody = {
+      roleId: state['roleId1'],
+      name: state['roleName1'],
+      description: state['roleDescription1'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/roles/search'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      expect(item).toBeDefined();
+      assertRequiredFields(item, roleRequiredFields);
+      assertEqualsForKeys(item, expectedBody, roleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Roles By Role Id', async ({request}) => {
+    const roleId = state['roleId2'];
+    const body = {
+      filter: {
+        roleId: roleId,
+      },
+    };
+    const expectedBody = {
+      roleId: state['roleId2'],
+      name: state['roleName2'],
+      description: state['roleDescription2'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/roles/search'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      expect(item).toBeDefined();
+      assertRequiredFields(item, roleRequiredFields);
+      assertEqualsForKeys(item, expectedBody, roleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Roles By Multiple Fields', async ({request}) => {
+    const requestBody = {
+      filter: {
+        roleId: state['roleId1'],
+        name: state['roleName1'],
+      },
+    };
+    const expectedBody = {
+      ...requestBody.filter,
+      description: state['roleDescription1'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/roles/search'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      expect(item).toBeDefined();
+      assertRequiredFields(item, roleRequiredFields);
+      assertEqualsForKeys(item, expectedBody, roleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Roles By Invalid Id', async ({request}) => {
+    const body = {
+      filter: {
+        roleId: 'invalidRoleId',
+      },
+    };
+
+    const res = await request.post(buildUrl('/roles/search'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+
+  test('Search Roles Unauthorized', async ({request}) => {
+    const body = {
+      filter: {
+        name: state['roleName1'],
+      },
+    };
+    const res = await request.post(buildUrl('/roles/search'), {
+      headers: {},
+      data: body,
+    });
+    await assertUnauthorizedRequest(res);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-clients-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-clients-api-tests.spec.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  assertPaginatedRequest,
+} from '../../../../utils/http';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+import {
+  assertClientsInResponse,
+  assignClientsToRole,
+  clientFromState,
+  createRole,
+} from '../../../../utils/requestHelpers';
+
+test.describe.parallel('Role Clients API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createRole(request, state, '1');
+    await createRole(request, state, '2');
+    await assignClientsToRole(request, 3, state['roleId1'] as string, state);
+    await assignClientsToRole(request, 1, state['roleId2'] as string, state);
+  });
+
+  test('Assign Role To Client', async ({request}) => {
+    const role = await createRole(request);
+    const clientId = 'test-client' + generateUniqueId();
+    const p = {clientId, roleId: role.roleId as string};
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/clients/{clientId}', p),
+        {headers: jsonHeaders()},
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Role To Client Non Existent Client Success', async ({
+    request,
+  }) => {
+    const p = {clientId: 'invalidClientId', roleId: state['roleId1'] as string};
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    expect(res.status()).toBe(204);
+  });
+
+  test('Assign Role To Client Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      clientId: clientFromState('roleId1', state) as string,
+      roleId: 'invalidRoleId',
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Role To Client Unauthorized', async ({request}) => {
+    const roleId = state['roleId1'] as string;
+    const p = {
+      clientId: clientFromState('roleId1', state) as string,
+      roleId,
+    };
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/clients/{clientId}', p),
+        {headers: {}},
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Already Added Client To Role Conflict', async ({request}) => {
+    const p = {
+      clientId: clientFromState('roleId1', state) as string,
+      roleId: state['roleId1'] as string,
+    };
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/clients/{clientId}', p),
+        {headers: jsonHeaders()},
+      );
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Clients', async ({request}) => {
+    const client1 = clientFromState('roleId1', state, 1);
+    const client2 = clientFromState('roleId1', state, 2);
+    const client3 = clientFromState('roleId1', state, 3);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/clients/search', {
+          roleId: state['roleId1'] as string,
+        }),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        totalItemsEqualTo: 3,
+        itemsLengthEqualTo: 3,
+      });
+      const json = await res.json();
+      assertClientsInResponse(json, client1);
+      assertClientsInResponse(json, client2);
+      assertClientsInResponse(json, client3);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Clients Unauthorized', async ({request}) => {
+    const p = {roleId: state['roleId1'] as string};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/clients/search', p),
+      {headers: {}, data: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Role Clients For Non Existent Role Empty', async ({request}) => {
+    const p = {roleId: 'invalidRoleId'};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/clients/search', p),
+      {headers: jsonHeaders(), data: {}},
+    );
+    await assertPaginatedRequest(res, {
+      totalItemsEqualTo: 0,
+      itemsLengthEqualTo: 0,
+    });
+  });
+
+  test('Unassign Role From Client', async ({request}) => {
+    const roleId = state['roleId2'] as string;
+    const clientId = clientFromState('roleId2', state, 1);
+    const p = {roleId: roleId, clientId: clientId};
+
+    await test.step('Unassign Role From Client', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/roles/{roleId}/clients/{clientId}', p),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Role Clients After Unassign', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/roles/{roleId}/clients/search', p),
+          {headers: jsonHeaders(), data: {}},
+        );
+        await assertPaginatedRequest(res, {
+          totalItemsEqualTo: 0,
+          itemsLengthEqualTo: 0,
+        });
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Unassign Role From Client Unauthorized', async ({request}) => {
+    const roleId = state['roleId1'] as string;
+    const clientId = clientFromState('roleId1', state, 1);
+    const p = {roleId: roleId, clientId: clientId};
+
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/clients/{clientId}', p),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign Role From Client Non Existent Client Not Found', async ({
+    request,
+  }) => {
+    const p = {clientId: 'invalidClientId', roleId: state['roleId1'] as string};
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Unassign Role From Client Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const clientId = clientFromState('roleId1', state, 1);
+    const p = {clientId, roleId: 'invalidRoleId'};
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-groups-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-groups-api-tests.spec.ts
@@ -101,7 +101,7 @@ test.describe.parallel('Role Groups API Tests', () => {
   test('Assign Group To Role Unauthorized', async ({request}) => {
     const stateParams: Record<string, string> = {
       groupId: groupIdFromState('roleId1', state) as string,
-      roleId: state['role1'] as string,
+      roleId: state['roleId1'] as string,
     };
 
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-groups-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-groups-api-tests.spec.ts
@@ -1,0 +1,283 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertRequiredFields,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  paginatedResponseFields,
+  assertPaginatedRequest,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  assertGroupsInResponse,
+  assignGroupsToRole,
+  createGroupAndStoreResponseFields,
+  createRole,
+  groupIdFromState,
+} from '../../../../utils/requestHelpers';
+import {ROLE_GROUP_EXPECTED_BODY} from '../../../../utils/beans/requestBeans';
+
+test.describe.parallel('Role Groups API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createRole(request, state, '1');
+    await createRole(request, state, '2');
+    await createRole(request, state, '3');
+    await assignGroupsToRole(request, 2, 'roleId1', state);
+    await assignGroupsToRole(request, 3, 'roleId2', state);
+    await assignGroupsToRole(request, 3, 'roleId3', state);
+  });
+
+  test('Assign Group To Role', async ({request}) => {
+    const groupKey = `${state['roleId1']}6`;
+    await createGroupAndStoreResponseFields(request, 1, state, groupKey);
+    const p = {
+      groupId: groupIdFromState(groupKey, state, 6) as string,
+      roleId: state['roleId1'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/groups/{groupId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Group To Role Non Existent Group Not Found', async ({
+    request,
+  }) => {
+    const stateParams: Record<string, string> = {
+      groupId: 'invalidGroupId',
+      roleId: state['roleId1'] as string,
+    };
+
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/groups/{groupId}', stateParams),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Group To Role Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const stateParams: Record<string, string> = {
+      groupId: groupIdFromState('roleId1', state) as string,
+      roleId: 'invalidRoleId',
+    };
+
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/groups/{groupId}', stateParams),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Group To Role Unauthorized', async ({request}) => {
+    const stateParams: Record<string, string> = {
+      groupId: groupIdFromState('roleId1', state) as string,
+      roleId: state['role1'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/groups/{groupId}', stateParams),
+        {
+          headers: {},
+        },
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Already Added Group To Role Conflict', async ({request}) => {
+    const stateParams: Record<string, string> = {
+      groupId: groupIdFromState('roleId1', state) as string,
+      roleId: state['roleId1'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/groups/{groupId}', stateParams),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Unassign Group From Role', async ({request}) => {
+    const p = {
+      groupId: groupIdFromState('roleId2', state) as string,
+      roleId: state['roleId2'] as string,
+    };
+    await test.step('Unassign Role From Group', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/roles/{roleId}/groups/{groupId}', p),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Group Roles For Group After Deletion', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/groups/{groupId}/roles/search', p),
+          {
+            headers: jsonHeaders(),
+            data: {},
+          },
+        );
+
+        expect(res.status()).toBe(200);
+        const json = await res.json();
+        assertRequiredFields(json, paginatedResponseFields);
+        expect(json.page.totalItems).toBe(0);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Unassign Role From Group Unauthorized', async ({request}) => {
+    const p = {
+      groupId: groupIdFromState('roleId2', state) as string,
+      roleId: state['roleId2'] as string,
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/groups/{groupId}', p),
+      {
+        headers: {},
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign Role From Group Non Existent Group Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      groupId: 'invalidGroupId',
+      roleId: state['roleId2'] as string,
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/groups/{groupId}', p),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Unassign Role From Group Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      groupId: groupIdFromState('roleId2', state) as string,
+      roleId: 'invalidRoleId',
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/groups/{groupId}', p),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Search Role Groups', async ({request}) => {
+    const p = {roleId: state['roleId3'] as string};
+    const group1 = groupIdFromState('roleId3', state, 1);
+    const group2 = groupIdFromState('roleId3', state, 2);
+    const group3 = groupIdFromState('roleId3', state, 3);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/groups/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 3,
+        totalItemsEqualTo: 3,
+      });
+      const json = await res.json();
+      assertGroupsInResponse(json, ROLE_GROUP_EXPECTED_BODY(group1), group1);
+      assertGroupsInResponse(json, ROLE_GROUP_EXPECTED_BODY(group2), group2);
+      assertGroupsInResponse(json, ROLE_GROUP_EXPECTED_BODY(group3), group3);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Groups Role With No Assignments Returns Empty', async ({
+    request,
+  }) => {
+    const role = await createRole(request);
+    const p = {roleId: role.roleId as string};
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/groups/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 0,
+        totalItemsEqualTo: 0,
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Groups Unauthorized', async ({request}) => {
+    const p = {roleId: state['roleId3'] as string};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/groups/search', p),
+      {headers: {}, data: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Role Groups Role Not Found', async ({request}) => {
+    const p = {roleId: 'invalid-role-id'};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/groups/search', p),
+      {headers: jsonHeaders(), data: {}},
+    );
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-groups-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-groups-api-tests.spec.ts
@@ -39,7 +39,7 @@ test.describe.parallel('Role Groups API Tests', () => {
     await assignGroupsToRole(request, 3, 'roleId3', state);
   });
 
-  test('Assign Group To Role', async ({request}) => {
+  test('Assign Role To Group', async ({request}) => {
     const groupKey = `${state['roleId1']}6`;
     await createGroupAndStoreResponseFields(request, 1, state, groupKey);
     const p = {
@@ -58,9 +58,7 @@ test.describe.parallel('Role Groups API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Assign Group To Role Non Existent Group Not Found', async ({
-    request,
-  }) => {
+  test('Assign Role To Group Non Existent Group Sucess', async ({request}) => {
     const stateParams: Record<string, string> = {
       groupId: 'invalidGroupId',
       roleId: state['roleId1'] as string,
@@ -72,13 +70,10 @@ test.describe.parallel('Role Groups API Tests', () => {
         headers: jsonHeaders(),
       },
     );
-    await assertNotFoundRequest(
-      res,
-      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
-    );
+    expect(res.status()).toBe(204);
   });
 
-  test('Assign Group To Role Non Existent Role Not Found', async ({
+  test('Assign Role To Group Non Existent Role Not Found', async ({
     request,
   }) => {
     const stateParams: Record<string, string> = {
@@ -98,7 +93,7 @@ test.describe.parallel('Role Groups API Tests', () => {
     );
   });
 
-  test('Assign Group To Role Unauthorized', async ({request}) => {
+  test('Assign Role To Group Unauthorized', async ({request}) => {
     const stateParams: Record<string, string> = {
       groupId: groupIdFromState('roleId1', state) as string,
       roleId: state['roleId1'] as string,
@@ -133,7 +128,7 @@ test.describe.parallel('Role Groups API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Unassign Group From Role', async ({request}) => {
+  test('Assign Role From Group', async ({request}) => {
     const p = {
       groupId: groupIdFromState('roleId2', state) as string,
       roleId: state['roleId2'] as string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-mapping-rules-api-tests.spec.ts
@@ -1,0 +1,403 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  assertPaginatedRequest,
+  assertRequiredFields,
+  assertEqualsForKeys,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  assignRolesToMappingRules,
+  createMappingRule,
+  createRole,
+  createRoleAndStoreResponseFields,
+  mappingRuleIdFromState,
+  mappingRuleNameFromState,
+} from '../../../../utils/requestHelpers';
+import {
+  MAPPING_RULE_EXPECTED_BODY_USING_STATE,
+  mappingRuleRequiredFields,
+} from '../../../../utils/beans/requestBeans';
+
+test.describe.parallel('Role Mapping Rules API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createRoleAndStoreResponseFields(request, 3, state);
+    await assignRolesToMappingRules(
+      request,
+      2,
+      state['roleId2'] as string,
+      state,
+    );
+    await assignRolesToMappingRules(
+      request,
+      1,
+      state['roleId3'] as string,
+      state,
+    );
+  });
+
+  test('Assign Role To Mapping Rule', async ({request}) => {
+    const body = await createMappingRule(request);
+    const p = {
+      roleId: state['roleId1'] as string,
+      mappingRuleId: body.mappingRuleId as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+        {headers: jsonHeaders()},
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Role To Mapping Rule Non Existent Mapping Rule Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      roleId: state['roleId1'] as string,
+      mappingRuleId: 'invalidMappingRuleId',
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Role To Mapping Rule Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      roleId: 'invalidRoleId',
+      mappingRuleId: mappingRuleIdFromState('roleId1', state) as string,
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Role To Mapping Rule Unauthorized', async ({request}) => {
+    const p = {
+      roleId: state['roleId1'] as string,
+      mappingRuleId: mappingRuleIdFromState('roleId1', state) as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+        {headers: {}},
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Already Added Mapping Rule To Role Conflict', async ({
+    request,
+  }) => {
+    const p = {
+      roleId: state['roleId1'] as string,
+      mappingRuleId: mappingRuleIdFromState('roleId2', state) as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+        {headers: jsonHeaders()},
+      );
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Unassign Role From Mapping Rule', async ({request}) => {
+    const p = {
+      roleId: state['roleId3'] as string,
+      mappingRuleId: mappingRuleIdFromState('roleId3', state) as string,
+    };
+    await test.step('Unassign Role From Mapping Rule', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Roles For Mapping Rule After Deletion', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/roles/{roleId}/mapping-rules/search', p),
+          {headers: jsonHeaders(), data: {}},
+        );
+        await assertPaginatedRequest(res, {
+          totalItemsEqualTo: 0,
+          itemsLengthEqualTo: 0,
+        });
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Unassign Role From Mapping Rule Unauthorized', async ({request}) => {
+    const p = {
+      roleId: state['roleId2'] as string,
+      mappingRuleId: mappingRuleIdFromState('roleId2', state) as string,
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign Role From Mapping Rule Non Existent Mapping Rule Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      roleId: state['roleId2'] as string,
+      mappingRuleId: 'invalidMappingRuleId',
+    };
+
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Unassign Role From Mapping Rule Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      roleId: 'invalidRoleId',
+      mappingRuleId: mappingRuleIdFromState('roleId2', state) as string,
+    };
+
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Search Role Mapping Rules', async ({request}) => {
+    const mappingRule1 = mappingRuleIdFromState('roleId2', state, 1) as string;
+    const mappingRule2 = mappingRuleIdFromState('roleId2', state, 2) as string;
+    const p = {
+      roleId: state['roleId2'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 2,
+        totalItemsEqualTo: 2,
+      });
+      const json = await res.json();
+      const matchingItem1 = json.items.find(
+        (it: {mappingRuleId: string}) => it.mappingRuleId === mappingRule1,
+      );
+
+      expect(matchingItem1).toBeDefined();
+      assertRequiredFields(matchingItem1, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        matchingItem1,
+        MAPPING_RULE_EXPECTED_BODY_USING_STATE('roleId2', state, 1),
+        mappingRuleRequiredFields,
+      );
+
+      const matchingItem2 = json.items.find(
+        (it: {mappingRuleId: string}) => it.mappingRuleId === mappingRule2,
+      );
+      expect(matchingItem2).toBeDefined();
+      assertRequiredFields(matchingItem2, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        matchingItem2,
+        MAPPING_RULE_EXPECTED_BODY_USING_STATE('roleId2', state, 2),
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Mapping Rules Filter By mappingRuleId', async ({
+    request,
+  }) => {
+    const p = {roleId: state.roleId2 as string};
+    const filterBody = {
+      filter: {
+        mappingRuleId: mappingRuleIdFromState('roleId2', state) as string,
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: filterBody},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      assertRequiredFields(item, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        item,
+        MAPPING_RULE_EXPECTED_BODY_USING_STATE('roleId2', state, 1),
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Mapping Rules Filter By name', async ({request}) => {
+    const p = {roleId: state.roleId2 as string};
+    const filterBody = {
+      filter: {
+        name: mappingRuleNameFromState('roleId2', state, 2) as string,
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: filterBody},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      assertRequiredFields(item, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        item,
+        MAPPING_RULE_EXPECTED_BODY_USING_STATE('roleId2', state, 2),
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Mapping Rules Filter By multiple fields', async ({
+    request,
+  }) => {
+    const p = {roleId: state.roleId2 as string};
+    const filterBody = {
+      filter: {
+        name: mappingRuleNameFromState('roleId2', state, 2) as string,
+        mappingRuleId: mappingRuleIdFromState('roleId2', state, 2) as string,
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: filterBody},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      assertRequiredFields(item, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        item,
+        MAPPING_RULE_EXPECTED_BODY_USING_STATE('roleId2', state, 2),
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Mapping Rules Filter Non Matching Returns Empty', async ({
+    request,
+  }) => {
+    const p = {roleId: state.roleId2 as string};
+    const body = {
+      filter: {
+        mappingRuleId: 'non-existent-mapping-rule',
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: body},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 0,
+        totalItemsEqualTo: 0,
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Mapping Rules Role With No Assignments Returns Empty', async ({
+    request,
+  }) => {
+    const lonelyRole = await createRole(request);
+    const p = {roleId: lonelyRole.roleId as string};
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 0,
+        totalItemsEqualTo: 0,
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Mapping Rules Unauthorized', async ({request}) => {
+    const p = {roleId: state.roleId2 as string};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/mapping-rules/search', p),
+      {headers: {}, data: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Role Mapping Rules Role Not Found', async ({request}) => {
+    const p = {roleId: 'invalid-role-id'};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/mapping-rules/search', p),
+      {headers: jsonHeaders(), data: {}},
+    );
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-users-api-tests.spec.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  assertPaginatedRequest,
+} from '../../../../utils/http';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+import {
+  assertUsersInResponse,
+  assignRoleToUsers,
+  createRole,
+  userFromState,
+} from '../../../../utils/requestHelpers';
+
+test.describe.parallel('Role Users API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createRole(request, state, '1');
+    await createRole(request, state, '2');
+    await assignRoleToUsers(request, 3, state['roleId1'] as string, state);
+    await assignRoleToUsers(request, 1, state['roleId2'] as string, state);
+  });
+
+  test('Assign Role To User', async ({request}) => {
+    const role = await createRole(request);
+    const user = 'test-user' + generateUniqueId();
+    const p = {
+      userId: user,
+      roleId: role.roleId as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/users/{userId}', p),
+        {headers: jsonHeaders()},
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Role To User Non Existent User Success', async ({request}) => {
+    const p = {
+      userId: 'invalidUserId',
+      roleId: state['roleId1'] as string,
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/users/{userId}', p),
+      {headers: jsonHeaders()},
+    );
+    expect(res.status()).toBe(204);
+  });
+
+  test('Assign Role To User Non Existent Role Not Found', async ({request}) => {
+    const p = {
+      userId: userFromState('roleId1', state) as string,
+      roleId: 'invalidRoleId',
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/users/{userId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Role To User Unauthorized', async ({request}) => {
+    const roleId: string = state['roleId1'] as string;
+    const p = {
+      userId: userFromState('roleId1', state) as string,
+      roleId: roleId,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/users/{userId}', p),
+        {headers: {}},
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Already Added User To Role Conflict', async ({request}) => {
+    const roleId: string = state['roleId1'] as string;
+    const p = {
+      userId: userFromState('roleId1', state) as string,
+      roleId: roleId,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/users/{userId}', p),
+        {headers: jsonHeaders()},
+      );
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Users', async ({request}) => {
+    const roleId: string = state['roleId1'] as string;
+    const p = {roleId: roleId};
+    const user1: string = userFromState('roleId1', state, 1);
+    const user2: string = userFromState('roleId1', state, 2);
+    const user3: string = userFromState('roleId1', state, 3);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/users/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        totalItemsEqualTo: 3,
+        itemsLengthEqualTo: 3,
+      });
+      const json = await res.json();
+      assertUsersInResponse(json, user1);
+      assertUsersInResponse(json, user2);
+      assertUsersInResponse(json, user3);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Users Unauthorized', async ({request}) => {
+    const roleId: string = state['roleId1'] as string;
+    const p = {userId: userFromState(roleId, state) as string};
+    const res = await request.post(
+      buildUrl('/roles/{userId}/users/search', p),
+      {headers: {}, data: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Role Users For Non Existent User Empty', async ({request}) => {
+    const p = {roleId: 'invalidRoleId'};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/users/search', p),
+      {headers: jsonHeaders(), data: {}},
+    );
+
+    await assertPaginatedRequest(res, {
+      totalItemsEqualTo: 0,
+      itemsLengthEqualTo: 0,
+    });
+  });
+
+  test('Unassign Role From User', async ({request}) => {
+    const roleId: string = state['roleId2'] as string;
+    const roleUser: string = userFromState('roleId2', state, 1);
+    const p = {
+      userId: roleUser,
+      roleId: roleId,
+    };
+
+    await test.step('Unassign Role From User', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/roles/{roleId}/users/{userId}', p),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Role Users After Unassign', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/roles/{userId}/users/search', p),
+          {headers: jsonHeaders(), data: {}},
+        );
+        await assertPaginatedRequest(res, {
+          totalItemsEqualTo: 0,
+          itemsLengthEqualTo: 0,
+        });
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Unassign Role From User Unauthorized', async ({request}) => {
+    const roleId: string = state['roleId1'] as string;
+    const p = {
+      userId: userFromState('roleId1', state) as string,
+      roleId: roleId,
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/users/{userId}', p),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign Role From User Non Existent User Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      userId: 'invalidUserId',
+      roleId: state['roleId1'] as string,
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/users/{userId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Unassign Role From User Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      userId: userFromState('roleId1', state) as string,
+      roleId: 'invalidRoleId',
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/users/{userId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-users-api-tests.spec.ts
@@ -139,7 +139,7 @@ test.describe.parallel('Role Users API Tests', () => {
     const roleId: string = state['roleId1'] as string;
     const p = {userId: userFromState(roleId, state) as string};
     const res = await request.post(
-      buildUrl('/roles/{userId}/users/search', p),
+      buildUrl('/roles/{roleId}/users/search', p),
       {headers: {}, data: {}},
     );
     await assertUnauthorizedRequest(res);
@@ -179,7 +179,7 @@ test.describe.parallel('Role Users API Tests', () => {
     await test.step('Search Role Users After Unassign', async () => {
       await expect(async () => {
         const res = await request.post(
-          buildUrl('/roles/{userId}/users/search', p),
+          buildUrl('/roles/{roleId}/users/search', p),
           {headers: jsonHeaders(), data: {}},
         );
         await assertPaginatedRequest(res, {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-api-tests.spec.ts
@@ -261,7 +261,7 @@ test.describe.parallel('Tenants API Tests', () => {
     });
     await assertNotFoundRequest(
       res,
-      "Command 'DELETE' rejected with code 'NOT_FOUND",
+      "Command 'DELETE' rejected with code 'NOT_FOUND'",
     );
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-api-tests.spec.ts
@@ -1,0 +1,426 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertRequiredFields,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  assertEqualsForKeys,
+  assertBadRequest,
+  assertPaginatedRequest,
+} from '../../../../utils/http';
+import {
+  CREATE_NEW_TENANT,
+  tenantRequiredFields, UPDATE_TENANT,
+} from '../../../../utils/beans/requestBeans';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  assertTenantInResponse,
+  createTenantAndStoreResponseFields
+} from '../../../../utils/requestHelpers';
+
+test.describe.parallel('Tenants API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createTenantAndStoreResponseFields(request, 3, state);
+  });
+
+  test('Create Tenant', async ({request}) => {
+    await expect(async () => {
+      const tenant = CREATE_NEW_TENANT();
+      const res = await request.post(buildUrl('/tenants'), {
+        headers: jsonHeaders(),
+        data: tenant,
+      });
+
+      expect(res.status()).toBe(201);
+      const json = await res.json();
+      assertRequiredFields(json, tenantRequiredFields);
+      assertEqualsForKeys(json, tenant, tenantRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Tenant Unauthorized', async ({request}) => {
+    const res = await request.post(buildUrl('/tenants'), {
+      headers: {},
+      data: CREATE_NEW_TENANT(),
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Create Tenant Missing Name Invalid Body 400', async ({request}) => {
+    const body = {description: 'only description provided'};
+    const res = await request.post(buildUrl('/tenants'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, /.*\b(name)\b.*/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Create Tenant Empty Name Invalid Body 400', async ({request}) => {
+    const body = {name: '', description: 'empty name'};
+    const res = await request.post(buildUrl('/tenants'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, /.*\b(name)\b.*/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Create Tenant Missing Tenant Id Invalid Body 400', async ({
+    request,
+  }) => {
+    const body = {
+      name: 'tenant name',
+      description: 'only description provided',
+    };
+    const res = await request.post(buildUrl('/tenants'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, /.*\b(tenantId)\b.*/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Create Tenant Conflict', async ({request}) => {
+    await expect(async () => {
+      const tenant = CREATE_NEW_TENANT();
+      tenant['tenantId'] = state['tenantId1'] as string;
+      const res = await request.post(buildUrl('/tenants'), {
+        headers: jsonHeaders(),
+        data: tenant,
+      });
+
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Tenant', async ({request}) => {
+    const p = {tenantId: state['tenantId1'] as string};
+    const expectedBody = {
+      tenantId: state['tenantId1'],
+      name: state['tenantName1'],
+      description: state['tenantDescription1'],
+    };
+
+    await expect(async () => {
+      const res = await request.get(buildUrl('/tenants/{tenantId}', p), {
+        headers: jsonHeaders(),
+      });
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, tenantRequiredFields);
+      assertEqualsForKeys(json, expectedBody, tenantRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Tenant Unauthorized', async ({request}) => {
+    const p = {tenantId: state['tenantId2'] as string};
+    const res = await request.get(buildUrl('/tenants/{tenantId}', p), {
+      headers: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Get Tenant Not Found', async ({request}) => {
+    const p = {tenantId: 'does-not-exist'};
+    const res = await request.get(buildUrl('/tenants/{tenantId}', p), {
+      headers: jsonHeaders(),
+    });
+    await assertNotFoundRequest(
+      res,
+      `Tenant with id '${p.tenantId}' not found`,
+    );
+  });
+
+  test('Update Tenant', async ({request}) => {
+    const p = {tenantId: state['tenantId2'] as string};
+    const requestBody = UPDATE_TENANT();
+    const expectedBody = {
+      ...p,
+      ...requestBody,
+    };
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/tenants/{tenantId}', p), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, tenantRequiredFields);
+      assertEqualsForKeys(json, expectedBody, tenantRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Tenant Empty Name Invalid Body 400', async ({request}) => {
+    const p = {tenantId: state['tenantId1'] as string};
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/tenants/{tenantId}', p), {
+        headers: jsonHeaders(),
+        data: {name: ''},
+      });
+      await assertBadRequest(res, /.*\b(name)\b.*/i, 'INVALID_ARGUMENT');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Tenant Missing Name Invalid Body 400', async ({request}) => {
+    const p = {tenantId: state['tenantId1'] as string};
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/tenants/{tenantId}', p), {
+        headers: jsonHeaders(),
+        data: {description: 'missing name only description'},
+      });
+      await assertBadRequest(res, /.*\b(name)\b.*/i, 'INVALID_ARGUMENT');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Tenant Missing Description Invalid Body 400', async ({
+    request,
+  }) => {
+    const p = {tenantId: state['tenantId1'] as string};
+    await expect(async () => {
+      const res = await request.put(buildUrl('/tenants/{tenantId}', p), {
+        headers: jsonHeaders(),
+        data: {name: 'missing description'},
+      });
+
+      await assertBadRequest(res, /.*\b(description)\b.*/i, 'INVALID_ARGUMENT');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Tenant Unauthorized', async ({request}) => {
+    const p = {tenantId: state['tenantId2'] as string};
+    const requestBody = UPDATE_TENANT();
+
+    const res = await request.put(buildUrl('/tenants/{tenantId}', p), {
+      headers: {},
+      data: requestBody,
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Update Tenant Not Found', async ({request}) => {
+    const p = {tenantId: 'invalid-tenant'};
+    const res = await request.put(buildUrl('/tenants/{tenantId}', p), {
+      headers: jsonHeaders(),
+      data: UPDATE_TENANT(),
+    });
+    await assertNotFoundRequest(
+      res,
+      "Command 'UPDATE' rejected with code 'NOT_FOUND'",
+    );
+  });
+
+  test('Delete tenant', async ({request}) => {
+    const p = {tenantId: state['tenantId3'] as string};
+    await test.step('Delete tenant 204', async () => {
+      await expect(async () => {
+        const res = await request.delete(buildUrl('/tenants/{tenantId}', p), {
+          headers: jsonHeaders(),
+        });
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Get Tenant After Deletion', async () => {
+      await expect(async () => {
+        const after = await request.get(buildUrl('/tenants/{tenantId}', p), {
+          headers: jsonHeaders(),
+        });
+        await assertNotFoundRequest(
+          after,
+          `Tenant with id '${p.tenantId}' not found`,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Delete tenant Unauthorized', async ({request}) => {
+    const p = {tenantId: state['tenantId3'] as string};
+    const res = await request.delete(buildUrl('/tenants/{tenantId}', p), {
+      headers: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Delete tenant Not Found', async ({request}) => {
+    const p = {tenantId: 'invalid-tenant'};
+    const res = await request.delete(buildUrl('/tenants/{tenantId}', p), {
+      headers: jsonHeaders(),
+    });
+    await assertNotFoundRequest(
+      res,
+      "Command 'DELETE' rejected with code 'NOT_FOUND",
+    );
+  });
+
+  test('Search Tenants', async ({request}) => {
+    const tenant1ExpectedBody = {
+      tenantId: state['tenantId1'],
+      name: state['tenantName1'],
+      description: state['tenantDescription1'],
+    };
+    const tenant2ExpectedBody = {
+      tenantId: state['tenantId2'],
+      name: state['tenantName2'],
+      description: state['tenantDescription2'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/tenants/search'), {
+        headers: jsonHeaders(),
+        data: {},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemLengthGreaterThan: 2,
+        totalItemGreaterThan: 2,
+      });
+      const json = await res.json();
+      assertTenantInResponse(
+        json,
+        tenant1ExpectedBody,
+        tenant1ExpectedBody.tenantId as string,
+      );
+      assertTenantInResponse(
+        json,
+        tenant2ExpectedBody,
+        tenant2ExpectedBody.tenantId as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Tenants By Name', async ({request}) => {
+    const tenantName = state['tenantName1'];
+    const body = {
+      filter: {
+        name: tenantName,
+      },
+    };
+    const expectedBody = {
+      tenantId: state['tenantId1'],
+      name: state['tenantName1'],
+      description: state['tenantDescription1'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/tenants/search'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      expect(item).toBeDefined();
+      assertRequiredFields(item, tenantRequiredFields);
+      assertEqualsForKeys(item, expectedBody, tenantRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Tenants By Tenant Id', async ({request}) => {
+    const tenantId = state['tenantId2'];
+    const body = {
+      filter: {
+        tenantId: tenantId,
+      },
+    };
+    const expectedBody = {
+      tenantId: state['tenantId2'],
+      name: state['tenantName2'],
+      description: state['tenantDescription2'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/tenants/search'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      expect(item).toBeDefined();
+      assertRequiredFields(item, tenantRequiredFields);
+      assertEqualsForKeys(item, expectedBody, tenantRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Tenants By Multiple Fields', async ({request}) => {
+    const requestBody = {
+      filter: {
+        tenantId: state['tenantId1'],
+        name: state['tenantName1'],
+      },
+    };
+    const expectedBody = {
+      ...requestBody.filter,
+      description: state['tenantDescription1'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/tenants/search'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      expect(item).toBeDefined();
+      assertRequiredFields(item, tenantRequiredFields);
+      assertEqualsForKeys(item, expectedBody, tenantRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Tenants By Invalid Id', async ({request}) => {
+    const body = {
+      filter: {
+        tenantId: 'invalidtenantId',
+      },
+    };
+
+    const res = await request.post(buildUrl('/tenants/search'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+
+  test('Search Tenants Unauthorized', async ({request}) => {
+    const body = {
+      filter: {
+        name: state['tenantName1'],
+      },
+    };
+    const res = await request.post(buildUrl('/tenants/search'), {
+      headers: {},
+      data: body,
+    });
+    await assertUnauthorizedRequest(res);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-clients-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-clients-api-tests.spec.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  assertPaginatedRequest,
+} from '../../../../utils/http';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+import {
+  assertClientsInResponse,
+  assignClientsToTenant,
+  clientFromState,
+  createTenant,
+} from '../../../../utils/requestHelpers';
+
+test.describe.parallel('Tenant Clients API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createTenant(request, state, '1');
+    await createTenant(request, state, '2');
+    await assignClientsToTenant(
+      request,
+      3,
+      state['tenantId1'] as string,
+      state,
+    );
+    await assignClientsToTenant(
+      request,
+      1,
+      state['tenantId2'] as string,
+      state,
+    );
+  });
+
+  test('Assign Client To Tenant', async ({request}) => {
+    const tenant = await createTenant(request);
+    const clientId = 'test-client' + generateUniqueId();
+    const p = {clientId, tenantId: tenant.tenantId as string};
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/tenants/{tenantId}/clients/{clientId}', p),
+        {headers: jsonHeaders()},
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Client To Tenant Non Existent Client Success', async ({
+    request,
+  }) => {
+    const p = {
+      clientId: 'invalidClientId',
+      tenantId: state['tenantId1'] as string,
+    };
+    const res = await request.put(
+      buildUrl('/tenants/{tenantId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    expect(res.status()).toBe(204);
+  });
+
+  test('Assign Client To Tenant Non Existent Tenant Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      clientId: clientFromState('tenantId1', state) as string,
+      tenantId: 'invalidTenantId',
+    };
+    const res = await request.put(
+      buildUrl('/tenants/{tenantId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Client To Tenant Unauthorized', async ({request}) => {
+    const tenantId = state['tenantId1'] as string;
+    const p = {
+      clientId: clientFromState('tenantId1', state) as string,
+      tenantId,
+    };
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/tenants/{tenantId}/clients/{clientId}', p),
+        {headers: {}},
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Already Added Client To Tenant Conflict', async ({request}) => {
+    const p = {
+      clientId: clientFromState('tenantId1', state) as string,
+      tenantId: state['tenantId1'] as string,
+    };
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/tenants/{tenantId}/clients/{clientId}', p),
+        {headers: jsonHeaders()},
+      );
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Tenant Clients', async ({request}) => {
+    const client1 = clientFromState('tenantId1', state, 1);
+    const client2 = clientFromState('tenantId1', state, 2);
+    const client3 = clientFromState('tenantId1', state, 3);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/tenants/{tenantId}/clients/search', {
+          tenantId: state['tenantId1'] as string,
+        }),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        totalItemsEqualTo: 3,
+        itemsLengthEqualTo: 3,
+      });
+      const json = await res.json();
+      assertClientsInResponse(json, client1);
+      assertClientsInResponse(json, client2);
+      assertClientsInResponse(json, client3);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Tenant Clients Unauthorized', async ({request}) => {
+    const p = {tenantId: state['tenantId1'] as string};
+    const res = await request.post(
+      buildUrl('/tenants/{tenantId}/clients/search', p),
+      {headers: {}, data: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Tenant Clients For Non Existent Tenant Empty', async ({
+    request,
+  }) => {
+    const p = {tenantId: 'invalidTenantId'};
+    const res = await request.post(
+      buildUrl('/tenants/{tenantId}/clients/search', p),
+      {headers: jsonHeaders(), data: {}},
+    );
+    await assertPaginatedRequest(res, {
+      totalItemsEqualTo: 0,
+      itemsLengthEqualTo: 0,
+    });
+  });
+
+  test('Unassign Client From Tenant', async ({request}) => {
+    const tenantId = state['tenantId2'] as string;
+    const clientId = clientFromState('tenantId2', state, 1);
+    const p = {tenantId: tenantId, clientId: clientId};
+
+    await test.step('Unassign Client From Tenant', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/tenants/{tenantId}/clients/{clientId}', p),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Tenant Clients After Unassign', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/tenants/{tenantId}/clients/search', p),
+          {headers: jsonHeaders(), data: {}},
+        );
+        await assertPaginatedRequest(res, {
+          totalItemsEqualTo: 0,
+          itemsLengthEqualTo: 0,
+        });
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Unassign Client From Tenant Unauthorized', async ({request}) => {
+    const tenantId = state['tenantId1'] as string;
+    const clientId = clientFromState('tenantId1', state, 1);
+    const p = {tenantId: tenantId, clientId: clientId};
+
+    const res = await request.delete(
+      buildUrl('/tenants/{tenantId}/clients/{clientId}', p),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign Client From Tenant Non Existent Client Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      clientId: 'invalidClientId',
+      tenantId: state['tenantId1'] as string,
+    };
+    const res = await request.delete(
+      buildUrl('/tenants/{tenantId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Unassign Client From Tenant Non Existent Tenant Not Found', async ({
+    request,
+  }) => {
+    const clientId = clientFromState('tenantId1', state, 1);
+    const p = {clientId, tenantId: 'invalidTenantId'};
+    const res = await request.delete(
+      buildUrl('/tenants/{tenantId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-groups-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-groups-api-tests.spec.ts
@@ -72,10 +72,7 @@ test.describe.parallel('Tenant Groups API Tests', () => {
         headers: jsonHeaders(),
       },
     );
-    await assertNotFoundRequest(
-      res,
-      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
-    );
+    expect(res.status()).toBe(204);
   });
 
   test('Assign Group To Tenant Non Existent Tenant Not Found', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-groups-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-groups-api-tests.spec.ts
@@ -20,36 +20,36 @@ import {
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {
   assertGroupsInResponse,
-  assignGroupsToRole,
+  assignGroupsToTenant,
   createGroupAndStoreResponseFields,
-  createRole,
+  createTenant,
   groupIdFromState,
 } from '../../../../utils/requestHelpers';
 import {GROUPS_EXPECTED_BODY} from '../../../../utils/beans/requestBeans';
 
-test.describe.parallel('Role Groups API Tests', () => {
+test.describe.parallel('Tenant Groups API Tests', () => {
   const state: Record<string, unknown> = {};
 
   test.beforeAll(async ({request}) => {
-    await createRole(request, state, '1');
-    await createRole(request, state, '2');
-    await createRole(request, state, '3');
-    await assignGroupsToRole(request, 2, 'roleId1', state);
-    await assignGroupsToRole(request, 3, 'roleId2', state);
-    await assignGroupsToRole(request, 3, 'roleId3', state);
+    await createTenant(request, state, '1');
+    await createTenant(request, state, '2');
+    await createTenant(request, state, '3');
+    await assignGroupsToTenant(request, 2, 'tenantId1', state);
+    await assignGroupsToTenant(request, 3, 'tenantId2', state);
+    await assignGroupsToTenant(request, 3, 'tenantId3', state);
   });
 
-  test('Assign Group To Role', async ({request}) => {
-    const groupKey = `${state['roleId1']}6`;
+  test('Assign Group To Tenant', async ({request}) => {
+    const groupKey = `${state['tenantId1']}6`;
     await createGroupAndStoreResponseFields(request, 1, state, groupKey);
     const p = {
       groupId: groupIdFromState(groupKey, state, 6) as string,
-      roleId: state['roleId1'] as string,
+      tenantId: state['tenantId1'] as string,
     };
 
     await expect(async () => {
       const res = await request.put(
-        buildUrl('/roles/{roleId}/groups/{groupId}', p),
+        buildUrl('/tenants/{tenantId}/groups/{groupId}', p),
         {
           headers: jsonHeaders(),
         },
@@ -58,16 +58,16 @@ test.describe.parallel('Role Groups API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Assign Group To Role Non Existent Group Not Found', async ({
+  test('Assign Group To Tenant Non Existent Group Not Found', async ({
     request,
   }) => {
     const stateParams: Record<string, string> = {
       groupId: 'invalidGroupId',
-      roleId: state['roleId1'] as string,
+      tenantId: state['tenantId1'] as string,
     };
 
     const res = await request.put(
-      buildUrl('/roles/{roleId}/groups/{groupId}', stateParams),
+      buildUrl('/tenants/{tenantId}/groups/{groupId}', stateParams),
       {
         headers: jsonHeaders(),
       },
@@ -78,16 +78,16 @@ test.describe.parallel('Role Groups API Tests', () => {
     );
   });
 
-  test('Assign Group To Role Non Existent Role Not Found', async ({
+  test('Assign Group To Tenant Non Existent Tenant Not Found', async ({
     request,
   }) => {
     const stateParams: Record<string, string> = {
-      groupId: groupIdFromState('roleId1', state) as string,
-      roleId: 'invalidRoleId',
+      groupId: groupIdFromState('tenantId1', state) as string,
+      tenantId: 'invalidTenantId',
     };
 
     const res = await request.put(
-      buildUrl('/roles/{roleId}/groups/{groupId}', stateParams),
+      buildUrl('/tenants/{tenantId}/groups/{groupId}', stateParams),
       {
         headers: jsonHeaders(),
       },
@@ -98,15 +98,15 @@ test.describe.parallel('Role Groups API Tests', () => {
     );
   });
 
-  test('Assign Group To Role Unauthorized', async ({request}) => {
+  test('Assign Group To Tenant Unauthorized', async ({request}) => {
     const stateParams: Record<string, string> = {
-      groupId: groupIdFromState('roleId1', state) as string,
-      roleId: state['roleId1'] as string,
+      groupId: groupIdFromState('tenantId1', state) as string,
+      tenantId: state['tenantId1'] as string,
     };
 
     await expect(async () => {
       const res = await request.put(
-        buildUrl('/roles/{roleId}/groups/{groupId}', stateParams),
+        buildUrl('/tenants/{tenantId}/groups/{groupId}', stateParams),
         {
           headers: {},
         },
@@ -115,15 +115,15 @@ test.describe.parallel('Role Groups API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Assign Already Added Group To Role Conflict', async ({request}) => {
+  test('Assign Already Added Group To Tenant Conflict', async ({request}) => {
     const stateParams: Record<string, string> = {
-      groupId: groupIdFromState('roleId1', state) as string,
-      roleId: state['roleId1'] as string,
+      groupId: groupIdFromState('tenantId1', state) as string,
+      tenantId: state['tenantId1'] as string,
     };
 
     await expect(async () => {
       const res = await request.put(
-        buildUrl('/roles/{roleId}/groups/{groupId}', stateParams),
+        buildUrl('/tenants/{tenantId}/groups/{groupId}', stateParams),
         {
           headers: jsonHeaders(),
         },
@@ -133,15 +133,15 @@ test.describe.parallel('Role Groups API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Unassign Group From Role', async ({request}) => {
+  test('Unassign Group From Tenant', async ({request}) => {
     const p = {
-      groupId: groupIdFromState('roleId2', state) as string,
-      roleId: state['roleId2'] as string,
+      groupId: groupIdFromState('tenantId2', state) as string,
+      tenantId: state['tenantId2'] as string,
     };
-    await test.step('Unassign Role From Group', async () => {
+    await test.step('Unassign Group From Tenant', async () => {
       await expect(async () => {
         const res = await request.delete(
-          buildUrl('/roles/{roleId}/groups/{groupId}', p),
+          buildUrl('/tenants/{tenantId}/groups/{groupId}', p),
           {
             headers: jsonHeaders(),
           },
@@ -150,10 +150,10 @@ test.describe.parallel('Role Groups API Tests', () => {
       }).toPass(defaultAssertionOptions);
     });
 
-    await test.step('Search Group Roles For Group After Deletion', async () => {
+    await test.step('Search Tenant Groups For Group After Deletion', async () => {
       await expect(async () => {
         const res = await request.post(
-          buildUrl('/groups/{groupId}/roles/search', p),
+          buildUrl('/tenants/{tenantId}/groups/search', p),
           {
             headers: jsonHeaders(),
             data: {},
@@ -168,13 +168,13 @@ test.describe.parallel('Role Groups API Tests', () => {
     });
   });
 
-  test('Unassign Role From Group Unauthorized', async ({request}) => {
+  test('Unassign Group From Tenant Unauthorized', async ({request}) => {
     const p = {
-      groupId: groupIdFromState('roleId2', state) as string,
-      roleId: state['roleId2'] as string,
+      groupId: groupIdFromState('tenantId2', state) as string,
+      tenantId: state['tenantId2'] as string,
     };
     const res = await request.delete(
-      buildUrl('/roles/{roleId}/groups/{groupId}', p),
+      buildUrl('/tenants/{tenantId}/groups/{groupId}', p),
       {
         headers: {},
       },
@@ -182,15 +182,15 @@ test.describe.parallel('Role Groups API Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  test('Unassign Role From Group Non Existent Group Not Found', async ({
+  test('Unassign Group From Tenant Non Existent Group Not Found', async ({
     request,
   }) => {
     const p = {
       groupId: 'invalidGroupId',
-      roleId: state['roleId2'] as string,
+      tenantId: state['tenantId2'] as string,
     };
     const res = await request.delete(
-      buildUrl('/roles/{roleId}/groups/{groupId}', p),
+      buildUrl('/tenants/{tenantId}/groups/{groupId}', p),
       {
         headers: jsonHeaders(),
       },
@@ -201,15 +201,15 @@ test.describe.parallel('Role Groups API Tests', () => {
     );
   });
 
-  test('Unassign Role From Group Non Existent Role Not Found', async ({
+  test('Unassign Group From Tenant Non Existent Tenant Not Found', async ({
     request,
   }) => {
     const p = {
-      groupId: groupIdFromState('roleId2', state) as string,
-      roleId: 'invalidRoleId',
+      groupId: groupIdFromState('tenantId2', state) as string,
+      tenantId: 'invalidTenantId',
     };
     const res = await request.delete(
-      buildUrl('/roles/{roleId}/groups/{groupId}', p),
+      buildUrl('/tenants/{tenantId}/groups/{groupId}', p),
       {
         headers: jsonHeaders(),
       },
@@ -220,15 +220,15 @@ test.describe.parallel('Role Groups API Tests', () => {
     );
   });
 
-  test('Search Role Groups', async ({request}) => {
-    const p = {roleId: state['roleId3'] as string};
-    const group1 = groupIdFromState('roleId3', state, 1);
-    const group2 = groupIdFromState('roleId3', state, 2);
-    const group3 = groupIdFromState('roleId3', state, 3);
+  test('Search Tenant Groups', async ({request}) => {
+    const p = {tenantId: state['tenantId3'] as string};
+    const group1 = groupIdFromState('tenantId3', state, 1);
+    const group2 = groupIdFromState('tenantId3', state, 2);
+    const group3 = groupIdFromState('tenantId3', state, 3);
 
     await expect(async () => {
       const res = await request.post(
-        buildUrl('/roles/{roleId}/groups/search', p),
+        buildUrl('/tenants/{tenantId}/groups/search', p),
         {headers: jsonHeaders(), data: {}},
       );
       await assertPaginatedRequest(res, {
@@ -242,15 +242,15 @@ test.describe.parallel('Role Groups API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Role Groups Role With No Assignments Returns Empty', async ({
+  test('Search Tenant Groups Tenant With No Assignments Returns Empty', async ({
     request,
   }) => {
-    const role = await createRole(request);
-    const p = {roleId: role.roleId as string};
+    const tenant = await createTenant(request);
+    const p = {tenantId: tenant.tenantId as string};
 
     await expect(async () => {
       const res = await request.post(
-        buildUrl('/roles/{roleId}/groups/search', p),
+        buildUrl('/tenants/{tenantId}/groups/search', p),
         {headers: jsonHeaders(), data: {}},
       );
       await assertPaginatedRequest(res, {
@@ -260,19 +260,19 @@ test.describe.parallel('Role Groups API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Role Groups Unauthorized', async ({request}) => {
-    const p = {roleId: state['roleId3'] as string};
+  test('Search Tenant Groups Unauthorized', async ({request}) => {
+    const p = {tenantId: state['tenantId3'] as string};
     const res = await request.post(
-      buildUrl('/roles/{roleId}/groups/search', p),
+      buildUrl('/tenants/{tenantId}/groups/search', p),
       {headers: {}, data: {}},
     );
     await assertUnauthorizedRequest(res);
   });
 
-  test('Search Role Groups Role Not Found', async ({request}) => {
-    const p = {roleId: 'invalid-role-id'};
+  test('Search Tenant Groups Tenant Not Found', async ({request}) => {
+    const p = {tenantId: 'invalid-tenant-id'};
     const res = await request.post(
-      buildUrl('/roles/{roleId}/groups/search', p),
+      buildUrl('/tenants/{tenantId}/groups/search', p),
       {headers: jsonHeaders(), data: {}},
     );
     await assertPaginatedRequest(res, {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-groups-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-groups-api-tests.spec.ts
@@ -35,7 +35,7 @@ test.describe.parallel('Tenant Groups API Tests', () => {
     await createTenant(request, state, '2');
     await createTenant(request, state, '3');
     await assignGroupsToTenant(request, 2, 'tenantId1', state);
-    await assignGroupsToTenant(request, 3, 'tenantId2', state);
+    await assignGroupsToTenant(request, 1, 'tenantId2', state);
     await assignGroupsToTenant(request, 3, 'tenantId3', state);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-users-api-tests.spec.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  assertPaginatedRequest,
+} from '../../../../utils/http';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+import {
+  assertUsersInResponse,
+  assignUsersToTenant,
+  createTenant,
+  userFromState,
+} from '../../../../utils/requestHelpers';
+
+test.describe.parallel('Tenant Users API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createTenant(request, state, '1');
+    await createTenant(request, state, '2');
+    await assignUsersToTenant(request, 3, state['tenantId1'] as string, state);
+    await assignUsersToTenant(request, 1, state['tenantId2'] as string, state);
+  });
+
+  test('Assign User To Tenant', async ({request}) => {
+    const tenant = await createTenant(request);
+    const user = 'test-user' + generateUniqueId();
+    const p = {
+      userName: user,
+      tenantId: tenant.tenantId as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/tenants/{tenantId}/users/{userName}', p),
+        {headers: jsonHeaders()},
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign User To Tenant Non Existent User Success', async ({request}) => {
+    const p = {
+      userName: 'invalidUserName',
+      tenantId: state['tenantId1'] as string,
+    };
+    const res = await request.put(
+      buildUrl('/tenants/{tenantId}/users/{userName}', p),
+      {headers: jsonHeaders()},
+    );
+    expect(res.status()).toBe(204);
+  });
+
+  test('Assign User To Tenant Non Existent Tenant Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      userName: userFromState('tenantId1', state) as string,
+      tenantId: 'invalidTenantId',
+    };
+    const res = await request.put(
+      buildUrl('/tenants/{tenantId}/users/{userName}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign User To Tenant Unauthorized', async ({request}) => {
+    const tenantId: string = state['tenantId1'] as string;
+    const p = {
+      userName: userFromState('tenantId1', state) as string,
+      tenantId: tenantId,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/tenants/{tenantId}/users/{userName}', p),
+        {headers: {}},
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Already Added User To Tenant Conflict', async ({request}) => {
+    const tenantId: string = state['tenantId1'] as string;
+    const p = {
+      userName: userFromState('tenantId1', state) as string,
+      tenantId: tenantId,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/tenants/{tenantId}/users/{userName}', p),
+        {headers: jsonHeaders()},
+      );
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Tenant Users', async ({request}) => {
+    const tenantId: string = state['tenantId1'] as string;
+    const p = {tenantId: tenantId};
+    const user1: string = userFromState('tenantId1', state, 1);
+    const user2: string = userFromState('tenantId1', state, 2);
+    const user3: string = userFromState('tenantId1', state, 3);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/tenants/{tenantId}/users/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        totalItemsEqualTo: 3,
+        itemsLengthEqualTo: 3,
+      });
+      const json = await res.json();
+      assertUsersInResponse(json, user1);
+      assertUsersInResponse(json, user2);
+      assertUsersInResponse(json, user3);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Tenant Users Unauthorized', async ({request}) => {
+    const tenantId: string = state['tenantId1'] as string;
+    const p = {userName: userFromState(tenantId, state) as string};
+    const res = await request.post(
+      buildUrl('/tenants/{tenantId}/users/search', p),
+      {headers: {}, data: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Tenant Users For Non Existent User Empty', async ({request}) => {
+    const p = {tenantId: 'invalidTenantId'};
+    const res = await request.post(
+      buildUrl('/tenants/{tenantId}/users/search', p),
+      {headers: jsonHeaders(), data: {}},
+    );
+
+    await assertPaginatedRequest(res, {
+      totalItemsEqualTo: 0,
+      itemsLengthEqualTo: 0,
+    });
+  });
+
+  test('Unassign User From Tenant', async ({request}) => {
+    const tenantId: string = state['tenantId2'] as string;
+    const tenantUser: string = userFromState('tenantId2', state, 1);
+    const p = {
+      userName: tenantUser,
+      tenantId: tenantId,
+    };
+
+    await test.step('Unassign User From Tenant', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/tenants/{tenantId}/users/{userName}', p),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Tenant Users After Unassign', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/tenants/{tenantId}/users/search', p),
+          {headers: jsonHeaders(), data: {}},
+        );
+        await assertPaginatedRequest(res, {
+          totalItemsEqualTo: 0,
+          itemsLengthEqualTo: 0,
+        });
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Unassign User From Tenant Unauthorized', async ({request}) => {
+    const tenantId: string = state['tenantId1'] as string;
+    const p = {
+      userName: userFromState('tenantId1', state) as string,
+      tenantId: tenantId,
+    };
+    const res = await request.delete(
+      buildUrl('/tenants/{tenantId}/users/{userName}', p),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign User From Tenant Non Existent User Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      userName: 'invalidUserId',
+      tenantId: state['tenantId1'] as string,
+    };
+    const res = await request.delete(
+      buildUrl('/tenants/{tenantId}/users/{userName}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Unassign User From Tenant Non Existent Tenant Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      userName: userFromState('tenantId1', state) as string,
+      tenantId: 'invalidTenantId',
+    };
+    const res = await request.delete(
+      buildUrl('/tenants/{tenantId}/users/{userName}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -129,6 +129,7 @@ test.describe('Groups functionalities', () => {
       const item = identityGroupsPage.groupCell(TEST_GROUP.name);
       await waitForItemInList(page, item, {
         clickNext: true,
+        timeout: 60000,
       });
       await expect(item).toBeVisible();
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -129,7 +129,6 @@ test.describe('Groups functionalities', () => {
       const item = identityGroupsPage.groupCell(TEST_GROUP.name);
       await waitForItemInList(page, item, {
         clickNext: true,
-        timeout: 60000,
       });
       await expect(item).toBeVisible();
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -81,8 +81,10 @@ test.describe.serial('groups CRUD', () => {
 
   test('deletes a group', async ({page, identityGroupsPage}) => {
     const group = identityGroupsPage.groupCell(EDITED_GROUP.name);
-    expect(await findLocatorInPaginatedList(page, group)).toBe(true);
-    await expect(group).toBeVisible();
+    await waitForItemInList(page, group, {
+      clickNext: true,
+      timeout: 60000,
+    });
 
     await identityGroupsPage.deleteGroup(EDITED_GROUP.name);
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
@@ -50,7 +50,10 @@ test.describe.serial('roles CRUD', () => {
 
   test('deletes a role', async ({page, identityRolesPage}) => {
     const item = identityRolesPage.roleCell(NEW_ROLE.name);
-    expect(await findLocatorInPaginatedList(page, item)).toBe(true);
+    await waitForItemInList(page, item, {
+      clickNext: true,
+      timeout: 60000,
+    });
     await identityRolesPage.deleteRole(NEW_ROLE.name);
 
     await waitForItemInList(page, item, {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
@@ -12,10 +12,7 @@ import {relativizePath, Paths} from 'utils/relativizePath';
 import {LOGIN_CREDENTIALS, createTestData} from 'utils/constants';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureFailureVideo, captureScreenshot} from '@setup';
-import {
-  findLocatorInPaginatedList,
-  waitForItemInList,
-} from '../../utils/waitForItemInList';
+import {waitForItemInList} from '../../utils/waitForItemInList';
 
 test.describe.serial('roles CRUD', () => {
   let NEW_ROLE: NonNullable<ReturnType<typeof createTestData>['authRole']>;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/tenants.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/tenants.spec.ts
@@ -47,10 +47,15 @@ test.describe.serial('tenants CRUD', () => {
       ).toBeHidden();
       await identityTenantsPage.createTenant(NEW_TENANT);
       const item = identityTenantsPage.tenantCell(NEW_TENANT.name);
-      await waitForItemInList(page, item, {timeout: 60000});
+      await waitForItemInList(page, item, {timeout: 60000, clickNext: true});
     });
 
     test('assign a user', async ({page, identityTenantsPage}) => {
+      await waitForItemInList(
+        page,
+        identityTenantsPage.tenantCell(NEW_TENANT.name),
+        {timeout: 60000, clickNext: true},
+      );
       await identityTenantsPage.openTenantDetails(NEW_TENANT.tenantId).click();
       await identityTenantsPage.assignUserToTenant(USER);
       const item = identityTenantsPage.userRow(USER.name);
@@ -61,6 +66,11 @@ test.describe.serial('tenants CRUD', () => {
     });
 
     test('remove a user', async ({page, identityTenantsPage}) => {
+      await waitForItemInList(
+        page,
+        identityTenantsPage.tenantCell(NEW_TENANT.name),
+        {timeout: 60000, clickNext: true},
+      );
       await identityTenantsPage.openTenantDetails(NEW_TENANT.tenantId).click();
       await identityTenantsPage.removeUserFromTenant(USER.name);
       const item = identityTenantsPage.userRow(USER.name);
@@ -71,12 +81,19 @@ test.describe.serial('tenants CRUD', () => {
     });
 
     test('delete a tenant', async ({page, identityTenantsPage}) => {
-      await expect(
-        identityTenantsPage.tenantCell(NEW_TENANT.name),
-      ).toBeVisible();
+      const item = identityTenantsPage.tenantCell(NEW_TENANT.name);
+      await waitForItemInList(page, item, {
+        clickNext: true,
+        timeout: 60000,
+      });
+
       await identityTenantsPage.deleteTenant(NEW_TENANT.name);
-      const item = identityTenantsPage.tenantRow(NEW_TENANT.name);
-      await waitForItemInList(page, item, {shouldBeVisible: false});
+
+      await waitForItemInList(page, item, {
+        shouldBeVisible: false,
+        clickNext: true,
+        timeout: 60000,
+      });
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -180,9 +180,18 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.selectProcess(
         'Process With Multiple Versions',
       );
-      await expect
-        .poll(() => operateFiltersPanelPage.processVersionFilter.innerText())
-        .toBe('2');
+      await waitForAssertion({
+        assertion: async () => {
+          await expect
+            .poll(() =>
+              operateFiltersPanelPage.processVersionFilter.innerText(),
+            )
+            .toBe('2');
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
     });
 
     await test.step('Change version and see flow node filter has been reset', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/accessVerification.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/accessVerification.ts
@@ -7,6 +7,7 @@
  */
 
 import {expect, Page} from '@playwright/test';
+import {waitForAssertion} from './waitForAssertion';
 
 export async function verifyAccess(
   page: Page,
@@ -23,6 +24,13 @@ export async function verifyAccess(
       await expect(page).toHaveURL(new RegExp(appName));
     }
   } else {
-    await expect(page).toHaveURL(/forbidden/);
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(page).toHaveURL(/forbidden/);
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -13,7 +13,6 @@ import {
   roleDescriptionFromState,
   roleNameFromState,
   mappingRuleIdFromState,
-  roleIdValueUsingCount,
   mappingRuleNameFromState,
   mappingRuleClaimNameFromState,
   mappingRuleClaimValueFromState,
@@ -122,10 +121,11 @@ export function UPDATE_ROLE() {
 }
 
 export function PUBLISH_NEW_MESSAGE() {
+  const uid = generateUniqueId();
   return {
-    name: `msg-${Date.now()}`,
-    correlationKey: `corr-${Math.random().toString(36).slice(2, 10)}`,
-    messageId: `corr-${Math.random().toString(36).slice(2, 10)}`,
+    name: `msg-${uid}`,
+    correlationKey: `corr-${uid}`,
+    messageId: `corr-${uid}`,
     timeToLive: 300000,
     variables: {foo: 'bar'},
   };

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -8,7 +8,19 @@
 
 import {generateUniqueId} from '../constants';
 import * as fs from 'node:fs';
-import {createMappingRule, mappingRuleIdFromState} from '../requestHelpers';
+import {
+  createMappingRule,
+  roleDescriptionFromState,
+  roleNameFromState,
+  mappingRuleIdFromState,
+  roleIdValueUsingCount,
+  mappingRuleNameFromState,
+  mappingRuleClaimNameFromState,
+  mappingRuleClaimValueFromState,
+  roleIdValueUsingKey,
+  userFromState,
+  mappingRuleIdFromKey,
+} from '../requestHelpers';
 import {APIRequestContext} from 'playwright-core';
 
 export const groupRequiredFields: string[] = ['groupId', 'name', 'description'];
@@ -99,6 +111,13 @@ export function CREATE_NEW_ROLE() {
     roleId: `role-${uid}`,
     name: `Test Role ${uid}`,
     description: 'E2E test role',
+  };
+}
+export function UPDATE_ROLE() {
+  const uid = generateUniqueId();
+  return {
+    name: `role-updated-${uid}`,
+    description: `Updated description-${uid}`,
   };
 }
 
@@ -217,20 +236,20 @@ export const CREATE_DOCUMENT_LINK_REQUEST = {
   timeToLive: 60000,
 };
 
-export function CREATE_MAPPING_EXPECTED_BODY_USING_GROUP(
-  groupId: string,
+export function MAPPING_RULE_EXPECTED_BODY_USING_STATE(
+  key: string,
   state: Record<string, unknown>,
   nth: number = 1,
 ) {
   return {
-    claimName: state[`${groupId}claimName${nth}`] as string,
-    claimValue: state[`${groupId}claimValue${nth}`] as string,
-    name: state[`${groupId}name${nth}`] as string,
-    mappingRuleId: state[`${groupId}mappingRule${nth}`] as string,
+    claimName: mappingRuleClaimNameFromState(key, state, nth) as string,
+    claimValue: mappingRuleClaimValueFromState(key, state, nth) as string,
+    name: mappingRuleNameFromState(key, state, nth) as string,
+    mappingRuleId: mappingRuleIdFromState(key, state, nth) as string,
   };
 }
 
-export function CREATE_MAPPING_EXPECTED_BODY(
+export function MAPPING_RULE_EXPECTED_BODY_USING_KEY(
   key: string,
   state: Record<string, unknown>,
 ) {
@@ -242,15 +261,15 @@ export function CREATE_MAPPING_EXPECTED_BODY(
   };
 }
 
-export function CREATE_GROUP_ROLE_EXPECTED_BODY_USING_GROUP(
-  groupId: string,
+export function ROLE_EXPECTED_BODY(
+  key: string,
   state: Record<string, unknown>,
   nth: number = 1,
 ) {
   return {
-    name: state[`${groupId}name${nth}`] as string,
-    roleId: state[`${groupId}roleId${nth}`] as string,
-    description: state[`${groupId}description${nth}`] as string,
+    name: roleNameFromState(key, state, nth),
+    roleId: roleIdValueUsingKey(key, state, nth),
+    description: roleDescriptionFromState(key, state, nth),
   };
 }
 
@@ -260,7 +279,13 @@ export function CREATE_GROUP_USERS_EXPECTED_BODY_USING_GROUP(
   nth: number = 1,
 ) {
   return {
-    username: state[`${groupId}user${nth}`] as string,
+    username: userFromState(groupId, state, nth),
+  };
+}
+
+export function ROLE_GROUP_EXPECTED_BODY(groupId: string) {
+  return {
+    groupId: groupId,
   };
 }
 
@@ -272,7 +297,7 @@ export async function mappingRuleBundle(
   await createMappingRule(request, state, mappingRuleKey);
   return {
     mappingRuleKey: mappingRuleKey,
-    mappingRuleId: mappingRuleIdFromState(mappingRuleKey, state),
-    responseBody: CREATE_MAPPING_EXPECTED_BODY(mappingRuleKey, state),
+    mappingRuleId: mappingRuleIdFromKey(mappingRuleKey, state),
+    responseBody: MAPPING_RULE_EXPECTED_BODY_USING_KEY(mappingRuleKey, state),
   };
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -23,6 +23,11 @@ import {
 import {APIRequestContext} from 'playwright-core';
 
 export const groupRequiredFields: string[] = ['groupId', 'name', 'description'];
+export const tenantRequiredFields: string[] = [
+  'tenantId',
+  'name',
+  'description',
+];
 export const mappingRuleRequiredFields: string[] = [
   'claimName',
   'claimValue',
@@ -116,6 +121,23 @@ export function UPDATE_ROLE() {
   const uid = generateUniqueId();
   return {
     name: `role-updated-${uid}`,
+    description: `Updated description-${uid}`,
+  };
+}
+
+export function CREATE_NEW_TENANT() {
+  const uid = generateUniqueId();
+  return {
+    tenantId: `tenant-${uid}`,
+    name: `Test Tenant ${uid}`,
+    description: `E2E test tenant ${uid}`,
+  };
+}
+
+export function UPDATE_TENANT() {
+  const uid = generateUniqueId();
+  return {
+    name: `tenant-updated-${uid}`,
     description: `Updated description-${uid}`,
   };
 }
@@ -283,7 +305,7 @@ export function CREATE_GROUP_USERS_EXPECTED_BODY_USING_GROUP(
   };
 }
 
-export function ROLE_GROUP_EXPECTED_BODY(groupId: string) {
+export function GROUPS_EXPECTED_BODY(groupId: string) {
   return {
     groupId: groupId,
   };

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -6,11 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import crypto from 'crypto';
 export const LOGIN_CREDENTIALS = {username: 'demo', password: 'demo'};
 
 // Generate a simple random alphanumeric string for test isolation
 export const generateUniqueId = () => {
-  return Math.random().toString(36).substring(2, 10);
+  return crypto.randomBytes(8).toString('base64url');
 };
 
 // Create unique user with optional custom ID

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -5,13 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-
-import crypto from 'crypto';
 export const LOGIN_CREDENTIALS = {username: 'demo', password: 'demo'};
 
 // Generate a simple random alphanumeric string for test isolation
 export const generateUniqueId = () => {
-  return crypto.randomBytes(8).toString('base64url');
+  return Math.random().toString(36).substring(2, 10);
 };
 
 // Create unique user with optional custom ID

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -5,6 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
+
 export const LOGIN_CREDENTIALS = {username: 'demo', password: 'demo'};
 
 // Generate a simple random alphanumeric string for test isolation

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers.ts
@@ -11,16 +11,24 @@ import {
   CREATE_NEW_MAPPING_RULE,
   CREATE_NEW_ROLE,
   groupRequiredFields,
+  roleRequiredFields,
 } from './beans/requestBeans';
-import {assertRequiredFields, buildUrl, jsonHeaders} from './http';
+import {
+  assertEqualsForKeys,
+  assertRequiredFields,
+  buildUrl,
+  jsonHeaders,
+} from './http';
 import {expect} from '@playwright/test';
 import type {APIRequestContext} from 'playwright-core';
 import {defaultAssertionOptions, generateUniqueId} from './constants';
+import {Serializable} from 'playwright-core/types/structs';
 
 export async function createGroupAndStoreResponseFields(
   request: APIRequestContext,
   numberOfGroups: number,
   state: Record<string, unknown>,
+  key?: string,
 ) {
   for (let i = 1; i <= numberOfGroups; i++) {
     const requestBody = CREATE_NEW_GROUP();
@@ -31,9 +39,10 @@ export async function createGroupAndStoreResponseFields(
     expect(res.status()).toBe(201);
     const json = await res.json();
     assertRequiredFields(json, groupRequiredFields);
-    state[`groupId${i}`] = json.groupId;
-    state[`name${i}`] = json.name;
-    state[`description${i}`] = json.description;
+    const arrayKey = key ? `${key}${i}` : `${i}`;
+    state[`groupId${arrayKey}`] = json.groupId;
+    state[`name${arrayKey}`] = json.name;
+    state[`description${arrayKey}`] = json.description;
   }
 }
 
@@ -57,8 +66,18 @@ export async function assignClientToGroup(
         },
       );
       expect(res.status()).toBe(204);
-      state[`${groupId}clientId${i}`] = clientId;
+      state[`clientId${groupId}${i}`] = clientId;
     }).toPass(defaultAssertionOptions);
+  }
+}
+
+export async function createRoleAndStoreResponseFields(
+  request: APIRequestContext,
+  numberOfRoles: number,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfRoles; i++) {
+    await createRole(request, state, `${i}`);
   }
 }
 
@@ -69,37 +88,69 @@ export async function assignMappingToGroup(
   state: Record<string, unknown>,
 ) {
   for (let i = 1; i <= numberOfMappings; i++) {
-    const mappingRule = await createMappingRule(request);
+    const mappingRule = await createMappingRule(
+      request,
+      state,
+      `${groupId}${i}`,
+    );
     const p = {
       groupId: groupId as string,
       mappingRuleId: mappingRule.mappingRuleId as string,
     };
 
-    const res = await request.put(
-      buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),
-      {
-        headers: jsonHeaders(),
-      },
-    );
-    expect(res.status()).toBe(204);
-    state[`${groupId}mappingRule${i}`] = mappingRule.mappingRuleId;
-    state[`${groupId}claimName${i}`] = mappingRule.claimName;
-    state[`${groupId}claimValue${i}`] = mappingRule.claimValue;
-    state[`${groupId}name${i}`] = mappingRule.name;
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
   }
 }
 
-export async function assignRolesToGroup(
+export async function assignRoleToGroups(
   request: APIRequestContext,
   numberOfRoles: number,
   groupId: string,
   state: Record<string, unknown>,
 ) {
   for (let i = 1; i <= numberOfRoles; i++) {
-    const role = await createRole(request);
+    const role = await createRole(request, state, `${groupId}${i}`);
     const p = {
       groupId: groupId as string,
       roleId: role.roleId as string,
+    };
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/groups/{groupId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  }
+}
+
+export async function assignGroupsToRole(
+  request: APIRequestContext,
+  numberOfGroups: number,
+  roleIdKey: string,
+  state: Record<string, unknown>,
+) {
+  const roleId = state[roleIdKey] as string;
+  await createGroupAndStoreResponseFields(
+    request,
+    numberOfGroups,
+    state,
+    roleId,
+  );
+  for (let i = 1; i <= numberOfGroups; i++) {
+    const p = {
+      groupId: groupIdFromState(roleIdKey, state, i) as string,
+      roleId: roleId as string,
     };
     const res = await request.put(
       buildUrl('/roles/{roleId}/groups/{groupId}', p),
@@ -108,9 +159,71 @@ export async function assignRolesToGroup(
       },
     );
     expect(res.status()).toBe(204);
-    state[`${groupId}roleId${i}`] = role.roleId;
-    state[`${groupId}name${i}`] = role.name;
-    state[`${groupId}description${i}`] = role.description;
+  }
+}
+
+export async function assignRolesToMappingRules(
+  request: APIRequestContext,
+  numberOfRules: number,
+  roleId: string,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfRules; i++) {
+    const rule = await createMappingRule(request, state, `${roleId}${i}`);
+    const p = {
+      roleId: roleId as string,
+      mappingRuleId: rule.mappingRuleId as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+        {headers: jsonHeaders()},
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  }
+}
+
+export async function assignRoleToUsers(
+  request: APIRequestContext,
+  numberOfUsers: number,
+  roleId: string,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfUsers; i++) {
+    const user = 'user' + generateUniqueId();
+    const p = {
+      userId: user,
+      roleId: roleId,
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/users/{userId}', p),
+      {headers: jsonHeaders()},
+    );
+    expect(res.status()).toBe(204);
+    state[`username${roleId}${i}`] = user;
+  }
+}
+
+export async function assignClientsToRole(
+  request: APIRequestContext,
+  numberOfClients: number,
+  roleId: string,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfClients; i++) {
+    const clientId = 'client' + generateUniqueId();
+    const p = {
+      roleId: roleId,
+      clientId: clientId,
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    expect(res.status()).toBe(204);
+    state[`client${roleId}${i}`] = clientId;
   }
 }
 
@@ -133,7 +246,17 @@ export async function assignUsersToGroup(
       },
     );
     expect(res.status()).toBe(204);
-    state[`${groupId}user${i}`] = user;
+    state[`username${groupId}${i}`] = user;
+  }
+}
+
+export async function createMappingRulesAndStoreResponseFields(
+  request: APIRequestContext,
+  numberOfRules: number,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfRules; i++) {
+    await createMappingRule(request, state, `${i}`);
   }
 }
 
@@ -160,7 +283,11 @@ export async function createMappingRule(
   return body;
 }
 
-export async function createRole(request: APIRequestContext) {
+export async function createRole(
+  request: APIRequestContext,
+  state?: Record<string, unknown>,
+  key?: string,
+) {
   const body = CREATE_NEW_ROLE();
 
   const res = await request.post(buildUrl('/roles'), {
@@ -169,44 +296,167 @@ export async function createRole(request: APIRequestContext) {
   });
 
   expect(res.status()).toBe(201);
+  const json = await res.json();
+  assertRequiredFields(json, roleRequiredFields);
+  if (state && key) {
+    const json = await res.json();
+    state[`roleId${key}`] = json.roleId;
+    state[`roleName${key}`] = json.name;
+    state[`roleDescription${key}`] = json.description;
+  }
   return body;
 }
 
-export function groupMappingRuleFromState(
-  group: string,
-  state: Record<string, unknown>,
-  nth: number = 1,
-): string {
-  return state[`${state[group]}mappingRule${nth}`] as string;
+export function assertUsersInResponse(json: Serializable, user: string) {
+  const matchingItem = json.items.find(
+    (it: {username: string}) => it.username === user,
+  );
+  expect(matchingItem).toBeDefined();
+  assertRequiredFields(matchingItem, ['username']);
+  assertEqualsForKeys(matchingItem, {username: user}, ['username']);
 }
 
-export function roleIdFromState(
-  group: string,
-  state: Record<string, unknown>,
-  nth: number = 1,
-): string {
-  return state[`${state[group]}roleId${nth}`] as string;
+export function assertClientsInResponse(json: Serializable, client: string) {
+  const matchingItem = json.items.find(
+    (it: {clientId: string}) => it.clientId === client,
+  );
+  expect(matchingItem).toBeDefined();
+  assertRequiredFields(matchingItem, ['clientId']);
+  assertEqualsForKeys(matchingItem, {clientId: client}, ['clientId']);
 }
 
-export function userFromState(
+export function assertRoleInResponse(
+  json: Serializable,
+  expectedBody: Serializable,
+  role: string,
+) {
+  const matchingItem = json.items.find(
+    (it: {roleId: string}) => it.roleId === role,
+  );
+  expect(matchingItem).toBeDefined();
+  assertRequiredFields(matchingItem, roleRequiredFields);
+  assertEqualsForKeys(matchingItem, expectedBody, roleRequiredFields);
+}
+
+export function assertGroupsInResponse(
+  json: Serializable,
+  expectedBody: Serializable,
   group: string,
+) {
+  const matchingItem = json.items.find(
+    (it: {groupId: string}) => it.groupId === group,
+  );
+  expect(matchingItem).toBeDefined();
+  assertRequiredFields(matchingItem, ['groupId']);
+  assertEqualsForKeys(matchingItem, expectedBody, ['groupId']);
+}
+
+export function groupIdFromState(
+  key: string,
   state: Record<string, unknown>,
   nth: number = 1,
 ): string {
-  return state[`${state[group]}user${nth}`] as string;
+  return state[`groupId${state[key]}${nth}`] as string;
+}
+
+export function groupNameFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`name${state[key]}${nth}`] as string;
+}
+
+export function roleIdValueUsingCount(
+  key: string,
+  state: Record<string, unknown>,
+): string {
+  return state[`roleId${key}`] as string;
+}
+
+export function roleIdValueUsingKey(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`roleId${state[key]}${nth}`] as string;
 }
 
 export function clientIdFromState(
-  group: string,
+  key: string,
   state: Record<string, unknown>,
   nth: number = 1,
 ): string {
-  return state[`${state[group]}clientId${nth}`] as string;
+  return state[`clientId${state[key]}${nth}`] as string;
 }
 
 export function mappingRuleIdFromState(
   key: string,
   state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`mappingRuleId${state[key]}${nth}`] as string;
+}
+
+export function mappingRuleIdFromKey(
+  key: string,
+  state: Record<string, unknown>,
 ): string {
   return state[`mappingRuleId${key}`] as string;
+}
+
+export function mappingRuleNameFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`name${state[key]}${nth}`] as string;
+}
+
+export function mappingRuleClaimNameFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`claimName${state[key]}${nth}`] as string;
+}
+
+export function mappingRuleClaimValueFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`claimValue${state[key]}${nth}`] as string;
+}
+
+export function userFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`username${state[key]}${nth}`] as string;
+}
+
+export function clientFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`client${state[key]}${nth}`] as string;
+}
+
+export function roleNameFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`roleName${state[key]}${nth}`] as string;
+}
+
+export function roleDescriptionFromState(
+  group: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`roleDescription${state[group]}${nth}`] as string;
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers.ts
@@ -299,7 +299,6 @@ export async function createRole(
   const json = await res.json();
   assertRequiredFields(json, roleRequiredFields);
   if (state && key) {
-    const json = await res.json();
     state[`roleId${key}`] = json.roleId;
     state[`roleName${key}`] = json.name;
     state[`roleDescription${key}`] = json.description;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/waitForItemInList.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/waitForItemInList.ts
@@ -13,7 +13,7 @@ export async function findLocatorInPaginatedList(
   page: Page,
   locator: Locator,
 ): Promise<boolean> {
-  const maxPage = 10;
+  const maxPage = 20;
   const nextButton = page.getByRole('button', {name: 'Next page'});
 
   for (let i = 0; i < maxPage; i++) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Unfortunately, I got mixed up some commits in [this PR](https://github.com/camunda/camunda/pull/37528/files) so I had to put both `Role` and `Tenant` API tests in this PR.

Run: https://github.com/camunda/camunda/actions/runs/17462843167

`Groups functionalities › As an Admin user can create a group with particular permissions and assign it to Test user` will failed due to [this bug](https://github.com/camunda/camunda/issues/37106).

## Checklist

**Create Role** (`POST /roles`)
- 201: Success (valid body, all required fields asserted)
- 401: Unauthorized (missing auth header)
- 400: Invalid bodies (missing name, empty name, missing roleId) → expects `INVALID_ARGUMENT` with missing field hints
- 409: Conflict (reusing existing roleId)

**Get Role** (`GET /roles/{roleId}`)
- 200: Success (valid roleId, all required fields asserted)
- 401: Unauthorized (missing auth header)
- 404: Not found (invalid roleId)

**Update Role** (`PUT /roles/{roleId}`)
- 200: Success (valid body, all required fields asserted)
- 401: Unauthorized (missing auth header)
- 400: Invalid bodies (empty name, missing name, missing description) → expects `INVALID_ARGUMENT` with missing field hints
- 404: Not found (invalid roleId)

**Delete Role** (`DELETE /roles/{roleId}`)
- 204: Success (valid roleId)
- 401: Unauthorized (missing auth header)
- 404: Not found (invalid roleId)

**Search Roles** (`POST /roles/search`)
- 200: Success (no filter, by name, by roleId, by multiple fields, all required fields asserted, correct pagination)
- 401: Unauthorized (missing auth header)
- 200: Success (invalid roleId filter returns empty result)

**Assign Role To Client** (`PUT /roles/{roleId}/clients/{clientId}`)
- 204: Success (valid roleId and clientId, assignment succeeds)
- 204: Success (non-existent client, assignment still succeeds)
- 401: Unauthorized (missing auth header) → expects unauthorized response
- 409: Conflict (client already assigned to role) → expects conflict response

**Search Role Clients** (`POST /roles/{roleId}/clients/search`)
- 200: Success (valid roleId, returns paginated list, asserts total and items)
- 401: Unauthorized (missing auth header) → expects unauthorized response
- 200: Success (invalid roleId, returns empty list, asserts total and items = 0)

**Unassign Role From Client** (`DELETE /roles/{roleId}/clients/{clientId}`)
- 204: Success (valid roleId and clientId, unassignment succeeds)
- 401: Unauthorized (missing auth header) → expects unauthorized response
- 404: Not found (invalid clientId or roleId) → expects `NOT_FOUND` with rejection message

**Assign Role To Group** (`PUT /roles/{roleId}/groups/{groupId}`)
- 204: Success (valid roleId and groupId, assignment succeeds)
- 204: Success (non-existent group, assignment still succeeds)
- 401: Unauthorized (missing auth header) → expects unauthorized response
- 404: Not found (invalid roleId) → expects `NOT_FOUND` with rejection message
- 409: Conflict (group already assigned to role) → expects conflict response

**Search Role Groups** (`POST /roles/{roleId}/groups/search`)
- 200: Success (valid roleId, returns paginated list, asserts total and items)
- 401: Unauthorized (missing auth header) → expects unauthorized response
- 200: Success (invalid roleId, returns empty list, asserts total and items = 0)

**Unassign Role From Group** (`DELETE /roles/{roleId}/groups/{groupId}`)
- 204: Success (valid roleId and groupId, unassignment succeeds)
- 401: Unauthorized (missing auth header) → expects unauthorized response
- 404: Not found (invalid groupId or roleId) → expects `NOT_FOUND` with rejection message

**Assign Role To Mapping Rule** (`PUT /roles/{roleId}/mapping-rules/{mappingRuleId}`)  
- 204: Success (valid roleId and mappingRuleId, assignment succeeds)  
- 401: Unauthorized (missing auth header) → expects unauthorized response  
- 404: Not found (invalid roleId or mappingRuleId) → expects `NOT_FOUND` with rejection message  
- 409: Conflict (mapping rule already assigned to role) → expects conflict response  

**Unassign Role From Mapping Rule** (`DELETE /roles/{roleId}/mapping-rules/{mappingRuleId}`)  
- 204: Success (valid roleId and mappingRuleId, unassignment succeeds)  
- 401: Unauthorized (missing auth header) → expects unauthorized response  
- 404: Not found (invalid roleId or mappingRuleId) → expects `NOT_FOUND` with rejection message  

**Search Role Mapping Rules** (`POST /roles/{roleId}/mapping-rules/search`)  
- 200: Success (valid roleId, returns paginated list, asserts total and items)  
- 200: Success (invalid roleId, returns empty list, asserts total and items = 0)  
- 401: Unauthorized (missing auth header) → expects unauthorized response  
- 200: Success (filter by mappingRuleId, name, or both, returns correct items)  
- 200: Success (non-matching filter, returns empty list)  
- 200: Success (role with no assignments, returns empty list)  


**Assign Role To Mapping Rule** (`PUT /roles/{roleId}/mapping-rules/{mappingRuleId}`)  
- 204: Success (valid roleId and mappingRuleId, assignment succeeds)  
- 401: Unauthorized (missing auth header) → expects unauthorized response  
- 404: Not found (invalid roleId or mappingRuleId) → expects NOT_FOUND with rejection message  
- 409: Conflict (mapping rule already assigned to role) → expects conflict response  

**Unassign Role From Mapping Rule** (`DELETE /roles/{roleId}/mapping-rules/{mappingRuleId}`)  
- 204: Success (valid roleId and mappingRuleId, unassignment succeeds)  
- 401: Unauthorized (missing auth header) → expects unauthorized response  
- 404: Not found (invalid roleId or mappingRuleId) → expects NOT_FOUND with rejection message  

**Search Role Mapping Rules** (`POST /roles/{roleId}/mapping-rules/search`)  
- 200: Success (valid roleId, returns paginated list, asserts total and items)  
- 200: Success (invalid roleId, returns empty list, asserts total and items = 0)  
- 401: Unauthorized (missing auth header) → expects unauthorized response  

**Create Tenant** (`POST /tenants`)
- 201: Success (valid body, all required fields asserted)
- 401: Unauthorized (missing auth header)
- 400: Invalid bodies (missing name, empty name, missing tenantId) → expects `INVALID_ARGUMENT` with missing field hints
- 409: Conflict (reusing existing tenantId)

**Get Tenant** (`GET /tenants/{tenantId}`)
- 200: Success (returns tenant)
- 401: Unauthorized (missing auth header)
- 404: Not Found (non-existent tenant) → expects `NOT_FOUND` with message

**Update Tenant** (`PUT /tenants/{tenantId}`)
- 200: Success (valid body, all required fields asserted)
- 400: Invalid bodies (empty name, missing name, missing description) → expects `INVALID_ARGUMENT` with missing field hints
- 401: Unauthorized (missing auth header)
- 404: Not Found (non-existent tenant) → expects `NOT_FOUND` with command hint

**Delete Tenant** (`DELETE /tenants/{tenantId}`)
- 204: Success (tenant deleted)
- 401: Unauthorized (missing auth header)
- 404: Not Found (non-existent tenant) → expects `NOT_FOUND` with command hint

**Search Tenants** (`POST /tenants/search`)
- 200: Success (returns paginated tenant list, supports filtering by name, tenantId, multiple fields)
- 401: Unauthorized (missing auth header)
- 200: Success (invalid tenantId returns empty list)


**Assign Client To Tenant** (`PUT /tenants/{tenantId}/clients/{clientId}`)
- 204: Success (client assigned to tenant, including non-existent client)
- 401: Unauthorized (missing auth header)
- 404: Not Found (non-existent tenant) → expects `NOT_FOUND` with command hint
- 409: Conflict (client already assigned) → expects `CONFLICT`

**Search Tenant Clients** (`POST /tenants/{tenantId}/clients/search`)
- 200: Success (returns paginated client list)
- 401: Unauthorized (missing auth header)
- 200: Success (non-existent tenant returns empty list)

**Unassign Client From Tenant** (`DELETE /tenants/{tenantId}/clients/{clientId}`)
- 204: Success (client unassigned from tenant)
- 401: Unauthorized (missing auth header)
- 404: Not Found (non-existent client or tenant) → expects `NOT_FOUND` with command hint

**Assign User To Tenant** (`PUT /tenants/{tenantId}/users/{userName}`)
- 204: Success (user assigned to tenant)
- 204: Success (non-existent user assigned)
- 401: Unauthorized (missing auth header)
- 404: Not Found (non-existent tenant) → expects `NOT_FOUND` with command hint
- 409: Conflict (user already assigned) → expects `CONFLICT`

**Search Tenant Users** (`POST /tenants/{tenantId}/users/search`)
- 200: Success (returns paginated user list)
- 401: Unauthorized (missing auth header)
- 200: Success (non-existent tenant returns empty list)

**Unassign User From Tenant** (`DELETE /tenants/{tenantId}/users/{userName}`)
- 204: Success (user unassigned from tenant)
- 401: Unauthorized (missing auth header)
- 404: Not Found (non-existent user or tenant) → expects `NOT_FOUND` with command hint


<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
