### PR TITLE
fix: capture emitted event to register completion

### DIFF
--- a/qa/migration-tests/pom.xml
+++ b/qa/migration-tests/pom.xml
@@ -213,6 +213,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
       <scope>test</scope>

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/AssignUserTaskMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/AssignUserTaskMigrationIT.java
@@ -16,6 +16,7 @@ import io.camunda.it.migration.util.MigrationITExtension;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
 import java.time.Duration;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -33,6 +34,7 @@ public class AssignUserTaskMigrationIT extends UserTaskMigrationHelper {
           .withBeforeUpgradeConsumer((db, migrator) -> setup(db, migrator, null));
 
   @Test
+  @Disabled("Should be re-enabled once https://github.com/camunda/camunda/issues/36027 is fixed")
   void shouldAssign87ZeebeTaskV1(final CamundaMigrator migrator) {
 
     final long taskKey = USER_TASK_KEYS.get("first");

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/CamundaMigrator.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/CamundaMigrator.java
@@ -35,8 +35,8 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import org.agrona.CloseHelper;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.context.ApplicationListener;
+import org.springframework.lang.NonNull;
 import org.testcontainers.utility.DockerImageName;
 
 public class CamundaMigrator extends ApiCallable implements AutoCloseable {
@@ -328,7 +328,7 @@ public class CamundaMigrator extends ApiCallable implements AutoCloseable {
     boolean migrationCompleted = false;
 
     @Override
-    public void onApplicationEvent(final @NotNull MigrationFinishedEvent event) {
+    public void onApplicationEvent(final @NonNull MigrationFinishedEvent event) {
       migrationCompleted = true;
     }
   }

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -52,6 +52,7 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ApplicationListener;
 import org.springframework.util.unit.DataSize;
 
 /**
@@ -203,6 +204,12 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
     withAuthenticatedAccess();
     withProperty("camunda.security.multiTenancy.checksEnabled", false);
     return withSecurityConfig(cfg -> cfg.getMultiTenancy().setChecksEnabled(false));
+  }
+
+  public TestCamundaApplication withApplicationEventListener(
+      final String qualifier, final ApplicationListener<?> listener) {
+    withBean(qualifier, listener, ApplicationListener.class);
+    return this;
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Instead of capturing application logs for registering completion, use the existing event emitted by the `AsyncMigrationsRunner` to capture the completion and poll upon it. The Spring event was already emitted to signal the termination of the Migration applications.

Introduce a `withApplicationEventListener` to the `TestStandaloneCamunda` to register Spring ApplicationListener beans in the context.

Disable flaky `shouldAssign87ZeebeTaskV1` with a known related bug.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
