### PR TITLE
[Backport stable/8.8] fix: uc: add storage type to SchemaUpdateIT

### DIFF
--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
@@ -85,6 +85,16 @@ class SchemaUpdateIT {
                     .forPort(9600)
                     .forPath("/actuator/health")
                     .withReadTimeout(Duration.ofSeconds(120)))
+<<<<<<< HEAD
+=======
+            .withEnv("CAMUNDA_DATABASE_TYPE", databaseType.toString())
+            .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_%s_URL".formatted(databaseType.name()), url)
+            .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", databaseType.toString())
+            .withEnv("CAMUNDA_DATABASE_URL", url)
+            .withEnv("CAMUNDA_DATABASE_INDEX_NUMBEROFREPLICAS", "1")
+            .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", indexPrefix)
+            .withEnv("CAMUNDA_DATABASE_RETENTION_ENABLED", "true")
+>>>>>>> ec8e3be1 (fix: uc: add storage type to SchemaUpdateIT)
             .withEnv("CAMUNDA_OPERATE_DATABASE", databaseType.toString())
             .withEnv("CAMUNDA_OPERATE_%s_URL".formatted(databaseType.name()), url)
             .withEnv("CAMUNDA_OPERATE_%s_NUMBEROFREPLICAS".formatted(databaseType.name()), "1")


### PR DESCRIPTION
# Description
Backport of #37561 to `stable/8.8`.

relates to 