### PR TITLE
[Backport main] [Backport stable/8.7] fix: properly decrement http client retries in zeebe rest client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
@@ -257,11 +257,14 @@ public final class HttpClient implements AutoCloseable {
       final HttpZeebeFuture<RespT> result,
       final ApiCallback<HttpT, RespT> callback) {
     final AtomicReference<ApiCallback<HttpT, RespT>> apiCallback = new AtomicReference<>(callback);
+<<<<<<< HEAD
 
     LOGGER.warn(
         "{} is deprecated and will be removed in version 8.10. Please migrate to {}",
         ZeebeClient.class.getSimpleName(),
         CamundaClient.class.getSimpleName());
+=======
+>>>>>>> 7b91bbe1 (fix: properly decrement http client retries in zeebe rest client)
 
     final URI target = buildRequestURI(path);
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiCallbackTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiCallbackTest.java
@@ -71,7 +71,11 @@ class ApiCallbackTest {
 
     // then
     verifyNoInteractions(retryAction);
+<<<<<<< HEAD
     assertThat(response.isCompletedExceptionally()).isTrue();
+=======
+    assertTrue(response.isCompletedExceptionally());
+>>>>>>> 7b91bbe1 (fix: properly decrement http client retries in zeebe rest client)
   }
 
   @Test
@@ -91,7 +95,11 @@ class ApiCallbackTest {
 
     // then: no new retry, future is exceptionally completed
     verify(retryAction, times(DEFAULT_REMAINING_RETRIES)).run();
+<<<<<<< HEAD
     assertThat(response.isCompletedExceptionally()).isTrue();
+=======
+    assertTrue(response.isCompletedExceptionally());
+>>>>>>> 7b91bbe1 (fix: properly decrement http client retries in zeebe rest client)
   }
 
   @Test
@@ -113,7 +121,11 @@ class ApiCallbackTest {
     // No retries left - should NOT call retryAction again
     apiCallback.completed(apiResponse);
     verifyNoInteractions(retryAction);
+<<<<<<< HEAD
     assertThat(response.isCompletedExceptionally()).isTrue();
+=======
+    assertTrue(response.isCompletedExceptionally());
+>>>>>>> 7b91bbe1 (fix: properly decrement http client retries in zeebe rest client)
   }
 
   @Test
@@ -129,6 +141,10 @@ class ApiCallbackTest {
 
     // Final attempt - should complete exceptionally, no further retry
     apiCallback.completed(apiResponse);
+<<<<<<< HEAD
     assertThat(response.isCompletedExceptionally()).isTrue();
+=======
+    assertTrue(response.isCompletedExceptionally());
+>>>>>>> 7b91bbe1 (fix: properly decrement http client retries in zeebe rest client)
   }
 }


### PR DESCRIPTION
# Description
Backport of #37764 to `main`.

relates to #35123 #26012