### PR TITLE
[Backport stable/8.8] fix: set missing Zeebe OpenSearch/Elasticsearch URL in unified config

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -82,6 +82,8 @@ public class OperatePropertiesOverride {
     override.getElasticsearch().setClusterName(database.getElasticsearch().getClusterName());
     override.getElasticsearch().setIndexPrefix(database.getElasticsearch().getIndexPrefix());
 
+    override.getZeebeElasticsearch().setUrl(database.getElasticsearch().getUrl());
+
     populateFromSecurity(
         database.getElasticsearch().getSecurity(),
         override.getElasticsearch()::getSsl,
@@ -96,6 +98,8 @@ public class OperatePropertiesOverride {
     override.getOpensearch().setPassword(database.getOpensearch().getPassword());
     override.getOpensearch().setClusterName(database.getOpensearch().getClusterName());
     override.getOpensearch().setIndexPrefix(database.getOpensearch().getIndexPrefix());
+
+    override.getZeebeOpensearch().setUrl(database.getOpensearch().getUrl());
 
     populateFromSecurity(
         database.getOpensearch().getSecurity(),

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -79,6 +79,8 @@ public class TasklistPropertiesOverride {
     override.getElasticsearch().setClusterName(database.getElasticsearch().getClusterName());
     override.getElasticsearch().setIndexPrefix(database.getElasticsearch().getIndexPrefix());
 
+    override.getZeebeElasticsearch().setUrl(database.getElasticsearch().getUrl());
+
     populateFromSecurity(
         database.getElasticsearch().getSecurity(),
         override.getElasticsearch()::getSsl,
@@ -93,6 +95,8 @@ public class TasklistPropertiesOverride {
     override.getOpenSearch().setPassword(database.getOpensearch().getPassword());
     override.getOpenSearch().setClusterName(database.getOpensearch().getClusterName());
     override.getOpenSearch().setIndexPrefix(database.getOpensearch().getIndexPrefix());
+
+    override.getZeebeOpenSearch().setUrl(database.getOpensearch().getUrl());
 
     populateFromSecurity(
         database.getOpensearch().getSecurity(),

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
+import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.operate.conditions.DatabaseType;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@ActiveProfiles({"broker", "tasklist", "operate"})
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  TasklistPropertiesOverride.class,
+  OperatePropertiesOverride.class,
+  BrokerBasedPropertiesOverride.class,
+  SearchEngineConnectPropertiesOverride.class
+})
+public class SecondaryStorageElasticsearchTest {
+  private static final String EXPECTED_CLUSTER_NAME = "sample-cluster";
+  private static final String EXPECTED_INDEX_PREFIX = "sample-index-prefix";
+
+  private static final String EXPECTED_USERNAME = "testUsername";
+  private static final String EXPECTED_PASSWORD = "testPassword";
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.secondary-storage.elasticsearch.url=http://expected-url:4321",
+        "camunda.data.secondary-storage.elasticsearch.username=" + EXPECTED_USERNAME,
+        "camunda.data.secondary-storage.elasticsearch.password=" + EXPECTED_PASSWORD,
+        "camunda.data.secondary-storage.elasticsearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
+        "camunda.data.secondary-storage.elasticsearch.index-prefix=" + EXPECTED_INDEX_PREFIX
+      })
+  class WithOnlyUnifiedConfigSet {
+    final OperateProperties operateProperties;
+    final TasklistProperties tasklistProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+
+    WithOnlyUnifiedConfigSet(
+        @Autowired final OperateProperties operateProperties,
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties) {
+      this.operateProperties = operateProperties;
+      this.tasklistProperties = tasklistProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+    }
+
+    @Test
+    void testCamundaDataSecondaryStorageOperateProperties() {
+      final DatabaseType expectedOperateDatabaseType = DatabaseType.Elasticsearch;
+      final String expectedUrl = "http://expected-url:4321";
+
+      assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
+      assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(operateProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(operateProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(operateProperties.getElasticsearch().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(operateProperties.getElasticsearch().getIndexPrefix())
+          .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(operateProperties.getZeebeElasticsearch().getUrl()).isEqualTo(expectedUrl);
+    }
+
+    @Test
+    void testCamundaDataSecondaryStorageTasklistProperties() {
+      final String expectedTasklistDatabaseType = "elasticsearch";
+      final String expectedUrl = "http://expected-url:4321";
+
+      assertThat(tasklistProperties.getDatabase()).isEqualTo(expectedTasklistDatabaseType);
+      assertThat(tasklistProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(tasklistProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(tasklistProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(tasklistProperties.getElasticsearch().getIndexPrefix())
+          .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(tasklistProperties.getZeebeElasticsearch().getUrl()).isEqualTo(expectedUrl);
+    }
+
+    @Test
+    void testCamundaDataSecondaryStorageCamundaExporterProperties() {
+      final String expectedType = "elasticsearch";
+      final String expectedUrl = "http://expected-url:4321";
+
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNotNull();
+
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToExporterConfiguration(args);
+      assertThat(exporterConfiguration.getConnect().getType()).isEqualTo(expectedType);
+      assertThat(exporterConfiguration.getConnect().getUrl()).isEqualTo(expectedUrl);
+      assertThat(exporterConfiguration.getConnect().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(exporterConfiguration.getConnect().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(exporterConfiguration.getConnect().getIndexPrefix())
+          .isEqualTo(EXPECTED_INDEX_PREFIX);
+    }
+
+    @Test
+    void testCamundaSearchEngineConnectProperties() {
+      assertThat(searchEngineConnectProperties.getType().toLowerCase()).isEqualTo("elasticsearch");
+      assertThat(searchEngineConnectProperties.getUrl()).isEqualTo("http://expected-url:4321");
+      assertThat(searchEngineConnectProperties.getIndexPrefix()).isEqualTo(EXPECTED_INDEX_PREFIX);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // type
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.database.type=elasticsearch",
+        "camunda.operate.database=elasticsearch",
+        "camunda.tasklist.database=elasticsearch",
+        // url
+        "camunda.data.secondary-storage.elasticsearch.url=http://matching-url:4321",
+        "camunda.database.url=http://matching-url:4321",
+        "camunda.tasklist.elasticsearch.url=http://matching-url:4321",
+        "camunda.tasklist.zeebeElasticsearch.url=http://matching-url:4321",
+        "camunda.operate.elasticsearch.url=http://matching-url:4321",
+        "camunda.operate.zeebeElasticsearch.url=http://matching-url:4321",
+        // username
+        "camunda.data.secondary-storage.elasticsearch.username=" + EXPECTED_USERNAME,
+        "camunda.database.username=" + EXPECTED_USERNAME,
+        "camunda.operate.elasticsearch.username=" + EXPECTED_USERNAME,
+        "camunda.tasklist.elasticsearch.username=" + EXPECTED_USERNAME,
+        // password
+        "camunda.data.secondary-storage.elasticsearch.password=" + EXPECTED_PASSWORD,
+        "camunda.database.password=" + EXPECTED_PASSWORD,
+        "camunda.operate.elasticsearch.password=" + EXPECTED_PASSWORD,
+        "camunda.tasklist.elasticsearch.password=" + EXPECTED_PASSWORD,
+        // NOTE: In the following blocks, the camundaExporter doesn't have to be configured, as
+        //  it is default with StandaloneCamunda. Any attempt of configuration will fail unless
+        //  the className is also configured.
+
+        // cluster name
+        "camunda.data.secondary-storage.elasticsearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
+        "camunda.data.clusterName=" + EXPECTED_CLUSTER_NAME,
+        "camunda.tasklist.elasticsearch.clusterName=" + EXPECTED_CLUSTER_NAME,
+        "camunda.operate.elasticsearch.clusterName=" + EXPECTED_CLUSTER_NAME,
+        "camunda.operate.elasticsearch.url=http://matching-url:4321",
+
+        // NOTE: In the following blocks, the camundaExporter doesn't have to be configured, as
+        //  it is default with StandaloneCamunda. Any attempt of configuration will fail unless
+        //  the className is also configured.
+
+        // index prefix
+        "camunda.data.secondary-storage.elasticsearch.index-prefix=" + EXPECTED_INDEX_PREFIX,
+        "camunda.database.indexPrefix=" + EXPECTED_INDEX_PREFIX,
+        "camunda.tasklist.elasticsearch.indexPrefix=" + EXPECTED_INDEX_PREFIX,
+        "camunda.operate.elasticsearch.indexPrefix=" + EXPECTED_INDEX_PREFIX,
+      })
+  class WithNewAndLegacySet {
+    final OperateProperties operateProperties;
+    final TasklistProperties tasklistProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+
+    WithNewAndLegacySet(
+        @Autowired final OperateProperties operateProperties,
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties) {
+      this.operateProperties = operateProperties;
+      this.tasklistProperties = tasklistProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+    }
+
+    @Test
+    void testCamundaDataSecondaryStorageOperateProperties() {
+      final DatabaseType expectedOperateDatabaseType = DatabaseType.Elasticsearch;
+      final String expectedUrl = "http://matching-url:4321";
+
+      assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
+      assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(operateProperties.getElasticsearch().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(operateProperties.getElasticsearch().getIndexPrefix())
+          .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(operateProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(operateProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(operateProperties.getZeebeElasticsearch().getUrl()).isEqualTo(expectedUrl);
+    }
+
+    @Test
+    void testCamundaDataSecondaryStorageTasklistProperties() {
+      final String expectedTasklistDatabaseType = "elasticsearch";
+      final String expectedUrl = "http://matching-url:4321";
+
+      assertThat(tasklistProperties.getDatabase()).isEqualTo(expectedTasklistDatabaseType);
+      assertThat(tasklistProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(tasklistProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(tasklistProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(tasklistProperties.getElasticsearch().getIndexPrefix())
+          .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(tasklistProperties.getElasticsearch().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(tasklistProperties.getZeebeElasticsearch().getUrl()).isEqualTo(expectedUrl);
+    }
+
+    @Test
+    void testCamundaDataSecondaryStorageCamundaExporterProperties() {
+      final String expectedType = "elasticsearch";
+      final String expectedUrl = "http://matching-url:4321";
+
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNotNull();
+
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToExporterConfiguration(args);
+      assertThat(exporterConfiguration.getConnect().getType()).isEqualTo(expectedType);
+      assertThat(exporterConfiguration.getConnect().getUrl()).isEqualTo(expectedUrl);
+      assertThat(exporterConfiguration.getConnect().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(exporterConfiguration.getConnect().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(exporterConfiguration.getConnect().getIndexPrefix())
+          .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(exporterConfiguration.getConnect().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
+    }
+
+    @Test
+    void testCamundaSearchEngineConnectProperties() {
+      assertThat(searchEngineConnectProperties.getType().toLowerCase()).isEqualTo("elasticsearch");
+      assertThat(searchEngineConnectProperties.getUrl()).isEqualTo("http://matching-url:4321");
+      assertThat(searchEngineConnectProperties.getIndexPrefix()).isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(searchEngineConnectProperties.getClusterName()).isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(searchEngineConnectProperties.getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(searchEngineConnectProperties.getPassword()).isEqualTo(EXPECTED_PASSWORD);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.secondary-storage.elasticsearch.url=http://matching-url:4321",
+        "zeebe.broker.exporters.camunda.class-name=io.camunda.exporter.CamundaExporter"
+      })
+  class ExporterTestWithoutArgs {
+    final OperateProperties operateProperties;
+    final TasklistProperties tasklistProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+
+    ExporterTestWithoutArgs(
+        @Autowired final OperateProperties operateProperties,
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties) {
+      this.operateProperties = operateProperties;
+      this.tasklistProperties = tasklistProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+    }
+
+    // https://github.com/camunda/camunda/issues/37880
+    // it is possible to have an exporter with no args defined
+    @Test
+    void testSecondaryStorageExporterCanWorkWithoutArgs() {
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNull();
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -37,7 +37,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
   BrokerBasedPropertiesOverride.class,
   SearchEngineConnectPropertiesOverride.class
 })
-public class SecondaryStorageTest {
+public class SecondaryStorageOpensearchTest {
   private static final String EXPECTED_CLUSTER_NAME = "sample-cluster";
   private static final String EXPECTED_INDEX_PREFIX = "sample-index-prefix";
 
@@ -47,12 +47,12 @@ public class SecondaryStorageTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.data.secondary-storage.type=elasticsearch",
-        "camunda.data.secondary-storage.elasticsearch.url=http://expected-url:4321",
-        "camunda.data.secondary-storage.elasticsearch.username=" + EXPECTED_USERNAME,
-        "camunda.data.secondary-storage.elasticsearch.password=" + EXPECTED_PASSWORD,
-        "camunda.data.secondary-storage.elasticsearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
-        "camunda.data.secondary-storage.elasticsearch.index-prefix=" + EXPECTED_INDEX_PREFIX
+        "camunda.data.secondary-storage.type=opensearch",
+        "camunda.data.secondary-storage.opensearch.url=http://expected-url:4321",
+        "camunda.data.secondary-storage.opensearch.username=" + EXPECTED_USERNAME,
+        "camunda.data.secondary-storage.opensearch.password=" + EXPECTED_PASSWORD,
+        "camunda.data.secondary-storage.opensearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
+        "camunda.data.secondary-storage.opensearch.index-prefix=" + EXPECTED_INDEX_PREFIX
       })
   class WithOnlyUnifiedConfigSet {
     final OperateProperties operateProperties;
@@ -73,35 +73,37 @@ public class SecondaryStorageTest {
 
     @Test
     void testCamundaDataSecondaryStorageOperateProperties() {
-      final DatabaseType expectedOperateDatabaseType = DatabaseType.Elasticsearch;
+      final DatabaseType expectedOperateDatabaseType = DatabaseType.Opensearch;
       final String expectedUrl = "http://expected-url:4321";
 
       assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
-      assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
-      assertThat(operateProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
-      assertThat(operateProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
-      assertThat(operateProperties.getElasticsearch().getClusterName())
+      assertThat(operateProperties.getOpensearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(operateProperties.getOpensearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(operateProperties.getOpensearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(operateProperties.getOpensearch().getClusterName())
           .isEqualTo(EXPECTED_CLUSTER_NAME);
-      assertThat(operateProperties.getElasticsearch().getIndexPrefix())
+      assertThat(operateProperties.getOpensearch().getIndexPrefix())
           .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(operateProperties.getZeebeOpensearch().getUrl()).isEqualTo(expectedUrl);
     }
 
     @Test
     void testCamundaDataSecondaryStorageTasklistProperties() {
-      final String expectedTasklistDatabaseType = "elasticsearch";
+      final String expectedTasklistDatabaseType = DatabaseType.Opensearch.name().toLowerCase();
       final String expectedUrl = "http://expected-url:4321";
 
       assertThat(tasklistProperties.getDatabase()).isEqualTo(expectedTasklistDatabaseType);
-      assertThat(tasklistProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
-      assertThat(tasklistProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
-      assertThat(tasklistProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
-      assertThat(tasklistProperties.getElasticsearch().getIndexPrefix())
+      assertThat(tasklistProperties.getOpenSearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(tasklistProperties.getOpenSearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(tasklistProperties.getOpenSearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(tasklistProperties.getOpenSearch().getIndexPrefix())
           .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(tasklistProperties.getZeebeOpenSearch().getUrl()).isEqualTo(expectedUrl);
     }
 
     @Test
     void testCamundaDataSecondaryStorageCamundaExporterProperties() {
-      final String expectedType = "elasticsearch";
+      final String expectedType = DatabaseType.Opensearch.name().toLowerCase();
       final String expectedUrl = "http://expected-url:4321";
 
       final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
@@ -121,7 +123,9 @@ public class SecondaryStorageTest {
 
     @Test
     void testCamundaSearchEngineConnectProperties() {
-      assertThat(searchEngineConnectProperties.getType().toLowerCase()).isEqualTo("elasticsearch");
+      final String expectedType = DatabaseType.Opensearch.name().toLowerCase();
+
+      assertThat(searchEngineConnectProperties.getType().toLowerCase()).isEqualTo(expectedType);
       assertThat(searchEngineConnectProperties.getUrl()).isEqualTo("http://expected-url:4321");
       assertThat(searchEngineConnectProperties.getIndexPrefix()).isEqualTo(EXPECTED_INDEX_PREFIX);
     }
@@ -131,45 +135,47 @@ public class SecondaryStorageTest {
   @TestPropertySource(
       properties = {
         // type
-        "camunda.data.secondary-storage.type=elasticsearch",
-        "camunda.database.type=elasticsearch",
-        "camunda.operate.database=elasticsearch",
-        "camunda.tasklist.database=elasticsearch",
+        "camunda.data.secondary-storage.type=opensearch",
+        "camunda.database.type=opensearch",
+        "camunda.operate.database=opensearch",
+        "camunda.tasklist.database=opensearch",
         // url
-        "camunda.data.secondary-storage.elasticsearch.url=http://matching-url:4321",
+        "camunda.data.secondary-storage.opensearch.url=http://matching-url:4321",
         "camunda.database.url=http://matching-url:4321",
-        "camunda.tasklist.elasticsearch.url=http://matching-url:4321",
-        "camunda.operate.elasticsearch.url=http://matching-url:4321",
+        "camunda.tasklist.opensearch.url=http://matching-url:4321",
+        "camunda.tasklist.zeebeOpensearch.url=http://matching-url:4321",
+        "camunda.operate.opensearch.url=http://matching-url:4321",
+        "camunda.operate.zeebeOpensearch.url=http://matching-url:4321",
         // username
-        "camunda.data.secondary-storage.elasticsearch.username=" + EXPECTED_USERNAME,
+        "camunda.data.secondary-storage.opensearch.username=" + EXPECTED_USERNAME,
         "camunda.database.username=" + EXPECTED_USERNAME,
-        "camunda.operate.elasticsearch.username=" + EXPECTED_USERNAME,
-        "camunda.tasklist.elasticsearch.username=" + EXPECTED_USERNAME,
+        "camunda.operate.opensearch.username=" + EXPECTED_USERNAME,
+        "camunda.tasklist.opensearch.username=" + EXPECTED_USERNAME,
         // password
-        "camunda.data.secondary-storage.elasticsearch.password=" + EXPECTED_PASSWORD,
+        "camunda.data.secondary-storage.opensearch.password=" + EXPECTED_PASSWORD,
         "camunda.database.password=" + EXPECTED_PASSWORD,
-        "camunda.operate.elasticsearch.password=" + EXPECTED_PASSWORD,
-        "camunda.tasklist.elasticsearch.password=" + EXPECTED_PASSWORD,
+        "camunda.operate.opensearch.password=" + EXPECTED_PASSWORD,
+        "camunda.tasklist.opensearch.password=" + EXPECTED_PASSWORD,
         // NOTE: In the following blocks, the camundaExporter doesn't have to be configured, as
         //  it is default with StandaloneCamunda. Any attempt of configuration will fail unless
         //  the className is also configured.
 
         // cluster name
-        "camunda.data.secondary-storage.elasticsearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
+        "camunda.data.secondary-storage.opensearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
         "camunda.data.clusterName=" + EXPECTED_CLUSTER_NAME,
-        "camunda.tasklist.elasticsearch.clusterName=" + EXPECTED_CLUSTER_NAME,
-        "camunda.operate.elasticsearch.clusterName=" + EXPECTED_CLUSTER_NAME,
-        "camunda.operate.elasticsearch.url=http://matching-url:4321",
+        "camunda.tasklist.opensearch.clusterName=" + EXPECTED_CLUSTER_NAME,
+        "camunda.operate.opensearch.clusterName=" + EXPECTED_CLUSTER_NAME,
+        "camunda.operate.opensearch.url=http://matching-url:4321",
 
         // NOTE: In the following blocks, the camundaExporter doesn't have to be configured, as
         //  it is default with StandaloneCamunda. Any attempt of configuration will fail unless
         //  the className is also configured.
 
         // index prefix
-        "camunda.data.secondary-storage.elasticsearch.index-prefix=" + EXPECTED_INDEX_PREFIX,
+        "camunda.data.secondary-storage.opensearch.index-prefix=" + EXPECTED_INDEX_PREFIX,
         "camunda.database.indexPrefix=" + EXPECTED_INDEX_PREFIX,
-        "camunda.tasklist.elasticsearch.indexPrefix=" + EXPECTED_INDEX_PREFIX,
-        "camunda.operate.elasticsearch.indexPrefix=" + EXPECTED_INDEX_PREFIX,
+        "camunda.tasklist.opensearch.indexPrefix=" + EXPECTED_INDEX_PREFIX,
+        "camunda.operate.opensearch.indexPrefix=" + EXPECTED_INDEX_PREFIX,
       })
   class WithNewAndLegacySet {
     final OperateProperties operateProperties;
@@ -190,37 +196,39 @@ public class SecondaryStorageTest {
 
     @Test
     void testCamundaDataSecondaryStorageOperateProperties() {
-      final DatabaseType expectedOperateDatabaseType = DatabaseType.Elasticsearch;
+      final DatabaseType expectedOperateDatabaseType = DatabaseType.Opensearch;
       final String expectedUrl = "http://matching-url:4321";
 
       assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
-      assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
-      assertThat(operateProperties.getElasticsearch().getClusterName())
+      assertThat(operateProperties.getOpensearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(operateProperties.getOpensearch().getClusterName())
           .isEqualTo(EXPECTED_CLUSTER_NAME);
-      assertThat(operateProperties.getElasticsearch().getIndexPrefix())
+      assertThat(operateProperties.getOpensearch().getIndexPrefix())
           .isEqualTo(EXPECTED_INDEX_PREFIX);
-      assertThat(operateProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
-      assertThat(operateProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(operateProperties.getOpensearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(operateProperties.getOpensearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(operateProperties.getZeebeOpensearch().getUrl()).isEqualTo(expectedUrl);
     }
 
     @Test
     void testCamundaDataSecondaryStorageTasklistProperties() {
-      final String expectedTasklistDatabaseType = "elasticsearch";
+      final String expectedTasklistDatabaseType = DatabaseType.Opensearch.name().toLowerCase();
       final String expectedUrl = "http://matching-url:4321";
 
       assertThat(tasklistProperties.getDatabase()).isEqualTo(expectedTasklistDatabaseType);
-      assertThat(tasklistProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
-      assertThat(tasklistProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
-      assertThat(tasklistProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
-      assertThat(tasklistProperties.getElasticsearch().getIndexPrefix())
+      assertThat(tasklistProperties.getOpenSearch().getUrl()).isEqualTo(expectedUrl);
+      assertThat(tasklistProperties.getOpenSearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(tasklistProperties.getOpenSearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(tasklistProperties.getOpenSearch().getIndexPrefix())
           .isEqualTo(EXPECTED_INDEX_PREFIX);
-      assertThat(tasklistProperties.getElasticsearch().getClusterName())
+      assertThat(tasklistProperties.getOpenSearch().getClusterName())
           .isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(tasklistProperties.getZeebeOpenSearch().getUrl()).isEqualTo(expectedUrl);
     }
 
     @Test
     void testCamundaDataSecondaryStorageCamundaExporterProperties() {
-      final String expectedType = "elasticsearch";
+      final String expectedType = DatabaseType.Opensearch.name().toLowerCase();
       final String expectedUrl = "http://matching-url:4321";
 
       final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
@@ -242,47 +250,14 @@ public class SecondaryStorageTest {
 
     @Test
     void testCamundaSearchEngineConnectProperties() {
-      assertThat(searchEngineConnectProperties.getType().toLowerCase()).isEqualTo("elasticsearch");
+      final String expectedType = DatabaseType.Opensearch.name().toLowerCase();
+
+      assertThat(searchEngineConnectProperties.getType().toLowerCase()).isEqualTo(expectedType);
       assertThat(searchEngineConnectProperties.getUrl()).isEqualTo("http://matching-url:4321");
       assertThat(searchEngineConnectProperties.getIndexPrefix()).isEqualTo(EXPECTED_INDEX_PREFIX);
       assertThat(searchEngineConnectProperties.getClusterName()).isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(searchEngineConnectProperties.getUsername()).isEqualTo(EXPECTED_USERNAME);
       assertThat(searchEngineConnectProperties.getPassword()).isEqualTo(EXPECTED_PASSWORD);
-    }
-  }
-
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.data.secondary-storage.type=elasticsearch",
-        "camunda.data.secondary-storage.elasticsearch.url=http://matching-url:4321",
-        "zeebe.broker.exporters.camunda.class-name=io.camunda.exporter.CamundaExporter"
-      })
-  class ExporterTestWithoutArgs {
-    final OperateProperties operateProperties;
-    final TasklistProperties tasklistProperties;
-    final BrokerBasedProperties brokerBasedProperties;
-    final SearchEngineConnectProperties searchEngineConnectProperties;
-
-    ExporterTestWithoutArgs(
-        @Autowired final OperateProperties operateProperties,
-        @Autowired final TasklistProperties tasklistProperties,
-        @Autowired final BrokerBasedProperties brokerBasedProperties,
-        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties) {
-      this.operateProperties = operateProperties;
-      this.tasklistProperties = tasklistProperties;
-      this.brokerBasedProperties = brokerBasedProperties;
-      this.searchEngineConnectProperties = searchEngineConnectProperties;
-    }
-
-    // https://github.com/camunda/camunda/issues/37880
-    // it is possible to have an exporter with no args defined
-    @Test
-    void testSecondaryStorageExporterCanWorkWithoutArgs() {
-      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
-      assertThat(camundaExporter).isNotNull();
-      final Map<String, Object> args = camundaExporter.getArgs();
-      assertThat(args).isNull();
     }
   }
 }

--- a/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
@@ -241,8 +241,6 @@ public class CamundaDockerIT {
         // Unified Configuration
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", DATABASE_TYPE)
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL", elasticsearchUrl())
-        .withEnv("CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL", elasticsearchUrl())
-        .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", elasticsearchUrl())
         // ---
         .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTED_API", "true")
         .withEnv("CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED", "false");
@@ -271,8 +269,6 @@ public class CamundaDockerIT {
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL", elasticsearchUrl())
         .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", DATABASE_TYPE)
         // ---
-        .withEnv("CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL", elasticsearchUrl())
-        .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", elasticsearchUrl())
         .withEnv("CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS", gatewayAddress())
         .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true");
   }


### PR DESCRIPTION
# Description
Backport of #37842 to `stable/8.8`.

relates to 