### PR TITLE
feat: deleteMappingRuleCommand

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -49,6 +49,7 @@ import io.camunda.client.api.command.CreateUserCommandStep1;
 import io.camunda.client.api.command.DeleteAuthorizationCommandStep1;
 import io.camunda.client.api.command.DeleteDocumentCommandStep1;
 import io.camunda.client.api.command.DeleteGroupCommandStep1;
+import io.camunda.client.api.command.DeleteMappingRuleCommandStep1;
 import io.camunda.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.client.api.command.DeleteRoleCommandStep1;
 import io.camunda.client.api.command.DeleteTenantCommandStep1;
@@ -1592,6 +1593,22 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   DeleteGroupCommandStep1 newDeleteGroupCommand(String groupId);
+
+  /**
+   * Command to delete a mapping rule.
+   *
+   * <pre>
+   * camundaClient
+   *  .newDeleteMappingRuleCommand("mappingRuleId")
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   *
+   * @param mappingRuleId the ID of the mapping rule to delete
+   * @return a builder for the command
+   */
+  DeleteMappingRuleCommandStep1 newDeleteMappingRuleCommand(String mappingRuleId);
 
   /**
    * Command to assign a user to a group.

--- a/clients/java/src/main/java/io/camunda/client/api/command/DeleteMappingRuleCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/DeleteMappingRuleCommandStep1.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.DeleteMappingRuleResponse;
+
+public interface DeleteMappingRuleCommandStep1
+    extends FinalCommandStep<DeleteMappingRuleResponse> {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/DeleteMappingRuleResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DeleteMappingRuleResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface DeleteMappingRuleResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -57,6 +57,7 @@ import io.camunda.client.api.command.CreateUserCommandStep1;
 import io.camunda.client.api.command.DeleteAuthorizationCommandStep1;
 import io.camunda.client.api.command.DeleteDocumentCommandStep1;
 import io.camunda.client.api.command.DeleteGroupCommandStep1;
+import io.camunda.client.api.command.DeleteMappingRuleCommandStep1;
 import io.camunda.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.client.api.command.DeleteRoleCommandStep1;
 import io.camunda.client.api.command.DeleteTenantCommandStep1;
@@ -195,6 +196,7 @@ import io.camunda.client.impl.command.CreateUserCommandImpl;
 import io.camunda.client.impl.command.DeleteAuthorizationCommandImpl;
 import io.camunda.client.impl.command.DeleteDocumentCommandImpl;
 import io.camunda.client.impl.command.DeleteGroupCommandImpl;
+import io.camunda.client.impl.command.DeleteMappingRuleCommandImpl;
 import io.camunda.client.impl.command.DeleteResourceCommandImpl;
 import io.camunda.client.impl.command.DeleteRoleCommandImpl;
 import io.camunda.client.impl.command.DeleteTenantCommandImpl;
@@ -1004,6 +1006,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public DeleteGroupCommandStep1 newDeleteGroupCommand(final String groupId) {
     return new DeleteGroupCommandImpl(groupId, httpClient);
+  }
+
+  @Override
+  public DeleteMappingRuleCommandStep1 newDeleteMappingRuleCommand(final String mappingRuleId) {
+    return new DeleteMappingRuleCommandImpl(mappingRuleId, httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteMappingRuleCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteMappingRuleCommandImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import static io.camunda.client.impl.command.ArgumentUtil.ensureNotNullNorEmpty;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.DeleteMappingRuleCommandStep1;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.DeleteMappingRuleResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.DeleteMappingRuleResponseImpl;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class DeleteMappingRuleCommandImpl implements DeleteMappingRuleCommandStep1 {
+
+  private final String mappingRuleId;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public DeleteMappingRuleCommandImpl(final String mappingRuleId, final HttpClient httpClient) {
+    this.mappingRuleId = mappingRuleId;
+    this.httpClient = httpClient;
+    this.httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public FinalCommandStep<DeleteMappingRuleResponse> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<DeleteMappingRuleResponse> send() {
+    ensureNotNullNorEmpty("mappingRuleId", mappingRuleId);
+    final HttpCamundaFuture<DeleteMappingRuleResponse> result = new HttpCamundaFuture<>();
+    httpClient.delete(
+        "/mapping-rules/" + mappingRuleId,
+        httpRequestConfig.build(),
+        DeleteMappingRuleResponseImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeleteMappingRuleResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeleteMappingRuleResponseImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.DeleteMappingRuleResponse;
+
+public class DeleteMappingRuleResponseImpl implements DeleteMappingRuleResponse {
+
+  public DeleteMappingRuleResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/test/java/io/camunda/client/mappingrule/DeleteMappingRuleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/mappingrule/DeleteMappingRuleTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.mappingrule;
+
+import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class DeleteMappingRuleTest extends ClientRestTest {
+
+  private static final String MAPPING_RULE_ID = "mappingRuleId";
+
+  @Test
+  void shouldDeleteMappingRule() {
+    // when
+    client.newDeleteMappingRuleCommand(MAPPING_RULE_ID).send().join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    final RequestMethod method = RestGatewayService.getLastRequest().getMethod();
+    assertThat(requestPath).isEqualTo(REST_API_PATH + "/mapping-rules/" + MAPPING_RULE_ID);
+    assertThat(method).isEqualTo(RequestMethod.DELETE);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullMappingRuleId() {
+    // when / then
+    assertThatThrownBy(() -> client.newDeleteMappingRuleCommand(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("mappingRuleId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyMappingRuleId() {
+    // when / then
+    assertThatThrownBy(() -> client.newDeleteMappingRuleCommand("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("mappingRuleId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNotFoundMappingRule() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/mapping-rules/" + MAPPING_RULE_ID,
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(() -> client.newDeleteMappingRuleCommand(MAPPING_RULE_ID).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnForbiddenRequest() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/mapping-rules/" + MAPPING_RULE_ID,
+        () -> new ProblemDetail().title("Forbidden").status(403));
+
+    // when / then
+    assertThatThrownBy(() -> client.newDeleteMappingRuleCommand(MAPPING_RULE_ID).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 403: 'Forbidden'");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MappingRuleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MappingRuleAuthorizationIT.java
@@ -136,7 +136,8 @@ class MappingRuleAuthorizationIT {
         .untilAsserted(
             () -> {
               final var searchResponseAfter =
-                  searchMappingRules(camundaClient.getConfiguration().getRestAddress().toString(), ADMIN);
+                  searchMappingRules(
+                      camundaClient.getConfiguration().getRestAddress().toString(), ADMIN);
               assertThat(searchResponseAfter.items())
                   .map(MappingRuleResponse::name)
                   .doesNotContain("authTestMappingRule2");


### PR DESCRIPTION
## Description

Adds the missing deleteMappingRuleCommand command to the Camunda Java Client that exposes the `DELETE /v2/mapping-rules/:mappingRuleId` API endpoint.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35770
