### PR TITLE
ci: use 8.8.0-alpha8 for Docker based tests

### DIFF
--- a/operate/qa/pom.xml
+++ b/operate/qa/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <!-- properties for ImportSeveralVersionsTest and import-old-zeebe-tests module -->
     <version.zeebe.old>8.1.0</version.zeebe.old>
-    <version.zeebe.docker.current>8.8.0-alpha8-rc3</version.zeebe.docker.current>
+    <version.zeebe.docker.current>8.8.0-alpha8</version.zeebe.docker.current>
     <version.zeebe.docker.repo>camunda/zeebe</version.zeebe.docker.repo>
     <version.identity.docker.current>8.5.0</version.identity.docker.current>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -48,7 +48,7 @@
     <project.previousVersion>8.7.0</project.previousVersion>
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
-    <zeebe.version>8.8.0-SNAPSHOT</zeebe.version>
+    <zeebe.version>8.8.0-alpha8</zeebe.version>
     <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
     <identity.version>8.7.5</identity.version>
     <!-- We use this for the Zeebe test container version only -->

--- a/tasklist/qa/pom.xml
+++ b/tasklist/qa/pom.xml
@@ -20,7 +20,7 @@
   </modules>
 
   <properties>
-    <version.zeebe.docker.current>8.8.0-alpha8-rc3</version.zeebe.docker.current>
+    <version.zeebe.docker.current>8.8.0-alpha8</version.zeebe.docker.current>
     <version.zeebe.docker.repo>camunda/zeebe</version.zeebe.docker.repo>
     <version.identity.docker.current>SNAPSHOT</version.identity.docker.current>
   </properties>


### PR DESCRIPTION
## Description

Unblocks camunda/optimize Docker image uploads to DockerHub (smoke test there fails due to 8.8.0 not being released yet: https://github.com/camunda/camunda/actions/runs/17460108800/job/49585555374 )

Expected outcome after merge: https://hub.docker.com/r/camunda/optimize/tags?name=8.8-SNAPSHOT should exist

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to https://github.com/camunda/camunda/issues/37374
