### PR TITLE
[Backport stable/8.7] deps: Update dependency io.netty:netty-bom to 4.1.127.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -74,7 +74,7 @@
     <version.mockito>5.13.0</version.mockito>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.10</version.msgpack>
-    <version.netty>4.1.124.Final</version.netty>
+    <version.netty>4.1.127.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
     <version.opensearch>2.9.0</version.opensearch>
     <version.opensearch.testcontainers>2.1.4</version.opensearch.testcontainers>


### PR DESCRIPTION
# Description
Backport of #37883 to `stable/8.7`.

relates to camunda/camunda#37881