### PR TITLE
feat:  Implement logic to catch and mark outdated …

### DIFF
--- a/.ci/scripts/outdated-pr-scripts/README.md
+++ b/.ci/scripts/outdated-pr-scripts/README.md
@@ -1,0 +1,78 @@
+# Outdated PR Detection Scripts
+
+Automated detection and labeling of pull requests that are significantly behind main branch or stale.
+
+## Detection Criteria
+
+A PR is marked **outdated** if either:
+- **>COMMIT_THRESHOLD commits** behind its base branch (configurable via `COMMIT_THRESHOLD`, defaults to `50`)
+- **>STALE_DAYS_THRESHOLD days** since last commit (configurable via `STALE_DAYS_THRESHOLD`, defaults to `7`)
+
+When **both conditions** are met, the comment will indicate both issues: "X commits behind and Y days stale".
+
+The base branch is automatically derived from each PR's target branch.
+
+## Structure
+
+```
+outdated-pr-scripts/
+├── process-pr.sh              # Main processing script
+└── lib/
+    ├── check-pr-commits.sh    # Calculate commits behind
+    └── update-outdated-pr.sh  # Add labels/comments
+```
+
+## Usage
+
+### Workflow Integration
+
+```yaml
+- name: Process PRs
+  env:
+    GH_TOKEN: ${{ github.token }}
+    DRY_RUN: ${{ inputs.dry_run == false && 'false' || 'true' }}
+  run: |
+    echo '${{ needs.get-prs.outputs.pr_list }}' | \
+      ./.ci/scripts/outdated-pr-scripts/process-pr.sh
+```
+
+### Manual Testing
+
+```bash
+# Test with sample data (using default 50 commit threshold, 7 days staleness)
+echo '[{"pr_number": 123, "branch_name": "feature", "base_branch": "main", "repo_owner": "camunda"}]' | \
+  ./.ci/scripts/outdated-pr-scripts/process-pr.sh
+
+# Test with custom thresholds
+COMMIT_THRESHOLD=25 STALE_DAYS_THRESHOLD=14 echo '[{"pr_number": 123, "branch_name": "feature", "base_branch": "develop", "repo_owner": "camunda"}]' | \
+  ./.ci/scripts/outdated-pr-scripts/process-pr.sh
+```
+
+**Script Output:**
+- **Processing logs**: Step-by-step status (e.g., "🔍 Processing PR #123", "📊 Calculating commits behind")
+- **Commit calculations**: Exact counts (e.g., "� Found 25 non-renovate commits behind main")
+- **Actions taken**: Label/comment status (e.g., "🏷️ Adding outdated-branch label" or "🔍 DRY-RUN: Would add label")
+
+## Environment Variables
+
+- `GH_TOKEN`: GitHub token for API access (required)
+- `GITHUB_REPOSITORY`: Repository in `owner/repo` format (auto-detected in GitHub Actions, optional for local testing)
+- `DRY_RUN`: Set to `true` for testing without changes (optional)
+- `COMMIT_THRESHOLD`: Number of commits behind to trigger outdated status (optional, defaults to `50`)
+- `STALE_DAYS_THRESHOLD`: Number of days since last commit to trigger outdated status (optional, defaults to `7`)
+
+## Features
+
+- **Smart filtering**: Excludes renovate bot commits
+- **Automatic labeling**: Adds `outdated-branch` label
+- **Dynamic commenting**: Creates or updates comments with current status
+- **Dual-threshold logic**: Combines commit count and staleness detection
+- **Dry-run support**: Safe testing mode with boolean checkbox input
+- **Duplicate prevention**: Updates existing comments instead of creating new ones
+
+## Dependencies
+
+- `git`, `gh` (GitHub CLI), `jq`, `date`/`gdate`
+- Repository with full git history (`fetch-depth: 0`)
+- GitHub token with PR write permissions
+

