### PR TITLE
fix: don't rewrap client exceptions

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpCamundaFuture.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpCamundaFuture.java
@@ -83,6 +83,8 @@ public class HttpCamundaFuture<RespT> extends CompletableFuture<RespT>
     final Throwable cause = e.getCause();
     if (cause instanceof ProblemException) {
       throw (ProblemException) cause;
+    } else if (cause instanceof ClientException) {
+      throw (ClientException) cause;
     } else {
       throw new ClientException(cause);
     }


### PR DESCRIPTION
Otherwise, certain code paths end up with a doubly-wrapped client exception. For example on connection issues:

```
Exception in thread "main"
  io.camunda.client.api.command.ClientException:
  io.camunda.client.api.command.ClientException:
    org.apache.hc.client5.http.HttpHostConnectException:
      Connect to http://localhost:8080 failed: Connection refused
```