### PR TITLE
fix: Fix Flaky OpenSearch IT

### DIFF
--- a/schema-manager/src/test/java/io/camunda/search/schema/opensearch/OpensearchEngineClientIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/opensearch/OpensearchEngineClientIT.java
@@ -327,31 +327,33 @@ public class OpensearchEngineClientIT {
       disabledReason = "Excluding from AWS OS IT CI - policies not allowed for shared DBs")
   void shouldAlwaysUpdateIndexLifeCyclePolicyEvenIfExistingHasSameValue() throws IOException {
     // given
-    opensearchEngineClient.putIndexLifeCyclePolicy("policy_name", "20d");
+    opensearchEngineClient.putIndexLifeCyclePolicy("always_update_ism_policy_name", "20d");
 
     // then: policy state after first creation
     final ISMPolicyState policyStateAfterCreation =
-        opensearchEngineClient.getCurrentISMPolicyState("policy_name");
+        opensearchEngineClient.getCurrentISMPolicyState("always_update_ism_policy_name");
 
     // then: verify state after creation
     assertThat(policyStateAfterCreation.exists()).isTrue();
-    assertThat(policyStateAfterCreation.seqNo()).isEqualTo(0); // first creation has seq no 0
-    assertThat(getPolicyMinAge("policy_name")).isEqualTo("20d");
+    assertThat(getPolicyMinAge("always_update_ism_policy_name")).isEqualTo("20d");
 
     // when: update ISM with same parameters
     assertThatNoException()
-        .isThrownBy(() -> opensearchEngineClient.putIndexLifeCyclePolicy("policy_name", "20d"));
+        .isThrownBy(
+            () ->
+                opensearchEngineClient.putIndexLifeCyclePolicy(
+                    "always_update_ism_policy_name", "20d"));
 
     // then: policy state after first creation
     final ISMPolicyState policyStateAfterUpdate =
-        opensearchEngineClient.getCurrentISMPolicyState("policy_name");
+        opensearchEngineClient.getCurrentISMPolicyState("always_update_ism_policy_name");
 
     // then: state seq no should increment, but others should remain the same
     assertThat(policyStateAfterUpdate.exists()).isTrue();
     assertThat(policyStateAfterUpdate.primaryTerm())
         .isEqualTo(policyStateAfterCreation.primaryTerm());
     assertThat(policyStateAfterUpdate.seqNo()).isGreaterThan(policyStateAfterCreation.seqNo());
-    assertThat(getPolicyMinAge("policy_name")).isEqualTo("20d");
+    assertThat(getPolicyMinAge("always_update_ism_policy_name")).isEqualTo("20d");
   }
 
   @Test


### PR DESCRIPTION


## Description

Given we are using the OpenSearch container we cannot assert that policy version is always 0 when starting (ISM policies does not get reset before tests). This remove the assert as well as make the policy name as unique.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).


