### PR TITLE
feat: remove gateway address

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
@@ -39,8 +39,6 @@ public class SpringCamundaClientConfiguration implements CamundaClientConfigurat
   private final List<AsyncExecChainHandler> chainHandlers;
   private final CamundaClientExecutorService zeebeClientExecutorService;
   private final CredentialsProvider credentialsProvider;
-  private final String gatewayAddress;
-  private final boolean plaintext;
 
   public SpringCamundaClientConfiguration(
       final CamundaClientProperties camundaClientProperties,
@@ -55,13 +53,6 @@ public class SpringCamundaClientConfiguration implements CamundaClientConfigurat
     this.chainHandlers = chainHandlers;
     this.zeebeClientExecutorService = zeebeClientExecutorService;
     this.credentialsProvider = credentialsProvider;
-    gatewayAddress = composeGatewayAddress();
-    plaintext = composePlaintext();
-  }
-
-  @Override
-  public String getGatewayAddress() {
-    return gatewayAddress;
   }
 
   @Override
@@ -122,11 +113,6 @@ public class SpringCamundaClientConfiguration implements CamundaClientConfigurat
   @Override
   public Duration getDefaultRequestTimeoutOffset() {
     return camundaClientProperties.getRequestTimeoutOffset();
-  }
-
-  @Override
-  public boolean isPlaintextConnectionEnabled() {
-    return plaintext;
   }
 
   @Override
@@ -260,11 +246,6 @@ public class SpringCamundaClientConfiguration implements CamundaClientConfigurat
         + zeebeClientExecutorService
         + ", credentialsProvider="
         + (credentialsProvider == null ? "null" : credentialsProvider.getClass())
-        + ", gatewayAddress='"
-        + gatewayAddress
-        + '\''
-        + ", plaintext="
-        + plaintext
         + '}';
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.spring.client.configuration;
 
 import io.camunda.client.CamundaClientConfiguration;
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
@@ -39,7 +40,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public String getGatewayAddress() {
-    return camundaClientConfiguration.getGatewayAddress();
+    return AddressUtil.composeGatewayAddress(getGrpcAddress());
   }
 
   @Override
