### PR TITLE
ci: allow Renovate to run on weekend days

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,8 +15,8 @@
   "prHourlyLimit": 10,
   "updateNotScheduled": false,
   "schedule": [
-    "before 8am every weekday",
-    "after 8pm every weekday"
+    "* 20-23,0-8 * * 1-5",
+    "* * * * 0,6"
   ],
   "helmv3": {
     "registryAliases": {


### PR DESCRIPTION
## Description

This PR extends the Renovate schedule to include allowing runs on weekend days, which see low usual developer activity -> CI should be free.

Our previous configuration used the [deprecated "later"](https://docs.renovatebot.com/key-concepts/scheduling/#deprecated-breejslater-syntax) syntax which Renovate recommends replacing with usual Cron syntax - this is done in the PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to #36956
