### PR TITLE
Fix Failing OC 8.7 Tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
@@ -64,7 +64,7 @@ class TaskPanelPage {
           ? 'assigned-to-me'
           : option.toLowerCase().replace(/\s+/g, '-');
 
-    await expect(this.page).toHaveURL(new RegExp(`${expectedSegment}`));
+    await expect(this.page).toHaveURL(new RegExp(`${expectedSegment}`), {timeout: 30000});
 
     await this.collapseSidePanelButton.click();
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
@@ -96,7 +96,7 @@ test.describe('variables page', () => {
     ).toBeHidden();
     await expect(
       taskDetailsPage.variablesTable.getByText('updatedValue'),
-    ).toBeVisible();
+    ).toBeVisible({timeout: 60000});
   });
 
   test('edited variable is not saved after refresh', async ({


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

One of the OC 8.7 tests is becoming flaky on the nightly test run. This PR aims to fix this.

Successful test run [here](https://github.com/camunda/camunda/actions/runs/17456606596/job/49571415226).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