@@ -104,7 +105,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public boolean isPlaintextConnectionEnabled() {
-    return camundaClientConfiguration.isPlaintextConnectionEnabled();
+    return AddressUtil.isPlaintextConnection(getGrpcAddress());
   }
 
   @Override

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/CamundaClientConfigurationDefaultPropertiesTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/CamundaClientConfigurationDefaultPropertiesTest.java
@@ -48,7 +48,6 @@ public class CamundaClientConfigurationDefaultPropertiesTest {
     final CamundaClientConfiguration configuration =
         applicationContext.getBean(CamundaClientConfiguration.class);
 
-    assertThat(configuration.isPlaintextConnectionEnabled()).isTrue();
     assertThat(configuration.getCaCertificatePath()).isNull();
     assertThat(configuration.getCredentialsProvider()).isInstanceOf(NoopCredentialsProvider.class);
     assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
@@ -61,7 +60,6 @@ public class CamundaClientConfigurationDefaultPropertiesTest {
     assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
     assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
     assertThat(configuration.getDefaultTenantId()).isEqualTo("<default>");
-    assertThat(configuration.getGatewayAddress()).isEqualTo("0.0.0.0:26500");
     assertThat(configuration.getGrpcAddress()).isEqualTo(new URI("http://0.0.0.0:26500"));
     assertThat(configuration.getKeepAlive()).isEqualTo(Duration.ofSeconds(45));
     assertThat(configuration.getMaxMessageSize()).isEqualTo(5 * ONE_MB);

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/SpringCamundaClientConfigurationSaasTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/SpringCamundaClientConfigurationSaasTest.java
@@ -124,11 +124,6 @@ public class SpringCamundaClientConfigurationSaasTest {
   }
 
   @Test
-  void shouldHavePlaintextConnectionEnabled() {
-    assertThat(camundaClientConfiguration.isPlaintextConnectionEnabled()).isEqualTo(false);
-  }
-
-  @Test
   void shouldHaveCaCertificatePath() {
     assertThat(camundaClientConfiguration.getCaCertificatePath())
         .isEqualTo(DEFAULT.getCaCertificatePath());

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/SpringCamundaClientConfigurationSelfManagedTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/SpringCamundaClientConfigurationSelfManagedTest.java
@@ -61,11 +61,6 @@ public class SpringCamundaClientConfigurationSelfManagedTest {
   }
 
   @Test
-  void shouldHaveGatewayAddress() {
-    assertThat(camundaClientConfiguration.getGatewayAddress()).isEqualTo("localhost:26500");
-  }
-
-  @Test
   void shouldHaveDefaultTenantId() {
     assertThat(camundaClientConfiguration.getDefaultTenantId())
         .isEqualTo(DEFAULT.getDefaultTenantId());
@@ -117,11 +112,6 @@ public class SpringCamundaClientConfigurationSelfManagedTest {
   void shouldHaveDefaultRequestTimeout() {
     assertThat(camundaClientConfiguration.getDefaultRequestTimeout())
         .isEqualTo(DEFAULT.getDefaultRequestTimeout());
-  }
-
-  @Test
-  void shouldHavePlaintextConnectionEnabled() {
-    assertThat(camundaClientConfiguration.isPlaintextConnectionEnabled()).isEqualTo(true);
   }
 
   @Test

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/SpringCamundaClientConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/SpringCamundaClientConfigurationTest.java
@@ -25,12 +25,9 @@ import io.camunda.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.client.spring.configuration.SpringCamundaClientConfiguration;
 import io.camunda.client.spring.properties.CamundaClientProperties;
 import io.grpc.ClientInterceptor;
-import java.net.URI;
 import java.util.List;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 public class SpringCamundaClientConfigurationTest {
   private static SpringCamundaClientConfiguration configuration(
@@ -73,23 +70,6 @@ public class SpringCamundaClientConfigurationTest {
     final CredentialsProvider credentialsProvider1 = configuration.getCredentialsProvider();
     final CredentialsProvider credentialsProvider2 = configuration.getCredentialsProvider();
     assertThat(credentialsProvider1).isSameAs(credentialsProvider2);
-  }
-
-  @ParameterizedTest
-  @CsvSource(value = {"http, true", "https, false", "grpc, true", "grpcs, false"})
-  void shouldConfigurePlaintextAndGatewayAddress(final String protocol, final boolean plaintext) {
-    final CamundaClientProperties properties = properties();
-    properties.setGrpcAddress(URI.create(String.format("%s://some-host:21500", protocol)));
-    final SpringCamundaClientConfiguration configuration =
-        configuration(
-            properties,
-            jsonMapper(),
-            List.of(),
-            List.of(),
-            executorService(),
-            credentialsProvider());
-    assertThat(configuration.isPlaintextConnectionEnabled()).isEqualTo(plaintext);
-    assertThat(configuration.getGatewayAddress()).isEqualTo("some-host:21500");
   }
 
   @Test

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/legacy/CamundaClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/legacy/CamundaClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -108,13 +108,10 @@ public class CamundaClientStarterAutoConfigurationCustomJsonMapperTest {
         AopTestUtils.getUltimateTargetObject(configuration.getJsonMapper());
     assertThat(clientJsonMapper).isSameAs(jsonMapper);
     assertThat(clientJsonMapper).isSameAs(applicationContext.getBean("overridingJsonMapper"));
-    assertThat(configuration.getGatewayAddress()).isEqualTo("localhost:1234");
     assertThat(configuration.getGrpcAddress().toString()).isEqualTo("https://localhost:1234");
     assertThat(configuration.getRestAddress().toString()).isEqualTo("https://localhost:8080");
     assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
     assertThat(configuration.getCaCertificatePath()).isEqualTo("aPath");
-    assertThat(configuration.isPlaintextConnectionEnabled())
-        .isFalse(); // because the grpc address points to https
     assertThat(configuration.getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
     assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofSeconds(99));
     assertThat(configuration.preferRestOverGrpc()).isTrue();

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/legacy/CamundaClientStarterAutoConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/legacy/CamundaClientStarterAutoConfigurationTest.java
@@ -102,12 +102,10 @@ public class CamundaClientStarterAutoConfigurationTest {
   void testClientConfiguration() {
     final CamundaClientConfiguration configuration =
         applicationContext.getBean(CamundaClientConfiguration.class);
-    assertThat(configuration.getGatewayAddress()).isEqualTo("localhost:1234");
     assertThat(configuration.getGrpcAddress().toString()).isEqualTo("https://localhost:1234");
     assertThat(configuration.getRestAddress().toString()).isEqualTo("https://localhost:8080");
     assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
     assertThat(configuration.getCaCertificatePath()).isEqualTo("aPath");
-    assertThat(configuration.isPlaintextConnectionEnabled()).isFalse(); // grpc address is https
     assertThat(configuration.getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
     assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofSeconds(99));
     assertThat(configuration.preferRestOverGrpc()).isTrue();

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
@@ -49,16 +49,6 @@ public interface CamundaClientBuilder {
       final boolean applyEnvironmentVariableOverrides);
 
   /**
-   * @deprecated since 8.5 for removal with 8.8, replaced by {@link
-   *     CamundaClientBuilder#grpcAddress(URI)}
-   * @param gatewayAddress the IP socket address of a gateway that the client can initially connect
-   *     to. Must be in format <code>host:port</code>. The default value is <code>0.0.0.0:26500
-   *     </code> .
-   */
-  @Deprecated
-  CamundaClientBuilder gatewayAddress(String gatewayAddress);
-
-  /**
    * @param restAddress the REST API address of a gateway that the client can connect to. The
    *     address must be an absolute URL, including the scheme.
    *     <p>The default value is {@code https://0.0.0.0:8080}.
@@ -157,9 +147,6 @@ public interface CamundaClientBuilder {
    */
   CamundaClientBuilder defaultRequestTimeoutOffset(Duration requestTimeoutOffset);
 
-  /** Use a plaintext connection between the client and the gateway. */
-  CamundaClientBuilder usePlaintext();
-
   /**
    * Path to a root CA certificate to be used instead of the certificate in the default default
    * store.
@@ -178,7 +165,7 @@ public interface CamundaClientBuilder {
   /**
    * Custom implementations of the gRPC {@code ClientInterceptor} middleware API. The interceptors
    * will be applied to every gRPC call that the client makes. More details can be found at {@link
-   * https://grpc.io/docs/guides/interceptors/}.
+   * <a href="https://grpc.io/docs/guides/interceptors/">grpc.io</a>}.
    */
   CamundaClientBuilder withInterceptors(ClientInterceptor... interceptor);
 
@@ -197,7 +184,7 @@ public interface CamundaClientBuilder {
    * <p>This method is intended for testing, but may safely be used outside of tests as an
    * alternative to DNS overrides.
    *
-   * <p>This setting does nothing if a {@link #usePlaintext() plaintext} connection is used.
+   * <p>This setting does nothing if a plaintext connection is used.
    *
    * @param authority The alternative authority to use, commonly in the form <code>host</code> or
    *     <code>host:port</code>

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientConfiguration.java
@@ -27,14 +27,6 @@ import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 public interface CamundaClientConfiguration {
 
   /**
-   * @deprecated since 8.5 for removal with 8.8, replaced by {@link
-   *     CamundaClientConfiguration#getGrpcAddress()}
-   * @see CamundaClientBuilder#grpcAddress(URI)
-   */
-  @Deprecated
-  String getGatewayAddress();
-
-  /**
    * @see CamundaClientBuilder#restAddress(URI)
    */
   URI getRestAddress();
@@ -93,11 +85,6 @@ public interface CamundaClientConfiguration {
    * @see CamundaClientBuilder#defaultRequestTimeoutOffset(Duration)
    */
   Duration getDefaultRequestTimeoutOffset();
-
-  /**
-   * @see CamundaClientBuilder#usePlaintext()
-   */
-  boolean isPlaintextConnectionEnabled();
 
   /**
    * @see CamundaClientBuilder#caCertificatePath(String)

--- a/clients/java/src/main/java/io/camunda/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/ClientProperties.java
@@ -100,6 +100,7 @@ public final class ClientProperties {
   /**
    * @see CamundaClientBuilder#usePlaintext()
    */
+  @Deprecated
   public static final String USE_PLAINTEXT_CONNECTION = "camunda.client.security.plaintext";
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/ClientProperties.java
@@ -98,12 +98,6 @@ public final class ClientProperties {
   public static final String DEFAULT_REQUEST_TIMEOUT_OFFSET = "camunda.client.requestTimeoutOffset";
 
   /**
-   * @see CamundaClientBuilder#usePlaintext()
-   */
-  @Deprecated
-  public static final String USE_PLAINTEXT_CONNECTION = "camunda.client.security.plaintext";
-
-  /**
    * @see CamundaClientBuilder#caCertificatePath(String)
    */
   public static final String CA_CERTIFICATE_PATH = "camunda.client.security.certpath";

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -257,9 +257,9 @@ public final class CamundaClientBuilderImpl
   }
 
   private void gatewayAddress(final String gatewayAddress) {
-    grpcAddress =
-        AddressUtil.composeGrpcAddress(
-            gatewayAddress, AddressUtil.isPlaintextConnection(grpcAddress));
+    // we apply the legacy behaviour here, the plaintext parameter can still be changed as the
+    // plaintext is checked AFTER the gateway address
+    grpcAddress = AddressUtil.composeGrpcAddress(gatewayAddress, false);
   }
 
   @Override
@@ -582,10 +582,9 @@ public final class CamundaClientBuilderImpl
     return new CamundaClientImpl(this);
   }
 
-  private CamundaClientBuilder usePlaintext(final boolean usePlaintext) {
+  private void usePlaintext(final boolean usePlaintext) {
     grpcAddress = AddressUtil.composeAddress(usePlaintext, grpcAddress);
     restAddress = AddressUtil.composeAddress(usePlaintext, restAddress);
-    return this;
   }
 
   private void keepAlive(final String keepAlive) {

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -356,6 +356,25 @@ public final class CamundaClientBuilderImpl
 
     BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        value -> {
+          /**
+           * The following condition is phrased in this particular way in order to be backwards
+           * compatible with older versions of the software. In older versions the content of the
+           * property was not interpreted. It was assumed to be true, whenever it was set. Because
+           * of that, code examples in this code base set the flag to an empty string. By phrasing
+           * the condition this way, the old code will still work with this new implementation. Only
+           * if somebody deliberately sets the flag to false, the behavior will change
+           */
+          if ("false".equalsIgnoreCase(value)) {
+            usePlaintext(false);
+          } else {
+            usePlaintext(true);
+          }
+        },
+        LegacyZeebeClientProperties.USE_PLAINTEXT_CONNECTION);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
         value -> maxMessageSize(DataSizeUtil.parse(value)),
         MAX_MESSAGE_SIZE,
         LegacyZeebeClientProperties.MAX_MESSAGE_SIZE);

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -39,7 +39,6 @@ import static io.camunda.client.impl.CamundaClientEnvironmentVariables.DEFAULT_T
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.GRPC_ADDRESS_VAR;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.KEEP_ALIVE_VAR;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OVERRIDE_AUTHORITY_VAR;
-import static io.camunda.client.impl.CamundaClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.PREFER_REST_VAR;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.REST_ADDRESS_VAR;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.USE_DEFAULT_RETRY_POLICY_VAR;
@@ -56,8 +55,6 @@ import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.client.impl.util.DataSizeUtil;
-import io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables;
-import io.camunda.client.impl.util.Environment;
 import io.grpc.ClientInterceptor;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -572,7 +569,6 @@ public final class CamundaClientBuilderImpl
   private void applyOverrides() {
     applyEnvironmentValueIfNotNull(
         value -> usePlaintext(Boolean.parseBoolean(value)),
-        PLAINTEXT_CONNECTION_VAR,
         LegacyZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR);
     applyEnvironmentValueIfNotNull(
         this::caCertificatePath,

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -342,20 +342,6 @@ public final class CamundaClientBuilderImpl
 
     BuilderUtils.applyPropertyValueIfNotNull(
         properties,
-        this::caCertificatePath,
-        CA_CERTIFICATE_PATH,
-        LegacyZeebeClientProperties.CA_CERTIFICATE_PATH);
-
-    BuilderUtils.applyPropertyValueIfNotNull(properties, this::keepAlive, KEEP_ALIVE);
-
-    BuilderUtils.applyPropertyValueIfNotNull(
-        properties,
-        this::overrideAuthority,
-        OVERRIDE_AUTHORITY,
-        LegacyZeebeClientProperties.OVERRIDE_AUTHORITY);
-
-    BuilderUtils.applyPropertyValueIfNotNull(
-        properties,
         value -> {
           /**
            * The following condition is phrased in this particular way in order to be backwards
@@ -372,6 +358,20 @@ public final class CamundaClientBuilderImpl
           }
         },
         LegacyZeebeClientProperties.USE_PLAINTEXT_CONNECTION);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        this::caCertificatePath,
+        CA_CERTIFICATE_PATH,
+        LegacyZeebeClientProperties.CA_CERTIFICATE_PATH);
+
+    BuilderUtils.applyPropertyValueIfNotNull(properties, this::keepAlive, KEEP_ALIVE);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        this::overrideAuthority,
+        OVERRIDE_AUTHORITY,
+        LegacyZeebeClientProperties.OVERRIDE_AUTHORITY);
 
     BuilderUtils.applyPropertyValueIfNotNull(
         properties,

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
@@ -353,7 +353,11 @@ public class CamundaClientCloudBuilderImpl
 
       if (AddressUtil.isPlaintextConnection(innerBuilder.getGrpcAddress())
           || AddressUtil.isPlaintextConnection(innerBuilder.getRestAddress())) {
-        Loggers.LOGGER.debug("Expected a secured protocol {} for gRPC and REST, but got {} and {}.", AddressUtil.ENCRYPTED_SCHEMES, innerBuilder.getGrpcAddress(), innerBuilder.getRestAddress());
+        Loggers.LOGGER.debug(
+            "Expected a secured protocol {} for gRPC and REST, but got {} and {}.",
+            AddressUtil.ENCRYPTED_SCHEMES,
+            innerBuilder.getGrpcAddress(),
+            innerBuilder.getRestAddress());
       }
       return builder
           .audience(String.format("%s.%s", ZEEBE_DOMAIN_COMPONENT, domain))

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
@@ -353,7 +353,7 @@ public class CamundaClientCloudBuilderImpl
 
       if (AddressUtil.isPlaintextConnection(innerBuilder.getGrpcAddress())
           || AddressUtil.isPlaintextConnection(innerBuilder.getRestAddress())) {
-        Loggers.LOGGER.debug("Expected setting 'usePlaintext' to be 'false', but found 'true'.");
+        Loggers.LOGGER.debug("Expected a secured protocol {} for gRPC and REST, but got {} and {}.", AddressUtil.ENCRYPTED_SCHEMES, innerBuilder.getGrpcAddress(), innerBuilder.getRestAddress());
       }
       return builder
           .audience(String.format("%s.%s", ZEEBE_DOMAIN_COMPONENT, domain))

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
@@ -34,6 +34,7 @@ import io.camunda.client.LegacyZeebeClientProperties;
 import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.client.impl.util.AddressUtil;
 import io.grpc.ClientInterceptor;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -140,12 +141,6 @@ public class CamundaClientCloudBuilderImpl
   }
 
   @Override
-  public CamundaClientBuilder gatewayAddress(final String gatewayAddress) {
-    innerBuilder.gatewayAddress(gatewayAddress);
-    return this;
-  }
-
-  @Override
   public CamundaClientBuilder restAddress(final URI restAddress) {
     innerBuilder.restAddress(restAddress);
     return this;
@@ -225,12 +220,6 @@ public class CamundaClientCloudBuilderImpl
   @Override
   public CamundaClientBuilder defaultRequestTimeoutOffset(final Duration requestTimeoutOffset) {
     innerBuilder.defaultRequestTimeoutOffset(requestTimeoutOffset);
-    return this;
-  }
-
-  @Override
-  public CamundaClientBuilder usePlaintext() {
-    innerBuilder.usePlaintext();
     return this;
   }
 
@@ -331,7 +320,7 @@ public class CamundaClientCloudBuilderImpl
   }
 
   private URI determineGrpcAddress() {
-    if (isNeedToSetCloudGrpcAddress() && isNeedToSetCloudGatewayAddress()) {
+    if (isNeedToSetCloudGrpcAddress()) {
       ensureNotNull("cluster id", clusterId);
       final String cloudGrpcAddress =
           String.format(
@@ -347,10 +336,10 @@ public class CamundaClientCloudBuilderImpl
       }
 
       Loggers.LOGGER.debug(
-          "Expected to use 'cluster id' to set gateway address in the client cloud builder, "
-              + "but overwriting with explicitly defined gateway address: {}.",
-          innerBuilder.getGatewayAddress());
-      return getURIFromString("https://" + innerBuilder.getGatewayAddress());
+          "Expected to use 'cluster id' to set grpc address in the client cloud builder, "
+              + "but overwriting with explicitly defined grpc address: {}.",
+          innerBuilder.getGrpcAddress());
+      return innerBuilder.getGrpcAddress();
     }
   }
 
@@ -362,7 +351,8 @@ public class CamundaClientCloudBuilderImpl
       ensureNotNull("client secret", clientSecret);
       final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
 
-      if (innerBuilder.isPlaintextConnectionEnabled()) {
+      if (AddressUtil.isPlaintextConnection(innerBuilder.getGrpcAddress())
+          || AddressUtil.isPlaintextConnection(innerBuilder.getRestAddress())) {
         Loggers.LOGGER.debug("Expected setting 'usePlaintext' to be 'false', but found 'true'.");
       }
       return builder
@@ -383,12 +373,6 @@ public class CamundaClientCloudBuilderImpl
     return innerBuilder.getGrpcAddress() == null
         || Objects.equals(
             innerBuilder.getGrpcAddress(), CamundaClientBuilderImpl.DEFAULT_GRPC_ADDRESS);
-  }
-
-  private boolean isNeedToSetCloudGatewayAddress() {
-    return innerBuilder.getGatewayAddress() == null
-        || Objects.equals(
-            innerBuilder.getGatewayAddress(), CamundaClientBuilderImpl.DEFAULT_GATEWAY_ADDRESS);
   }
 
   private boolean isNeedToSetCloudRestAddress() {

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientEnvironmentVariables.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientEnvironmentVariables.java
@@ -16,7 +16,6 @@
 package io.camunda.client.impl;
 
 public final class CamundaClientEnvironmentVariables {
-  public static final String PLAINTEXT_CONNECTION_VAR = "CAMUNDA_INSECURE_CONNECTION";
   public static final String CA_CERTIFICATE_VAR = "CAMUNDA_CA_CERTIFICATE_PATH";
   public static final String KEEP_ALIVE_VAR = "CAMUNDA_KEEP_ALIVE";
   public static final String OVERRIDE_AUTHORITY_VAR = "CAMUNDA_OVERRIDE_AUTHORITY";

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -296,6 +296,7 @@ import io.camunda.client.impl.search.request.VariableSearchRequestImpl;
 import io.camunda.client.impl.statistics.request.ProcessDefinitionElementStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.ProcessInstanceElementStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.UsageMetricsStatisticsRequestImpl;
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.client.impl.util.ExecutorResource;
 import io.camunda.client.impl.util.VersionUtil;
 import io.camunda.client.impl.worker.JobClientImpl;
@@ -431,7 +432,8 @@ public final class CamundaClientImpl implements CamundaClient {
 
   private static void configureConnectionSecurity(
       final CamundaClientConfiguration config, final NettyChannelBuilder channelBuilder) {
-    if (!config.isPlaintextConnectionEnabled()) {
+    final URI grpcAddress = config.getGrpcAddress();
+    if (!AddressUtil.isPlaintextConnection(grpcAddress)) {
       final String certificatePath = config.getCaCertificatePath();
       SslContext sslContext = null;
 

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.impl.NoopCredentialsProvider;
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.client.impl.util.VersionUtil;
 import java.io.File;
 import java.io.FileInputStream;
@@ -109,7 +110,6 @@ public class HttpClientFactory {
 
     try {
       final URIBuilder builder = new URIBuilder(basePath).appendPath(REST_API_PATH);
-      builder.setScheme(config.isPlaintextConnectionEnabled() ? "http" : "https");
 
       return builder.build();
     } catch (final URISyntaxException e) {
@@ -168,7 +168,8 @@ public class HttpClientFactory {
   }
 
   private SSLContext createSslContext() {
-    if (config.isPlaintextConnectionEnabled() || config.getCaCertificatePath() == null) {
+    if (AddressUtil.isPlaintextConnection(config.getRestAddress())
+        || config.getCaCertificatePath() == null) {
       return SSLContexts.createDefault();
     }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/util/AddressUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/AddressUtil.java
@@ -17,12 +17,16 @@ package io.camunda.client.impl.util;
 
 import io.camunda.client.api.command.ClientException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.hc.core5.net.URIBuilder;
 
-public class AddressUtil {
+public final class AddressUtil {
   public static final List<String> PLAINTEXT_SCHEMES = Arrays.asList("http", "grpc");
   public static final List<String> ENCRYPTED_SCHEMES = Arrays.asList("https", "grpcs");
+
+  private AddressUtil() {}
 
   public static boolean isPlaintextConnection(final URI address) {
     if (address == null) {
@@ -35,6 +39,32 @@ public class AddressUtil {
       return false;
     } else {
       throw new ClientException(String.format("Unrecognized scheme '%s'", scheme));
+    }
+  }
+
+  public static String composeGatewayAddress(final URI grpcAddress) {
+    final int port = grpcAddress.getPort();
+    if (port == -1) {
+      return grpcAddress.getHost();
+    }
+    return String.format("%s:%d", grpcAddress.getHost(), port);
+  }
+
+  public static URI composeGrpcAddress(final String gatewayAddress, final boolean plaintext) {
+    final String composedGrpcAddress = String.format("%s://%s", scheme(plaintext), gatewayAddress);
+    return URI.create(composedGrpcAddress);
+  }
+
+  public static String scheme(final boolean plaintext) {
+    return plaintext ? PLAINTEXT_SCHEMES.get(0) : ENCRYPTED_SCHEMES.get(0);
+  }
+
+  public static URI composeAddress(final boolean plaintext, final URI address) {
+    final String scheme = scheme(plaintext);
+    try {
+      return new URIBuilder(address).setScheme(scheme).build();
+    } catch (final URISyntaxException e) {
+      throw new ClientException("Error while composing address", e);
     }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/util/AddressUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/AddressUtil.java
@@ -16,6 +16,8 @@
 package io.camunda.client.impl.util;
 
 import io.camunda.client.api.command.ClientException;
+import io.netty.util.NetUtil;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -48,6 +50,11 @@ public final class AddressUtil {
       return grpcAddress.getHost();
     }
     return String.format("%s:%d", grpcAddress.getHost(), port);
+  }
+
+  public static URI composeGrpcAddress(
+      final InetSocketAddress gatewayAddress, final boolean plaintext) {
+    return composeGrpcAddress(NetUtil.toSocketAddressString(gatewayAddress), plaintext);
   }
 
   public static URI composeGrpcAddress(final String gatewayAddress, final boolean plaintext) {

--- a/clients/java/src/main/java/io/camunda/client/impl/util/AddressUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/AddressUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import io.camunda.client.api.command.ClientException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+public class AddressUtil {
+  public static final List<String> PLAINTEXT_SCHEMES = Arrays.asList("http", "grpc");
+  public static final List<String> ENCRYPTED_SCHEMES = Arrays.asList("https", "grpcs");
+
+  public static boolean isPlaintextConnection(final URI address) {
+    if (address == null) {
+      return true;
+    }
+    final String scheme = address.getScheme();
+    if (PLAINTEXT_SCHEMES.contains(scheme)) {
+      return true;
+    } else if (ENCRYPTED_SCHEMES.contains(scheme)) {
+      return false;
+    } else {
+      throw new ClientException(String.format("Unrecognized scheme '%s'", scheme));
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -146,31 +146,13 @@ public final class CamundaClientTest {
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {
-        PLAINTEXT_CONNECTION_VAR,
-        LegacyZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR
-      })
-  public void shouldUseInsecureWithEnvVar(final String envVarName) {
-    // given
-    Environment.system().put(envVarName, "true");
-    final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
-
-    // when
-    builder.build();
-
-    // then
-    assertThat(builder.isPlaintextConnectionEnabled()).isTrue();
-  }
-
-  @ParameterizedTest
   @CsvSource({
-    PLAINTEXT_CONNECTION_VAR + "," + USE_PLAINTEXT_CONNECTION,
-    LegacyZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR + "," + USE_PLAINTEXT_CONNECTION,
-    PLAINTEXT_CONNECTION_VAR + "," + LegacyZeebeClientProperties.USE_PLAINTEXT_CONNECTION,
-    LegacyZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR
+    PREFER_REST_VAR + "," + PREFER_REST_OVER_GRPC,
+    LegacyZeebeClientEnvironmentVariables.PREFER_REST_VAR + "," + PREFER_REST_OVER_GRPC,
+    PREFER_REST_VAR + "," + LegacyZeebeClientProperties.PREFER_REST_OVER_GRPC,
+    LegacyZeebeClientEnvironmentVariables.PREFER_REST_VAR
         + ","
-        + LegacyZeebeClientProperties.USE_PLAINTEXT_CONNECTION
+        + LegacyZeebeClientProperties.PREFER_REST_OVER_GRPC
   })
   public void shouldOverridePropertyWithEnvVariable(
       final String envName, final String propertyName) {
@@ -185,17 +167,17 @@ public final class CamundaClientTest {
     builder.build();
 
     // then
-    assertThat(builder.isPlaintextConnectionEnabled()).isFalse();
+    assertThat(builder.preferRestOverGrpc()).isFalse();
   }
 
   @ParameterizedTest
   @CsvSource({
-    PLAINTEXT_CONNECTION_VAR + "," + USE_PLAINTEXT_CONNECTION,
-    LegacyZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR + "," + USE_PLAINTEXT_CONNECTION,
-    PLAINTEXT_CONNECTION_VAR + "," + LegacyZeebeClientProperties.USE_PLAINTEXT_CONNECTION,
-    LegacyZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR
+    PREFER_REST_VAR + "," + PREFER_REST_OVER_GRPC,
+    LegacyZeebeClientEnvironmentVariables.PREFER_REST_VAR + "," + PREFER_REST_OVER_GRPC,
+    PREFER_REST_VAR + "," + LegacyZeebeClientProperties.PREFER_REST_OVER_GRPC,
+    LegacyZeebeClientEnvironmentVariables.PREFER_REST_VAR
         + ","
-        + LegacyZeebeClientProperties.USE_PLAINTEXT_CONNECTION
+        + LegacyZeebeClientProperties.PREFER_REST_OVER_GRPC
   })
   public void shouldNotOverridePropertyWithEnvVariableIfOverridingIsDisabled(
       final String envName, final String propertyName) {
@@ -211,7 +193,7 @@ public final class CamundaClientTest {
     builder.build();
 
     // then
-    assertThat(builder.isPlaintextConnectionEnabled()).isTrue();
+    assertThat(builder.preferRestOverGrpc()).isTrue();
   }
 
   @ParameterizedTest

--- a/clients/java/src/test/java/io/camunda/client/ClientRestInterceptorTest.java
+++ b/clients/java/src/test/java/io/camunda/client/ClientRestInterceptorTest.java
@@ -112,7 +112,6 @@ public class ClientRestInterceptorTest {
 
   private CamundaClient createClient(final WireMockRuntimeInfo mockInfo) throws URISyntaxException {
     return CamundaClient.newClientBuilder()
-        .usePlaintext()
         .preferRestOverGrpc(true)
         .restAddress(new URI(mockInfo.getHttpBaseUrl()))
         .withChainHandlers(new TestTopologyInterceptor(), new TestUserTasksInterceptor())

--- a/clients/java/src/test/java/io/camunda/client/CredentialsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CredentialsTest.java
@@ -73,20 +73,18 @@ public final class CredentialsTest {
     // given
     final String bearerToken = "Bearer someToken";
 
-    builder
-        .usePlaintext()
-        .credentialsProvider(
-            new CredentialsProvider() {
-              @Override
-              public void applyCredentials(final CredentialsApplier applier) {
-                applier.put("Authorization", bearerToken);
-              }
+    builder.credentialsProvider(
+        new CredentialsProvider() {
+          @Override
+          public void applyCredentials(final CredentialsApplier applier) {
+            applier.put("Authorization", bearerToken);
+          }
 
-              @Override
-              public boolean shouldRetryRequest(final StatusCode statusCode) {
-                return false;
-              }
-            });
+          @Override
+          public boolean shouldRetryRequest(final StatusCode statusCode) {
+            return false;
+          }
+        });
     client = new CamundaClientImpl(builder, serverRule.getChannel());
 
     // when
@@ -120,7 +118,7 @@ public final class CredentialsTest {
                 return true;
               }
             });
-    builder.usePlaintext().credentialsProvider(provider);
+    builder.credentialsProvider(provider);
     client = new CamundaClientImpl(builder, serverRule.getChannel());
 
     // when
@@ -155,7 +153,7 @@ public final class CredentialsTest {
               }
             });
 
-    builder.usePlaintext().credentialsProvider(provider);
+    builder.credentialsProvider(provider);
     client = new CamundaClientImpl(builder, serverRule.getChannel());
 
     // when/then
@@ -169,7 +167,6 @@ public final class CredentialsTest {
   @Test
   public void shouldNotChangeHeadersWithNoProvider() {
     // given
-    builder.usePlaintext();
     client = new CamundaClientImpl(builder, serverRule.getChannel());
 
     // when
@@ -183,20 +180,18 @@ public final class CredentialsTest {
   public void shouldCredentialsProviderRunFromGRPCThreadPool() {
     // given
     final AtomicReference<String> credentialsProviderThreadReference = new AtomicReference<>();
-    builder
-        .usePlaintext()
-        .credentialsProvider(
-            new CredentialsProvider() {
-              @Override
-              public void applyCredentials(final CredentialsApplier ignored) {
-                credentialsProviderThreadReference.set(Thread.currentThread().getName());
-              }
+    builder.credentialsProvider(
+        new CredentialsProvider() {
+          @Override
+          public void applyCredentials(final CredentialsApplier ignored) {
+            credentialsProviderThreadReference.set(Thread.currentThread().getName());
+          }
 
-              @Override
-              public boolean shouldRetryRequest(final StatusCode statusCode) {
-                return false;
-              }
-            });
+          @Override
+          public boolean shouldRetryRequest(final StatusCode statusCode) {
+            return false;
+          }
+        });
     client = new CamundaClientImpl(builder, serverRule.getChannel());
 
     // when

--- a/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderTest.java
@@ -734,7 +734,6 @@ public final class OAuthCredentialsProviderTest {
 
     private CamundaClientBuilder clientBuilder() throws URISyntaxException {
       return CamundaClient.newClientBuilder()
-          .usePlaintext()
           .grpcAddress(new URI("http://localhost:" + grpcServer.getPort()))
           .restAddress(new URI(currentWiremockRuntimeInfo.getHttpBaseUrl()))
           .credentialsProvider(

--- a/clients/java/src/test/java/io/camunda/client/util/ClientRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/util/ClientRestTest.java
@@ -44,7 +44,6 @@ public abstract class ClientRestTest {
 
   private CamundaClient createClient(final WireMockRuntimeInfo mockInfo) throws URISyntaxException {
     return CamundaClient.newClientBuilder()
-        .usePlaintext()
         .preferRestOverGrpc(true)
         .restAddress(new URI(mockInfo.getHttpBaseUrl()))
         .build();

--- a/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
@@ -124,14 +124,13 @@ public class CamundaDockerIT {
     startContainer(camundaContainer);
 
     final String host = "http://" + createCamundaContainer().getHost() + ":";
-    final String camundaEndpoint = host + camundaContainer.getMappedPort(SERVER_PORT);
+    final URI camundaEndpoint = URI.create(host + camundaContainer.getMappedPort(SERVER_PORT));
     try (final CamundaClient camundaClient =
         new CamundaClientBuilderImpl()
             // set a longer timeout because containers in CI infrastructure can be slow
             .defaultRequestTimeout(Duration.ofSeconds(60))
-            .usePlaintext()
             .preferRestOverGrpc(true)
-            .restAddress(new URI(camundaEndpoint))
+            .restAddress(camundaEndpoint)
             .build()) {
 
       camundaClient

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/App.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/App.java
@@ -62,7 +62,7 @@ abstract class App implements Runnable {
     Path credentialsCachePath = null;
     try {
       credentialsCachePath = Files.createTempDirectory(".camunda").resolve("credentials.json");
-    } catch (IOException e) {
+    } catch (final IOException e) {
       LOG.warn(
           """
           Failed to create credentials cache directory; there will be no credentials cache, and \
@@ -119,7 +119,7 @@ abstract class App implements Runnable {
     if (credentialsCachePath != null) {
       try {
         FileUtil.deleteFolderIfExists(credentialsCachePath.getParent());
-      } catch (IOException e) {
+      } catch (final IOException e) {
         LOG.debug("Failed to delete credentials cache directory", e);
       }
     }
@@ -159,10 +159,6 @@ abstract class App implements Runnable {
             .preferRestOverGrpc(config.isPreferRest())
             .withProperties(System.getProperties())
             .withInterceptors(monitoringInterceptor);
-
-    if (!config.isTls()) {
-      builder.usePlaintext();
-    }
 
     final var auth = config.getAuth();
     final var credentialsProvider =

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/AppCfg.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/AppCfg.java
@@ -12,7 +12,6 @@ public class AppCfg {
   private String brokerUrl;
   private String brokerRestUrl;
   private boolean preferRest;
-  private boolean tls;
   private int monitoringPort;
   private StarterCfg starter;
   private WorkerCfg worker;
@@ -40,14 +39,6 @@ public class AppCfg {
 
   public void setPreferRest(final boolean preferRest) {
     this.preferRest = preferRest;
-  }
-
-  public boolean isTls() {
-    return tls;
-  }
-
-  public void setTls(final boolean tls) {
-    this.tls = tls;
   }
 
   public StarterCfg getStarter() {

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -24,7 +24,6 @@ public class ConfigTest {
     assertThat(appCfg.getBrokerUrl()).isEqualTo("http://localhost:26500");
     assertThat(appCfg.getBrokerRestUrl()).isEqualTo("http://localhost:8080");
     assertThat(appCfg.isPreferRest()).isFalse();
-    assertThat(appCfg.isTls()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
 
     // authentication
@@ -78,7 +77,6 @@ public class ConfigTest {
     assertThat(appCfg.getBrokerUrl()).isEqualTo("http://localhost:26500");
     assertThat(appCfg.getBrokerRestUrl()).isEqualTo("http://localhost:8081");
     assertThat(appCfg.isPreferRest()).isTrue();
-    assertThat(appCfg.isTls()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
 
     // authentication

--- a/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeConnector.java
@@ -9,6 +9,7 @@ package io.camunda.operate.zeebe;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.property.ZeebeProperties;
 import io.camunda.operate.util.ConditionalOnOperateCompatibility;
@@ -39,13 +40,13 @@ public class ZeebeConnector {
     final CamundaClientBuilder builder =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .gatewayAddress(gatewayAddress)
+            .grpcAddress(
+                AddressUtil.composeGrpcAddress(gatewayAddress, !zeebeProperties.isSecure()))
             .defaultJobWorkerMaxJobsActive(JOB_WORKER_MAX_JOBS_ACTIVE);
     if (zeebeProperties.isSecure()) {
       builder.caCertificatePath(zeebeProperties.getCertificatePath());
       LOGGER.info("Use TLS connection to zeebe");
     } else {
-      builder.usePlaintext();
       LOGGER.info("Use plaintext connection to zeebe");
     }
     return builder.build();

--- a/operate/data-generator/src/main/java/io/camunda/operate/DataGeneratorModuleConfiguration.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/DataGeneratorModuleConfiguration.java
@@ -36,6 +36,6 @@ public class DataGeneratorModuleConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public CamundaClient camundaClient() {
-    return CamundaClient.newClientBuilder().usePlaintext().build();
+    return CamundaClient.newClientBuilder().build();
   }
 }

--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/DataGenerator.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/DataGenerator.java
@@ -84,8 +84,7 @@ public class DataGenerator {
     camundaClient =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .gatewayAddress(testContext.getExternalZeebeContactPoint())
-            .usePlaintext()
+            .grpcAddress(testContext.getZeebeGrpcAddress())
             .build();
     esClient = testContext.getEsClient();
     operateRestClient = testContext.getOperateRestClient();

--- a/operate/qa/data-generator/src/main/java/io/camunda/operate/data/generation/DataGeneratorConfig.java
+++ b/operate/qa/data-generator/src/main/java/io/camunda/operate/data/generation/DataGeneratorConfig.java
@@ -27,12 +27,10 @@ public class DataGeneratorConfig {
   @Autowired private DataGeneratorProperties dataGeneratorProperties;
 
   public CamundaClient createCamundaClient() {
-    final String gatewayAddress = dataGeneratorProperties.getZeebeGatewayAddress();
     final CamundaClientBuilder builder =
         CamundaClient.newClientBuilder()
-            .gatewayAddress(gatewayAddress)
-            .defaultJobWorkerMaxJobsActive(JOB_WORKER_MAX_JOBS_ACTIVE)
-            .usePlaintext();
+            .grpcAddress(dataGeneratorProperties.getZeebeGrpcAddress())
+            .defaultJobWorkerMaxJobsActive(JOB_WORKER_MAX_JOBS_ACTIVE);
     return builder.build();
   }
 

--- a/operate/qa/data-generator/src/main/java/io/camunda/operate/data/generation/DataGeneratorProperties.java
+++ b/operate/qa/data-generator/src/main/java/io/camunda/operate/data/generation/DataGeneratorProperties.java
@@ -9,6 +9,7 @@ package io.camunda.operate.data.generation;
 
 import static io.camunda.operate.data.generation.DataGeneratorProperties.PROPERTIES_PREFIX;
 
+import java.net.URI;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -28,7 +29,7 @@ public class DataGeneratorProperties {
 
   private int resolvedIncidentCount = 100;
 
-  private String zeebeGatewayAddress = "localhost:26500";
+  private URI zeebeGrpcAddress = URI.create("http://localhost:26500");
 
   private String elasticsearchHost = "localhost";
 
@@ -44,7 +45,7 @@ public class DataGeneratorProperties {
     return processCount;
   }
 
-  public void setProcessCount(int processCount) {
+  public void setProcessCount(final int processCount) {
     this.processCount = processCount;
   }
 
@@ -52,7 +53,7 @@ public class DataGeneratorProperties {
     return processInstanceCount;
   }
 
-  public void setProcessInstanceCount(int processInstanceCount) {
+  public void setProcessInstanceCount(final int processInstanceCount) {
     this.processInstanceCount = processInstanceCount;
   }
 
@@ -70,7 +71,7 @@ public class DataGeneratorProperties {
     return incidentCount;
   }
 
-  public void setIncidentCount(int incidentCount) {
+  public void setIncidentCount(final int incidentCount) {
     this.incidentCount = incidentCount;
   }
 
@@ -83,19 +84,19 @@ public class DataGeneratorProperties {
     return this;
   }
 
-  public String getZeebeGatewayAddress() {
-    return zeebeGatewayAddress;
+  public URI getZeebeGrpcAddress() {
+    return zeebeGrpcAddress;
   }
 
-  public void setZeebeGatewayAddress(String gatewayAddress) {
-    this.zeebeGatewayAddress = gatewayAddress;
+  public void setZeebeGrpcAddress(final URI gatewayAddress) {
+    zeebeGrpcAddress = gatewayAddress;
   }
 
   public String getElasticsearchHost() {
     return elasticsearchHost;
   }
 
-  public void setElasticsearchHost(String elasticsearchHost) {
+  public void setElasticsearchHost(final String elasticsearchHost) {
     this.elasticsearchHost = elasticsearchHost;
   }
 
@@ -103,7 +104,7 @@ public class DataGeneratorProperties {
     return elasticsearchPort;
   }
 
-  public void setElasticsearchPort(int elasticsearchPort) {
+  public void setElasticsearchPort(final int elasticsearchPort) {
     this.elasticsearchPort = elasticsearchPort;
   }
 
@@ -111,7 +112,7 @@ public class DataGeneratorProperties {
     return zeebeElasticsearchPrefix;
   }
 
-  public void setZeebeElasticsearchPrefix(String zeebeElasticsearchPrefix) {
+  public void setZeebeElasticsearchPrefix(final String zeebeElasticsearchPrefix) {
     this.zeebeElasticsearchPrefix = zeebeElasticsearchPrefix;
   }
 
@@ -119,7 +120,7 @@ public class DataGeneratorProperties {
     return queueSize;
   }
 
-  public void setQueueSize(int queueSize) {
+  public void setQueueSize(final int queueSize) {
     this.queueSize = queueSize;
   }
 

--- a/operate/qa/data-generator/src/main/resources/application.yml
+++ b/operate/qa/data-generator/src/main/resources/application.yml
@@ -4,7 +4,7 @@ camunda.operate.qa.data:
   processInstanceCount: 240000
   callActivityProcessInstanceCount: 20000
   incidentCount: 20000
-  zeebeGatewayAddress: localhost:26500
+  zeebeGrpcAddress: http://localhost:26500
   elasticsearchHost: localhost
   elasticsearchPort: 9200
   queueSize: 50

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchOperateZeebeRuleProvider.java
@@ -153,8 +153,7 @@ public class ElasticsearchOperateZeebeRuleProvider implements OperateZeebeRulePr
     client =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
-            .usePlaintext()
+            .grpcAddress(zeebeContainer.getGrpcAddress())
             .defaultRequestTimeout(REQUEST_TIMEOUT)
             .build();
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
@@ -132,8 +132,7 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
     client =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
-            .usePlaintext()
+            .grpcAddress(zeebeContainer.getGrpcAddress())
             .defaultRequestTimeout(REQUEST_TIMEOUT)
             .build();
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/ZeebeContainerManager.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/ZeebeContainerManager.java
@@ -62,8 +62,7 @@ public abstract class ZeebeContainerManager {
     client =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
-            .usePlaintext()
+            .grpcAddress(zeebeContainer.getGrpcAddress())
             .defaultRequestTimeout(REQUEST_TIMEOUT)
             .build();
 

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
@@ -585,8 +585,7 @@ public class TestContainerUtil {
 
       testContext.setInternalZeebeContactPoint(
           broker.getInternalAddress(ZeebePort.GATEWAY.getPort()));
-      testContext.setExternalZeebeContactPoint(
-          broker.getExternalAddress(ZeebePort.GATEWAY.getPort()));
+      testContext.setZeebeGrpcAddress(broker.getGrpcAddress());
     } else {
       throw new IllegalStateException("Broker is already started. Call stopZeebe first.");
     }
@@ -674,7 +673,7 @@ public class TestContainerUtil {
   public void stopZeebe(final TestContext testContext, final File tmpFolder) {
     stopZeebe(tmpFolder);
     testContext.setInternalZeebeContactPoint(null);
-    testContext.setExternalZeebeContactPoint(null);
+    testContext.setZeebeGrpcAddress(null);
   }
 
   @SuppressWarnings("checkstyle:NestedIfDepth")

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContext.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContext.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.qa.util;
 
 import java.io.File;
+import java.net.URI;
 import java.util.*;
 import junit.framework.AssertionFailedError;
 import org.testcontainers.containers.Network;
@@ -34,7 +35,7 @@ public class TestContext<T extends TestContext<T>> {
   private String internalKeycloakHost;
   private Integer internalKeycloakPort;
 
-  private String externalZeebeContactPoint;
+  private URI zeebeGrpcAddress;
   private String internalZeebeContactPoint;
 
   private String zeebeIndexPrefix = "zeebe-record";
@@ -50,12 +51,12 @@ public class TestContext<T extends TestContext<T>> {
 
   private String connectionType;
 
-  public void setDatabaseType(String databaseType) {
-    this.databaseType = databaseType;
-  }
-
   public String getDatabaseType() {
     return databaseType;
+  }
+
+  public void setDatabaseType(final String databaseType) {
+    this.databaseType = databaseType;
   }
 
   public File getZeebeDataFolder() {
@@ -220,12 +221,12 @@ public class TestContext<T extends TestContext<T>> {
     return this;
   }
 
-  public String getExternalZeebeContactPoint() {
-    return externalZeebeContactPoint;
+  public URI getZeebeGrpcAddress() {
+    return zeebeGrpcAddress;
   }
 
-  public T setExternalZeebeContactPoint(final String externalZeebeContactPoint) {
-    this.externalZeebeContactPoint = externalZeebeContactPoint;
+  public T setZeebeGrpcAddress(final URI grpcAddress) {
+    zeebeGrpcAddress = grpcAddress;
     return (T) this;
   }
 

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
@@ -26,7 +26,6 @@ import io.camunda.optimize.service.util.importing.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.containers.ZeebeContainer;
 import java.io.IOException;
-import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
@@ -101,19 +100,14 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
       camundaClient =
           CamundaClient.newClientBuilder()
               .defaultRequestTimeout(Duration.ofMillis(15000))
-              .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
-              .usePlaintext()
+              .grpcAddress(zeebeContainer.getGrpcAddress())
               .build();
     } else {
       camundaClient =
           CamundaClient.newClientBuilder()
               .defaultRequestTimeout(Duration.ofMillis(15000))
-              .grpcAddress(
-                  URI.create(
-                      String.format("http://%s", zeebeContainer.getExternalGatewayAddress())))
-              .restAddress(
-                  URI.create(String.format("http://%s", zeebeContainer.getExternalAddress(8080))))
-              .usePlaintext()
+              .grpcAddress(zeebeContainer.getGrpcAddress())
+              .restAddress(zeebeContainer.getRestAddress())
               .build();
     }
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
@@ -200,7 +200,6 @@ final class SecuredClusteredMessagingIT {
     final Topology topology;
     try (final var client =
         CamundaClient.newClientBuilder()
-            .usePlaintext()
             .restAddress(
                 URI.create("http://" + zeebe.getExternalHost() + ":" + zeebe.getMappedPort(8080)))
             .grpcAddress(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/OidcNoSecondaryStorageTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/OidcNoSecondaryStorageTest.java
@@ -137,7 +137,6 @@ public class OidcNoSecondaryStorageTest {
         CamundaClient.newClientBuilder()
             .grpcAddress(broker.grpcAddress())
             .restAddress(broker.restAddress())
-            .usePlaintext()
             .defaultRequestTimeout(Duration.ofSeconds(15))
             .credentialsProvider(
                 new OAuthCredentialsProviderBuilder()
@@ -157,7 +156,6 @@ public class OidcNoSecondaryStorageTest {
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
             .grpcAddress(broker.grpcAddress())
-            .usePlaintext()
             .defaultRequestTimeout(Duration.ofSeconds(15))
             .credentialsProvider(
                 new OAuthCredentialsProviderBuilder()

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/OidcCamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/OidcCamundaClientTestFactory.java
@@ -101,7 +101,6 @@ public final class OidcCamundaClientTestFactory implements CamundaClientTestFact
             .preferRestOverGrpc(true)
             .restAddress(gateway.restAddress())
             .grpcAddress(gateway.grpcAddress())
-            .usePlaintext()
             .defaultRequestTimeout(Duration.ofSeconds(15))
             .credentialsProvider(
                 new OAuthCredentialsProviderBuilder()

--- a/tasklist/common/src/main/java/io/camunda/tasklist/zeebe/ZeebeConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/zeebe/ZeebeConnector.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.zeebe;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.property.ZeebeProperties;
 import io.camunda.tasklist.util.ConditionalOnTasklistCompatibility;
@@ -44,7 +45,9 @@ public class ZeebeConnector {
     final CamundaClientBuilder builder =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .gatewayAddress(zeebeProperties.getGatewayAddress())
+            .grpcAddress(
+                AddressUtil.composeGrpcAddress(
+                    zeebeProperties.getGatewayAddress(), !zeebeProperties.isSecure()))
             // .restAddress(getURIFromString(zeebeProperties.getRestAddress()))
             .restAddress(getURIFromSaaSOrProperties(zeebeProperties.getRestAddress()))
             .defaultJobWorkerMaxJobsActive(JOB_WORKER_MAX_JOBS_ACTIVE);
@@ -52,7 +55,6 @@ public class ZeebeConnector {
       builder.caCertificatePath(zeebeProperties.getCertificatePath());
       LOGGER.info("Use TLS connection to zeebe");
     } else {
-      builder.usePlaintext();
       LOGGER.info("Use plaintext connection to zeebe");
     }
 

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -18,6 +18,7 @@ import io.camunda.tasklist.qa.util.TestContainerUtil;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.webapps.backup.TakeBackupResponseDto;
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
@@ -140,7 +141,7 @@ public class BackupRestoreTest {
     createElsSnapshotRepository(testContext);
 
     testContainerUtil.startZeebe(IMAGE_REPO, VERSION, testContext);
-    createZeebeClient(testContext.getExternalZeebeContactPoint());
+    createCamundaClient(testContext.getZeebeGrpcAddress());
   }
 
   private OpenSearchClient createOsClient() {
@@ -164,7 +165,7 @@ public class BackupRestoreTest {
     createOsSnapshotRepository(testContext);
 
     testContainerUtil.startZeebe(IMAGE_REPO, VERSION, testContext);
-    createZeebeClient(testContext.getExternalZeebeContactPoint());
+    createCamundaClient(testContext.getZeebeGrpcAddress());
   }
 
   private void startTasklist() {
@@ -286,12 +287,9 @@ public class BackupRestoreTest {
                         .settings(s -> s.location(REPOSITORY_NAME))));
   }
 
-  private CamundaClient createZeebeClient(final String zeebeGateway) {
+  private CamundaClient createCamundaClient(final URI grpcAddress) {
     final CamundaClientBuilder builder =
-        CamundaClient.newClientBuilder()
-            .gatewayAddress(zeebeGateway)
-            .defaultJobWorkerMaxJobsActive(5)
-            .usePlaintext();
+        CamundaClient.newClientBuilder().grpcAddress(grpcAddress).defaultJobWorkerMaxJobsActive(5);
     camundaClient = builder.build();
     return camundaClient;
   }

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/generator/AbstractBackupRestoreDataGenerator.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/generator/AbstractBackupRestoreDataGenerator.java
@@ -58,8 +58,7 @@ public abstract class AbstractBackupRestoreDataGenerator implements BackupRestor
     camundaClient =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .gatewayAddress(testContext.getExternalZeebeContactPoint())
-            .usePlaintext()
+            .grpcAddress(testContext.getZeebeGrpcAddress())
             .build();
 
     initClient(testContext);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
@@ -87,11 +87,10 @@ public abstract class TasklistZeebeExtension
     client =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
+            .grpcAddress(zeebeContainer.getGrpcAddress())
             .restAddress(
                 getURIFromString(
                     String.format("http://%s:%s", zeebeContainer.getExternalHost(), zeebeRestPort)))
-            .usePlaintext()
             .defaultRequestTimeout(REQUEST_TIMEOUT)
             .build();
   }

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -537,8 +537,7 @@ public class TestContainerUtil {
 
       testContext.setInternalZeebeContactPoint(
           broker.getInternalAddress(ZeebePort.GATEWAY.getPort()));
-      testContext.setExternalZeebeContactPoint(
-          broker.getExternalAddress(ZeebePort.GATEWAY.getPort()));
+      testContext.setZeebeGrpcAddress(broker.getGrpcAddress());
     } else {
       throw new IllegalStateException("Broker is already started. Call stopZeebe first.");
     }
@@ -602,7 +601,7 @@ public class TestContainerUtil {
       broker = null;
     }
     testContext.setInternalZeebeContactPoint(null);
-    testContext.setExternalZeebeContactPoint(null);
+    testContext.setZeebeGrpcAddress(null);
   }
 
   protected void stopTasklist(final TestContext testContext) {

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContext.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContext.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.qa.util;
 
 import java.io.File;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import junit.framework.AssertionFailedError;
@@ -39,7 +40,7 @@ public class TestContext<T extends TestContext<T>> {
   private String internalKeycloakHost;
   private Integer internalKeycloakPort;
 
-  private String externalZeebeContactPoint;
+  private URI zeebeGrpcAddress;
   private String internalZeebeContactPoint;
 
   private String zeebeIndexPrefix;
@@ -141,12 +142,12 @@ public class TestContext<T extends TestContext<T>> {
     return (T) this;
   }
 
-  public String getExternalZeebeContactPoint() {
-    return externalZeebeContactPoint;
+  public URI getZeebeGrpcAddress() {
+    return zeebeGrpcAddress;
   }
 
-  public T setExternalZeebeContactPoint(final String externalZeebeContactPoint) {
-    this.externalZeebeContactPoint = externalZeebeContactPoint;
+  public T setZeebeGrpcAddress(final URI zeebeGrpcAddress) {
+    this.zeebeGrpcAddress = zeebeGrpcAddress;
     return (T) this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
@@ -200,7 +200,6 @@ public class CamundaProcessTestContainerRuntime
         CamundaClient.newClientBuilder()
             .restAddress(getCamundaRestApiAddress())
             .grpcAddress(getCamundaGrpcApiAddress())
-            .usePlaintext()
             .defaultRequestTimeout(camundaClientRequestTimeout);
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientProperties.java
@@ -165,7 +165,7 @@ public class RemoteRuntimeClientProperties {
   }
 
   private CamundaClientBuilder buildSelfManagedClientFactory() {
-    return CamundaClient.newClientBuilder().usePlaintext();
+    return CamundaClient.newClientBuilder();
   }
 
   public enum ClientMode {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
@@ -91,8 +91,7 @@ public class JunitExtensionTest {
             () ->
                 CamundaClient.newClientBuilder()
                     .grpcAddress(GRPC_API_ADDRESS)
-                    .restAddress(REST_API_ADDRESS)
-                    .usePlaintext());
+                    .restAddress(REST_API_ADDRESS));
 
     when(extensionContext.getRequiredTestInstances()).thenReturn(testInstances);
     when(testInstances.getAllInstances()).thenReturn(Collections.singletonList(this));

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/RemoteCamundaProcessTestExtensionIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/RemoteCamundaProcessTestExtensionIT.java
@@ -92,7 +92,6 @@ public class RemoteCamundaProcessTestExtensionIT {
           .withRemoteCamundaClientBuilderFactory(
               () ->
                   CamundaClient.newClientBuilder()
-                      .usePlaintext()
                       .restAddress(REMOTE_CAMUNDA_CONTAINER.getRestApiAddress())
                       .grpcAddress(REMOTE_CAMUNDA_CONTAINER.getGrpcApiAddress()))
           .withRemoteCamundaMonitoringApiAddress(

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
@@ -115,7 +115,7 @@ public class CamundaSpringProcessTestRuntimeBuilder {
       return createCamundaSaasClientBuilder(clientProperties);
 
     } else {
-      return CamundaClient.newClientBuilder().usePlaintext();
+      return CamundaClient.newClientBuilder();
     }
   }
 

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
@@ -112,8 +112,7 @@ public class ExecutionListenerTest {
             () ->
                 CamundaClient.newClientBuilder()
                     .grpcAddress(GRPC_API_ADDRESS)
-                    .restAddress(REST_API_ADDRESS)
-                    .usePlaintext());
+                    .restAddress(REST_API_ADDRESS));
 
     when(processCoverageBuilder.build()).thenReturn(processCoverage);
     when(testContext.getApplicationContext()).thenReturn(applicationContext);

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
@@ -165,13 +165,13 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
 
     assertThat(configuration.getRestAddress())
         .hasHost("0.0.0.0")
-        .hasPort(ContainerRuntimePorts.CAMUNDA_REST_API);
+        .hasPort(ContainerRuntimePorts.CAMUNDA_REST_API)
+        .hasScheme("http");
 
     assertThat(configuration.getGrpcAddress())
         .hasHost("0.0.0.0")
-        .hasPort(ContainerRuntimePorts.CAMUNDA_GATEWAY_API);
-
-    assertThat(configuration.isPlaintextConnectionEnabled()).isTrue();
+        .hasPort(ContainerRuntimePorts.CAMUNDA_GATEWAY_API)
+        .hasScheme("http");
   }
 
   @Test
@@ -215,7 +215,6 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
 
     assertThat(configuration.getRestAddress()).isEqualTo(remoteCamundaRestApiAddress);
     assertThat(configuration.getGrpcAddress()).isEqualTo(remoteCamundaGrpcApiAddress);
-    assertThat(configuration.isPlaintextConnectionEnabled()).isTrue();
     assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofHours(1));
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.broker.test.TestClusterFactory;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -70,8 +71,9 @@ final class PartitionLeaveTest {
     try (final var client =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .usePlaintext()
-            .gatewayAddress("localhost:" + broker0.getConfig().getGateway().getNetwork().getPort())
+            .grpcAddress(
+                URI.create(
+                    "http://localhost:" + broker0.getConfig().getGateway().getNetwork().getPort()))
             .build()) {
       Awaitility.await()
           .untilAsserted(
@@ -126,8 +128,9 @@ final class PartitionLeaveTest {
     try (final var client =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .usePlaintext()
-            .gatewayAddress("localhost:" + broker0.getConfig().getGateway().getNetwork().getPort())
+            .grpcAddress(
+                URI.create(
+                    "http://localhost:" + broker0.getConfig().getGateway().getNetwork().getPort()))
             .build()) {
       Awaitility.await()
           .untilAsserted(
@@ -186,8 +189,9 @@ final class PartitionLeaveTest {
     try (final var client =
         CamundaClient.newClientBuilder()
             .preferRestOverGrpc(false)
-            .usePlaintext()
-            .gatewayAddress("localhost:" + broker0.getConfig().getGateway().getNetwork().getPort())
+            .grpcAddress(
+                URI.create(
+                    "http://localhost:" + broker0.getConfig().getGateway().getNetwork().getPort()))
             .build()) {
       Awaitility.await()
           .untilAsserted(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.snapshots.SnapshotId;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
-import io.netty.util.NetUtil;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.agrona.CloseHelper;
@@ -50,11 +49,9 @@ public class BrokerSnapshotTest {
     journalReader = raftPartition.getServer().openReader();
     brokerAdminService = brokerRule.getBroker().getBrokerContext().getBrokerAdminService();
 
-    final String contactPoint = NetUtil.toSocketAddressString(brokerRule.getGatewayAddress());
     final CamundaClientBuilder camundaClientBuilder =
         CamundaClient.newClientBuilder()
-            .usePlaintext()
-            .gatewayAddress(contactPoint)
+            .grpcAddress(brokerRule.getGrpcAddress())
             .preferRestOverGrpc(false);
     client = camundaClientBuilder.build();
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -16,6 +16,7 @@ import static io.camunda.zeebe.broker.test.EmbeddedBrokerConfigurator.setInterna
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.security.configuration.SecurityConfigurations;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -43,6 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -189,6 +191,10 @@ public final class EmbeddedBrokerRule extends ExternalResource {
     return brokerCfg.getGateway().getNetwork().toSocketAddress();
   }
 
+  public URI getGrpcAddress() {
+    return AddressUtil.composeGrpcAddress(NetUtil.toSocketAddressString(getGatewayAddress()), true);
+  }
+
   public Broker getBroker() {
     return broker;
   }
@@ -268,8 +274,9 @@ public final class EmbeddedBrokerRule extends ExternalResource {
       try (final var client =
           CamundaClient.newClientBuilder()
               .preferRestOverGrpc(false)
-              .gatewayAddress(NetUtil.toSocketAddressString(getGatewayAddress()))
-              .usePlaintext()
+              .grpcAddress(
+                  AddressUtil.composeGrpcAddress(
+                      NetUtil.toSocketAddressString(getGatewayAddress()), true))
               .build()) {
         Awaitility.await("until we have a complete topology")
             .ignoreExceptions()

--- a/zeebe/gateway-grpc/pom.xml
+++ b/zeebe/gateway-grpc/pom.xml
@@ -201,12 +201,6 @@
 
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
     </dependency>
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
@@ -16,6 +16,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.security.configuration.SecurityConfigurations;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -36,9 +37,9 @@ import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.grpc.Status.Code;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.netty.util.NetUtil;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -113,13 +114,9 @@ class UnavailableBrokersTest {
             mock(JwtDecoder.class));
     gateway.start().join();
 
-    final String gatewayAddress = NetUtil.toSocketAddressString(networkCfg.toSocketAddress());
+    final URI grpcAddress = AddressUtil.composeGrpcAddress(networkCfg.toSocketAddress(), true);
     client =
-        CamundaClient.newClientBuilder()
-            .preferRestOverGrpc(false)
-            .gatewayAddress(gatewayAddress)
-            .usePlaintext()
-            .build();
+        CamundaClient.newClientBuilder().preferRestOverGrpc(false).grpcAddress(grpcAddress).build();
   }
 
   @AfterAll

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
@@ -15,6 +15,7 @@ import io.atomix.utils.net.Address;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.security.configuration.SecurityConfigurations;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -35,7 +36,6 @@ import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.grpc.StatusRuntimeException;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.netty.util.NetUtil;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -182,9 +182,9 @@ final class InterceptorIT {
   private CamundaClient createCamundaClient() {
     return CamundaClient.newClientBuilder()
         .preferRestOverGrpc(false)
-        .gatewayAddress(
-            NetUtil.toSocketAddressString(gateway.getGatewayCfg().getNetwork().toSocketAddress()))
-        .usePlaintext()
+        .grpcAddress(
+            AddressUtil.composeGrpcAddress(
+                gateway.getGatewayCfg().getNetwork().toSocketAddress(), true))
         .build();
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
@@ -141,7 +141,6 @@ public class OidcAuthOverGrpcIT {
         CamundaClient.newClientBuilder()
             .grpcAddress(broker.grpcAddress())
             .restAddress(broker.restAddress())
-            .usePlaintext()
             .preferRestOverGrpc(false)
             .defaultRequestTimeout(Duration.ofSeconds(15))
             .credentialsProvider(
@@ -162,7 +161,6 @@ public class OidcAuthOverGrpcIT {
         CamundaClient.newClientBuilder()
             .grpcAddress(broker.grpcAddress())
             .restAddress(broker.restAddress())
-            .usePlaintext()
             .preferRestOverGrpc(false)
             .defaultRequestTimeout(Duration.ofSeconds(15))
             .credentialsProvider(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
@@ -141,7 +141,6 @@ public class OidcAuthOverRestIT {
         CamundaClient.newClientBuilder()
             .grpcAddress(broker.grpcAddress())
             .restAddress(broker.restAddress())
-            .usePlaintext()
             .preferRestOverGrpc(true)
             .defaultRequestTimeout(Duration.ofSeconds(15))
             .credentialsProvider(
@@ -162,7 +161,6 @@ public class OidcAuthOverRestIT {
         CamundaClient.newClientBuilder()
             .grpcAddress(broker.grpcAddress())
             .restAddress(broker.restAddress())
-            .usePlaintext()
             .preferRestOverGrpc(true)
             .defaultRequestTimeout(Duration.ofSeconds(15))
             .credentialsProvider(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/ClientExceptionHandlingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/ClientExceptionHandlingTest.java
@@ -11,12 +11,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import io.camunda.client.api.command.ClientException;
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
 import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.grpc.StatusRuntimeException;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.util.concurrent.ExecutionException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,8 +31,7 @@ public final class ClientExceptionHandlingTest {
 
   public final GrpcClientRule clientRule =
       new GrpcClientRule(
-          brokerRule,
-          clientBuilder -> clientBuilder.gatewayAddress(getInvalidGatewayHostAndPort()));
+          brokerRule, clientBuilder -> clientBuilder.grpcAddress(getInvalidGrpcAddress()));
 
   @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(clientRule);
 
@@ -58,7 +59,8 @@ public final class ClientExceptionHandlingTest {
         .hasMessageContaining(":" + invalidGatewayAddress.getPort());
   }
 
-  private String getInvalidGatewayHostAndPort() {
-    return invalidGatewayAddress.getHostName() + ":" + invalidGatewayAddress.getPort();
+  private URI getInvalidGrpcAddress() {
+    return AddressUtil.composeGrpcAddress(
+        invalidGatewayAddress.getHostName() + ":" + invalidGatewayAddress.getPort(), true);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
@@ -157,7 +157,7 @@ public class LongPollingActivateJobsTest {
   private void sendActivateRequestsAndClose(final boolean useRest, final String jobType)
       throws InterruptedException {
     for (int i = 0; i < 3; i++) {
-      final CamundaClient tempClient = zeebe.newClientBuilder().usePlaintext().build();
+      final CamundaClient tempClient = zeebe.newClientBuilder().build();
 
       getCommand(tempClient, useRest)
           .jobType(jobType)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -34,6 +34,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.response.BrokerInfo;
 import io.camunda.client.api.response.Topology;
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.security.configuration.SecurityConfigurations;
@@ -172,7 +173,7 @@ public class ClusteringRule extends ExternalResource {
         clusterSize,
         configurator,
         gatewayCfg -> {},
-        CamundaClientBuilder::usePlaintext);
+        builder -> {});
   }
 
   public ClusteringRule(
@@ -187,7 +188,7 @@ public class ClusteringRule extends ExternalResource {
         clusterSize,
         brokerConfigurator,
         gatewayConfigurator,
-        CamundaClientBuilder::usePlaintext);
+        builder -> {});
   }
 
   public ClusteringRule(
@@ -543,11 +544,12 @@ public class ClusteringRule extends ExternalResource {
   }
 
   private CamundaClient createClient() {
-    final String contactPoint =
-        NetUtil.toSocketAddressString(
-            gatewayResource.gateway.getGatewayCfg().getNetwork().toSocketAddress());
     final CamundaClientBuilder camundaClientBuilder =
-        CamundaClient.newClientBuilder().gatewayAddress(contactPoint).preferRestOverGrpc(false);
+        CamundaClient.newClientBuilder()
+            .grpcAddress(
+                AddressUtil.composeGrpcAddress(
+                    gatewayResource.gateway.getGatewayCfg().getNetwork().toSocketAddress(), true))
+            .preferRestOverGrpc(false);
 
     clientConfigurator.accept(camundaClientBuilder);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/RestoreTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/RestoreTest.java
@@ -10,9 +10,9 @@ package io.camunda.zeebe.it.clustering;
 import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.it.util.GrpcClientRule;
-import io.netty.util.NetUtil;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.concurrent.ThreadLocalRandom;
@@ -47,9 +47,9 @@ public final class RestoreTest {
           config ->
               config
                   .preferRestOverGrpc(false)
-                  .gatewayAddress(NetUtil.toSocketAddressString(clusteringRule.getGatewayAddress()))
-                  .defaultRequestTimeout(Duration.ofMinutes(1))
-                  .usePlaintext());
+                  .grpcAddress(
+                      AddressUtil.composeGrpcAddress(clusteringRule.getGatewayAddress(), true))
+                  .defaultRequestTimeout(Duration.ofMinutes(1)));
 
   @Rule public RuleChain ruleChain = RuleChain.outerRule(clusteringRule).around(clientRule);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/StateMigrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/StateMigrationTest.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.it.clustering;
 
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.zeebe.it.util.GrpcClientRule;
-import io.netty.util.NetUtil;
 import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
@@ -36,9 +36,9 @@ public class StateMigrationTest {
           config ->
               config
                   .preferRestOverGrpc(false)
-                  .gatewayAddress(NetUtil.toSocketAddressString(clusteringRule.getGatewayAddress()))
-                  .defaultRequestTimeout(Duration.ofMinutes(1))
-                  .usePlaintext());
+                  .grpcAddress(
+                      AddressUtil.composeGrpcAddress(clusteringRule.getGatewayAddress(), true))
+                  .defaultRequestTimeout(Duration.ofMinutes(1)));
 
   @Rule public RuleChain ruleChain = RuleChain.outerRule(clusteringRule).around(clientRule);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/EmbeddedGatewayWithOneCpuThreadIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/EmbeddedGatewayWithOneCpuThreadIT.java
@@ -13,6 +13,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import java.net.URI;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -39,8 +40,7 @@ public final class EmbeddedGatewayWithOneCpuThreadIT {
     final var port = gtwConfig.getNetwork().getPort();
 
     return CamundaClient.newClientBuilder()
-        .usePlaintext()
-        .gatewayAddress("localhost:" + port)
+        .grpcAddress(URI.create("http://localhost:" + port))
         .build();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationNoneIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationNoneIT.java
@@ -204,8 +204,7 @@ public class GatewayAuthenticationNoneIT {
     return CamundaClient.newClientBuilder()
         .grpcAddress(zeebe.grpcAddress())
         .restAddress(zeebe.restAddress())
-        .defaultRequestTimeout(Duration.ofMinutes(1))
-        .usePlaintext();
+        .defaultRequestTimeout(Duration.ofMinutes(1));
   }
 
   private static String getIdentityImageTag() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/DefaultAdvertisedAddressIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/DefaultAdvertisedAddressIT.java
@@ -61,7 +61,6 @@ final class DefaultAdvertisedAddressIT {
     // given
     final var clientBuilder =
         CamundaClient.newClientBuilder()
-            .usePlaintext()
             .restAddress(
                 URI.create("http://localhost:" + cluster.getAvailableGateway().getMappedPort(8080)))
             .grpcAddress(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/NetworkCompressionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/NetworkCompressionTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.it.network;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
-import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
@@ -28,12 +27,7 @@ public class NetworkCompressionTest {
 
   public final ClusteringRule clusteringRule =
       new ClusteringRule(
-          1,
-          3,
-          3,
-          this::configureClusterWithCompression,
-          this::configureGatewayWithCompression,
-          CamundaClientBuilder::usePlaintext);
+          1, 3, 3, this::configureClusterWithCompression, this::configureGatewayWithCompression);
 
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/headers/SecurityHeadersOidcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/headers/SecurityHeadersOidcIT.java
@@ -239,7 +239,6 @@ public class SecurityHeadersOidcIT extends SecurityHeadersBaseIT {
     return CamundaClient.newClientBuilder()
         .grpcAddress(broker.grpcAddress())
         .restAddress(broker.restAddress())
-        .usePlaintext()
         .preferRestOverGrpc(true)
         .defaultRequestTimeout(Duration.ofSeconds(15))
         .credentialsProvider(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/NonDefaultContainerSetupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/NonDefaultContainerSetupTest.java
@@ -96,8 +96,7 @@ public class NonDefaultContainerSetupTest {
       try (final CamundaClient client =
           CamundaClient.newClientBuilder()
               .preferRestOverGrpc(false)
-              .usePlaintext()
-              .gatewayAddress(gateway.getExternalGatewayAddress())
+              .grpcAddress(gateway.getGrpcAddress())
               .build()) {
         // when
         client

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/GrpcClientRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/GrpcClientRule.java
@@ -9,12 +9,12 @@ package io.camunda.zeebe.it.util;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.zeebe.broker.TestLoggers;
 import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
 import io.camunda.zeebe.it.clustering.ClusteringRule;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
-import io.netty.util.NetUtil;
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
@@ -39,10 +39,7 @@ public final class GrpcClientRule extends ExternalResource {
       final EmbeddedBrokerRule brokerRule, final Consumer<CamundaClientBuilder> configurator) {
     this(
         config -> {
-          config
-              .preferRestOverGrpc(false)
-              .gatewayAddress(NetUtil.toSocketAddressString(brokerRule.getGatewayAddress()))
-              .usePlaintext();
+          config.preferRestOverGrpc(false).grpcAddress(brokerRule.getGrpcAddress());
           configurator.accept(config);
         });
   }
@@ -52,8 +49,8 @@ public final class GrpcClientRule extends ExternalResource {
         config ->
             config
                 .preferRestOverGrpc(false)
-                .gatewayAddress(NetUtil.toSocketAddressString(clusteringRule.getGatewayAddress()))
-                .usePlaintext());
+                .grpcAddress(
+                    AddressUtil.composeGrpcAddress(clusteringRule.getGatewayAddress(), true)));
   }
 
   public GrpcClientRule(final Consumer<CamundaClientBuilder> configurator) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeContainerUtil.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeContainerUtil.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.it.util;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.impl.util.AddressUtil;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.cluster.ZeebeCluster;
 import io.zeebe.containers.engine.ContainerEngine;
@@ -24,14 +25,12 @@ public final class ZeebeContainerUtil {
 
     return CamundaClient.newClientBuilder()
         .preferRestOverGrpc(false)
-        .usePlaintext()
-        .gatewayAddress(gateway.getExternalGatewayAddress());
+        .grpcAddress(gateway.getGrpcAddress());
   }
 
   public static CamundaClientBuilder newClientBuilder(final ContainerEngine containerEngine) {
     return CamundaClient.newClientBuilder()
         .preferRestOverGrpc(false)
-        .usePlaintext()
-        .gatewayAddress(containerEngine.getGatewayAddress());
+        .grpcAddress(AddressUtil.composeGrpcAddress(containerEngine.getGatewayAddress(), true));
   }
 }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -365,8 +365,7 @@ final class RollingUpdateTest {
   private CamundaClient newClient(final ZeebeGatewayNode<?> gateway) {
     return CamundaClient.newClientBuilder()
         .preferRestOverGrpc(false)
-        .usePlaintext()
-        .gatewayAddress(gateway.getExternalGatewayAddress())
+        .grpcAddress(gateway.getGrpcAddress())
         .build();
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -267,7 +267,6 @@ public final class TestCluster implements CloseableSilently {
   public CamundaClientBuilder newClientBuilder() {
     return CamundaClient.newClientBuilder()
         .preferRestOverGrpc(false)
-        .usePlaintext()
         .restAddress(availableGateway().restAddress())
         .grpcAddress(availableGateway().grpcAddress());
   }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -108,8 +108,6 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
     final var restSSL = property("server.ssl.enabled", Boolean.class, false);
     if (security.isEnabled() || restSSL) {
       builder.caCertificatePath(security.getCertificateChainPath().getAbsolutePath());
-    } else {
-      builder.usePlaintext();
     }
 
     return builder;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR removes the `gatewayAddress` as well as the `plaintext` properties from the camunda java client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37818
