### PR TITLE
Java Client: ensure all mandatory parameters are provided for the commands

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignClientToGroupCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignClientToGroupCommandStep1.java
@@ -27,15 +27,17 @@ public interface AssignClientToGroupCommandStep1 {
    */
   AssignClientToGroupCommandStep2 clientId(String clientId);
 
-  interface AssignClientToGroupCommandStep2 extends FinalCommandStep<AssignClientToGroupResponse> {
+  interface AssignClientToGroupCommandStep2 {
 
     /**
      * Sets the group ID.
      *
      * @param groupId the ID of the group
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link AssignClientToGroupCommandStep3#send()} to
+     *     complete the command and send it to the broker.
      */
-    AssignClientToGroupCommandStep2 groupId(String groupId);
+    AssignClientToGroupCommandStep3 groupId(String groupId);
   }
+
+  interface AssignClientToGroupCommandStep3 extends FinalCommandStep<AssignClientToGroupResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignClientToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignClientToTenantCommandStep1.java
@@ -27,16 +27,18 @@ public interface AssignClientToTenantCommandStep1 {
    */
   AssignClientToTenantCommandStep2 clientId(String clientId);
 
-  interface AssignClientToTenantCommandStep2
-      extends FinalCommandStep<AssignClientToTenantResponse> {
+  interface AssignClientToTenantCommandStep2 {
 
     /**
      * Sets the tenant ID.
      *
      * @param tenantId the ID of the tenant
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link AssignClientToTenantCommandStep3#send()} to
+     *     complete the command and send it to the broker.
      */
-    AssignClientToTenantCommandStep2 tenantId(String tenantId);
+    AssignClientToTenantCommandStep3 tenantId(String tenantId);
   }
+
+  interface AssignClientToTenantCommandStep3
+      extends FinalCommandStep<AssignClientToTenantResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignGroupToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignGroupToTenantCommandStep1.java
@@ -27,15 +27,17 @@ public interface AssignGroupToTenantCommandStep1 {
    */
   AssignGroupToTenantCommandStep2 groupId(String groupId);
 
-  interface AssignGroupToTenantCommandStep2 extends FinalCommandStep<AssignGroupToTenantResponse> {
+  interface AssignGroupToTenantCommandStep2 {
 
     /**
      * Sets the tenant ID.
      *
      * @param tenantId the tenantId of the tenant
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link AssignGroupToTenantCommandStep3#send()} to
+     *     complete the command and send it to the broker.
      */
-    AssignGroupToTenantCommandStep2 tenantId(String tenantId);
+    AssignGroupToTenantCommandStep3 tenantId(String tenantId);
   }
+
+  interface AssignGroupToTenantCommandStep3 extends FinalCommandStep<AssignGroupToTenantResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignMappingRuleToGroupStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignMappingRuleToGroupStep1.java
@@ -27,16 +27,18 @@ public interface AssignMappingRuleToGroupStep1 {
    */
   AssignMappingRuleToGroupStep2 mappingRuleId(String mappingRuleId);
 
-  interface AssignMappingRuleToGroupStep2
-      extends FinalCommandStep<AssignMappingRuleToGroupResponse> {
+  interface AssignMappingRuleToGroupStep2 {
 
     /**
      * Sets the group ID.
      *
      * @param groupId the groupId of the group
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link AssignMappingRuleToGroupStep3#send()} to
+     *     complete the command and send it to the broker.
      */
-    AssignMappingRuleToGroupStep2 groupId(String groupId);
+    AssignMappingRuleToGroupStep3 groupId(String groupId);
   }
+
+  interface AssignMappingRuleToGroupStep3
+      extends FinalCommandStep<AssignMappingRuleToGroupResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignMappingRuleToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignMappingRuleToTenantCommandStep1.java
@@ -28,16 +28,19 @@ public interface AssignMappingRuleToTenantCommandStep1 {
    */
   AssignMappingRuleToTenantCommandStep2 mappingRuleId(String mappingRuleId);
 
-  interface AssignMappingRuleToTenantCommandStep2
-      extends FinalCommandStep<AssignMappingRuleToTenantResponse> {
+  interface AssignMappingRuleToTenantCommandStep2 {
 
     /**
      * Sets the tenant ID.
      *
      * @param tenantId the tenantId of the tenant
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link
+     *     AssignMappingRuleToTenantCommandStep3#send()} to complete the command and send it to the
+     *     broker.
      */
-    AssignMappingRuleToTenantCommandStep2 tenantId(String tenantId);
+    AssignMappingRuleToTenantCommandStep3 tenantId(String tenantId);
   }
+
+  interface AssignMappingRuleToTenantCommandStep3
+      extends FinalCommandStep<AssignMappingRuleToTenantResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignRoleToClientCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignRoleToClientCommandStep1.java
@@ -26,15 +26,17 @@ public interface AssignRoleToClientCommandStep1 {
    */
   AssignRoleToClientCommandStep2 roleId(String roleId);
 
-  interface AssignRoleToClientCommandStep2 extends FinalCommandStep<AssignRoleToClientResponse> {
+  interface AssignRoleToClientCommandStep2 {
 
     /**
      * Sets the client ID.
      *
      * @param clientId the clientId of the client
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link AssignRoleToClientCommandStep3#send()} to
+     *     complete the command and send it to the broker.
      */
-    AssignRoleToClientCommandStep2 clientId(String clientId);
+    AssignRoleToClientCommandStep3 clientId(String clientId);
   }
+
+  interface AssignRoleToClientCommandStep3 extends FinalCommandStep<AssignRoleToClientResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignRoleToGroupCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignRoleToGroupCommandStep1.java
@@ -27,15 +27,17 @@ public interface AssignRoleToGroupCommandStep1 {
    */
   AssignRoleToGroupCommandStep2 roleId(String roleId);
 
-  interface AssignRoleToGroupCommandStep2 extends FinalCommandStep<AssignRoleToGroupResponse> {
+  interface AssignRoleToGroupCommandStep2 {
 
     /**
      * Sets the group ID.
      *
      * @param groupId the groupId of the group
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link AssignRoleToGroupCommandStep3#send()} to
+     *     complete the command and send it to the broker.
      */
-    AssignRoleToGroupCommandStep2 groupId(String groupId);
+    AssignRoleToGroupCommandStep3 groupId(String groupId);
   }
+
+  interface AssignRoleToGroupCommandStep3 extends FinalCommandStep<AssignRoleToGroupResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignRoleToMappingRuleCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignRoleToMappingRuleCommandStep1.java
@@ -28,15 +28,17 @@ public interface AssignRoleToMappingRuleCommandStep1 {
    */
   AssignRoleToMappingRuleCommandStep2 roleId(String roleId);
 
-  interface AssignRoleToMappingRuleCommandStep2
-      extends FinalCommandStep<AssignRoleToMappingRuleResponse> {
+  interface AssignRoleToMappingRuleCommandStep2 {
     /**
      * Sets the mapping rule ID.
      *
      * @param mappingRuleId the id of the mapping rule
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link AssignRoleToMappingRuleCommandStep3#send()}
+     *     to complete the command and send it to the broker.
      */
-    AssignRoleToMappingRuleCommandStep2 mappingRuleId(String mappingRuleId);
+    AssignRoleToMappingRuleCommandStep3 mappingRuleId(String mappingRuleId);
   }
+
+  interface AssignRoleToMappingRuleCommandStep3
+      extends FinalCommandStep<AssignRoleToMappingRuleResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignRoleToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignRoleToTenantCommandStep1.java
@@ -28,15 +28,17 @@ public interface AssignRoleToTenantCommandStep1 {
    */
   AssignRoleToTenantCommandStep2 roleId(String roleId);
 
-  interface AssignRoleToTenantCommandStep2 extends FinalCommandStep<AssignRoleToTenantResponse> {
+  interface AssignRoleToTenantCommandStep2 {
 
     /**
      * Sets the tenant ID.
      *
      * @param tenantId the tenantId of the tenant
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link AssignRoleToTenantCommandStep3#send()} to
+     *     complete the command and send it to the broker.
      */
-    AssignRoleToTenantCommandStep2 tenantId(String tenantId);
+    AssignRoleToTenantCommandStep3 tenantId(String tenantId);
   }
+
+  interface AssignRoleToTenantCommandStep3 extends FinalCommandStep<AssignRoleToTenantResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignRoleToUserCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignRoleToUserCommandStep1.java
@@ -42,14 +42,17 @@ public interface AssignRoleToUserCommandStep1 {
    */
   AssignRoleToUserCommandStep2 roleId(String roleId);
 
-  interface AssignRoleToUserCommandStep2 extends FinalCommandStep<AssignRoleToUserResponse> {
+  interface AssignRoleToUserCommandStep2 {
 
     /**
      * Sets the username of the user to assign the role to.
      *
      * @param username the username
-     * @return the builder for this command. Call {@link #send()} to execute.
+     * @return the builder for this command. Call {@link AssignRoleToUserCommandStep3#send()} to
+     *     execute.
      */
-    AssignRoleToUserCommandStep2 username(String username);
+    AssignRoleToUserCommandStep3 username(String username);
   }
+
+  interface AssignRoleToUserCommandStep3 extends FinalCommandStep<AssignRoleToUserResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToGroupCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToGroupCommandStep1.java
@@ -27,14 +27,16 @@ public interface AssignUserToGroupCommandStep1 {
    */
   AssignUserToGroupCommandStep2 username(String username);
 
-  interface AssignUserToGroupCommandStep2 extends FinalCommandStep<AssignUserToGroupResponse> {
+  interface AssignUserToGroupCommandStep2 {
     /**
      * Sets the group ID.
      *
      * @param groupId the id of the group
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link AssignUserToGroupCommandStep3#send()} to
+     *     complete the command and send it to the broker.
      */
-    AssignUserToGroupCommandStep2 groupId(String groupId);
+    AssignUserToGroupCommandStep3 groupId(String groupId);
   }
+
+  interface AssignUserToGroupCommandStep3 extends FinalCommandStep<AssignUserToGroupResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToTenantCommandStep1.java
@@ -28,14 +28,16 @@ public interface AssignUserToTenantCommandStep1 {
    */
   AssignUserToTenantCommandStep2 username(String username);
 
-  interface AssignUserToTenantCommandStep2 extends FinalCommandStep<AssignUserToTenantResponse> {
+  interface AssignUserToTenantCommandStep2 {
     /**
      * Sets the tenant ID.
      *
      * @param tenantId the id of the tenant
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link AssignUserToTenantCommandStep3#send()} to
+     *     complete the command and send it to the broker.
      */
-    AssignUserToTenantCommandStep2 tenantId(String tenantId);
+    AssignUserToTenantCommandStep3 tenantId(String tenantId);
   }
+
+  interface AssignUserToTenantCommandStep3 extends FinalCommandStep<AssignUserToTenantResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignClientFromGroupCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignClientFromGroupCommandStep1.java
@@ -27,16 +27,18 @@ public interface UnassignClientFromGroupCommandStep1 {
    */
   UnassignClientFromGroupCommandStep2 clientId(String clientId);
 
-  interface UnassignClientFromGroupCommandStep2
-      extends FinalCommandStep<UnassignClientFromGroupResponse> {
+  interface UnassignClientFromGroupCommandStep2 {
 
     /**
      * Sets the group ID.
      *
      * @param groupId the id of the group
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link UnassignClientFromGroupCommandStep3#send()}
+     *     to complete the command and send it to the broker.
      */
-    UnassignClientFromGroupCommandStep2 groupId(String groupId);
+    UnassignClientFromGroupCommandStep3 groupId(String groupId);
   }
+
+  interface UnassignClientFromGroupCommandStep3
+      extends FinalCommandStep<UnassignClientFromGroupResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignClientFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignClientFromTenantCommandStep1.java
@@ -33,8 +33,9 @@ public interface UnassignClientFromTenantCommandStep1 {
      * Sets the tenant ID.
      *
      * @param tenantId the ID of the tenant
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link
+     *     UnassignClientFromTenantCommandStep3#send()} to complete the command and send it to the
+     *     broker.
      */
     UnassignClientFromTenantCommandStep3 tenantId(String tenantId);
   }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignMappingRuleFromGroupStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignMappingRuleFromGroupStep1.java
@@ -27,15 +27,17 @@ public interface UnassignMappingRuleFromGroupStep1 {
    */
   UnassignMappingRuleFromGroupStep2 mappingRuleId(String mappingRuleId);
 
-  interface UnassignMappingRuleFromGroupStep2
-      extends FinalCommandStep<UnassignMappingRuleFromGroupResponse> {
+  interface UnassignMappingRuleFromGroupStep2 {
     /**
      * Sets the group ID.
      *
      * @param groupId the id of the group
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link UnassignMappingRuleFromGroupStep3#send()}
+     *     to complete the command and send it to the broker.
      */
-    UnassignMappingRuleFromGroupStep2 groupId(String groupId);
+    UnassignMappingRuleFromGroupStep3 groupId(String groupId);
   }
+
+  interface UnassignMappingRuleFromGroupStep3
+      extends FinalCommandStep<UnassignMappingRuleFromGroupResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignRoleFromClientCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignRoleFromClientCommandStep1.java
@@ -27,15 +27,17 @@ public interface UnassignRoleFromClientCommandStep1 {
    */
   UnassignRoleFromClientCommandStep2 roleId(String roleId);
 
-  interface UnassignRoleFromClientCommandStep2
-      extends FinalCommandStep<UnassignRoleFromClientResponse> {
+  interface UnassignRoleFromClientCommandStep2 {
     /**
      * Sets the client ID.
      *
      * @param clientId the id of the client
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link UnassignRoleFromClientCommandStep3#send()}
+     *     to complete the command and send it to the broker.
      */
-    UnassignRoleFromClientCommandStep2 clientId(String clientId);
+    UnassignRoleFromClientCommandStep3 clientId(String clientId);
   }
+
+  interface UnassignRoleFromClientCommandStep3
+      extends FinalCommandStep<UnassignRoleFromClientResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignRoleFromGroupCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignRoleFromGroupCommandStep1.java
@@ -27,15 +27,17 @@ public interface UnassignRoleFromGroupCommandStep1 {
    */
   UnassignRoleFromGroupCommandStep2 roleId(String roleId);
 
-  interface UnassignRoleFromGroupCommandStep2
-      extends FinalCommandStep<UnassignRoleFromGroupResponse> {
+  interface UnassignRoleFromGroupCommandStep2 {
     /**
      * Sets the group ID.
      *
      * @param groupId the id of the group
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link UnassignRoleFromGroupCommandStep3#send()}
+     *     to complete the command and send it to the broker.
      */
-    UnassignRoleFromGroupCommandStep2 groupId(String groupId);
+    UnassignRoleFromGroupCommandStep3 groupId(String groupId);
   }
+
+  interface UnassignRoleFromGroupCommandStep3
+      extends FinalCommandStep<UnassignRoleFromGroupResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignRoleFromMappingRuleCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignRoleFromMappingRuleCommandStep1.java
@@ -27,16 +27,19 @@ public interface UnassignRoleFromMappingRuleCommandStep1 {
    */
   UnassignRoleFromMappingRuleCommandStep2 roleId(String roleId);
 
-  interface UnassignRoleFromMappingRuleCommandStep2
-      extends FinalCommandStep<UnassignRoleFromMappingRuleResponse> {
+  interface UnassignRoleFromMappingRuleCommandStep2 {
 
     /**
      * Sets the mapping rule ID.
      *
      * @param mappingRuleId the mappingRuleId of the mapping rule
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link
+     *     UnassignRoleFromMappingRuleCommandStep3#send()} to complete the command and send it to
+     *     the broker.
      */
-    UnassignRoleFromMappingRuleCommandStep2 mappingRuleId(String mappingRuleId);
+    UnassignRoleFromMappingRuleCommandStep3 mappingRuleId(String mappingRuleId);
   }
+
+  interface UnassignRoleFromMappingRuleCommandStep3
+      extends FinalCommandStep<UnassignRoleFromMappingRuleResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignRoleFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignRoleFromTenantCommandStep1.java
@@ -27,16 +27,18 @@ public interface UnassignRoleFromTenantCommandStep1 {
    */
   UnassignRoleFromTenantCommandStep2 roleId(String roleId);
 
-  interface UnassignRoleFromTenantCommandStep2
-      extends FinalCommandStep<UnassignRoleFromTenantResponse> {
+  interface UnassignRoleFromTenantCommandStep2 {
 
     /**
      * Sets the tenant ID.
      *
      * @param tenantId the tenantId of the tenant
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link UnassignRoleFromTenantCommandStep3#send()}
+     *     to complete the command and send it to the broker.
      */
-    UnassignRoleFromTenantCommandStep2 tenantId(String tenantId);
+    UnassignRoleFromTenantCommandStep3 tenantId(String tenantId);
   }
+
+  interface UnassignRoleFromTenantCommandStep3
+      extends FinalCommandStep<UnassignRoleFromTenantResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignRoleFromUserCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignRoleFromUserCommandStep1.java
@@ -27,16 +27,18 @@ public interface UnassignRoleFromUserCommandStep1 {
    */
   UnassignRoleFromUserCommandStep2 roleId(String roleId);
 
-  interface UnassignRoleFromUserCommandStep2
-      extends FinalCommandStep<UnassignUserFromRoleResponse> {
+  interface UnassignRoleFromUserCommandStep2 {
 
     /**
      * Sets the username for the unassignment.
      *
      * @param username the username of the user
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link UnassignRoleFromUserCommandStep3#send()} to
+     *     complete the command and send it to the broker.
      */
-    UnassignRoleFromUserCommandStep2 username(String username);
+    UnassignRoleFromUserCommandStep3 username(String username);
   }
+
+  interface UnassignRoleFromUserCommandStep3
+      extends FinalCommandStep<UnassignUserFromRoleResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignUserFromGroupCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignUserFromGroupCommandStep1.java
@@ -27,16 +27,18 @@ public interface UnassignUserFromGroupCommandStep1 {
    */
   UnassignUserFromGroupCommandStep2 username(String username);
 
-  interface UnassignUserFromGroupCommandStep2
-      extends FinalCommandStep<UnassignUserFromGroupResponse> {
+  interface UnassignUserFromGroupCommandStep2 {
 
     /**
      * Sets the group ID for the unassignment.
      *
      * @param groupId the groupId of the group
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link UnassignUserFromGroupCommandStep3#send()}
+     *     to complete the command and send it to the broker.
      */
-    UnassignUserFromGroupCommandStep2 groupId(String groupId);
+    UnassignUserFromGroupCommandStep3 groupId(String groupId);
   }
+
+  interface UnassignUserFromGroupCommandStep3
+      extends FinalCommandStep<UnassignUserFromGroupResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignUserFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignUserFromTenantCommandStep1.java
@@ -23,20 +23,23 @@ public interface UnassignUserFromTenantCommandStep1 {
   /**
    * Sets the username for unassignment.
    *
+   * @param username the username of the user
    * @return the builder for this command.
    */
   UnassignUserFromTenantCommandStep2 username(String username);
 
-  interface UnassignUserFromTenantCommandStep2
-      extends FinalCommandStep<UnassignUserFromTenantResponse> {
+  interface UnassignUserFromTenantCommandStep2 {
 
     /**
      * Sets the tenant ID.
      *
      * @param tenantId the tenantId of the tenant
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
+     * @return the builder for this command. Call {@link UnassignUserFromTenantCommandStep3#send()}
+     *     to complete the command and send it to the broker.
      */
-    UnassignUserFromTenantCommandStep2 tenantId(String tenantId);
+    UnassignUserFromTenantCommandStep3 tenantId(String tenantId);
   }
+
+  interface UnassignUserFromTenantCommandStep3
+      extends FinalCommandStep<UnassignUserFromTenantResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignClientToGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignClientToGroupCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignClientToGroupCommandStep1;
 import io.camunda.client.api.command.AssignClientToGroupCommandStep1.AssignClientToGroupCommandStep2;
+import io.camunda.client.api.command.AssignClientToGroupCommandStep1.AssignClientToGroupCommandStep3;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignClientToGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class AssignClientToGroupCommandImpl
-    implements AssignClientToGroupCommandStep1, AssignClientToGroupCommandStep2 {
+    implements AssignClientToGroupCommandStep1,
+        AssignClientToGroupCommandStep2,
+        AssignClientToGroupCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class AssignClientToGroupCommandImpl
   }
 
   @Override
-  public AssignClientToGroupCommandStep2 groupId(final String groupId) {
+  public AssignClientToGroupCommandStep3 groupId(final String groupId) {
     this.groupId = groupId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignClientToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignClientToTenantCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignClientToTenantCommandStep1;
 import io.camunda.client.api.command.AssignClientToTenantCommandStep1.AssignClientToTenantCommandStep2;
+import io.camunda.client.api.command.AssignClientToTenantCommandStep1.AssignClientToTenantCommandStep3;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignClientToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class AssignClientToTenantCommandImpl
-    implements AssignClientToTenantCommandStep1, AssignClientToTenantCommandStep2 {
+    implements AssignClientToTenantCommandStep1,
+        AssignClientToTenantCommandStep2,
+        AssignClientToTenantCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class AssignClientToTenantCommandImpl
   }
 
   @Override
-  public AssignClientToTenantCommandStep2 tenantId(final String tenantId) {
+  public AssignClientToTenantCommandStep3 tenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignGroupToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignGroupToTenantCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignGroupToTenantCommandStep1;
 import io.camunda.client.api.command.AssignGroupToTenantCommandStep1.AssignGroupToTenantCommandStep2;
+import io.camunda.client.api.command.AssignGroupToTenantCommandStep1.AssignGroupToTenantCommandStep3;
 import io.camunda.client.api.response.AssignGroupToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -27,7 +28,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class AssignGroupToTenantCommandImpl
-    implements AssignGroupToTenantCommandStep1, AssignGroupToTenantCommandStep2 {
+    implements AssignGroupToTenantCommandStep1,
+        AssignGroupToTenantCommandStep2,
+        AssignGroupToTenantCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -46,13 +49,13 @@ public final class AssignGroupToTenantCommandImpl
   }
 
   @Override
-  public AssignGroupToTenantCommandStep2 tenantId(final String tenantId) {
+  public AssignGroupToTenantCommandStep3 tenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }
 
   @Override
-  public AssignGroupToTenantCommandStep2 requestTimeout(final Duration timeout) {
+  public AssignGroupToTenantCommandStep3 requestTimeout(final Duration timeout) {
     httpRequestConfig.setResponseTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingRuleToGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingRuleToGroupCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignMappingRuleToGroupStep1;
 import io.camunda.client.api.command.AssignMappingRuleToGroupStep1.AssignMappingRuleToGroupStep2;
+import io.camunda.client.api.command.AssignMappingRuleToGroupStep1.AssignMappingRuleToGroupStep3;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignMappingRuleToGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class AssignMappingRuleToGroupCommandImpl
-    implements AssignMappingRuleToGroupStep1, AssignMappingRuleToGroupStep2 {
+    implements AssignMappingRuleToGroupStep1,
+        AssignMappingRuleToGroupStep2,
+        AssignMappingRuleToGroupStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class AssignMappingRuleToGroupCommandImpl
   }
 
   @Override
-  public AssignMappingRuleToGroupStep2 groupId(final String groupId) {
+  public AssignMappingRuleToGroupStep3 groupId(final String groupId) {
     this.groupId = groupId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingRuleToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingRuleToTenantCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignMappingRuleToTenantCommandStep1;
 import io.camunda.client.api.command.AssignMappingRuleToTenantCommandStep1.AssignMappingRuleToTenantCommandStep2;
+import io.camunda.client.api.command.AssignMappingRuleToTenantCommandStep1.AssignMappingRuleToTenantCommandStep3;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignMappingRuleToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class AssignMappingRuleToTenantCommandImpl
-    implements AssignMappingRuleToTenantCommandStep1, AssignMappingRuleToTenantCommandStep2 {
+    implements AssignMappingRuleToTenantCommandStep1,
+        AssignMappingRuleToTenantCommandStep2,
+        AssignMappingRuleToTenantCommandStep3 {
 
   private String tenantId;
   private String mappingRuleId;
@@ -47,7 +50,7 @@ public final class AssignMappingRuleToTenantCommandImpl
   }
 
   @Override
-  public AssignMappingRuleToTenantCommandStep2 tenantId(final String tenantId) {
+  public AssignMappingRuleToTenantCommandStep3 tenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToClientCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToClientCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignRoleToClientCommandStep1;
 import io.camunda.client.api.command.AssignRoleToClientCommandStep1.AssignRoleToClientCommandStep2;
+import io.camunda.client.api.command.AssignRoleToClientCommandStep1.AssignRoleToClientCommandStep3;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignRoleToClientResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class AssignRoleToClientCommandImpl
-    implements AssignRoleToClientCommandStep1, AssignRoleToClientCommandStep2 {
+    implements AssignRoleToClientCommandStep1,
+        AssignRoleToClientCommandStep2,
+        AssignRoleToClientCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class AssignRoleToClientCommandImpl
   }
 
   @Override
-  public AssignRoleToClientCommandStep2 clientId(final String clientId) {
+  public AssignRoleToClientCommandStep3 clientId(final String clientId) {
     this.clientId = clientId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToGroupCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignRoleToGroupCommandStep1;
 import io.camunda.client.api.command.AssignRoleToGroupCommandStep1.AssignRoleToGroupCommandStep2;
+import io.camunda.client.api.command.AssignRoleToGroupCommandStep1.AssignRoleToGroupCommandStep3;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignRoleToGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class AssignRoleToGroupCommandImpl
-    implements AssignRoleToGroupCommandStep1, AssignRoleToGroupCommandStep2 {
+    implements AssignRoleToGroupCommandStep1,
+        AssignRoleToGroupCommandStep2,
+        AssignRoleToGroupCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class AssignRoleToGroupCommandImpl
   }
 
   @Override
-  public AssignRoleToGroupCommandStep2 groupId(final String groupId) {
+  public AssignRoleToGroupCommandStep3 groupId(final String groupId) {
     this.groupId = groupId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToMappingRuleCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToMappingRuleCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignRoleToMappingRuleCommandStep1;
 import io.camunda.client.api.command.AssignRoleToMappingRuleCommandStep1.AssignRoleToMappingRuleCommandStep2;
+import io.camunda.client.api.command.AssignRoleToMappingRuleCommandStep1.AssignRoleToMappingRuleCommandStep3;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignRoleToMappingRuleResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class AssignRoleToMappingRuleCommandImpl
-    implements AssignRoleToMappingRuleCommandStep1, AssignRoleToMappingRuleCommandStep2 {
+    implements AssignRoleToMappingRuleCommandStep1,
+        AssignRoleToMappingRuleCommandStep2,
+        AssignRoleToMappingRuleCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class AssignRoleToMappingRuleCommandImpl
   }
 
   @Override
-  public AssignRoleToMappingRuleCommandStep2 mappingRuleId(final String mappingRuleId) {
+  public AssignRoleToMappingRuleCommandStep3 mappingRuleId(final String mappingRuleId) {
     this.mappingRuleId = mappingRuleId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToTenantCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignRoleToTenantCommandStep1;
 import io.camunda.client.api.command.AssignRoleToTenantCommandStep1.AssignRoleToTenantCommandStep2;
+import io.camunda.client.api.command.AssignRoleToTenantCommandStep1.AssignRoleToTenantCommandStep3;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignRoleToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class AssignRoleToTenantCommandImpl
-    implements AssignRoleToTenantCommandStep1, AssignRoleToTenantCommandStep2 {
+    implements AssignRoleToTenantCommandStep1,
+        AssignRoleToTenantCommandStep2,
+        AssignRoleToTenantCommandStep3 {
 
   private String tenantId;
   private String roleId;
@@ -47,7 +50,7 @@ public final class AssignRoleToTenantCommandImpl
   }
 
   @Override
-  public AssignRoleToTenantCommandStep2 tenantId(final String tenantId) {
+  public AssignRoleToTenantCommandStep3 tenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToUserCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignRoleToUserCommandStep1;
 import io.camunda.client.api.command.AssignRoleToUserCommandStep1.AssignRoleToUserCommandStep2;
+import io.camunda.client.api.command.AssignRoleToUserCommandStep1.AssignRoleToUserCommandStep3;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignRoleToUserResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class AssignRoleToUserCommandImpl
-    implements AssignRoleToUserCommandStep1, AssignRoleToUserCommandStep2 {
+    implements AssignRoleToUserCommandStep1,
+        AssignRoleToUserCommandStep2,
+        AssignRoleToUserCommandStep3 {
 
   private String roleId;
   private String username;
@@ -47,7 +50,7 @@ public final class AssignRoleToUserCommandImpl
   }
 
   @Override
-  public AssignRoleToUserCommandStep2 username(final String username) {
+  public AssignRoleToUserCommandStep3 username(final String username) {
     this.username = username;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToGroupCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignUserToGroupCommandStep1;
 import io.camunda.client.api.command.AssignUserToGroupCommandStep1.AssignUserToGroupCommandStep2;
+import io.camunda.client.api.command.AssignUserToGroupCommandStep1.AssignUserToGroupCommandStep3;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignUserToGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class AssignUserToGroupCommandImpl
-    implements AssignUserToGroupCommandStep1, AssignUserToGroupCommandStep2 {
+    implements AssignUserToGroupCommandStep1,
+        AssignUserToGroupCommandStep2,
+        AssignUserToGroupCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class AssignUserToGroupCommandImpl
   }
 
   @Override
-  public AssignUserToGroupCommandStep2 groupId(final String groupId) {
+  public AssignUserToGroupCommandStep3 groupId(final String groupId) {
     this.groupId = groupId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToTenantCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignUserToTenantCommandStep1;
 import io.camunda.client.api.command.AssignUserToTenantCommandStep1.AssignUserToTenantCommandStep2;
+import io.camunda.client.api.command.AssignUserToTenantCommandStep1.AssignUserToTenantCommandStep3;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignUserToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class AssignUserToTenantCommandImpl
-    implements AssignUserToTenantCommandStep1, AssignUserToTenantCommandStep2 {
+    implements AssignUserToTenantCommandStep1,
+        AssignUserToTenantCommandStep2,
+        AssignUserToTenantCommandStep3 {
 
   private String tenantId;
   private String username;
@@ -47,7 +50,7 @@ public final class AssignUserToTenantCommandImpl
   }
 
   @Override
-  public AssignUserToTenantCommandStep2 tenantId(final String tenantId) {
+  public AssignUserToTenantCommandStep3 tenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignClientFromGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignClientFromGroupCommandImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1.UnassignClientFromGroupCommandStep2;
+import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1.UnassignClientFromGroupCommandStep3;
 import io.camunda.client.api.response.UnassignClientFromGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class UnassignClientFromGroupCommandImpl
-    implements UnassignClientFromGroupCommandStep1, UnassignClientFromGroupCommandStep2 {
+    implements UnassignClientFromGroupCommandStep1,
+        UnassignClientFromGroupCommandStep2,
+        UnassignClientFromGroupCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class UnassignClientFromGroupCommandImpl
   }
 
   @Override
-  public UnassignClientFromGroupCommandStep2 groupId(final String groupId) {
+  public UnassignClientFromGroupCommandStep3 groupId(final String groupId) {
     this.groupId = groupId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignMappingRuleFromGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignMappingRuleFromGroupCommandImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignMappingRuleFromGroupStep1;
 import io.camunda.client.api.command.UnassignMappingRuleFromGroupStep1.UnassignMappingRuleFromGroupStep2;
+import io.camunda.client.api.command.UnassignMappingRuleFromGroupStep1.UnassignMappingRuleFromGroupStep3;
 import io.camunda.client.api.response.UnassignMappingRuleFromGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class UnassignMappingRuleFromGroupCommandImpl
-    implements UnassignMappingRuleFromGroupStep1, UnassignMappingRuleFromGroupStep2 {
+    implements UnassignMappingRuleFromGroupStep1,
+        UnassignMappingRuleFromGroupStep2,
+        UnassignMappingRuleFromGroupStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class UnassignMappingRuleFromGroupCommandImpl
   }
 
   @Override
-  public UnassignMappingRuleFromGroupStep2 groupId(final String groupId) {
+  public UnassignMappingRuleFromGroupStep3 groupId(final String groupId) {
     this.groupId = groupId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromClientCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromClientCommandImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignRoleFromClientCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromClientCommandStep1.UnassignRoleFromClientCommandStep2;
+import io.camunda.client.api.command.UnassignRoleFromClientCommandStep1.UnassignRoleFromClientCommandStep3;
 import io.camunda.client.api.response.UnassignRoleFromClientResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class UnassignRoleFromClientCommandImpl
-    implements UnassignRoleFromClientCommandStep1, UnassignRoleFromClientCommandStep2 {
+    implements UnassignRoleFromClientCommandStep1,
+        UnassignRoleFromClientCommandStep2,
+        UnassignRoleFromClientCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class UnassignRoleFromClientCommandImpl
   }
 
   @Override
-  public UnassignRoleFromClientCommandStep2 clientId(final String clientId) {
+  public UnassignRoleFromClientCommandStep3 clientId(final String clientId) {
     this.clientId = clientId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromGroupCommandImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignRoleFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromGroupCommandStep1.UnassignRoleFromGroupCommandStep2;
+import io.camunda.client.api.command.UnassignRoleFromGroupCommandStep1.UnassignRoleFromGroupCommandStep3;
 import io.camunda.client.api.response.UnassignRoleFromGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class UnassignRoleFromGroupCommandImpl
-    implements UnassignRoleFromGroupCommandStep1, UnassignRoleFromGroupCommandStep2 {
+    implements UnassignRoleFromGroupCommandStep1,
+        UnassignRoleFromGroupCommandStep2,
+        UnassignRoleFromGroupCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class UnassignRoleFromGroupCommandImpl
   }
 
   @Override
-  public UnassignRoleFromGroupCommandStep2 groupId(final String groupId) {
+  public UnassignRoleFromGroupCommandStep3 groupId(final String groupId) {
     this.groupId = groupId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromMappingRuleCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromMappingRuleCommandImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignRoleFromMappingRuleCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromMappingRuleCommandStep1.UnassignRoleFromMappingRuleCommandStep2;
+import io.camunda.client.api.command.UnassignRoleFromMappingRuleCommandStep1.UnassignRoleFromMappingRuleCommandStep3;
 import io.camunda.client.api.response.UnassignRoleFromMappingRuleResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class UnassignRoleFromMappingRuleCommandImpl
-    implements UnassignRoleFromMappingRuleCommandStep1, UnassignRoleFromMappingRuleCommandStep2 {
+    implements UnassignRoleFromMappingRuleCommandStep1,
+        UnassignRoleFromMappingRuleCommandStep2,
+        UnassignRoleFromMappingRuleCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class UnassignRoleFromMappingRuleCommandImpl
   }
 
   @Override
-  public UnassignRoleFromMappingRuleCommandStep2 mappingRuleId(final String mappingRuleId) {
+  public UnassignRoleFromMappingRuleCommandStep3 mappingRuleId(final String mappingRuleId) {
     this.mappingRuleId = mappingRuleId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromTenantCommandImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignRoleFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromTenantCommandStep1.UnassignRoleFromTenantCommandStep2;
+import io.camunda.client.api.command.UnassignRoleFromTenantCommandStep1.UnassignRoleFromTenantCommandStep3;
 import io.camunda.client.api.response.UnassignRoleFromTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class UnassignRoleFromTenantCommandImpl
-    implements UnassignRoleFromTenantCommandStep1, UnassignRoleFromTenantCommandStep2 {
+    implements UnassignRoleFromTenantCommandStep1,
+        UnassignRoleFromTenantCommandStep2,
+        UnassignRoleFromTenantCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public final class UnassignRoleFromTenantCommandImpl
   }
 
   @Override
-  public UnassignRoleFromTenantCommandStep2 tenantId(final String tenantId) {
+  public UnassignRoleFromTenantCommandStep3 tenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromUserCommandImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignRoleFromUserCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromUserCommandStep1.UnassignRoleFromUserCommandStep2;
+import io.camunda.client.api.command.UnassignRoleFromUserCommandStep1.UnassignRoleFromUserCommandStep3;
 import io.camunda.client.api.response.UnassignUserFromRoleResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class UnassignRoleFromUserCommandImpl
-    implements UnassignRoleFromUserCommandStep1, UnassignRoleFromUserCommandStep2 {
+    implements UnassignRoleFromUserCommandStep1,
+        UnassignRoleFromUserCommandStep2,
+        UnassignRoleFromUserCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class UnassignRoleFromUserCommandImpl
   }
 
   @Override
-  public UnassignRoleFromUserCommandStep2 username(final String username) {
+  public UnassignRoleFromUserCommandStep3 username(final String username) {
     this.username = username;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromGroupCommandImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignUserFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignUserFromGroupCommandStep1.UnassignUserFromGroupCommandStep2;
+import io.camunda.client.api.command.UnassignUserFromGroupCommandStep1.UnassignUserFromGroupCommandStep3;
 import io.camunda.client.api.response.UnassignUserFromGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class UnassignUserFromGroupCommandImpl
-    implements UnassignUserFromGroupCommandStep1, UnassignUserFromGroupCommandStep2 {
+    implements UnassignUserFromGroupCommandStep1,
+        UnassignUserFromGroupCommandStep2,
+        UnassignUserFromGroupCommandStep3 {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
@@ -47,7 +50,7 @@ public class UnassignUserFromGroupCommandImpl
   }
 
   @Override
-  public UnassignUserFromGroupCommandStep2 groupId(final String groupId) {
+  public UnassignUserFromGroupCommandStep3 groupId(final String groupId) {
     this.groupId = groupId;
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromTenantCommandImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignUserFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignUserFromTenantCommandStep1.UnassignUserFromTenantCommandStep2;
+import io.camunda.client.api.command.UnassignUserFromTenantCommandStep1.UnassignUserFromTenantCommandStep3;
 import io.camunda.client.api.response.UnassignUserFromTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -28,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class UnassignUserFromTenantCommandImpl
-    implements UnassignUserFromTenantCommandStep1, UnassignUserFromTenantCommandStep2 {
+    implements UnassignUserFromTenantCommandStep1,
+        UnassignUserFromTenantCommandStep2,
+        UnassignUserFromTenantCommandStep3 {
 
   private String tenantId;
   private String username;
@@ -47,7 +50,7 @@ public final class UnassignUserFromTenantCommandImpl
   }
 
   @Override
-  public UnassignUserFromTenantCommandStep2 tenantId(final String tenantId) {
+  public UnassignUserFromTenantCommandStep3 tenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }


### PR DESCRIPTION
## Description
Some Java Client API commands specify mandatory parameters that are part of their sub-interface of FinalCommandStep, i.e. the parameters are offered to the user on the same level as the #send method.

Example [UnassignUserFromTenantCommand](https://github.com/camunda/camunda/blob/1da7ed0592a46bf411360af9b6adcbb00e7d987e/clients/java/src/main/java/io/camunda/client/api/command/UnassignUserFromTenantCommandStep1.java):
This code compiles: `client.newUnassignUserFromTenantCommand().username("foo").send();` but it will always fail because it misses the mandatory tenandId parameter
Accordingly, it is possible to formulate invalid commands.

Fix: For the example above, the tenant id parameter should be in a separate `UnassignUserFromTenantCommandStep2` that only accepts the tenant id and there should be a third `UnassignUserFromTenantCommandStep3` that extends `FinalCommandStep` with no additional parameters (placeholder for future optional parameters if we ever add any)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37389
