### PR TITLE
[Backport stable/8.8] test: v2 tenant and role endpoints

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
@@ -16,12 +16,25 @@ import {
   paginatedResponseFields,
 } from '../../../../utils/http';
 import {
+<<<<<<< HEAD
   CREATE_NEW_GROUP,
   groupRequiredFields,
   mappingRuleRequiredFields,
 } from '../../../../utils/beans/request-beans';
 import {sleep} from '../../../../utils/sleep';
 import {CREATE_NEW_MAPPING_RULE} from '../../../../utils/beans/request-beans';
+=======
+  MAPPING_RULE_EXPECTED_BODY_USING_STATE,
+  mappingRuleRequiredFields,
+} from '../../../../utils/beans/requestBeans';
+import {
+  assignMappingToGroup,
+  createGroupAndStoreResponseFields,
+  createMappingRule,
+  mappingRuleIdFromState,
+} from '../../../../utils/requestHelpers';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+>>>>>>> 4fa4510d (test: v2 role endpoints implemented)
 
 test.describe('Group Mapping Rules API Tests', () => {
   const state: Record<string, unknown> = {};
@@ -64,6 +77,7 @@ test.describe('Group Mapping Rules API Tests', () => {
       expect(res.status()).toBe(204);
     });
 
+<<<<<<< HEAD
     await test.step('Search Mapping Rules For Group', async () => {
       await sleep(10000);
       const p = {groupId: state['groupId'] as string};
@@ -74,6 +88,35 @@ test.describe('Group Mapping Rules API Tests', () => {
         mappingRuleId: state['mappingRuleId'] as string,
       };
 
+=======
+  test('Assign Already Added Mapping Rule To Group Conflict', async ({
+    request,
+  }) => {
+    const stateParams: Record<string, string> = {
+      groupId: state['groupId2'] as string,
+      mappingRuleId: mappingRuleIdFromState('groupId2', state) as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl(
+          '/groups/{groupId}/mapping-rules/{mappingRuleId}',
+          stateParams,
+        ),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules For Group', async ({request}) => {
+    const groupId: string = state['groupId2'] as string;
+
+    await expect(async () => {
+>>>>>>> 4fa4510d (test: v2 role endpoints implemented)
       const res = await request.post(
         buildUrl('/groups/{groupId}/mapping-rules/search', p),
         {
@@ -88,7 +131,7 @@ test.describe('Group Mapping Rules API Tests', () => {
       assertRequiredFields(json.items[0], mappingRuleRequiredFields);
       assertEqualsForKeys(
         json.items[0],
-        expectedBody,
+        MAPPING_RULE_EXPECTED_BODY_USING_STATE('groupId2', state),
         mappingRuleRequiredFields,
       );
     });
@@ -123,8 +166,13 @@ test.describe('Group Mapping Rules API Tests', () => {
 
     await test.step('Unassign Mapping Rule From Group', async () => {
       const p = {
+<<<<<<< HEAD
         groupId: state['groupId'] as string,
         mappingRuleId: state['mappingRuleId'] as string,
+=======
+        groupId: state['groupId3'] as string,
+        mappingRuleId: mappingRuleIdFromState('groupId3', state) as string,
+>>>>>>> 4fa4510d (test: v2 role endpoints implemented)
       };
       const res = await request.delete(
         buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),
@@ -153,6 +201,7 @@ test.describe('Group Mapping Rules API Tests', () => {
       expect(json.items.length).toBe(0);
     });
 
+<<<<<<< HEAD
     await test.step('Unassign Mapping Rule From Group Unauthorized', async () => {
       const p = {
         groupId: state['groupId'] as string,
@@ -180,5 +229,36 @@ test.describe('Group Mapping Rules API Tests', () => {
       );
       expect(res.status()).toBe(404);
     });
+=======
+  test('Unassign Mapping Rule From Group Unauthorized', async ({request}) => {
+    const p = {
+      groupId: state['groupId2'] as string,
+      mappingRuleId: mappingRuleIdFromState('groupId2', state) as string,
+    };
+    const res = await request.delete(
+      buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),
+      {
+        headers: {},
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign Mapping Rule From Group Not Found', async ({request}) => {
+    const p = {
+      groupId: 'invalidGroupId',
+      mappingRuleId: mappingRuleIdFromState('groupId2', state) as string,
+    };
+    const res = await request.delete(
+      buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+>>>>>>> 4fa4510d (test: v2 role endpoints implemented)
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
@@ -13,6 +13,7 @@ import {
   buildUrl,
   assertRequiredFields,
   assertEqualsForKeys,
+<<<<<<< HEAD
   paginatedResponseFields,
 } from '../../../../utils/http';
 import {
@@ -22,10 +23,28 @@ import {
   roleRequiredFields,
 } from '../../../../utils/beans/request-beans';
 import {sleep} from '../../../../utils/sleep';
+=======
+  assertUnauthorizedRequest,
+  assertPaginatedRequest,
+} from '../../../../utils/http';
+import {
+  ROLE_EXPECTED_BODY,
+  roleRequiredFields,
+} from '../../../../utils/beans/requestBeans';
+import {
+  assignRoleToGroups,
+  createGroupAndStoreResponseFields,
+  roleNameFromState,
+  roleIdValueUsingKey,
+  assertRoleInResponse,
+} from '../../../../utils/requestHelpers';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+>>>>>>> 4fa4510d (test: v2 role endpoints implemented)
 
 test.describe('Group Roles API Tests', () => {
   const state: Record<string, unknown> = {};
 
+<<<<<<< HEAD
   test('CRUD', async ({request}) => {
     await test.step('Create Group', async () => {
       const requestBody = CREATE_NEW_GROUP();
@@ -79,14 +98,35 @@ test.describe('Group Roles API Tests', () => {
 
       const res = await request.post(
         buildUrl('/groups/{groupId}/roles/search', p),
+=======
+  test.beforeAll(async ({request}) => {
+    await createGroupAndStoreResponseFields(request, 1, state);
+    await assignRoleToGroups(request, 2, state['groupId1'] as string, state);
+  });
+
+  test('Search Group Roles', async ({request}) => {
+    const groupIdKey: string = 'groupId1';
+    const role1: string = roleIdValueUsingKey('groupId1', state, 1);
+    const role2: string = roleIdValueUsingKey('groupId1', state, 2);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/roles/search', {
+          groupId: state[groupIdKey] as string,
+        }),
+>>>>>>> 4fa4510d (test: v2 role endpoints implemented)
         {
           headers: jsonHeaders(),
           data: {},
         },
       );
 
-      expect(res.status()).toBe(200);
+      await assertPaginatedRequest(res, {
+        totalItemsEqualTo: 2,
+        itemsLengthEqualTo: 2,
+      });
       const json = await res.json();
+<<<<<<< HEAD
       assertRequiredFields(json, paginatedResponseFields);
       expect(json.page.totalItems).toBe(1);
       assertRequiredFields(json.items[0], roleRequiredFields);
@@ -182,4 +222,146 @@ test.describe('Group Roles API Tests', () => {
       expect(res.status()).toBe(404);
     });
   });
+=======
+      assertRoleInResponse(
+        json,
+        ROLE_EXPECTED_BODY(groupIdKey, state, 1),
+        role1,
+      );
+      assertRoleInResponse(
+        json,
+        ROLE_EXPECTED_BODY(groupIdKey, state, 2),
+        role2,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Group Roles Unauthorized', async ({request}) => {
+    const res = await request.post(
+      buildUrl('/groups/{groupId}/roles/search', {
+        groupId: state['groupId1'] as string,
+      }),
+      {
+        headers: {},
+        data: {},
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Group Roles Not Found', async ({request}) => {
+    const res = await request.post(
+      buildUrl('/groups/{groupId}/roles/search', {groupId: 'invalidGroup'}),
+      {
+        headers: jsonHeaders(),
+        data: {},
+      },
+    );
+
+    await assertPaginatedRequest(res, {
+      totalItemsEqualTo: 0,
+      itemsLengthEqualTo: 0,
+    });
+  });
+
+  test('Search Group Roles By Role Name', async ({request}) => {
+    const roleName: string = roleNameFromState('groupId1', state, 1);
+    const groupIdKey: string = 'groupId1';
+    const roleId: string = roleIdValueUsingKey('groupId1', state, 1);
+    const body = {
+      filter: {
+        name: roleName,
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/roles/search', {
+          groupId: state[groupIdKey] as string,
+        }),
+        {
+          headers: jsonHeaders(),
+          data: body,
+        },
+      );
+
+      await assertPaginatedRequest(res, {
+        totalItemsEqualTo: 1,
+        itemsLengthEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRoleInResponse(
+        json,
+        ROLE_EXPECTED_BODY(groupIdKey, state, 1),
+        roleId,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Group Roles By Role Id', async ({request}) => {
+    const roleId: string = roleIdValueUsingKey('groupId1', state, 2);
+    const groupIdKey: string = 'groupId1';
+    const body = {
+      filter: {
+        roleId: roleId,
+      },
+    };
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/roles/search', {
+          groupId: state[groupIdKey] as string,
+        }),
+        {
+          headers: jsonHeaders(),
+          data: body,
+        },
+      );
+
+      await assertPaginatedRequest(res, {
+        totalItemsEqualTo: 1,
+        itemsLengthEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRoleInResponse(
+        json,
+        ROLE_EXPECTED_BODY(groupIdKey, state, 2),
+        roleId,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Group Roles By Multiple Fields', async ({request}) => {
+    const roleId: string = roleIdValueUsingKey('groupId1', state, 1);
+    const roleName: string = roleNameFromState('groupId1', state, 1);
+    const groupIdKey: string = 'groupId1';
+    const body = {
+      filter: {
+        roleId: roleId,
+        name: roleName,
+      },
+    };
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/groups/{groupId}/roles/search', {
+          groupId: state[groupIdKey] as string,
+        }),
+        {
+          headers: jsonHeaders(),
+          data: body,
+        },
+      );
+
+      await assertPaginatedRequest(res, {
+        totalItemsEqualTo: 1,
+        itemsLengthEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRoleInResponse(
+        json,
+        ROLE_EXPECTED_BODY(groupIdKey, state, 1),
+        roleId,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+>>>>>>> 4fa4510d (test: v2 role endpoints implemented)
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
@@ -96,6 +96,18 @@ test.describe('Group Users API Tests', () => {
       const expectedBody = {username: state['username'] as string};
       const requiredFields = Object.keys(expectedBody);
 
+<<<<<<< HEAD
+=======
+  test('Search Users For Group', async ({request}) => {
+    const groupId: string = state['groupId2'] as string;
+    const expectedBody = CREATE_GROUP_USERS_EXPECTED_BODY_USING_GROUP(
+      'groupId2',
+      state,
+    );
+    const requiredFields = Object.keys(expectedBody);
+
+    await expect(async () => {
+>>>>>>> 4fa4510d (test: v2 role endpoints implemented)
       const res = await request.post(
         buildUrl('/groups/{groupId}/users/search', stateParams),
         {headers: jsonHeaders()},

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
@@ -1,0 +1,578 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertRequiredFields,
+  assertUnauthorizedRequest,
+  paginatedResponseFields,
+  assertNotFoundRequest,
+  assertEqualsForKeys,
+  assertBadRequest,
+  assertConflictRequest,
+  assertPaginatedRequest,
+} from '../../../utils/http';
+import {defaultAssertionOptions} from '../../../utils/constants';
+import {
+  CREATE_NEW_MAPPING_RULE,
+  mappingRuleBundle,
+  mappingRuleRequiredFields,
+} from '../../../utils/beans/requestBeans';
+
+test.describe.parallel('Mapping Rules API Tests', () => {
+  const state: Record<string, unknown> = {};
+  let mappingRule1: Record<string, unknown>;
+  let mappingRule2: Record<string, unknown>;
+  let mappingRule3: Record<string, unknown>;
+  let mappingRule4: Record<string, unknown>;
+
+  test.beforeAll(async ({request}) => {
+    mappingRule1 = await mappingRuleBundle(request, state);
+    mappingRule2 = await mappingRuleBundle(request, state);
+    mappingRule3 = await mappingRuleBundle(request, state);
+    mappingRule4 = await mappingRuleBundle(request, state);
+  });
+
+  test('Create Mapping Rule', async ({request}) => {
+    await expect(async () => {
+      const requestBody = CREATE_NEW_MAPPING_RULE();
+      const res = await request.post(buildUrl('/mapping-rules'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+
+      expect(res.status()).toBe(201);
+      const json = await res.json();
+      assertRequiredFields(json, mappingRuleRequiredFields);
+      assertEqualsForKeys(json, requestBody, mappingRuleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Mapping Rule Unauthorized', async ({request}) => {
+    const requestBody = CREATE_NEW_MAPPING_RULE();
+
+    const res = await request.post(buildUrl('/mapping-rules'), {
+      headers: {},
+      data: requestBody,
+    });
+
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Create Mapping Rule With Only Claim Name Invalid Body 400', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/mapping-rules'), {
+      headers: jsonHeaders(),
+      data: {claimName: 'claimName'},
+    });
+
+    await assertBadRequest(
+      res,
+      /.*\b(mappingRuleId|name|claimValue)\b.*/,
+      'INVALID_ARGUMENT',
+    );
+  });
+
+  test('Create Mapping Rule With Only Claim Value Invalid Body 400', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/mapping-rules'), {
+      headers: jsonHeaders(),
+      data: {claimValue: 'claimValue'},
+    });
+
+    await assertBadRequest(
+      res,
+      /.*\b(mappingRuleId|name|claimName)\b.*/,
+      'INVALID_ARGUMENT',
+    );
+  });
+
+  test('Create Mapping Rule With Only Name Invalid Body 400', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/mapping-rules'), {
+      headers: jsonHeaders(),
+      data: {name: 'name'},
+    });
+
+    await assertBadRequest(
+      res,
+      /.*\b(mappingRuleId|claimValue|claimName)\b.*/,
+      'INVALID_ARGUMENT',
+    );
+  });
+
+  test('Create Mapping Rule With Only Mapping Rule Id Invalid Body 400', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/mapping-rules'), {
+      headers: jsonHeaders(),
+      data: {mappingRuleId: 'mappingRuleId'},
+    });
+
+    await assertBadRequest(
+      res,
+      /.*\b(name|claimValue|claimName)\b.*/,
+      'INVALID_ARGUMENT',
+    );
+  });
+
+  test('Create Mapping Rule With Same Id Conflict', async ({request}) => {
+    const requestBody = {
+      ...CREATE_NEW_MAPPING_RULE(),
+      mappingRuleId: mappingRule1.mappingRuleId,
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Mapping Rule', async ({request}) => {
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl('/mapping-rules/{mappingRuleId}', {
+          mappingRuleId: mappingRule1.mappingRuleId as string,
+        }),
+        {headers: jsonHeaders()},
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json,
+        mappingRule1.responseBody as Record<string, unknown>,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Mapping Rule Not Found', async ({request}) => {
+    const p = {mappingRuleId: 'does-not-exist'};
+    const res = await request.get(
+      buildUrl('/mapping-rules/{mappingRuleId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Mapping Rule with id '${p.mappingRuleId}' not found`,
+    );
+  });
+
+  test('Get Mapping Rule Unauthorized', async ({request}) => {
+    const p = {
+      mappingRuleId: mappingRule1.mappingRuleId as string,
+    };
+
+    const res = await request.get(
+      buildUrl('/mapping-rules/{mappingRuleId}', p),
+      {headers: {}},
+    );
+
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Mapping Rules', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+        headers: jsonHeaders(),
+        data: {},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemLengthGreaterThan: 2,
+        totalItemGreaterThan: 2,
+      });
+      const json = await res.json();
+
+      const matchingItem1 = json.items.find(
+        (it: {mappingRuleId: string}) =>
+          it.mappingRuleId === mappingRule1.mappingRuleId,
+      );
+      expect(matchingItem1).toBeDefined();
+      assertRequiredFields(matchingItem1, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        matchingItem1,
+        mappingRule1.responseBody as Record<string, unknown>,
+        mappingRuleRequiredFields,
+      );
+
+      const matchingItem2 = json.items.find(
+        (it: {mappingRuleId: string}) =>
+          it.mappingRuleId === mappingRule2.mappingRuleId,
+      );
+      expect(matchingItem2).toBeDefined();
+      assertRequiredFields(matchingItem2, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        matchingItem2,
+        mappingRule2.responseBody as Record<string, unknown>,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules By Id', async ({request}) => {
+    const body = {
+      filter: {
+        mappingRuleId: mappingRule2.mappingRuleId,
+      },
+    };
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      assertRequiredFields(json.items[0], mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json.items[0],
+        mappingRule2.responseBody as Record<string, unknown>,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules By Name', async ({request}) => {
+    const mappingRule = mappingRule1.responseBody as Record<string, unknown>;
+    const body = {
+      filter: {
+        name: mappingRule.name as string,
+      },
+    };
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRequiredFields(json.items[0], mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json.items[0],
+        mappingRule,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules By Claim Value', async ({request}) => {
+    const mappingRule = mappingRule2.responseBody as Record<string, unknown>;
+    const body = {
+      filter: {
+        claimValue: mappingRule.claimValue as string,
+      },
+    };
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRequiredFields(json.items[0], mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json.items[0],
+        mappingRule,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules By Claim Name', async ({request}) => {
+    const mappingRule = mappingRule2.responseBody as Record<string, unknown>;
+    const body = {
+      filter: {
+        claimName: mappingRule.claimName as string,
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRequiredFields(json.items[0], mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json.items[0],
+        mappingRule,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules No Matching Item', async ({request}) => {
+    const body = {
+      filter: {
+        mappingRuleId: 'invalidMappingRule',
+      },
+    };
+
+    const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+
+  test('Search Mapping Rules By Multiple Fields', async ({request}) => {
+    const mappingRule = mappingRule2.responseBody as Record<string, unknown>;
+    const body = {
+      filter: {
+        mappingRuleId: mappingRule2.mappingRuleId as string,
+        claimName: mappingRule.claimName as string,
+        claimValue: mappingRule.claimValue as string,
+        name: mappingRule.name as string,
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertRequiredFields(json.items[0], mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        json.items[0],
+        mappingRule,
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Mapping Rules Unauthorized', async ({request}) => {
+    const res = await request.post(buildUrl('/mapping-rules/search', {}), {
+      headers: {},
+      data: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Update Mapping Rule', async ({request}) => {
+    const p = {mappingRuleId: mappingRule3.mappingRuleId as string};
+    const mappingRule = mappingRule3.responseBody as Record<string, unknown>;
+    const updateBody = {
+      claimName: `${mappingRule.claimName}-updated`,
+      claimValue: `${mappingRule.claimValue}-updated`,
+      name: `${mappingRule.name}-updated`,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+          data: updateBody,
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, mappingRuleRequiredFields);
+      expect(json.claimName).toBe(updateBody.claimName);
+      expect(json.name).toBe(updateBody.name);
+      expect(json.claimValue).toBe(updateBody.claimValue);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Mapping Rule With Only Claim Name Invalid Body 400', async ({
+    request,
+  }) => {
+    const p = {mappingRuleId: mappingRule3.mappingRuleId as string};
+    const mappingRule = mappingRule3.responseBody as Record<string, unknown>;
+    const updateBody = {
+      claimName: `${mappingRule.claimName}-updated`,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+          data: updateBody,
+        },
+      );
+
+      await assertBadRequest(
+        res,
+        /.*\b(mappingRuleId|name|claimValue)\b.*/,
+        'INVALID_ARGUMENT',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Mapping Rule With Only Claim Value Invalid Body 400', async ({
+    request,
+  }) => {
+    const p = {mappingRuleId: mappingRule3.mappingRuleId as string};
+    const mappingRule = mappingRule3.responseBody as Record<string, unknown>;
+    const updateBody = {
+      claimValue: `${mappingRule.claimValue}-updated`,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+          data: updateBody,
+        },
+      );
+      await assertBadRequest(
+        res,
+        /.*\b(mappingRuleId|name|claimName)\b.*/,
+        'INVALID_ARGUMENT',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Mapping Rule With Only Name Invalid Body 400', async ({
+    request,
+  }) => {
+    const p = {mappingRuleId: mappingRule3.mappingRuleId as string};
+    const mappingRule = mappingRule3.responseBody as Record<string, unknown>;
+    const updateBody = {
+      name: `${mappingRule.name}-updated`,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+          data: updateBody,
+        },
+      );
+
+      await assertBadRequest(
+        res,
+        /.*\b(mappingRuleId|claimValue|claimName)\b.*/,
+        'INVALID_ARGUMENT',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Mapping Rule Not Found', async ({request}) => {
+    const p = {mappingRuleId: 'missing-id'};
+    const res = await request.put(
+      buildUrl('/mapping-rules/{mappingRuleId}', p),
+      {
+        headers: jsonHeaders(),
+        data: {
+          claimName: 'new-value',
+          claimValue: 'new-value',
+          name: 'new-value',
+        },
+      },
+    );
+
+    await assertNotFoundRequest(
+      res,
+      `Command 'UPDATE' rejected with code 'NOT_FOUND`,
+    );
+  });
+
+  test('Update Mapping Rule Unauthorized', async ({request}) => {
+    const p = {mappingRuleId: mappingRule3.mappingRuleId as string};
+    const res = await request.put(
+      buildUrl('/mapping-rules/{mappingRuleId}', p),
+      {
+        headers: {},
+        data: {
+          claimName: 'new-value',
+          claimValue: 'new-value',
+          name: 'new-value',
+        },
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Delete Mapping Rule', async ({request}) => {
+    const p = {mappingRuleId: mappingRule4.mappingRuleId as string};
+
+    await test.step('Delete Mapping Rule', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/mapping-rules/{mappingRuleId}', p),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Get Mapping Rule After Deletion', async () => {
+      await expect(async () => {
+        const resGet = await request.get(
+          buildUrl('/mapping-rules/{mappingRuleId}', p),
+          {headers: jsonHeaders()},
+        );
+        await assertNotFoundRequest(
+          resGet,
+          `Mapping Rule with id '${p.mappingRuleId}' not found`,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Delete Mapping Rule Not Found', async ({request}) => {
+    const p = {mappingRuleId: 'non-existent-rule'};
+    const res = await request.delete(
+      buildUrl('/mapping-rules/{mappingRuleId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'DELETE' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Delete Mapping Rule Unauthorized', async ({request}) => {
+    const p = {mappingRuleId: state['mappingRuleId1'] as string};
+    const res = await request.delete(
+      buildUrl('/mapping-rules/{mappingRuleId}', p),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-api-tests.spec.ts
@@ -1,0 +1,419 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertRequiredFields,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  assertEqualsForKeys,
+  assertBadRequest,
+  assertPaginatedRequest,
+} from '../../../../utils/http';
+import {
+  CREATE_NEW_ROLE,
+  roleRequiredFields,
+  UPDATE_ROLE,
+} from '../../../../utils/beans/requestBeans';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  assertRoleInResponse,
+  createRoleAndStoreResponseFields,
+} from '../../../../utils/requestHelpers';
+
+test.describe.parallel('Roles API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createRoleAndStoreResponseFields(request, 3, state);
+  });
+
+  test('Create Role', async ({request}) => {
+    await expect(async () => {
+      const role = CREATE_NEW_ROLE();
+      const res = await request.post(buildUrl('/roles'), {
+        headers: jsonHeaders(),
+        data: role,
+      });
+
+      expect(res.status()).toBe(201);
+      const json = await res.json();
+      assertRequiredFields(json, roleRequiredFields);
+      assertEqualsForKeys(json, role, roleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Role Unauthorized', async ({request}) => {
+    const res = await request.post(buildUrl('/roles'), {
+      headers: {},
+      data: CREATE_NEW_ROLE(),
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Create Role Missing Name Invalid Body 400', async ({request}) => {
+    const body = {description: 'only description provided'};
+    const res = await request.post(buildUrl('/roles'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, /.*\b(name)\b.*/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Create Role Empty Name Invalid Body 400', async ({request}) => {
+    const body = {name: '', description: 'empty name'};
+    const res = await request.post(buildUrl('/roles'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, /.*\b(name)\b.*/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Create Role Missing Role Id Invalid Body 400', async ({request}) => {
+    const body = {name: 'role name', description: 'only description provided'};
+    const res = await request.post(buildUrl('/roles'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertBadRequest(res, /.*\b(roleId)\b.*/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Create Role Conflict', async ({request}) => {
+    await expect(async () => {
+      const role = CREATE_NEW_ROLE();
+      role['roleId'] = state['roleId1'] as string;
+      const res = await request.post(buildUrl('/roles'), {
+        headers: jsonHeaders(),
+        data: role,
+      });
+
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Role', async ({request}) => {
+    const p = {roleId: state['roleId1'] as string};
+    const expectedBody = {
+      roleId: state['roleId1'],
+      name: state['roleName1'],
+      description: state['roleDescription1'],
+    };
+
+    await expect(async () => {
+      const res = await request.get(buildUrl('/roles/{roleId}', p), {
+        headers: jsonHeaders(),
+      });
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, roleRequiredFields);
+      assertEqualsForKeys(json, expectedBody, roleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Role Unauthorized', async ({request}) => {
+    const p = {roleId: state['roleId2'] as string};
+    const res = await request.get(buildUrl('/roles/{roleId}', p), {
+      headers: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Get Role Not Found', async ({request}) => {
+    const p = {roleId: 'does-not-exist'};
+    const res = await request.get(buildUrl('/roles/{roleId}', p), {
+      headers: jsonHeaders(),
+    });
+    await assertNotFoundRequest(res, `Role with id '${p.roleId}' not found`);
+  });
+
+  test('Update Role', async ({request}) => {
+    const p = {roleId: state['roleId2'] as string};
+    const requestBody = UPDATE_ROLE();
+    const expectedBody = {
+      ...p,
+      ...requestBody,
+    };
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/roles/{roleId}', p), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, roleRequiredFields);
+      assertEqualsForKeys(json, expectedBody, roleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Role Empty Name Invalid Body 400', async ({request}) => {
+    const p = {roleId: state['roleId1'] as string};
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/roles/{roleId}', p), {
+        headers: jsonHeaders(),
+        data: {name: ''},
+      });
+      await assertBadRequest(res, /.*\b(name)\b.*/i, 'INVALID_ARGUMENT');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Role Missing Name Invalid Body 400', async ({request}) => {
+    const p = {roleId: state['roleId1'] as string};
+
+    await expect(async () => {
+      const res = await request.put(buildUrl('/roles/{roleId}', p), {
+        headers: jsonHeaders(),
+        data: {description: 'missing name only description'},
+      });
+      await assertBadRequest(res, /.*\b(name)\b.*/i, 'INVALID_ARGUMENT');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Role Missing Description Invalid Body 400', async ({
+    request,
+  }) => {
+    const p = {roleId: state['roleId1'] as string};
+    await expect(async () => {
+      const res = await request.put(buildUrl('/roles/{roleId}', p), {
+        headers: jsonHeaders(),
+        data: {name: 'missing description'},
+      });
+
+      await assertBadRequest(res, /.*\b(description)\b.*/i, 'INVALID_ARGUMENT');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Role Unauthorized', async ({request}) => {
+    const p = {roleId: state['roleId2'] as string};
+    const requestBody = UPDATE_ROLE();
+
+    const res = await request.put(buildUrl('/roles/{roleId}', p), {
+      headers: {},
+      data: requestBody,
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Update Role Not Found', async ({request}) => {
+    const p = {roleId: 'invalid-role'};
+    const res = await request.put(buildUrl('/roles/{roleId}', p), {
+      headers: jsonHeaders(),
+      data: UPDATE_ROLE(),
+    });
+    await assertNotFoundRequest(
+      res,
+      "Command 'UPDATE' rejected with code 'NOT_FOUND'",
+    );
+  });
+
+  test('Delete Role', async ({request}) => {
+    const p = {roleId: state['roleId3'] as string};
+    await test.step('Delete Role 204', async () => {
+      await expect(async () => {
+        const res = await request.delete(buildUrl('/roles/{roleId}', p), {
+          headers: jsonHeaders(),
+        });
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Get Role After Deletion', async () => {
+      await expect(async () => {
+        const after = await request.get(buildUrl('/roles/{roleId}', p), {
+          headers: jsonHeaders(),
+        });
+        await assertNotFoundRequest(
+          after,
+          `Role with id '${p.roleId}' not found`,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Delete Role Unauthorized', async ({request}) => {
+    const p = {roleId: state['roleId3'] as string};
+    const res = await request.delete(buildUrl('/roles/{roleId}', p), {
+      headers: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Delete Role Not Found', async ({request}) => {
+    const p = {roleId: 'invalid-role'};
+    const res = await request.delete(buildUrl('/roles/{roleId}', p), {
+      headers: jsonHeaders(),
+    });
+    await assertNotFoundRequest(
+      res,
+      "Command 'DELETE' rejected with code 'NOT_FOUND",
+    );
+  });
+
+  test('Search Roles', async ({request}) => {
+    const role1ExpectedBody = {
+      roleId: state['roleId1'],
+      name: state['roleName1'],
+      description: state['roleDescription1'],
+    };
+    const role2ExpectedBody = {
+      roleId: state['roleId2'],
+      name: state['roleName2'],
+      description: state['roleDescription2'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/roles/search'), {
+        headers: jsonHeaders(),
+        data: {},
+      });
+
+      await assertPaginatedRequest(res, {
+        itemLengthGreaterThan: 2,
+        totalItemGreaterThan: 2,
+      });
+      const json = await res.json();
+      assertRoleInResponse(
+        json,
+        role1ExpectedBody,
+        role1ExpectedBody.roleId as string,
+      );
+      assertRoleInResponse(
+        json,
+        role2ExpectedBody,
+        role2ExpectedBody.roleId as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Roles By Name', async ({request}) => {
+    const roleName = state['roleName1'];
+    const body = {
+      filter: {
+        name: roleName,
+      },
+    };
+    const expectedBody = {
+      roleId: state['roleId1'],
+      name: state['roleName1'],
+      description: state['roleDescription1'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/roles/search'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      expect(item).toBeDefined();
+      assertRequiredFields(item, roleRequiredFields);
+      assertEqualsForKeys(item, expectedBody, roleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Roles By Role Id', async ({request}) => {
+    const roleId = state['roleId2'];
+    const body = {
+      filter: {
+        roleId: roleId,
+      },
+    };
+    const expectedBody = {
+      roleId: state['roleId2'],
+      name: state['roleName2'],
+      description: state['roleDescription2'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/roles/search'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      expect(item).toBeDefined();
+      assertRequiredFields(item, roleRequiredFields);
+      assertEqualsForKeys(item, expectedBody, roleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Roles By Multiple Fields', async ({request}) => {
+    const requestBody = {
+      filter: {
+        roleId: state['roleId1'],
+        name: state['roleName1'],
+      },
+    };
+    const expectedBody = {
+      ...requestBody.filter,
+      description: state['roleDescription1'],
+    };
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/roles/search'), {
+        headers: jsonHeaders(),
+        data: requestBody,
+      });
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      expect(item).toBeDefined();
+      assertRequiredFields(item, roleRequiredFields);
+      assertEqualsForKeys(item, expectedBody, roleRequiredFields);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Roles By Invalid Id', async ({request}) => {
+    const body = {
+      filter: {
+        roleId: 'invalidRoleId',
+      },
+    };
+
+    const res = await request.post(buildUrl('/roles/search'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+
+  test('Search Roles Unauthorized', async ({request}) => {
+    const body = {
+      filter: {
+        name: state['roleName1'],
+      },
+    };
+    const res = await request.post(buildUrl('/roles/search'), {
+      headers: {},
+      data: body,
+    });
+    await assertUnauthorizedRequest(res);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-clients-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-clients-api-tests.spec.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  assertPaginatedRequest,
+} from '../../../../utils/http';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+import {
+  assertClientsInResponse,
+  assignClientsToRole,
+  clientFromState,
+  createRole,
+} from '../../../../utils/requestHelpers';
+
+test.describe.parallel('Role Clients API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createRole(request, state, '1');
+    await createRole(request, state, '2');
+    await assignClientsToRole(request, 3, state['roleId1'] as string, state);
+    await assignClientsToRole(request, 1, state['roleId2'] as string, state);
+  });
+
+  test('Assign Role To Client', async ({request}) => {
+    const role = await createRole(request);
+    const clientId = 'test-client' + generateUniqueId();
+    const p = {clientId, roleId: role.roleId as string};
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/clients/{clientId}', p),
+        {headers: jsonHeaders()},
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Role To Client Non Existent Client Success', async ({
+    request,
+  }) => {
+    const p = {clientId: 'invalidClientId', roleId: state['roleId1'] as string};
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    expect(res.status()).toBe(204);
+  });
+
+  test('Assign Role To Client Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      clientId: clientFromState('roleId1', state) as string,
+      roleId: 'invalidRoleId',
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Role To Client Unauthorized', async ({request}) => {
+    const roleId = state['roleId1'] as string;
+    const p = {
+      clientId: clientFromState('roleId1', state) as string,
+      roleId,
+    };
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/clients/{clientId}', p),
+        {headers: {}},
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Already Added Client To Role Conflict', async ({request}) => {
+    const p = {
+      clientId: clientFromState('roleId1', state) as string,
+      roleId: state['roleId1'] as string,
+    };
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/clients/{clientId}', p),
+        {headers: jsonHeaders()},
+      );
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Clients', async ({request}) => {
+    const client1 = clientFromState('roleId1', state, 1);
+    const client2 = clientFromState('roleId1', state, 2);
+    const client3 = clientFromState('roleId1', state, 3);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/clients/search', {
+          roleId: state['roleId1'] as string,
+        }),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        totalItemsEqualTo: 3,
+        itemsLengthEqualTo: 3,
+      });
+      const json = await res.json();
+      assertClientsInResponse(json, client1);
+      assertClientsInResponse(json, client2);
+      assertClientsInResponse(json, client3);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Clients Unauthorized', async ({request}) => {
+    const p = {roleId: state['roleId1'] as string};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/clients/search', p),
+      {headers: {}, data: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Role Clients For Non Existent Role Empty', async ({request}) => {
+    const p = {roleId: 'invalidRoleId'};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/clients/search', p),
+      {headers: jsonHeaders(), data: {}},
+    );
+    await assertPaginatedRequest(res, {
+      totalItemsEqualTo: 0,
+      itemsLengthEqualTo: 0,
+    });
+  });
+
+  test('Unassign Role From Client', async ({request}) => {
+    const roleId = state['roleId2'] as string;
+    const clientId = clientFromState('roleId2', state, 1);
+    const p = {roleId: roleId, clientId: clientId};
+
+    await test.step('Unassign Role From Client', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/roles/{roleId}/clients/{clientId}', p),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Role Clients After Unassign', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/roles/{roleId}/clients/search', p),
+          {headers: jsonHeaders(), data: {}},
+        );
+        await assertPaginatedRequest(res, {
+          totalItemsEqualTo: 0,
+          itemsLengthEqualTo: 0,
+        });
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Unassign Role From Client Unauthorized', async ({request}) => {
+    const roleId = state['roleId1'] as string;
+    const clientId = clientFromState('roleId1', state, 1);
+    const p = {roleId: roleId, clientId: clientId};
+
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/clients/{clientId}', p),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign Role From Client Non Existent Client Not Found', async ({
+    request,
+  }) => {
+    const p = {clientId: 'invalidClientId', roleId: state['roleId1'] as string};
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Unassign Role From Client Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const clientId = clientFromState('roleId1', state, 1);
+    const p = {clientId, roleId: 'invalidRoleId'};
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-groups-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-groups-api-tests.spec.ts
@@ -1,0 +1,283 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertRequiredFields,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  paginatedResponseFields,
+  assertPaginatedRequest,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  assertGroupsInResponse,
+  assignGroupsToRole,
+  createGroupAndStoreResponseFields,
+  createRole,
+  groupIdFromState,
+} from '../../../../utils/requestHelpers';
+import {ROLE_GROUP_EXPECTED_BODY} from '../../../../utils/beans/requestBeans';
+
+test.describe.parallel('Role Groups API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createRole(request, state, '1');
+    await createRole(request, state, '2');
+    await createRole(request, state, '3');
+    await assignGroupsToRole(request, 2, 'roleId1', state);
+    await assignGroupsToRole(request, 3, 'roleId2', state);
+    await assignGroupsToRole(request, 3, 'roleId3', state);
+  });
+
+  test('Assign Group To Role', async ({request}) => {
+    const groupKey = `${state['roleId1']}6`;
+    await createGroupAndStoreResponseFields(request, 1, state, groupKey);
+    const p = {
+      groupId: groupIdFromState(groupKey, state, 6) as string,
+      roleId: state['roleId1'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/groups/{groupId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Group To Role Non Existent Group Not Found', async ({
+    request,
+  }) => {
+    const stateParams: Record<string, string> = {
+      groupId: 'invalidGroupId',
+      roleId: state['roleId1'] as string,
+    };
+
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/groups/{groupId}', stateParams),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Group To Role Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const stateParams: Record<string, string> = {
+      groupId: groupIdFromState('roleId1', state) as string,
+      roleId: 'invalidRoleId',
+    };
+
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/groups/{groupId}', stateParams),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Group To Role Unauthorized', async ({request}) => {
+    const stateParams: Record<string, string> = {
+      groupId: groupIdFromState('roleId1', state) as string,
+      roleId: state['role1'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/groups/{groupId}', stateParams),
+        {
+          headers: {},
+        },
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Already Added Group To Role Conflict', async ({request}) => {
+    const stateParams: Record<string, string> = {
+      groupId: groupIdFromState('roleId1', state) as string,
+      roleId: state['roleId1'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/groups/{groupId}', stateParams),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Unassign Group From Role', async ({request}) => {
+    const p = {
+      groupId: groupIdFromState('roleId2', state) as string,
+      roleId: state['roleId2'] as string,
+    };
+    await test.step('Unassign Role From Group', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/roles/{roleId}/groups/{groupId}', p),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Group Roles For Group After Deletion', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/groups/{groupId}/roles/search', p),
+          {
+            headers: jsonHeaders(),
+            data: {},
+          },
+        );
+
+        expect(res.status()).toBe(200);
+        const json = await res.json();
+        assertRequiredFields(json, paginatedResponseFields);
+        expect(json.page.totalItems).toBe(0);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Unassign Role From Group Unauthorized', async ({request}) => {
+    const p = {
+      groupId: groupIdFromState('roleId2', state) as string,
+      roleId: state['roleId2'] as string,
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/groups/{groupId}', p),
+      {
+        headers: {},
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign Role From Group Non Existent Group Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      groupId: 'invalidGroupId',
+      roleId: state['roleId2'] as string,
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/groups/{groupId}', p),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Unassign Role From Group Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      groupId: groupIdFromState('roleId2', state) as string,
+      roleId: 'invalidRoleId',
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/groups/{groupId}', p),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Search Role Groups', async ({request}) => {
+    const p = {roleId: state['roleId3'] as string};
+    const group1 = groupIdFromState('roleId3', state, 1);
+    const group2 = groupIdFromState('roleId3', state, 2);
+    const group3 = groupIdFromState('roleId3', state, 3);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/groups/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 3,
+        totalItemsEqualTo: 3,
+      });
+      const json = await res.json();
+      assertGroupsInResponse(json, ROLE_GROUP_EXPECTED_BODY(group1), group1);
+      assertGroupsInResponse(json, ROLE_GROUP_EXPECTED_BODY(group2), group2);
+      assertGroupsInResponse(json, ROLE_GROUP_EXPECTED_BODY(group3), group3);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Groups Role With No Assignments Returns Empty', async ({
+    request,
+  }) => {
+    const role = await createRole(request);
+    const p = {roleId: role.roleId as string};
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/groups/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 0,
+        totalItemsEqualTo: 0,
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Groups Unauthorized', async ({request}) => {
+    const p = {roleId: state['roleId3'] as string};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/groups/search', p),
+      {headers: {}, data: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Role Groups Role Not Found', async ({request}) => {
+    const p = {roleId: 'invalid-role-id'};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/groups/search', p),
+      {headers: jsonHeaders(), data: {}},
+    );
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-mapping-rules-api-tests.spec.ts
@@ -1,0 +1,403 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  assertPaginatedRequest,
+  assertRequiredFields,
+  assertEqualsForKeys,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  assignRolesToMappingRules,
+  createMappingRule,
+  createRole,
+  createRoleAndStoreResponseFields,
+  mappingRuleIdFromState,
+  mappingRuleNameFromState,
+} from '../../../../utils/requestHelpers';
+import {
+  MAPPING_RULE_EXPECTED_BODY_USING_STATE,
+  mappingRuleRequiredFields,
+} from '../../../../utils/beans/requestBeans';
+
+test.describe.parallel('Role Mapping Rules API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createRoleAndStoreResponseFields(request, 3, state);
+    await assignRolesToMappingRules(
+      request,
+      2,
+      state['roleId2'] as string,
+      state,
+    );
+    await assignRolesToMappingRules(
+      request,
+      1,
+      state['roleId3'] as string,
+      state,
+    );
+  });
+
+  test('Assign Role To Mapping Rule', async ({request}) => {
+    const body = await createMappingRule(request);
+    const p = {
+      roleId: state['roleId1'] as string,
+      mappingRuleId: body.mappingRuleId as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+        {headers: jsonHeaders()},
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Role To Mapping Rule Non Existent Mapping Rule Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      roleId: state['roleId1'] as string,
+      mappingRuleId: 'invalidMappingRuleId',
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Role To Mapping Rule Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      roleId: 'invalidRoleId',
+      mappingRuleId: mappingRuleIdFromState('roleId1', state) as string,
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Role To Mapping Rule Unauthorized', async ({request}) => {
+    const p = {
+      roleId: state['roleId1'] as string,
+      mappingRuleId: mappingRuleIdFromState('roleId1', state) as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+        {headers: {}},
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Already Added Mapping Rule To Role Conflict', async ({
+    request,
+  }) => {
+    const p = {
+      roleId: state['roleId1'] as string,
+      mappingRuleId: mappingRuleIdFromState('roleId2', state) as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+        {headers: jsonHeaders()},
+      );
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Unassign Role From Mapping Rule', async ({request}) => {
+    const p = {
+      roleId: state['roleId3'] as string,
+      mappingRuleId: mappingRuleIdFromState('roleId3', state) as string,
+    };
+    await test.step('Unassign Role From Mapping Rule', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Roles For Mapping Rule After Deletion', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/roles/{roleId}/mapping-rules/search', p),
+          {headers: jsonHeaders(), data: {}},
+        );
+        await assertPaginatedRequest(res, {
+          totalItemsEqualTo: 0,
+          itemsLengthEqualTo: 0,
+        });
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Unassign Role From Mapping Rule Unauthorized', async ({request}) => {
+    const p = {
+      roleId: state['roleId2'] as string,
+      mappingRuleId: mappingRuleIdFromState('roleId2', state) as string,
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign Role From Mapping Rule Non Existent Mapping Rule Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      roleId: state['roleId2'] as string,
+      mappingRuleId: 'invalidMappingRuleId',
+    };
+
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Unassign Role From Mapping Rule Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      roleId: 'invalidRoleId',
+      mappingRuleId: mappingRuleIdFromState('roleId2', state) as string,
+    };
+
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Search Role Mapping Rules', async ({request}) => {
+    const mappingRule1 = mappingRuleIdFromState('roleId2', state, 1) as string;
+    const mappingRule2 = mappingRuleIdFromState('roleId2', state, 2) as string;
+    const p = {
+      roleId: state['roleId2'] as string,
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 2,
+        totalItemsEqualTo: 2,
+      });
+      const json = await res.json();
+      const matchingItem1 = json.items.find(
+        (it: {mappingRuleId: string}) => it.mappingRuleId === mappingRule1,
+      );
+
+      expect(matchingItem1).toBeDefined();
+      assertRequiredFields(matchingItem1, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        matchingItem1,
+        MAPPING_RULE_EXPECTED_BODY_USING_STATE('roleId2', state, 1),
+        mappingRuleRequiredFields,
+      );
+
+      const matchingItem2 = json.items.find(
+        (it: {mappingRuleId: string}) => it.mappingRuleId === mappingRule2,
+      );
+      expect(matchingItem2).toBeDefined();
+      assertRequiredFields(matchingItem2, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        matchingItem2,
+        MAPPING_RULE_EXPECTED_BODY_USING_STATE('roleId2', state, 2),
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Mapping Rules Filter By mappingRuleId', async ({
+    request,
+  }) => {
+    const p = {roleId: state.roleId2 as string};
+    const filterBody = {
+      filter: {
+        mappingRuleId: mappingRuleIdFromState('roleId2', state) as string,
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: filterBody},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      assertRequiredFields(item, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        item,
+        MAPPING_RULE_EXPECTED_BODY_USING_STATE('roleId2', state, 1),
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Mapping Rules Filter By name', async ({request}) => {
+    const p = {roleId: state.roleId2 as string};
+    const filterBody = {
+      filter: {
+        name: mappingRuleNameFromState('roleId2', state, 2) as string,
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: filterBody},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      assertRequiredFields(item, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        item,
+        MAPPING_RULE_EXPECTED_BODY_USING_STATE('roleId2', state, 2),
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Mapping Rules Filter By multiple fields', async ({
+    request,
+  }) => {
+    const p = {roleId: state.roleId2 as string};
+    const filterBody = {
+      filter: {
+        name: mappingRuleNameFromState('roleId2', state, 2) as string,
+        mappingRuleId: mappingRuleIdFromState('roleId2', state, 2) as string,
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: filterBody},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      const item = json.items[0];
+      assertRequiredFields(item, mappingRuleRequiredFields);
+      assertEqualsForKeys(
+        item,
+        MAPPING_RULE_EXPECTED_BODY_USING_STATE('roleId2', state, 2),
+        mappingRuleRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Mapping Rules Filter Non Matching Returns Empty', async ({
+    request,
+  }) => {
+    const p = {roleId: state.roleId2 as string};
+    const body = {
+      filter: {
+        mappingRuleId: 'non-existent-mapping-rule',
+      },
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: body},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 0,
+        totalItemsEqualTo: 0,
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Mapping Rules Role With No Assignments Returns Empty', async ({
+    request,
+  }) => {
+    const lonelyRole = await createRole(request);
+    const p = {roleId: lonelyRole.roleId as string};
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/mapping-rules/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 0,
+        totalItemsEqualTo: 0,
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Mapping Rules Unauthorized', async ({request}) => {
+    const p = {roleId: state.roleId2 as string};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/mapping-rules/search', p),
+      {headers: {}, data: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Role Mapping Rules Role Not Found', async ({request}) => {
+    const p = {roleId: 'invalid-role-id'};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/mapping-rules/search', p),
+      {headers: jsonHeaders(), data: {}},
+    );
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-users-api-tests.spec.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertConflictRequest,
+  assertPaginatedRequest,
+} from '../../../../utils/http';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+import {
+  assertUsersInResponse,
+  assignRoleToUsers,
+  createRole,
+  userFromState,
+} from '../../../../utils/requestHelpers';
+
+test.describe.parallel('Role Users API Tests', () => {
+  const state: Record<string, unknown> = {};
+
+  test.beforeAll(async ({request}) => {
+    await createRole(request, state, '1');
+    await createRole(request, state, '2');
+    await assignRoleToUsers(request, 3, state['roleId1'] as string, state);
+    await assignRoleToUsers(request, 1, state['roleId2'] as string, state);
+  });
+
+  test('Assign Role To User', async ({request}) => {
+    const role = await createRole(request);
+    const user = 'test-user' + generateUniqueId();
+    const p = {
+      userId: user,
+      roleId: role.roleId as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/users/{userId}', p),
+        {headers: jsonHeaders()},
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Role To User Non Existent User Success', async ({request}) => {
+    const p = {
+      userId: 'invalidUserId',
+      roleId: state['roleId1'] as string,
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/users/{userId}', p),
+      {headers: jsonHeaders()},
+    );
+    expect(res.status()).toBe(204);
+  });
+
+  test('Assign Role To User Non Existent Role Not Found', async ({request}) => {
+    const p = {
+      userId: userFromState('roleId1', state) as string,
+      roleId: 'invalidRoleId',
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/users/{userId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Assign Role To User Unauthorized', async ({request}) => {
+    const roleId: string = state['roleId1'] as string;
+    const p = {
+      userId: userFromState('roleId1', state) as string,
+      roleId: roleId,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/users/{userId}', p),
+        {headers: {}},
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign Already Added User To Role Conflict', async ({request}) => {
+    const roleId: string = state['roleId1'] as string;
+    const p = {
+      userId: userFromState('roleId1', state) as string,
+      roleId: roleId,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/users/{userId}', p),
+        {headers: jsonHeaders()},
+      );
+      await assertConflictRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Users', async ({request}) => {
+    const roleId: string = state['roleId1'] as string;
+    const p = {roleId: roleId};
+    const user1: string = userFromState('roleId1', state, 1);
+    const user2: string = userFromState('roleId1', state, 2);
+    const user3: string = userFromState('roleId1', state, 3);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/roles/{roleId}/users/search', p),
+        {headers: jsonHeaders(), data: {}},
+      );
+      await assertPaginatedRequest(res, {
+        totalItemsEqualTo: 3,
+        itemsLengthEqualTo: 3,
+      });
+      const json = await res.json();
+      assertUsersInResponse(json, user1);
+      assertUsersInResponse(json, user2);
+      assertUsersInResponse(json, user3);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Role Users Unauthorized', async ({request}) => {
+    const roleId: string = state['roleId1'] as string;
+    const p = {userId: userFromState(roleId, state) as string};
+    const res = await request.post(
+      buildUrl('/roles/{userId}/users/search', p),
+      {headers: {}, data: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Role Users For Non Existent User Empty', async ({request}) => {
+    const p = {roleId: 'invalidRoleId'};
+    const res = await request.post(
+      buildUrl('/roles/{roleId}/users/search', p),
+      {headers: jsonHeaders(), data: {}},
+    );
+
+    await assertPaginatedRequest(res, {
+      totalItemsEqualTo: 0,
+      itemsLengthEqualTo: 0,
+    });
+  });
+
+  test('Unassign Role From User', async ({request}) => {
+    const roleId: string = state['roleId2'] as string;
+    const roleUser: string = userFromState('roleId2', state, 1);
+    const p = {
+      userId: roleUser,
+      roleId: roleId,
+    };
+
+    await test.step('Unassign Role From User', async () => {
+      await expect(async () => {
+        const res = await request.delete(
+          buildUrl('/roles/{roleId}/users/{userId}', p),
+          {headers: jsonHeaders()},
+        );
+        expect(res.status()).toBe(204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Role Users After Unassign', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/roles/{userId}/users/search', p),
+          {headers: jsonHeaders(), data: {}},
+        );
+        await assertPaginatedRequest(res, {
+          totalItemsEqualTo: 0,
+          itemsLengthEqualTo: 0,
+        });
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Unassign Role From User Unauthorized', async ({request}) => {
+    const roleId: string = state['roleId1'] as string;
+    const p = {
+      userId: userFromState('roleId1', state) as string,
+      roleId: roleId,
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/users/{userId}', p),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Unassign Role From User Non Existent User Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      userId: 'invalidUserId',
+      roleId: state['roleId1'] as string,
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/users/{userId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+
+  test('Unassign Role From User Non Existent Role Not Found', async ({
+    request,
+  }) => {
+    const p = {
+      userId: userFromState('roleId1', state) as string,
+      roleId: 'invalidRoleId',
+    };
+    const res = await request.delete(
+      buildUrl('/roles/{roleId}/users/{userId}', p),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -1,0 +1,303 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {generateUniqueId} from '../constants';
+import * as fs from 'node:fs';
+import {
+  createMappingRule,
+  roleDescriptionFromState,
+  roleNameFromState,
+  mappingRuleIdFromState,
+  roleIdValueUsingCount,
+  mappingRuleNameFromState,
+  mappingRuleClaimNameFromState,
+  mappingRuleClaimValueFromState,
+  roleIdValueUsingKey,
+  userFromState,
+  mappingRuleIdFromKey,
+} from '../requestHelpers';
+import {APIRequestContext} from 'playwright-core';
+
+export const groupRequiredFields: string[] = ['groupId', 'name', 'description'];
+export const mappingRuleRequiredFields: string[] = [
+  'claimName',
+  'claimValue',
+  'name',
+  'mappingRuleId',
+];
+export const roleRequiredFields: string[] = ['roleId', 'name', 'description'];
+export const licenseRequiredFields: string[] = [
+  'validLicense',
+  'licenseType',
+  'isCommercial',
+];
+export const messageSubscriptionRequiredFields = [
+  'messageSubscriptionKey',
+  'processDefinitionId',
+  'processDefinitionKey',
+  'processInstanceKey',
+  'elementId',
+  'elementInstanceKey',
+  'messageSubscriptionType',
+  'lastUpdatedDate',
+  'messageName',
+  'correlationKey',
+  'tenantId',
+];
+export const documentRequiredFields = [
+  'camunda.document.type',
+  'storeId',
+  'documentId',
+  'contentHash',
+  'metadata',
+];
+export const multipleDocumentsRequiredFields = [
+  'createdDocuments',
+  'failedDocuments',
+];
+export const correlateMessageRequiredFields: string[] = [
+  'tenantId',
+  'messageKey',
+  'processInstanceKey',
+];
+export const expectedMessageSubscription1 = {
+  messageName: 'Message_143t419',
+  correlationKey: '143419',
+  tenantId: '<default>',
+  elementId: 'Event_1idbbd5',
+  processDefinitionId: 'messageCatchEvent1',
+};
+export const expectedMessageSubscription2 = {
+  messageName: 'Message_3p6krla',
+  correlationKey: '3234432',
+  tenantId: '<default>',
+  elementId: 'Event_1aspkyg',
+  processDefinitionId: 'messageCatchEvent3',
+};
+export const expectedMessageSubscription3 = {
+  messageName: 'Message_3tvi9o8',
+  correlationKey: '3838383',
+  tenantId: '<default>',
+  elementId: 'Event_17u9bac',
+  processDefinitionId: 'messageCatchEvent1',
+};
+
+export function CREATE_NEW_GROUP() {
+  return {
+    groupId: 'group' + generateUniqueId(),
+    name: 'new group' + generateUniqueId(),
+    description: 'Test group description',
+  };
+}
+
+export function CREATE_NEW_MAPPING_RULE() {
+  const uniqueName = generateUniqueId();
+  return {
+    claimName: 'claimName' + uniqueName,
+    claimValue: 'claimValue' + uniqueName,
+    name: 'name' + uniqueName,
+    mappingRuleId: 'rule' + uniqueName,
+  };
+}
+
+export function CREATE_NEW_ROLE() {
+  const uid = generateUniqueId();
+  return {
+    roleId: `role-${uid}`,
+    name: `Test Role ${uid}`,
+    description: 'E2E test role',
+  };
+}
+export function UPDATE_ROLE() {
+  const uid = generateUniqueId();
+  return {
+    name: `role-updated-${uid}`,
+    description: `Updated description-${uid}`,
+  };
+}
+
+export function PUBLISH_NEW_MESSAGE() {
+  return {
+    name: `msg-${Date.now()}`,
+    correlationKey: `corr-${Math.random().toString(36).slice(2, 10)}`,
+    messageId: `corr-${Math.random().toString(36).slice(2, 10)}`,
+    timeToLive: 300000,
+    variables: {foo: 'bar'},
+  };
+}
+
+export const CORRELATE_MESSAGE = {
+  name: expectedMessageSubscription3.messageName,
+  correlationKey: expectedMessageSubscription3.correlationKey,
+  variables: {foo: 'bar'},
+};
+
+export function CREATE_TXT_DOCUMENT_REQUEST() {
+  const form = new FormData();
+  form.append(
+    'file',
+    new Blob([fs.readFileSync('./resources/helloworld.txt')], {
+      type: 'text/plain',
+    }),
+    'helloworld.txt',
+  );
+  return form;
+}
+
+export function CREATE_DOC_INVALID_REQUEST() {
+  const form = new FormData();
+  form.append('metadata', '{}');
+  return form;
+}
+
+export function CREATE_TXT_DOC_RESPONSE_BODY(name: string, size: number) {
+  return {
+    'camunda.document.type': 'camunda',
+    storeId: 'in-memory',
+    metadata: {
+      contentType: 'text/plain',
+      fileName: `${name}.txt`,
+      size: size,
+      customProperties: {},
+    },
+  };
+}
+
+export function CREATE_TXT_DOC_RESPONSE_WITH_METADATA(
+  name: string,
+  size: number,
+) {
+  return {
+    'camunda.document.type': 'camunda',
+    storeId: 'in-memory',
+    metadata: {
+      contentType: 'text/plain',
+      fileName: `${name}.txt`,
+      size: size,
+      processDefinitionId: name,
+      processInstanceKey: '123456',
+      customProperties: {foo: 'bar'},
+    },
+  };
+}
+
+export function CREATE_ON_FLY_DOCUMENT_REQUEST_BODY_WITH_METADATA(
+  name: string,
+) {
+  const form = new FormData();
+  form.append(
+    'file',
+    new File([`Hello World ${name}!`], `${name}.txt`, {
+      type: 'text/ plain',
+    }),
+  );
+  form.append(
+    'metadata',
+    new Blob(
+      [
+        JSON.stringify({
+          contentType: 'text/plain',
+          fileName: `${name}.txt`,
+          processDefinitionId: name,
+          processInstanceKey: '123456',
+          customProperties: {foo: 'bar'},
+        }),
+      ],
+      {
+        type: 'application/json',
+      },
+    ),
+  );
+  return form;
+}
+
+export function CREATE_ON_FLY_MULTIPLE_DOCUMENTS_REQUEST_BODY(
+  name: string,
+  numberOfDocs: number = 1,
+) {
+  const form = new FormData();
+  for (let i = 1; i <= numberOfDocs; i++) {
+    form.append(
+      'files',
+      new File([`Hello World ${name + i}!`], `${name}${i}.txt`, {
+        type: 'text/plain',
+      }),
+    );
+  }
+  return form;
+}
+
+export const CREATE_DOCUMENT_LINK_REQUEST = {
+  timeToLive: 60000,
+};
+
+export function MAPPING_RULE_EXPECTED_BODY_USING_STATE(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+) {
+  return {
+    claimName: mappingRuleClaimNameFromState(key, state, nth) as string,
+    claimValue: mappingRuleClaimValueFromState(key, state, nth) as string,
+    name: mappingRuleNameFromState(key, state, nth) as string,
+    mappingRuleId: mappingRuleIdFromState(key, state, nth) as string,
+  };
+}
+
+export function MAPPING_RULE_EXPECTED_BODY_USING_KEY(
+  key: string,
+  state: Record<string, unknown>,
+) {
+  return {
+    claimName: state[`claimName${key}`] as string,
+    claimValue: state[`claimValue${key}`] as string,
+    name: state[`name${key}`] as string,
+    mappingRuleId: state[`mappingRuleId${key}`] as string,
+  };
+}
+
+export function ROLE_EXPECTED_BODY(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+) {
+  return {
+    name: roleNameFromState(key, state, nth),
+    roleId: roleIdValueUsingKey(key, state, nth),
+    description: roleDescriptionFromState(key, state, nth),
+  };
+}
+
+export function CREATE_GROUP_USERS_EXPECTED_BODY_USING_GROUP(
+  groupId: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+) {
+  return {
+    username: userFromState(groupId, state, nth),
+  };
+}
+
+export function ROLE_GROUP_EXPECTED_BODY(groupId: string) {
+  return {
+    groupId: groupId,
+  };
+}
+
+export async function mappingRuleBundle(
+  request: APIRequestContext,
+  state: Record<string, unknown>,
+) {
+  const mappingRuleKey = 'mappingRuleId' + generateUniqueId();
+  await createMappingRule(request, state, mappingRuleKey);
+  return {
+    mappingRuleKey: mappingRuleKey,
+    mappingRuleId: mappingRuleIdFromKey(mappingRuleKey, state),
+    responseBody: MAPPING_RULE_EXPECTED_BODY_USING_KEY(mappingRuleKey, state),
+  };
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers.ts
@@ -1,0 +1,462 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  CREATE_NEW_GROUP,
+  CREATE_NEW_MAPPING_RULE,
+  CREATE_NEW_ROLE,
+  groupRequiredFields,
+  roleRequiredFields,
+} from './beans/requestBeans';
+import {
+  assertEqualsForKeys,
+  assertRequiredFields,
+  buildUrl,
+  jsonHeaders,
+} from './http';
+import {expect} from '@playwright/test';
+import type {APIRequestContext} from 'playwright-core';
+import {defaultAssertionOptions, generateUniqueId} from './constants';
+import {Serializable} from 'playwright-core/types/structs';
+
+export async function createGroupAndStoreResponseFields(
+  request: APIRequestContext,
+  numberOfGroups: number,
+  state: Record<string, unknown>,
+  key?: string,
+) {
+  for (let i = 1; i <= numberOfGroups; i++) {
+    const requestBody = CREATE_NEW_GROUP();
+    const res = await request.post(buildUrl('/groups'), {
+      headers: jsonHeaders(),
+      data: requestBody,
+    });
+    expect(res.status()).toBe(201);
+    const json = await res.json();
+    assertRequiredFields(json, groupRequiredFields);
+    const arrayKey = key ? `${key}${i}` : `${i}`;
+    state[`groupId${arrayKey}`] = json.groupId;
+    state[`name${arrayKey}`] = json.name;
+    state[`description${arrayKey}`] = json.description;
+  }
+}
+
+export async function assignClientToGroup(
+  request: APIRequestContext,
+  numberOfClients: number,
+  groupId: string,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfClients; i++) {
+    const clientId = `test-client` + generateUniqueId();
+    const p = {
+      groupId: groupId as string,
+      clientId: clientId as string,
+    };
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/groups/{groupId}/clients/{clientId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+      state[`clientId${groupId}${i}`] = clientId;
+    }).toPass(defaultAssertionOptions);
+  }
+}
+
+export async function createRoleAndStoreResponseFields(
+  request: APIRequestContext,
+  numberOfRoles: number,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfRoles; i++) {
+    await createRole(request, state, `${i}`);
+  }
+}
+
+export async function assignMappingToGroup(
+  request: APIRequestContext,
+  numberOfMappings: number,
+  groupId: string,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfMappings; i++) {
+    const mappingRule = await createMappingRule(
+      request,
+      state,
+      `${groupId}${i}`,
+    );
+    const p = {
+      groupId: groupId as string,
+      mappingRuleId: mappingRule.mappingRuleId as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/groups/{groupId}/mapping-rules/{mappingRuleId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  }
+}
+
+export async function assignRoleToGroups(
+  request: APIRequestContext,
+  numberOfRoles: number,
+  groupId: string,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfRoles; i++) {
+    const role = await createRole(request, state, `${groupId}${i}`);
+    const p = {
+      groupId: groupId as string,
+      roleId: role.roleId as string,
+    };
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/groups/{groupId}', p),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  }
+}
+
+export async function assignGroupsToRole(
+  request: APIRequestContext,
+  numberOfGroups: number,
+  roleIdKey: string,
+  state: Record<string, unknown>,
+) {
+  const roleId = state[roleIdKey] as string;
+  await createGroupAndStoreResponseFields(
+    request,
+    numberOfGroups,
+    state,
+    roleId,
+  );
+  for (let i = 1; i <= numberOfGroups; i++) {
+    const p = {
+      groupId: groupIdFromState(roleIdKey, state, i) as string,
+      roleId: roleId as string,
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/groups/{groupId}', p),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    expect(res.status()).toBe(204);
+  }
+}
+
+export async function assignRolesToMappingRules(
+  request: APIRequestContext,
+  numberOfRules: number,
+  roleId: string,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfRules; i++) {
+    const rule = await createMappingRule(request, state, `${roleId}${i}`);
+    const p = {
+      roleId: roleId as string,
+      mappingRuleId: rule.mappingRuleId as string,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/roles/{roleId}/mapping-rules/{mappingRuleId}', p),
+        {headers: jsonHeaders()},
+      );
+      expect(res.status()).toBe(204);
+    }).toPass(defaultAssertionOptions);
+  }
+}
+
+export async function assignRoleToUsers(
+  request: APIRequestContext,
+  numberOfUsers: number,
+  roleId: string,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfUsers; i++) {
+    const user = 'user' + generateUniqueId();
+    const p = {
+      userId: user,
+      roleId: roleId,
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/users/{userId}', p),
+      {headers: jsonHeaders()},
+    );
+    expect(res.status()).toBe(204);
+    state[`username${roleId}${i}`] = user;
+  }
+}
+
+export async function assignClientsToRole(
+  request: APIRequestContext,
+  numberOfClients: number,
+  roleId: string,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfClients; i++) {
+    const clientId = 'client' + generateUniqueId();
+    const p = {
+      roleId: roleId,
+      clientId: clientId,
+    };
+    const res = await request.put(
+      buildUrl('/roles/{roleId}/clients/{clientId}', p),
+      {headers: jsonHeaders()},
+    );
+    expect(res.status()).toBe(204);
+    state[`client${roleId}${i}`] = clientId;
+  }
+}
+
+export async function assignUsersToGroup(
+  request: APIRequestContext,
+  numberOfUsers: number,
+  groupId: string,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfUsers; i++) {
+    const user = 'test-user' + generateUniqueId();
+    const stateParams: Record<string, string> = {
+      groupId: groupId,
+      username: user,
+    };
+    const res = await request.put(
+      buildUrl('/groups/{groupId}/users/{username}', stateParams),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    expect(res.status()).toBe(204);
+    state[`username${groupId}${i}`] = user;
+  }
+}
+
+export async function createMappingRulesAndStoreResponseFields(
+  request: APIRequestContext,
+  numberOfRules: number,
+  state: Record<string, unknown>,
+) {
+  for (let i = 1; i <= numberOfRules; i++) {
+    await createMappingRule(request, state, `${i}`);
+  }
+}
+
+export async function createMappingRule(
+  request: APIRequestContext,
+  state?: Record<string, unknown>,
+  key?: string,
+) {
+  const body = CREATE_NEW_MAPPING_RULE();
+  await expect(async () => {
+    const res = await request.post(buildUrl('/mapping-rules'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    expect(res.status()).toBe(201);
+    if (state && key) {
+      const json = await res.json();
+      state[`mappingRuleId${key}`] = json.mappingRuleId;
+      state[`claimName${key}`] = json.claimName;
+      state[`claimValue${key}`] = json.claimValue;
+      state[`name${key}`] = json.name;
+    }
+  }).toPass(defaultAssertionOptions);
+  return body;
+}
+
+export async function createRole(
+  request: APIRequestContext,
+  state?: Record<string, unknown>,
+  key?: string,
+) {
+  const body = CREATE_NEW_ROLE();
+
+  const res = await request.post(buildUrl('/roles'), {
+    headers: jsonHeaders(),
+    data: body,
+  });
+
+  expect(res.status()).toBe(201);
+  const json = await res.json();
+  assertRequiredFields(json, roleRequiredFields);
+  if (state && key) {
+    const json = await res.json();
+    state[`roleId${key}`] = json.roleId;
+    state[`roleName${key}`] = json.name;
+    state[`roleDescription${key}`] = json.description;
+  }
+  return body;
+}
+
+export function assertUsersInResponse(json: Serializable, user: string) {
+  const matchingItem = json.items.find(
+    (it: {username: string}) => it.username === user,
+  );
+  expect(matchingItem).toBeDefined();
+  assertRequiredFields(matchingItem, ['username']);
+  assertEqualsForKeys(matchingItem, {username: user}, ['username']);
+}
+
+export function assertClientsInResponse(json: Serializable, client: string) {
+  const matchingItem = json.items.find(
+    (it: {clientId: string}) => it.clientId === client,
+  );
+  expect(matchingItem).toBeDefined();
+  assertRequiredFields(matchingItem, ['clientId']);
+  assertEqualsForKeys(matchingItem, {clientId: client}, ['clientId']);
+}
+
+export function assertRoleInResponse(
+  json: Serializable,
+  expectedBody: Serializable,
+  role: string,
+) {
+  const matchingItem = json.items.find(
+    (it: {roleId: string}) => it.roleId === role,
+  );
+  expect(matchingItem).toBeDefined();
+  assertRequiredFields(matchingItem, roleRequiredFields);
+  assertEqualsForKeys(matchingItem, expectedBody, roleRequiredFields);
+}
+
+export function assertGroupsInResponse(
+  json: Serializable,
+  expectedBody: Serializable,
+  group: string,
+) {
+  const matchingItem = json.items.find(
+    (it: {groupId: string}) => it.groupId === group,
+  );
+  expect(matchingItem).toBeDefined();
+  assertRequiredFields(matchingItem, ['groupId']);
+  assertEqualsForKeys(matchingItem, expectedBody, ['groupId']);
+}
+
+export function groupIdFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`groupId${state[key]}${nth}`] as string;
+}
+
+export function groupNameFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`name${state[key]}${nth}`] as string;
+}
+
+export function roleIdValueUsingCount(
+  key: string,
+  state: Record<string, unknown>,
+): string {
+  return state[`roleId${key}`] as string;
+}
+
+export function roleIdValueUsingKey(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`roleId${state[key]}${nth}`] as string;
+}
+
+export function clientIdFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`clientId${state[key]}${nth}`] as string;
+}
+
+export function mappingRuleIdFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`mappingRuleId${state[key]}${nth}`] as string;
+}
+
+export function mappingRuleIdFromKey(
+  key: string,
+  state: Record<string, unknown>,
+): string {
+  return state[`mappingRuleId${key}`] as string;
+}
+
+export function mappingRuleNameFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`name${state[key]}${nth}`] as string;
+}
+
+export function mappingRuleClaimNameFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`claimName${state[key]}${nth}`] as string;
+}
+
+export function mappingRuleClaimValueFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`claimValue${state[key]}${nth}`] as string;
+}
+
+export function userFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`username${state[key]}${nth}`] as string;
+}
+
+export function clientFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`client${state[key]}${nth}`] as string;
+}
+
+export function roleNameFromState(
+  key: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`roleName${state[key]}${nth}`] as string;
+}
+
+export function roleDescriptionFromState(
+  group: string,
+  state: Record<string, unknown>,
+  nth: number = 1,
+): string {
+  return state[`roleDescription${state[group]}${nth}`] as string;
+}


### PR DESCRIPTION
# Description
Backport of #37554 to `stable/8.8`.

relates to 