### PR TITLE
Prevent NPE during snapshot bootstrap

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.partitioning;
 
+import static io.camunda.zeebe.scheduler.Actor.ACTOR_PROP_PARTITION_ID;
+
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.partition.RaftPartition;
@@ -24,6 +26,7 @@ import io.camunda.zeebe.scheduler.startup.StartupProcess;
 import io.camunda.zeebe.util.FileUtil;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,6 +69,7 @@ final class Partition {
     return new Partition(
         context,
         new StartupProcess<>(
+            Map.of(ACTOR_PROP_PARTITION_ID, context.partitionId().toString()),
             LOGGER,
             List.of(
                 new MetricsStep(context.partitionId()),
@@ -80,6 +84,8 @@ final class Partition {
     return new Partition(
         context,
         new StartupProcess<>(
+            Map.of(ACTOR_PROP_PARTITION_ID, context.partitionId().toString()),
+            LOGGER,
             List.of(
                 new MetricsStep(context.partitionId()),
                 new PartitionDirectoryStep(context.partitionId()),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
@@ -68,12 +68,12 @@ final class Partition {
         new StartupProcess<>(
             LOGGER,
             List.of(
-                new MetricsStep(),
-                new PartitionDirectoryStep(),
-                new SnapshotStoreStep(),
-                new RaftBootstrapStep(),
-                new ZeebePartitionStep(),
-                new PartitionRegistrationStep())));
+                new MetricsStep(context.partitionId()),
+                new PartitionDirectoryStep(context.partitionId()),
+                new SnapshotStoreStep(context.partitionId()),
+                new RaftBootstrapStep(context.partitionId()),
+                new ZeebePartitionStep(context.partitionId()),
+                new PartitionRegistrationStep(context.partitionId()))));
   }
 
   static Partition joining(final PartitionStartupContext context) {
@@ -81,12 +81,12 @@ final class Partition {
         context,
         new StartupProcess<>(
             List.of(
-                new MetricsStep(),
-                new PartitionDirectoryStep(),
-                new SnapshotStoreStep(),
-                new RaftJoinStep(),
-                new ZeebePartitionStep(),
-                new PartitionRegistrationStep())));
+                new MetricsStep(context.partitionId()),
+                new PartitionDirectoryStep(context.partitionId()),
+                new SnapshotStoreStep(context.partitionId()),
+                new RaftJoinStep(context.partitionId()),
+                new ZeebePartitionStep(context.partitionId()),
+                new PartitionRegistrationStep(context.partitionId()))));
   }
 
   ActorFuture<Partition> start() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/SnapshotInitializationUtil.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/SnapshotInitializationUtil.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.startup;
+
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
+import io.camunda.zeebe.snapshots.transfer.SnapshotTransfer;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Utility class for handling bootstrapping a partition via snapshot from partition 1. */
+public final class SnapshotInitializationUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SnapshotInitializationUtil.class);
+
+  private SnapshotInitializationUtil() {
+    // Utility class
+  }
+
+  /**
+   * Initializes a partition's snapshot store from a snapshot from partition 1, handling all the
+   * necessary validation and cleanup steps. This method is idempotent and can be safely retried
+   * after failures at different steps.
+   *
+   * @param snapshotStore the snapshot store to use
+   * @param snapshotTransfer the snapshot transfer service
+   * @param concurrencyControl the concurrency control for actor futures
+   * @return a future that completes when initialization is finished
+   */
+  public static ActorFuture<Void> initializeFromSnapshot(
+      final FileBasedSnapshotStore snapshotStore,
+      final SnapshotTransfer snapshotTransfer,
+      final ConcurrencyControl concurrencyControl) {
+
+    return validateAndCleanupExistingSnapshot(snapshotStore, concurrencyControl)
+        .andThen(
+            ignored -> fetchAndRestoreSnapshot(snapshotTransfer, snapshotStore, concurrencyControl),
+            concurrencyControl)
+        .andThen(
+            ignored -> cleanupBootstrapSnapshot(snapshotStore, concurrencyControl),
+            concurrencyControl);
+  }
+
+  /**
+   * Validates existing snapshots and cleans up bootstrap snapshots if necessary. If a bootstrap
+   * snapshot is already present, it might be from a previous failed bootstrap attempt. Since it is
+   * not easy to verify if it is the required snapshot, we will delete it so that a new snapshot can
+   * be requested. It is not expected to have snapshot not for bootstrap, because this partition has
+   * not started yet. So for safety we will fail and manual intervention is required.
+   */
+  private static ActorFuture<Void> validateAndCleanupExistingSnapshot(
+      final FileBasedSnapshotStore snapshotStore, final ConcurrencyControl concurrencyControl) {
+
+    final Optional<PersistedSnapshot> latestSnapshot = snapshotStore.getLatestSnapshot();
+
+    if (latestSnapshot.isEmpty()) {
+      LOG.trace("No existing snapshot found, proceeding with initialization");
+      return CompletableActorFuture.completed();
+    }
+
+    final PersistedSnapshot snapshot = latestSnapshot.get();
+    final boolean isBootstrap = snapshot.getMetadata().isBootstrap();
+
+    if (isBootstrap) {
+      LOG.info(
+          "A bootstrapped snapshot is present, deleting it in order to be able to fetch it again and bootstrap cleanly.");
+      return snapshotStore.delete().thenApply(empty -> null, concurrencyControl);
+    } else {
+      final String errorMessage =
+          "Snapshot "
+              + snapshot.getId()
+              + " is not for bootstrap, aborting bootstrap. Manual intervention is required to successfully bootstrap this partition. Verify why the snapshot is present and if it's safe to do so please delete it.";
+      return CompletableActorFuture.completedExceptionally(new IllegalStateException(errorMessage));
+    }
+  }
+
+  /** Fetches the latest snapshot from the leader and restores it if available. */
+  private static ActorFuture<Void> fetchAndRestoreSnapshot(
+      final SnapshotTransfer snapshotTransfer,
+      final FileBasedSnapshotStore snapshotStore,
+      final ConcurrencyControl concurrencyControl) {
+
+    final ActorFuture<PersistedSnapshot> fetchFuture =
+        snapshotTransfer.getLatestSnapshot(Protocol.DEPLOYMENT_PARTITION);
+
+    return fetchFuture.andThen(
+        snapshot -> {
+          if (snapshot == null) {
+            LOG.info("Received no snapshot from leader, skipping restore from snapshot");
+            return CompletableActorFuture.completed();
+          } else {
+            LOG.info("Received snapshot {} from leader, restoring from snapshot", snapshot.getId());
+            return snapshotStore.restore(snapshot);
+          }
+        },
+        concurrencyControl);
+  }
+
+  private static ActorFuture<Void> cleanupBootstrapSnapshot(
+      final FileBasedSnapshotStore snapshotStore, final ConcurrencyControl concurrencyControl) {
+
+    return snapshotStore.deleteBootstrapSnapshots();
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
@@ -16,9 +16,15 @@ import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 
 public class MetricsStep implements StartupStep<PartitionStartupContext> {
 
+  private final String name;
+
+  public MetricsStep(final int partitionId) {
+    name = String.format("Partition %d - Metrics Step", partitionId);
+  }
+
   @Override
   public String getName() {
-    return "Partition Metrics Startup Step";
+    return name;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionDirectoryStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionDirectoryStep.java
@@ -18,9 +18,15 @@ import java.nio.file.Paths;
 
 public final class PartitionDirectoryStep implements StartupStep<PartitionStartupContext> {
 
+  private final String name;
+
+  public PartitionDirectoryStep(final int partitionId) {
+    name = String.format("Partition %d - Directory", partitionId);
+  }
+
   @Override
   public String getName() {
-    return "Partition Directory";
+    return name;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
@@ -14,9 +14,15 @@ import io.camunda.zeebe.scheduler.startup.StartupStep;
 
 public final class PartitionRegistrationStep implements StartupStep<PartitionStartupContext> {
 
+  private final String name;
+
+  public PartitionRegistrationStep(final int partitionId) {
+    name = String.format("Partition %d - Registration", partitionId);
+  }
+
   @Override
   public String getName() {
-    return "Partition Registration";
+    return name;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftBootstrapStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftBootstrapStep.java
@@ -13,9 +13,15 @@ import io.camunda.zeebe.scheduler.startup.StartupStep;
 
 public final class RaftBootstrapStep implements StartupStep<PartitionStartupContext> {
 
+  private final String name;
+
+  public RaftBootstrapStep(final int partitionId) {
+    name = String.format("Partition %d - Bootstrapping Raft", partitionId);
+  }
+
   @Override
   public String getName() {
-    return "Bootstrapped Raft Partition";
+    return name;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftJoinStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftJoinStep.java
@@ -13,9 +13,15 @@ import io.camunda.zeebe.scheduler.startup.StartupStep;
 
 public class RaftJoinStep implements StartupStep<PartitionStartupContext> {
 
+  private final String name;
+
+  public RaftJoinStep(final int partitionId) {
+    name = String.format("Partition %d - Joining Raft", partitionId);
+  }
+
   @Override
   public String getName() {
-    return "Joining Raft Partition";
+    return name;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -21,9 +21,15 @@ import io.camunda.zeebe.snapshots.transfer.SnapshotTransferImpl;
 
 public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
 
+  private final String name;
+
+  public SnapshotStoreStep(final int partitionId) {
+    name = String.format("Partition %d - Snapshot Store", partitionId);
+  }
+
   @Override
   public String getName() {
-    return "Snapshot Store";
+    return name;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -11,21 +11,15 @@ import static io.camunda.zeebe.scheduler.AsyncClosable.closeHelper;
 
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotTransferServiceClient;
 import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
+import io.camunda.zeebe.broker.partitioning.startup.SnapshotInitializationUtil;
 import io.camunda.zeebe.db.impl.rocksdb.ChecksumProviderRocksDBImpl;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.snapshots.transfer.SnapshotTransferImpl;
-import java.util.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(SnapshotStoreStep.class);
 
   @Override
   public String getName() {
@@ -49,31 +43,6 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
             .thenApply(v -> context.snapshotStore(snapshotStore), context.concurrencyControl());
 
     if (context.isInitializeFromSnapshot()) {
-      // Delete the persisted snapshot if the id is the same we "expect" when bootstrapping
-      // this may happen if the startup fails in later steps, but the snapshot was already
-      // persisted.
-      // It's not possible to persist the same snapshot twice, so we must delete it first
-      if (snapshotStore.getLatestSnapshot().isPresent()) {
-        final var latestSnapshot = snapshotStore.getLatestSnapshot().get();
-        final var isBootstrap = latestSnapshot.getMetadata().isBootstrap();
-        if (isBootstrap) {
-          LOG.info(
-              "A bootstrapped snapshot is present, deleting it in order to be able to fetch it again and bootstrap cleanly.");
-          result =
-              result.andThen(
-                  ctx -> snapshotStore.delete().thenApply(empty -> ctx),
-                  context.concurrencyControl());
-        } else {
-          final var errorMessage =
-              "Snapshot {} is not for bootstrap, aborting bootstrap. Manual intervention is required to successfully bootstrap this partition. Verify why the snapshot is present and if it's safe to to do so please delete it."
-                  .formatted(latestSnapshot.getId());
-          result.andThen(
-              ctx ->
-                  CompletableActorFuture.completedExceptionally(
-                      new IllegalStateException(errorMessage)),
-              context.concurrencyControl());
-        }
-      }
       result =
           result
               .andThen(
@@ -94,8 +63,14 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
                             context.concurrencyControl());
                   },
                   context.concurrencyControl())
-              .andThen(this::initializeFromBootstrapSnapshot, context.concurrencyControl())
-              .andThen(this::deleteBootstrapSnapshot, context.concurrencyControl());
+              .andThen(
+                  ctx ->
+                      SnapshotInitializationUtil.initializeFromSnapshot(
+                              snapshotStore,
+                              context.snapshotTransfer(),
+                              context.concurrencyControl())
+                          .thenApply(ignored -> ctx, context.concurrencyControl()),
+                  context.concurrencyControl());
     }
     return result;
   }
@@ -105,42 +80,5 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
     return closeHelper(context.snapshotTransfer())
         .andThen(ignore -> closeHelper(context.snapshotStore()), context.concurrencyControl())
         .thenApply(ignored -> context.snapshotStore(null), context.concurrencyControl());
-  }
-
-  /** Deletes the snapshot for bootstrap, even if an error was raised. */
-  private ActorFuture<PartitionStartupContext> deleteBootstrapSnapshot(
-      final PartitionStartupContext context, final Throwable error) {
-    final var result =
-        Optional.ofNullable(context.snapshotStore())
-            .map(FileBasedSnapshotStore::deleteBootstrapSnapshots)
-            .orElse(CompletableActorFuture.completed());
-
-    return result.andThen(
-        ignored -> {
-          if (error != null) {
-            return CompletableActorFuture.completedExceptionally(error);
-          } else {
-            return CompletableActorFuture.completed(context);
-          }
-        },
-        context.concurrencyControl());
-  }
-
-  private ActorFuture<PartitionStartupContext> initializeFromBootstrapSnapshot(
-      final PartitionStartupContext context) {
-    final var fut = context.snapshotTransfer().getLatestSnapshot(Protocol.DEPLOYMENT_PARTITION);
-    return fut.andThen(
-            snapshot -> {
-              if (snapshot == null) {
-                LOG.info("Received no snapshot from leader, skipping restore from snapshot");
-                return CompletableActorFuture.completed();
-              } else {
-                LOG.info(
-                    "Received snapshot {} from leader, restoring from snapshot", snapshot.getId());
-                return context.snapshotStore().restore(snapshot);
-              }
-            },
-            context.concurrencyControl())
-        .thenApply(ignored -> context, context.concurrencyControl());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/ZeebePartitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/ZeebePartitionStep.java
@@ -13,9 +13,15 @@ import io.camunda.zeebe.scheduler.startup.StartupStep;
 
 public final class ZeebePartitionStep implements StartupStep<PartitionStartupContext> {
 
+  private final String name;
+
+  public ZeebePartitionStep(final int partitionId) {
+    name = String.format("Partition %d - Zeebe Partition", partitionId);
+  }
+
   @Override
   public String getName() {
-    return "Zeebe Partition";
+    return name;
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/SnapshotInitializationUtilTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/SnapshotInitializationUtilTest.java
@@ -1,0 +1,440 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.test.TestActorSchedulerFactory;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.SnapshotCopyUtil;
+import io.camunda.zeebe.snapshots.TransientSnapshot;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
+import io.camunda.zeebe.snapshots.transfer.SnapshotTransfer;
+import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SnapshotInitializationUtilTest {
+
+  @TempDir private Path tempDir;
+
+  @Mock private SnapshotTransfer snapshotTransfer;
+
+  private ActorScheduler scheduler;
+  private Actor concurrencyControl;
+  private FileBasedSnapshotStore receiverSnapshotStore;
+  private FileBasedSnapshotStore senderSnapshotStore;
+  private PersistedSnapshot senderBootstrapSnapshot;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    final var brokerConfig = new BrokerCfg();
+    scheduler = TestActorSchedulerFactory.ofBrokerConfig(brokerConfig);
+    concurrencyControl = new Actor() {};
+    scheduler.submitActor(concurrencyControl);
+
+    // Create receiver snapshot store (the one being tested)
+    final var receiverSnapshotDir = Files.createDirectory(tempDir.resolve("receiver-snapshots"));
+    receiverSnapshotStore =
+        new FileBasedSnapshotStore(
+            1, // brokerId
+            2, // partitionId
+            receiverSnapshotDir,
+            snapshotPath -> Map.of(),
+            new SimpleMeterRegistry());
+
+    // Create sender snapshot store (simulates the leader/sender)
+    final var senderSnapshotDir = Files.createDirectory(tempDir.resolve("sender-snapshots"));
+    senderSnapshotStore =
+        new FileBasedSnapshotStore(
+            2, // different brokerId
+            1, // same partitionId
+            senderSnapshotDir,
+            snapshotPath -> Map.of(),
+            new SimpleMeterRegistry());
+
+    scheduler.submitActor(receiverSnapshotStore).join();
+    scheduler.submitActor(senderSnapshotStore).join();
+
+    senderBootstrapSnapshot = createBootstrapSnapshotOnSender();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (scheduler != null) {
+      scheduler.stop();
+    }
+  }
+
+  @Test
+  void shouldCompleteSuccessfullyWithNoExistingSnapshot() {
+    // given - create a bootstrap snapshot on the sender side for transfer
+    mockTransferSnapshot();
+
+    // when
+    final ActorFuture<Void> result =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            receiverSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    // then
+    assertThat(result.join()).isNull();
+    verify(snapshotTransfer).getLatestSnapshot(Protocol.DEPLOYMENT_PARTITION);
+
+    // Verify bootstrap snapshot was restored on receiver side
+    assertThat(receiverSnapshotStore.getLatestSnapshot())
+        .isPresent()
+        .get()
+        .satisfies(
+            snapshot -> {
+              assertThat(snapshot.getId()).isEqualTo(senderBootstrapSnapshot.getId());
+              assertThat(snapshot.getMetadata().isBootstrap()).isTrue();
+            });
+  }
+
+  @Test
+  void shouldFailWithNonBootstrapSnapshot() {
+    // given - create a non-bootstrap snapshot on receiver side
+    createNonBootstrapSnapshotOnReceiver();
+
+    // when
+    final ActorFuture<Void> result =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            receiverSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    // then
+    assertThatThrownBy(result::join)
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is not for bootstrap");
+  }
+
+  @Test
+  void shouldHandleNoSnapshotFromLeader() {
+    // given - no snapshot available from sender
+    when(snapshotTransfer.getLatestSnapshot(Protocol.DEPLOYMENT_PARTITION))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final ActorFuture<Void> result =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            receiverSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    // then
+    assertThat(result.join()).isNull();
+    assertThat(receiverSnapshotStore.getLatestSnapshot()).isEmpty();
+  }
+
+  @Test
+  void shouldPropagateRestoreFailure() {
+    // given - create a snapshot on sender and corrupt it
+    mockTransferSnapshot();
+    final var spiedSnapshotStore = org.mockito.Mockito.spy(receiverSnapshotStore);
+    doReturn(CompletableActorFuture.completedExceptionally(new RuntimeException("Forced failure")))
+        .when(spiedSnapshotStore)
+        .restore(any(PersistedSnapshot.class));
+
+    // when
+    final ActorFuture<Void> result =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            spiedSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    // then
+    assertThatThrownBy(result::join)
+        .isInstanceOf(ExecutionException.class)
+        .hasMessageContaining("Forced failure");
+  }
+
+  @Test
+  void shouldPropagateSnapshotTransferFailure() {
+    // given
+    final RuntimeException transferError = new RuntimeException("Transfer failed");
+    when(snapshotTransfer.getLatestSnapshot(Protocol.DEPLOYMENT_PARTITION))
+        .thenReturn(CompletableActorFuture.completedExceptionally(transferError));
+
+    // when
+    final ActorFuture<Void> result =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            receiverSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    // then
+    assertThatThrownBy(result::join).isInstanceOf(ExecutionException.class).hasCause(transferError);
+  }
+
+  @Test
+  void shouldBeIdempotent() {
+    // given - transfer bootstrap snapshot to receiver side
+    mockTransferSnapshot();
+    SnapshotInitializationUtil.initializeFromSnapshot(
+            receiverSnapshotStore, snapshotTransfer, concurrencyControl)
+        .join();
+
+    // when
+    // Retry is always with a new snapshot store instance
+    restartReceiverSnapshotStore();
+
+    final ActorFuture<Void> retryResult =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            receiverSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    // then
+    assertThat(retryResult).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  void shouldBeIdempotentAfterValidationFailure() {
+    // given - create a non-bootstrap snapshot on receiver side
+    createNonBootstrapSnapshotOnReceiver();
+
+    // when - first attempt fails
+    final ActorFuture<Void> firstResult =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            receiverSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    assertThatThrownBy(firstResult::join)
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class);
+
+    // Retry is always with a new snapshot store instance
+    restartReceiverSnapshotStore();
+
+    // when - retry the validation
+    final ActorFuture<Void> retryResult =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            receiverSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    // then - should fail the same way (idempotent)
+    assertThatThrownBy(retryResult::join)
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is not for bootstrap");
+  }
+
+  @Test
+  void shouldBeIdempotentOnFetchFailure() {
+    // given
+    final RuntimeException transferError = new RuntimeException("Transfer failed");
+    doReturn(CompletableActorFuture.completedExceptionally(transferError))
+        // second attempt succeeds
+        .doAnswer(ignore -> transferSnapshot(senderBootstrapSnapshot))
+        .when(snapshotTransfer)
+        .getLatestSnapshot(Protocol.DEPLOYMENT_PARTITION);
+
+    final ActorFuture<Void> result =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            receiverSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    assertThatThrownBy(result::join).isInstanceOf(ExecutionException.class).hasCause(transferError);
+
+    // when - retry
+
+    // Retry is always with a new snapshot store instance
+    restartReceiverSnapshotStore();
+
+    final ActorFuture<Void> retryResult =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            receiverSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    // then
+    assertThat(retryResult).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  void shouldBeIdempotentIfRestoreFails() {
+    // given - bootstrap snapshot exists on receiver side
+    mockTransferSnapshot();
+    final var spiedSnapshotStore = org.mockito.Mockito.spy(receiverSnapshotStore);
+    doAnswer(
+            ignore ->
+                CompletableActorFuture.completedExceptionally(
+                    new RuntimeException("Force fail restore")))
+        .when(spiedSnapshotStore)
+        .restore(any(PersistedSnapshot.class));
+
+    final ActorFuture<Void> firstResult =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            spiedSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    assertThat(firstResult)
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("Force fail");
+
+    // when - retry
+
+    // Retry is always with a new snapshot store instance
+    restartReceiverSnapshotStore();
+
+    final ActorFuture<Void> retryResult =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            receiverSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    // then - second call also succeeds without trying to delete again
+    assertThat(retryResult).succeedsWithin(Duration.ofSeconds(1));
+    assertThat(receiverSnapshotStore.getBootstrapSnapshot()).isEmpty();
+  }
+
+  @Test
+  void shouldBeIdempotentOnDeleteFailure() {
+    // given - create a snapshot on sender and corrupt it
+    mockTransferSnapshot();
+    final var spiedSnapshotStore = org.mockito.Mockito.spy(receiverSnapshotStore);
+    // Fail first attempt
+    doReturn(
+            CompletableActorFuture.completedExceptionally(
+                new RuntimeException("Force fail first time")))
+        .when(spiedSnapshotStore)
+        .deleteBootstrapSnapshots();
+
+    // when
+    final ActorFuture<Void> firstTry =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            spiedSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    // then
+    assertThatThrownBy(firstTry::join)
+        .isInstanceOf(ExecutionException.class)
+        .hasMessageContaining("Force fail first time");
+    assertThat(receiverSnapshotStore.getLatestSnapshot()).isNotEmpty();
+
+    // when
+    // Retry is always with a new snapshot store instance
+    restartReceiverSnapshotStore();
+
+    final ActorFuture<Void> secondTry =
+        SnapshotInitializationUtil.initializeFromSnapshot(
+            receiverSnapshotStore, snapshotTransfer, concurrencyControl);
+
+    // then
+    assertThat(secondTry).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  private ActorFuture<PersistedSnapshot> transferSnapshot(
+      final PersistedSnapshot senderBootstrapSnapshot) {
+    final var tempReceiveSnapshot =
+        receiverSnapshotStore.newReceivedSnapshot(senderBootstrapSnapshot.getId());
+
+    return tempReceiveSnapshot.andThen(
+        receivedSnapshot -> {
+          try (final var reader = senderBootstrapSnapshot.newChunkReader()) {
+            while (reader.hasNext()) {
+              receivedSnapshot.apply(reader.next());
+            }
+            return receivedSnapshot.persist();
+          }
+        },
+        concurrencyControl);
+  }
+
+  private void restartReceiverSnapshotStore() {
+    receiverSnapshotStore.close();
+    final var receiverSnapshotDir = tempDir.resolve("receiver-snapshots");
+    receiverSnapshotStore =
+        new FileBasedSnapshotStore(
+            1, // brokerId
+            2, // partitionId
+            receiverSnapshotDir,
+            snapshotPath -> Map.of(),
+            new SimpleMeterRegistry());
+    scheduler.submitActor(receiverSnapshotStore).join();
+  }
+
+  private void mockTransferSnapshot() {
+    doAnswer(ignore -> transferSnapshot(senderBootstrapSnapshot))
+        .when(snapshotTransfer)
+        .getLatestSnapshot(Protocol.DEPLOYMENT_PARTITION);
+  }
+
+  private PersistedSnapshot createBootstrapSnapshotOnSender() {
+    return createBootstrapSnapshot(senderSnapshotStore);
+  }
+
+  private PersistedSnapshot createBootstrapSnapshot(final FileBasedSnapshotStore snapshotStore) {
+    // Create a regular snapshot first on sender
+    final var regularSnapshot = createPersistedSnapshot(snapshotStore, 2L, "base");
+
+    // Copy it for bootstrap
+    return snapshotStore.copyForBootstrap(regularSnapshot, SnapshotCopyUtil::copyAllFiles).join();
+  }
+
+  private void createNonBootstrapSnapshotOnReceiver() {
+    createPersistedSnapshotOnReceiver(1L, "non-bootstrap");
+  }
+
+  private PersistedSnapshot createPersistedSnapshotOnReceiver(
+      final long index, final String suffix) {
+    return createPersistedSnapshot(receiverSnapshotStore, index, suffix);
+  }
+
+  private PersistedSnapshot createPersistedSnapshot(
+      final FileBasedSnapshotStore snapshotStore, final long index, final String suffix) {
+    return takeTransientSnapshotWithFiles(snapshotStore, index, 200L + index, suffix)
+        .persist()
+        .join();
+  }
+
+  private TransientSnapshot takeTransientSnapshotWithFiles(
+      final FileBasedSnapshotStore store,
+      final long index,
+      final long processedPosition,
+      final String suffix) {
+    final var transientSnapshot =
+        store.newTransientSnapshot(index, 1L, processedPosition, 0L, false).get();
+
+    final var snapshotFileNames =
+        List.of("zeebe.metadata", "table-0.sst", "table-1.sst", "table-2.sst");
+    transientSnapshot
+        .take(
+            path -> {
+              try {
+                FileUtil.ensureDirectoryExists(path);
+                for (final var filename : snapshotFileNames) {
+                  final var file = new File(path.toString(), filename);
+                  // Create file if it doesn't exist, ignore if it does
+                  file.createNewFile();
+                  try (final var fos = new FileOutputStream(file)) {
+                    fos.write((suffix + "-content-" + processedPosition).getBytes());
+                    fos.flush();
+                  }
+                }
+                FileUtil.flushDirectory(path);
+              } catch (final IOException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .join();
+    return transientSnapshot;
+  }
+}

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/startup/StartupProcess.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/startup/StartupProcess.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.scheduler.startup;
 
 import static java.util.Collections.singletonList;
+import static org.slf4j.MDC.*;
 
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -15,11 +16,13 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 /**
  * Executes a number of steps in a startup/shutdown process.
@@ -69,6 +72,7 @@ public final class StartupProcess<CONTEXT> {
   private boolean startupCalled = false;
   private ActorFuture<CONTEXT> shutdownFuture;
   private ActorFuture<CONTEXT> startupFuture;
+  private Map<String, String> loggingContext = Map.of();
 
   /**
    * Constructs the startup process
@@ -89,6 +93,24 @@ public final class StartupProcess<CONTEXT> {
   public StartupProcess(final Logger logger, final List<? extends StartupStep<CONTEXT>> steps) {
     this.steps = new ArrayDeque<>(Objects.requireNonNull(steps));
     this.logger = Objects.requireNonNull(logger);
+  }
+
+  /**
+   * @param loggingContext temporary logging context to set during execution of the steps. For
+   *     example, if the actor that executes this process is shared by different partitions, you can
+   *     provide this key to temporarily set the partitionId in the MDC which will be picked by the
+   *     logging during the execution of the steps. must not be {@code null}
+   * @param logger the logger to use for messages related to the startup process; must not be {@code
+   *     * null}
+   * @param steps the steps to execute; must not be {@code null}
+   */
+  public StartupProcess(
+      final Map<String, String> loggingContext,
+      final Logger logger,
+      final List<? extends StartupStep<CONTEXT>> steps) {
+    this.steps = new ArrayDeque<>(Objects.requireNonNull(steps));
+    this.logger = Objects.requireNonNull(logger);
+    this.loggingContext = Objects.requireNonNull(loggingContext);
   }
 
   /**
@@ -125,7 +147,9 @@ public final class StartupProcess<CONTEXT> {
       final ConcurrencyControl concurrencyControl,
       final CONTEXT context,
       final ActorFuture<CONTEXT> startupFuture) {
+    setCustomMDC();
     logger.debug("Startup was called with context: {}", context);
+    clearCustomMDC();
     if (startupCalled) {
       throw new IllegalStateException("startup(...) must only be called once");
     }
@@ -147,9 +171,13 @@ public final class StartupProcess<CONTEXT> {
       final ActorFuture<CONTEXT> startupFuture) {
     if (stepsToStart.isEmpty()) {
       startupFuture.complete(context);
+      setCustomMDC();
       logger.debug("Finished startup process");
+      clearCustomMDC();
     } else if (shutdownFuture != null) {
+      setCustomMDC();
       logger.info("Aborting startup process because shutdown was called");
+      clearCustomMDC();
       startupFuture.completeExceptionally(
           new StartupProcessShutdownException(
               "Aborting startup process because shutdown was called"));
@@ -178,8 +206,10 @@ public final class StartupProcess<CONTEXT> {
       final ActorFuture<CONTEXT> startupFuture,
       final StartupStep<CONTEXT> stepToStart,
       final Throwable error) {
+    setCustomMDC();
     logger.warn(
         "Aborting startup process due to exception during step " + stepToStart.getName(), error);
+    clearCustomMDC();
     startupFuture.completeExceptionally(
         aggregateExceptionsSynchronized(
             "Startup",
@@ -190,7 +220,9 @@ public final class StartupProcess<CONTEXT> {
       final ConcurrencyControl concurrencyControl,
       final CONTEXT context,
       final ActorFuture<CONTEXT> resultFuture) {
+    setCustomMDC();
     logger.debug("Shutdown was called with context: {}", context);
+    clearCustomMDC();
     if (shutdownFuture == null) {
       shutdownFuture = resultFuture;
 
@@ -208,7 +240,9 @@ public final class StartupProcess<CONTEXT> {
             concurrencyControl, context, shutdownFuture, new ArrayList<>());
       }
     } else {
+      setCustomMDC();
       logger.info("Shutdown already in progress");
+      clearCustomMDC();
 
       concurrencyControl.runOnCompletion(
           shutdownFuture,
@@ -260,11 +294,14 @@ public final class StartupProcess<CONTEXT> {
       final List<StartupProcessStepException> collectedExceptions) {
     if (collectedExceptions.isEmpty()) {
       shutdownFuture.complete(context);
+      setCustomMDC();
       logger.debug("Finished shutdown process");
+      clearCustomMDC();
     } else {
       final var umbrellaException =
           aggregateExceptionsSynchronized("Shutdown", collectedExceptions);
       shutdownFuture.completeExceptionally(umbrellaException);
+      setCustomMDC();
       logger.warn(umbrellaException.getMessage(), umbrellaException);
     }
   }
@@ -286,6 +323,28 @@ public final class StartupProcess<CONTEXT> {
   }
 
   private void logCurrentStepSynchronized(final String process, final StartupStep<CONTEXT> step) {
+    setCustomMDC();
     logger.info(process + " " + step.getName());
+    clearCustomMDC();
+  }
+
+  private void setCustomMDC() {
+    loggingContext.forEach(
+        (key, value) -> {
+          if (key != null && value != null) {
+            MDC.put(key, value);
+          }
+        });
+  }
+
+  private void clearCustomMDC() {
+    loggingContext
+        .keySet()
+        .forEach(
+            key -> {
+              if (key != null) {
+                MDC.remove(key);
+              }
+            });
   }
 }


### PR DESCRIPTION
## Description

This PR addresses a NullPointerException (NPE) that was observed during chaos testing related to scaling partitions. 

There were mainly two issues that resulted in the NPE:

1. Unporotected access to context:  In `SnapshotStoreStep#deleteBootstrapSnapshot` the context is accessed without checking if an error exists. This caused the NPE and hide the actual error. 
2. Incorrect chaining of futures: The actual error was `SansphotAlreadyExists` when receiving a bootstrap snapshot from the leader again. The intended behavior is that we check if a snapshot already exists and delete it before requesting a snapshot again. However, due to incorrect chaining of the futures, this check is done before the `SnapshotStore` is started. So it does not find any snapshot to delete and thus requests a new one. But when the new one is received the previous snapshot is loaded and cause the exception. 

The actual error is not reproducible in a deterministic test, but was able to simulate it by hard-coding some failures in the code that caused the retry of the partition bootstrap operation. Though we cannot reproduce it reliably, there is a reasonably high probability that the above error is the actual root cause for the NPE observed in the chaos tests. 

This PR consists of 
1. The fix: The chaining of the future is fixed. The logic of initializing `SnapshotStore` from the bootstrap snapshot is extracted into a utility to make it testable.
2. Another test is added in `PartitionBootstrapTest` to verify that bootstrap from snapshot is idempotent - but it fails to reproduce the above error because upon restarting the leader of partition 1,  a new bootstrap snapshot with a new id (that differs in the checksum) is generated. On receiving this new snapshot `SnapshotAlreadyExists` error does not happen because the id differs.
3. Added partition Id to Partition startup steps to improve the observability. Previously the logs contains only statements like `Started snapshot store step` with out any reference to the partition Id in the logs statement or the log context. In addition partitionId is added to MDC for these steps.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37495 
