### PR TITLE
deps: update camunda version to 8.8.0-alpha8

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -6,4 +6,3 @@ CONNECTORS_VERSION=8.8.0-alpha8
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.8
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.8
-

--- a/c8run/.env
+++ b/c8run/.env
@@ -6,3 +6,4 @@ CONNECTORS_VERSION=8.8.0-alpha8
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.8
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.8
+

--- a/c8run/.env
+++ b/c8run/.env
@@ -1,8 +1,8 @@
 ELASTICSEARCH_VERSION=8.17.3
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.8.0-alpha7
+CAMUNDA_VERSION=8.8.0-alpha8
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
-CONNECTORS_VERSION=8.8.0-alpha7
+CONNECTORS_VERSION=8.8.0-alpha8
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.8
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.8


### PR DESCRIPTION
## Description

Update c8run camunda version to 8.8.0-alpha8 for stable/8.8

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
