### PR TITLE
fix: Process Instance Deletion via v1 API

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchDocumentOperations.java
@@ -337,12 +337,15 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
   }
 
   public DeleteByQueryResponse delete(final String index, final String field, final String value) {
-    final var deleteRequestBuilder =
-        new DeleteByQueryRequest.Builder().index(index).query(term(field, value));
+    return executeWithRetries(
+        () -> {
+          final var deleteRequestBuilder =
+              new DeleteByQueryRequest.Builder().index(index).query(term(field, value));
 
-    return safe(
-        () -> openSearchClient.deleteByQuery(deleteRequestBuilder.build()),
-        e -> defaultDeleteErrorMessage(index));
+          return safe(
+              () -> openSearchClient.deleteByQuery(deleteRequestBuilder.build()),
+              e -> defaultDeleteErrorMessage(index));
+        });
   }
 
   public long deleteByQuery(final String index, final Query query) {

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchRetryOperation.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchRetryOperation.java
@@ -10,6 +10,7 @@ package io.camunda.operate.store.opensearch.client.sync;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.store.opensearch.client.OpenSearchFailedShardsException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +64,7 @@ public abstract class OpenSearchRetryOperation extends OpenSearchSyncOperation {
           new RetryPolicy<T>()
               .handle(
                   IOException.class,
+                  UncheckedIOException.class,
                   OpenSearchException.class,
                   OpenSearchFailedShardsException.class)
               .withDelay(Duration.ofSeconds(delayIntervalInSeconds))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1ApiPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1ApiPermissionsIT.java
@@ -539,11 +539,9 @@ public class OperateV1ApiPermissionsIT {
 
   private static Stream<Arguments> deleteRequestParameters() {
     return Stream.of(
-        /* depends on fix for https://github.com/camunda/camunda/issues/36067
         Arguments.of(AUTHORIZED_USERNAME, HttpStatus.OK.value()),
         Arguments.of(ROLE_AUTHORIZED_USERNAME, HttpStatus.OK.value()),
         Arguments.of(GROUP_AUTHORIZED_USERNAME, HttpStatus.OK.value()),
-        */
         Arguments.of(UNAUTHORIZED_USERNAME, HttpStatus.FORBIDDEN.value()));
   }
 }


### PR DESCRIPTION

## Description

Process instance deletion tests via the v1 API fails on the Opensearch container due to an index version conflict. The test initialisation appears to interfere with the delete operation.

A simple solution is to retry the deletion operation, which resolves the test failure and helps guard against intermittent production issues.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36067
