### PR TITLE
feat: create ES/OS reader for correlated message search

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationItemDbReader;
+import io.camunda.db.rdbms.read.service.CorrelatedMessageDbReader;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
 import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
@@ -63,6 +64,7 @@ public class RdbmsService {
   private final UsageMetricsDbReader usageMetricReader;
   private final UsageMetricTUDbReader usageMetricTUDbReader;
   private final MessageSubscriptionDbReader messageSubscriptionReader;
+  private final CorrelatedMessageDbReader correlatedMessageReader;
 
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
@@ -88,7 +90,8 @@ public class RdbmsService {
       final JobDbReader jobReader,
       final UsageMetricsDbReader usageMetricReader,
       final UsageMetricTUDbReader usageMetricTUDbReader,
-      final MessageSubscriptionDbReader messageSubscriptionReader) {
+      final MessageSubscriptionDbReader messageSubscriptionReader,
+      final CorrelatedMessageDbReader correlatedMessageReader) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
     this.authorizationReader = authorizationReader;
     this.decisionRequirementsReader = decisionRequirementsReader;
@@ -113,6 +116,7 @@ public class RdbmsService {
     this.usageMetricReader = usageMetricReader;
     this.usageMetricTUDbReader = usageMetricTUDbReader;
     this.messageSubscriptionReader = messageSubscriptionReader;
+    this.correlatedMessageReader = correlatedMessageReader;
   }
 
   public AuthorizationDbReader getAuthorizationReader() {
@@ -205,6 +209,10 @@ public class RdbmsService {
 
   public MessageSubscriptionDbReader getMessageSubscriptionReader() {
     return messageSubscriptionReader;
+  }
+
+  public CorrelatedMessageDbReader getCorrelatedMessageReader() {
+    return correlatedMessageReader;
   }
 
   public RdbmsWriter createWriter(final long partitionId) { // todo fix in all itests afterwards?

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/CorrelatedMessageDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/CorrelatedMessageDbReader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.sql.CorrelatedMessageMapper;
+import io.camunda.db.rdbms.sql.columns.CorrelatedMessageSearchColumn;
+import io.camunda.search.clients.reader.CorrelatedMessageReader;
+import io.camunda.search.entities.CorrelatedMessageEntity;
+import io.camunda.search.query.CorrelatedMessageQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.Collections;
+import java.util.Optional;
+
+public class CorrelatedMessageDbReader extends AbstractEntityReader<CorrelatedMessageEntity>
+    implements CorrelatedMessageReader {
+
+  public CorrelatedMessageDbReader(final CorrelatedMessageMapper mapper) {
+    super(CorrelatedMessageSearchColumn.values());
+  }
+
+  public SearchQueryResult<CorrelatedMessageEntity> search(final CorrelatedMessageQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
+  }
+
+  @Override
+  public SearchQueryResult<CorrelatedMessageEntity> search(
+      final CorrelatedMessageQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    final var dbSort =
+        convertSort(
+            query.sort(),
+            CorrelatedMessageSearchColumn.MESSAGE_KEY,
+            CorrelatedMessageSearchColumn.SUBSCRIPTION_KEY);
+    // TODO add RDBMS search capabilities
+    return buildSearchQueryResult(0, Collections.emptyList(), dbSort);
+  }
+
+  public Optional<CorrelatedMessageEntity> findOne(
+      final long messageKey, final long subscriptionKey) {
+    final var result =
+        search(
+            CorrelatedMessageQuery.of(
+                b -> b.filter(f -> f.messageKeys(messageKey).subscriptionKeys(subscriptionKey))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationItemDbReader;
+import io.camunda.db.rdbms.read.service.CorrelatedMessageDbReader;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
 import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
@@ -66,6 +67,7 @@ import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
+import io.camunda.search.clients.reader.CorrelatedMessageReader;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.springframework.context.annotation.Bean;
@@ -234,6 +236,12 @@ public class RdbmsConfiguration {
   }
 
   @Bean
+  public CorrelatedMessageReader correlatedMessageReader(
+      final CorrelatedMessageMapper correlatedMessageMapper) {
+    return new CorrelatedMessageDbReader(correlatedMessageMapper);
+  }
+
+  @Bean
   public RdbmsWriterFactory rdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
       final ExporterPositionMapper exporterPositionMapper,
@@ -301,7 +309,8 @@ public class RdbmsConfiguration {
       final JobDbReader jobReader,
       final UsageMetricsDbReader usageMetricReader,
       final UsageMetricTUDbReader usageMetricTUDbReader,
-      final MessageSubscriptionDbReader messageSubscriptionReader) {
+      final MessageSubscriptionDbReader messageSubscriptionReader,
+      final CorrelatedMessageDbReader correlatedMessageReader) {
     return new RdbmsService(
         rdbmsWriterFactory,
         authorizationReader,
@@ -326,6 +335,7 @@ public class RdbmsConfiguration {
         jobReader,
         usageMetricReader,
         usageMetricTUDbReader,
-        messageSubscriptionReader);
+        messageSubscriptionReader,
+        correlatedMessageReader);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -15,6 +15,7 @@ import io.camunda.search.clients.impl.NoDBSearchClientsProxy;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.BatchOperationItemReader;
 import io.camunda.search.clients.reader.BatchOperationReader;
+import io.camunda.search.clients.reader.CorrelatedMessageReader;
 import io.camunda.search.clients.reader.DecisionDefinitionReader;
 import io.camunda.search.clients.reader.DecisionInstanceReader;
 import io.camunda.search.clients.reader.DecisionRequirementsReader;
@@ -105,6 +106,7 @@ public class SearchClientDatabaseConfiguration {
       final AuthorizationReader authorizationReader,
       final BatchOperationReader batchOperationReader,
       final BatchOperationItemReader batchOperationItemReader,
+      final CorrelatedMessageReader correlatedMessageReader,
       final DecisionDefinitionReader decisionDefinitionReader,
       final DecisionInstanceReader decisionInstanceReader,
       final DecisionRequirementsReader decisionRequirementsReader,
@@ -134,6 +136,7 @@ public class SearchClientDatabaseConfiguration {
         authorizationReader,
         batchOperationReader,
         batchOperationItemReader,
+        correlatedMessageReader,
         decisionDefinitionReader,
         decisionInstanceReader,
         decisionRequirementsReader,

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
@@ -17,6 +17,8 @@ import io.camunda.search.clients.reader.BatchOperationDocumentReader;
 import io.camunda.search.clients.reader.BatchOperationItemDocumentReader;
 import io.camunda.search.clients.reader.BatchOperationItemReader;
 import io.camunda.search.clients.reader.BatchOperationReader;
+import io.camunda.search.clients.reader.CorrelatedMessageDocumentReader;
+import io.camunda.search.clients.reader.CorrelatedMessageReader;
 import io.camunda.search.clients.reader.DecisionDefinitionDocumentReader;
 import io.camunda.search.clients.reader.DecisionDefinitionReader;
 import io.camunda.search.clients.reader.DecisionInstanceDocumentReader;
@@ -83,6 +85,7 @@ import io.camunda.webapps.schema.descriptors.index.UsageMetricIndex;
 import io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.EventTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
@@ -136,6 +139,13 @@ public class SearchClientReaderConfiguration {
   public BatchOperationItemReader batchOperationItemReader(
       final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
     return new BatchOperationItemDocumentReader(executor, descriptors.get(OperationTemplate.class));
+  }
+
+  @Bean
+  public CorrelatedMessageReader correlatedMessagesReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new CorrelatedMessageDocumentReader(
+        executor, descriptors.get(CorrelatedMessageTemplate.class));
   }
 
   @Bean

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/CorrelatedMessageDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/CorrelatedMessageDocumentReader.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.CorrelatedMessageEntity;
+import io.camunda.search.query.CorrelatedMessageQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class CorrelatedMessageDocumentReader extends DocumentBasedReader
+    implements CorrelatedMessageReader {
+
+  public CorrelatedMessageDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public SearchQueryResult<CorrelatedMessageEntity> search(
+      final CorrelatedMessageQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .search(
+            query,
+            io.camunda.webapps.schema.entities.CorrelatedMessageEntity.class,
+            resourceAccessChecks);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -38,6 +38,7 @@ import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsTUA
 import io.camunda.search.clients.transformers.entity.AuthorizationEntityTransformer;
 import io.camunda.search.clients.transformers.entity.BatchOperationEntityTransformer;
 import io.camunda.search.clients.transformers.entity.BatchOperationItemEntityTransformer;
+import io.camunda.search.clients.transformers.entity.CorrelatedMessageEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DecisionDefinitionEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DecisionInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DecisionRequirementsEntityTransformer;
@@ -62,6 +63,7 @@ import io.camunda.search.clients.transformers.entity.VariableEntityTransformer;
 import io.camunda.search.clients.transformers.filter.AuthorizationFilterTransformer;
 import io.camunda.search.clients.transformers.filter.BatchOperationFilterTransformer;
 import io.camunda.search.clients.transformers.filter.BatchOperationItemFilterTransformer;
+import io.camunda.search.clients.transformers.filter.CorrelatedMessageFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DateValueFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DecisionDefinitionFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DecisionInstanceFilterTransformer;
@@ -94,6 +96,7 @@ import io.camunda.search.clients.transformers.result.ProcessInstanceResultConfig
 import io.camunda.search.clients.transformers.sort.AuthorizationFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.BatchOperationFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.BatchOperationItemFieldSortingTransformer;
+import io.camunda.search.clients.transformers.sort.CorrelatedMessageFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DecisionDefinitionFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DecisionInstanceFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DecisionRequirementsFieldSortingTransformer;
@@ -116,6 +119,7 @@ import io.camunda.search.clients.transformers.sort.VariableFieldSortingTransform
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.BatchOperationFilter;
 import io.camunda.search.filter.BatchOperationItemFilter;
+import io.camunda.search.filter.CorrelatedMessageFilter;
 import io.camunda.search.filter.DateValueFilter;
 import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.filter.DecisionInstanceFilter;
@@ -144,6 +148,7 @@ import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.search.query.CorrelatedMessageQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
@@ -173,6 +178,7 @@ import io.camunda.search.result.ProcessInstanceQueryResultConfig;
 import io.camunda.search.sort.AuthorizationSort;
 import io.camunda.search.sort.BatchOperationItemSort;
 import io.camunda.search.sort.BatchOperationSort;
+import io.camunda.search.sort.CorrelatedMessageSort;
 import io.camunda.search.sort.DecisionDefinitionSort;
 import io.camunda.search.sort.DecisionInstanceSort;
 import io.camunda.search.sort.DecisionRequirementsSort;
@@ -206,6 +212,7 @@ import io.camunda.webapps.schema.descriptors.index.UsageMetricIndex;
 import io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.EventTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
@@ -216,6 +223,7 @@ import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.SequenceFlowTemplate;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
+import io.camunda.webapps.schema.entities.CorrelatedMessageEntity;
 import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
@@ -309,6 +317,7 @@ public final class ServiceTransformers {
             AuthorizationQuery.class,
             BatchOperationQuery.class,
             BatchOperationItemQuery.class,
+            CorrelatedMessageQuery.class,
             DecisionDefinitionQuery.class,
             DecisionInstanceQuery.class,
             DecisionRequirementsQuery.class,
@@ -316,72 +325,74 @@ public final class ServiceTransformers {
             FormQuery.class,
             GroupQuery.class,
             IncidentQuery.class,
+            JobQuery.class,
             MappingRuleQuery.class,
+            MessageSubscriptionQuery.class,
             ProcessDefinitionQuery.class,
             ProcessDefinitionFlowNodeStatisticsQuery.class,
             ProcessInstanceQuery.class,
             ProcessInstanceFlowNodeStatisticsQuery.class,
             RoleQuery.class,
+            SequenceFlowQuery.class,
             TenantQuery.class,
-            UserTaskQuery.class,
-            UserQuery.class,
-            VariableQuery.class,
             UsageMetricsQuery.class,
             UsageMetricsTUQuery.class,
-            SequenceFlowQuery.class,
-            JobQuery.class,
-            MessageSubscriptionQuery.class)
+            UserTaskQuery.class,
+            UserQuery.class,
+            VariableQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
+    mappers.put(AuthorizationEntity.class, new AuthorizationEntityTransformer());
+    mappers.put(BatchOperationEntity.class, new BatchOperationEntityTransformer());
+    mappers.put(CorrelatedMessageEntity.class, new CorrelatedMessageEntityTransformer());
     mappers.put(DecisionDefinitionEntity.class, new DecisionDefinitionEntityTransformer());
     mappers.put(DecisionRequirementsEntity.class, new DecisionRequirementsEntityTransformer());
     mappers.put(DecisionInstanceEntity.class, new DecisionInstanceEntityTransformer());
-    mappers.put(ProcessEntity.class, new ProcessDefinitionEntityTransfomer());
-    mappers.put(ProcessInstanceForListViewEntity.class, new ProcessInstanceEntityTransformer());
-    mappers.put(IncidentEntity.class, new IncidentEntityTransformer());
+    mappers.put(EventEntity.class, new MessageSubscriptionEntityTransformer());
     mappers.put(FlowNodeInstanceEntity.class, new FlowNodeInstanceEntityTransformer());
-    mappers.put(TaskEntity.class, new UserTaskEntityTransformer());
     mappers.put(FormEntity.class, new FormEntityTransformer());
-    mappers.put(VariableEntity.class, new VariableEntityTransformer());
-    mappers.put(AuthorizationEntity.class, new AuthorizationEntityTransformer());
-    mappers.put(RoleEntity.class, new RoleEntityTransformer());
-    mappers.put(RoleMemberEntity.class, new RoleMemberEntityTransformer());
-    mappers.put(TenantEntity.class, new TenantEntityTransformer());
-    mappers.put(TenantMemberEntity.class, new TenantMemberEntityTransformer());
     mappers.put(GroupEntity.class, new GroupEntityTransformer());
     mappers.put(GroupMemberEntity.class, new GroupMemberEntityTransformer());
-    mappers.put(UserEntity.class, new UserEntityTransformer());
-    mappers.put(MappingRuleEntity.class, new MappingRuleEntityTransformer());
-    mappers.put(BatchOperationEntity.class, new BatchOperationEntityTransformer());
-    mappers.put(OperationEntity.class, new BatchOperationItemEntityTransformer());
-    mappers.put(SequenceFlowEntity.class, new SequenceFlowEntityTransformer());
+    mappers.put(IncidentEntity.class, new IncidentEntityTransformer());
     mappers.put(JobEntity.class, new JobEntityTransformer());
-    mappers.put(EventEntity.class, new MessageSubscriptionEntityTransformer());
+    mappers.put(MappingRuleEntity.class, new MappingRuleEntityTransformer());
+    mappers.put(OperationEntity.class, new BatchOperationItemEntityTransformer());
+    mappers.put(ProcessEntity.class, new ProcessDefinitionEntityTransfomer());
+    mappers.put(ProcessInstanceForListViewEntity.class, new ProcessInstanceEntityTransformer());
+    mappers.put(RoleEntity.class, new RoleEntityTransformer());
+    mappers.put(RoleMemberEntity.class, new RoleMemberEntityTransformer());
+    mappers.put(SequenceFlowEntity.class, new SequenceFlowEntityTransformer());
+    mappers.put(TaskEntity.class, new UserTaskEntityTransformer());
+    mappers.put(VariableEntity.class, new VariableEntityTransformer());
+    mappers.put(TenantEntity.class, new TenantEntityTransformer());
+    mappers.put(TenantMemberEntity.class, new TenantMemberEntityTransformer());
+    mappers.put(UserEntity.class, new UserEntityTransformer());
 
     // domain field sorting -> database field sorting
+    mappers.put(AuthorizationSort.class, new AuthorizationFieldSortingTransformer());
+    mappers.put(BatchOperationSort.class, new BatchOperationFieldSortingTransformer());
+    mappers.put(BatchOperationItemSort.class, new BatchOperationItemFieldSortingTransformer());
+    mappers.put(CorrelatedMessageSort.class, new CorrelatedMessageFieldSortingTransformer());
     mappers.put(DecisionDefinitionSort.class, new DecisionDefinitionFieldSortingTransformer());
     mappers.put(DecisionRequirementsSort.class, new DecisionRequirementsFieldSortingTransformer());
     mappers.put(DecisionInstanceSort.class, new DecisionInstanceFieldSortingTransformer());
+    mappers.put(FlowNodeInstanceSort.class, new FlowNodeInstanceFieldSortingTransformer());
+    mappers.put(FormSort.class, new FormFieldSortingTransformer());
+    mappers.put(GroupSort.class, new GroupFieldSortingTransformer());
+    mappers.put(IncidentSort.class, new IncidentFieldSortingTransformer());
+    mappers.put(JobSort.class, new JobFieldSortingTransformer());
+    mappers.put(MappingRuleSort.class, new MappingRuleFieldSortingTransformer());
+    mappers.put(MessageSubscriptionSort.class, new MessageSubscriptionFieldSortingTransformer());
     mappers.put(ProcessDefinitionSort.class, new ProcessDefinitionFieldSortingTransformer());
     mappers.put(ProcessInstanceSort.class, new ProcessInstanceFieldSortingTransformer());
-    mappers.put(IncidentSort.class, new IncidentFieldSortingTransformer());
-    mappers.put(TenantSort.class, new TenantFieldSortingTransformer());
-    mappers.put(FlowNodeInstanceSort.class, new FlowNodeInstanceFieldSortingTransformer());
-    mappers.put(UserTaskSort.class, new UserTaskFieldSortingTransformer());
-    mappers.put(FormSort.class, new FormFieldSortingTransformer());
-    mappers.put(VariableSort.class, new VariableFieldSortingTransformer());
-    mappers.put(AuthorizationSort.class, new AuthorizationFieldSortingTransformer());
     mappers.put(RoleSort.class, new RoleFieldSortingTransformer());
     mappers.put(TenantSort.class, new TenantFieldSortingTransformer());
-    mappers.put(GroupSort.class, new GroupFieldSortingTransformer());
-    mappers.put(UserSort.class, new UserFieldSortingTransformer());
-    mappers.put(MappingRuleSort.class, new MappingRuleFieldSortingTransformer());
+    mappers.put(UserTaskSort.class, new UserTaskFieldSortingTransformer());
+    mappers.put(VariableSort.class, new VariableFieldSortingTransformer());
+    mappers.put(TenantSort.class, new TenantFieldSortingTransformer());
     mappers.put(UsageMetricsSort.class, new UsageMetricsFieldSortingTransformer());
-    mappers.put(BatchOperationSort.class, new BatchOperationFieldSortingTransformer());
-    mappers.put(BatchOperationItemSort.class, new BatchOperationItemFieldSortingTransformer());
-    mappers.put(JobSort.class, new JobFieldSortingTransformer());
-    mappers.put(MessageSubscriptionSort.class, new MessageSubscriptionFieldSortingTransformer());
+    mappers.put(UserSort.class, new UserFieldSortingTransformer());
 
     // filters -> search query
     mappers.put(
@@ -458,7 +469,10 @@ public final class ServiceTransformers {
     mappers.put(
         MessageSubscriptionFilter.class,
         new MessageSubscriptionFilterTransformer(indexDescriptors.get(EventTemplate.class)));
-
+    mappers.put(
+        CorrelatedMessageFilter.class,
+        new CorrelatedMessageFilterTransformer(
+            indexDescriptors.get(CorrelatedMessageTemplate.class)));
     // result config -> source config
     mappers.put(
         DecisionInstanceQueryResultConfig.class, new DecisionInstanceResultConfigTransformer());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/CorrelatedMessageEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/CorrelatedMessageEntityTransformer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.CorrelatedMessageEntity;
+
+public class CorrelatedMessageEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.CorrelatedMessageEntity, CorrelatedMessageEntity> {
+
+  @Override
+  public CorrelatedMessageEntity apply(
+      final io.camunda.webapps.schema.entities.CorrelatedMessageEntity value) {
+    return new CorrelatedMessageEntity(
+        value.getCorrelationKey(),
+        value.getCorrelationTime(),
+        value.getFlowNodeId(),
+        value.getFlowNodeInstanceKey(),
+        value.getMessageKey(),
+        value.getMessageName(),
+        value.getPartitionId(),
+        value.getBpmnProcessId(),
+        value.getProcessDefinitionKey(),
+        value.getProcessInstanceKey(),
+        value.getSubscriptionKey(),
+        value.getTenantId());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/CorrelatedMessageFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/CorrelatedMessageFilterTransformer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.intOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.webapps.schema.descriptors.template.CorrelatedMessageTemplate.*;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.CorrelatedMessageFilter;
+import io.camunda.security.auth.Authorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class CorrelatedMessageFilterTransformer
+    extends IndexFilterTransformer<CorrelatedMessageFilter> {
+
+  public CorrelatedMessageFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final CorrelatedMessageFilter filter) {
+    return and(
+        stringOperations(CORRELATION_KEY, filter.correlationKeyOperations()),
+        dateTimeOperations(CORRELATION_TIME, filter.correlationTimeOperations()),
+        stringOperations(FLOW_NODE_ID, filter.flowNodeIdOperations()),
+        longOperations(FLOW_NODE_INSTANCE_KEY, filter.flowNodeInstanceKeyOperations()),
+        stringOperations(MESSAGE_NAME, filter.messageNameOperations()),
+        longOperations(MESSAGE_KEY, filter.messageKeyOperations()),
+        intOperations(PARTITION_ID, filter.partitionIdOperations()),
+        stringOperations(BPMN_PROCESS_ID, filter.processDefinitionIdOperations()),
+        longOperations(PROCESS_DEFINITION_KEY, filter.processDefinitionKeyOperations()),
+        longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()),
+        longOperations(SUBSCRIPTION_KEY, filter.subscriptionKeyOperations()),
+        stringOperations(TENANT_ID, filter.tenantIdOperations()));
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
+    return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/CorrelatedMessageFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/CorrelatedMessageFieldSortingTransformer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.template.CorrelatedMessageTemplate.*;
+
+public class CorrelatedMessageFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "correlationKey" -> CORRELATION_KEY;
+      case "correlationTime" -> CORRELATION_TIME;
+      case "elementId" -> FLOW_NODE_ID;
+      case "elementInstanceKey" -> FLOW_NODE_INSTANCE_KEY;
+      case "messageKey" -> MESSAGE_KEY;
+      case "messageName" -> MESSAGE_NAME;
+      case "partitionId" -> PARTITION_ID;
+      case "processDefinitionId" -> BPMN_PROCESS_ID;
+      case "processDefinitionKey" -> PROCESS_DEFINITION_KEY;
+      case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
+      case "subscriptionKey" -> SUBSCRIPTION_KEY;
+      case "tenantId" -> TENANT_ID;
+      default -> throw new IllegalArgumentException("Unknown field: " + domainField);
+    };
+  }
+
+  @Override
+  public String defaultSortField() {
+    return "messageKey";
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/CorrelatedMessageQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/CorrelatedMessageQueryTransformerTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchMatchNoneQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.clients.query.SearchTermsQuery;
+import io.camunda.search.clients.types.TypedValue;
+import io.camunda.search.filter.CorrelatedMessageFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.reader.AuthorizationCheck;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.security.reader.TenantCheck;
+import io.camunda.util.ObjectBuilder;
+import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageTemplate;
+import io.camunda.webapps.schema.descriptors.template.EventTemplate;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class CorrelatedMessageQueryTransformerTest extends AbstractTransformerTest {
+
+  @ParameterizedTest
+  @MethodSource("queryFilterParameters")
+  void shouldQueryByMessageSubscriptionKey(
+      final Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>
+          filterFunction,
+      final String expectedFieldName,
+      final Object expectedValue) {
+    // Given
+    final var filter = FilterBuilders.correlatedMessage(filterFunction);
+
+    // When
+    final var searchQuery = transformQuery(filter);
+
+    // Then
+    final var queryVariant = searchQuery.queryOption();
+
+    Assertions.assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              Assertions.assertThat(t.field()).isEqualTo(expectedFieldName);
+              Assertions.assertThat(t.value().value()).isEqualTo(expectedValue);
+            });
+  }
+
+  private static Stream<Arguments> queryFilterParameters() {
+    return Stream.of(
+        Arguments.of(
+            (Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>)
+                b -> b.correlationKeys("key1"),
+            "correlationKey",
+            "key1"),
+        Arguments.of(
+            (Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>)
+                b -> b.correlationTimes(OffsetDateTime.parse("2024-07-24T00:00Z")),
+            "correlationTime",
+            OffsetDateTime.parse("2024-07-24T00:00Z")
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"))),
+        Arguments.of(
+            (Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>)
+                b -> b.flowNodeIds("abcd"),
+            "flowNodeId",
+            "abcd"),
+        Arguments.of(
+            (Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>)
+                b -> b.flowNodeInstanceKeys(784L),
+            "flowNodeInstanceKey",
+            784L),
+        Arguments.of(
+            (Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>)
+                b -> b.messageKeys(345L),
+            "messageKey",
+            345L),
+        Arguments.of(
+            (Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>)
+                b -> b.messageNames("msg_name"),
+            "messageName",
+            "msg_name"),
+        Arguments.of(
+            (Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>)
+                b -> b.partitionIds(4),
+            "partitionId",
+            4),
+        Arguments.of(
+            (Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>)
+                b -> b.processDefinitionIds("abcd"),
+            "bpmnProcessId",
+            "abcd"),
+        Arguments.of(
+            (Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>)
+                b -> b.processDefinitionKeys(456L),
+            "processDefinitionKey",
+            456L),
+        Arguments.of(
+            (Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>)
+                b -> b.processInstanceKeys(999L),
+            "processInstanceKey",
+            999L),
+        Arguments.of(
+            (Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>)
+                b -> b.subscriptionKeys(555L),
+            "subscriptionKey",
+            555L),
+        Arguments.of(
+            (Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>)
+                b -> b.tenantIds("tnt1"),
+            "tenantId",
+            "tnt1"));
+  }
+
+  @Test
+  public void shouldApplyAuthorizationCheck() {
+    // given
+    final var authorization =
+        Authorization.of(
+            a -> a.processDefinition().readProcessInstance().resourceIds(List.of("1", "2")));
+    final var authorizationCheck = AuthorizationCheck.enabled(authorization);
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(authorizationCheck, TenantCheck.disabled());
+
+    // when
+    final var searchQuery =
+        transformQuery(
+            FilterBuilders.correlatedMessage(b -> b.messageNames("abc")), resourceAccessChecks);
+
+    // then
+    final var queryVariant = searchQuery.queryOption();
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            query -> {
+              assertThat(query.must().size()).isEqualTo(2);
+              assertThat(query.must().getFirst().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      termQuery ->
+                          assertThat(termQuery.field())
+                              .isEqualTo(CorrelatedMessageTemplate.MESSAGE_NAME));
+              assertThat(query.must().get(1).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermsQuery.class,
+                      termQuery -> {
+                        assertThat(termQuery.field()).isEqualTo(EventTemplate.BPMN_PROCESS_ID);
+                        Assertions.assertThat(termQuery.values()).hasSize(2);
+                        Assertions.assertThat(
+                                termQuery.values().stream().map(TypedValue::stringValue).toList())
+                            .containsExactlyInAnyOrder("1", "2");
+                      });
+            });
+  }
+
+  @Test
+  public void shouldReturnNonMatchWhenNoResourceIdsProvided() {
+    // given
+    final var authorization = Authorization.of(a -> a.processDefinition().readProcessInstance());
+    final var authorizationCheck = AuthorizationCheck.enabled(authorization);
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(authorizationCheck, TenantCheck.disabled());
+
+    // when
+    final var searchQuery =
+        transformQuery(FilterBuilders.correlatedMessage(b -> b), resourceAccessChecks);
+
+    // then
+    final var queryVariant = searchQuery.queryOption();
+    Assertions.assertThat(queryVariant).isInstanceOf(SearchMatchNoneQuery.class);
+  }
+
+  @Test
+  public void shouldIgnoreAuthorizationCheckWhenDisabled() {
+    // given
+    final var authorizationCheck = AuthorizationCheck.disabled();
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(authorizationCheck, TenantCheck.disabled());
+
+    // when
+    final var searchQuery =
+        transformQuery(
+            FilterBuilders.correlatedMessage(b -> b.messageNames("abc")), resourceAccessChecks);
+
+    // then
+    final var queryVariant = searchQuery.queryOption();
+    Assertions.assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t ->
+                Assertions.assertThat(t.field()).isEqualTo(CorrelatedMessageTemplate.MESSAGE_NAME));
+  }
+
+  @Test
+  public void shouldApplyTenantCheck() {
+    // given
+    final var tenantCheck = TenantCheck.enabled(List.of("a", "b"));
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), tenantCheck);
+
+    // when
+    final var searchQuery =
+        transformQuery(
+            FilterBuilders.correlatedMessage(b -> b.messageNames("abc")), resourceAccessChecks);
+
+    // then
+    final var queryVariant = searchQuery.queryOption();
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            query -> {
+              assertThat(query.must().size()).isEqualTo(2);
+              assertThat(query.must().getFirst().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      termQuery ->
+                          assertThat(termQuery.field())
+                              .isEqualTo(CorrelatedMessageTemplate.MESSAGE_NAME));
+              assertThat(query.must().get(1).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermsQuery.class,
+                      termsQuery -> {
+                        Assertions.assertThat(termsQuery.field())
+                            .isEqualTo(CorrelatedMessageTemplate.TENANT_ID);
+                        Assertions.assertThat(
+                                termsQuery.values().stream().map(TypedValue::stringValue).toList())
+                            .containsExactlyInAnyOrder("a", "b");
+                      });
+            });
+  }
+
+  @Test
+  public void shouldIgnoreTenantCheckWhenDisabled() {
+    // given
+    final var tenantCheck = TenantCheck.disabled();
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), tenantCheck);
+
+    // when
+    final var searchQuery =
+        transformQuery(
+            FilterBuilders.correlatedMessage(b -> b.messageNames("abc")), resourceAccessChecks);
+
+    // then
+    final var queryVariant = searchQuery.queryOption();
+    Assertions.assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t ->
+                Assertions.assertThat(t.field()).isEqualTo(CorrelatedMessageTemplate.MESSAGE_NAME));
+  }
+
+  @Test
+  public void shouldApplyFilterAndChecks() {
+    // given
+    final var authorization =
+        Authorization.of(
+            a -> a.processDefinition().readProcessInstance().resourceIds(List.of("1", "2")));
+
+    final var authorizationCheck = AuthorizationCheck.enabled(authorization);
+    final var tenantCheck = TenantCheck.enabled(List.of("a", "b"));
+    final var resourceAccessChecks = ResourceAccessChecks.of(authorizationCheck, tenantCheck);
+
+    // when
+    final var searchQuery =
+        transformQuery(
+            FilterBuilders.correlatedMessage(b -> b.messageNames("abc")), resourceAccessChecks);
+
+    // then
+    final var queryVariant = searchQuery.queryOption();
+    Assertions.assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class, t -> Assertions.assertThat(t.must()).hasSize(3));
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/CorrelatedMessageSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/CorrelatedMessageSortTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.sort.CorrelatedMessageSort;
+import io.camunda.search.sort.SearchSortOptions;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class CorrelatedMessageSortTest extends AbstractSortTransformerTest {
+
+  private static Stream<Arguments> provideSortParameters() {
+    return Stream.of(
+        new TestArguments("correlationKey", SortOrder.ASC, s -> s.correlationKey().asc()),
+        new TestArguments("correlationTime", SortOrder.ASC, s -> s.correlationTime().asc()),
+        new TestArguments("flowNodeId", SortOrder.ASC, s -> s.elementId().asc()),
+        new TestArguments("flowNodeInstanceKey", SortOrder.ASC, s -> s.elementInstanceKey().asc()),
+        new TestArguments("messageKey", SortOrder.ASC, s -> s.messageKey().asc()),
+        new TestArguments("messageName", SortOrder.ASC, s -> s.messageName().asc()),
+        new TestArguments("partitionId", SortOrder.ASC, s -> s.partitionId().asc()),
+        new TestArguments("bpmnProcessId", SortOrder.ASC, s -> s.processDefinitionId().asc()),
+        new TestArguments(
+            "processDefinitionKey", SortOrder.ASC, s -> s.processDefinitionKey().asc()),
+        new TestArguments("processInstanceKey", SortOrder.ASC, s -> s.processInstanceKey().asc()),
+        new TestArguments("subscriptionKey", SortOrder.ASC, s -> s.subscriptionKey().asc()),
+        new TestArguments("tenantId", SortOrder.ASC, s -> s.tenantId().asc()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSortParameters")
+  public void shouldSortByField(
+      final String field,
+      final SortOrder sortOrder,
+      final Function<CorrelatedMessageSort.Builder, ObjectBuilder<CorrelatedMessageSort>> fn) {
+    // when
+    final var request = SearchQueryBuilders.correlatedMessageSearchQuery(q -> q.sort(fn));
+    final var sort = transformRequest(request);
+
+    // then
+    assertThat(sort).hasSize(2);
+    assertThat(sort.get(0))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(field);
+              assertThat(t.field().order()).isEqualTo(sortOrder);
+            });
+    assertThat(sort.get(1))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo("messageKey");
+              assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  private record TestArguments(
+      String field,
+      SortOrder sortOrder,
+      Function<CorrelatedMessageSort.Builder, ObjectBuilder<CorrelatedMessageSort>> fn)
+      implements Arguments {
+
+    @Override
+    public Object[] get() {
+      return new Object[] {field, sortOrder, fn};
+    }
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/CorrelatedMessageReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/CorrelatedMessageReader.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.entities.CorrelatedMessageEntity;
+import io.camunda.search.query.CorrelatedMessageQuery;
+
+public interface CorrelatedMessageReader
+    extends SearchEntityReader<CorrelatedMessageEntity, CorrelatedMessageQuery> {}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -11,6 +11,7 @@ public record SearchClientReaders(
     AuthorizationReader authorizationReader,
     BatchOperationReader batchOperationReader,
     BatchOperationItemReader batchOperationItemReader,
+    CorrelatedMessageReader correlatedMessageReader,
     DecisionDefinitionReader decisionDefinitionReader,
     DecisionInstanceReader decisionInstanceReader,
     DecisionRequirementsReader decisionRequirementsReader,

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -128,7 +128,7 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<CorrelatedMessageEntity> searchCorrelatedMessages(
       final CorrelatedMessageQuery query) {
-    throw new RuntimeException("Not implemented yet");
+    return doSearchWithReader(readers.correlatedMessageReader(), query);
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -202,4 +202,9 @@ public final class SearchQueryBuilders {
   public static CorrelatedMessageQuery.Builder correlatedMessageSearchQuery() {
     return new CorrelatedMessageQuery.Builder();
   }
+
+  public static CorrelatedMessageQuery correlatedMessageSearchQuery(
+      final Function<CorrelatedMessageQuery.Builder, ObjectBuilder<CorrelatedMessageQuery>> fn) {
+    return fn.apply(correlatedMessageSearchQuery()).build();
+  }
 }


### PR DESCRIPTION
## Description

Creates document readers and transformers for ES/OS to search for correlated messages.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37735 
