### PR TITLE
[Backport stable/8.6] fix: re-install MigrationSnapshotDirector on each role transition

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotAfterMigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotAfterMigrationTransitionStep.java
@@ -22,7 +22,7 @@ public class SnapshotAfterMigrationTransitionStep implements PartitionTransition
   @Override
   public ActorFuture<Void> prepareTransition(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
-    if (targetRole == Role.INACTIVE & migrationSnapshotDirector != null) {
+    if (migrationSnapshotDirector != null) {
       migrationSnapshotDirector.close();
       migrationSnapshotDirector = null;
     }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotMigrationTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotMigrationTransitionStepTest.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 
 public class SnapshotMigrationTransitionStepTest {
   @AutoClose
-  private static final ActorScheduler scheduler = ActorScheduler.newActorScheduler().build();
+  private static final ActorScheduler SCHEDULER = ActorScheduler.newActorScheduler().build();
 
   private static final Logger LOG =
       LoggerFactory.getLogger(SnapshotMigrationTransitionStepTest.class);
@@ -76,13 +76,13 @@ public class SnapshotMigrationTransitionStepTest {
 
   @BeforeAll
   static void setupAll() {
-    scheduler.start();
+    SCHEDULER.start();
   }
 
   @BeforeEach
   void setup() {
     actor.setMonitor(healthMonitor);
-    scheduler.submitActor(actor).join();
+    SCHEDULER.submitActor(actor).join();
     transitionContext.setConcurrencyControl(actor);
     transitionContext.setSnapshotDirector(snapshotDirector);
     transitionContext.setConcurrencyControl(concurrencyControl);


### PR DESCRIPTION
# Description
Backport of #37333 to `stable/8.6`.

relates to #37234