### PR TITLE
test: v2 Users and Authentication API Tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -184,6 +184,8 @@ export class IdentityAuthorizationsPage {
     await waitForItemInList(this.page, item, {
       onAfterReload: () =>
         this.selectResourceTypeTab(authorization.resourceType),
+      timeout: 60000,
+      clickNext: true,
     });
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -184,7 +184,7 @@ export class IdentityAuthorizationsPage {
     await waitForItemInList(this.page, item, {
       onAfterReload: () =>
         this.selectResourceTypeTab(authorization.resourceType),
-      timeout: 60000,
+      timeout: 30000,
       clickNext: true,
     });
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
@@ -10,6 +10,7 @@ import {Page, Locator, expect} from '@playwright/test';
 import {relativizePath, Paths} from 'utils/relativizePath';
 import {sleep} from 'utils/sleep';
 import {defaultAssertionOptions} from '../utils/constants';
+import {waitForItemInList} from '../utils/waitForItemInList';
 
 export class IdentityGroupsPage {
   private page: Page;
@@ -168,6 +169,11 @@ export class IdentityGroupsPage {
   }
 
   async deleteGroup(groupName: string) {
+    const group = this.groupCell(groupName);
+    await waitForItemInList(this.page, group, {
+      clickNext: true,
+      timeout: 60000,
+    });
     await expect(async () => {
       await expect(this.deleteGroupButton(groupName)).toBeVisible({
         timeout: 20000,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
@@ -172,7 +172,7 @@ export class IdentityGroupsPage {
     const group = this.groupCell(groupName);
     await waitForItemInList(this.page, group, {
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
     await expect(async () => {
       await expect(this.deleteGroupButton(groupName)).toBeVisible({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
@@ -124,7 +124,7 @@ export class IdentityRolesPage {
     const item = this.roleCell(role.name);
 
     await waitForItemInList(this.page, item, {
-      timeout: 60000,
+      timeout: 30000,
       clickNext: true,
     });
   }
@@ -137,7 +137,7 @@ export class IdentityRolesPage {
   async deleteRole(roleName: string) {
     await waitForItemInList(this.page, this.roleCell(roleName), {
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
     await expect(async () => {
       await expect(this.deleteRoleButton(roleName)).toBeVisible({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
@@ -135,6 +135,10 @@ export class IdentityRolesPage {
   }
 
   async deleteRole(roleName: string) {
+    await waitForItemInList(this.page, this.roleCell(roleName), {
+      clickNext: true,
+      timeout: 60000,
+    });
     await expect(async () => {
       await expect(this.deleteRoleButton(roleName)).toBeVisible({
         timeout: 20000,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
@@ -9,6 +9,7 @@
 import {Page, Locator, expect} from '@playwright/test';
 import {relativizePath, Paths} from 'utils/relativizePath';
 import {waitForItemInList} from 'utils/waitForItemInList';
+import {defaultAssertionOptions} from '../utils/constants';
 
 export class IdentityUsersPage {
   private page: Page;
@@ -39,6 +40,7 @@ export class IdentityUsersPage {
   readonly deleteUserModalDeleteButton: Locator;
   readonly emptyState: Locator;
   readonly userCell: (name: string) => Locator;
+  private usersHeading: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -153,6 +155,7 @@ export class IdentityUsersPage {
     this.emptyState = page.getByText('No users created yet', {exact: true});
     this.userCell = (name) =>
       this.usersList.getByRole('cell', {name, exact: true});
+    this.usersHeading = this.page.getByRole('heading', {name: 'Users'});
   }
 
   async navigateToUsers() {
@@ -180,7 +183,8 @@ export class IdentityUsersPage {
     });
 
     await waitForItemInList(this.page, item, {
-      emptyStateLocator: this.emptyState,
+      clickNext: true,
+      timeout: 60000,
     });
   }
 
@@ -197,7 +201,13 @@ export class IdentityUsersPage {
   }
 
   async deleteUser(user: {username: string; email: string}) {
-    await this.deleteUserButton(user.username).click();
+    await expect(async () => {
+      await expect(this.deleteUserButton(user.username)).toBeVisible({
+        timeout: 20000,
+      });
+      await this.usersHeading.click();
+      await this.deleteUserButton(user.username).click({timeout: 20000});
+    }).toPass(defaultAssertionOptions);
     await expect(this.deleteUserModal).toBeVisible();
     await this.deleteUserModalDeleteButton.click();
     await expect(this.deleteUserModal).toBeHidden();
@@ -205,10 +215,10 @@ export class IdentityUsersPage {
     const item = this.usersList.getByRole('cell', {
       name: user.email,
     });
-
     await waitForItemInList(this.page, item, {
       shouldBeVisible: false,
-      emptyStateLocator: this.emptyState,
+      clickNext: true,
+      timeout: 60000,
     });
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
@@ -184,7 +184,7 @@ export class IdentityUsersPage {
 
     await waitForItemInList(this.page, item, {
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
   }
 
@@ -194,7 +194,7 @@ export class IdentityUsersPage {
   ) {
     await waitForItemInList(this.page, this.userCell(currentUser.email), {
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
     await this.editUserButton(currentUser.email).click();
     await expect(this.editUserModal).toBeVisible();
@@ -207,7 +207,7 @@ export class IdentityUsersPage {
   async deleteUser(user: {username: string; email: string}) {
     await waitForItemInList(this.page, this.userCell(user.email), {
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
     await expect(async () => {
       await expect(this.deleteUserButton(user.username)).toBeVisible({
@@ -226,7 +226,7 @@ export class IdentityUsersPage {
     await waitForItemInList(this.page, item, {
       shouldBeVisible: false,
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
@@ -40,7 +40,7 @@ export class IdentityUsersPage {
   readonly deleteUserModalDeleteButton: Locator;
   readonly emptyState: Locator;
   readonly userCell: (name: string) => Locator;
-  private usersHeading: Locator;
+  readonly usersHeading: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -192,6 +192,10 @@ export class IdentityUsersPage {
     currentUser: {email: string},
     updatedUser: {name: string; email: string},
   ) {
+    await waitForItemInList(this.page, this.userCell(currentUser.email), {
+      clickNext: true,
+      timeout: 60000,
+    });
     await this.editUserButton(currentUser.email).click();
     await expect(this.editUserModal).toBeVisible();
     await this.editNameField.fill(updatedUser.name);
@@ -201,6 +205,10 @@ export class IdentityUsersPage {
   }
 
   async deleteUser(user: {username: string; email: string}) {
+    await waitForItemInList(this.page, this.userCell(user.email), {
+      clickNext: true,
+      timeout: 60000,
+    });
     await expect(async () => {
       await expect(this.deleteUserButton(user.username)).toBeVisible({
         timeout: 20000,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authentication-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authentication-api-tests.spec.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertRequiredFields,
+  assertUnauthorizedRequest,
+  assertEqualsForKeys,
+  encode,
+} from '../../../utils/http';
+import {defaultAssertionOptions} from '../../../utils/constants';
+import {
+  createComponentAuthorization,
+  createGroupAndStoreResponseFields,
+  createRole,
+  createTenant,
+  createUsersAndStoreResponseFields,
+} from '../../../utils/requestHelpers';
+import {
+  authenticationRequiredFields,
+  CREATE_COMPONENT_AUTHORIZATION,
+  GET_CURRENT_USER_EXPECTED_BODY,
+  TENANT_EXPECTED_BODY,
+} from '../../../utils/beans/requestBeans';
+
+test.describe.parallel('Authentication API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createUsersAndStoreResponseFields(request, 2, state);
+  });
+
+  test('Get Current User', async ({request}) => {
+    await expect(async () => {
+      const res = await request.get(buildUrl('/authentication/me'), {
+        headers: jsonHeaders(),
+        data: {},
+      });
+      const expectedBody = GET_CURRENT_USER_EXPECTED_BODY(
+        'demo',
+        'Demo',
+        'demo@example.com',
+        {
+          authorizedComponents: ['*'],
+          tenants: [
+            {
+              name: 'Default',
+              tenantId: '<default>',
+              description: '',
+            },
+          ],
+          roles: ['admin'],
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, authenticationRequiredFields);
+      assertEqualsForKeys(json, expectedBody, authenticationRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Current User Unauthorized', async ({request}) => {
+    const res = await request.get(buildUrl('/authentication/me'), {
+      headers: {},
+      data: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Get Current User With Group, Tenants and Authorization', async ({
+    request,
+  }) => {
+    await test.step('Create Group and Assign User', async () => {
+      await createGroupAndStoreResponseFields(request, 1, state, 'Auth');
+      const stateParams: Record<string, string> = {
+        groupId: state['groupIdAuth1'] as string,
+        username: state['username1'] as string,
+      };
+
+      await expect(async () => {
+        const res = await request.put(
+          buildUrl('/groups/{groupId}/users/{username}', stateParams),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Create Role and Assign User', async () => {
+      await createRole(request, state, 'Auth1');
+      const p: Record<string, string> = {
+        roleId: state['roleIdAuth1'] as string,
+        username: state['username1'] as string,
+      };
+
+      await expect(async () => {
+        const res = await request.put(
+          buildUrl('/roles/{roleId}/users/{username}', p),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Create Tenant and Assign User', async () => {
+      const tenant = await createTenant(request, state, '1');
+      const p = {
+        username: state['username1'] as string,
+        tenantId: tenant.tenantId as string,
+      };
+
+      await expect(async () => {
+        const res = await request.put(
+          buildUrl('/tenants/{tenantId}/users/{username}', p),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Create Authorization for User', async () => {
+      await createComponentAuthorization(
+        request,
+        CREATE_COMPONENT_AUTHORIZATION('USER', state['username1'] as string),
+      );
+    });
+
+    await test.step('Get Current User', async () => {
+      const expectedBody = GET_CURRENT_USER_EXPECTED_BODY(
+        state['username1'] as string,
+        state['name1'] as string,
+        state['email1'] as string,
+        {
+          authorizedComponents: ['*'],
+          tenants: [
+            TENANT_EXPECTED_BODY(
+              state['tenantName1'] as string,
+              state['tenantId1'] as string,
+              state['tenantDescription1'] as string,
+            ),
+          ],
+          groups: [state['groupIdAuth1'] as string],
+          roles: [state['roleIdAuth1'] as string],
+        },
+      );
+
+      await expect(async () => {
+        const res = await request.get(buildUrl('/authentication/me'), {
+          headers: jsonHeaders(
+            encode(`${state['username1']}:${state['password1']}`),
+          ),
+        });
+
+        expect(res.status()).toBe(200);
+        const json = await res.json();
+        assertRequiredFields(json, authenticationRequiredFields);
+        assertEqualsForKeys(json, expectedBody, authenticationRequiredFields);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Get Current User Without Group, Tenants and Authorization', async ({
+    request,
+  }) => {
+    const expectedBody = GET_CURRENT_USER_EXPECTED_BODY(
+      state['username2'] as string,
+      state['name2'] as string,
+      state['email2'] as string,
+    );
+
+    await expect(async () => {
+      const res = await request.get(buildUrl('/authentication/me'), {
+        headers: jsonHeaders(
+          encode(`${state['username2']}:${state['password2']}`),
+        ),
+      });
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, authenticationRequiredFields);
+      assertEqualsForKeys(json, expectedBody, authenticationRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
@@ -10,15 +10,10 @@ import {test, expect} from '@playwright/test';
 import {
   jsonHeaders,
   buildUrl,
-  assertRequiredFields,
-  assertEqualsForKeys,
   assertUnauthorizedRequest,
   assertPaginatedRequest,
 } from '../../../../utils/http';
-import {
-  ROLE_EXPECTED_BODY,
-  roleRequiredFields,
-} from '../../../../utils/beans/requestBeans';
+import {ROLE_EXPECTED_BODY} from '../../../../utils/beans/requestBeans';
 import {
   assignRoleToGroups,
   createGroupAndStoreResponseFields,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-users-api-tests.spec.ts
@@ -20,7 +20,7 @@ import {
   generateUniqueId,
 } from '../../../../utils/constants';
 import {
-  assertUsersInResponse,
+  assertUserNameInResponse,
   assignRoleToUsers,
   createRole,
   userFromState,
@@ -129,9 +129,9 @@ test.describe.parallel('Role Users API Tests', () => {
         itemsLengthEqualTo: 3,
       });
       const json = await res.json();
-      assertUsersInResponse(json, user1);
-      assertUsersInResponse(json, user2);
-      assertUsersInResponse(json, user3);
+      assertUserNameInResponse(json, user1);
+      assertUserNameInResponse(json, user2);
+      assertUserNameInResponse(json, user3);
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-users-api-tests.spec.ts
@@ -20,7 +20,7 @@ import {
   generateUniqueId,
 } from '../../../../utils/constants';
 import {
-  assertUsersInResponse,
+  assertUserNameInResponse,
   assignUsersToTenant,
   createTenant,
   userFromState,
@@ -131,9 +131,9 @@ test.describe.parallel('Tenant Users API Tests', () => {
         itemsLengthEqualTo: 3,
       });
       const json = await res.json();
-      assertUsersInResponse(json, user1);
-      assertUsersInResponse(json, user2);
-      assertUsersInResponse(json, user3);
+      assertUserNameInResponse(json, user1);
+      assertUserNameInResponse(json, user2);
+      assertUserNameInResponse(json, user3);
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
@@ -1,0 +1,547 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertRequiredFields,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertEqualsForKeys,
+  assertBadRequest,
+  assertConflictRequest,
+  assertPaginatedRequest,
+} from '../../../utils/http';
+import {defaultAssertionOptions} from '../../../utils/constants';
+import {
+  assertUserInResponse,
+  createUsersAndStoreResponseFields,
+} from '../../../utils/requestHelpers';
+import {
+  CREATE_NEW_USER,
+  UPDATE_USER,
+  userRequiredFields,
+} from 'utils/beans/requestBeans';
+
+test.describe.parallel('Users API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createUsersAndStoreResponseFields(request, 5, state);
+  });
+
+  test('Create User', async ({request}) => {
+    await expect(async () => {
+      const user = CREATE_NEW_USER();
+      const res = await request.post(buildUrl('/users'), {
+        headers: jsonHeaders(),
+        data: user,
+      });
+
+      expect(res.status()).toBe(201);
+      const json = await res.json();
+      assertRequiredFields(json, userRequiredFields);
+      assertEqualsForKeys(json, user, userRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create User Existing Email Success', async ({request}) => {
+    const user = CREATE_NEW_USER();
+    user['email'] = state['email1'] as string;
+    const expectedBodyForSecondUser = {
+      name: user.name,
+      username: user.username,
+      email: user['email'],
+    };
+    const expectedBodyForFirstUser = {
+      name: state['name1'],
+      username: state['username1'],
+      email: state['email1'],
+    };
+
+    await test.step('Create User With Existing Email', async () => {
+      await expect(async () => {
+        const res = await request.post(buildUrl('/users'), {
+          headers: jsonHeaders(),
+          data: user,
+        });
+
+        expect(res.status()).toBe(201);
+        const json = await res.json();
+        assertRequiredFields(json, userRequiredFields);
+        assertEqualsForKeys(
+          json,
+          expectedBodyForSecondUser,
+          userRequiredFields,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Users By Email', async () => {
+      const body = {
+        filter: {
+          email: user.email,
+        },
+      };
+
+      await expect(async () => {
+        const res = await request.post(buildUrl('/users/search'), {
+          headers: jsonHeaders(),
+          data: body,
+        });
+
+        await assertPaginatedRequest(res, {
+          itemsLengthEqualTo: 2,
+          totalItemsEqualTo: 2,
+        });
+        const json = await res.json();
+        assertUserInResponse(
+          json,
+          expectedBodyForFirstUser,
+          expectedBodyForFirstUser.username as string,
+        );
+        assertUserInResponse(
+          json,
+          expectedBodyForSecondUser,
+          expectedBodyForSecondUser.username as string,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Create User Unauthorized', async ({request}) => {
+    const res = await request.post(buildUrl('/users'), {
+      headers: {},
+      data: CREATE_NEW_USER(),
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Create User Missing Username Invalid Body 400', async ({request}) => {
+    const body = {
+      email: 'onlyemail@example.com',
+      password: 'pass',
+      name: 'user',
+    };
+    const res = await request.post(buildUrl('/users'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, 'No username provided', 'INVALID_ARGUMENT');
+  });
+
+  test('Create User Missing Password Invalid Body 400', async ({request}) => {
+    const body = {
+      email: 'onlyemail@example.com',
+      username: 'username',
+      name: 'user',
+    };
+    const res = await request.post(buildUrl('/users'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, 'No password provided', 'INVALID_ARGUMENT');
+  });
+
+  test('Create User Missing Email Invalid Body 400', async ({request}) => {
+    const body = {
+      username: 'username',
+      password: 'password',
+      name: 'user',
+    };
+    const res = await request.post(buildUrl('/users'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, 'No email provided', 'INVALID_ARGUMENT');
+  });
+
+  test('Create User Missing Password Invalid Body 400', async ({request}) => {
+    const body = {
+      email: 'onlyemail@example.com',
+      username: 'username',
+      password: 'password',
+    };
+    const res = await request.post(buildUrl('/users'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, 'No name provided', 'INVALID_ARGUMENT');
+  });
+
+  test('Create User Empty Username Invalid Body 400', async ({request}) => {
+    const body = {username: '', email: 'empty@example.com', password: 'pass'};
+    const res = await request.post(buildUrl('/users'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, 'No username provided', 'INVALID_ARGUMENT');
+  });
+
+  test('Create User Invalid Email Invalid Body 400', async ({request}) => {
+    const body = CREATE_NEW_USER();
+    body['email'] = 'invalid-email';
+
+    const res = await request.post(buildUrl('/users'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(
+      res,
+      `The provided email '${body['email']}' is not valid.`,
+      'INVALID_ARGUMENT',
+    );
+  });
+
+  test('Create User Conflict', async ({request}) => {
+    await expect(async () => {
+      const user = CREATE_NEW_USER();
+      user['username'] = state['username1'] as string;
+
+      const res = await request.post(buildUrl('/users'), {
+        headers: jsonHeaders(),
+        data: user,
+      });
+
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get User', async ({request}) => {
+    const p = {username: state['username1'] as string};
+    const expectedBody = {
+      name: state['name1'],
+      username: state['username1'],
+      email: state['email1'],
+    };
+
+    await expect(async () => {
+      const res = await request.get(buildUrl('/users/{username}', p), {
+        headers: jsonHeaders(),
+      });
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, userRequiredFields);
+      assertEqualsForKeys(json, expectedBody, userRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get User Unauthorized', async ({request}) => {
+    const p = {username: state['username2'] as string};
+    const res = await request.get(buildUrl('/users/{username}', p), {
+      headers: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Get User Not Found', async ({request}) => {
+    const p = {username: 'does-not-exist'};
+    const res = await request.get(buildUrl('/users/{username}', p), {
+      headers: jsonHeaders(),
+    });
+    await assertNotFoundRequest(res, `User with id '${p.username}' not found`);
+  });
+
+  test('Update User', async ({request}) => {
+    const p = {username: state['username2'] as string};
+    const requestBody = UPDATE_USER();
+    const expectedBody = {
+      ...p,
+      ...requestBody,
+    };
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/users/{username}', p), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, userRequiredFields);
+      assertEqualsForKeys(json, expectedBody, userRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update User Empty Name Invalid Body 400', async ({request}) => {
+    const p = {username: state['username1'] as string};
+    const requestBody = UPDATE_USER();
+    requestBody['name'] = '';
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/users/{username}', p), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+      expect(res.status()).toBe(400);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update User Missing Name Invalid Body 400', async ({request}) => {
+    const p = {username: state['username1'] as string};
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/users/{username}', p), {
+        headers: jsonHeaders(),
+        data: {email: 'missingusername@example.com'},
+      });
+      expect(res.status()).toBe(400);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update User Missing Email Invalid Body 400', async ({request}) => {
+    const p = {username: state['username1'] as string};
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/users/{username}', p), {
+        headers: jsonHeaders(),
+        data: {name: 'userwithmissingemail'},
+      });
+      expect(res.status()).toBe(400);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update User Missing Password Success', async ({request}) => {
+    const p = {username: state['username4'] as string};
+    const body = {
+      name: 'userWithMissingPassword',
+      email: 'userWithMissingPassword@example.com',
+    };
+    const expectedResponseBody = {
+      ...p,
+      ...body,
+    };
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/users/{username}', p), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, userRequiredFields);
+      assertEqualsForKeys(json, expectedResponseBody, userRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update User Unauthorized', async ({request}) => {
+    const p = {username: state['username2'] as string};
+    const requestBody = UPDATE_USER();
+
+    const res = await request.put(buildUrl('/users/{username}', p), {
+      headers: {},
+      data: requestBody,
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Update User Not Found', async ({request}) => {
+    const p = {username: 'invalid-user'};
+    const res = await request.put(buildUrl('/users/{username}', p), {
+      headers: jsonHeaders(),
+      data: UPDATE_USER(),
+    });
+    await assertNotFoundRequest(
+      res,
+      "Command 'UPDATE' rejected with code 'NOT_FOUND'",
+    );
+  });
+
+  test('Delete User', async ({request}) => {
+    const p = {username: state['username3'] as string};
+    await test.step('Delete User 204', async () => {
+      await expect(async () => {
+        const res = await request.delete(buildUrl('/users/{username}', p), {
+          headers: jsonHeaders(),
+        });
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Get User After Deletion', async () => {
+      await expect(async () => {
+        const after = await request.get(buildUrl('/users/{username}', p), {
+          headers: jsonHeaders(),
+        });
+        await assertNotFoundRequest(
+          after,
+          `User with id '${p.username}' not found`,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Delete User Unauthorized', async ({request}) => {
+    const p = {username: state['username3'] as string};
+    const res = await request.delete(buildUrl('/users/{username}', p), {
+      headers: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Delete User Not Found', async ({request}) => {
+    const p = {username: 'invalid-user'};
+    const res = await request.delete(buildUrl('/users/{username}', p), {
+      headers: jsonHeaders(),
+    });
+    await assertNotFoundRequest(
+      res,
+      "Command 'DELETE' rejected with code 'NOT_FOUND'",
+    );
+  });
+
+  test('Search Users', async ({request}) => {
+    const user1ExpectedBody = {
+      username: state['username1'],
+      name: state['name1'],
+      email: state['email1'],
+    };
+    const user2ExpectedBody = {
+      username: state['username5'],
+      name: state['name5'],
+      email: state['email5'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/users/search'), {
+        headers: jsonHeaders(),
+        data: {},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemLengthGreaterThan: 2,
+        totalItemGreaterThan: 2,
+      });
+      const json = await res.json();
+      assertUserInResponse(
+        json,
+        user1ExpectedBody,
+        user1ExpectedBody.username as string,
+      );
+      assertUserInResponse(
+        json,
+        user2ExpectedBody,
+        user2ExpectedBody.username as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Users By Username', async ({request}) => {
+    const username = state['username5'];
+    const body = {
+      filter: {
+        username: username,
+      },
+    };
+    const expectedBody = {
+      username: state['username5'],
+      name: state['name5'],
+      email: state['email5'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/users/search'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertUserInResponse(json, expectedBody, expectedBody.username as string);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Users By Name', async ({request}) => {
+    const body = {
+      filter: {
+        name: state['name5'],
+      },
+    };
+    const expectedBody = {
+      username: state['username5'],
+      name: state['name5'],
+      email: state['email5'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/users/search'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertUserInResponse(json, expectedBody, expectedBody.username as string);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Users By Multiple Fields', async ({request}) => {
+    const requestBody = {
+      filter: {
+        username: state['username1'],
+        name: state['name1'],
+      },
+    };
+    const expectedBody = {
+      ...requestBody.filter,
+      email: state['email1'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/users/search'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertUserInResponse(json, expectedBody, expectedBody.username as string);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Users By Invalid User Name', async ({request}) => {
+    const body = {
+      filter: {
+        username: 'invalidusername',
+      },
+    };
+
+    const res = await request.post(buildUrl('/users/search'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+
+  test('Search Users Unauthorized', async ({request}) => {
+    const body = {
+      filter: {
+        username: state['username1'],
+      },
+    };
+    const res = await request.post(buildUrl('/users/search'), {
+      headers: {},
+      data: body,
+    });
+    await assertUnauthorizedRequest(res);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
@@ -30,7 +30,7 @@ import {
   CREATE_NEW_USER,
   UPDATE_USER,
   userRequiredFields,
-} from 'utils/beans/requestBeans';
+} from '../../../utils/beans/requestBeans';
 
 test.describe.parallel('Users API Tests', () => {
   const state: Record<string, unknown> = {};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
@@ -544,6 +544,33 @@ test.describe.parallel('Users API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
+  test('Search Users By Email', async ({request}) => {
+    const body = {
+      filter: {
+        email: state['email5'],
+      },
+    };
+    const expectedBody = {
+      username: state['username5'],
+      name: state['name5'],
+      email: state['email5'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/users/search'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertUserInResponse(json, expectedBody, expectedBody.username as string);
+    }).toPass(defaultAssertionOptions);
+  });
+
   test('Search Users By Multiple Fields', async ({request}) => {
     const requestBody = {
       filter: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
@@ -162,7 +162,7 @@ test.describe.parallel('Users API Tests', () => {
     await assertBadRequest(res, 'No email provided', 'INVALID_ARGUMENT');
   });
 
-  test('Create User Missing Password Invalid Body 400', async ({request}) => {
+  test('Create User Missing Name Invalid Body 400', async ({request}) => {
     const body = {
       email: 'onlyemail@example.com',
       username: 'username',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -125,7 +125,7 @@ test.describe.serial('component authorizations CRUD', () => {
     await expect(identityUsersPage.userCell('demo@example.com')).toBeVisible();
     await waitForItemInList(page, identityUsersPage.userCell(NEW_USER.email), {
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -115,14 +115,18 @@ test.describe.serial('component authorizations CRUD', () => {
     identityAuthorizationsPage,
     identityHeader,
     loginPage,
+    page,
   }) => {
     await identityAuthorizationsPage.createAuthorization(
       NEW_COMPONENT_AUTHORIZATION,
     );
     await identityHeader.logout();
     await loginPage.login(NEW_USER.username, NEW_USER.password);
-    await expect(identityUsersPage.userCell(NEW_USER.email)).toBeVisible();
     await expect(identityUsersPage.userCell('demo@example.com')).toBeVisible();
+    await waitForItemInList(page, identityUsersPage.userCell(NEW_USER.email), {
+      clickNext: true,
+      timeout: 60000,
+    });
   });
 
   test('delete component authorization for role', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -174,6 +174,7 @@ test.describe.serial('component authorizations CRUD', () => {
         LOGIN_CREDENTIALS.username,
         LOGIN_CREDENTIALS.password,
       );
+      await expect(identityUsersPage.usersHeading).toBeVisible();
       await identityUsersPage.deleteUser(NEW_USER);
       const userItem = identityUsersPage.userCell(NEW_USER.username);
       await waitForItemInList(page, userItem, {shouldBeVisible: false});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/create-new-user.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/create-new-user.spec.ts
@@ -43,7 +43,7 @@ test.describe.parallel('login page', () => {
       name: testUser.email,
     });
 
-    await waitForItemInList(page, item, {timeout: 60000});
+    await waitForItemInList(page, item, {timeout: 60000, clickNext: true});
 
     await expect(
       identityUsersPage.usersList.getByRole('cell', {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -87,7 +87,7 @@ test.describe.serial('groups CRUD', () => {
     await waitForItemInList(page, item, {
       shouldBeVisible: false,
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -80,12 +80,6 @@ test.describe.serial('groups CRUD', () => {
   });
 
   test('deletes a group', async ({page, identityGroupsPage}) => {
-    const group = identityGroupsPage.groupCell(EDITED_GROUP.name);
-    await waitForItemInList(page, group, {
-      clickNext: true,
-      timeout: 60000,
-    });
-
     await identityGroupsPage.deleteGroup(EDITED_GROUP.name);
 
     const item = identityGroupsPage.groupCell(EDITED_GROUP.name);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules.spec.ts
@@ -64,7 +64,7 @@ test.describe.serial('mapping rules CRUD', () => {
 
     await waitForItemInList(page, item, {
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
   });
 
@@ -105,7 +105,7 @@ test.describe.serial('mapping rules CRUD', () => {
     await waitForItemInList(page, item, {
       shouldBeVisible: false,
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules.spec.ts
@@ -64,7 +64,7 @@ test.describe.serial('mapping rules CRUD', () => {
 
     await waitForItemInList(page, item, {
       clickNext: true,
-      timeout: 30000,
+      timeout: 60000,
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
@@ -47,10 +47,6 @@ test.describe.serial('roles CRUD', () => {
 
   test('deletes a role', async ({page, identityRolesPage}) => {
     const item = identityRolesPage.roleCell(NEW_ROLE.name);
-    await waitForItemInList(page, item, {
-      clickNext: true,
-      timeout: 60000,
-    });
     await identityRolesPage.deleteRole(NEW_ROLE.name);
 
     await waitForItemInList(page, item, {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
@@ -52,7 +52,7 @@ test.describe.serial('roles CRUD', () => {
     await waitForItemInList(page, item, {
       shouldBeVisible: false,
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
@@ -42,23 +42,36 @@ test.describe.serial('users CRUD', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('create a user', async ({identityUsersPage}) => {
+  test('create a user', async ({identityUsersPage, page}) => {
     await expect(identityUsersPage.userCell('demo@example.com')).toBeVisible();
     await identityUsersPage.createUser(NEW_USER);
-    await expect(identityUsersPage.userCell(NEW_USER.email)).toBeVisible();
+    await waitForItemInList(page, identityUsersPage.userCell(NEW_USER.email), {
+      clickNext: true,
+      timeout: 60000,
+    });
   });
 
   test('edit a user', async ({identityUsersPage, page}) => {
-    await expect(identityUsersPage.userCell(NEW_USER.email)).toBeVisible();
+    await waitForItemInList(page, identityUsersPage.userCell(NEW_USER.email), {
+      clickNext: true,
+      timeout: 60000,
+    });
     await identityUsersPage.editUser(NEW_USER, EDITED_USER);
     const item = identityUsersPage.userCell(EDITED_USER.email);
     await waitForItemInList(page, item);
   });
 
-  test('delete a user', async ({identityUsersPage}) => {
-    await expect(identityUsersPage.userCell(EDITED_USER.name)).toBeVisible();
+  test('delete a user', async ({identityUsersPage, page}) => {
+    const item = identityUsersPage.userCell(EDITED_USER.email);
+    await waitForItemInList(page, item, {
+      clickNext: true,
+      timeout: 60000,
+    });
     await identityUsersPage.deleteUser(EDITED_USER);
-    await expect(identityUsersPage.userCell(EDITED_USER.name)).toBeHidden({
+
+    await waitForItemInList(page, item, {
+      shouldBeVisible: false,
+      clickNext: true,
       timeout: 60000,
     });
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
@@ -47,7 +47,7 @@ test.describe.serial('users CRUD', () => {
     await identityUsersPage.createUser(NEW_USER);
     await waitForItemInList(page, identityUsersPage.userCell(NEW_USER.email), {
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
   });
 
@@ -56,7 +56,7 @@ test.describe.serial('users CRUD', () => {
     const item = identityUsersPage.userCell(EDITED_USER.email);
     await waitForItemInList(page, item, {
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
   });
 
@@ -67,7 +67,7 @@ test.describe.serial('users CRUD', () => {
     await waitForItemInList(page, item, {
       shouldBeVisible: false,
       clickNext: true,
-      timeout: 60000,
+      timeout: 30000,
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
@@ -52,10 +52,6 @@ test.describe.serial('users CRUD', () => {
   });
 
   test('edit a user', async ({identityUsersPage, page}) => {
-    await waitForItemInList(page, identityUsersPage.userCell(NEW_USER.email), {
-      clickNext: true,
-      timeout: 60000,
-    });
     await identityUsersPage.editUser(NEW_USER, EDITED_USER);
     const item = identityUsersPage.userCell(EDITED_USER.email);
     await waitForItemInList(page, item, {
@@ -66,10 +62,6 @@ test.describe.serial('users CRUD', () => {
 
   test('delete a user', async ({identityUsersPage, page}) => {
     const item = identityUsersPage.userCell(EDITED_USER.email);
-    await waitForItemInList(page, item, {
-      clickNext: true,
-      timeout: 60000,
-    });
     await identityUsersPage.deleteUser(EDITED_USER);
 
     await waitForItemInList(page, item, {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
@@ -58,7 +58,10 @@ test.describe.serial('users CRUD', () => {
     });
     await identityUsersPage.editUser(NEW_USER, EDITED_USER);
     const item = identityUsersPage.userCell(EDITED_USER.email);
-    await waitForItemInList(page, item);
+    await waitForItemInList(page, item, {
+      clickNext: true,
+      timeout: 60000,
+    });
   });
 
   test('delete a user', async ({identityUsersPage, page}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -35,6 +35,7 @@ export const mappingRuleRequiredFields: string[] = [
   'mappingRuleId',
 ];
 export const roleRequiredFields: string[] = ['roleId', 'name', 'description'];
+export const userRequiredFields: string[] = ['username', 'name', 'email'];
 export const licenseRequiredFields: string[] = [
   'validLicense',
   'licenseType',
@@ -117,6 +118,26 @@ export function CREATE_NEW_ROLE() {
     description: 'E2E test role',
   };
 }
+
+export function CREATE_NEW_USER() {
+  const uid = generateUniqueId();
+  return {
+    username: `username-${uid}`,
+    name: `name-${uid}`,
+    email: `email-${uid}@example.com`,
+    password: `password-${uid}`,
+  };
+}
+
+export function UPDATE_USER() {
+  const uid = generateUniqueId();
+  return {
+    name: `updated-name-${uid}`,
+    email: `updated-email-${uid}@example.com`,
+    password: `updated-password-${uid}`,
+  };
+}
+
 export function UPDATE_ROLE() {
   const uid = generateUniqueId();
   return {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -134,7 +134,6 @@ export function UPDATE_USER() {
   return {
     name: `updated-name-${uid}`,
     email: `updated-email-${uid}@example.com`,
-    password: `updated-password-${uid}`,
   };
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -35,7 +35,19 @@ export const mappingRuleRequiredFields: string[] = [
   'mappingRuleId',
 ];
 export const roleRequiredFields: string[] = ['roleId', 'name', 'description'];
+export const authorizedComponentRequiredFields: string[] = ['authorizationKey'];
 export const userRequiredFields: string[] = ['username', 'name', 'email'];
+export const authenticationRequiredFields: string[] = [
+  'username',
+  'displayName',
+  'email',
+  'authorizedComponents',
+  'tenants',
+  'groups',
+  'roles',
+  'c8Links',
+  'canLogout',
+];
 export const licenseRequiredFields: string[] = [
   'validLicense',
   'licenseType',
@@ -159,6 +171,18 @@ export function UPDATE_TENANT() {
   return {
     name: `tenant-updated-${uid}`,
     description: `Updated description-${uid}`,
+  };
+}
+
+export function TENANT_EXPECTED_BODY(
+  name: string,
+  tenantId: string,
+  description: string,
+) {
+  return {
+    name: name,
+    tenantId: tenantId,
+    description: description,
   };
 }
 
@@ -328,6 +352,48 @@ export function CREATE_GROUP_USERS_EXPECTED_BODY_USING_GROUP(
 export function GROUPS_EXPECTED_BODY(groupId: string) {
   return {
     groupId: groupId,
+  };
+}
+
+export function CREATE_COMPONENT_AUTHORIZATION(
+  ownerType: 'ROLE' | 'USER' | 'GROUP',
+  ownerId: string,
+) {
+  return {
+    ownerType: ownerType,
+    ownerId: ownerId,
+    resourceType: 'COMPONENT',
+    resourceId: '*',
+    permissionTypes: ['ACCESS'],
+  };
+}
+
+export function GET_CURRENT_USER_EXPECTED_BODY(
+  username: string,
+  name: string,
+  email: string,
+  assignedResources: {
+    authorizedComponents?: string[];
+    tenants?: {name: string; tenantId: string; description: string}[];
+    groups?: string[];
+    roles?: string[];
+  } = {
+    authorizedComponents: [],
+    tenants: [],
+    groups: [],
+    roles: [],
+  },
+) {
+  return {
+    username: username,
+    displayName: name,
+    email: email,
+    authorizedComponents: assignedResources.authorizedComponents ?? [],
+    tenants: assignedResources.tenants ?? [],
+    groups: assignedResources.groups ?? [],
+    roles: assignedResources.roles ?? [],
+    c8Links: {},
+    canLogout: true,
   };
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -15,14 +15,18 @@ export type Credentials = {
 
 export const credentials: Credentials = {
   baseUrl: 'http://localhost:8080',
-  accessToken: Buffer.from(`demo:demo`).toString('base64'),
+  accessToken: encode(`demo:demo`),
 };
+
+export function encode(auth: string) {
+  return Buffer.from(auth).toString('base64');
+}
 
 export const paginatedResponseFields: string[] = ['items', 'page'];
 
 export function authHeaders(token?: string): Record<string, string> {
   const h: Record<string, string> = {};
-  if (token) h.Authorization = `Basic ${credentials.accessToken}`;
+  if (token) h.Authorization = `Basic ${token}`;
   return h;
 }
 
@@ -174,10 +178,12 @@ export function assertEqualsForKeys(
   }
 }
 
-export function jsonHeaders(): Record<string, string> {
+export function jsonHeaders(
+  auth: string = credentials.accessToken,
+): Record<string, string> {
   return {
     'Content-Type': 'application/json',
-    ...authHeaders(credentials.accessToken),
+    ...authHeaders(auth),
   };
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers.ts
@@ -12,6 +12,7 @@ import {
   CREATE_NEW_ROLE,
   CREATE_NEW_TENANT,
   CREATE_NEW_USER,
+  authorizedComponentRequiredFields,
   groupRequiredFields,
   roleRequiredFields,
   tenantRequiredFields,
@@ -400,6 +401,20 @@ export async function createRole(
   return body;
 }
 
+export async function createComponentAuthorization(
+  request: APIRequestContext,
+  body: Serializable,
+) {
+  const res = await request.post(buildUrl('/authorizations'), {
+    headers: jsonHeaders(),
+    data: body,
+  });
+
+  expect(res.status()).toBe(201);
+  const json = await res.json();
+  assertRequiredFields(json, authorizedComponentRequiredFields);
+}
+
 export async function createUser(
   request: APIRequestContext,
   state?: Record<string, unknown>,
@@ -419,6 +434,7 @@ export async function createUser(
     state[`username${key}`] = json.username;
     state[`name${key}`] = json.name;
     state[`email${key}`] = json.email;
+    state[`password${key}`] = body.password;
   }
   return body;
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/waitForItemInList.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/waitForItemInList.ts
@@ -71,7 +71,7 @@ export const waitForItemInList = async (
           .getByRole('cell')
           .filter({hasText: /.+/, hasNot: page.locator('div')})
           .first()
-          .waitFor();
+          .waitFor({timeout: 20000});
       }
 
       if (clickNext) {


### PR DESCRIPTION
## Description

PR includes `User` and `Authentication` API tests.

Test run: https://github.com/camunda/camunda/actions/runs/17560428816

Tests failed due to following bugs:
- [Create/Update User optional fields bug](https://github.com/camunda/camunda/issues/37720)
- [Authorizations fail to load paginated Groups and Users](https://github.com/camunda/camunda/issues/37106)
- [Variable Editing bug](https://github.com/camunda/camunda/issues/36368)

## USER API:
**Create User** (`POST /users`)
- 201: Success (all fields)  
- 201: Success (missing `email` → stored as empty string)  
- 201: Success (missing `name` → stored as empty string)  
- 201: Success (explicit empty `name`)  
- 201: Success (duplicate `email` allowed; later search returns 2 users)  
- 401: Unauthorized (missing auth header)  
- 400: Invalid body (missing `username`) → `INVALID_ARGUMENT` ("No username provided")  
- 400: Invalid body (missing `password`) → `INVALID_ARGUMENT` ("No password provided")  
- 400: Invalid body (empty `username`) → `INVALID_ARGUMENT` ("No username provided")  
- 400: Invalid body (invalid email format) → `INVALID_ARGUMENT`  
- 409: Conflict (duplicate `username`)  

**Get User** (`GET /users/{username}`)
- 200: Success (required fields present)  
- 401: Unauthorized  
- 404: Not found (nonexistent username)  

**Update User** (`PUT /users/{username}`)
- 200: Success (full update: `name`, `email`, `password` — password not echoed)  
- 200: Success (update `email` only; `name` preserved)  
- 200: Success (update `name` only; `email` preserved)  
- 200: Success (includes `password`; not returned)  
- 401: Unauthorized  
- 404: Not found (invalid username)  

**Delete User** (`DELETE /users/{username}`)
- 204: Success (user deleted)  
- 404: Verified by subsequent GET (user no longer exists)  
- 401: Unauthorized  
- 404: Not found (invalid username)  

**Search Users** (`POST /users/search`)
- 200: Success (no filter → paginated list, >2 items)  
- 200: Success (filter by `username`)  
- 200: Success (filter by `name`)  
- 200: Success (filter by `username` + `name`)  
- 200: Success (filter by `email` with duplicate email → 2 items)  
- 200: Success (invalid `username` filter → 0 items)  
- 401: Unauthorized  

## Authentication API 

**Get Current User** (`GET /authentication/me`)
- 200: Success (default `demo` user; required fields asserted; `authorizedComponents`=`['*']`, default tenant `<default>`, role `admin`)
- 401: Unauthorized (missing auth header)

**Get Current User (with Group, Role, Tenant, Authorization)** (`GET /authentication/me`)
- 200: Success (dynamically created user1; assigned group, role, tenant, component authorization; response includes those IDs and `authorizedComponents`=`['*']`)

**Get Current User (baseline user without assignments)** (`GET /authentication/me`)
- 200: Success (second created user2; no extra groups/roles/tenants beyond defaults)



<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
