### PR TITLE
fix: c8run runs on port 8088

### DIFF
--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -157,7 +157,7 @@ func createStartFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
 	startFlagSet := flag.NewFlagSet("start", flag.ExitOnError)
 	startFlagSet.StringVar(&settings.Config, "config", "", "Applies the specified configuration file.")
 	startFlagSet.BoolVar(&settings.Detached, "detached", false, "Starts Camunda Run as a detached process")
-	startFlagSet.IntVar(&settings.Port, "port", 8080, "Port to run Camunda on")
+	startFlagSet.IntVar(&settings.Port, "port", 8088, "Port to run Camunda on")
 	startFlagSet.StringVar(&settings.Keystore, "keystore", "", "Provide a JKS filepath to enable TLS")
 	startFlagSet.StringVar(&settings.KeystorePassword, "keystorePassword", "", "Provide a password to unlock your JKS keystore")
 	startFlagSet.StringVar(&settings.LogLevel, "log-level", "", "Adjust the log level of Camunda")

--- a/c8run/cmd/c8run/main_test.go
+++ b/c8run/cmd/c8run/main_test.go
@@ -22,7 +22,7 @@ func TestCamundaCmdWithKeystoreSettings(t *testing.T) {
 	settings := types.C8RunSettings{
 		Config:           "",
 		Detached:         false,
-		Port:             8080,
+		Port:             8088,
 		Keystore:         "/tmp/camundatest/certs/secret.jks",
 		KeystorePassword: "changeme",
 		Username:         "demo",
@@ -51,7 +51,7 @@ func TestCamundaCmdKeystoreRequiresPassword(t *testing.T) {
 	settings := types.C8RunSettings{
 		Config:           "",
 		Detached:         false,
-		Port:             8080,
+		Port:             8088,
 		Keystore:         "/tmp/camundatest/certs/secret.jks",
 		KeystorePassword: "",
 	}

--- a/c8run/configuration/application.yaml
+++ b/c8run/configuration/application.yaml
@@ -23,3 +23,6 @@ zeebe:
         args:
           createSchema: true
         className: io.camunda.exporter.CamundaExporter
+
+server:
+  port: 8088

--- a/c8run/connectors-application.properties
+++ b/c8run/connectors-application.properties
@@ -1,6 +1,6 @@
 zeebe.client.broker.gateway-address=http://127.0.0.1:26500
 zeebe.client.security.plaintext=true
-camunda.operate.client.url=http://localhost:8080
+camunda.operate.client.url=http://localhost:8088
 camunda.operate.client.username=demo
 camunda.operate.client.password=demo
 server.port=8086

--- a/c8run/connectors-application.properties
+++ b/c8run/connectors-application.properties
@@ -1,4 +1,5 @@
 zeebe.client.broker.gateway-address=http://127.0.0.1:26500
+zeebe.client.broker.rest-address=http://127.0.0.1:8088
 zeebe.client.security.plaintext=true
 camunda.operate.client.url=http://localhost:8088
 camunda.operate.client.username=demo

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -2,7 +2,7 @@
 
 printf "\nTest: Operate process instance api\n"
 
-curl -f -L -X POST 'http://localhost:8080/v2/process-instances/search' \
+curl -f -L -X POST 'http://localhost:8088/v2/process-instances/search' \
         -H 'Content-Type: application/json' \
         -H 'Accept: application/json' \
         --data-raw '{
@@ -20,7 +20,7 @@ if [[ "$returnCode" != 0 ]]; then
 fi
 
 printf "\nTest: Tasklist user task\n"
-curl -f -L -X POST 'http://localhost:8080/v2/user-tasks/search' \
+curl -f -L -X POST 'http://localhost:8088/v2/user-tasks/search' \
         -H 'Content-Type: application/json' \
         -H 'Accept: application/json' \
         --data-raw '{}'
@@ -33,7 +33,7 @@ if [[ "$returnCode" != 0 ]]; then
 fi
 
 printf "\nTest: Zeebe topology endpoint\n"
-curl localhost:8080/v2/topology
+curl localhost:8088/v2/topology
 
 returnCode=$?
 if [[ "$returnCode" != 0 ]]; then

--- a/c8run/e2e_tests/prefix-config.yaml
+++ b/c8run/e2e_tests/prefix-config.yaml
@@ -5,3 +5,6 @@ camunda:
   tasklist:
     zeebeElasticsearch:
       prefix: "extra-prefix-zeebe-record"
+
+server:
+  port: 8088

--- a/c8run/e2e_tests/tests/operate_login.spec.ts
+++ b/c8run/e2e_tests/tests/operate_login.spec.ts
@@ -3,7 +3,7 @@ const playwright = require('playwright');
 
 test('test', async ({ page }) => {
   test.setTimeout(60000);
-  await page.goto('http://localhost:8080/operate');
+  await page.goto('http://localhost:8088/operate');
   await page.getByPlaceholder('Username').click();
   await page.getByPlaceholder('Username').fill('demo');
   await page.getByPlaceholder('Username').press('Tab');

--- a/c8run/e2e_tests/tests/tasklist_login.spec.ts
+++ b/c8run/e2e_tests/tests/tasklist_login.spec.ts
@@ -3,7 +3,7 @@ const playwright = require('playwright');
 
 test('test', async ({ page }) => {
   test.setTimeout(60000);
-  await page.goto('http://localhost:8080/tasklist');
+  await page.goto('http://localhost:8088/tasklist');
   await page.getByPlaceholder('Username').click();
   await page.getByPlaceholder('Username').fill('demo');
   await page.getByPlaceholder('Username').press('Tab');

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -88,12 +88,12 @@ func isRunning(ctx context.Context, name, url string, retries int, delay time.Du
 }
 
 func PrintStatus(settings types.C8RunSettings) error {
-	operatePort, tasklistPort, identityPort, camundaPort := 8080, 8080, 8080, 8080
+	operatePort, tasklistPort, identityPort, camundaPort := 8088, 8088, 8088, 8088
 
 	// Overwrite ports if Docker is enabled
 	if settings.Docker {
-		operatePort = 8081
-		tasklistPort = 8082
+		operatePort = 8088
+		tasklistPort = 8088
 		identityPort = 8084
 		camundaPort = 8088
 	}

--- a/c8run/internal/overrides/overrides.go
+++ b/c8run/internal/overrides/overrides.go
@@ -50,7 +50,7 @@ func AdjustJavaOpts(javaOpts string, settings types.C8RunSettings) string {
 		javaOpts = javaOpts + " -Dserver.ssl.keystore=file:" + settings.Keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.KeystorePassword
 		protocol = "https"
 	}
-	if settings.Port != 8080 {
+	if settings.Port != 8088 {
 		javaOpts = javaOpts + " -Dserver.port=" + strconv.Itoa(settings.Port)
 	}
 	// as demo is set in the default config, we only add the user settings if they differ


### PR DESCRIPTION
## Description

Related to #1108 

Related to https://github.com/camunda/team-distribution/issues/578

All distributions, c8run, docker compose, and helm should use the same port number everywhere, and we have decided that port number for orchestration core should be 8088.


<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
