### PR TITLE
fix: prevent NPE for DMN with missing `ruleId` by failing evaluation and raising incident

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -220,8 +220,8 @@ public class DecisionBehavior {
         .forEach(
             evaluatedInput -> addInputToEvaluationEvent(evaluatedInput, evaluatedDecisionRecord));
 
-    evaluatedDecision
-        .matchedRules()
+    evaluatedDecision.matchedRules().stream()
+        .filter(r -> r.ruleId() != null && !r.ruleId().isBlank())
         .forEach(
             matchedRule -> addMatchedRuleToEvaluationEvent(matchedRule, evaluatedDecisionRecord));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/StandaloneDecisionEvaluationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/StandaloneDecisionEvaluationTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
@@ -30,6 +31,9 @@ public class StandaloneDecisionEvaluationTest {
   private static final String DMN_WITH_ASSERTION = "/dmn/drg-force-user-with-assertions.dmn";
   private static final String DMN_DECISION_TABLE = "/dmn/decision-table.dmn";
   private static final String DMN_DECISION_TABLE_V2 = "/dmn/decision-table_v2.dmn";
+  private static final String DMN_DECISION_WITH_MISSING_RULE_ID =
+      "/dmn/decision-table-with-missing-ruleId.dmn";
+  private static final String DMN_MISSING_RULE_DECISION_ID = "shippingDecision";
   private static final String DECISION_ID = "jedi_or_sith";
   private static final String EXPECTED_DECISION_OUTPUT = "\"Jedi\"";
   private static final String EXPECTED_FAILURE_MSG =
@@ -191,5 +195,33 @@ public class StandaloneDecisionEvaluationTest {
                 + falseDecisionKey
                 + "'");
     assertThat(record.getValue()).hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  public void shouldFailEvaluationWhenRuleIdMissing() {
+    // given
+    ENGINE.deployment().withXmlClasspathResource(DMN_DECISION_WITH_MISSING_RULE_ID).deploy();
+
+    // when
+    final Record<DecisionEvaluationRecordValue> record =
+        ENGINE
+            .decision()
+            .ofDecisionId(DMN_MISSING_RULE_DECISION_ID)
+            .withVariable("amount", 200) // matches the rule WITHOUT id
+            .expectFailure()
+            .evaluate();
+
+    // then
+    Assertions.assertThat(record).hasIntent(DecisionEvaluationIntent.FAILED);
+    Assertions.assertThat(record.getValue())
+        .hasDecisionId(DMN_MISSING_RULE_DECISION_ID)
+        .hasFailedDecisionId(DMN_MISSING_RULE_DECISION_ID)
+        .hasEvaluationFailureMessage(
+            """
+                Expected to evaluate decision '%s', but matched rule(s) without id (ruleId) were found.
+                Offending locations: decision '%s' -> rule indices [2].
+                Fix: add an 'id' attribute to every <rule> in the affected decision table(s),
+                deploy a new DMN version, then retry the evaluation."""
+                .formatted(DMN_MISSING_RULE_DECISION_ID, DMN_MISSING_RULE_DECISION_ID));
   }
 }

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-fixed-ruleId_v2.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-fixed-ruleId_v2.dmn
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  - Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  - one or more contributor license agreements. See the NOTICE file distributed
+  - with this work for additional information regarding copyright ownership.
+  - Licensed under the Camunda License 1.0. You may not use this file
+  - except in compliance with the Camunda License 1.0.
+  -->
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+  xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1whs8i1" name="DRD"
+  namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.36.1"
+  modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <decision id="shippingDecision" name="Shipping decision">
+    <decisionTable id="shippingTable" hitPolicy="FIRST">
+      <input id="Input_1" label="Amount">
+        <inputExpression id="InputExpression_1" typeRef="number">
+          <text>amount</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Shipping" name="shipping" typeRef="string">
+        <outputValues id="UnaryTests_0dlr7qd">
+          <text>"STANDARD","EXPRESS"</text>
+        </outputValues>
+      </output>
+      <!-- Rule with ID (safe) -->
+      <rule id="rule_1_standard">
+        <inputEntry id="UnaryTests_0upjivp">
+          <text>&lt;= 100</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1pkzjur">
+          <text>"STANDARD"</text>
+        </outputEntry>
+      </rule>
+      <!-- Rule with another ID (safe) -->
+      <rule id="rule_2_express">
+        <inputEntry id="UnaryTests_1pqn5oz">
+          <text>&gt; 100</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_17do8e0">
+          <text>"EXPRESS"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="shipping_decision">
+        <dc:Bounds height="80" width="180" x="160" y="100"/>
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-missing-ruleId.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-missing-ruleId.dmn
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  - Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  - one or more contributor license agreements. See the NOTICE file distributed
+  - with this work for additional information regarding copyright ownership.
+  - Licensed under the Camunda License 1.0. You may not use this file
+  - except in compliance with the Camunda License 1.0.
+  -->
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+  xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1whs8i1" name="DRD"
+  namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.36.1"
+  modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <decision id="shippingDecision" name="Shipping decision">
+    <decisionTable id="shippingTable" hitPolicy="FIRST">
+      <input id="Input_1" label="Amount">
+        <inputExpression id="InputExpression_1" typeRef="number">
+          <text>amount</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Shipping" name="shipping" typeRef="string">
+        <outputValues id="UnaryTests_0dlr7qd">
+          <text>"STANDARD","EXPRESS"</text>
+        </outputValues>
+      </output>
+      <!-- Rule with ID (safe) -->
+      <rule id="rule_1_standard">
+        <inputEntry id="UnaryTests_0upjivp">
+          <text>&lt;= 100</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1pkzjur">
+          <text>"STANDARD"</text>
+        </outputEntry>
+      </rule>
+      <!-- Rule WITHOUT id on purpose -->
+      <rule>
+        <inputEntry id="UnaryTests_1pqn5oz">
+          <text>&gt; 100</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_17do8e0">
+          <text>"EXPRESS"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="shipping_decision">
+        <dc:Bounds height="80" width="180" x="160" y="100"/>
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
## Description

Option 1

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36900
