### PR TITLE
ci: change data structure used and update readme

### DIFF
--- a/.github/actions/flaky-tests-summary-comment/README.md
+++ b/.github/actions/flaky-tests-summary-comment/README.md
@@ -40,10 +40,9 @@ Creates or updates a PR comment with a comprehensive summary of flaky tests acro
     "jobs": [
       "elasticsearch-integration-tests"
     ],
-    "thisRunFailures": 1,
-    "previousRunFailures": 0,
-    "totalFailures": 1,
-    "totalRuns": 1
+    "failuresHistory": [1, 1],
+    "overallRetries": 2,
+    "totalRuns": 2
   }
 ]
 ```

--- a/.github/actions/flaky-tests-summary-comment/README.md
+++ b/.github/actions/flaky-tests-summary-comment/README.md
@@ -40,7 +40,10 @@ Creates or updates a PR comment with a comprehensive summary of flaky tests acro
     "jobs": [
       "elasticsearch-integration-tests"
     ],
-    "occurrences": 1
+    "thisRunFailures": 1,
+    "previousRunFailures": 0,
+    "totalFailures": 1,
+    "totalRuns": 1
   }
 ]
 ```

--- a/.github/actions/flaky-tests-summary-comment/src/flaky-tests-comment-generator.js
+++ b/.github/actions/flaky-tests-summary-comment/src/flaky-tests-comment-generator.js
@@ -52,8 +52,8 @@ async function buildComment(mergedData, github, branchName) {
     lines.push(`  - Jobs: \`${test.jobs.join(', ')}\``);
     lines.push(`  - Package: \`${test.packageName}\``);
     lines.push(`  - Class: \`${test.className ? test.className : "-"}\``);
-    lines.push(`  - Overall retries: ${test.overallRetries || 0} (per run: [${failuresHistoryStr}])`);
     lines.push(`  - Pipeline runs: ${test.totalRuns || 1}`);
+    lines.push(`  - **Overall retries: ${test.overallRetries || 0} (per run: [${failuresHistoryStr}])**`);
     lines.push('');
   }
 

--- a/.github/actions/flaky-tests-summary-comment/src/flaky-tests-comment-generator.js
+++ b/.github/actions/flaky-tests-summary-comment/src/flaky-tests-comment-generator.js
@@ -39,19 +39,21 @@ async function buildComment(mergedData, github, branchName) {
     ``
   ];
 
-  mergedData.sort((a, b) => b.flakiness - a.flakiness);
+  mergedData.sort((a, b) => b.overallRetries - a.overallRetries);
 
   for (const test of mergedData) {
-    const icon = getFlakyIcon(test.flakiness);
     const url = await generateTestSourceUrl(test, github, branchName);
 
     const testName = test.methodName || test.fullName;
     const formattedName = url ? `[**${testName}**](${url})` : `**${testName}**`;
-    lines.push(`- ${formattedName} – ${icon} **${test.flakiness}% flakiness**`);
+    const failuresHistoryStr = test.failuresHistory.join(', ');
+    
+    lines.push(`- ${formattedName}`);
     lines.push(`  - Jobs: \`${test.jobs.join(', ')}\``);
     lines.push(`  - Package: \`${test.packageName}\``);
     lines.push(`  - Class: \`${test.className ? test.className : "-"}\``);
-    lines.push(`  - Occurrences: ${test.occurrences} / ${test.totalRuns}`);
+    lines.push(`  - Overall retries: **${test.overallRetries || 0}** (per run: [${failuresHistoryStr}])`);
+    lines.push(`  - Pipeline runs: **${test.totalRuns || 1}**`);
     lines.push('');
   }
 
@@ -61,12 +63,6 @@ async function buildComment(mergedData, github, branchName) {
   );
 
   return lines.join('\n');
