### PR TITLE
[Backport stable/8.8] fix: remove confusing enum type and API tag

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/MessageSubscriptionType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/MessageSubscriptionType.java
@@ -16,7 +16,7 @@
 package io.camunda.client.api.search.enums;
 
 public enum MessageSubscriptionType {
-  CORRELATED,
   CREATED,
   MIGRATED,
+  UNKNOWN_ENUM_VALUE
 }

--- a/clients/java/src/test/java/io/camunda/client/impl/util/EnumUtilTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/util/EnumUtilTest.java
@@ -25,6 +25,7 @@ import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.enums.ElementInstanceType;
 import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.IncidentState;
+import io.camunda.client.api.search.enums.MessageSubscriptionType;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
@@ -34,6 +35,7 @@ import io.camunda.client.protocol.rest.BatchOperationError;
 import io.camunda.client.protocol.rest.BatchOperationItemResponse;
 import io.camunda.client.protocol.rest.BatchOperationResponse;
 import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
+import io.camunda.client.protocol.rest.MessageSubscriptionTypeEnum;
 import io.camunda.client.protocol.rest.UserTaskStateEnum;
 import org.junit.jupiter.api.Test;
 
@@ -516,6 +518,32 @@ public class EnumUtilTest {
       assertThat(value).isNotNull();
       if (protocolValue == BatchOperationError.TypeEnum.UNKNOWN_DEFAULT_OPEN_API) {
         assertThat(value).isEqualTo(BatchOperationErrorType.UNKNOWN_ENUM_VALUE);
+      } else {
+        assertThat(value.name()).isEqualTo(protocolValue.name());
+      }
+    }
+  }
+
+  @Test
+  public void shouldConvertMessageSubscriptionType() {
+
+    for (final MessageSubscriptionType value : MessageSubscriptionType.values()) {
+      final MessageSubscriptionTypeEnum protocolValue =
+          EnumUtil.convert(value, MessageSubscriptionTypeEnum.class);
+      assertThat(protocolValue).isNotNull();
+      if (value == MessageSubscriptionType.UNKNOWN_ENUM_VALUE) {
+        assertThat(protocolValue).isEqualTo(MessageSubscriptionTypeEnum.UNKNOWN_DEFAULT_OPEN_API);
+      } else {
+        assertThat(protocolValue.name()).isEqualTo(value.name());
+      }
+    }
+
+    for (final MessageSubscriptionTypeEnum protocolValue : MessageSubscriptionTypeEnum.values()) {
+      final MessageSubscriptionType value =
+          EnumUtil.convert(protocolValue, MessageSubscriptionType.class);
+      assertThat(value).isNotNull();
+      if (protocolValue == MessageSubscriptionTypeEnum.UNKNOWN_DEFAULT_OPEN_API) {
+        assertThat(value).isEqualTo(MessageSubscriptionType.UNKNOWN_ENUM_VALUE);
       } else {
         assertThat(value.name()).isEqualTo(protocolValue.name());
       }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
@@ -27,7 +27,7 @@ public class MessageSubscriptionEntityMapperTest {
             .processInstanceKey(1L)
             .flowNodeId("flowNodeId")
             .flowNodeInstanceKey(1L)
-            .messageSubscriptionType(MessageSubscriptionType.CORRELATED)
+            .messageSubscriptionType(MessageSubscriptionType.CREATED)
             .dateTime(OffsetDateTime.now().plusDays(1))
             .messageName("testMessageName")
             .correlationKey("testCorrelationKey")

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
@@ -39,7 +39,6 @@ public class MessageSubscriptionEntityTransformer
     return switch (value) {
       case CREATED -> MessageSubscriptionType.CREATED;
       case MIGRATED -> MessageSubscriptionType.MIGRATED;
-      case CORRELATED -> MessageSubscriptionType.CORRELATED;
       default -> throw new IllegalArgumentException("Unknown EventType: " + value);
     };
   }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
@@ -113,7 +113,6 @@ public record MessageSubscriptionEntity(
   }
 
   public enum MessageSubscriptionType {
-    CORRELATED,
     CREATED,
     MIGRATED,
   }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4343,7 +4343,6 @@ paths:
   /message-subscriptions/search:
     post:
       tags:
-        - Message
         - Message subscription
       operationId: searchMessageSubscriptions
       summary: Search message subscriptions
@@ -7256,7 +7255,6 @@ components:
       enum:
         - CREATED
         - MIGRATED
-        - CORRELATED
     AdvancedMessageSubscriptionTypeFilter:
       title: Advanced filter
       description: Advanced MessageSubscriptionTypeEnum filter


### PR DESCRIPTION
# Description
Backport of #37437 to `stable/8.8`.

Closes #37432