### PR TITLE
feat: unassignMappingRuleFromTenant

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -72,6 +72,7 @@ import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignClientFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignGroupFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignMappingRuleFromGroupStep1;
+import io.camunda.client.api.command.UnassignMappingRuleFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromClientCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromMappingRuleCommandStep1;
@@ -2290,6 +2291,24 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder to configure and send the unassign client from tenant command
    */
   UnassignClientFromTenantCommandStep1 newUnassignClientFromTenantCommand();
+
+  /**
+   * Command to unassign a mapping rule from a tenant.
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newUnassignMappingRuleFromTenantCommand()
+   *  .mappingRuleId("mappingRuleId")
+   *  .tenantId("tenantId")
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   *
+   * @return a builder to configure and send the unassign mapping rule from tenant command
+   */
+  UnassignMappingRuleFromTenantCommandStep1 newUnassignMappingRuleFromTenantCommand();
 
   /**
    * Command to create an authorization

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignMappingRuleFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignMappingRuleFromTenantCommandStep1.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.UnassignMappingRuleFromTenantResponse;
+
+public interface UnassignMappingRuleFromTenantCommandStep1 {
+
+  /**
+   * Sets the ID of the mapping rule to be unassigned from a tenant.
+   *
+   * @param mappingRuleId the ID of the mapping rule
+   * @return the builder for this command.
+   */
+  UnassignMappingRuleFromTenantCommandStep2 mappingRuleId(String mappingRuleId);
+
+  interface UnassignMappingRuleFromTenantCommandStep2 {
+
+    /**
+     * Sets the tenant ID.
+     *
+     * @param tenantId the ID of the tenant
+     * @return the builder for this command. Call {@link
+     *     UnassignMappingRuleFromTenantCommandStep3#send()} to complete the command and send it to
+     *     the broker.
+     */
+    UnassignMappingRuleFromTenantCommandStep3 tenantId(String tenantId);
+  }
+
+  interface UnassignMappingRuleFromTenantCommandStep3
+      extends FinalCommandStep<UnassignMappingRuleFromTenantResponse> {}
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/UnassignMappingRuleFromTenantResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UnassignMappingRuleFromTenantResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface UnassignMappingRuleFromTenantResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -83,6 +83,7 @@ import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignClientFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignGroupFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignMappingRuleFromGroupStep1;
+import io.camunda.client.api.command.UnassignMappingRuleFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromClientCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignRoleFromMappingRuleCommandStep1;
@@ -222,6 +223,7 @@ import io.camunda.client.impl.command.UnassignClientFromGroupCommandImpl;
 import io.camunda.client.impl.command.UnassignClientFromTenantCommandImpl;
 import io.camunda.client.impl.command.UnassignGroupFromTenantCommandImpl;
 import io.camunda.client.impl.command.UnassignMappingRuleFromGroupCommandImpl;
+import io.camunda.client.impl.command.UnassignMappingRuleFromTenantCommandImpl;
 import io.camunda.client.impl.command.UnassignRoleFromClientCommandImpl;
 import io.camunda.client.impl.command.UnassignRoleFromGroupCommandImpl;
 import io.camunda.client.impl.command.UnassignRoleFromMappingRuleCommandImpl;
