### PR TITLE
[Backport stable/8.8] ci: disable conistently failing optimize e2e sm test

### DIFF
--- a/.github/workflows/optimize-e2e-tests-sm.yml
+++ b/.github/workflows/optimize-e2e-tests-sm.yml
@@ -44,6 +44,7 @@ jobs:
     name: E2E Self-Managed
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    if: false # this test is disabled
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Description
Backport of #37481 to `stable/8.8`.

relates to camunda/camunda#37480