### PR TITLE
test: fix network disconnect test

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -721,21 +721,22 @@ public class ClusteringRule extends ExternalResource {
             .getRaftPartition(partitionId)
             .getServer();
 
-    Awaitility.await("Promote request is successful")
-        .pollInterval(Duration.ofMillis(500))
-        .timeout(Duration.ofMinutes(1))
-        .untilAsserted(
-            () ->
-                assertThat(serverOfExpectedLeader.promote())
-                    .succeedsWithin(Duration.ofSeconds(15)));
-
     Awaitility.await("New leader of partition %s is %s".formatted(partitionId, expectedLeaderId))
         .pollInterval(Duration.ofMillis(500))
         .atMost(Duration.ofMinutes(1))
         .ignoreExceptions()
-        .until(
-            () -> getLeaderForPartition(partitionId),
-            (leader) -> leader.getNodeId() == expectedLeaderId);
+        .untilAsserted(
+            () -> {
+              assertThat(serverOfExpectedLeader.promote())
+                  .describedAs("Promote request is successful")
+                  .succeedsWithin(Duration.ofSeconds(15));
+              final int currentLeaderId = getLeaderForPartition(partitionId).getNodeId();
+              assertThat(currentLeaderId)
+                  .withFailMessage(
+                      "Expected the leader of partition %d to be %d, but was %d",
+                      partitionId, expectedLeaderId, currentLeaderId)
+                  .isEqualTo(expectedLeaderId);
+            });
   }
 
   public void waitForTopology(final Consumer<TopologyAssert> assertions) {
@@ -850,11 +851,15 @@ public class ClusteringRule extends ExternalResource {
     var currentSegments = 0;
     var writtenEntries = 0;
     while (currentSegments < minimumSegmentCount || writtenEntries < minimumWrittenEntries) {
-      client.newPublishMessageCommand().messageName("msg").correlationKey("key").send().join();
+      publishMessage();
       currentSegments =
           brokers.stream().map(this::getSegmentsCount).min(Integer::compareTo).orElse(0);
       writtenEntries += 1;
     }
+  }
+
+  public void publishMessage() {
+    client.newPublishMessageCommand().messageName("msg").correlationKey("key").send().join();
   }
 
   /**


### PR DESCRIPTION
## Description

Using segment count to verify whether broker has received new entries is fragile, because a snapshot in the meantime can compact the logs resulting in flaky tests. Besides that this is too dependent on the internal implementation which is not suitable for an integration test.

To fix the flaky test, we now verify that the reconnected node can become leader. It can become leader again only if it has received new entries.

Besides this a unit test in raft already verifies that a reconnected node receives new entries.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37807
