### PR TITLE
feat: accept create documents metadata in req

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4463,21 +4463,11 @@ paths:
 
         The caller must provide a file name for each document, which will be used in case of a multi-status response
         to identify which documents failed to upload. The file name can be provided in the `Content-Disposition` header
-        of the file part or in the `fileName` field of the metadata, which can be configured with
-        the `X-Document-Metadata` header for each file part. If both are provided, the `fileName` metadata field
-        takes precedence. For example, given the following headers for a file:
-        ```
-        Content-Disposition: form-data; name="files"; filename="bill.pdf"
-        X-Document-Metadata: {"fileName": "invoice.pdf", "size": 1234567}
-        ```
-
-        The filename will be `invoice.pdf`, but in the following example:
-        ```
-        Content-Disposition: form-data; name="files"; filename="bill.pdf"
-        X-Document-Metadata: {"size": 1234567}
-        ```
-
-        it would be `bill.pdf`.
+        of the file part or in the `fileName` field of the metadata. You can add a parallel array of metadata objects. These
+        are matched with the files based on index, and must have the same length as the files array. 
+        To pass homogenous metadata for all files, spread the metadata over the metadata array. 
+        A filename value provided explicitly via the metadata array in the request overrides the `Content-Disposition` header
+        of the file part. 
 
         In case of a multi-status response, the response body will contain a list of `DocumentBatchProblemDetail` objects,
         each of which contains the file name of the document that failed to upload and the reason for the failure.
@@ -4504,6 +4494,12 @@ paths:
                   items:
                     type: string
                     format: binary
+                  minItems: 1
+                metadataList:
+                  type: array
+                  description: Optional JSON array; index aligns with each files entry. Takes precedence over per-file X-Document-Metadata headers when provided.
+                  items:
+                    $ref: "#/components/schemas/DocumentMetadata"
               required:
                 - files
             encoding:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
@@ -62,9 +62,11 @@ public class DocumentController {
   @CamundaPostMapping(path = "/batch", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public CompletableFuture<ResponseEntity<Object>> createDocuments(
       @RequestPart(value = "files") final List<Part> files,
+      @RequestPart(value = "metadataList", required = false)
+          final List<DocumentMetadata> metadataList,
       @RequestParam(required = false) final String storeId) {
-
-    return RequestMapper.toDocumentCreateRequestBatch(files, storeId, objectMapper)
+    // Pass metadataList to let mapper prefer it over legacy headers when provided
+    return RequestMapper.toDocumentCreateRequestBatch(files, storeId, objectMapper, metadataList)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createDocumentBatch);
   }
 


### PR DESCRIPTION
## Description

This PR adds an additional (preferred) surface to declare the metadata for multiple documents when batch uploading — via a sidecar array of DocumentMetadata in the multi-part form data. 

See #37856 for the motivation for this feature.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37856
