### PR TITLE
deps: Update dependency io.netty:netty-bom to 4.1.127.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,7 +75,7 @@
     <version.mockito>5.18.0</version.mockito>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.10</version.msgpack>
-    <version.netty>4.1.124.Final</version.netty>
+    <version.netty>4.1.127.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
     <version.opensearch>2.17.0</version.opensearch>
     <version.opensearch-java>2.19.0</version.opensearch-java>


### PR DESCRIPTION
## Description

Update dependency io.netty:netty-bom to 4.1.127.Final

## Related issues

related to https://github.com/camunda/camunda/issues/37881