-}
-
-function getFlakyIcon(percent) {
-  if (percent < 30) return '👀';
-  if (percent <= 80) return '⚠️';
-  return '💀';
 }
 
 async function generateTestSourceUrl(test, github, branchName) {

--- a/.github/actions/flaky-tests-summary-comment/src/flaky-tests-comment-generator.js
+++ b/.github/actions/flaky-tests-summary-comment/src/flaky-tests-comment-generator.js
@@ -52,8 +52,8 @@ async function buildComment(mergedData, github, branchName) {
     lines.push(`  - Jobs: \`${test.jobs.join(', ')}\``);
     lines.push(`  - Package: \`${test.packageName}\``);
     lines.push(`  - Class: \`${test.className ? test.className : "-"}\``);
-    lines.push(`  - Overall retries: **${test.overallRetries || 0}** (per run: [${failuresHistoryStr}])`);
-    lines.push(`  - Pipeline runs: **${test.totalRuns || 1}**`);
+    lines.push(`  - Overall retries: ${test.overallRetries || 0} (per run: [${failuresHistoryStr}])`);
+    lines.push(`  - Pipeline runs: ${test.totalRuns || 1}`);
     lines.push('');
   }
 

--- a/.github/actions/flaky-tests-summary-comment/src/flaky-tests-data-processor.js
+++ b/.github/actions/flaky-tests-summary-comment/src/flaky-tests-data-processor.js
@@ -22,12 +22,12 @@ function processFlakyTestsData(rawData) {
         if (!existingTest.jobs.includes(job)) {
           existingTest.jobs.push(job);
         }
-        existingTest.occurrences++;
+        existingTest.currentRunFailures++;
       } else {
         testMap.set(key, {
           ...parsedTest,
           jobs: [job],
-          occurrences: 1
+          currentRunFailures: 1
         });
       }
     });

