### PR TITLE
fix: enable unified config on migration apps

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneDataMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneDataMigration.java
@@ -9,6 +9,9 @@ package io.camunda.application;
 
 import io.camunda.application.commons.migration.AsyncMigrationsRunner;
 import io.camunda.application.commons.migration.MigrationFinishedEvent;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import java.io.IOException;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
@@ -41,7 +44,12 @@ public class StandaloneDataMigration implements ApplicationListener<MigrationFin
         new SpringApplicationBuilder()
             .logStartupInfo(true)
             .web(WebApplicationType.SERVLET)
-            .sources(StandaloneDataMigration.class, AsyncMigrationsRunner.class)
+            .sources(
+                StandaloneDataMigration.class,
+                AsyncMigrationsRunner.class,
+                UnifiedConfigurationHelper.class,
+                UnifiedConfiguration.class,
+                SearchEngineConnectPropertiesOverride.class)
             .profiles(
                 Profile.USAGE_METRIC_MIGRATION.getId(),
                 Profile.PROCESS_MIGRATION.getId(),

--- a/dist/src/main/java/io/camunda/application/StandaloneProcessMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneProcessMigration.java
@@ -9,6 +9,9 @@ package io.camunda.application;
 
 import io.camunda.application.commons.migration.AsyncMigrationsRunner;
 import io.camunda.application.commons.migration.MigrationFinishedEvent;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
@@ -39,7 +42,12 @@ public class StandaloneProcessMigration implements ApplicationListener<Migration
         new SpringApplicationBuilder()
             .logStartupInfo(true)
             .web(WebApplicationType.SERVLET)
-            .sources(StandaloneProcessMigration.class, AsyncMigrationsRunner.class)
+            .sources(
+                StandaloneProcessMigration.class,
+                AsyncMigrationsRunner.class,
+                UnifiedConfigurationHelper.class,
+                UnifiedConfiguration.class,
+                SearchEngineConnectPropertiesOverride.class)
             .profiles(Profile.PROCESS_MIGRATION.getId())
             .addCommandLineProperties(true)
             .build(args);

--- a/dist/src/main/java/io/camunda/application/StandaloneTaskMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneTaskMigration.java
@@ -9,6 +9,9 @@ package io.camunda.application;
 
 import io.camunda.application.commons.migration.AsyncMigrationsRunner;
 import io.camunda.application.commons.migration.MigrationFinishedEvent;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
@@ -39,7 +42,12 @@ public class StandaloneTaskMigration implements ApplicationListener<MigrationFin
         new SpringApplicationBuilder()
             .logStartupInfo(true)
             .web(WebApplicationType.SERVLET)
-            .sources(StandaloneTaskMigration.class, AsyncMigrationsRunner.class)
+            .sources(
+                StandaloneTaskMigration.class,
+                AsyncMigrationsRunner.class,
+                UnifiedConfigurationHelper.class,
+                UnifiedConfiguration.class,
+                SearchEngineConnectPropertiesOverride.class)
             .profiles(Profile.TASK_MIGRATION.getId())
             .addCommandLineProperties(true)
             .build(args);

--- a/dist/src/main/java/io/camunda/application/StandaloneUsageMetricMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneUsageMetricMigration.java
@@ -9,16 +9,21 @@ package io.camunda.application;
 
 import io.camunda.application.commons.migration.AsyncMigrationsRunner;
 import io.camunda.application.commons.migration.MigrationFinishedEvent;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import java.io.IOException;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.lang.NonNull;
 
 @SpringBootConfiguration(proxyBeanMethods = false)
+@EnableAutoConfiguration
 public class StandaloneUsageMetricMigration implements ApplicationListener<MigrationFinishedEvent> {
 
   private static ApplicationContext applicationContext;
@@ -29,12 +34,23 @@ public class StandaloneUsageMetricMigration implements ApplicationListener<Migra
         "java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
     MainSupport.putSystemPropertyIfAbsent(
         "spring.banner.location", "classpath:/assets/camunda_banner.txt");
+    MainSupport.putSystemPropertyIfAbsent(
+        "spring.config.location",
+        "optional:classpath:/,optional:classpath:/config/,optional:file:./,optional:file:./config/");
+    MainSupport.putSystemPropertyIfAbsent(
+        "management.endpoints.web.exposure.include", "health, prometheus, loggers");
+    MainSupport.putSystemPropertyIfAbsent("management.server.port", "9600");
 
     final SpringApplication application =
         new SpringApplicationBuilder()
             .logStartupInfo(true)
-            .web(WebApplicationType.NONE)
-            .sources(StandaloneUsageMetricMigration.class, AsyncMigrationsRunner.class)
+            .web(WebApplicationType.SERVLET)
+            .sources(
+                StandaloneUsageMetricMigration.class,
+                AsyncMigrationsRunner.class,
+                UnifiedConfigurationHelper.class,
+                UnifiedConfiguration.class,
+                SearchEngineConnectPropertiesOverride.class)
             .profiles(Profile.USAGE_METRIC_MIGRATION.getId())
             .addCommandLineProperties(true)
             .build(args);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

UnifiedConfiguration changes to the Application runners were not applied to the Migration applications. This PR enables UnifiedConfiguration in these applications.

Also includes a minor fix for `StandaloneUsageMetricMigration`, marking it as a Servlet to enable metrics export

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
