### PR TITLE
Ensure one principle identifier is set

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
@@ -8,6 +8,7 @@
 package io.camunda.authentication.converter;
 
 import io.camunda.authentication.service.MembershipService;
+import io.camunda.authentication.service.MembershipService.PrincipalType;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.OidcPrincipalLoader;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -44,6 +45,16 @@ public class TokenClaimsConverter {
               .formatted(usernameClaim, clientIdClaim));
     }
 
-    return membershipService.resolveMemberships(tokenClaims, username, clientId);
+    final String principalName;
+    final PrincipalType principalType;
+    if (clientId != null) {
+      principalName = clientId;
+      principalType = PrincipalType.CLIENT;
+    } else {
+      principalName = username;
+      principalType = PrincipalType.USER;
+    }
+
+    return membershipService.resolveMemberships(tokenClaims, principalName, principalType);
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -69,6 +69,11 @@ public class DefaultMembershipService implements MembershipService {
       final String principalId,
       final PrincipalType principalType)
       throws OAuth2AuthenticationException {
+    if (username != null && clientId != null) {
+      throw new OAuth2AuthenticationException(
+          "Both username and clientId are set. Only one of them must be set.");
+    }
+
     final var ownerTypeToIds = new HashMap<EntityType, Set<String>>();
 
     ownerTypeToIds.put(

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -69,11 +69,6 @@ public class DefaultMembershipService implements MembershipService {
       final String principalId,
       final PrincipalType principalType)
       throws OAuth2AuthenticationException {
-    if (username != null && clientId != null) {
-      throw new OAuth2AuthenticationException(
-          "Both username and clientId are set. Only one of them must be set.");
-    }
-
     final var ownerTypeToIds = new HashMap<EntityType, Set<String>>();
 
     ownerTypeToIds.put(

--- a/authentication/src/main/java/io/camunda/authentication/service/MembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/MembershipService.java
@@ -23,15 +23,21 @@ public interface MembershipService {
    *
    * @param tokenClaims the raw claims extracted from the authentication token (e.g., JWT/OIDC
    *     token). These are used for matching against mapping rules and extracting groups from the
-   *     token itself
-   * @param username the username to resolve memberships for
-   * @param clientId the client ID to resolve memberships for
+   *     token itself AUTHORIZED_USERNAME, AUTHORIZED_CLIENT_ID, USER_TOKEN_CLAIMS). These claims
+   *     are passed to the broker for authorization decisions
+   * @param principalId the principal ID to resolve memberships for
+   * @param principalType the type of principal (USER or CLIENT)
    * @return a {@link CamundaAuthentication} containing the resolved groups, roles, tenants, and
    *     mappings
    * @throws org.springframework.security.oauth2.core.OAuth2AuthenticationException if membership
    *     resolution fails
    */
   CamundaAuthentication resolveMemberships(
-      Map<String, Object> tokenClaims, String username, String clientId)
+      Map<String, Object> tokenClaims, String principalId, PrincipalType principalType)
       throws OAuth2AuthenticationException;
+
+  enum PrincipalType {
+    USER,
+    CLIENT
+  }
 }

--- a/authentication/src/main/java/io/camunda/authentication/service/NoDBMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/NoDBMembershipService.java
@@ -34,7 +34,9 @@ public class NoDBMembershipService implements MembershipService {
 
   @Override
   public CamundaAuthentication resolveMemberships(
-      final Map<String, Object> tokenClaims, final String username, final String clientId)
+      final Map<String, Object> tokenClaims,
+      final String principalId,
+      final PrincipalType principalType)
       throws OAuth2AuthenticationException {
     final Set<String> groups =
         isGroupsClaimConfigured
@@ -42,13 +44,17 @@ public class NoDBMembershipService implements MembershipService {
             : Collections.emptySet();
 
     return CamundaAuthentication.of(
-        a ->
-            a.user(username)
-                .clientId(clientId)
-                .roleIds(Collections.emptyList())
-                .groupIds(groups.stream().toList())
-                .mappingRule(Collections.emptyList())
-                .tenants(Collections.emptyList())
-                .claims(tokenClaims));
+        a -> {
+          if (principalType.equals(PrincipalType.CLIENT)) {
+            a.clientId(principalId);
+          } else {
+            a.user(principalId);
+          }
+          return a.roleIds(Collections.emptyList())
+              .groupIds(groups.stream().toList())
+              .mappingRule(Collections.emptyList())
+              .tenants(Collections.emptyList())
+              .claims(tokenClaims);
+        });
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
@@ -8,6 +8,7 @@
 package io.camunda.authentication;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -96,5 +97,47 @@ public class DefaultCamundaAuthenticationProviderTest {
     assertThat(actualAuthentication).isNotNull();
     assertThat(actualAuthentication).isEqualTo(expectedAuthentication);
     verify(holder, times(0)).set(eq(expectedAuthentication));
+  }
+
+  @Test
+  void shouldNotCheckCacheWhenRefreshCalled() {
+    // given
+    final var expectedAuthentication = CamundaAuthentication.of(b -> b.user("foo"));
+
+    final var mockAuthentication = mock(Authentication.class);
+    when(mockAuthentication.getPrincipal()).thenReturn("foo");
+    SecurityContextHolder.getContext().setAuthentication(mockAuthentication);
+    when(authenticationConverter.convert(eq(mockAuthentication)))
+        .thenReturn(expectedAuthentication);
+
+    // when
+    authenticationProvider.refresh();
+
+    // then
+    verify(holder, never()).get();
+    verify(holder).set(eq(expectedAuthentication));
+  }
+
+  @Test
+  void shouldFailToConvertWithUsernameAndClientId() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> CamundaAuthentication.of(b -> b.user("foo").clientId("bar")));
+  }
+
+  @Test
+  void shouldAllowNeitherUsernameOrClientWhenAnonymous() {
+    // given
+    final var expectedAuthentication = CamundaAuthentication.anonymous();
+
+    final var mockAuthentication = mock(Authentication.class);
+    SecurityContextHolder.getContext().setAuthentication(mockAuthentication);
+    when(holder.get()).thenReturn(expectedAuthentication);
+
+    // when
+    final var actualAuthentication = authenticationProvider.getCamundaAuthentication();
+
+    // then
+    assertThat(actualAuthentication).isNotNull();
+    assertThat(actualAuthentication).isEqualTo(expectedAuthentication);
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/DefaultCamundaAuthenticationProviderTest.java
@@ -100,25 +100,6 @@ public class DefaultCamundaAuthenticationProviderTest {
   }
 
   @Test
-  void shouldNotCheckCacheWhenRefreshCalled() {
-    // given
-    final var expectedAuthentication = CamundaAuthentication.of(b -> b.user("foo"));
-
-    final var mockAuthentication = mock(Authentication.class);
-    when(mockAuthentication.getPrincipal()).thenReturn("foo");
-    SecurityContextHolder.getContext().setAuthentication(mockAuthentication);
-    when(authenticationConverter.convert(eq(mockAuthentication)))
-        .thenReturn(expectedAuthentication);
-
-    // when
-    authenticationProvider.refresh();
-
-    // then
-    verify(holder, never()).get();
-    verify(holder).set(eq(expectedAuthentication));
-  }
-
-  @Test
   void shouldFailToConvertWithUsernameAndClientId() {
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> CamundaAuthentication.of(b -> b.user("foo").clientId("bar")));

--- a/authentication/src/test/java/io/camunda/authentication/SessionAuthenticationRefreshTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/SessionAuthenticationRefreshTest.java
@@ -160,7 +160,7 @@ public class SessionAuthenticationRefreshTest {
     private CamundaAuthentication createMockAuthentication() {
       return new CamundaAuthentication(
           TestUserDetailsService.DEMO_USERNAME,
-          "",
+          null,
           Collections.emptyList(),
           Collections.emptyList(),
           Collections.emptyList(),

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
@@ -35,7 +35,7 @@ public class OidcFlowTestContext {
   public CamundaAuthenticationProvider createCamundaAuthenticationProvider() {
     return () ->
         new CamundaAuthentication(
-            "dummyUsername", "dummyClientId", List.of(), List.of(), List.of(), List.of(), Map.of());
+            "dummyUsername", null, List.of(), List.of(), List.of(), List.of(), Map.of());
   }
 
   @Bean

--- a/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterTest.java
@@ -153,9 +153,6 @@ public class TokenClaimsConverterTest {
       assertThat(camundaAuthentication).isNotNull();
       assertThat(camundaAuthentication.authenticatedClientId()).isEqualTo("preferred");
       assertThat(camundaAuthentication.authenticatedUsername()).isNull();
-      assertThat(camundaAuthentication.claims())
-          .containsEntry(AUTHORIZED_CLIENT_ID, "preferred")
-          .doesNotContainKey(USERNAME_CLAIM);
     }
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/SessionAuthenticationRefreshFilterTest.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */

--- a/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthenticationProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/CamundaAuthenticationProvider.java
@@ -7,8 +7,24 @@
  */
 package io.camunda.security.auth;
 
+/**
+ * Provides the current {@link CamundaAuthentication} representing the authentication context for a
+ * user, client, or anonymous principal.
+ */
 public interface CamundaAuthenticationProvider {
 
+  /**
+   * Returns the current {@link CamundaAuthentication} representing the authentication context for a
+   * user, client, or anonymous user.
+   *
+   * <p>The returned {@link CamundaAuthentication} may represent an anonymous user ({@code
+   * authenticatedUsername} and {@code authenticatedClientId} will be null and {@code claims will
+   * contain an entry of key:Authorization.AUTHORIZED_ANONYMOUS_USER value:true}) or a unique
+   * principal (either {@code authenticatedUsername} or {@code authenticatedClientId} will be set,
+   * but never both)
+   *
+   * @return the current {@link CamundaAuthentication}
+   */
   CamundaAuthentication getCamundaAuthentication();
 
   default CamundaAuthentication getAnonymousCamundaAuthentication() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -115,10 +115,10 @@ public final class AuthorizationCheckBehavior {
       final AuthorizationRequest request, final List<AuthorizationRejection> aggregatedRejections) {
     final var username = getUsername(request);
     final var clientId = getClientId(request);
-    if (username.isPresent()) {
-      return checkAccessForEntity(request, EntityType.USER, username.get(), aggregatedRejections);
-    } else if (clientId.isPresent()) {
+    if (clientId.isPresent()) {
       return checkAccessForEntity(request, EntityType.CLIENT, clientId.get(), aggregatedRejections);
+    } else if (username.isPresent()) {
+      return checkAccessForEntity(request, EntityType.USER, username.get(), aggregatedRejections);
     }
     return new AuthorizationResult(false, false);
   }
@@ -355,28 +355,28 @@ public final class AuthorizationCheckBehavior {
 
     final var authorizedScopes = new HashSet<AuthorizationScope>();
 
-    final var optionalUsername = getUsername(request);
-    if (optionalUsername.isPresent()) {
+    final var optionalClientId = getClientId(request);
+    if (optionalClientId.isPresent()) {
       getAuthorizedScopes(
               request.command,
-              EntityType.USER,
-              optionalUsername.get(),
+              EntityType.CLIENT,
+              optionalClientId.get(),
               request.getResourceType(),
               request.getPermissionType())
           .forEach(authorizedScopes::add);
     }
-    // If a username was present, don't use the client id
+    // If a clientId was present, don't use the username
     else {
-      getClientId(request)
+      getUsername(request)
           .map(
-              clientId ->
+              username ->
                   getAuthorizedScopes(
                       request.command,
-                      EntityType.CLIENT,
-                      clientId,
+                      EntityType.USER,
+                      username,
                       request.getResourceType(),
                       request.getPermissionType()))
-          .ifPresent(idsForClientId -> idsForClientId.forEach(authorizedScopes::add));
+          .ifPresent(idsForUsername -> idsForUsername.forEach(authorizedScopes::add));
     }
 
     // mapping rules can layer on top of username/client id


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
As per the parent issue, this PR achieves two core tasks:
1. Implement a defensive constraint to ensure that only one of the principle identifiers is set on the `CamundaAuthentication` object (describing this in javadocs too so calling code/implementations from a plugin system can abide by a known construct in our system)
2. In places where we detect the principles prefer the client ID over username

I have for now decided against including configuration to allow selection of the preference because, as mentioned by @ThorbenLindhauer , this can always be added at a later date.

## Related issues

closes #37473
