### PR TITLE
[Backport stable/8.8] 35673 ensure identity entities are returned as a copy

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -158,7 +158,8 @@ public class DbAuthorizationState implements MutableAuthorizationState {
   public Optional<PersistedAuthorization> get(final long authorizationKey) {
     this.authorizationKey.wrapLong(authorizationKey);
     final var persistedAuthorization =
-        authorizationByAuthorizationKeyColumnFamily.get(this.authorizationKey);
+        authorizationByAuthorizationKeyColumnFamily.get(
+            this.authorizationKey, PersistedAuthorization::new);
     return Optional.ofNullable(persistedAuthorization);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingRuleState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingRuleState.java
@@ -125,7 +125,7 @@ public class DbMappingRuleState implements MutableMappingRuleState {
     mappingRuleId.wrapString(id);
     final var fk = claimByIdColumnFamily.get(mappingRuleId);
     if (fk != null) {
-      return Optional.of(mappingRuleColumnFamily.get(fk.inner()));
+      return Optional.of(mappingRuleColumnFamily.get(fk.inner(), PersistedMappingRule::new));
     }
     return Optional.empty();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbRoleState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbRoleState.java
@@ -55,7 +55,7 @@ public class DbRoleState implements MutableRoleState {
   @Override
   public Optional<PersistedRole> getRole(final String roleId) {
     this.roleId.wrapString(roleId);
-    final var persistedRole = roleColumnFamily.get(this.roleId);
+    final var persistedRole = roleColumnFamily.get(this.roleId, PersistedRole::new);
     return Optional.ofNullable(persistedRole);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -57,7 +57,7 @@ public class DbGroupState implements MutableGroupState {
   @Override
   public Optional<PersistedGroup> get(final String groupId) {
     this.groupId.wrapString(groupId);
-    final var persistedGroup = groupColumnFamily.get(this.groupId);
+    final var persistedGroup = groupColumnFamily.get(this.groupId, PersistedGroup::new);
     return Optional.ofNullable(persistedGroup);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
@@ -60,7 +60,7 @@ public class DbTenantState implements MutableTenantState {
   @Override
   public Optional<PersistedTenant> getTenantById(final String tenantId) {
     this.tenantId.wrapString(tenantId);
-    final var persistedTenant = tenantsColumnFamily.get(this.tenantId);
+    final var persistedTenant = tenantsColumnFamily.get(this.tenantId, PersistedTenant::new);
     return Optional.ofNullable(persistedTenant);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -571,4 +571,23 @@ public class AuthorizationStateTest {
     final var keys2 = authorizationState.getAuthorizationKeysForOwner(ownerType2, ownerId2);
     assertThat(keys2).containsExactly(authorizationKey2);
   }
+
+  @Test
+  void shouldReturnNewCopiesOnGet() {
+    // given
+    final long key = 123L;
+    authorizationState.create(
+        key,
+        new AuthorizationRecord()
+            .setOwnerId("ownerId")
+            .setOwnerType(AuthorizationOwnerType.CLIENT)
+            .setResourceMatcher(AuthorizationResourceMatcher.ID));
+
+    // when
+    final var auth1 = authorizationState.get(key).get();
+    final var auth2 = authorizationState.get(key).get();
+
+    // then
+    assertThat(auth1).isNotSameAs(auth2);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingRuleStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingRuleStateTest.java
@@ -195,4 +195,23 @@ public class MappingRuleStateTest {
     assertThat(mappingByClaim.getName()).isEqualTo(newName);
     assertThat(mappingByClaim.getMappingRuleId()).isEqualTo(mappingRuleId);
   }
+
+  @Test
+  void shouldReturnNewCopiesOnGet() {
+    // given
+    final String id = "mappingRuleId";
+    mappingRuleState.create(
+        new MappingRuleRecord()
+            .setMappingRuleKey(123L)
+            .setMappingRuleId(id)
+            .setClaimName("claimName")
+            .setClaimValue("claimValue"));
+
+    // when
+    final var rule1 = mappingRuleState.get(id).get();
+    final var rule2 = mappingRuleState.get(id).get();
+
+    // then
+    assertThat(rule1).isNotSameAs(rule2);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/RoleStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/RoleStateTest.java
@@ -99,4 +99,18 @@ public class RoleStateTest {
     final var deletedRole = roleState.getRole(roleId);
     assertThat(deletedRole).isEmpty();
   }
+
+  @Test
+  void shouldReturnNewCopiesOnGet() {
+    // given
+    final String id = "id";
+    roleState.create(new RoleRecord().setRoleId(id).setRoleKey(123L).setName("name"));
+
+    // when
+    final var role1 = roleState.getRole(id).get();
+    final var role2 = roleState.getRole(id).get();
+
+    // then
+    assertThat(role1).isNotSameAs(role2);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -121,4 +121,18 @@ public class GroupStateTest {
     final var group = groupState.get(groupId);
     assertThat(group).isEmpty();
   }
+
+  @Test
+  void shouldReturnNewCopiesOnGet() {
+    // given
+    final String id = "id";
+    groupState.create(new GroupRecord().setGroupId(id).setGroupKey(123L).setName("name"));
+
+    // when
+    final var group1 = groupState.get(id).get();
+    final var group2 = groupState.get(id).get();
+
+    // then
+    assertThat(group1).isNotSameAs(group2);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/tenant/DbTenantStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/tenant/DbTenantStateTest.java
@@ -114,4 +114,18 @@ public class DbTenantStateTest {
     assertThat(tenant).isPresent();
     assertThat(tenant.get().getTenantKey()).isEqualTo(tenantKey);
   }
+
+  @Test
+  void shouldReturnNewCopiesOnGet() {
+    // given
+    final String id = "id";
+    tenantState.createTenant(new TenantRecord().setTenantId(id).setTenantKey(123L).setName("name"));
+
+    // when
+    final var tenant1 = tenantState.getTenantById(id).get();
+    final var tenant2 = tenantState.getTenantById(id).get();
+
+    // then
+    assertThat(tenant1).isNotSameAs(tenant2);
+  }
 }


### PR DESCRIPTION
# Description
Backport of #37344 to `stable/8.8`.

relates to #35673