@@ -1209,6 +1211,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public UnassignClientFromTenantCommandStep1 newUnassignClientFromTenantCommand() {
     return new UnassignClientFromTenantCommandImpl(httpClient);
+  }
+
+  @Override
+  public UnassignMappingRuleFromTenantCommandStep1 newUnassignMappingRuleFromTenantCommand() {
+    return new UnassignMappingRuleFromTenantCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignMappingRuleFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignMappingRuleFromTenantCommandImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import static io.camunda.client.impl.command.ArgumentUtil.ensureNotNullNorEmpty;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.UnassignMappingRuleFromTenantCommandStep1;
+import io.camunda.client.api.command.UnassignMappingRuleFromTenantCommandStep1.UnassignMappingRuleFromTenantCommandStep2;
+import io.camunda.client.api.command.UnassignMappingRuleFromTenantCommandStep1.UnassignMappingRuleFromTenantCommandStep3;
+import io.camunda.client.api.response.UnassignMappingRuleFromTenantResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UnassignMappingRuleFromTenantResponseImpl;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class UnassignMappingRuleFromTenantCommandImpl
+    implements UnassignMappingRuleFromTenantCommandStep1,
+        UnassignMappingRuleFromTenantCommandStep2,
+        UnassignMappingRuleFromTenantCommandStep3 {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private String mappingRuleId;
+  private String tenantId;
+
+  public UnassignMappingRuleFromTenantCommandImpl(final HttpClient httpClient) {
+    this.httpClient = httpClient;
+    this.httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public UnassignMappingRuleFromTenantCommandStep2 mappingRuleId(final String mappingRuleId) {
+    this.mappingRuleId = mappingRuleId;
+    return this;
+  }
+
+  @Override
+  public UnassignMappingRuleFromTenantCommandStep3 tenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<UnassignMappingRuleFromTenantResponse> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<UnassignMappingRuleFromTenantResponse> send() {
+    ensureNotNullNorEmpty("mappingRuleId", mappingRuleId);
+    ensureNotNullNorEmpty("tenantId", tenantId);
+    final HttpCamundaFuture<UnassignMappingRuleFromTenantResponse> result =
+        new HttpCamundaFuture<>();
+    httpClient.delete(
+        "/tenants/" + tenantId + "/mapping-rules/" + mappingRuleId,
+        Collections.emptyMap(), // No query parameters needed
+        httpRequestConfig.build(),
+        UnassignMappingRuleFromTenantResponseImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UnassignMappingRuleFromTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UnassignMappingRuleFromTenantResponseImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.UnassignMappingRuleFromTenantResponse;
+
+public class UnassignMappingRuleFromTenantResponseImpl
+    implements UnassignMappingRuleFromTenantResponse {
+
+  public UnassignMappingRuleFromTenantResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/test/java/io/camunda/client/tenant/UnassignMappingRuleFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/UnassignMappingRuleFromTenantTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.tenant;
+
+import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class UnassignMappingRuleFromTenantTest extends ClientRestTest {
+
+  public static final String MAPPING_RULE_ID = "mappingRuleId";
+  public static final String TENANT_ID = "tenantId";
+
+  @Test
+  void shouldUnassignMappingRuleFromTenant() {
+    // when
+    client
+        .newUnassignMappingRuleFromTenantCommand()
+        .mappingRuleId(MAPPING_RULE_ID)
+        .tenantId(TENANT_ID)
+        .send()
+        .join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    final RequestMethod method = RestGatewayService.getLastRequest().getMethod();
+    assertThat(requestPath)
+        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/mapping-rules/" + MAPPING_RULE_ID);
+    assertThat(method).isEqualTo(RequestMethod.DELETE);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullMappingRuleIdWhenUnassigningMappingRuleFromTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignMappingRuleFromTenantCommand()
+                    .mappingRuleId(null)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("mappingRuleId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyMappingRuleIdWhenUnassigningMappingRuleFromTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignMappingRuleFromTenantCommand()
+                    .mappingRuleId("")
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("mappingRuleId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullTenantIdWhenUnassigningMappingRuleFromTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignMappingRuleFromTenantCommand()
+                    .mappingRuleId(MAPPING_RULE_ID)
+                    .tenantId(null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyTenantIdWhenUnassigningMappingRuleFromTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignMappingRuleFromTenantCommand()
+                    .mappingRuleId(MAPPING_RULE_ID)
+                    .tenantId("")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be empty");
+  }
+}


### PR DESCRIPTION
## Description

Adds the missing unassignMappingRuleFromTenant command to the Camunda Java Client that exposes the `DELETE /v2/tenants/:tenantId/mapping-rules/:mappingRuleId` API endpoint.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/35771 
