### PR TITLE
deps: Update dependency io.netty:netty-bom to 4.1.127.Final

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -89,7 +89,7 @@
     <elasticsearch-test-container.version>1.19.8</elasticsearch-test-container.version>
     <postgres-test-container.version>1.17.6</postgres-test-container.version>
     <wiremock.version>3.9.2</wiremock.version>
-    <netty.version>4.1.124.Final</netty.version>
+    <netty.version>4.1.127.Final</netty.version>
     <version.docker-java-api>3.3.6</version.docker-java-api>
     <version.httpclient>4.5.14</version.httpclient>
     <version.elasticsearch7>7.17.29</version.elasticsearch7>


### PR DESCRIPTION
## Description

Update dependency io.netty:netty-bom to 4.1.127.Final

## Related issues

related to https://github.com/camunda/camunda/issues/37881