--- a/.github/actions/flaky-tests-summary-comment/src/helpers.js
+++ b/.github/actions/flaky-tests-summary-comment/src/helpers.js
@@ -37,7 +37,7 @@ function parseComment(body) {
 
     for (const line of lines) {
       //Match method name
-      const methodMatch = line.match(/-\s(?:\[\*\*(.+?)\*\*\]\(.+?\)|(\S+?))\s–/);
+      const methodMatch = line.match(/-\s(?:\[\*\*(.+?)\*\*\]\(.+?\))/);
       if (methodMatch) {
         // If no hyperlink exists
         if (Object.keys(currentTest).length > 0) {

--- a/.github/actions/flaky-tests-summary-comment/src/helpers.js
+++ b/.github/actions/flaky-tests-summary-comment/src/helpers.js
@@ -67,16 +67,10 @@ function parseComment(body) {
       }
 
       // Match overall retries
-      const overallMatch = line.match(/Overall retries:\s+\*\*(\d+)\*\*\s+\(per run:\s+\[([^\]]+)\]\)/);
+      const overallMatch = line.match(/Overall retries:\s+(?:\*\*)?(\d+)(?:\*\*)?\s+\(per run:\s+\[([^\]]+)\]\)/);
       if (overallMatch) {
         currentTest.overallRetries = parseInt(overallMatch[1], 10);
         currentTest.failuresHistory = overallMatch[2].split(',').map(n => parseInt(n.trim(), 10));
-      }
-
-      // Match total failures
-      const totalMatch = line.match(/Total failures:\s+(\d+)/);
-      if (totalMatch) {
-        currentTest.totalFailures = parseInt(totalMatch[1], 10);
       }
 
       // Match pipeline runs
@@ -93,7 +87,14 @@ function parseComment(body) {
         const occurrences = parseInt(occMatch[1], 10);
         const totalRuns = parseInt(occMatch[2], 10);
         
-        currentTest.failuresHistory = [occurrences];
+        // For old format, we assume failures were distributed across early runs
+        // Create a history array where failures are spread at the beginning
+        const history = Array(totalRuns).fill(0);
+        for (let i = 0; i < Math.min(occurrences, totalRuns); i++) {
+          history[i] = 1;
+        }
+        
+        currentTest.failuresHistory = history;
         currentTest.overallRetries = occurrences;
         currentTest.totalRuns = totalRuns;
       }
@@ -116,11 +117,16 @@ function mergeFlakyData(current, historical) {
   const newTotal = historical[0].totalRuns + 1;
   const merged = new Map();
 
+  // First, add all historical tests and prepare them for the new run
+  // If they don't appear in current run, they'll have 0 failures
   historical.forEach(oldTest => {
-    merged.set(getTestKey(oldTest), {
-      ...oldTest,
-      totalRuns: newTotal
-    });
+    if (oldTest.failuresHistory && Array.isArray(oldTest.failuresHistory)) {
+      merged.set(getTestKey(oldTest), {
+        ...oldTest,
+        failuresHistory: [...oldTest.failuresHistory, 0],
+        totalRuns: newTotal
+      });
+    }
   });
 
   current.forEach(test => {
@@ -129,26 +135,23 @@ function mergeFlakyData(current, historical) {
 
     if (existing) {
       const jobs = [...new Set([...existing.jobs, ...test.jobs])];
-      const newFailuresHistory = [...existing.failuresHistory, test.currentRunFailures];
-      const newOverallRetries = existing.overallRetries + test.currentRunFailures;
+      existing.failuresHistory[existing.failuresHistory.length - 1] = test.currentRunFailures || 0;
+      existing.overallRetries += test.currentRunFailures || 0;
 
       merged.set(key, {
         ...existing,
-        jobs,
-        failuresHistory: newFailuresHistory,
-        overallRetries: newOverallRetries,
-        totalRuns: newTotal
+        jobs
       });
     } else {
-      // This test appears for the first time in the current run
+      // Test appears for the first time in the current run
       // Pad with zeros for all previous runs where this test didn't fail
       const previousRuns = newTotal - 1;
-      const paddedHistory = Array(previousRuns).fill(0).concat(test.currentRunFailures);
+      const paddedHistory = Array(previousRuns).fill(0).concat(test.currentRunFailures || 0);
       
       merged.set(key, {
         ...test,
         failuresHistory: paddedHistory,
-        overallRetries: (test.currentRunFailures || 0),
+        overallRetries: test.currentRunFailures || 0,
         totalRuns: newTotal
       });
     }


### PR DESCRIPTION
## Description

This pull request updates the flaky test summary comment generator to provide more detailed and accurate tracking of test flakiness over multiple pipeline runs. The changes focus on replacing the previous "occurrences" and "flakiness percentage" metrics with a new "overall retries" and per-run failure history, resulting in improved reporting and easier identification of flaky tests.

**Flaky test data model and reporting improvements:**

* Replaced the old `occurrences` and `flakiness` metrics with `overallRetries`, `failuresHistory` (an array of failures per run), and `totalRuns` in both the data model and the generated summary comment. This provides a clearer and more granular view of test flakiness over time. [[1]](diffhunk://#diff-d5841c2be84617ea804b1701600b9733c85a532acc262b3396f0e825cdc7297bL43-R45) [[2]](diffhunk://#diff-0c00c106abd9943bceb5614c106b76343706b10e69672a162373d19d813eff06L25-R30) [[3]](diffhunk://#diff-ae4e40ad60bf1705e51f55cf10251de5178a4dc50bf1fb4ee28f5494021e9423L42-R56) [[4]](diffhunk://#diff-def2a1810c869e1ebe0cafafd513d60f3b119295687bd3fbefbd6d4a326671e6R138-R174)
* Updated the summary comment format to display "Overall retries" and a per-run breakdown, along with the total number of pipeline runs, instead of a flakiness percentage and occurrences. [[1]](diffhunk://#diff-ae4e40ad60bf1705e51f55cf10251de5178a4dc50bf1fb4ee28f5494021e9423L42-R56) [[2]](diffhunk://#diff-d5841c2be84617ea804b1701600b9733c85a532acc262b3396f0e825cdc7297bL43-R45)
* Improved the merging logic for flaky test data so that each test's failure history is tracked across runs, padding with zeros for runs where the test did not fail, and updating the retry counts accordingly. [[1]](diffhunk://#diff-def2a1810c869e1ebe0cafafd513d60f3b119295687bd3fbefbd6d4a326671e6R120-R129) [[2]](diffhunk://#diff-def2a1810c869e1ebe0cafafd513d60f3b119295687bd3fbefbd6d4a326671e6R138-R174)

**Backward compatibility and parsing:**

* Enhanced the comment parsing logic to support both the new and old formats, transforming legacy "Occurrences" entries into the new structure for backward compatibility.

**Code cleanup:**

* Removed the unused `getFlakyIcon` function and all references to flakiness percentage icons, as the new format no longer uses them.
<img width="610" height="726" alt="image" src="https://github.com/user-attachments/assets/afc4a6d1-4989-4bac-8b17-406f35831f05" />
<img width="661" height="622" alt="image" src="https://github.com/user-attachments/assets/31f0f302-4446-47cd-8d00-13611dd82bb6" />
<img width="661" height="853" alt="image" src="https://github.com/user-attachments/assets/23662538-c1ec-43ea-a1c9-85c213f1a858" />


## Checklist

## Related issues

closes #
