### PR TITLE
Expose cluster Id in topology response

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -328,6 +328,7 @@ final class ClusterApiUtils {
     topology
         .routingState()
         .ifPresent(routingState -> response.routing(mapRoutingState(routingState)));
+    topology.clusterId().ifPresent(response::clusterId);
     return response;
   }
 

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -136,6 +136,10 @@ schemas:
         $ref: "components.yaml#/schemas/TopologyChange"
       routing:
         $ref: "components.yaml#/schemas/RoutingState"
+      clusterId:
+        type: string
+        description: The unique ID of the cluster
+        example: "cluster-1234"
 
   RoutingState:
     description: The routing state, i.e. where requests are sent to and how messages are correlated

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
@@ -48,4 +48,6 @@ public interface BrokerClusterState {
   PartitionHealthStatus getPartitionHealth(int brokerId, int partition);
 
   long getLastCompletedChangeId();
+
+  String getClusterId();
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
@@ -33,12 +33,18 @@ public record BrokerClientTopologyImpl(
 
   public static final int UNINITIALIZED_CLUSTER_SIZE = -1;
   public static final long NO_COMPLETED_LAST_CHANGE_ID = -1;
+  public static final String NO_CLUSTER_ID = null;
 
   public static BrokerClientTopologyImpl uninitialized() {
     return new BrokerClientTopologyImpl(
         new LiveClusterState(Set.of()),
         new ConfiguredClusterState(
-            UNINITIALIZED_CLUSTER_SIZE, 0, 0, List.of(), NO_COMPLETED_LAST_CHANGE_ID));
+            UNINITIALIZED_CLUSTER_SIZE,
+            0,
+            0,
+            List.of(),
+            NO_COMPLETED_LAST_CHANGE_ID,
+            NO_CLUSTER_ID));
   }
 
   @Override
@@ -122,6 +128,11 @@ public record BrokerClientTopologyImpl(
     return configuredClusterState.lastChangeId;
   }
 
