### PR TITLE
fix: avoid NPE when exporting starts before schema readiness

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/IdentityMigrator.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/IdentityMigrator.java
@@ -72,6 +72,13 @@ public class IdentityMigrator implements Migrator {
 
     if (joinedCluster) {
       LOG.info("Successfully connected to Orchestration Cluster, starting migration.");
+      LOG.info(
+          "List of brokers in the cluster: {}", brokerTopologyManager.getTopology().getBrokers());
+      LOG.info(
+          "List of brokers addresses: {}",
+          brokerTopologyManager.getTopology().getBrokers().stream()
+              .map(i -> brokerTopologyManager.getTopology().getBrokerAddress(i))
+              .toList());
     } else {
       final String message =
           "Failed to connect to Orchestration Cluster within %s."

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -33,7 +33,6 @@ import io.camunda.zeebe.qa.util.actuator.ExportingActuator;
 import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.testcontainers.AzuriteContainer;
 import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
@@ -92,7 +91,6 @@ public class BackupRestoreIT {
   protected ExportingActuator exportingActuator;
   protected BackupActuator backupActuator;
 
-  @TestZeebe(autoStart = false)
   protected TestStandaloneApplication<?> testStandaloneApplication;
 
   protected BackupDBClient webappsDBClient;
@@ -113,8 +111,10 @@ public class BackupRestoreIT {
 
   @AfterEach
   public void tearDown() {
-    CloseHelper.quietCloseAll(
-        webappsDBClient, camundaClient, generator, searchContainer, testStandaloneApplication);
+    CloseHelper.quietCloseAll(webappsDBClient, camundaClient, generator, searchContainer);
+    if (testStandaloneApplication != null) {
+      testStandaloneApplication.stop();
+    }
   }
 
   private void setup(final BackupRestoreTestConfig config) throws Exception {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -113,7 +113,8 @@ public class BackupRestoreIT {
 
   @AfterEach
   public void tearDown() {
-    CloseHelper.quietCloseAll(webappsDBClient, camundaClient, generator, searchContainer);
+    CloseHelper.quietCloseAll(
+        webappsDBClient, camundaClient, generator, searchContainer, testStandaloneApplication);
   }
 
   private void setup(final BackupRestoreTestConfig config) throws Exception {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/IdentityMigrationFailureIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/IdentityMigrationFailureIT.java
@@ -65,20 +65,21 @@ public class IdentityMigrationFailureIT {
     migrationProperties.getManagementIdentity().setClientSecret(IDENTITY_CLIENT_SECRET);
     migrationProperties.getManagementIdentity().setAudience(CAMUNDA_IDENTITY_RESOURCE_SERVER);
 
-    final TestStandaloneIdentityMigration testIdentityMigration =
-        new TestStandaloneIdentityMigration(migrationProperties);
-    setupLogCapturing(testIdentityMigration, BlockingMigrationsRunner.class);
+    try (final TestStandaloneIdentityMigration testIdentityMigration =
+        new TestStandaloneIdentityMigration(migrationProperties)) {
+      setupLogCapturing(testIdentityMigration, BlockingMigrationsRunner.class);
 
-    // when
-    testIdentityMigration.start();
+      // when
+      testIdentityMigration.start();
 
-    // then
-    assertThat(testIdentityMigration.getExitCode()).isEqualTo(1);
-    assertThat(
-            logCapturer.contains(
-                "IdentityMigrator failed with: Failed to connect to Orchestration Cluster within PT1S.",
-                Level.ERROR))
-        .isTrue();
+      // then
+      assertThat(testIdentityMigration.getExitCode()).isEqualTo(1);
+      assertThat(
+              logCapturer.contains(
+                  "IdentityMigrator failed with: Failed to connect to Orchestration Cluster within PT1S.",
+                  Level.ERROR))
+          .isTrue();
+    }
   }
 
   @Test
@@ -91,24 +92,25 @@ public class IdentityMigrationFailureIT {
         .setInitialContactPoints(List.of("localhost:" + BROKER.mappedPort(CLUSTER)));
     // but no other config, e.g. for management identity connection
 
-    final TestStandaloneIdentityMigration testIdentityMigration =
-        new TestStandaloneIdentityMigration(migrationProperties);
-    setupLogCapturing(testIdentityMigration, BlockingMigrationsRunner.class);
+    try (final TestStandaloneIdentityMigration testIdentityMigration =
+        new TestStandaloneIdentityMigration(migrationProperties)) {
+      setupLogCapturing(testIdentityMigration, BlockingMigrationsRunner.class);
 
-    // when
-    final Throwable thrown = catchThrowable(testIdentityMigration::start);
+      // when
+      final Throwable thrown = catchThrowable(testIdentityMigration::start);
 
-    // then
-    assertThat(thrown)
-        .isInstanceOf(ConfigurationPropertiesBindException.class)
-        .cause()
-        .cause()
-        .hasMessageContainingAll(
-            "Audience must be provided",
-            "Issuer Backend URL must be provided",
-            "Client Secret must be provided",
-            "Client ID must be provided",
-            "Base URL must be provided");
+      // then
+      assertThat(thrown)
+          .isInstanceOf(ConfigurationPropertiesBindException.class)
+          .cause()
+          .cause()
+          .hasMessageContainingAll(
+              "Audience must be provided",
+              "Issuer Backend URL must be provided",
+              "Client Secret must be provided",
+              "Client ID must be provided",
+              "Base URL must be provided");
+    }
   }
 
   /**

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/IdentityMigrationFailureIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/IdentityMigrationFailureIT.java
@@ -87,9 +87,7 @@ public class IdentityMigrationFailureIT {
     // given
     final IdentityMigrationProperties migrationProperties = new IdentityMigrationProperties();
     // connection to broker is set
-    migrationProperties
-        .getCluster()
-        .setInitialContactPoints(List.of("localhost:" + BROKER.mappedPort(CLUSTER)));
+    migrationProperties.getCluster().setInitialContactPoints(List.of(BROKER.address(CLUSTER)));
     // but no other config, e.g. for management identity connection
 
     try (final TestStandaloneIdentityMigration testIdentityMigration =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -198,9 +198,7 @@ public class KeycloakIdentityMigrationIT {
     migrationProperties.getManagementIdentity().setClientId(IDENTITY_CLIENT);
     migrationProperties.getManagementIdentity().setClientSecret(IDENTITY_CLIENT_SECRET);
     migrationProperties.getManagementIdentity().setAudience(CAMUNDA_IDENTITY_RESOURCE_SERVER);
-    migrationProperties
-        .getCluster()
-        .setInitialContactPoints(List.of("localhost:" + BROKER.mappedPort(CLUSTER)));
+    migrationProperties.getCluster().setInitialContactPoints(List.of(BROKER.address(CLUSTER)));
     migration = new TestStandaloneIdentityMigration(migrationProperties);
 
     client = BROKER.newClientBuilder().build();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -209,6 +209,9 @@ public class KeycloakIdentityMigrationIT {
   @AfterEach
   void tearDown() {
     migration.close();
+    if (client != null) {
+      client.close();
+    }
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
@@ -156,9 +156,7 @@ public class OidcIdentityMigrationIT {
     migrationProperties.getManagementIdentity().setClientId(IDENTITY_CLIENT);
     migrationProperties.getManagementIdentity().setClientSecret(IDENTITY_CLIENT_SECRET);
     migrationProperties.getManagementIdentity().setAudience(CAMUNDA_IDENTITY_RESOURCE_SERVER);
-    migrationProperties
-        .getCluster()
-        .setInitialContactPoints(List.of("localhost:" + BROKER.mappedPort(CLUSTER)));
+    migrationProperties.getCluster().setInitialContactPoints(List.of(BROKER.address(CLUSTER)));
     migrationProperties.getOidc().getAudience().setIdentity(CAMUNDA_IDENTITY_RESOURCE_SERVER);
     migration = new TestStandaloneIdentityMigration(migrationProperties);
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -164,9 +164,7 @@ public class SaaSIdentityMigrationIT {
         new TestStandaloneIdentityMigration(migrationProperties)
             .withAppConfig(
                 config -> {
-                  config
-                      .getCluster()
-                      .setInitialContactPoints(List.of("localhost:" + BROKER.mappedPort(CLUSTER)));
+                  config.getCluster().setInitialContactPoints(List.of(BROKER.address(CLUSTER)));
                 });
 
     client = BROKER.newClientBuilder().build();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/BasicAuthNoSecondaryStorageTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/BasicAuthNoSecondaryStorageTest.java
@@ -29,15 +29,16 @@ public class BasicAuthNoSecondaryStorageTest {
   @Test
   void shouldFailToStartWithBasicAuthAndNoSecondaryStorage() {
     // given - Basic Authentication configured with no secondary storage
-    final var broker =
+    try (final var broker =
         new TestStandaloneBroker()
             .withBasicAuth()
             .withAuthenticationMethod(AuthenticationMethod.BASIC)
-            .withProperty(PROPERTY_CAMUNDA_DATABASE_TYPE, CAMUNDA_DATABASE_TYPE_NONE);
+            .withProperty(PROPERTY_CAMUNDA_DATABASE_TYPE, CAMUNDA_DATABASE_TYPE_NONE)) {
 
-    // when/then - application startup should fail with the expected exception
-    assertThatThrownBy(broker::start)
-        .isInstanceOf(BeanCreationException.class)
-        .hasRootCauseInstanceOf(BasicAuthenticationNotSupportedException.class);
+      // when/then - application startup should fail with the expected exception
+      assertThatThrownBy(broker::start)
+          .isInstanceOf(BeanCreationException.class)
+          .hasRootCauseInstanceOf(BasicAuthenticationNotSupportedException.class);
+    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -81,8 +81,8 @@ public class CamundaExporter implements Exporter {
   private CamundaExporterMetrics metrics;
   private BackgroundTaskManager taskManager;
   private ExporterMetadata metadata;
-  private boolean schemaIsReady = false;
-  private boolean exporterCanFlush = false;
+  private volatile boolean schemaIsReady = false;
+  private volatile boolean exporterCanFlush = false;
   private boolean zeebeIndicesVersion87Exist = false;
   private SearchEngineClient searchEngineClient;
   private int partitionId;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
