### PR TITLE
[Backport stable/8.8] fix: protect api resource only and not all

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -242,11 +242,24 @@ public class WebSecurityConfig {
   public SecurityFilterChain protectedUnhandledPathsSecurityFilterChain(
       final HttpSecurity httpSecurity) throws Exception {
     // all resources not yet explicitly handled by any previous chain require an authenticated user
-    // thus by default unhandled paths are always protected
+    // thus by default access to unhandled paths will always be denied
     return httpSecurity
         .securityMatcher("/**")
         .authorizeHttpRequests(
-            (authorizeHttpRequests) -> authorizeHttpRequests.anyRequest().denyAll())
+            authorizeHttpRequests -> authorizeHttpRequests.anyRequest().denyAll())
+        .exceptionHandling(
+            // for unhandled paths return a 404 instead of a 403 - improves UX to detect
+            // misconfiguration of paths
+            ex ->
+                ex.accessDeniedHandler(
+                    (request, response, accessDeniedException) ->
+                        response.sendError(HttpServletResponse.SC_NOT_FOUND)))
+        // disable csrf, anonymous auth to prevent session cookie creation on unhandled paths
+        // avoiding follow-up request failures due to a session created by this chain
+        .csrf(AbstractHttpConfigurer::disable)
+        .cors(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .anonymous(AbstractHttpConfigurer::disable)
         .build();
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/config/ProtectedApiSecurityFilterChainTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ProtectedApiSecurityFilterChainTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.authentication.config.controllers.TestApiController;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+/**
+ * Tests for the security filter chain behavior, specifically testing: - Valid /v2 endpoints with
+ * authorized/unauthorized users - Invalid endpoints returning 404 (security by obscurity) -
+ * Catch-all filter chain behavior
+ */
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityConfig.class,
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=basic"
+    })
+public class ProtectedApiSecurityFilterChainTest extends AbstractWebSecurityConfigTest {
+
+  @Test
+  public void shouldReturn200ForValidV2EndpointWithAuthorizedUser() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(basicAuthDemo())
+            .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatusOk();
+  }
+
+  @Test
+  public void shouldReturn401ForValidV2EndpointWithoutAuthentication() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  public void shouldReturn401ForValidV2EndpointWithInvalidCredentials() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(basicAuthInvalid())
+            .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  public void shouldReturn404ForUnhandledApiEndpointWithoutAuthentication() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .uri("https://localhost" + TestApiController.DUMMY_UNHANDLED_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldReturn404ForUnhandledApiEndpointWithValidAuthentication() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(basicAuthDemo())
+            .uri("https://localhost" + TestApiController.DUMMY_UNHANDLED_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldReturn404ForUnhandledApiEndpointWithInvalidAuthentication() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(basicAuthInvalid())
+            .uri("https://localhost" + TestApiController.DUMMY_UNHANDLED_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+  }
+
+  private static HttpHeaders basicAuthDemo() {
+    final HttpHeaders headers = new HttpHeaders();
+    headers.add(HttpHeaders.AUTHORIZATION, basicAuthentication("demo", "demo"));
+    return headers;
+  }
+
+  private static HttpHeaders basicAuthInvalid() {
+    final HttpHeaders headers = new HttpHeaders();
+    headers.add(HttpHeaders.AUTHORIZATION, basicAuthentication("invalid", "invalid"));
+    return headers;
+  }
+
+  private static String basicAuthentication(final String username, final String password) {
+    return "Basic "
+        + Base64.getEncoder()
+            .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -21,6 +21,7 @@ public class TestApiController {
   public static final String DUMMY_V2_API_ENDPOINT = "/v2/foo";
   public static final String DUMMY_WEBAPP_ENDPOINT = "/decisions";
   public static final String DUMMY_UNPROTECTED_ENDPOINT = "/new/foo";
+  public static final String DUMMY_UNHANDLED_ENDPOINT = "/non-existent-endpoint";
 
   @RequestMapping(DUMMY_OPERATE_INTERNAL_API_ENDPOINT)
   public @ResponseBody String dummyOperateInternalApiEndpoint() {


### PR DESCRIPTION
# Description
Backport of #37395 to `stable/8.8`.

relates to #37041