### PR TITLE
fix: log code and reason on camunda client completed exceptionally response

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/ApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/ApiEntityConsumer.java
@@ -49,7 +49,7 @@ import org.apache.hc.core5.http.nio.entity.AbstractBinAsyncEntityConsumer;
  */
 final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntity<T>> {
   private static final List<ContentType> SUPPORTED_TEXT_CONTENT_TYPES =
-      Arrays.asList(ContentType.TEXT_XML);
+      Arrays.asList(ContentType.TEXT_XML, ContentType.TEXT_HTML, ContentType.TEXT_PLAIN);
   private final ObjectMapper json;
   private final Class<T> type;
   private final int chunkSize;

--- a/clients/java/src/test/java/io/camunda/client/impl/http/ApiEntityConsumerTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/http/ApiEntityConsumerTest.java
@@ -17,6 +17,7 @@ package io.camunda.client.impl.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.impl.http.ApiEntity.Error;
 import io.camunda.client.impl.http.ApiEntity.Response;
@@ -31,13 +32,16 @@ import org.junit.jupiter.api.Test;
 
 class ApiEntityConsumerTest {
 
+  public static final ObjectMapper JSON_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
   @Test
   void testJsonApiEntityConsumerWithValidJsonResponse() throws IOException {
     // given
     final String jsonResponse = "{\"name\":\"test\",\"value\":123}";
     final ByteBuffer byteBuffer = ByteBuffer.wrap(jsonResponse.getBytes());
     final ApiEntityConsumer<TestEntity> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), TestEntity.class, 2048);
+        new ApiEntityConsumer<>(JSON_MAPPER, TestEntity.class, 2048);
 
     // when
     // Start the stream with the correct content type
@@ -56,67 +60,13 @@ class ApiEntityConsumerTest {
   }
 
   @Test
-  void testJsonApiEntityConsumerWithValidJsonOtherTypeResponse() throws IOException {
-    // given
-    final String jsonResponse = "{\"foo\":\"test\",\"bar\":123}";
-    final ByteBuffer byteBuffer = ByteBuffer.wrap(jsonResponse.getBytes());
-    final ApiEntityConsumer<TestEntity> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), TestEntity.class, 2048);
-
-    // when
-    // Start the stream with the correct content type
-    consumer.streamStart(ContentType.APPLICATION_JSON);
-    // Feed the data
-    consumer.data(byteBuffer, true);
-    // Generate the content
-    final ApiEntity<TestEntity> entity = consumer.generateContent();
-
-    // then
-    assertThat(entity).isInstanceOf(Error.class);
-    final ProblemDetail response = entity.problem();
-    assertThat(response).isNotNull();
-    assertThat(response.getTitle()).isEqualTo("Cannot parse the server JSON response");
-    assertThat(response.getDetail())
-        .contains(jsonResponse)
-        .contains("The client failed to parse the JSON response")
-        .contains("Unrecognized field \"foo\"");
-  }
-
-  @Test
-  void testJsonApiEntityConsumerWithValidJsonOtherTypeErrorResponse() throws IOException {
-    // given
-    final String jsonResponse = "{\"foo\":\"test\",\"bar\":123}";
-    final ByteBuffer byteBuffer = ByteBuffer.wrap(jsonResponse.getBytes());
-    final ApiEntityConsumer<TestEntity> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), TestEntity.class, 2048);
-
-    // when
-    // Start the stream with the correct content type
-    consumer.streamStart(ContentType.APPLICATION_PROBLEM_JSON);
-    // Feed the data
-    consumer.data(byteBuffer, true);
-    // Generate the content
-    final ApiEntity<TestEntity> entity = consumer.generateContent();
-
-    // then
-    assertThat(entity).isInstanceOf(Error.class);
-    final ProblemDetail response = entity.problem();
-    assertThat(response).isNotNull();
-    assertThat(response.getTitle()).isEqualTo("Cannot parse the server JSON response");
-    assertThat(response.getDetail())
-        .contains(jsonResponse)
-        .contains("The client failed to parse the JSON response")
-        .contains("Unrecognized field \"foo\"");
-  }
-
-  @Test
   void testJsonApiEntityConsumerWithProblemDetailResponse() throws IOException {
     // given
     final String problemDetailResponse =
         "{\"type\":\"about:blank\",\"title\":\"Something went wrong\",\"status\":400,\"detail\":\"Invalid request\",\"instance\":\"/v1/entity/123\"}";
     final ByteBuffer byteBuffer = ByteBuffer.wrap(problemDetailResponse.getBytes());
     final ApiEntityConsumer<ProblemDetail> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), ProblemDetail.class, 2048);
