### PR TITLE
feat: add csrf support for swagger

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -98,6 +98,11 @@ spring.autoconfigure.exclude=\
 management.metrics.distribution.percentiles-histogram.http.server.requests=true
 management.metrics.distribution.percentiles.http.server.requests=0.5,0.95,0.99
 
+springdoc.swagger-ui.csrf.enabled=true
+springdoc.swagger-ui.csrf.header-name=X-CSRF-TOKEN
+springdoc.swagger-ui.csrf.session-storage-key=X-CSRF-TOKEN
+springdoc.swagger-ui.csrf.use-session-storage=true
+
 camunda.security.multiTenancy.checksEnabled=${zeebe.broker.gateway.multiTenancy.enabled:false}
 
 # Jackson configuration to prevent coercion of scalars


### PR DESCRIPTION
## Description

When running in SaaS, we've noticed that requests were denied even with an active session (see [slack](https://camunda.slack.com/archives/C06UYJMMETZ/p1757330236180069?thread_ts=1756822618.266749&cid=C06UYJMMETZ)). This is happening because the CSRF header is missing from the request (which should be added by Swagger automatically).

The springdocs recommend us to use [csrf configs directly](https://springdoc.org/#how-can-i-enable-csrf-support).

After enabling the default csrf interceptor and doing some debugging of the Swagger js bundles. It turns out the interceptor was trying to read the CSRF value from `document.cookie`  which only returns `osano_`  consent cookies and not the `X-CSRF-TOKEN` (despite it being stored inside the application cookies).

Since we already store `X-CSRF-TOKEN` inside our session (when logging in to Operate), we can use the token stored in the session directly. This PR is configuring Swagger to do so.

With this change, the header is correctly sent to the backend and we no longer get 
```
Invalid CSRF Token 'null' was found on the request parameter '_csrf' or header 'X-CSRF-TOKEN'.
```

<img width="1220" height="407" alt="Screenshot 2568-09-11 at 09 27 12" src="https://github.com/user-attachments/assets/dc7d7a9a-4b0b-4fcb-9b20-d04766e5e336" />

## Related issues

closes #37950
