### PR TITLE
feat: all selectors (of the same type) can now be combined

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionSelector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionSelector.java
@@ -46,4 +46,32 @@ public interface DecisionSelector {
    * @param filter the filter used to limit the decision instance search
    */
   default void applyFilter(final DecisionInstanceFilter filter) {}
+
+  /**
+   * Combines two decision selectors together.
+   *
+   * @param other decision selector to be added.
+   * @return the combined decision selector
+   */
+  default DecisionSelector and(DecisionSelector other) {
+    final DecisionSelector self = this;
+
+    return new DecisionSelector() {
+      @Override
+      public boolean test(final DecisionInstance decisionInstance) {
+        return self.test(decisionInstance) && other.test(decisionInstance);
+      }
+
+      @Override
+      public String describe() {
+        return String.format("%s, %s", self.describe(), other.describe());
+      }
+
+      @Override
+      public void applyFilter(final DecisionInstanceFilter filter) {
+        self.applyFilter(filter);
+        other.applyFilter(filter);
+      }
+    };
+  }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionSelectors.java
@@ -74,9 +74,9 @@ public class DecisionSelectors {
 
   private static final class DecisionProcessInstanceKeySelector implements DecisionSelector {
 
-    private final Long processInstanceKey;
+    private final long processInstanceKey;
 
-    private DecisionProcessInstanceKeySelector(final Long processInstanceKey) {
+    private DecisionProcessInstanceKeySelector(final long processInstanceKey) {
       this.processInstanceKey = processInstanceKey;
     }
 
@@ -87,7 +87,7 @@ public class DecisionSelectors {
 
     @Override
     public String describe() {
-      return String.format("%d", processInstanceKey);
+      return "processInstanceKey: " + processInstanceKey;
     }
 
     @Override
@@ -119,9 +119,9 @@ public class DecisionSelectors {
     public String describe() {
       if (processInstanceKey != null) {
         return String.format(
-            "%s (processInstanceKey: %d)", decisionDefinitionId, processInstanceKey);
+            "decisionId: %s, processInstanceKey: %d", decisionDefinitionId, processInstanceKey);
       } else {
-        return decisionDefinitionId;
+        return "decisionId: " + decisionDefinitionId;
       }
     }
 
@@ -159,9 +159,9 @@ public class DecisionSelectors {
     public String describe() {
       if (processInstanceKey != null) {
         return String.format(
-            "%s (processInstanceKey: %d)", decisionDefinitionName, processInstanceKey);
+            "name: %s, processInstanceKey: %d", decisionDefinitionName, processInstanceKey);
       } else {
-        return decisionDefinitionName;
+        return "name: " + decisionDefinitionName;
       }
     }
 
@@ -191,7 +191,7 @@ public class DecisionSelectors {
     @Override
     public String describe() {
       return String.format(
-          "%s (decisionId: %s)", response.getDecisionName(), response.getDecisionId());
+          "name: %s, decisionId: %s", response.getDecisionName(), response.getDecisionId());
     }
 
     @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ElementSelector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ElementSelector.java
@@ -47,4 +47,32 @@ public interface ElementSelector {
    * @param filter the filter used to limit the element instance search
    */
   default void applyFilter(final ElementInstanceFilter filter) {}
+
+  /**
+   * Combines two element selectors together.
+   *
+   * @param other element instance selector to be added.
+   * @return the combined element instance selector
+   */
+  default ElementSelector and(ElementSelector other) {
+    final ElementSelector self = this;
+
+    return new ElementSelector() {
+      @Override
+      public boolean test(final ElementInstance elementInstance) {
+        return self.test(elementInstance) && other.test(elementInstance);
+      }
+
+      @Override
+      public String describe() {
+        return String.format("%s, %s", self.describe(), other.describe());
+      }
+
+      @Override
+      public void applyFilter(final ElementInstanceFilter filter) {
+        self.applyFilter(filter);
+        other.applyFilter(filter);
+      }
+    };
+  }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceSelector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceSelector.java
@@ -47,4 +47,32 @@ public interface ProcessInstanceSelector {
    * @param filter the filter used to limit the process instance search
    */
   default void applyFilter(final ProcessInstanceFilter filter) {}
+
+  /**
+   * Combines two process selectors together.
+   *
+   * @param other process instance selector to be added.
+   * @return the combined process instance selector
+   */
+  default ProcessInstanceSelector and(ProcessInstanceSelector other) {
+    final ProcessInstanceSelector self = this;
+
+    return new ProcessInstanceSelector() {
+      @Override
+      public boolean test(final ProcessInstance processInstance) {
+        return self.test(processInstance) && other.test(processInstance);
+      }
+
+      @Override
+      public String describe() {
+        return String.format("%s, %s", self.describe(), other.describe());
+      }
+
+      @Override
+      public void applyFilter(final ProcessInstanceFilter filter) {
+        self.applyFilter(filter);
+        other.applyFilter(filter);
+      }
+    };
+  }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/UserTaskSelector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/UserTaskSelector.java
@@ -47,4 +47,32 @@ public interface UserTaskSelector {
    * @param filter the filter used to limit the user task search
    */
   default void applyFilter(final UserTaskFilter filter) {}
+
+  /**
+   * Combines two user task selectors together.
+   *
+   * @param other user task selector to be added.
+   * @return the combined user task selector
+   */
+  default UserTaskSelector and(UserTaskSelector other) {
+    final UserTaskSelector self = this;
+
+    return new UserTaskSelector() {
+      @Override
+      public boolean test(final UserTask userTask) {
+        return self.test(userTask) && other.test(userTask);
+      }
+
+      @Override
+      public String describe() {
+        return String.format("%s, %s", self.describe(), other.describe());
+      }
+
+      @Override
+      public void applyFilter(final UserTaskFilter filter) {
+        self.applyFilter(filter);
+        other.applyFilter(filter);
+      }
+    };
+  }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/UserTaskSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/UserTaskSelectors.java
@@ -64,6 +64,16 @@ public class UserTaskSelectors {
     return new UserTaskNameSelector(taskName, processInstanceKey);
   }
 
+  /**
+   * Select the BPMN user task by its processInstanceKey.
+   *
+   * @param processInstanceKey the associated process instance
+   * @return the selector
+   */
+  public static UserTaskSelector byProcessInstanceKey(final long processInstanceKey) {
+    return new UserTaskProcessInstanceSelector(processInstanceKey);
+  }
+
   private static final class UserTaskElementIdSelector implements UserTaskSelector {
 
     private final String elementId;
@@ -86,9 +96,10 @@ public class UserTaskSelectors {
     @Override
     public String describe() {
       if (processInstanceKey != null) {
-        return String.format("%s (processInstanceKey: %d)", elementId, processInstanceKey);
+        return String.format(
+            "elementId: %s, processInstanceKey: %d", elementId, processInstanceKey);
       } else {
-        return elementId;
+        return "elementId: " + elementId;
       }
     }
 
@@ -123,9 +134,9 @@ public class UserTaskSelectors {
     @Override
     public String describe() {
       if (processInstanceKey != null) {
-        return String.format("%s (processInstanceKey: %d)", taskName, processInstanceKey);
+        return String.format("taskName: %s, processInstanceKey: %d", taskName, processInstanceKey);
       } else {
-        return taskName;
+        return "taskName: " + taskName;
       }
     }
 
@@ -134,6 +145,30 @@ public class UserTaskSelectors {
       if (processInstanceKey != null) {
         filter.processInstanceKey(processInstanceKey);
       }
+    }
+  }
+
+  private static final class UserTaskProcessInstanceSelector implements UserTaskSelector {
+
+    private final long processInstanceKey;
+
+    private UserTaskProcessInstanceSelector(final long processInstanceKey) {
+      this.processInstanceKey = processInstanceKey;
+    }
+
+    @Override
+    public boolean test(final UserTask userTask) {
+      return userTask.getProcessInstanceKey().equals(processInstanceKey);
+    }
+
+    @Override
+    public String describe() {
+      return String.format("processInstanceKey: %d", processInstanceKey);
+    }
+
+    @Override
+    public void applyFilter(final UserTaskFilter filter) {
+      filter.processInstanceKey(processInstanceKey);
     }
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionInstanceAssertTest.java
@@ -29,6 +29,7 @@ import io.camunda.client.protocol.rest.DecisionInstanceResult;
 import io.camunda.client.protocol.rest.DecisionInstanceStateEnum;
 import io.camunda.client.protocol.rest.EvaluatedDecisionOutputItem;
 import io.camunda.client.protocol.rest.MatchedDecisionRuleItem;
+import io.camunda.process.test.api.assertions.DecisionSelector;
 import io.camunda.process.test.api.assertions.DecisionSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.utils.CamundaAssertExpectFailure;
@@ -174,6 +175,34 @@ public class DecisionInstanceAssertTest {
   }
 
   @Nested
+  public class CombineSelectors {
+    @Test
+    public void canCombineSelectors() {
+      // when
+      mockDecisionInstanceSearch(
+          decisionInstance(d -> d.state(DecisionInstanceStateEnum.EVALUATED)));
+
+      // then
+      final DecisionSelector combined =
+          DecisionSelectors.byName(NAME).and(DecisionSelectors.byProcessInstanceKey(3));
+
+      assertThatDecision(combined).isEvaluated();
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    public void combinedSelectorsRequireAllTestsToPass() {
+      // then
+      final DecisionSelector badCombination =
+          DecisionSelectors.byName("bad_name").and(DecisionSelectors.byProcessInstanceKey(3));
+
+      // then
+      Assertions.assertThatThrownBy(() -> assertThatDecision(badCombination).isEvaluated())
+          .hasMessage("No DecisionInstance [name: bad_name, processInstanceKey: 3] found.");
+    }
+  }
+
+  @Nested
   public class IsEvaluated {
 
     @Test
@@ -195,7 +224,8 @@ public class DecisionInstanceAssertTest {
       // then
       Assertions.assertThatThrownBy(
               () -> assertThatDecision(DecisionSelectors.byName(NAME)).isEvaluated())
-          .hasMessage("Expected DecisionInstance [name] to have been evaluated, but was failed");
+          .hasMessage(
+              "Expected DecisionInstance [name: name] to have been evaluated, but was failed");
     }
   }
 
@@ -242,14 +272,14 @@ public class DecisionInstanceAssertTest {
       Assertions.assertThatThrownBy(
               () -> assertThatDecision(DecisionSelectors.byName(NAME)).hasOutput("foo"))
           .hasMessage(
-              "Expected DecisionInstance [name] to have output '\"foo\"', but was '\"outputValue\"'");
+              "Expected DecisionInstance [name: name] to have output '\"foo\"', but was '\"outputValue\"'");
 
       final Map<String, Object> expected = new HashMap<>();
       expected.put("a", "b");
       Assertions.assertThatThrownBy(
               () -> assertThatDecision(DecisionSelectors.byName(NAME)).hasOutput(expected))
           .hasMessage(
-              "Expected DecisionInstance [name] to have output '{\"a\":\"b\"}', but was '\"outputValue\"'");
+              "Expected DecisionInstance [name: name] to have output '{\"a\":\"b\"}', but was '\"outputValue\"'");
     }
 
     @Test
@@ -262,14 +292,14 @@ public class DecisionInstanceAssertTest {
       Assertions.assertThatThrownBy(
               () -> assertThatDecision(DecisionSelectors.byName(NAME)).hasOutput("foo"))
           .hasMessage(
-              "Expected DecisionInstance [name] to have output '\"foo\"', but was '{\"a\":\"b\",\"v\":2}'");
+              "Expected DecisionInstance [name: name] to have output '\"foo\"', but was '{\"a\":\"b\",\"v\":2}'");
 
       final Map<String, Object> expected = new HashMap<>();
       expected.put("a", "b");
       Assertions.assertThatThrownBy(
               () -> assertThatDecision(DecisionSelectors.byName(NAME)).hasOutput(expected))
           .hasMessage(
-              "Expected DecisionInstance [name] to have output '{\"a\":\"b\"}', but was '{\"a\":\"b\",\"v\":2}'");
+              "Expected DecisionInstance [name: name] to have output '{\"a\":\"b\"}', but was '{\"a\":\"b\",\"v\":2}'");
     }
 
     @Test
@@ -282,14 +312,14 @@ public class DecisionInstanceAssertTest {
       Assertions.assertThatThrownBy(
               () -> assertThatDecision(DecisionSelectors.byName(NAME)).hasOutput("foo"))
           .hasMessage(
-              "Expected DecisionInstance [name] to have output '\"foo\"', but was '[{\"a\":1,\"b\":2},{\"c\":3,\"d\":4}]'");
+              "Expected DecisionInstance [name: name] to have output '\"foo\"', but was '[{\"a\":1,\"b\":2},{\"c\":3,\"d\":4}]'");
 
       final Map<String, Object> expected = new HashMap<>();
       expected.put("a", "b");
       Assertions.assertThatThrownBy(
               () -> assertThatDecision(DecisionSelectors.byName(NAME)).hasOutput(expected))
           .hasMessage(
-              "Expected DecisionInstance [name] to have output '{\"a\":\"b\"}', but was '[{\"a\":1,\"b\":2},{\"c\":3,\"d\":4}]'");
+              "Expected DecisionInstance [name: name] to have output '{\"a\":\"b\"}', but was '[{\"a\":1,\"b\":2},{\"c\":3,\"d\":4}]'");
     }
   }
 
@@ -336,7 +366,7 @@ public class DecisionInstanceAssertTest {
       Assertions.assertThatThrownBy(
               () -> assertThatDecision(DecisionSelectors.byName(NAME)).hasMatchedRules(2))
           .hasMessage(
-              "Expected DecisionInstance [name] to have matched rules [2], but did not. Matches:\n"
+              "Expected DecisionInstance [name: name] to have matched rules [2], but did not. Matches:\n"
                   + "\t- matched: []\n"
                   + "\t- missing: [2]\n"
                   + "\t- unexpected: [1]");
@@ -373,7 +403,7 @@ public class DecisionInstanceAssertTest {
       Assertions.assertThatThrownBy(
               () -> assertThatDecision(DecisionSelectors.byName(NAME)).hasNotMatchedRules(1))
           .hasMessage(
-              "Expected DecisionInstance [name] to not have matched rules [1], but matched [1]");
+              "Expected DecisionInstance [name: name] to not have matched rules [1], but matched [1]");
     }
 
     @Test
@@ -386,7 +416,7 @@ public class DecisionInstanceAssertTest {
       Assertions.assertThatThrownBy(
               () -> assertThatDecision(DecisionSelectors.byName(NAME)).hasNotMatchedRules(4, 1, 5))
           .hasMessage(
-              "Expected DecisionInstance [name] to not have matched rules [4, 1, 5], but matched [1]");
+              "Expected DecisionInstance [name: name] to not have matched rules [4, 1, 5], but matched [1]");
     }
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -451,7 +451,8 @@ public class CamundaProcessTestContextIT {
     Assertions.assertThatThrownBy(
             () ->
                 processTestContext.completeUserTask(UserTaskSelectors.byElementId("unknown-task")))
-        .hasMessage("Expected to complete user task [unknown-task] but no job is available.");
+        .hasMessage(
+            "Expected to complete user task [elementId: unknown-task] but no job is available.");
   }
 
   @Test
@@ -534,7 +535,7 @@ public class CamundaProcessTestContextIT {
   }
 
   @Test
-  void shouldFindUserTaskByTaskNameAndProcessInstanceKey() {
+  void shouldFindUserTaskByTaskNameAndByProcessInstanceKey() {
     // Given
     final long firstInstanceKey = deployProcessModel(processModelWithUserTask());
     final long secondInstanceKey = deployProcessModel(processModelWithUserTask());
@@ -548,6 +549,10 @@ public class CamundaProcessTestContextIT {
     // Then
     assertThatUserTask(
             UserTaskSelectors.byTaskName("user-task", processInstanceEvent.getProcessInstanceKey()))
+        .hasProcessInstanceKey(processInstanceEvent.getProcessInstanceKey());
+
+    assertThatUserTask(
+            UserTaskSelectors.byProcessInstanceKey(processInstanceEvent.getProcessInstanceKey()))
         .hasProcessInstanceKey(processInstanceEvent.getProcessInstanceKey());
   }
 
@@ -804,15 +809,15 @@ public class CamundaProcessTestContextIT {
     // Then
     Assertions.assertThatThrownBy(() -> assertThatDecision(response).isEvaluated())
         .hasMessage(
-            "No DecisionInstance [Determine Overall Happiness "
-                + "(decisionId: decision_overall_happiness)] "
+            "No DecisionInstance [name: Determine Overall Happiness"
+                + ", decisionId: decision_overall_happiness] "
                 + "found.");
 
     Assertions.assertThatThrownBy(
             () ->
                 assertThatDecision(DecisionSelectors.byId("decision_overall_happiness"))
                     .isEvaluated())
-        .hasMessage("No DecisionInstance [decision_overall_happiness] found.");
+        .hasMessage("No DecisionInstance [decisionId: decision_overall_happiness] found.");
   }
 
   /**


### PR DESCRIPTION
## Description

Allows assertion selectors such as ProcessInstanceSelector to be combined, merging their attributes together, for ease of use.

## Related issues

closes #36412 
