### PR TITLE
fix: update operate application yml with the new config structure

### DIFF
--- a/operate/config/application.yml
+++ b/operate/config/application.yml
@@ -1,13 +1,16 @@
 springfox.documentation.swagger.v2.path: /documentation
+camunda:
+  data:
+    secondary-storage:
+      elasticsearch:
+        cluster-name: docker-cluster
+        host: localhost
+        port: 9200
+      opensearch:
+        cluster-name: opensearch-cluster
+        host: localhost
+        port: 9200
 camunda.operate:
-  elasticsearch:
-    clusterName: docker-cluster
-    host: localhost
-    port: 9200
-  opensearch:
-    clusterName: opensearch-cluster
-    host: localhost
-    port: 9200
   zeebe:
     gatewayAddress: localhost:26500
   zeebeElasticsearch:


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
When doing mvn evn-up there is an error related the cluster-name changes (might be related to 37207)
i tried adjusting config/application.yml  to the new structure locally and it seems to work for the basic case but i am not sure if other changes are needed for the other properties. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to [37207](https://github.com/camunda/camunda/pull/37207)