+        new ApiEntityConsumer<>(JSON_MAPPER, ProblemDetail.class, 2048);
 
     // when
     // Start the stream with content type application/problem+json
@@ -143,7 +93,7 @@ class ApiEntityConsumerTest {
     final String textXmlResponse = "<xml/>";
     final ByteBuffer byteBuffer = ByteBuffer.wrap(textXmlResponse.getBytes());
     final ApiEntityConsumer<String> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), String.class, 2048);
+        new ApiEntityConsumer<>(JSON_MAPPER, String.class, 2048);
 
     // when
     // Start the stream with a supported text content type (text/xml)
@@ -164,7 +114,7 @@ class ApiEntityConsumerTest {
         "<xml>Thís ís á UTF-8 text wíth specíal cháracters: €, ñ, ö, 测试</xml>";
     final ByteBuffer byteBuffer = ByteBuffer.wrap(textXmlResponse.getBytes());
     final ApiEntityConsumer<String> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), String.class, 2048);
+        new ApiEntityConsumer<>(JSON_MAPPER, String.class, 2048);
 
     // when
     // Start the stream with a supported text content type (text/xml)
@@ -186,7 +136,7 @@ class ApiEntityConsumerTest {
     final ByteBuffer byteBuffer1 = ByteBuffer.wrap(part1.getBytes(StandardCharsets.UTF_8));
     final ByteBuffer byteBuffer2 = ByteBuffer.wrap(part2.getBytes(StandardCharsets.UTF_8));
     final ApiEntityConsumer<TestEntity> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), TestEntity.class, 2048);
+        new ApiEntityConsumer<>(JSON_MAPPER, TestEntity.class, 2048);
 
     // when
     // Start the stream with a supported content type (application/json)
@@ -212,7 +162,7 @@ class ApiEntityConsumerTest {
     final ByteBuffer byteBuffer1 = ByteBuffer.wrap(part1.getBytes());
     final ByteBuffer byteBuffer2 = ByteBuffer.wrap(part2.getBytes());
     final ApiEntityConsumer<String> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), String.class, 2048);
+        new ApiEntityConsumer<>(JSON_MAPPER, String.class, 2048);
 
     // when
     // Start the stream with a supported content type (text/xml)
@@ -230,25 +180,48 @@ class ApiEntityConsumerTest {
   }
 
   @Test
-  void testUnknownContentType() throws IOException {
+  void testRawApiEntityConsumerWithHtmlData() throws IOException {
     // given
-    final String unsupportedData = "<html>";
-    final ByteBuffer byteBuffer = ByteBuffer.wrap(unsupportedData.getBytes());
+    final String part1 = "<html>";
+    final String part2 = "</html>>";
+    final ByteBuffer byteBuffer1 = ByteBuffer.wrap(part1.getBytes());
+    final ByteBuffer byteBuffer2 = ByteBuffer.wrap(part2.getBytes());
     final ApiEntityConsumer<String> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), String.class, 2048);
+        new ApiEntityConsumer<>(JSON_MAPPER, String.class, 2048);
 
     // when
     // Start the stream with an unsupported content type
     consumer.streamStart(ContentType.TEXT_HTML);
-    // Feed the data
+    // Feed the first part of the data
+    consumer.data(byteBuffer1, false);
+    // Feed the second part of the data
+    consumer.data(byteBuffer2, true);
+    // Generate the content (should return raw data as ByteBuffer)
+    final ApiEntity<String> entity = consumer.generateContent();
+
+    // then
+    assertThat(entity).isInstanceOf(Response.class);
+    assertThat(entity.response()).isEqualTo(part1 + part2);
+  }
+
+  @Test
+  void testRawApiEntityConsumerWithPlainText() throws IOException {
+    // given
+    final String plain = "Just some plain text.";
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(plain.getBytes());
+    final ApiEntityConsumer<String> consumer =
+        new ApiEntityConsumer<>(JSON_MAPPER, String.class, 2048);
+
+    // when
+    // Start the stream with an unsupported content type
+    consumer.streamStart(ContentType.TEXT_PLAIN);
     consumer.data(byteBuffer, true);
     // Generate the content (should return raw data as ByteBuffer)
     final ApiEntity<String> entity = consumer.generateContent();
 
     // then
-    assertThat(entity).isInstanceOf(Unknown.class);
-    assertThat(StandardCharsets.UTF_8.decode(entity.unknown()).toString())
-        .isEqualTo(unsupportedData);
+    assertThat(entity).isInstanceOf(Response.class);
+    assertThat(entity.response()).isEqualTo(plain);
   }
 
   @Test