+  @Override
+  public String getClusterId() {
+    return configuredClusterState.clusterId;
+  }
+
   public static BrokerClientTopologyImpl fromMemberProperties(
       final Collection<BrokerInfo> values, final ConfiguredClusterState clusterConfiguration) {
     return new BrokerClientTopologyImpl(new LiveClusterState(values), clusterConfiguration);
@@ -132,7 +143,8 @@ public record BrokerClientTopologyImpl(
       int partitionCount,
       int replicationFactor,
       List<Integer> partitionIds,
-      long lastChangeId) {}
+      long lastChangeId,
+      String clusterId) {}
 
   static class LiveClusterState {
     private static final Long TERM_NONE = -1L;

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
@@ -33,7 +33,7 @@ public record BrokerClientTopologyImpl(
 
   public static final int UNINITIALIZED_CLUSTER_SIZE = -1;
   public static final long NO_COMPLETED_LAST_CHANGE_ID = -1;
-  public static final String NO_CLUSTER_ID = null;
+  public static final String NO_CLUSTER_ID = "";
 
   public static BrokerClientTopologyImpl uninitialized() {
     return new BrokerClientTopologyImpl(

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -218,7 +218,7 @@ public final class BrokerTopologyManagerImpl extends Actor
     final var newClusterSize = clusterTopology.clusterSize();
     final var newPartitionsCount = clusterTopology.partitionCount();
     final var newReplicationFactor = clusterTopology.minReplicationFactor();
-    // cluster id is never null as the cluster id is always initialized in the cluster topology.
+    // cluster id is not expected to be null as it is always initialized in the cluster topology.
     // Unless the persisted topology is modified manually, and set to null.
     final var clusterId = clusterTopology.clusterId().orElse("");
     final long newLastChange =

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -218,6 +218,9 @@ public final class BrokerTopologyManagerImpl extends Actor
     final var newClusterSize = clusterTopology.clusterSize();
     final var newPartitionsCount = clusterTopology.partitionCount();
     final var newReplicationFactor = clusterTopology.minReplicationFactor();
+    // cluster id is never null as the cluster id is always initialized in the cluster topology.
+    // Unless the persisted topology is modified manually, and set to null.
+    final var clusterId = clusterTopology.clusterId().orElse("");
     final long newLastChange =
         clusterTopology
             .lastChange()
@@ -248,7 +251,8 @@ public final class BrokerTopologyManagerImpl extends Actor
               newPartitionsCount,
               newReplicationFactor,
               partitionIds,
-              newLastChange);
+              newLastChange,
+              clusterId);
 
       return new BrokerClientTopologyImpl(oldTopology.liveClusterState(), newClusterInfo);
     }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -146,6 +146,11 @@ final class TestTopologyManager implements BrokerTopologyManager {
       return 0;
     }
 
+    @Override
+    public String getClusterId() {
+      return null;
+    }
+
     public void addBrokerIfAbsent(final int leaderId) {
       brokers.add(leaderId);
     }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -148,7 +148,7 @@ final class TestTopologyManager implements BrokerTopologyManager {
 
     @Override
     public String getClusterId() {
-      return null;
+      return "";
     }
 
     public void addBrokerIfAbsent(final int leaderId) {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -340,7 +340,8 @@ public final class EndpointManager {
       topologyResponseBuilder
           .setClusterSize(topology.getClusterSize())
           .setPartitionsCount(topology.getPartitionsCount())
-          .setReplicationFactor(topology.getReplicationFactor());
+          .setReplicationFactor(topology.getReplicationFactor())
+          .setClusterId(topology.getClusterId());
 
       topology
           .getBrokers()

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
@@ -222,6 +222,11 @@ public class ExportingControlServiceTest {
       public long getLastCompletedChangeId() {
         return 0;
       }
+
+      @Override
+      public String getClusterId() {
+        throw new UnsupportedOperationException();
+      }
     };
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/topology/TopologyTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/topology/TopologyTest.java
@@ -41,6 +41,15 @@ public final class TopologyTest extends GatewayTest {
   }
 
   @Test
+  public void clusterIdShouldBePresent() {
+    // when
+    final var response = client.topology(TopologyRequest.newBuilder().build());
+
+    // then
+    assertThat(response.getClusterId()).isNotEmpty();
+  }
+
+  @Test
   public void shouldUpdatePartitionHealthHealthy() {
     // given
     final var topologyManager = (StubbedTopologyManager) brokerClient.getTopologyManager();
@@ -65,6 +74,7 @@ public final class TopologyTest extends GatewayTest {
 
     // then
     final var health = response.getBrokers(0).getPartitions(0).getHealth();
+
     assertThat(health).isEqualTo(PartitionBrokerHealth.UNHEALTHY);
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/topology/TopologyTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/topology/TopologyTest.java
@@ -42,11 +42,15 @@ public final class TopologyTest extends GatewayTest {
 
   @Test
   public void clusterIdShouldBePresent() {
+    // given
+    final var topologyManager = (StubbedTopologyManager) brokerClient.getTopologyManager();
+    topologyManager.setClusterId("test-cluster-id");
+
     // when
     final var response = client.topology(TopologyRequest.newBuilder().build());
 
     // then
-    assertThat(response.getClusterId()).isNotEmpty();
+    assertThat(response.getClusterId()).isEqualTo("test-cluster-id");
   }
 
   @Test

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -648,16 +648,18 @@ message TopologyRequest {
 }
 
 message TopologyResponse {
+  // the cluster's unique ID
+  string clusterId = 1;
   // list of brokers part of this cluster
-  repeated BrokerInfo brokers = 1;
+  repeated BrokerInfo brokers = 2;
   // how many nodes are in the cluster
-  int32 clusterSize = 2;
+  int32 clusterSize = 3;
   // how many partitions are spread across the cluster
-  int32 partitionsCount = 3;
+  int32 partitionsCount = 4;
   // configured replication factor for this cluster
-  int32 replicationFactor = 4;
+  int32 replicationFactor = 5;
   // gateway version
-  string gatewayVersion = 5;
+  string gatewayVersion = 6;
 }
 
 message BrokerInfo {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -648,18 +648,18 @@ message TopologyRequest {
 }
 
 message TopologyResponse {
-  // the cluster's unique ID
-  string clusterId = 1;
   // list of brokers part of this cluster
-  repeated BrokerInfo brokers = 2;
+  repeated BrokerInfo brokers = 1;
   // how many nodes are in the cluster
-  int32 clusterSize = 3;
+  int32 clusterSize = 2;
   // how many partitions are spread across the cluster
-  int32 partitionsCount = 4;
+  int32 partitionsCount = 3;
   // configured replication factor for this cluster
-  int32 replicationFactor = 5;
+  int32 replicationFactor = 4;
   // gateway version
-  string gatewayVersion = 6;
+  string gatewayVersion = 5;
+  // the cluster's unique ID
+  string clusterId = 6;
 }
 
 message BrokerInfo {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api-v1.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api-v1.yaml
@@ -214,6 +214,10 @@ components:
           nullable: true
           items:
             $ref: "#/components/schemas/BrokerInfo"
+        clusterId:
+          description: The cluster Id.
+          type: string
+          nullable: true
         clusterSize:
           description: The number of brokers in the cluster.
           type: integer

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4464,10 +4464,10 @@ paths:
         The caller must provide a file name for each document, which will be used in case of a multi-status response
         to identify which documents failed to upload. The file name can be provided in the `Content-Disposition` header
         of the file part or in the `fileName` field of the metadata. You can add a parallel array of metadata objects. These
-        are matched with the files based on index, and must have the same length as the files array. 
-        To pass homogenous metadata for all files, spread the metadata over the metadata array. 
+        are matched with the files based on index, and must have the same length as the files array.
+        To pass homogenous metadata for all files, spread the metadata over the metadata array.
         A filename value provided explicitly via the metadata array in the request overrides the `Content-Disposition` header
-        of the file part. 
+        of the file part.
 
         In case of a multi-status response, the response body will contain a list of `DocumentBatchProblemDetail` objects,
         each of which contains the file name of the document that failed to upload and the reason for the failure.
@@ -8609,7 +8609,7 @@ components:
         clusterId:
           description: The cluster Id.
           type: string
-          nullable: false
+          nullable: true
         clusterSize:
           description: The number of brokers in the cluster.
           type: integer

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8606,6 +8606,10 @@ components:
           nullable: true
           items:
             $ref: "#/components/schemas/BrokerInfo"
+        clusterId:
+          description: The cluster Id.
+          type: string
+          nullable: true
         clusterSize:
           description: The number of brokers in the cluster.
           type: integer

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8609,7 +8609,7 @@ components:
         clusterId:
           description: The cluster Id.
           type: string
-          nullable: true
+          nullable: false
         clusterSize:
           description: The number of brokers in the cluster.
           type: integer

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
@@ -45,6 +45,7 @@ public final class TopologyController {
 
     if (topology != null) {
       response
+          .clusterId(client.getTopologyManager().getClusterConfiguration().clusterId().get())
           .clusterSize(topology.getClusterSize())
           .partitionsCount(topology.getPartitionsCount())
           .replicationFactor(topology.getReplicationFactor())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
@@ -45,7 +45,7 @@ public final class TopologyController {
 
     if (topology != null) {
       response
-          .clusterId(client.getTopologyManager().getClusterConfiguration().clusterId().get())
+          .clusterId(topology.getClusterId())
           .clusterSize(topology.getClusterSize())
           .partitionsCount(topology.getPartitionsCount())
           .replicationFactor(topology.getReplicationFactor())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
@@ -20,6 +20,7 @@ import io.camunda.service.ProcessInstanceServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -33,6 +34,7 @@ abstract class RestApiConfigurationTest extends RestControllerTest {
   @MockitoBean MultiTenancyConfiguration multiTenancyConfiguration;
   @MockitoBean BrokerClient brokerClient;
   @MockitoBean BrokerTopologyManager topologyManager;
+  @MockitoBean ClusterConfiguration clusterConfiguration;
 
   @BeforeEach
   void setupServices() {
@@ -42,5 +44,7 @@ abstract class RestApiConfigurationTest extends RestControllerTest {
     when(processInstanceServices.search(any(ProcessInstanceQuery.class)))
         .thenReturn(new Builder<ProcessInstanceEntity>().build());
     when(topologyManager.getTopology()).thenReturn(mock(BrokerClusterState.class));
+    when(topologyManager.getClusterConfiguration()).thenReturn(clusterConfiguration);
+    when(clusterConfiguration.clusterId()).thenReturn(java.util.Optional.of("cluster-id"));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -42,6 +42,7 @@ public class TopologyControllerTest extends RestControllerTest {
   public void shouldGetTopology(final String baseUrl) {
     // given
     final var version = VersionUtil.getVersion();
+    final var clusterId = "cluster-id";
     final var expectedResponse =
         """
         {
@@ -95,9 +96,8 @@ public class TopologyControllerTest extends RestControllerTest {
         }
         """
             .formatted(version, version, version, version);
-    final var brokerClusterState = new TestBrokerClusterState(version);
+    final var brokerClusterState = new TestBrokerClusterState(version, clusterId);
     final ClusterConfiguration clusterConfiguration = Mockito.mock(ClusterConfiguration.class);
-    Mockito.when(clusterConfiguration.clusterId()).thenReturn(java.util.Optional.of("cluster-id"));
     Mockito.when(topologyManager.getClusterConfiguration()).thenReturn(clusterConfiguration);
     Mockito.when(topologyManager.getTopology()).thenReturn(brokerClusterState);
 
@@ -147,7 +147,8 @@ public class TopologyControllerTest extends RestControllerTest {
    * Topology stub which returns a static topology with 3 brokers, 1 partition, replication factor
    * 3, where 0 is the leader (healthy), 1 is the follower (healthy), and 2 is inactive (unhealthy).
    */
-  private record TestBrokerClusterState(String version) implements BrokerClusterState {
+  private record TestBrokerClusterState(String version, String clusterId)
+      implements BrokerClusterState {
 
     @Override
     public boolean isInitialized() {
@@ -229,7 +230,7 @@ public class TopologyControllerTest extends RestControllerTest {
 
     @Override
     public String getClusterId() {
-      return null;
+      return clusterId;
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.VersionUtil;
@@ -44,6 +45,7 @@ public class TopologyControllerTest extends RestControllerTest {
     final var expectedResponse =
         """
         {
+          "clusterId": "cluster-id",
           "gatewayVersion": "%s",
           "clusterSize": 3,
           "partitionsCount": 1,
@@ -94,6 +96,9 @@ public class TopologyControllerTest extends RestControllerTest {
         """
             .formatted(version, version, version, version);
     final var brokerClusterState = new TestBrokerClusterState(version);
+    final ClusterConfiguration clusterConfiguration = Mockito.mock(ClusterConfiguration.class);
+    Mockito.when(clusterConfiguration.clusterId()).thenReturn(java.util.Optional.of("cluster-id"));
+    Mockito.when(topologyManager.getClusterConfiguration()).thenReturn(clusterConfiguration);
     Mockito.when(topologyManager.getTopology()).thenReturn(brokerClusterState);
 
     // when / then

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -226,5 +226,10 @@ public class TopologyControllerTest extends RestControllerTest {
     public long getLastCompletedChangeId() {
       return 1;
     }
+
+    @Override
+    public String getClusterId() {
+      return null;
+    }
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import java.util.UUID;
 
 public final class StubbedTopologyManager implements BrokerTopologyManager {
 
@@ -28,6 +29,7 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
     clusterConfiguration = ClusterConfiguration.uninitialized();
     clusterState = new TestBrokerClusterState(partitionsCount);
     clusterState.addBroker(0, "localhost:26501");
+    clusterState.setClusterId(UUID.randomUUID().toString());
     for (int partitionOffset = 0; partitionOffset < partitionsCount; partitionOffset++) {
       clusterState.setPartitionLeader(START_PARTITION_ID + partitionOffset, 0, 1);
       clusterState.addPartition(START_PARTITION_ID + partitionOffset);
@@ -62,6 +64,10 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
   public void setPartitionHealthStatus(
       final int nodeId, final int partitionId, final PartitionHealthStatus partitionHealthStatus) {
     clusterState.setPartitionHealthStatus(nodeId, partitionId, partitionHealthStatus);
+  }
+
+  public void setClusterId(final String clusterId) {
+    clusterState.setClusterId(clusterId);
   }
 
   public void addPartitionInactive(final int partitionId, final int nodeId) {

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
@@ -29,7 +29,7 @@ public final class TestBrokerClusterState implements BrokerClusterState {
       new HashMap<>();
   private final Map<Integer, Set<Integer>> inactivePartitionsToNodeIds = new HashMap<>();
   private final Map<Integer, Set<Integer>> followerPartitionToNodeIds = new HashMap<>();
-  private String clusterId = null;
+  private String clusterId = "";
 
   public TestBrokerClusterState() {
     this(0);

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
@@ -29,6 +29,7 @@ public final class TestBrokerClusterState implements BrokerClusterState {
       new HashMap<>();
   private final Map<Integer, Set<Integer>> inactivePartitionsToNodeIds = new HashMap<>();
   private final Map<Integer, Set<Integer>> followerPartitionToNodeIds = new HashMap<>();
+  private String clusterId = null;
 
   public TestBrokerClusterState() {
     this(0);
@@ -117,6 +118,15 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   @Override
   public long getLastCompletedChangeId() {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  public void setClusterId(final String clusterId) {
+    this.clusterId = clusterId;
   }
 
   public void addBroker(final int nodeId, final String address) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointResponseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointResponseIT.java
@@ -28,7 +28,10 @@ final class ClusterEndpointResponseIT {
     broker =
         new TestStandaloneBroker()
             .withBrokerConfig(
-                cfg -> cfg.getExperimental().getFeatures().setEnablePartitionScaling(true));
+                cfg -> {
+                  cfg.getExperimental().getFeatures().setEnablePartitionScaling(true);
+                  cfg.getCluster().setClusterId("cluster-id");
+                });
   }
 
   @Test
@@ -73,7 +76,8 @@ final class ClusterEndpointResponseIT {
                 "strategy": "HashMod",
                 "partitionCount": 1
               }
-            }
+            },
+            "clusterId": "cluster-id"
           }""");
     }
   }


### PR DESCRIPTION
## Description

This PR exposes the cluster ID in the Camunda API in /topology (including the gRPC endpoint) and also in the management endpoint in `/cluster`.
Which means that the cluster ID also added to the `BrokerClusterState`.
Therefore the enpoints that now contain this new field are:

`http://localhost:9600/actuator/cluster`
`http://localhost:8080/v1/topology`
`http://localhost:8080/v2/topology`

Follow up with changes to the API docs https://github.com/camunda/camunda/issues/37663

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/37439