--- a/.ci/scripts/outdated-pr-scripts/lib/check-pr-commits.sh
+++ b/.ci/scripts/outdated-pr-scripts/lib/check-pr-commits.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Check PR commits behind base branch filtering out commits made by renovate
+
+check_pr_commits() {
+  local pr_number="$1"
+  local branch_name="$2" 
+  local base_branch="$3"
+  local repo_owner="$4"
+  
+  echo "📊 Calculating commits behind for PR #$pr_number (excluding renovate commits)..." >&2
+  
+  # Only process internal branches
+  if [[ "$repo_owner" != "${GITHUB_REPOSITORY_OWNER}" ]]; then
+    echo "0"
+    return
+  fi
+  
+  # Get commits and filter renovate
+  local commit_list commits_behind
+  commit_list=$(git rev-list origin/"$branch_name"..origin/"$base_branch" --pretty=format:"%H|%an|%ae" --no-merges)
+  commits_behind=$(echo "$commit_list" | grep "^[a-f0-9]" | grep -c -v "|renovate\[bot\]|mend\[bot\]" | tr -d ' ')
+  
+  echo "🔧 Found $commits_behind non-renovate and non-mend commits behind $base_branch" >&2
+  echo "$commits_behind"
+}

--- a/.ci/scripts/outdated-pr-scripts/lib/update-outdated-pr.sh
+++ b/.ci/scripts/outdated-pr-scripts/lib/update-outdated-pr.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Update outdated PR with label and comment
+
+update_outdated_pr() {
+  local pr_number="$1"
+  local commits_behind="$2"
+  local base_branch="$3"
+  local threshold="${4:-50}"
+  local latest_age_days="${5:-0}"
+  local stale_threshold="${6:-7}"
+  local dry_run="${7:-true}"
+  
+  # Get all PR data in one call and extract what we need
+  local pr_data existing_labels existing_comment_id existing_comment_body
+  pr_data=$(gh pr view "$pr_number" --json title,labels,comments,url)
+  existing_labels=$(echo "$pr_data" | jq -r '.labels[] | select(.name == "outdated-branch") | .name' || true)
+  existing_comment_id=$(echo "$pr_data" | jq -r '.comments[] | select(.body | contains("🚨") and (contains("last updated") or contains("commits behind"))) | .url' | head -1 | sed 's/.*#issuecomment-//' || true)
+  existing_comment_body=$(echo "$pr_data" | jq -r '.comments[] | select(.body | contains("🚨") and (contains("last updated") or contains("commits behind"))) | .body' | head -1 || true)
+  
+  if [[ "$dry_run" == "true" ]]; then
+    echo "🔍 DRY-RUN: Would add 'outdated-branch' label and comment to PR #$pr_number" >&2
+    return 0
+  fi
+  
+  # Check and add label if needed
+  if [ -z "$existing_labels" ]; then
+    echo "🏷️  Adding outdated-branch label..." >&2
+    if ! gh pr edit "$pr_number" --add-label "outdated-branch"; then
+      echo "❌ Failed to add label" >&2
+    fi
+  else
+    echo "ℹ️  PR already has outdated-branch label" >&2
+  fi
+  
+  # Check and add/update comment
+  local comment_body details=""
+  
+  # Build detailed status message
+  if [[ "$commits_behind" -gt "$threshold" ]]; then
+    details="**$commits_behind commits behind** the $base_branch branch (threshold: $threshold)"
+  fi
+  
+  if [[ "$latest_age_days" -gt "$stale_threshold" ]]; then
+    if [[ -n "$details" ]]; then
+      details="$details and **last updated $latest_age_days days ago** (threshold: $stale_threshold days)"
+    else
+      details="**last updated $latest_age_days days ago** (threshold: $stale_threshold days)"
+    fi
+  fi
+  
+  comment_body=$(cat <<EOF
+🚨 **This PR needs attention** 🚨
+
+This PR is currently $details. Please update your branch before this PR can be merged.
+EOF
+)
+  
+  if [[ -n "$existing_comment_id" && "$existing_comment_id" != "null" ]]; then
+    # Update existing comment if content changed
+    if [[ "$existing_comment_body" != "$comment_body" ]]; then
+      echo "💬 Updating existing comment with new conditions... (Comment ID: $existing_comment_id)" >&2
+      if gh api /repos/"$GITHUB_REPOSITORY"/issues/comments/"$existing_comment_id" -X PATCH -f body="$comment_body" >/dev/null 2>&1; then
+        echo "✅ Successfully updated comment" >&2
+      else
+        echo "❌ Failed to update PR comment" >&2
+      fi
+    else
+      echo "ℹ️  Comment is already up-to-date" >&2
+    fi
+  else
+    # Create new comment since PR is outdated and no comment exists
+    echo "💬 Adding new comment about outdated branch..." >&2
+    if ! gh pr comment "$pr_number" --body "$comment_body"; then
+      echo "❌ Failed to add comment" >&2
+    fi
+  fi
+  
+  echo "🔧 Updated PR #$pr_number (labeled + commented)" >&2
+}

