### PR TITLE
[Backport stable/8.5] fix: properly decrement http client retries in zeebe rest client

### DIFF
--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.client.api.command.ClientException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
 import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
@@ -41,6 +42,8 @@ import org.slf4j.LoggerFactory;
  */
 public final class HttpClient implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpClient.class);
+
+  private static final int MAX_RETRY_ATTEMPTS = 2;
 
   private final CloseableHttpAsyncClient client;
   private final ObjectMapper jsonMapper;
@@ -133,6 +136,30 @@ public final class HttpClient implements AutoCloseable {
       final Class<HttpT> responseType,
       final JsonResponseTransformer<HttpT, RespT> transformer,
       final HttpZeebeFuture<RespT> result) {
+    sendRequest(
+        httpMethod,
+        path,
+        body,
+        requestConfig,
+        MAX_RETRY_ATTEMPTS,
+        responseType,
+        transformer,
+        result,
+        null);
+  }
+
+  private <HttpT, RespT> void sendRequest(
+      final Method httpMethod,
+      final String path,
+      final String body,
+      final RequestConfig requestConfig,
+      final int maxRetries,
+      final Class<HttpT> responseType,
+      final JsonResponseTransformer<HttpT, RespT> transformer,
+      final HttpZeebeFuture<RespT> result,
+      final ApiCallback<HttpT, RespT> callback) {
+    final AtomicReference<ApiCallback<HttpT, RespT>> apiCallback = new AtomicReference<>(callback);
+
     final URI target = buildRequestURI(path);
     final Runnable retryAction =
         () -> {
@@ -140,8 +167,16 @@ public final class HttpClient implements AutoCloseable {
             // skip if the request was already cancelled
             return;
           }
-
-          sendRequest(httpMethod, path, body, requestConfig, responseType, transformer, result);
+          sendRequest(
+              httpMethod,
+              path,
+              body,
+              requestConfig,
+              maxRetries,
+              responseType,
+              transformer,
+              result,
+              apiCallback.get());
         };
 
     final SimpleRequestBuilder requestBuilder =
@@ -161,12 +196,21 @@ public final class HttpClient implements AutoCloseable {
     final SimpleHttpRequest request = requestBuilder.build();
     request.setConfig(requestConfig);
 
+    if (apiCallback.get() == null) {
+      apiCallback.set(
+          new ApiCallback<>(
+              result,
+              transformer,
+              credentialsProvider::shouldRetryRequest,
+              retryAction,
+              maxRetries));
+    }
+
     result.transportFuture(
         client.execute(
             SimpleRequestProducer.create(request),
             new ApiResponseConsumer<>(jsonMapper, responseType, maxMessageSize),
-            new ApiCallback<>(
-                result, transformer, credentialsProvider::shouldRetryRequest, retryAction)));
+            apiCallback.get()));
   }
 
   private URI buildRequestURI(final String path) {

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiCallbackTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiCallbackTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ApiCallbackTest {
+  public static final int DEFAULT_REMAINING_RETRIES = 2;
 
   private CompletableFuture<String> response;
   private JsonResponseTransformer<String, String> transformer;
@@ -39,23 +40,95 @@ class ApiCallbackTest {
     transformer = mock(JsonResponseTransformer.class);
     retryPredicate = mock(Predicate.class);
     retryAction = mock(Runnable.class);
-    apiCallback = new ApiCallback<>(response, transformer, retryPredicate, retryAction);
+    apiCallback =
+        new ApiCallback<>(
+            response, transformer, retryPredicate, retryAction, DEFAULT_REMAINING_RETRIES);
   }
 
   @Test
-  void shouldLimitRetries() {
-    // Arrange
+  void shouldRetryWhenRetryPredicateIsTrue() {
+    // given
     final ApiResponse<String> apiResponse = mock(ApiResponse.class);
     when(apiResponse.getCode()).thenReturn(500);
     when(retryPredicate.test(any())).thenReturn(true);
 
-    // Act
-    apiCallback.completed(apiResponse);
-    apiCallback.completed(apiResponse);
+    // when
     apiCallback.completed(apiResponse);
 
-    // Assert
-    verify(retryAction, times(2)).run();
+    // then
+    verify(retryAction, times(1)).run();
+  }
+
+  @Test
+  void shouldNotRetryWhenRetryPredicateIsFalse() {
+    // given
+    final ApiResponse<String> apiResponse = mock(ApiResponse.class);
+    when(apiResponse.getCode()).thenReturn(400);
+    when(retryPredicate.test(any())).thenReturn(false);
+
+    // when
+    apiCallback.completed(apiResponse);
+
+    // then
+    verifyNoInteractions(retryAction);
+    assertTrue(response.isCompletedExceptionally());
+  }
+
+  @Test
+  void shouldNotRetryWhenNoRetriesLeft() {
+    // given
+    final ApiResponse<String> apiResponse = mock(ApiResponse.class);
+    when(apiResponse.getCode()).thenReturn(500);
+    when(retryPredicate.test(any())).thenReturn(true);
+
+    // Exhaust retries
+    for (int i = 0; i < DEFAULT_REMAINING_RETRIES; i++) {
+      apiCallback.completed(apiResponse);
+    }
+
+    // when: another call, no retries left
+    apiCallback.completed(apiResponse);
+
+    // then: no new retry, future is exceptionally completed
+    verify(retryAction, times(DEFAULT_REMAINING_RETRIES)).run();
+    assertTrue(response.isCompletedExceptionally());
+  }
+
+  @Test
+  void shouldReuseSameApiCallbackInstanceAcrossRetries() {
+    final ApiResponse<String> apiResponse = mock(ApiResponse.class);
+    when(apiResponse.getCode()).thenReturn(503);
+    when(retryPredicate.test(any())).thenReturn(true);
+
+    // First retry
+    apiCallback.completed(apiResponse);
+    verify(retryAction, times(1)).run();
+    reset(retryAction);
+
+    // Second retry
+    apiCallback.completed(apiResponse);
+    verify(retryAction, times(1)).run();
+    reset(retryAction);
+
+    // No retries left - should NOT call retryAction again
+    apiCallback.completed(apiResponse);
+    verifyNoInteractions(retryAction);
+    assertTrue(response.isCompletedExceptionally());
+  }
+
+  @Test
+  void shouldFailGracefullyAfterRetriesExhausted() {
+    final ApiResponse<String> apiResponse = mock(ApiResponse.class);
+    when(apiResponse.getCode()).thenReturn(500);
+    when(retryPredicate.test(any())).thenReturn(true);
+
+    // Exhaust retries
+    for (int i = 0; i < DEFAULT_REMAINING_RETRIES; i++) {
+      apiCallback.completed(apiResponse);
+    }
+
+    // Final attempt - should complete exceptionally, no further retry
+    apiCallback.completed(apiResponse);
     assertTrue(response.isCompletedExceptionally());
   }
 }


### PR DESCRIPTION
# Description
Backport of #35123 to `stable/8.5`.

relates to #26012