### PR TITLE
POC: prepare routing Renovate PRs related to build tooling

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,8 +18,10 @@
     "* 20-23,0-8 * * 1-5",
     "* * * * 0,6"
   ],
+  "labels": ["dependencies"],
   "vulnerabilityAlerts": {
     "labels": [
+      "dependencies",
       "area/security"
     ],
     "enabled": true

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -69,6 +69,33 @@
       "enabled": false
     },
     {
+      "description": "Identify updates related to builds, tooling, etc. that should be routed to Monorepo DevOps team.",
+      "matchManagers": [
+        "dockerfile",
+        "maven-wrapper",
+        "github-actions",
+        "nvm",
+        "helmv3"
+      ],
+      "addLabels": [
+        "area/build",
+        "component/build-pipeline"
+      ]
+    },
+    {
+      "description": "Identify updates related to builds, tooling, etc. that should be routed to Monorepo DevOps team.",
+      "matchManagers": [
+        "regex"
+      ],
+      "matchFileNames": [
+        ".github/**"
+      ],
+      "addLabels": [
+        "area/build",
+        "component/build-pipeline"
+      ]
+    },
+    {
       "description": "Allow minor updates for Spring and Spring-boot for stable branches where the Spring support window is not matching the Camunda support window yet. Right now these are 8.6+. Since Spring has a 1-year support cycle while C8 is supported for 18 months, we allow minor updates to help mitigate security risks.",
       "matchBaseBranches": [
         "/^stable\\/8\\.([6-9]|\\d\\d)/",


### PR DESCRIPTION
## Description

As part of https://github.com/camunda/camunda/issues/36956 I want to start using Renovate to label dependency PRs based on their type etc to allow routing them to capable engineers. First will be the Monorepo DevOps team itself.

I looked at all discovered dependencies on https://developer.mend.io/github/camunda/camunda and identified where we can use the type of dependency (GHA, Docker files, Node version manager, and similar) to already say that it is in our scope -> coded the rules for Renovate in this PR. Can be refined later.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related https://github.com/camunda/camunda/issues/36956
