### PR TITLE
feat: add executor queueCapacity to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Executor.java
+++ b/configuration/src/main/java/io/camunda/configuration/Executor.java
@@ -19,6 +19,8 @@ public class Executor {
       Set.of("camunda.rest.apiExecutor.maxPoolSizeMultiplier");
   private static final Set<String> LEGACY_KEEP_ALIVE_SECONDS_PROPERTIES =
       Set.of("camunda.rest.apiExecutor.keepAliveSeconds");
+  private static final Set<String> LEGACY_KEEP_QUEUE_CAPACITY_PROPERTIES =
+      Set.of("camunda.rest.apiExecutor.queueCapacity");
 
   /**
    * Multiplier applied to the number of available processors to compute the executor's core pool
@@ -57,6 +59,14 @@ public class Executor {
    * ApiExecutorConfiguration#DEFAULT_KEEP_ALIVE_SECONDS})
    */
   private Duration keepAlive = Duration.ofSeconds(60);
+
+  /**
+   * Capacity of the executor's task queue. A small bounded queue (e.g. 64) is recommended to handle
+   * short bursts while still allowing the pool to grow.
+   *
+   * <p>Default value: 64 (as defined in ApiExecutorConfiguration#DEFAULT_QUEUE_CAPACITY)
+   */
+  private int queueCapacity = 64;
 
   public int getCorePoolSizeMultiplier() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
@@ -97,5 +107,18 @@ public class Executor {
 
   public void setKeepAlive(final Duration keepAlive) {
     this.keepAlive = keepAlive;
+  }
+
+  public int getQueueCapacity() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".queue-capacity",
+        queueCapacity,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_KEEP_QUEUE_CAPACITY_PROPERTIES);
+  }
+
+  public void setQueueCapacity(final int queueCapacity) {
+    this.queueCapacity = queueCapacity;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
@@ -62,5 +62,6 @@ public class GatewayRestPropertiesOverride {
     apiExecutorConfiguration.setCorePoolSizeMultiplier(executor.getCorePoolSizeMultiplier());
     apiExecutorConfiguration.setMaxPoolSizeMultiplier(executor.getMaxPoolSizeMultiplier());
     apiExecutorConfiguration.setKeepAliveSeconds(executor.getKeepAlive().getSeconds());
+    apiExecutorConfiguration.setQueueCapacity(executor.getQueueCapacity());
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/ApiRestExecutorTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiRestExecutorTest.java
@@ -30,6 +30,7 @@ public class ApiRestExecutorTest {
         "camunda.api.rest.executor.core-pool-size-multiplier=5",
         "camunda.api.rest.executor.max-pool-size-multiplier=10",
         "camunda.api.rest.executor.keep-alive=120s",
+        "camunda.api.rest.executor.queue-capacity=128",
       })
   class WithOnlyUnifiedConfigSet {
     final GatewayRestProperties gatewayRestProperties;
@@ -53,6 +54,11 @@ public class ApiRestExecutorTest {
     void shouldSetKeepAliveSeconds() {
       assertThat(gatewayRestProperties.getApiExecutor().getKeepAliveSeconds()).isEqualTo(120);
     }
+
+    @Test
+    void shouldSetQueueCapacity() {
+      assertThat(gatewayRestProperties.getApiExecutor().getQueueCapacity()).isEqualTo(128);
+    }
   }
 
   @Nested
@@ -61,6 +67,7 @@ public class ApiRestExecutorTest {
         "camunda.rest.apiExecutor.corePoolSizeMultiplier=10",
         "camunda.rest.apiExecutor.maxPoolSizeMultiplier=15",
         "camunda.rest.apiExecutor.keepAliveSeconds=180",
+        "camunda.rest.apiExecutor.queueCapacity=192",
       })
   class WithOnlyLegacySet {
     final GatewayRestProperties gatewayRestProperties;
@@ -83,6 +90,11 @@ public class ApiRestExecutorTest {
     void shouldSetKeepAliveSeconds() {
       assertThat(gatewayRestProperties.getApiExecutor().getKeepAliveSeconds()).isEqualTo(180);
     }
+
+    @Test
+    void shouldSetQueueCapacity() {
+      assertThat(gatewayRestProperties.getApiExecutor().getQueueCapacity()).isEqualTo(192);
+    }
   }
 
   @Nested
@@ -92,10 +104,12 @@ public class ApiRestExecutorTest {
         "camunda.api.rest.executor.core-pool-size-multiplier=5",
         "camunda.api.rest.executor.max-pool-size-multiplier=10",
         "camunda.api.rest.executor.keep-alive=120s",
+        "camunda.api.rest.executor.queue-capacity=128",
         // legacy
         "camunda.rest.apiExecutor.corePoolSizeMultiplier=10",
         "camunda.rest.apiExecutor.maxPoolSizeMultiplier=15",
         "camunda.rest.apiExecutor.keepAliveSeconds=180",
+        "camunda.rest.apiExecutor.queueCapacity=192",
       })
   class WithNewAndLegacySet {
     final GatewayRestProperties gatewayRestProperties;
@@ -117,6 +131,11 @@ public class ApiRestExecutorTest {
     @Test
     void shouldSetKeepAliveSecondsFromNew() {
       assertThat(gatewayRestProperties.getApiExecutor().getKeepAliveSeconds()).isEqualTo(120);
+    }
+
+    @Test
+    void shouldSetQueueCapacity() {
+      assertThat(gatewayRestProperties.getApiExecutor().getQueueCapacity()).isEqualTo(128);
     }
   }
 }


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.api.rest.executor in unified config.

The legacy properties are:

camunda.rest.apiExecutor.queueCapacity

The new properties are:

camunda.api.rest.executor.queue-capacity

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [x] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [x] The new property fields are documented in the code
## Related issues

related to #34911