### PR TITLE
Create RDBMS reader for correlated message search

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/CorrelatedMessageDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/CorrelatedMessageDbQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.CorrelatedMessageEntity;
+import io.camunda.search.filter.CorrelatedMessageFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record CorrelatedMessageDbQuery(
+    CorrelatedMessageFilter filter,
+    DbQuerySorting<CorrelatedMessageEntity> sort,
+    DbQueryPage page) {
+
+  public static CorrelatedMessageDbQuery of(
+      final Function<Builder, ObjectBuilder<CorrelatedMessageDbQuery>> fn) {
+    return fn.apply(new CorrelatedMessageDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<CorrelatedMessageDbQuery> {
+    private static final CorrelatedMessageFilter EMPTY_FILTER =
+        FilterBuilders.correlatedMessage().build();
+
+    private CorrelatedMessageFilter filter;
+    private DbQuerySorting<CorrelatedMessageEntity> sort;
+    private DbQueryPage page;
+
+    public Builder filter(final CorrelatedMessageFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<CorrelatedMessageEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<CorrelatedMessageFilter.Builder, ObjectBuilder<CorrelatedMessageFilter>>
+            fn) {
+      return filter(FilterBuilders.correlatedMessage(fn));
+    }
+
+    public Builder sort(
+        final Function<
+                DbQuerySorting.Builder<CorrelatedMessageEntity>,
+                ObjectBuilder<DbQuerySorting<CorrelatedMessageEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
+    }
+
+    @Override
+    public CorrelatedMessageDbQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
+      return new CorrelatedMessageDbQuery(filter, sort, page);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageEntityMapper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import io.camunda.db.rdbms.write.domain.CorrelatedMessageDbModel;
+import io.camunda.search.entities.CorrelatedMessageEntity;
+
+public class CorrelatedMessageEntityMapper {
+
+  public static CorrelatedMessageEntity toEntity(final CorrelatedMessageDbModel dbModel) {
+    return CorrelatedMessageEntity.builder()
+        .correlationKey(dbModel.correlationKey())
+        .correlationTime(dbModel.correlationTime())
+        .flowNodeId(dbModel.flowNodeId())
+        .flowNodeInstanceKey(dbModel.flowNodeInstanceKey())
+        .messageKey(dbModel.messageKey())
+        .messageName(dbModel.messageName())
+        .partitionId(dbModel.partitionId())
+        .processDefinitionId(dbModel.processDefinitionId())
+        .processDefinitionKey(dbModel.processDefinitionKey())
+        .processInstanceKey(dbModel.processInstanceKey())
+        .subscriptionKey(dbModel.subscriptionKey())
+        .tenantId(dbModel.tenantId())
+        .build();
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/CorrelatedMessageMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/CorrelatedMessageMapper.java
@@ -7,9 +7,15 @@
  */
 package io.camunda.db.rdbms.sql;
 
+import io.camunda.db.rdbms.read.domain.CorrelatedMessageDbQuery;
 import io.camunda.db.rdbms.write.domain.CorrelatedMessageDbModel;
+import java.util.List;
 
 public interface CorrelatedMessageMapper extends HistoryCleanupMapper {
 
+  Long count(CorrelatedMessageDbQuery query);
+
   void insert(CorrelatedMessageDbModel correlatedMessage);
+
+  List<CorrelatedMessageDbModel> search(CorrelatedMessageDbQuery query);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/CorrelatedMessageSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/CorrelatedMessageSearchColumn.java
@@ -16,6 +16,7 @@ public enum CorrelatedMessageSearchColumn implements SearchColumn<CorrelatedMess
   FLOW_NODE_INSTANCE_KEY("flowNodeInstanceKey"),
   MESSAGE_KEY("messageKey"),
   MESSAGE_NAME("messageName"),
+  PARTITION_ID("partitionId"),
   PROCESS_DEFINITION_ID("processDefinitionId"),
   PROCESS_DEFINITION_KEY("processDefinitionKey"),
   PROCESS_INSTANCE_KEY("processInstanceKey"),

--- a/db/rdbms/src/main/resources/mapper/CorrelatedMessageMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/CorrelatedMessageMapper.xml
@@ -12,6 +12,24 @@
 
 <mapper namespace="io.camunda.db.rdbms.sql.CorrelatedMessageMapper">
 
+  <resultMap id="correlatedMessageResultMap" type="io.camunda.db.rdbms.write.domain.CorrelatedMessageDbModel">
+    <constructor>
+      <arg column="CORRELATION_KEY" javaType="java.lang.String"/>
+      <arg column="CORRELATION_TIME" javaType="java.time.OffsetDateTime"/>
+      <arg column="FLOW_NODE_ID" javaType="java.lang.String"/>
+      <arg column="FLOW_NODE_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <arg column="HISTORY_CLEANUP_DATE" javaType="java.time.OffsetDateTime"/>
+      <idArg column="MESSAGE_KEY" javaType="java.lang.Long"/>
+      <arg column="MESSAGE_NAME" javaType="java.lang.String"/>
+      <arg column="PARTITION_ID" javaType="java.lang.Integer"/>
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
+      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
+      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <idArg column="SUBSCRIPTION_KEY" javaType="java.lang.Long"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"/>
+    </constructor>
+  </resultMap>
+
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.CorrelatedMessageDbModel">
     INSERT INTO ${prefix}CORRELATED_MESSAGE (
       CORRELATION_KEY,
@@ -44,6 +62,114 @@
       #{tenantId}
     )
   </insert>
+
+  <select id="count" parameterType="io.camunda.db.rdbms.read.domain.CorrelatedMessageDbQuery" resultType="long">
+    SELECT COUNT(*)
+    FROM ${prefix}CORRELATED_MESSAGE
+    <include refid="io.camunda.db.rdbms.sql.CorrelatedMessageMapper.searchFilter"/>
+  </select>
+
+  <!-- default search statement for databases supporting LIMIT/OFFSET-->
+  <select id="search" parameterType="io.camunda.db.rdbms.read.domain.CorrelatedMessageDbQuery" resultMap="correlatedMessageResultMap">
+    SELECT * FROM (
+      SELECT
+        CORRELATION_KEY,
+        CORRELATION_TIME,
+        FLOW_NODE_ID,
+        FLOW_NODE_INSTANCE_KEY,
+        HISTORY_CLEANUP_DATE,
+        MESSAGE_KEY,
+        MESSAGE_NAME,
+        PARTITION_ID,
+        PROCESS_DEFINITION_ID,
+        PROCESS_DEFINITION_KEY,
+        PROCESS_INSTANCE_KEY,
+        SUBSCRIPTION_KEY,
+        TENANT_ID
+      FROM ${prefix}CORRELATED_MESSAGE
+    <include refid="io.camunda.db.rdbms.sql.CorrelatedMessageMapper.searchFilter"/>
+    ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+  </select>
+
+  <sql id="searchFilter">
+    WHERE 1 = 1
+    <!-- basic filter -->
+    <if test="filter.correlationKeyOperations != null and !filter.correlationKeyOperations.isEmpty()">
+      <foreach collection="filter.correlationKeyOperations" item="operation">
+        AND CORRELATION_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.correlationTimeOperations != null and !filter.correlationTimeOperations.isEmpty()">
+      <foreach collection="filter.correlationTimeOperations" item="operation">
+        AND CORRELATION_TIME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.flowNodeIdOperations != null and !filter.flowNodeIdOperations.isEmpty()">
+      <foreach collection="filter.flowNodeIdOperations" item="operation">
+        AND FLOW_NODE_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.flowNodeInstanceKeyOperations != null and !filter.flowNodeInstanceKeyOperations.isEmpty()">
+      <foreach collection="filter.flowNodeInstanceKeyOperations" item="operation">
+        AND FLOW_NODE_INSTANCE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.messageKeyOperations != null and !filter.messageKeyOperations.isEmpty()">
+      <foreach collection="filter.messageKeyOperations" item="operation">
+        AND MESSAGE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.messageNameOperations != null and !filter.messageNameOperations.isEmpty()">
+      <foreach collection="filter.messageNameOperations" item="operation">
+        AND MESSAGE_NAME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.partitionIdOperations != null and !filter.partitionIdOperations.isEmpty()">
+      <foreach collection="filter.partitionIdOperations" item="operation">
+        AND PARTITION_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
+      <foreach collection="filter.processDefinitionIdOperations" item="operation">
+        AND PROCESS_DEFINITION_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.processDefinitionKeyOperations != null and !filter.processDefinitionKeyOperations.isEmpty()">
+      <foreach collection="filter.processDefinitionKeyOperations" item="operation">
+        AND PROCESS_DEFINITION_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
+      <foreach collection="filter.processInstanceKeyOperations" item="operation">
+        AND PROCESS_INSTANCE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.subscriptionKeyOperations != null and !filter.subscriptionKeyOperations.isEmpty()">
+      <foreach collection="filter.subscriptionKeyOperations" item="operation">
+        AND SUBSCRIPTION_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.tenantIdOperations != null and !filter.tenantIdOperations.isEmpty()">
+      <foreach collection="filter.tenantIdOperations" item="operation">
+        AND TENANT_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+  </sql>
 
   <update id="updateHistoryCleanupDate">
     UPDATE ${prefix}CORRELATED_MESSAGE SET

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/CorrelatedMessageEntityMapperTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.CorrelatedMessageDbModel;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+public class CorrelatedMessageEntityMapperTest {
+
+  @Test
+  public void testToEntity() {
+    // Given
+    final var model =
+        new CorrelatedMessageDbModel.Builder()
+            .correlationKey("testCorrelationKey")
+            .correlationTime(OffsetDateTime.now().plusDays(1))
+            .historyCleanupDate(OffsetDateTime.now().plusDays(3))
+            .messageKey(123L)
+            .messageName("testMessageName")
+            .flowNodeId("testFlowNodeId")
+            .flowNodeInstanceKey(456L)
+            .partitionId(4)
+            .processDefinitionId("processDefinitionId")
+            .processDefinitionKey(789L)
+            .processInstanceKey(1011L)
+            .subscriptionKey(321L)
+            .tenantId("tenantId")
+            .build();
+
+    // When
+    final var entity = CorrelatedMessageEntityMapper.toEntity(model);
+
+    // Then
+    assertThat(entity).usingRecursiveComparison().isEqualTo(model);
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/CorrelatedMessageDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/CorrelatedMessageDbReaderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.db.rdbms.sql.CorrelatedMessageMapper;
+import io.camunda.search.query.CorrelatedMessageQuery;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.reader.AuthorizationCheck;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.security.reader.TenantCheck;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CorrelatedMessageDbReaderTest {
+  private final CorrelatedMessageMapper correlatedMessageMapper =
+      mock(CorrelatedMessageMapper.class);
+  private final CorrelatedMessageDbReader correlatedMessageDbReader =
+      new CorrelatedMessageDbReader(correlatedMessageMapper);
+
+  @Test
+  void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {
+    final CorrelatedMessageQuery query = CorrelatedMessageQuery.of(b -> b);
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(
+            AuthorizationCheck.enabled(Authorization.of(a -> a.readProcessInstance().read())),
+            TenantCheck.disabled());
+
+    final var items = correlatedMessageDbReader.search(query, resourceAccessChecks).items();
+    assertThat(items).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenAuthorizedTenantIdsIsNull() {
+    final CorrelatedMessageQuery query = CorrelatedMessageQuery.of(b -> b);
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of()));
+
+    final var items = correlatedMessageDbReader.search(query, resourceAccessChecks).items();
+    assertThat(items).isEmpty();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -67,7 +67,6 @@ import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
-import io.camunda.search.clients.reader.CorrelatedMessageReader;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.springframework.context.annotation.Bean;
@@ -236,7 +235,7 @@ public class RdbmsConfiguration {
   }
 
   @Bean
-  public CorrelatedMessageReader correlatedMessageReader(
+  public CorrelatedMessageDbReader correlatedMessageReader(
       final CorrelatedMessageMapper correlatedMessageMapper) {
     return new CorrelatedMessageDbReader(correlatedMessageMapper);
   }


### PR DESCRIPTION
## Description

Creates DB readers and mappers for RDBMS to search for correlated messages.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37737 
