### PR TITLE
fix: CamundaExporter starts exporting before being opened

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -63,7 +63,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   private static final Logger LOG = Loggers.EXPORTER_LOGGER;
   private final AtomicBoolean isOpened = new AtomicBoolean(false);
-  private final AtomicBoolean allExportersOpened = new AtomicBoolean(false);
+  // using primitive boolean since it is only used in actor
+  private boolean allExportersOpened;
 
   // Use concrete type because it must be modifiable
   private final ArrayList<ExporterContainer> containers;
@@ -567,7 +568,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     actor.runOnCompletion(
         containerOpenFutures,
         (error) -> {
-          allExportersOpened.set(true);
+          allExportersOpened = true;
           if (state.hasExporters()) {
             final long snapshotPosition = state.getLowestPosition();
             // start reading and exporting
@@ -654,7 +655,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   private boolean shouldExport() {
     return isOpened.get()
-        && allExportersOpened.get()
+        && allExportersOpened
         && !idle
         && logStreamReader.hasNext()
         && !inExportingPhase

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -63,6 +63,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   private static final Logger LOG = Loggers.EXPORTER_LOGGER;
   private final AtomicBoolean isOpened = new AtomicBoolean(false);
+  private final AtomicBoolean allExportersOpened = new AtomicBoolean(false);
 
   // Use concrete type because it must be modifiable
   private final ArrayList<ExporterContainer> containers;
@@ -566,6 +567,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     actor.runOnCompletion(
         containerOpenFutures,
         (error) -> {
+          allExportersOpened.set(true);
           if (state.hasExporters()) {
             final long snapshotPosition = state.getLowestPosition();
             // start reading and exporting
@@ -652,6 +654,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   private boolean shouldExport() {
     return isOpened.get()
+        && allExportersOpened.get()
         && !idle
         && logStreamReader.hasNext()
         && !inExportingPhase


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This pull request improves the reliability of the exporter startup sequence in the Zeebe broker by ensuring that exporting does not resume until all exporters have finished opening.

* Added a new `AtomicBoolean allExportersOpened` flag to `ExporterDirector` to track when all exporters have successfully opened.
* Updated the logic in `ExporterDirector` so that exporting only starts when both `isOpened` (a state of the director itself) and `allExportersOpened` are true, preventing premature exporting.
* Set `allExportersOpened` to true only after all exporters have finished opening in the `startActiveExportingMode` method.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #32009 
