### PR TITLE
[Backport release-8.8.0-alpha8] ci: update zeebe version in Operate and Tasklist tests

### DIFF
--- a/operate/qa/pom.xml
+++ b/operate/qa/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <!-- properties for ImportSeveralVersionsTest and import-old-zeebe-tests module -->
     <version.zeebe.old>8.1.0</version.zeebe.old>
-    <version.zeebe.docker.current>SNAPSHOT</version.zeebe.docker.current>
+    <version.zeebe.docker.current>8.8.0-alpha8-rc3</version.zeebe.docker.current>
     <version.zeebe.docker.repo>camunda/zeebe</version.zeebe.docker.repo>
     <version.identity.docker.current>8.5.0</version.identity.docker.current>
 

--- a/tasklist/qa/pom.xml
+++ b/tasklist/qa/pom.xml
@@ -20,7 +20,7 @@
   </modules>
 
   <properties>
-    <version.zeebe.docker.current>SNAPSHOT</version.zeebe.docker.current>
+    <version.zeebe.docker.current>8.8.0-alpha8-rc3</version.zeebe.docker.current>
     <version.zeebe.docker.repo>camunda/zeebe</version.zeebe.docker.repo>
     <version.identity.docker.current>SNAPSHOT</version.identity.docker.current>
   </properties>


### PR DESCRIPTION
# Description
Backport of #37562 to `release-8.8.0-alpha8`.

relates to 