### PR TITLE
[Backport stable/8.8] refactor: cleanup created groups after tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
@@ -35,7 +35,7 @@ export class IdentityGroupsPage {
   readonly closeDeleteGroupModal: Locator;
   readonly deleteGroupModalCancelButton: Locator;
   readonly deleteGroupModalDeleteButton: Locator;
-  readonly emptyState: Locator;
+  readonly emptyStateLocator: Locator;
   readonly assignUserButton: Locator;
   readonly searchBox: Locator;
   readonly searchBoxResult: Locator;
@@ -128,7 +128,7 @@ export class IdentityGroupsPage {
         name: 'Delete group',
       },
     );
-    this.emptyState = page.getByText('No groups created yet');
+    this.emptyStateLocator = page.getByText('No groups created yet');
     this.assignUserButton = page.getByRole('button', {name: 'Assign user'});
     this.searchBox = page.getByRole('searchbox');
     this.searchBoxResult = page.getByRole('listitem');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
@@ -13,6 +13,7 @@ export class IdentityHeader {
   readonly logoutButton: Locator;
   readonly rolesTab: Locator;
   readonly tenantsTab: Locator;
+  readonly AuthorizationTab: Locator;
 
   constructor(page: Page) {
     this.openSettingsButton = page.getByRole('button', {
@@ -21,6 +22,9 @@ export class IdentityHeader {
     this.logoutButton = page.getByRole('button', {name: 'Log out'});
     this.rolesTab = page.locator('nav a').filter({hasText: /^Roles$/});
     this.tenantsTab = page.locator('nav a').filter({hasText: /^Tenants$/});
+    this.AuthorizationTab = page
+      .locator('nav a')
+      .filter({hasText: /^Authorizations$/});
   }
 
   async logout() {
@@ -34,5 +38,9 @@ export class IdentityHeader {
 
   async navigateToTenants() {
     await this.tenantsTab.click();
+  }
+
+  async navigateToAuthorizations() {
+    await this.AuthorizationTab.click();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
@@ -23,12 +23,23 @@ import {
 } from '../../../../utils/beans/requestBeans';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {createGroupAndStoreResponseFields} from '../../../../utils/requestHelpers';
+import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Groups API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdGroups: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
+    createdGroups.push(
+      state['groupId1'] as string,
+      state['groupId2'] as string,
+      state['groupId3'] as string,
+    );
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupGroups(request, createdGroups);
   });
 
   test('Create Group', async ({request}) => {
@@ -41,6 +52,9 @@ test.describe.parallel('Groups API Tests', () => {
 
     expect(res.status()).toBe(201);
     const json = await res.json();
+
+    createdGroups.push(json.groupId);
+
     assertRequiredFields(json, groupRequiredFields);
     assertEqualsForKeys(json, requestBody, groupRequiredFields);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
@@ -27,19 +27,14 @@ import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Groups API Tests', () => {
   const state: Record<string, unknown> = {};
-  const createdGroups: string[] = [];
+  state['createdIds'] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
-    createdGroups.push(
-      state['groupId1'] as string,
-      state['groupId2'] as string,
-      state['groupId3'] as string,
-    );
   });
 
   test.afterAll(async ({request}) => {
-    await cleanupGroups(request, createdGroups);
+    await cleanupGroups(request, state['createdIds'] as string[]);
   });
 
   test('Create Group', async ({request}) => {
@@ -53,8 +48,7 @@ test.describe.parallel('Groups API Tests', () => {
     expect(res.status()).toBe(201);
     const json = await res.json();
 
-    createdGroups.push(json.groupId);
-
+    (state['createdIds'] as string[]).push(json.groupId);
     assertRequiredFields(json, groupRequiredFields);
     assertEqualsForKeys(json, requestBody, groupRequiredFields);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
@@ -30,22 +30,16 @@ import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Groups Clients API Tests', () => {
   const state: Record<string, unknown> = {};
-  const createdGroups: string[] = [];
+  state['createdIds'] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
     await assignClientToGroup(request, 1, state['groupId2'] as string, state);
     await assignClientToGroup(request, 1, state['groupId3'] as string, state);
-
-    createdGroups.push(
-      state['groupId1'] as string,
-      state['groupId2'] as string,
-      state['groupId3'] as string,
-    );
   });
 
   test.afterAll(async ({request}) => {
-    await cleanupGroups(request, createdGroups);
+    await cleanupGroups(request, state['createdIds'] as string[]);
   });
 
   test('Assign Client To Group', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
@@ -26,14 +26,26 @@ import {
   defaultAssertionOptions,
   generateUniqueId,
 } from '../../../../utils/constants';
+import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Groups Clients API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdGroups: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
     await assignClientToGroup(request, 1, state['groupId2'] as string, state);
     await assignClientToGroup(request, 1, state['groupId3'] as string, state);
+
+    createdGroups.push(
+      state['groupId1'] as string,
+      state['groupId2'] as string,
+      state['groupId3'] as string,
+    );
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupGroups(request, createdGroups);
   });
 
   test('Assign Client To Group', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
@@ -28,14 +28,27 @@ import {
   mappingRuleIdFromState,
 } from '../../../../utils/requestHelpers';
 import {defaultAssertionOptions} from '../../../../utils/constants';
+import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Group Mapping Rules API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdGroups: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
+
+    createdGroups.push(
+      state['groupId1'] as string,
+      state['groupId2'] as string,
+      state['groupId3'] as string,
+    );
+
     await assignMappingToGroup(request, 1, state['groupId2'] as string, state);
     await assignMappingToGroup(request, 1, state['groupId3'] as string, state);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupGroups(request, createdGroups);
   });
 
   test('Assign Mapping Rule To Group', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
@@ -32,23 +32,17 @@ import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Group Mapping Rules API Tests', () => {
   const state: Record<string, unknown> = {};
-  const createdGroups: string[] = [];
+  state['createdIds'] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
-
-    createdGroups.push(
-      state['groupId1'] as string,
-      state['groupId2'] as string,
-      state['groupId3'] as string,
-    );
 
     await assignMappingToGroup(request, 1, state['groupId2'] as string, state);
     await assignMappingToGroup(request, 1, state['groupId3'] as string, state);
   });
 
   test.afterAll(async ({request}) => {
-    await cleanupGroups(request, createdGroups);
+    await cleanupGroups(request, state['createdIds'] as string[]);
   });
 
   test('Assign Mapping Rule To Group', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
@@ -22,13 +22,22 @@ import {
   assertRoleInResponse,
 } from '../../../../utils/requestHelpers';
 import {defaultAssertionOptions} from '../../../../utils/constants';
+import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Group Roles API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdGroups: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 1, state);
+
+    createdGroups.push(state['groupId1'] as string);
+
     await assignRoleToGroups(request, 2, state['groupId1'] as string, state);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupGroups(request, createdGroups);
   });
 
   test('Search Group Roles', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
@@ -26,18 +26,16 @@ import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Group Roles API Tests', () => {
   const state: Record<string, unknown> = {};
-  const createdGroups: string[] = [];
+  state['createdIds'] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 1, state);
-
-    createdGroups.push(state['groupId1'] as string);
 
     await assignRoleToGroups(request, 2, state['groupId1'] as string, state);
   });
 
   test.afterAll(async ({request}) => {
-    await cleanupGroups(request, createdGroups);
+    await cleanupGroups(request, state['createdIds'] as string[]);
   });
 
   test('Search Group Roles', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
@@ -27,14 +27,27 @@ import {
   defaultAssertionOptions,
   generateUniqueId,
 } from '../../../../utils/constants';
+import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Group Users API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdGroups: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
+
+    createdGroups.push(
+      state['groupId1'] as string,
+      state['groupId2'] as string,
+      state['groupId3'] as string,
+    );
+
     await assignUsersToGroup(request, 1, state['groupId2'] as string, state);
     await assignUsersToGroup(request, 1, state['groupId3'] as string, state);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupGroups(request, createdGroups);
   });
 
   test('Assign User To Group Not Found', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
@@ -31,23 +31,17 @@ import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 test.describe.parallel('Group Users API Tests', () => {
   const state: Record<string, unknown> = {};
-  const createdGroups: string[] = [];
+  state['createdIds'] = [];
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
-
-    createdGroups.push(
-      state['groupId1'] as string,
-      state['groupId2'] as string,
-      state['groupId3'] as string,
-    );
 
     await assignUsersToGroup(request, 1, state['groupId2'] as string, state);
     await assignUsersToGroup(request, 1, state['groupId3'] as string, state);
   });
 
   test.afterAll(async ({request}) => {
-    await cleanupGroups(request, createdGroups);
+    await cleanupGroups(request, state['createdIds'] as string[]);
   });
 
   test('Assign User To Group Not Found', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -87,8 +87,16 @@ test.describe.serial('groups CRUD', () => {
 
     await waitForItemInList(page, item, {
       shouldBeVisible: false,
+      timeout: 60000,
       clickNext: true,
-      timeout: 30000,
+      emptyStateLocator: identityGroupsPage.emptyStateLocator,
+      onAfterReload: async () => {
+        await page.goto(relativizePath(Paths.groups()));
+        await Promise.race([
+          identityGroupsPage.groupsList.waitFor({timeout: 15000}),
+          identityGroupsPage.emptyStateLocator.waitFor({timeout: 15000}),
+        ]);
+      },
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/groupsCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/groupsCleanup.ts
@@ -20,9 +20,20 @@ export async function cleanupGroups(
   await Promise.allSettled(
     groupIds.map(async (groupId) => {
       try {
-        await request.delete(buildUrl('/groups/{groupId}', {groupId}), {
-          headers: jsonHeaders(),
-        });
+        const response = await request.delete(
+          buildUrl('/groups/{groupId}', {groupId}),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+
+        if (response.status() === 204) {
+          console.log(`Successfully deleted group: ${groupId}`);
+        } else {
+          console.warn(
+            `Unexpected response status ${response.status()} for group ${groupId}`,
+          );
+        }
       } catch {}
     }),
   );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/groupsCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/groupsCleanup.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext, Page} from '@playwright/test';
+import {jsonHeaders, buildUrl} from './http';
+
+export async function cleanupGroups(
+  request: APIRequestContext,
+  groupIds: string[],
+): Promise<void> {
+  if (groupIds.length === 0) return;
+
+  console.log(`Cleaning up ${groupIds.length} groups via API...`);
+
+  await Promise.allSettled(
+    groupIds.map(async (groupId) => {
+      try {
+        await request.delete(buildUrl('/groups/{groupId}', {groupId}), {
+          headers: jsonHeaders(),
+        });
+      } catch {}
+    }),
+  );
+}
+
+export async function cleanupGroupsSafely(
+  page: Page,
+  groupIds: string[],
+): Promise<void> {
+  if (groupIds.length === 0) return;
+
+  try {
+    const request = page.request;
+    await cleanupGroups(request, groupIds);
+  } catch (error) {
+    console.log('API cleanup failed:', error);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #37879 to `stable/8.8`.

relates to 