### PR TITLE
[Backport stable/8.8] ci: ensure credentials are available to allow pushing

### DIFF
--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         name: Build setup
         with:
-          dockerhub: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
+          dockerhub: ${{ env.IS_MAIN_OR_STABLE_BRANCH == 'true' }}
           harbor: true
           java-distribution: adopt
           maven-cache-key-modifier: operate

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         name: Build setup
         with:
-          dockerhub: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
+          dockerhub: ${{ env.IS_MAIN_OR_STABLE_BRANCH == 'true' }}
           harbor: true
           java-distribution: adopt
           maven-cache-key-modifier: tasklist


### PR DESCRIPTION
# Description
Backport of #37601 to `stable/8.8`.

relates to camunda/camunda#37374