### PR TITLE
Catch straight through processing loops with script tasks

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CancelProcessInstanceInBatchesTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CancelProcessInstanceInBatchesTest.java
@@ -37,6 +37,9 @@ public final class CancelProcessInstanceInBatchesTest {
                 .setMaxMessageSize(DataSize.ofKilobytes(MAX_MESSAGE_SIZE_KB));
             // Note: this is a bout the batch for writing to the logstream, not the terminate batch
             cfg.getProcessing().setMaxCommandsInBatch(1);
+            cfg.getExperimental()
+                .getFeatures()
+                .setEnableStraightThroughProcessingLoopDetector(false);
           });
   private static final GrpcClientRule CLIENT_RULE =
       new GrpcClientRule(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Script tasks are considered to be straight through processed as long as they're not handled by a Job worker. This PR allows catching these in our validator.

I had to do a small refactoring to allow more thorough validations on the element that gets validated. I did this by changing the `EnumSet` to a `HashMap` and allowing each element type to specify a function to determine if they're straight through or not. As of  now, only the scrip task makes use of this.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36895
