### PR TITLE
fix: configure jackson mapper to fail for unknown properties in the REST request and disable coercion

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -99,3 +99,6 @@ management.metrics.distribution.percentiles-histogram.http.server.requests=true
 management.metrics.distribution.percentiles.http.server.requests=0.5,0.95,0.99
 
 camunda.security.multiTenancy.checksEnabled=${zeebe.broker.gateway.multiTenancy.enabled:false}
+
+# Jackson configuration to prevent coercion of scalars
+spring.jackson.mapper.allow-coercion-of-scalars=false

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/FlowNodeInstanceControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/FlowNodeInstanceControllerIT.java
@@ -101,8 +101,7 @@ public class FlowNodeInstanceControllerIT {
   @Test
   public void shouldAcceptQueryWithFilter() throws Exception {
     assertPostToWithSucceed(
-        URI + SEARCH,
-        "{\"filter\": { \"" + FlowNodeInstance.PROCESS_INSTANCE_KEY + "\": \"1\" } }");
+        URI + SEARCH, "{\"filter\": { \"" + FlowNodeInstance.PROCESS_INSTANCE_KEY + "\": 1 } }");
     verify(flowNodeInstanceDao)
         .search(
             new Query<FlowNodeInstance>()
@@ -128,9 +127,9 @@ public class FlowNodeInstanceControllerIT {
         URI + SEARCH,
         "{\"filter\": { \""
             + FlowNodeInstance.PROCESS_DEFINITION_KEY
-            + "\": \""
+            + "\": "
             + processDefinitionKey
-            + "\" } }");
+            + " } }");
     verify(flowNodeInstanceDao)
         .search(
             new Query<FlowNodeInstance>()

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/IncidentControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/IncidentControllerIT.java
@@ -102,7 +102,7 @@ public class IncidentControllerIT {
   @Test
   public void shouldAcceptQueryWithFilter() throws Exception {
     assertPostToWithSucceed(
-        URI + SEARCH, "{\"filter\": { \"" + Incident.PROCESS_INSTANCE_KEY + "\": \"1\" } }");
+        URI + SEARCH, "{\"filter\": { \"" + Incident.PROCESS_INSTANCE_KEY + "\": 1 } }");
     verify(incidentDao)
         .search(new Query<Incident>().setFilter(new Incident().setProcessInstanceKey(1L)));
   }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/ProcessInstanceQueryControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/ProcessInstanceQueryControllerIT.java
@@ -104,7 +104,7 @@ public class ProcessInstanceQueryControllerIT {
 
   @Test
   public void shouldAcceptQueryWithFilter() throws Exception {
-    assertPostToWithSucceed(URI + SEARCH, "{\"filter\": { \"" + VERSION + "\": \"1\" } }");
+    assertPostToWithSucceed(URI + SEARCH, "{\"filter\": { \"" + VERSION + "\": 1 } }");
     verify(processInstanceDao)
         .search(new Query<ProcessInstance>().setFilter(new ProcessInstance().setProcessVersion(1)));
   }
@@ -112,7 +112,7 @@ public class ProcessInstanceQueryControllerIT {
   @Test
   public void shouldAcceptQueryWithParentKeyFilter() throws Exception {
     assertPostToWithSucceed(
-        URI + SEARCH, "{\"filter\": { " + "\"" + VERSION + "\": \"1\"," + "\"parentKey\": 345} }");
+        URI + SEARCH, "{\"filter\": { " + "\"" + VERSION + "\": 1," + "\"parentKey\": 345} }");
     verify(processInstanceDao)
         .search(
             new Query<ProcessInstance>()
@@ -123,7 +123,7 @@ public class ProcessInstanceQueryControllerIT {
   public void shouldAcceptQueryWithParentProcessInstanceKeyFilter() throws Exception {
     assertPostToWithSucceed(
         URI + SEARCH,
-        "{\"filter\": { " + "\"" + VERSION + "\": \"1\"," + "\"parentProcessInstanceKey\": 345} }");
+        "{\"filter\": { " + "\"" + VERSION + "\": 1," + "\"parentProcessInstanceKey\": 345} }");
 
     verify(processInstanceDao)
         .search(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.camunda.zeebe.gateway.protocol.rest.BasicStringFilterProperty;
@@ -84,6 +85,8 @@ public class JacksonConfig {
   public ObjectMapper objectMapper() {
     final var builder = Jackson2ObjectMapperBuilder.json();
     gatewayRestObjectMapperCustomizer().accept(builder);
-    return builder.build();
+    final var mapper = builder.build();
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    return mapper;
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -148,9 +148,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                 "version": 1,
                 "decisionRequirementsId": "drId",
                 "decisionRequirementsKey": "2",
-                "decisionDefinitionId": "dId",
-                "decisionRequirementsName": "drName",
-                "decisionRequirementsVersion": 3
+                "decisionDefinitionId": "dId"
               }
             }""";
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FaultyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FaultyControllerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.service.ProcessInstanceServices;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(value = ProcessInstanceController.class)
+public class FaultyControllerTest extends RestControllerTest {
+
+  static final String PROCESS_INSTANCES_START_URL = "/v2/process-instances";
+
+  @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean ProcessInstanceServices processInstanceServices;
+
+  @BeforeEach
+  void setupServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+    when(processInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(processInstanceServices);
+  }
+
+  @Test
+  void shouldRejectUnrecognizedField() {
+    // given
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
+
+    final var request =
+        """
+        {
+            "test": "123"
+        }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_START_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .json(
+            """
+             {
+                 "type": "about:blank",
+                 "title": "Bad Request",
+                 "status": 400,
+                 "detail": "%s",
+                 "instance": "%s"
+             }
+             """
+                .formatted("Request property [test] cannot be parsed", PROCESS_INSTANCES_START_URL),
+            JsonCompareMode.STRICT);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -616,7 +616,6 @@ public class JobControllerTest extends RestControllerTest {
           {
             "result": {
               "type": "userTask",
-              "unknownField": true,
               "corrections": {}
             }
           }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -606,41 +606,6 @@ public class JobControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldCompleteJobWithResultAndIgnoreUnknownField() {
-    // given
-    when(jobServices.completeJob(anyLong(), any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
-
-    final var request =
-        """
-          {
-            "result": {
-              "type": "userTask",
-              "corrections": {}
-            }
-          }
-        """;
-
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/completion")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
-
-    final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
-        ArgumentCaptor.forClass(JobResult.class);
-    Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture());
-    assertThat(jobResultArgumentCaptor.getValue().isDenied()).isFalse();
-    assertThat(jobResultArgumentCaptor.getValue().getDeniedReason()).isEqualTo("");
-  }
-
-  @Test
   void shouldCompleteJobWithVariables() {
     // given
     when(jobServices.completeJob(anyLong(), any(), any()))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -434,7 +434,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     final var request =
         """
             {
-                "version": 1,
+                "processDefinitionVersion": 1,
                 "awaitCompletion": true
             }""";
 
@@ -472,7 +472,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             {
                 "processDefinitionId": "bpmnProcessId",
                 "processDefinitionKey": 123,
-                "version": 1
+                "processDefinitionVersion": 1
             }""";
 
     final var expectedBody =

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleControllerTest.java
@@ -333,6 +333,13 @@ public class MappingRuleControllerTest extends RestControllerTest {
   void updateMappingRuleRuleShouldReturnOk(final String id) {
     // given
     final var dto = validUpdateMappingRuleRuleRequest(id);
+    final var request =
+        """
+            {
+              "claimName": "newClaimName",
+              "claimValue": "newClaimValue",
+              "name": "mapName"
+            }""";
     final var mappingRecord =
         new MappingRuleRecord()
             .setMappingRuleKey(1L)
@@ -350,7 +357,7 @@ public class MappingRuleControllerTest extends RestControllerTest {
         .uri(MAPPING_RULES_PATH + "/" + id)
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(dto)
+        .bodyValue(request)
         .exchange()
         .expectStatus()
         .isOk();

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -84,7 +84,7 @@ public interface ClusterActuator {
    */
   @RequestLine("POST /brokers/{brokerId}/partitions/{partitionId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
-  @Body("%7B\"priority\": \"{priority}\"%7D")
+  @Body("%7B\"priority\": {priority}%7D")
   PlannedOperationsResponse joinPartition(
       @Param final int brokerId, @Param final int partitionId, @Param final int priority);
 


### PR DESCRIPTION
## Description

This PR configure Jackson Object Mapper to fail if unknown property are provided in the REST request object and disable coercion for all types

## Related issues

closes #37865 
