### PR TITLE
Remove leftover todo

### DIFF
--- a/service/src/main/java/io/camunda/service/ApiServicesExecutorProvider.java
+++ b/service/src/main/java/io/camunda/service/ApiServicesExecutorProvider.java
@@ -61,7 +61,6 @@ public final class ApiServicesExecutorProvider {
     final int cap = Math.max(1, queueCapacity);
     final BlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(cap);
 
-    // TODO - possibly need to map RejectedExecutionException
     final ThreadPoolExecutor executor =
         new ThreadPoolExecutor(
             corePoolSize,


### PR DESCRIPTION
Not needed as we run with CallerRunsPolicy, no rejection will happen from the executor thread.

## Description

<!-- Describe the goal and purpose of this PR. -->

See related comment https://github.com/camunda/camunda/pull/37736#discussion_r2332287395

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
