### PR TITLE
[Backport stable/8.8] fix: add missing monaco editor contributions

### DIFF
--- a/operate/client/src/modules/loadMonaco.ts
+++ b/operate/client/src/modules/loadMonaco.ts
@@ -10,6 +10,8 @@ import {loader} from '@monaco-editor/react';
 import 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
 import 'monaco-editor/esm/vs/editor/browser/coreCommands.js';
 import 'monaco-editor/esm/vs/editor/contrib/find/browser/findController.js';
+import 'monaco-editor/esm/vs/editor/contrib/hover/browser/hoverContribution.js';
+import 'monaco-editor/esm/vs/editor/contrib/gotoError/browser/gotoError.js';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
 


### PR DESCRIPTION
# Description
Backport of #37679 to `stable/8.8`.

relates to #36367