### PR TITLE
build: update docker file for OC test suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     ports:
       - 5601:5601
     environment:
-      - elasticsearch.hosts=elasticsearch:9200
+      - elasticsearch.hosts=http://elasticsearch:9200
     depends_on:
       - elasticsearch
     networks:
@@ -116,6 +116,8 @@ services:
       - CAMUNDA_SECURITY_INITIALIZATION_USERS_1_NAME=lisa
       - CAMUNDA_SECURITY_INITIALIZATION_USERS_1_EMAIL=lisa@example.com
       - CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_1=lisa
+      - CAMUNDA_DATA_SECONDARY_STORAGE_TYPE=elasticsearch
+      - CAMUNDA_DATA_SECONDARY_STORAGE_ELASTICSEARCH_URL=http://elasticsearch:9200
     ports:
       - 26500:26500
       - 9600:9600
@@ -124,5 +126,3 @@ services:
       - ${DATABASE}
     networks:
       - zeebe_network
-    env_file:
-      - envs/.env.database.${DATABASE}


### PR DESCRIPTION
## Description

Camunda container was failing to start due to ambiguous Elasticsearch configuration, causing E2E tests to fail. This PR Updats docker-compose configuration to use the new configuration properties:
- `CAMUNDA_DATA_SECONDARY_STORAGE_TYPE=elasticsearch`
- `CAMUNDA_DATA_SECONDARY_STORAGE_ELASTICSEARCH_URL=http://elasticsearch:9200`

🧪 Successful test run [here](https://github.com/camunda/camunda/actions/runs/17458279099/job/49576789977)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