--- a/.ci/scripts/outdated-pr-scripts/process-pr.sh
+++ b/.ci/scripts/outdated-pr-scripts/process-pr.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Process PRs in batch using our modular functions
+# This script reads PR data from stdin (JSON) and processes each PR
+
+set -euo pipefail
+
+# Configuration
+COMMIT_THRESHOLD="${COMMIT_THRESHOLD:-50}"
+STALE_DAYS_THRESHOLD="${STALE_DAYS_THRESHOLD:-7}"
+
+# Get the script directory and source our library functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/check-pr-commits.sh"
+source "$SCRIPT_DIR/lib/update-outdated-pr.sh"
+
+# Check if running in dry-run mode
+DRY_RUN="${DRY_RUN:-false}"
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "🔍 DRY-RUN MODE: Will calculate commits but not add labels/comments"
+fi
+
+DATE_PROGRAM=date
+if command -v gdate >/dev/null; then
+  DATE_PROGRAM=gdate
+fi
+
+# Read and process PRs from stdin
+while IFS=' ' read -r pr_number branch_name base_branch repo_owner; do
+  echo "🔍 Processing PR #$pr_number ($branch_name from $repo_owner targeting $base_branch)"
+  
+  commits_behind=$(check_pr_commits "$pr_number" "$branch_name" "$base_branch" "$repo_owner")
+  
+  # Check branch staleness
+  latest_commit_date=$(git log origin/"$base_branch"..origin/"$branch_name" --pretty=format:"%ai" | head -1 2>/dev/null || echo "")
+  latest_commit_timestamp=$("$DATE_PROGRAM" -d "$latest_commit_date" +%s 2>/dev/null || echo "0")
+  current_timestamp=$("$DATE_PROGRAM" +%s)
+  latest_age_days=$(( (current_timestamp - latest_commit_timestamp) / 86400 ))
+  
+  # Only call update function if PR is actually outdated
+  reasons=()
+  [[ "$commits_behind" -gt $COMMIT_THRESHOLD ]] && reasons+=("$commits_behind commits behind")
+  [[ $latest_age_days -gt $STALE_DAYS_THRESHOLD ]] && reasons+=("$latest_age_days days stale")
+
+  if [[ ${#reasons[@]} -gt 0 ]]; then
+    reason=$(IFS=" and "; echo "${reasons[*]}")
+    echo "🚨 PR #$pr_number is outdated: $reason" >&2
+    update_outdated_pr "$pr_number" "$commits_behind" "$base_branch" "$COMMIT_THRESHOLD" "$latest_age_days" "$STALE_DAYS_THRESHOLD" "$DRY_RUN"
+  else
+    echo "✅ PR #$pr_number is up-to-date" >&2
+  fi
+  
+  echo "---"
+done < <(jq -r '.[] | "\(.pr_number) \(.branch_name) \(.base_branch) \(.repo_owner)"')

--- a/.github/workflows/check-outdated-prs.yml
+++ b/.github/workflows/check-outdated-prs.yml
@@ -1,0 +1,106 @@
+# type: CI
+# owner: @camunda/monorepo-devops-team
+
+#Description: 
+#This GitHub Actions workflow automatically monitors pull requests that are significantly behind the main branch and adds warning labels/comments to notify contributors.
+#It runs daily at 4 AM UTC to check all open PRs, can be triggered manually with dry-run or live modes, and also processes individual PRs during PR events.
+#The workflow intelligently filters out bot PRs and draft PRs, focusing only on human-created, ready-for-review pull requests.
+#It uses configurable thresholds to determine when a PR is outdated and generates daily summary reports for visibility. This helps maintain code quality by proactively identifying stale branches that need attention.
+name: Check Outdated PRs
+
+on:
+  schedule:
+    # Run daily at 4 AM UTC
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (no changes will be made)'
+        required: false
+        default: true
+        type: boolean
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  get-prs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      pr_list: ${{ steps.get_prs.outputs.pr_list }}
+    steps:
+      - name: Get PR list
+        id: get_prs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+          PR_IS_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            # Single PR mode - validate if PR is draft
+            if [[ -n "$PR_IS_DRAFT" && "$PR_IS_DRAFT" == "true" ]]; then
+              echo "⏭️  Skipping draft PR #$PR_NUMBER"
+              pr_list='[]'
+            else
+              echo "Processing single PR from pull_request event..."
+              pr_list='[{"pr_number": '"$PR_NUMBER"', "branch_name": "'"$PR_HEAD_REF"'", "base_branch": "'"$PR_BASE_REF"'", "repo_owner": "'"$PR_HEAD_OWNER"'"}]'
+            fi
+          else
+            # Batch mode - get all human-created, ready PRs
+            echo "Getting list of human-created, ready PRs..."
+            pr_list=$(gh api repos/"$GITHUB_REPOSITORY"/pulls --paginate --slurp | \
+            jq -c '[.[][] | select(
+              .base.ref == "main" and 
+              .state == "open" and
+              .head.repo.owner != null and 
+              .draft == false and
+              (.user.login | IN("app/dependabot", "dependabot[bot]", "backport-action", "app/renovate", "app/copilot-swe-agent", "app/", "renovate[bot]", "mend[bot]") | not) and
+              ([.labels[].name] | contains(["outdated-branch"]) | not)
+            ) | {
+              pr_number: .number,
+              branch_name: .head.ref,
+              base_branch: .base.ref,
+              repo_owner: .head.repo.owner.login
+            }]')
+          fi
+          
+          printf "pr_list=%s\n" "$pr_list" >> "$GITHUB_OUTPUT"
+          echo "Found $(echo "$pr_list" | jq length) PRs to process"
+
+  check-prs:
+    if: needs.get-prs.outputs.pr_list != '[]'
+    needs: get-prs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Process all PRs
+        id: process_prs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # Default to dry-run for schedule and pull_request, allow override for workflow_dispatch
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == false && 'false' || 'true' }}
+        run: |
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "🔍 Running in DRY-RUN mode - no labels or comments will be added"
+            echo "💡 Event: ${{ github.event_name }}"
+          else
+            echo "🚀 Running in LIVE mode - will add labels and comments"
+          fi
+          
+          echo '${{ needs.get-prs.outputs.pr_list }}' | ./.ci/scripts/outdated-pr-scripts/process-pr.sh "$DRY_RUN"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -47,6 +47,7 @@
 /.github/workflows/retry-workflow.yml                    @camunda/monorepo-devops-team
 /.github/workflows/statistics-daily.yml                  @camunda/monorepo-devops-team
 /.github/workflows/zeebe-release-stable-dry-run.yml      @camunda/monorepo-devops-team
+/.github/workflows/check-outdated-prs.yml                @camunda/monorepo-devops-team
 
 ###################
 ## Core Features ##


### PR DESCRIPTION
## 🎯 Purpose
Automatically detects PRs significantly behind main branch and notifies developers to prevent merge conflicts.

## ⚡ Triggers
- **PR Events**: opened, synchronize, ready_for_review, reopened
- **Daily**: 4 AM UTC batch processing
- **Manual**: workflow_dispatch with dry-run/live modes

## 🔧 What It Does
- **Filters out**: bots (renovate, dependabot, etc.) and draft PRs
- **Detects**: PRs >50 commits behind main OR stale branches (>7 days without commits)
- **Labels**: adds "outdated-branch" label to outdated PRs
- **Comments**: adds warning comments to notify contributors about outdated branches
- **Prevents spam**: no duplicate labels/comments on already processed PRs
- **Smart processing**: single PR mode for PR events, batch mode for scheduled runs

## Related issues
[Avoid CI problems by notifying PRs with outdated branches](https://github.com/camunda/camunda/issues/24649)