### PR TITLE
ci: ensure credentials are available to allow pushing

### DIFF
--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         name: Build setup
         with:
-          dockerhub: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
+          dockerhub: ${{ env.IS_MAIN_OR_STABLE_BRANCH == 'true' }}
           harbor: true
           java-distribution: adopt
           maven-cache-key-modifier: operate

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         name: Build setup
         with:
-          dockerhub: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
+          dockerhub: ${{ env.IS_MAIN_OR_STABLE_BRANCH == 'true' }}
           harbor: true
           java-distribution: adopt
           maven-cache-key-modifier: tasklist


### PR DESCRIPTION
## Description

On new stable branches image pushes for Operate and Tasklist fail. Reason is that credentials are not loaded because of a wrong condition. This PR adjusts the condition on `main` (`main` itself is unaffected) and backports that to `stable/8.8` - same condition as in https://github.com/camunda/camunda/blob/8ecbbb5053c045e8113d04b9d4f03196333b4110/.github/workflows/operate-ci-build-reusable.yml#L143 now (consistent).

Example failures on `stable/8.8`

* https://github.com/camunda/camunda/actions/runs/17460108800/job/49585555374

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to https://github.com/camunda/camunda/issues/37374
