### PR TITLE
refactor: cleanup created groups after tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
@@ -23,12 +23,23 @@ import {
 } from '../../../../utils/beans/requestBeans';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {createGroupAndStoreResponseFields} from '../../../../utils/requestHelpers';
+import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Groups API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdGroups: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
+    createdGroups.push(
+      state['groupId1'] as string,
+      state['groupId2'] as string,
+      state['groupId3'] as string,
+    );
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupGroups(request, createdGroups);
   });
 
   test('Create Group', async ({request}) => {
@@ -41,6 +52,9 @@ test.describe.parallel('Groups API Tests', () => {
 
     expect(res.status()).toBe(201);
     const json = await res.json();
+
+    createdGroups.push(json.groupId);
+
     assertRequiredFields(json, groupRequiredFields);
     assertEqualsForKeys(json, requestBody, groupRequiredFields);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
@@ -27,19 +27,14 @@ import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Groups API Tests', () => {
   const state: Record<string, unknown> = {};
-  const createdGroups: string[] = [];
+  state['createdIds'] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
-    createdGroups.push(
-      state['groupId1'] as string,
-      state['groupId2'] as string,
-      state['groupId3'] as string,
-    );
   });
 
   test.afterAll(async ({request}) => {
-    await cleanupGroups(request, createdGroups);
+    await cleanupGroups(request, state['createdIds'] as string[]);
   });
 
   test('Create Group', async ({request}) => {
@@ -53,8 +48,7 @@ test.describe.parallel('Groups API Tests', () => {
     expect(res.status()).toBe(201);
     const json = await res.json();
 
-    createdGroups.push(json.groupId);
-
+    (state['createdIds'] as string[]).push(json.groupId);
     assertRequiredFields(json, groupRequiredFields);
     assertEqualsForKeys(json, requestBody, groupRequiredFields);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
@@ -30,22 +30,16 @@ import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Groups Clients API Tests', () => {
   const state: Record<string, unknown> = {};
-  const createdGroups: string[] = [];
+  state['createdIds'] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
     await assignClientToGroup(request, 1, state['groupId2'] as string, state);
     await assignClientToGroup(request, 1, state['groupId3'] as string, state);
-
-    createdGroups.push(
-      state['groupId1'] as string,
-      state['groupId2'] as string,
-      state['groupId3'] as string,
-    );
   });
 
   test.afterAll(async ({request}) => {
-    await cleanupGroups(request, createdGroups);
+    await cleanupGroups(request, state['createdIds'] as string[]);
   });
 
   test('Assign Client To Group', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
@@ -26,14 +26,26 @@ import {
   defaultAssertionOptions,
   generateUniqueId,
 } from '../../../../utils/constants';
+import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Groups Clients API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdGroups: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
     await assignClientToGroup(request, 1, state['groupId2'] as string, state);
     await assignClientToGroup(request, 1, state['groupId3'] as string, state);
+
+    createdGroups.push(
+      state['groupId1'] as string,
+      state['groupId2'] as string,
+      state['groupId3'] as string,
+    );
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupGroups(request, createdGroups);
   });
 
   test('Assign Client To Group', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
@@ -28,14 +28,27 @@ import {
   mappingRuleIdFromState,
 } from '../../../../utils/requestHelpers';
 import {defaultAssertionOptions} from '../../../../utils/constants';
+import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Group Mapping Rules API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdGroups: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
+
+    createdGroups.push(
+      state['groupId1'] as string,
+      state['groupId2'] as string,
+      state['groupId3'] as string,
+    );
+
     await assignMappingToGroup(request, 1, state['groupId2'] as string, state);
     await assignMappingToGroup(request, 1, state['groupId3'] as string, state);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupGroups(request, createdGroups);
   });
 
   test('Assign Mapping Rule To Group', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
@@ -32,23 +32,17 @@ import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Group Mapping Rules API Tests', () => {
   const state: Record<string, unknown> = {};
-  const createdGroups: string[] = [];
+  state['createdIds'] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
-
-    createdGroups.push(
-      state['groupId1'] as string,
-      state['groupId2'] as string,
-      state['groupId3'] as string,
-    );
 
     await assignMappingToGroup(request, 1, state['groupId2'] as string, state);
     await assignMappingToGroup(request, 1, state['groupId3'] as string, state);
   });
 
   test.afterAll(async ({request}) => {
-    await cleanupGroups(request, createdGroups);
+    await cleanupGroups(request, state['createdIds'] as string[]);
   });
 
   test('Assign Mapping Rule To Group', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
@@ -22,13 +22,22 @@ import {
   assertRoleInResponse,
 } from '../../../../utils/requestHelpers';
 import {defaultAssertionOptions} from '../../../../utils/constants';
+import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Group Roles API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdGroups: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 1, state);
+
+    createdGroups.push(state['groupId1'] as string);
+
     await assignRoleToGroups(request, 2, state['groupId1'] as string, state);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupGroups(request, createdGroups);
   });
 
   test('Search Group Roles', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
@@ -26,18 +26,16 @@ import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Group Roles API Tests', () => {
   const state: Record<string, unknown> = {};
-  const createdGroups: string[] = [];
+  state['createdIds'] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 1, state);
-
-    createdGroups.push(state['groupId1'] as string);
 
     await assignRoleToGroups(request, 2, state['groupId1'] as string, state);
   });
 
   test.afterAll(async ({request}) => {
-    await cleanupGroups(request, createdGroups);
+    await cleanupGroups(request, state['createdIds'] as string[]);
   });
 
   test('Search Group Roles', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
@@ -27,14 +27,27 @@ import {
   defaultAssertionOptions,
   generateUniqueId,
 } from '../../../../utils/constants';
+import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Group Users API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdGroups: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
+
+    createdGroups.push(
+      state['groupId1'] as string,
+      state['groupId2'] as string,
+      state['groupId3'] as string,
+    );
+
     await assignUsersToGroup(request, 1, state['groupId2'] as string, state);
     await assignUsersToGroup(request, 1, state['groupId3'] as string, state);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupGroups(request, createdGroups);
   });
 
   test('Assign User To Group Not Found', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
@@ -31,23 +31,17 @@ import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Group Users API Tests', () => {
   const state: Record<string, unknown> = {};
-  const createdGroups: string[] = [];
+  state['createdIds'] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
-
-    createdGroups.push(
-      state['groupId1'] as string,
-      state['groupId2'] as string,
-      state['groupId3'] as string,
-    );
 
     await assignUsersToGroup(request, 1, state['groupId2'] as string, state);
     await assignUsersToGroup(request, 1, state['groupId3'] as string, state);
   });
 
   test.afterAll(async ({request}) => {
-    await cleanupGroups(request, createdGroups);
+    await cleanupGroups(request, state['createdIds'] as string[]);
   });
 
   test('Assign User To Group Not Found', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -16,6 +16,7 @@ import {
   findLocatorInPaginatedList,
   waitForItemInList,
 } from 'utils/waitForItemInList';
+import {cleanupGroupsSafely} from 'utils/groupsCleanup';
 
 test.describe.serial('groups CRUD', () => {
   let NEW_GROUP: NonNullable<ReturnType<typeof createTestData>['group']>;
@@ -101,6 +102,8 @@ test.describe.serial('groups CRUD', () => {
 });
 
 test.describe('Groups functionalities', () => {
+  const createdGroupIds: string[] = [];
+
   test.beforeEach(async ({page, loginPage, identityGroupsPage}) => {
     await navigateToApp(page, 'identity');
     await loginPage.login('demo', 'demo');
@@ -112,15 +115,33 @@ test.describe('Groups functionalities', () => {
     await captureFailureVideo(page, testInfo);
   });
 
+  test.afterAll(async ({browser}) => {
+    if (createdGroupIds.length > 0) {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+
+      try {
+        await cleanupGroupsSafely(page, createdGroupIds);
+      } catch (error) {
+        console.warn('Cleanup failed:', error);
+      } finally {
+        await context.close();
+      }
+    }
+  });
+
   test('As an Admin user can create a group with particular permissions and assign it to Test user', async ({
     page,
     identityGroupsPage,
     identityAuthorizationsPage,
+    identityHeader,
   }) => {
     const testData = createTestData({
       group: true,
     });
     const TEST_GROUP = testData.group!;
+
+    createdGroupIds.push(TEST_GROUP.groupId);
 
     await test.step('Create test group', async () => {
       await identityGroupsPage.navigateToGroups();
@@ -133,6 +154,7 @@ test.describe('Groups functionalities', () => {
       const item = identityGroupsPage.groupCell(TEST_GROUP.name);
       await waitForItemInList(page, item, {
         clickNext: true,
+        timeout: 60000,
       });
       await expect(item).toBeVisible();
     });
@@ -144,7 +166,7 @@ test.describe('Groups functionalities', () => {
     });
 
     await test.step('Create authorization for group', async () => {
-      await identityAuthorizationsPage.navigateToAuthorizations();
+      await identityHeader.navigateToAuthorizations();
       await identityAuthorizationsPage.createAuthorization({
         ownerType: 'Group',
         ownerId: TEST_GROUP.name,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/groupsCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/groupsCleanup.ts
@@ -20,9 +20,20 @@ export async function cleanupGroups(
   await Promise.allSettled(
     groupIds.map(async (groupId) => {
       try {
-        await request.delete(buildUrl('/groups/{groupId}', {groupId}), {
-          headers: jsonHeaders(),
-        });
+        const response = await request.delete(
+          buildUrl('/groups/{groupId}', {groupId}),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+
+        if (response.status() === 204) {
+          console.log(`Successfully deleted group: ${groupId}`);
+        } else {
+          console.warn(
+            `Unexpected response status ${response.status()} for group ${groupId}`,
+          );
+        }
       } catch {}
     }),
   );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/groupsCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/groupsCleanup.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext, Page} from '@playwright/test';
+import {jsonHeaders, buildUrl} from './http';
+
+export async function cleanupGroups(
+  request: APIRequestContext,
+  groupIds: string[],
+): Promise<void> {
+  if (groupIds.length === 0) return;
+
+  console.log(`Cleaning up ${groupIds.length} groups via API...`);
+
+  await Promise.allSettled(
+    groupIds.map(async (groupId) => {
+      try {
+        await request.delete(buildUrl('/groups/{groupId}', {groupId}), {
+          headers: jsonHeaders(),
+        });
+      } catch {}
+    }),
+  );
+}
+
+export async function cleanupGroupsSafely(
+  page: Page,
+  groupIds: string[],
+): Promise<void> {
+  if (groupIds.length === 0) return;
+
+  try {
+    const request = page.request;
+    await cleanupGroups(request, groupIds);
+  } catch (error) {
+    console.log('API cleanup failed:', error);
+  }
+}


### PR DESCRIPTION
## Description
Introduces robust group cleanup for test maintenance and enhances authorization pagination.

### Changes
- **Added `utils/groupsCleanup.ts`** with API and UI cleanup functions
- **Updated all group test files** with cleanup integration
- **Enhanced `assertAuthorizationExists()`** with pagination support

### Files Modified
```
utils/groupsCleanup.ts                                    # New
tests/api/v2/group/*.spec.ts                             # Added cleanup
tests/identity/groups.spec.ts                            # Enhanced UI cleanup
pages/IdentityAuthorizationsPage.ts                      # Pagination fix
```



Test run: [here](https://github.com/camunda/camunda/actions/runs/17610556968/job/50031437418), failing tests will be fixed in a separate PR for users cleanup

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
