### PR TITLE
[Backport stable/8.8] fix: don't rewrap client exceptions

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpCamundaFuture.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpCamundaFuture.java
@@ -83,6 +83,8 @@ public class HttpCamundaFuture<RespT> extends CompletableFuture<RespT>
     final Throwable cause = e.getCause();
     if (cause instanceof ProblemException) {
       throw (ProblemException) cause;
+    } else if (cause instanceof ClientException) {
+      throw (ClientException) cause;
     } else {
       throw new ClientException(cause);
     }


### PR DESCRIPTION
# Description
Backport of #37906 to `stable/8.8`.

relates to 