### PR TITLE
feat: Configure retention policy for new dated indices

### DIFF
--- a/migration/task-migration/pom.xml
+++ b/migration/task-migration/pom.xml
@@ -39,6 +39,14 @@
       <artifactId>webapps-schema</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-schema-manager</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
     </dependency>

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/TaskMigrator.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/TaskMigrator.java
@@ -21,6 +21,7 @@ import io.camunda.migration.task.adapter.os.OpensearchAdapter;
 import io.camunda.migration.task.util.MigrationUtils;
 import io.camunda.migration.task.util.TaskMigrationMetricRegistry;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.zeebe.util.retry.RetryDecorator;
@@ -48,12 +49,13 @@ public class TaskMigrator implements Migrator {
   public TaskMigrator(
       final ConnectConfiguration connect,
       final MigrationProperties properties,
-      final MeterRegistry meterRegistry) {
+      final MeterRegistry meterRegistry,
+      final RetentionConfiguration retentionConfiguration) {
     configuration = properties.getMigrationConfiguration(getClass());
     adapter =
         connect.getTypeEnum().isElasticSearch()
-            ? new ElasticsearchAdapter(configuration, connect)
-            : new OpensearchAdapter(configuration, connect);
+            ? new ElasticsearchAdapter(configuration, connect, retentionConfiguration)
+            : new OpensearchAdapter(configuration, connect, retentionConfiguration);
     scheduler = Executors.newScheduledThreadPool(1);
     metricRegistry = new TaskMigrationMetricRegistry(meterRegistry);
   }

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/SearchAndCreateTaskMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/SearchAndCreateTaskMigrationIT.java
@@ -62,7 +62,12 @@ public class SearchAndCreateTaskMigrationIT extends UserTaskMigrationHelper {
               Map.of(
                   "CAMUNDA_TASKLIST_ARCHIVER_WAITPERIODBEFOREARCHIVING",
                   ARCHIVING_WAITING_PERIOD_SECONDS + "s"))
-          .withUpgradeSystemPropertyOverrides(Map.of("camunda.database.retention.enabled", "true"));
+          .withUpgradeSystemPropertyOverrides(
+              Map.of(
+                  "camunda.database.retention.enabled",
+                  "true",
+                  "camunda.database.retention.minimumAge",
+                  "30d"));
 
   private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
@@ -52,10 +52,9 @@ public class MigrationITExtension
     implements AfterAllCallback, BeforeAllCallback, ParameterResolver {
   private static final String TASKLIST = "tasklist";
   private static final String OPERATE = "operate";
-
   private final List<AutoCloseable> closables = new ArrayList<>();
   private Map<String, String> initialEnvOverrides = new HashMap<>();
-  private Map<String, String> upgradeEnvOverrides = new HashMap<>();
+  private Map<String, String> upgradeSystemPropertyOverrides = new HashMap<>();
   private final DatabaseType databaseType;
   private String indexPrefix;
   private String databaseUrl;
@@ -93,7 +92,7 @@ public class MigrationITExtension
       if (beforeUpgradeConsumer != null) {
         beforeUpgradeConsumer.accept(databaseType, migrator);
       }
-      upgrade(upgradeEnvOverrides);
+      upgrade(upgradeSystemPropertyOverrides);
     }
   }
 
@@ -115,8 +114,17 @@ public class MigrationITExtension
     return this;
   }
 
-  public MigrationITExtension withUpgradeEnvOverrides(final Map<String, String> envOverrides) {
-    upgradeEnvOverrides = envOverrides;
+  /**
+   * Allows the provision of system property overrides that will be used by the migration container.
+   * This can be used to enable features that are required for the upgrade process. For example
+   * "camunda.database.retention.enabled" -> "true".
+   *
+   * @param systemPropertyOverrides the system property overrides to set
+   * @return self for chaining
+   */
+  public MigrationITExtension withUpgradeSystemPropertyOverrides(
+      final Map<String, String> systemPropertyOverrides) {
+    upgradeSystemPropertyOverrides = systemPropertyOverrides;
     return this;
   }
 
@@ -128,6 +136,14 @@ public class MigrationITExtension
 
   public String getDatabaseUrl() {
     return databaseUrl;
+  }
+
+  public boolean isElasticSearch() {
+    return databaseType == DatabaseType.ES || databaseType == DatabaseType.LOCAL;
+  }
+
+  public String getIndexPrefix() {
+    return indexPrefix;
   }
 
   private void upgrade(final Map<String, String> envOverrides) {


### PR DESCRIPTION
## Description

Configure retention policy for new dated indices if retention is enabled.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/35861
