### PR TITLE
fix: support compensation of ad-hoc sub-process

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -96,7 +96,9 @@ public class BpmnCompensationSubscriptionBehaviour {
   private boolean isFlowScopeWithSubscriptions(final BpmnElementContext context) {
     final BpmnElementType bpmnElementType = context.getBpmnElementType();
     if (bpmnElementType != BpmnElementType.SUB_PROCESS
-        && bpmnElementType != BpmnElementType.MULTI_INSTANCE_BODY) {
+        && bpmnElementType != BpmnElementType.MULTI_INSTANCE_BODY
+        && bpmnElementType != BpmnElementType.AD_HOC_SUB_PROCESS
+        && bpmnElementType != BpmnElementType.AD_HOC_SUB_PROCESS_INNER_INSTANCE) {
       return false; // avoid accessing the state for elements that are not a flow scope
     }
 

--- a/zeebe/engine/src/test/resources/compensation/compensation-adhoc-subprocess-handler.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-adhoc-subprocess-handler.bpmn
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="definitions_51c88d32-dc2c-4d83-a720-6aa1410b6644" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <process id="compensation-process" name="A" isExecutable="true">
+    <startEvent id="Event_1yfhzbl">
+      <outgoing>Flow_1mwrsen</outgoing>
+    </startEvent>
+    <sequenceFlow id="Flow_1mwrsen" sourceRef="Event_1yfhzbl" targetRef="compensableActivity" />
+    <sequenceFlow id="Flow_08ge0ph" sourceRef="compensableActivity" targetRef="Event_0vtgg13" />
+    <endEvent id="Event_09fawg4">
+      <incoming>Flow_0klrid6</incoming>
+    </endEvent>
+    <serviceTask id="compensableActivity" name="A">
+      <extensionElements>
+        <zeebe:taskDefinition type="compensableActivity" />
+      </extensionElements>
+      <incoming>Flow_1mwrsen</incoming>
+      <outgoing>Flow_08ge0ph</outgoing>
+    </serviceTask>
+    <boundaryEvent id="Event_0xm6yf8" attachedToRef="compensableActivity">
+      <compensateEventDefinition id="CompensateEventDefinition_0mnc4nz" />
+    </boundaryEvent>
+    <adHocSubProcess id="adhoc-subprocess" name="adhoc-subprocess" isForCompensation="true">
+      <extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;compensationHandler&#34;]" />
+      </extensionElements>
+      <serviceTask id="compensationHandler" name="B">
+        <extensionElements>
+          <zeebe:taskDefinition type="compensationHandler" />
+        </extensionElements>
+      </serviceTask>
+    </adHocSubProcess>
+    <sequenceFlow id="Flow_0klrid6" sourceRef="Event_0vtgg13" targetRef="Event_09fawg4" />
+    <intermediateThrowEvent id="Event_0vtgg13">
+      <incoming>Flow_08ge0ph</incoming>
+      <outgoing>Flow_0klrid6</outgoing>
+      <compensateEventDefinition id="CompensateEventDefinition_12rfhh2" />
+    </intermediateThrowEvent>
+    <association id="Association_0ud2ky6" associationDirection="One" sourceRef="Event_0xm6yf8" targetRef="adhoc-subprocess" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_d458583a-dbd3-44f4-9045-ef478ea1576c">
+    <bpmndi:BPMNPlane id="BPMNPlane_b1706292-8b4e-48dd-9ca2-e5d428c1f478" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="Event_1yfhzbl_di" bpmnElement="Event_1yfhzbl">
+        <dc:Bounds x="172" y="107" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_09fawg4_di" bpmnElement="Event_09fawg4">
+        <dc:Bounds x="502" y="107" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ftdfxh_di" bpmnElement="compensableActivity">
+        <dc:Bounds x="260" y="85" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1r3u9dr_di" bpmnElement="Event_0vtgg13">
+        <dc:Bounds x="412" y="107" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00z9vfr_di" bpmnElement="adhoc-subprocess" isExpanded="true">
+        <dc:Bounds x="450" y="200" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0o7gekd_di" bpmnElement="compensationHandler">
+        <dc:Bounds x="500" y="260" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0ud2ky6_di" bpmnElement="Association_0ud2ky6">
+        <di:waypoint x="340" y="183" />
+        <di:waypoint x="340" y="300" />
+        <di:waypoint x="450" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1ed56xc_di" bpmnElement="Event_0xm6yf8">
+        <dc:Bounds x="322" y="147" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1mwrsen_di" bpmnElement="Flow_1mwrsen">
+        <di:waypoint x="208" y="125" />
+        <di:waypoint x="260" y="125" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08ge0ph_di" bpmnElement="Flow_08ge0ph">
+        <di:waypoint x="360" y="125" />
+        <di:waypoint x="412" y="125" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0klrid6_di" bpmnElement="Flow_0klrid6">
+        <di:waypoint x="448" y="125" />
+        <di:waypoint x="502" y="125" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/zeebe/engine/src/test/resources/compensation/compensation-adhoc-subprocess.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-adhoc-subprocess.bpmn
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="definitions_51c88d32-dc2c-4d83-a720-6aa1410b6644" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <process id="compensation-process" name="A" isExecutable="true">
+    <endEvent id="CompensationEndEvent" name="compensation-end-event">
+      <incoming>sequenceFlow_66c420e0-5c3a-48e0-a48b-5c4018e1d2b0</incoming>
+      <compensateEventDefinition id="compensateEventDefinition_5d72abc1-92ff-4ae5-aa58-87e240755e2d" />
+    </endEvent>
+    <sequenceFlow id="sequenceFlow_66c420e0-5c3a-48e0-a48b-5c4018e1d2b0" sourceRef="ad-hoc_sub-process" targetRef="CompensationEndEvent" />
+    <startEvent id="Event_1yfhzbl">
+      <outgoing>Flow_03ax6ho</outgoing>
+    </startEvent>
+    <adHocSubProcess id="ad-hoc_sub-process" name="ad-hoc sub-process">
+      <extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;ActivityToCompensate&#34;, &#34;subprocess&#34;]" />
+      </extensionElements>
+      <incoming>Flow_03ax6ho</incoming>
+      <outgoing>sequenceFlow_66c420e0-5c3a-48e0-a48b-5c4018e1d2b0</outgoing>
+      <serviceTask id="ActivityToCompensate" name="A">
+        <extensionElements>
+          <zeebe:taskDefinition type="compensableActivity" />
+        </extensionElements>
+      </serviceTask>
+      <subProcess id="subprocess">
+        <startEvent id="Event_1dv5r5e">
+          <outgoing>Flow_1y9dj9o</outgoing>
+        </startEvent>
+        <sequenceFlow id="Flow_1y9dj9o" sourceRef="Event_1dv5r5e" targetRef="ActivityToCompensate2" />
+        <serviceTask id="ActivityToCompensate2" name="B">
+          <extensionElements>
+            <zeebe:taskDefinition type="compensableActivity2" />
+          </extensionElements>
+          <incoming>Flow_1y9dj9o</incoming>
+          <outgoing>Flow_0xiywb4</outgoing>
+        </serviceTask>
+        <endEvent id="Event_1czul0f">
+          <incoming>Flow_0xiywb4</incoming>
+        </endEvent>
+        <sequenceFlow id="Flow_0xiywb4" sourceRef="ActivityToCompensate2" targetRef="Event_1czul0f" />
+        <boundaryEvent id="Event_0okfsuj" attachedToRef="ActivityToCompensate2">
+          <compensateEventDefinition id="CompensateEventDefinition_1md4gy8" />
+        </boundaryEvent>
+        <serviceTask id="CompensationHandler2" name="undo B" isForCompensation="true">
+          <extensionElements>
+            <zeebe:taskDefinition type="compensationHandler2" />
+          </extensionElements>
+        </serviceTask>
+        <association id="Association_0w1o7k9" associationDirection="One" sourceRef="Event_0okfsuj" targetRef="CompensationHandler2" />
+      </subProcess>
+      <boundaryEvent id="Event_0u821xi" attachedToRef="ActivityToCompensate">
+        <compensateEventDefinition id="CompensateEventDefinition_1o7xvwo" />
+      </boundaryEvent>
+      <serviceTask id="CompensationHandler" name="undo A" isForCompensation="true">
+        <extensionElements>
+          <zeebe:taskDefinition type="compensationHandler" />
+        </extensionElements>
+      </serviceTask>
+      <association id="Association_03pbpib" associationDirection="One" sourceRef="Event_0u821xi" targetRef="CompensationHandler" />
+    </adHocSubProcess>
+    <sequenceFlow id="Flow_03ax6ho" sourceRef="Event_1yfhzbl" targetRef="ad-hoc_sub-process" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_d458583a-dbd3-44f4-9045-ef478ea1576c">
+    <bpmndi:BPMNPlane id="BPMNPlane_b1706292-8b4e-48dd-9ca2-e5d428c1f478" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="BPMNShape_d1c01a2c-653f-4d5a-ab99-3c3b4dad5202" bpmnElement="CompensationEndEvent">
+        <dc:Bounds x="892" y="367" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="874" y="403" width="73" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1yfhzbl_di" bpmnElement="Event_1yfhzbl">
+        <dc:Bounds x="172" y="367" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12o9tv9_di" bpmnElement="ad-hoc_sub-process" isExpanded="true">
+        <dc:Bounds x="290" y="80" width="510" height="610" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0nijovb_di" bpmnElement="ActivityToCompensate">
+        <dc:Bounds x="380" y="230" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14xtpaq_di" bpmnElement="CompensationHandler">
+        <dc:Bounds x="530" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14summf_di" bpmnElement="subprocess" isExpanded="true">
+        <dc:Bounds x="380" y="350" width="350" height="290" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1dv5r5e_di" bpmnElement="Event_1dv5r5e">
+        <dc:Bounds x="420" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_105pp9v_di" bpmnElement="ActivityToCompensate2">
+        <dc:Bounds x="510" y="410" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1czul0f_di" bpmnElement="Event_1czul0f">
+        <dc:Bounds x="672" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16icj3e_di" bpmnElement="CompensationHandler2">
+        <dc:Bounds x="610" y="530" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0w1o7k9_di" bpmnElement="Association_0w1o7k9">
+        <di:waypoint x="570" y="508" />
+        <di:waypoint x="570" y="570" />
+        <di:waypoint x="610" y="570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1ach2mb_di" bpmnElement="Event_0okfsuj">
+        <dc:Bounds x="552" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1y9dj9o_di" bpmnElement="Flow_1y9dj9o">
+        <di:waypoint x="456" y="450" />
+        <di:waypoint x="510" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xiywb4_di" bpmnElement="Flow_0xiywb4">
+        <di:waypoint x="610" y="450" />
+        <di:waypoint x="672" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_03pbpib_di" bpmnElement="Association_03pbpib">
+        <di:waypoint x="430" y="212" />
+        <di:waypoint x="430" y="160" />
+        <di:waypoint x="530" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0edlw69_di" bpmnElement="Event_0u821xi">
+        <dc:Bounds x="412" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_09a09196-11c6-4f3d-a22f-75c90adf2051" bpmnElement="sequenceFlow_66c420e0-5c3a-48e0-a48b-5c4018e1d2b0">
+        <di:waypoint x="800" y="385" />
+        <di:waypoint x="892" y="385" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03ax6ho_di" bpmnElement="Flow_03ax6ho">
+        <di:waypoint x="208" y="385" />
+        <di:waypoint x="290" y="385" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/zeebe/engine/src/test/resources/compensation/compensation-single-adhoc-subprocess.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-single-adhoc-subprocess.bpmn
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="definitions_51c88d32-dc2c-4d83-a720-6aa1410b6644" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <process id="compensation-process" isExecutable="true">
+    <startEvent id="startEvent_0aa5c6c8-21bc-4491-ad62-7e87e17c8590">
+      <outgoing>sequenceFlow_49d15526-b405-48ef-9939-8f260437e2d4</outgoing>
+    </startEvent>
+    <sequenceFlow id="sequenceFlow_49d15526-b405-48ef-9939-8f260437e2d4" sourceRef="startEvent_0aa5c6c8-21bc-4491-ad62-7e87e17c8590" targetRef="Gateway_1h9kfph" />
+    <sequenceFlow id="sequenceFlow_66c420e0-5c3a-48e0-a48b-5c4018e1d2b0" sourceRef="adhoc-subprocess" targetRef="Gateway_1vnlp1m" />
+    <sequenceFlow id="Flow_0ggq2x0" sourceRef="Gateway_1h9kfph" targetRef="adhoc-subprocess" />
+    <parallelGateway id="Gateway_1h9kfph">
+      <incoming>sequenceFlow_49d15526-b405-48ef-9939-8f260437e2d4</incoming>
+      <outgoing>Flow_0ggq2x0</outgoing>
+      <outgoing>Flow_16v3jw3</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="Flow_165qz3q" sourceRef="Gateway_1vnlp1m" targetRef="CompensationEndEvent" />
+    <parallelGateway id="Gateway_1vnlp1m">
+      <incoming>sequenceFlow_66c420e0-5c3a-48e0-a48b-5c4018e1d2b0</incoming>
+      <incoming>Flow_1oqhyjt</incoming>
+      <outgoing>Flow_165qz3q</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="Flow_16v3jw3" sourceRef="Gateway_1h9kfph" targetRef="ActivityToComplete" />
+    <sequenceFlow id="Flow_1oqhyjt" sourceRef="Event_1051say" targetRef="Gateway_1vnlp1m" />
+    <intermediateThrowEvent id="Event_1051say">
+      <incoming>Flow_0tm7usg</incoming>
+      <outgoing>Flow_1oqhyjt</outgoing>
+      <compensateEventDefinition id="CompensateEventDefinition_0zpkqa4" />
+    </intermediateThrowEvent>
+    <endEvent id="CompensationEndEvent" name="compensation-end-event">
+      <incoming>Flow_165qz3q</incoming>
+    </endEvent>
+    <sequenceFlow id="Flow_0tm7usg" sourceRef="ActivityToComplete" targetRef="Event_1051say" />
+    <serviceTask id="ActivityToComplete" name="C">
+      <extensionElements>
+        <zeebe:taskDefinition type="completableActivity" />
+      </extensionElements>
+      <incoming>Flow_16v3jw3</incoming>
+      <outgoing>Flow_0tm7usg</outgoing>
+    </serviceTask>
+    <adHocSubProcess id="adhoc-subprocess" name="adhoc-subprocess">
+      <extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;ActivityToCompensate&#34;]" />
+      </extensionElements>
+      <incoming>Flow_0ggq2x0</incoming>
+      <outgoing>sequenceFlow_66c420e0-5c3a-48e0-a48b-5c4018e1d2b0</outgoing>
+      <serviceTask id="ActivityToCompensate" name="A">
+        <extensionElements>
+          <zeebe:taskDefinition type="compensableActivity" />
+        </extensionElements>
+        <outgoing>Flow_1oin5ut</outgoing>
+      </serviceTask>
+      <serviceTask id="CompensationHandler" name="undo A" isForCompensation="true">
+        <extensionElements>
+          <zeebe:taskDefinition type="compensationHandler" />
+        </extensionElements>
+      </serviceTask>
+      <serviceTask id="NotActivableTask" name="B">
+        <extensionElements>
+          <zeebe:taskDefinition type="NotActivableTask" />
+        </extensionElements>
+        <incoming>Flow_1oin5ut</incoming>
+      </serviceTask>
+      <boundaryEvent id="Event_0u821xi" attachedToRef="ActivityToCompensate">
+        <compensateEventDefinition id="CompensateEventDefinition_1o7xvwo" />
+      </boundaryEvent>
+      <sequenceFlow id="Flow_1oin5ut" sourceRef="ActivityToCompensate" targetRef="NotActivableTask" />
+      <association id="Association_03pbpib" associationDirection="One" sourceRef="Event_0u821xi" targetRef="CompensationHandler" />
+    </adHocSubProcess>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_d458583a-dbd3-44f4-9045-ef478ea1576c">
+    <bpmndi:BPMNPlane id="BPMNPlane_b1706292-8b4e-48dd-9ca2-e5d428c1f478" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="BPMNShape_39875287-c8bc-4920-a2fc-c48f0596fc43" bpmnElement="startEvent_0aa5c6c8-21bc-4491-ad62-7e87e17c8590">
+        <dc:Bounds x="152" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_12izjn7_di" bpmnElement="Gateway_1h9kfph">
+        <dc:Bounds x="245" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_19aiyeb_di" bpmnElement="Gateway_1vnlp1m">
+        <dc:Bounds x="945" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0y1s349_di" bpmnElement="Event_1051say">
+        <dc:Bounds x="782" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yebn4i_di" bpmnElement="CompensationEndEvent">
+        <dc:Bounds x="1072" y="242" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1053" y="205" width="73" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0va6dpn_di" bpmnElement="ActivityToComplete">
+        <dc:Bounds x="480" y="460" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0a0e86w_di" bpmnElement="adhoc-subprocess" isExpanded="true">
+        <dc:Bounds x="320" y="120" width="560" height="270" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1cknqj2_di" bpmnElement="ActivityToCompensate">
+        <dc:Bounds x="480" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14xtpaq_di" bpmnElement="CompensationHandler">
+        <dc:Bounds x="620" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1o48ey1_di" bpmnElement="NotActivableTask">
+        <dc:Bounds x="640" y="260" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_03pbpib_di" bpmnElement="Association_03pbpib">
+        <di:waypoint x="550" y="242" />
+        <di:waypoint x="550" y="200" />
+        <di:waypoint x="620" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0edlw69_di" bpmnElement="Event_0u821xi">
+        <dc:Bounds x="532" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1oin5ut_di" bpmnElement="Flow_1oin5ut">
+        <di:waypoint x="580" y="300" />
+        <di:waypoint x="640" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_d542daa3-5c92-48be-9082-8fb2a0f5df1a" bpmnElement="sequenceFlow_49d15526-b405-48ef-9939-8f260437e2d4">
+        <di:waypoint x="188" y="260" />
+        <di:waypoint x="245" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_09a09196-11c6-4f3d-a22f-75c90adf2051" bpmnElement="sequenceFlow_66c420e0-5c3a-48e0-a48b-5c4018e1d2b0">
+        <di:waypoint x="880" y="260" />
+        <di:waypoint x="945" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ggq2x0_di" bpmnElement="Flow_0ggq2x0">
+        <di:waypoint x="295" y="260" />
+        <di:waypoint x="320" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_165qz3q_di" bpmnElement="Flow_165qz3q">
+        <di:waypoint x="995" y="260" />
+        <di:waypoint x="1072" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16v3jw3_di" bpmnElement="Flow_16v3jw3">
+        <di:waypoint x="270" y="285" />
+        <di:waypoint x="270" y="500" />
+        <di:waypoint x="480" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1oqhyjt_di" bpmnElement="Flow_1oqhyjt">
+        <di:waypoint x="818" y="500" />
+        <di:waypoint x="970" y="500" />
+        <di:waypoint x="970" y="285" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tm7usg_di" bpmnElement="Flow_0tm7usg">
+        <di:waypoint x="580" y="500" />
+        <di:waypoint x="782" y="500" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

With the introduction of the ad-hoc sub-process inner instance, compensation dind't work properly anymore. We must ensure we create the compensation subscription for the inner instance in order to find the subscriptions when a compensation is thrown.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/ad-hoc-sub-process-phase-3/issues/20
