### PR TITLE
test: use old docker configurations

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           echo "Checking if services are up..."
           ready=false
-          for i in {1..10}; do
+          for i in {1..90}; do
             if [[ "$NON_STANDALONE" == "true" ]]; then
               tasklist_status=$(curl -s -m 5 http://localhost:8080 || echo "Failed")
               operate_status=$(curl -s -m 5 http://localhost:8081 || echo "Failed")

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -81,6 +81,8 @@ jobs:
           if [[ "$NON_STANDALONE" == "true" ]]; then
             DATABASE=elasticsearch docker compose up -d operate tasklist
           else
+            export DATABASE=elasticsearch
+            echo "Starting Camunda with NON_STANDALONE:$NON_STANDALONE, database:$DATABASE"
             DATABASE=elasticsearch docker compose up -d camunda
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           echo "Checking if services are up..."
           ready=false
-          for i in {1..90}; do
+          for i in {1..10}; do
             if [[ "$NON_STANDALONE" == "true" ]]; then
               tasklist_status=$(curl -s -m 5 http://localhost:8080 || echo "Failed")
               operate_status=$(curl -s -m 5 http://localhost:8081 || echo "Failed")

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -126,3 +126,5 @@ services:
       - ${DATABASE}
     networks:
       - zeebe_network
+    env_file:
+      - envs/.env.database.${DATABASE}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Run: https://github.com/camunda/camunda/actions/runs/17608101194

- The epic (#prj-pdp-2486-unified-config-for-orchestration-cluster) updates configuration values for the OC repo.
- These changes affect how we set up dockerized Camunda.
- This doc listing the new values, but we’ll need to manually check the mapping (from … → to …) so no direct lookup atm.
- Igor mentioned we can continue using the old values for now, since they’re backward compatible except for CAMUNDA_DATA_SECONDARY_STORAGE_TYPE, which has changed.
- After we finish the current priority tickets, let's update to the new values.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