@@ -257,7 +230,7 @@ class ApiEntityConsumerTest {
     final String unsupportedData = "<unexpected/>";
     final ByteBuffer byteBuffer = ByteBuffer.wrap(unsupportedData.getBytes());
     final ApiEntityConsumer<TestEntity> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), TestEntity.class, 2048);
+        new ApiEntityConsumer<>(JSON_MAPPER, TestEntity.class, 2048);
 
     // when
     // Start the stream with a supported content type
@@ -277,8 +250,7 @@ class ApiEntityConsumerTest {
   void testVoidTypeWithApplicationJson() throws IOException {
     // given
 
-    final ApiEntityConsumer<Void> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), Void.class, 2048);
+    final ApiEntityConsumer<Void> consumer = new ApiEntityConsumer<>(JSON_MAPPER, Void.class, 2048);
 
     // when
     // Start the stream with application/json content type
@@ -296,8 +268,7 @@ class ApiEntityConsumerTest {
     final String problemDetailResponse =
         "{\"type\":\"about:blank\",\"title\":\"Something went wrong\",\"status\":400,\"detail\":\"Invalid request\",\"instance\":\"/v1/entity/123\"}";
     final ByteBuffer byteBuffer = ByteBuffer.wrap(problemDetailResponse.getBytes());
-    final ApiEntityConsumer<Void> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), Void.class, 2048);
+    final ApiEntityConsumer<Void> consumer = new ApiEntityConsumer<>(JSON_MAPPER, Void.class, 2048);
 
     // when
     // Start the stream with application/problem+json content type

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalErrorControllerNoAuthTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalErrorControllerNoAuthTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.zeebe.test.util.asserts.TopologyAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.response.Topology;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class GlobalErrorControllerNoAuthTest {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withAuthorizationsDisabled().withAuthenticatedAccess();
+
+  @Test
+  void shouldPass() throws URISyntaxException {
+    try (final CamundaClient client = createClient("")) {
+
+      final Topology topology = client.newTopologyRequest().send().join();
+
+      assertThat(topology).isNotNull();
+    }
+  }
+
+  @Test
+  void shouldThrowClientException() throws URISyntaxException {
+    try (final CamundaClient client = createClient("/wrong")) {
+
+      assertThatThrownBy(() -> client.newTopologyRequest().send().join())
+          .isInstanceOf(ClientException.class)
+          .hasMessage(
+              "Failed with code 404: 'Not Found'. Details: 'class ProblemDetail {\n"
+                  + "    type: about:blank\n"
+                  + "    title: Not Found\n"
+                  + "    status: 404\n"
+                  + "    detail: No endpoint GET /wrong/v2/topology.\n"
+                  + "    instance: /wrong/v2/topology\n"
+                  + "}'");
+    }
+  }
+
+  private static CamundaClient createClient(final String path) throws URISyntaxException {
+    return BROKER
+        .newClientBuilder()
+        .restAddress(new URI("http://localhost:" + BROKER.mappedPort(TestZeebePort.REST) + path))
+        .defaultRequestTimeout(Duration.ofMinutes(10))
+        .preferRestOverGrpc(true)
+        .build();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalErrorControllerWithAuthTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalErrorControllerWithAuthTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.client.api.search.enums.PermissionType.*;
+import static io.camunda.client.api.search.enums.ResourceType.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.statistics.response.UsageMetricsStatistics;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class GlobalErrorControllerWithAuthTest {
+
+  private static final String ADMIN = "admin";
+  private static final String PASSWORD = "password";
+  private static final String UNAUTHORIZED = "unauthorizedUser";
+
+  @MultiDbTestApplication
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER =
+      new TestUser(
+          ADMIN,
+          PASSWORD,
+          List.of(
+              new Permissions(RESOURCE, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(SYSTEM, READ_USAGE_METRIC, List.of("*")),
+              new Permissions(TENANT, CREATE, List.of("*")),
+              new Permissions(TENANT, UPDATE, List.of("*")),
+              new Permissions(TENANT, READ, List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser UNAUTHORIZED_USER = new TestUser(UNAUTHORIZED, PASSWORD, List.of());
+
+  @Test
+  void shouldPass() throws URISyntaxException {
+    try (final CamundaClient client = createClient(ADMIN_USER, "")) {
+
+      final UsageMetricsStatistics usageMetrics =
+          client
+              .newUsageMetricsRequest(OffsetDateTime.now().minusDays(1), OffsetDateTime.now())
+              .send()
+              .join();
+
+      assertThat(usageMetrics).isNotNull();
+    }
+  }
+
+  @Test
+  void shouldThrowClientExceptionUnauthorized() throws URISyntaxException {
+    try (final CamundaClient client = createClient(UNAUTHORIZED_USER, "/wrong")) {
+
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUsageMetricsRequest(
+                          OffsetDateTime.now().minusDays(1), OffsetDateTime.now())
+                      .send()
+                      .join())
+          .isInstanceOf(ClientException.class)
+          .hasMessage(
+              "Failed with code 404: 'Not Found'. Details: 'class ProblemDetail {\n"
+                  + "    type: about:blank\n"
+                  + "    title: Not Found\n"
+                  + "    status: 404\n"
+                  + "    detail: No message available\n"
+                  + "    instance: /wrong/v2/system/usage-metrics\n"
+                  + "}'");
+    }
+  }
+
+  @Test
+  void shouldThrowClientExceptionAuthorized() throws URISyntaxException {
+    try (final CamundaClient client = createClient(ADMIN_USER, "/wrong")) {
+
+      assertThatThrownBy(
+              () ->
+                  client
+                      .newUsageMetricsRequest(
+                          OffsetDateTime.now().minusDays(1), OffsetDateTime.now())
+                      .send()
+                      .join())
+          .isInstanceOf(ClientException.class)
+          .hasMessage(
+              "Failed with code 404: 'Not Found'. Details: 'class ProblemDetail {\n"
+                  + "    type: about:blank\n"
+                  + "    title: Not Found\n"
+                  + "    status: 404\n"
+                  + "    detail: No message available\n"
+                  + "    instance: /wrong/v2/system/usage-metrics\n"
+                  + "}'");
+    }
+  }
+
+  private static CamundaClient createClient(final TestUser user, String path)
+      throws URISyntaxException {
+    return BROKER
+        .newClientBuilder()
+        .restAddress(new URI("http://localhost:" + BROKER.mappedPort(TestZeebePort.REST) + path))
+        .defaultRequestTimeout(Duration.ofMinutes(10))
+        .preferRestOverGrpc(true)
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder()
+                .username(user.username())
+                .password(user.password())
+                .build())
+        .build();
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/GlobalErrorController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/GlobalErrorController.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.error.ErrorAttributeOptions.Include;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+
+@CamundaRestController
+public class GlobalErrorController implements ErrorController {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GlobalErrorController.class);
+
+  private final ErrorAttributes errorAttributes;
+
+  public GlobalErrorController(ErrorAttributes errorAttributes) {
+    this.errorAttributes = errorAttributes;
+  }
+
+  @RequestMapping("/error")
+  public ResponseEntity<ProblemDetail> handleError(HttpServletRequest request) {
+    final WebRequest webRequest = new ServletWebRequest(request);
+    final ErrorAttributeOptions options =
+        ErrorAttributeOptions.of(Include.MESSAGE, Include.PATH, Include.STATUS);
+
+    final Map<String, Object> attributes = errorAttributes.getErrorAttributes(webRequest, options);
+    LOG.trace("GlobalErrorController: error attributes = {}", attributes);
+
+    final String path = (String) attributes.getOrDefault("path", request.getRequestURI());
+    final int status = (int) attributes.getOrDefault("status", 500);
+    final String detail = (String) attributes.getOrDefault("message", "No message available");
+
+    final ProblemDetail problemDetail =
+        ProblemDetail.forStatusAndDetail(HttpStatus.valueOf(status), detail);
+    problemDetail.setInstance(URI.create(path != null ? path : "/unknown"));
+    return RestErrorMapper.mapProblemToResponse(problemDetail);
+  }
+}


### PR DESCRIPTION
## Description

Old [Slack discussion](https://camunda.slack.com/archives/C06UKS51QV9/p1751031897344889) for `FAIL_ON_UNKNOWN_PROPERTIES, false`

Relevant [Slack discussion](https://camunda.slack.com/archives/C01H4NG9XDY/p1757702603865169) for `FAIL_ON_UNKNOWN_PROPERTIES, true`


### Fix

Add `GlobalErrorController` to handle all yet unhandled errors. [Slack discussion](https://camunda.slack.com/archives/C08MRKHJ0CD/p1758187002147099)

## Related issues

related to #37232