### PR TITLE
test: workflows changes to main branch to enable stable/8.8 runs

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [stable/8.6, stable/8.7, main] # Run all three branches in parallel
+        branch: [stable/8.6, stable/8.7, stable/8.8, main] # Run all four branches in parallel
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [stable/8.6, stable/8.7, stable/8.8, main] # Run all four branches in parallel
+        branch: [stable/8.6, stable/8.7, stable/8.8, main]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -43,9 +43,9 @@ jobs:
         run: |
           branch="${{ github.event.inputs.branch }}"
           echo "Detecting base branch for input branch: $branch"
-          git fetch origin stable/8.6 stable/8.7 main "$branch"
+          git fetch origin stable/8.6 stable/8.7 stable/8.8 main "$branch"
           base="main"
-          for candidate in stable/8.6 stable/8.7 main; do
+          for candidate in stable/8.6 stable/8.7 stable/8.8 main; do
             if git merge-base --is-ancestor origin/$candidate origin/$branch; then
               base="$candidate"
               break

--- a/qa/c8-orchestration-cluster-e2e-test-suite/README.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/README.md
@@ -55,7 +55,7 @@ npx playwright install
 
 ### 3. Configure Environment Variables
 
-Create a `.env` file inside `c8-orchestration-cluster-e2e-test-suite`.  
+Create a `.env` file inside `c8-orchestration-cluster-e2e-test-suite`.
 This file configures test parameters, including application URLs and credentials.
 **Note**: Do not commit the `.env` file to GitHub to avoid exposing sensitive information.
 
@@ -138,7 +138,7 @@ This test suite follows the **Page Object Model (POM)** pattern for reusability 
 
 1. Go to [C8 Orchestration Cluster E2E Tests On Demand](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml)
 2. Click **"Run workflow"**
-3. Choose the desired branch (e.g., `main`, `stable/8.6`, `stable/8.7`)
+3. Choose the desired branch (e.g., `main`, `stable/8.6`, `stable/8.7`, `stable/8.8`)
 4. Click **"Run workflow"**
 
 ---
@@ -200,5 +200,5 @@ If you want to suggest a new test case without submitting code:
 
 ---
 
-Thank you for using the C8 Orchestration Cluster End-to-End Test Suite.  
+Thank you for using the C8 Orchestration Cluster End-to-End Test Suite.
 Happy testing! 🚀 For help, reach out to the DRI.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -97,7 +97,7 @@ services:
 
   camunda:
     container_name: camunda
-    image: camunda/camunda:8.8-SNAPSHOT
+    image: camunda/camunda:SNAPSHOT
     environment:
       - 'JAVA_TOOL_OPTIONS=-Xms512m -Xmx1g'
       - ZEEBE_BROKER_NETWORK_HOST=camunda

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -97,7 +97,7 @@ services:
 
   camunda:
     container_name: camunda
-    image: camunda/camunda:SNAPSHOT
+    image: camunda/camunda:8.8-SNAPSHOT
     environment:
       - 'JAVA_TOOL_OPTIONS=-Xms512m -Xmx1g'
       - ZEEBE_BROKER_NETWORK_HOST=camunda


### PR DESCRIPTION
## Description

This PR is for enabling `stable/8.8` on on-demand and nighlty runs.

The run: https://github.com/camunda/camunda/actions/runs/17584200427
- Workflow branch: `test-stable-8.8-workflw` from `main`
- Tests branch: `test-enable-8.8` from `stable/8.8` 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
