### PR TITLE
test: fix flakiness in SchemaUpdateIT

### DIFF
--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
@@ -116,6 +116,10 @@ class SchemaUpdateIT {
     // enable retention policy for the test and set replicas to 1
     config.retention().setEnabled(true);
     config.index().setNumberOfReplicas(1);
+    if (config.connect().getTypeEnum().isOpenSearch()) {
+      // Opensearch uses optimistic lock on ISM policies update, so we need to increase the retries
+      config.schemaManager().getRetry().setMaxRetries(10);
+    }
     final var indexDescriptors =
         new IndexDescriptors(
             config.connect().getIndexPrefix(), config.connect().getTypeEnum().isElasticSearch());

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
@@ -113,12 +113,14 @@ class SchemaUpdateIT {
       final SearchEngineConfiguration config, final SearchClientAdapter searchClientAdapter)
       throws InterruptedException, IOException {
     // given
+    final int numberOfThreads = 12;
     // enable retention policy for the test and set replicas to 1
     config.retention().setEnabled(true);
     config.index().setNumberOfReplicas(1);
     if (config.connect().getTypeEnum().isOpenSearch()) {
       // Opensearch uses optimistic lock on ISM policies update, so we need to increase the retries
-      config.schemaManager().getRetry().setMaxRetries(10);
+      config.schemaManager().getRetry().setMaxRetries(numberOfThreads);
+      config.schemaManager().getRetry().setMaxRetryDelay(Duration.ofSeconds(1));
     }
     final var indexDescriptors =
         new IndexDescriptors(
@@ -139,7 +141,6 @@ class SchemaUpdateIT {
     final var exceptions = new ConcurrentLinkedQueue<Throwable>();
 
     // when
-    final int numberOfThreads = 12;
     final var threads =
         IntStream.range(0, numberOfThreads)
             .mapToObj(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Flakiness was reported for `SchemaUpdateIT.shouldRunConcurrentUpdates` when run for Opensearch
```
Caused by: org.opensearch.client.transport.httpclient5.ResponseException: method [PUT], host [http://localhost:32789], URI [_plugins/_ism/policies/camunda-retention-policy?if_primary_term=1&if_seq_no=12], status line [HTTP/1.1 409 Conflict]
{"error":{"root_cause":[{"type":"version_conflict_engine_exception","reason":"[camunda-retention-policy]: version conflict, required seqNo [12], primary term [1]. current document has seqNo [13] and primary term [1]","index":".opendistro-ism-config","shard":"0","index_uuid":"nwtAuGWSRbi4PtsYeKKkWw"}],"type":"version_conflict_engine_exception","reason":"[camunda-retention-policy]: version conflict, required seqNo [12], primary term [1]. current document has seqNo [13] and primary term [1]","index":".opendistro-ism-config","shard":"0","index_uuid":"nwtAuGWSRbi4PtsYeKKkWw"},"status":409}
```

This happens in case of concurrent update, where the seqNo gets incremented between the GET and the PUT 
increasing the schema manager retries for Opensearch, the max retries for the tests is 3

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
