### PR TITLE
fix: prevent setup oidc when the auth method is set to basic.

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -404,6 +404,21 @@ public class WebSecurityConfig {
   @ConditionalOnSecondaryStorageEnabled
   public static class BasicConfiguration {
 
+    private final SecurityConfiguration securityConfiguration;
+
+    public BasicConfiguration(final SecurityConfiguration securityConfiguration) {
+      this.securityConfiguration = securityConfiguration;
+    }
+
+    @PostConstruct
+    public void verifyBasicConfiguration() {
+      if (securityConfiguration.getAuthentication().getOidc() != null
+          && securityConfiguration.getAuthentication().getOidc().isSet()) {
+        throw new IllegalStateException(
+            "Oidc configuration is not supported with `BASIC` authentication method");
+      }
+    }
+
     @Bean
     public CamundaAuthenticationConverter<Authentication> usernamePasswordAuthenticationConverter(
         final RoleServices roleServices,

--- a/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigParameterizedTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigParameterizedTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.service.UserServices;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class BasicAuthWebSecurityConfigParameterizedTest {
+
+  @Test
+  void validConfigurationApplicationStarted() {
+    new SpringApplicationBuilder(TestApplication.class)
+        .web(WebApplicationType.NONE)
+        .properties(getBasicProperties())
+        .run();
+  }
+
+  @ParameterizedTest
+  @MethodSource("getAllInvalidProperties")
+  void invalidConfigurationApplicationFailed(final Map<String, Object> invalidProperties) {
+    assertThatThrownBy(
+            () -> {
+              new SpringApplicationBuilder(TestApplication.class)
+                  .web(WebApplicationType.NONE)
+                  .properties(invalidProperties)
+                  .run();
+            })
+        .getCause()
+        .hasMessageContaining(
+            "Oidc configuration is not supported with `BASIC` authentication method");
+  }
+
+  private Stream<Map<String, Object>> getAllInvalidProperties() {
+    return Stream.of(
+        getProperties("camunda.security.authentication.oidc.client-id", "test-client"),
+        getProperties("camunda.security.authentication.oidc.client-secret", "test-secret"),
+        getProperties("camunda.security.authentication.oidc.organization-id", "org"),
+        getProperties("camunda.security.authentication.oidc.issuer-uri", "http://uri"),
+        getProperties("camunda.security.authentication.oidc.token-uri", "http://uri"),
+        getProperties("camunda.security.authentication.oidc.jwk-set-uri", "http://uri"),
+        getProperties("camunda.security.authentication.oidc.authorization-uri", "http://uri"),
+        getProperties("camunda.security.authentication.oidc.redirect-uri", "http://uri"),
+        getProperties("camunda.security.authentication.oidc.groups-claim", "group"),
+        getProperties("camunda.security.authentication.oidc.username-claim", "sub1"),
+        getProperties("camunda.security.authentication.oidc.grant-type", "client_credentials"));
+  }
+
+  private Map<String, Object> getProperties(final String property, final String value) {
+    final Map<String, Object> properties = getBasicProperties();
+    properties.put(property, value);
+    return properties;
+  }
+
+  private Map<String, Object> getBasicProperties() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put("spring.profiles.active", "consolidated-auth");
+    properties.put("spring.main.allow-bean-definition-overriding", true);
+    properties.put("camunda.security.authentication.unprotected-api", false);
+    properties.put("camunda.security.authentication.method", "basic");
+    return properties;
+  }
+
+  @AutoConfigureMockMvc
+  @AutoConfigureWebMvc
+  @ComponentScan(
+      basePackages = {"io.camunda.authentication"},
+      excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*Controller"))
+  public static class TestApplication {
+    @Bean
+    public UserServices userServices() {
+      return new UserServices(null, null, null, null, null);
+    }
+
+    @Bean
+    public HandlerMappingIntrospector mvcHandlerMappingIntrospector() {
+      return new HandlerMappingIntrospector();
+    }
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcAuthenticationConfigurationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcAuthenticationConfigurationTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import io.camunda.security.configuration.AuthorizeRequestConfiguration;
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class OidcAuthenticationConfigurationTest {
+
+  @ParameterizedTest(name = "{index}: {0}")
+  @MethodSource("oidcAuthentications")
+  @DisplayName("Check OIDC configuration is set")
+  void testIsSet(
+      final String description,
+      final OidcAuthenticationConfiguration oidcAuthenticationConfiguration,
+      final boolean expected) {
+    Assertions.assertThat(oidcAuthenticationConfiguration.isSet()).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> oidcAuthentications() {
+    return Stream.of(
+        Arguments.of(
+            "audience is set",
+            OidcAuthenticationConfiguration.builder().audiences(Set.of("aud")).build(),
+            true),
+        Arguments.of(
+            "authorizationUri is set",
+            OidcAuthenticationConfiguration.builder().authorizationUri("auth-uri").build(),
+            true),
+        Arguments.of(
+            "clientId is set",
+            OidcAuthenticationConfiguration.builder().clientId("cid").build(),
+            true),
+        Arguments.of(
+            "clientSecret is set",
+            OidcAuthenticationConfiguration.builder().clientSecret("cs").build(),
+            true),
+        Arguments.of(
+            "authorizeRequestConfiguration is set to null",
+            OidcAuthenticationConfiguration.builder().authorizeRequestConfiguration(null).build(),
+            true),
+        Arguments.of(
+            "authorizeRequestConfiguration is set to null",
+            OidcAuthenticationConfiguration.builder()
+                .authorizeRequestConfiguration(
+                    AuthorizeRequestConfiguration.builder().additionalParameter("k1", "v1").build())
+                .build(),
+            true),
+        Arguments.of(
+            "grantType is set to empty",
+            OidcAuthenticationConfiguration.builder().grantType("").build(),
+            true),
+        Arguments.of(
+            "grantType is set",
+            OidcAuthenticationConfiguration.builder().grantType("client_credentials").build(),
+            true),
+        Arguments.of(
+            "clientIdClaim is set",
+            OidcAuthenticationConfiguration.builder().clientIdClaim("cclaim").build(),
+            true),
+        Arguments.of(
+            "groupsClaim is set",
+            OidcAuthenticationConfiguration.builder().groupsClaim("gclaim").build(),
+            true),
+        Arguments.of(
+            "usernameClaim is set to null",
+            OidcAuthenticationConfiguration.builder().usernameClaim(null).build(),
+            true),
+        Arguments.of(
+            "usernameClaim is set empty",
+            OidcAuthenticationConfiguration.builder().usernameClaim("").build(),
+            true),
+        Arguments.of(
+            "usernameClaim is set",
+            OidcAuthenticationConfiguration.builder().usernameClaim("sub1").build(),
+            true),
+        Arguments.of(
+            "issuerUri is set",
+            OidcAuthenticationConfiguration.builder().issuerUri("issuer").build(),
+            true),
+        Arguments.of(
+            "jwk-url is set",
+            OidcAuthenticationConfiguration.builder().jwkSetUri("jwk-url").build(),
+            true),
+        Arguments.of(
+            "scope is set to null",
+            OidcAuthenticationConfiguration.builder().scope(null).build(),
+            true),
+        Arguments.of(
+            "scope is set to empty",
+            OidcAuthenticationConfiguration.builder().scope(new ArrayList<>()).build(),
+            true),
+        Arguments.of(
+            "scope is set",
+            OidcAuthenticationConfiguration.builder().scope(List.of("profile")).build(),
+            true),
+        Arguments.of(
+            "redirectUri is set",
+            OidcAuthenticationConfiguration.builder().redirectUri("redirect").build(),
+            true),
+        Arguments.of(
+            "tokeUri is set",
+            OidcAuthenticationConfiguration.builder().tokenUri("token").build(),
+            true),
+        Arguments.of(
+            "organizationId is set",
+            OidcAuthenticationConfiguration.builder().organizationId("org").build(),
+            true),
+        Arguments.of("default", new OidcAuthenticationConfiguration(), false),
+        Arguments.of(
+            "default authorizeRequestConfiguration is set",
+            OidcAuthenticationConfiguration.builder()
+                .authorizeRequestConfiguration(new AuthorizeRequestConfiguration())
+                .build(),
+            false),
+        Arguments.of(
+            "default grantType is set",
+            OidcAuthenticationConfiguration.builder().grantType("authorization_code").build(),
+            false),
+        Arguments.of(
+            "default usernameClaim is set",
+            OidcAuthenticationConfiguration.builder().usernameClaim("sub").build(),
+            false),
+        Arguments.of(
+            "default scope is set",
+            OidcAuthenticationConfiguration.builder().scope(List.of("openid", "profile")).build(),
+            false));
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthorizeRequestConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthorizeRequestConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.security.configuration;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class AuthorizeRequestConfiguration {
@@ -18,5 +19,38 @@ public class AuthorizeRequestConfiguration {
 
   public void setAdditionalParameters(final Map<String, Object> additionalParameters) {
     this.additionalParameters = additionalParameters;
+  }
+
+  public boolean isSet() {
+    return additionalParameters != null;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  // Builder class
+  public static class Builder {
+    private final Map<String, Object> additionalParameters;
+
+    public Builder() {
+      additionalParameters = new HashMap<>();
+    }
+
+    public Builder additionalParameter(final String key, final Object value) {
+      additionalParameters.put(key, value);
+      return this;
+    }
+
+    public Builder additionalParameters(final Map<String, Object> additionalParameters) {
+      this.additionalParameters.putAll(additionalParameters);
+      return this;
+    }
+
+    public AuthorizeRequestConfiguration build() {
+      final AuthorizeRequestConfiguration config = new AuthorizeRequestConfiguration();
+      config.setAdditionalParameters(additionalParameters);
+      return config;
+    }
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -154,4 +154,143 @@ public class OidcAuthenticationConfiguration {
     new OidcGroupsLoader(groupsClaim);
     this.groupsClaim = groupsClaim;
   }
+
+  public boolean isSet() {
+    return issuerUri != null
+        || clientId != null
+        || clientSecret != null
+        || !"authorization_code".equals(grantType)
+        || redirectUri != null
+        || !Arrays.asList("openid", "profile").equals(scope)
+        || jwkSetUri != null
+        || authorizationUri != null
+        || tokenUri != null
+        || authorizeRequestConfiguration == null
+        || authorizeRequestConfiguration.isSet()
+        || !"sub".equals(usernameClaim)
+        || audiences != null
+        || clientIdClaim != null
+        || groupsClaim != null
+        || organizationId != null;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String issuerUri;
+    private String clientId;
+    private String clientSecret;
+    private String grantType = "authorization_code";
+    private String redirectUri;
+    private List<String> scope = Arrays.asList("openid", "profile");
+    private String jwkSetUri;
+    private String authorizationUri;
+    private String tokenUri;
+    private AuthorizeRequestConfiguration authorizeRequestConfiguration =
+        new AuthorizeRequestConfiguration();
+    private Set<String> audiences;
+    private String usernameClaim = "sub";
+    private String clientIdClaim;
+    private String groupsClaim;
+    private String organizationId;
+
+    public Builder issuerUri(final String issuerUri) {
+      this.issuerUri = issuerUri;
+      return this;
+    }
+
+    public Builder clientId(final String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    public Builder clientSecret(final String clientSecret) {
+      this.clientSecret = clientSecret;
+      return this;
+    }
+
+    public Builder grantType(final String grantType) {
+      this.grantType = grantType;
+      return this;
+    }
+
+    public Builder redirectUri(final String redirectUri) {
+      this.redirectUri = redirectUri;
+      return this;
+    }
+
+    public Builder scope(final List<String> scope) {
+      this.scope = scope;
+      return this;
+    }
+
+    public Builder jwkSetUri(final String jwkSetUri) {
+      this.jwkSetUri = jwkSetUri;
+      return this;
+    }
+
+    public Builder authorizationUri(final String authorizationUri) {
+      this.authorizationUri = authorizationUri;
+      return this;
+    }
+
+    public Builder tokenUri(final String tokenUri) {
+      this.tokenUri = tokenUri;
+      return this;
+    }
+
+    public Builder authorizeRequestConfiguration(
+        final AuthorizeRequestConfiguration authorizeRequestConfiguration) {
+      this.authorizeRequestConfiguration = authorizeRequestConfiguration;
+      return this;
+    }
+
+    public Builder audiences(final Set<String> audiences) {
+      this.audiences = audiences;
+      return this;
+    }
+
+    public Builder usernameClaim(final String usernameClaim) {
+      this.usernameClaim = usernameClaim;
+      return this;
+    }
+
+    public Builder clientIdClaim(final String clientIdClaim) {
+      this.clientIdClaim = clientIdClaim;
+      return this;
+    }
+
+    public Builder groupsClaim(final String groupsClaim) {
+      new OidcGroupsLoader(groupsClaim); // Validation from original setter
+      this.groupsClaim = groupsClaim;
+      return this;
+    }
+
+    public Builder organizationId(final String organizationId) {
+      this.organizationId = organizationId;
+      return this;
+    }
+
+    public OidcAuthenticationConfiguration build() {
+      final OidcAuthenticationConfiguration config = new OidcAuthenticationConfiguration();
+      config.setIssuerUri(issuerUri);
+      config.setClientId(clientId);
+      config.setClientSecret(clientSecret);
+      config.setGrantType(grantType);
+      config.setRedirectUri(redirectUri);
+      config.setScope(scope);
+      config.setJwkSetUri(jwkSetUri);
+      config.setAuthorizationUri(authorizationUri);
+      config.setTokenUri(tokenUri);
+      config.setAuthorizeRequest(authorizeRequestConfiguration);
+      config.setAudiences(audiences);
+      config.setUsernameClaim(usernameClaim);
+      config.setClientIdClaim(clientIdClaim);
+      config.setGroupsClaim(groupsClaim);
+      config.setOrganizationId(organizationId);
+      return config;
+    }
+  }
 }


### PR DESCRIPTION
## Description

When basic auth is enabled, we should validate that no OIDC configuration properties are specified
This would be a mixed configuration where we would have to guess what the user's intention is
Starting with a mixed configuration also leads to unexpected behavior, e.g. we only display the groups tab in the UI [when the OIDC groups claim is not configured](https://github.com/camunda/camunda/blob/781e784a336247e06d736b5df9d11cc1817923ae/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java#L74-L80); this check is indepedent whether OIDC or basic auth are set as the authentication mode; we should try to avoid such inconsistencies entirely
It's then best to fail fast and let the user resolve the problem

## Related issues

closes #37287 
backport of #37461 
