### PR TITLE
ci: new matrix jobs lacked proper fail-fast setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,7 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     strategy:
+      fail-fast: false
       matrix:
         module:
           - name: QA Acceptance Tests
@@ -505,6 +506,7 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     strategy:
+      fail-fast: false
       matrix:
         module:
           - name: QA Acceptance Tests


### PR DESCRIPTION
## Description

Existing `matrix` GHA jobs in the Unified CI like Zeebe unit tests or integration tests jobs use `fail-fast: false`. We want jobs to run to completion to give a consistent job status result. The newly added matrix tests lacked that setting due to an oversight, this PR adds it now.

This prevents situations like https://github.com/camunda/camunda/actions/runs/17605870139/job/50016483169 which gets cancelled without apparent reason stated because https://github.com/camunda/camunda/actions/runs/17605870139/job/50016483170 failed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)) - no, migration tests only exist on 8.8

## Related issues

None
