### PR TITLE
pg/stabilize-migration-tests

### DIFF
--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
@@ -238,8 +238,9 @@ public class MigrationITExtension
     logger.addAppender(appender);
 
     Awaitility.await()
+        .pollInterval(Duration.ofSeconds(5))
         .atMost(Duration.ofSeconds(60))
-        .untilAsserted(() -> assertThat(appender.logs.size()).isGreaterThan(0));
+        .untilAsserted(() -> assertThat(appender.completed).isTrue());
 
     logger.detachAndStopAllAppenders();
   }
@@ -289,12 +290,14 @@ public class MigrationITExtension
 
   static class LogAppender extends AppenderBase<ILoggingEvent> {
 
-    final List<ILoggingEvent> logs = new ArrayList<>();
+    boolean completed = false;
 
     @Override
     protected void append(final ILoggingEvent iLoggingEvent) {
       if (iLoggingEvent.getMessage().contains("All migration tasks completed")) {
-        logs.add(iLoggingEvent);
+        synchronized (this) {
+          completed = true;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Attempt to stabilize Migration IT jobs by using a sync block and allowing poll interval in the log appender which captures the migrations completed log.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
