### PR TITLE
refactor: create and own executor service as part of store

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
-import java.util.concurrent.Executors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
@@ -69,6 +68,6 @@ final class BackupStoreComponent {
   private static BackupStore buildFilesystemBackupStore(final BackupStoreCfg backupStoreCfg) {
     final var storeConfig =
         FilesystemBackupStoreConfig.toStoreConfig(backupStoreCfg.getFilesystem());
-    return FilesystemBackupStore.of(storeConfig, Executors.newVirtualThreadPerTaskExecutor());
+    return FilesystemBackupStore.of(storeConfig);
   }
 }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,17 +46,21 @@ public final class FilesystemBackupStore implements BackupStore {
   private final FileSetManager fileSetManager;
   private final ManifestManager manifestManager;
 
+  FilesystemBackupStore(final FilesystemBackupConfig config) {
+    this(config, Executors.newVirtualThreadPerTaskExecutor());
+  }
+
   FilesystemBackupStore(final FilesystemBackupConfig config, final ExecutorService executor) {
     validateConfig(config);
-    this.executor = executor;
 
+    this.executor = executor;
     fileSetManager = new FileSetManager(config.basePath());
     manifestManager = new ManifestManager(config.basePath());
   }
 
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
-    LOG.info("Saving {}", backup.id());
+    LOG.debug("Saving {}", backup.id());
     return CompletableFuture.runAsync(
         () -> {
           final var manifest = manifestManager.createInitialManifest(backup);
@@ -148,24 +153,32 @@ public final class FilesystemBackupStore implements BackupStore {
             executor.shutdown();
             final var closed = executor.awaitTermination(1, TimeUnit.MINUTES);
             if (!closed) {
-              LOG.warn("Failed to orderly shutdown Filesystem Store Executor within one minute.");
+              LOG.debug(
+                  """
+                Expected file system backup store executor to shutdown within a minute, but one \
+                task is hanging; will forcefully shutdown, but some backup may not be written \
+                properly""");
               executor.shutdownNow();
             }
-          } catch (final Exception e) {
-            LOG.error("Failed to shutdown of Filesystem Store Executor.");
-            throw new RuntimeException(e);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.debug(
+                """
+              Interrupted while awaiting shutdown of file system store executor, possible resource \
+              leak""",
+                e);
           }
         });
   }
 
   public static void validateConfig(final FilesystemBackupConfig config) {
     if (config.basePath() == null || config.basePath().isBlank()) {
-      throw new IllegalArgumentException("Base directory is required");
+      throw new IllegalArgumentException(
+          "Expected a basePath to be provided, but got [%s]".formatted(config.basePath()));
     }
   }
 
-  public static BackupStore of(
-      final FilesystemBackupConfig storeConfig, final ExecutorService executorService) {
-    return new FilesystemBackupStore(storeConfig, executorService).logging(LOG, Level.INFO);
+  public static BackupStore of(final FilesystemBackupConfig storeConfig) {
+    return new FilesystemBackupStore(storeConfig).logging(LOG, Level.INFO);
   }
 }

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ConfigTest.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ConfigTest.java
@@ -34,7 +34,7 @@ public class ConfigTest {
 
     Assertions.assertThatCode(
             () -> new FilesystemBackupStore(backupConfig, Mockito.mock(ExecutorService.class)))
-        .hasMessage("Base directory is required");
+        .hasMessage("Expected a basePath to be provided, but got [null]");
   }
 
   @Test
@@ -44,6 +44,6 @@ public class ConfigTest {
 
     Assertions.assertThatCode(
             () -> new FilesystemBackupStore(backupConfig, Mockito.mock(ExecutorService.class)))
-        .hasMessage("Base directory is required");
+        .hasMessage("Expected a basePath to be provided, but got []");
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import java.util.concurrent.Executors;
 
 public final class BackupStoreTransitionStep implements PartitionTransitionStep {
 
@@ -133,9 +132,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final var brokerFilesystemConfig = backupCfg.getFilesystem();
       final var storeFilesystemConfig =
           FilesystemBackupStoreConfig.toStoreConfig(brokerFilesystemConfig);
-      final var filesystemStore =
-          FilesystemBackupStore.of(
-              storeFilesystemConfig, Executors.newVirtualThreadPerTaskExecutor());
+      final var filesystemStore = FilesystemBackupStore.of(storeFilesystemConfig);
       context.setBackupStore(filesystemStore);
       installed.complete(null);
     } catch (final Exception error) {


### PR DESCRIPTION
## Description

Instead of always passing the virtual executor, just create it but leave the possibility of injecting one for testing. This helps emphasize that the executor is closed by the store, which could be misleading otherwise, and is not consistent with other stores.

This also fixes some minor logging issues, like logging at info level when we save a backup.
