### PR TITLE
Identity e2e admin user can remove user from a group

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -23,6 +23,7 @@ import {PublicFormsPage} from '@pages/PublicFormsPage';
 import {IdentityHeader} from '@pages/IdentityHeader';
 import {IdentityAuthorizationsPage} from '@pages/IdentityAuthorizationsPage';
 import {IdentityGroupsPage} from '@pages/IdentityGroupsPage';
+import {IdentityGroupDetailsPage} from '@pages/IdentityGroupDetailsPage';
 import {IdentityUsersPage} from '@pages/IdentityUsersPage';
 import {IdentityMappingRulesPage} from '@pages/IdentityMappingRulesPage';
 import {IdentityRolesPage} from '@pages/IdentityRolesPage';
@@ -54,6 +55,7 @@ type PlaywrightFixtures = {
   identityRolesPage: IdentityRolesPage;
   identityTenantsPage: IdentityTenantsPage;
   identityRolesDetailsPage: IdentityRolesDetailsPage;
+  identityGroupDetailsPage: IdentityGroupDetailsPage;
 };
 
 const test = base.extend<PlaywrightFixtures>({
@@ -160,6 +162,10 @@ const test = base.extend<PlaywrightFixtures>({
 
   identityRolesDetailsPage: async ({page}, use) => {
     await use(new IdentityRolesDetailsPage(page));
+  },
+
+  identityGroupDetailsPage: async ({page}, use) => {
+    await use(new IdentityGroupDetailsPage(page));
   },
 });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -8,6 +8,7 @@
 
 import {Page, Locator, expect} from '@playwright/test';
 import {relativizePath, Paths} from 'utils/relativizePath';
+import {sleep} from 'utils/sleep';
 import {waitForItemInList} from 'utils/waitForItemInList';
 
 export class IdentityAuthorizationsPage {
@@ -50,10 +51,7 @@ export class IdentityAuthorizationsPage {
       name: 'Create authorization',
     });
     this.createAuthorizationOwnerComboBox =
-      this.createAuthorizationModal.getByRole('combobox', {
-        name: 'Owner',
-        exact: true,
-      });
+      this.createAuthorizationModal.getByPlaceholder('Select an owner');
     this.createAuthorizationOwnerOption = (name) =>
       this.createAuthorizationModal.getByRole('option', {
         name,
@@ -166,27 +164,49 @@ export class IdentityAuthorizationsPage {
     resourceId: string;
     accessPermissions: string[];
   }) {
-    await this.createAuthorizationButton.click();
-    await expect(this.createAuthorizationModal).toBeVisible();
-    await this.selectAuthorizationOwnerType({
-      ownerType: authorization.ownerType,
-    });
-    await this.selectAuthorizationOwner({
-      ownerId: authorization.ownerId,
-    });
-    await this.selectResourceType(authorization.resourceType);
-    await this.fillResourceId(authorization.resourceId);
-    await this.selectAccessPermissions(authorization.accessPermissions);
-    await this.createAuthorizationSubmitButton.click();
-    await expect(this.createAuthorizationModal).toBeHidden();
-    await this.selectResourceTypeTab(authorization.resourceType);
-    const item = this.getAuthorizationCell(authorization.ownerId);
-    await waitForItemInList(this.page, item, {
-      clickNext: true,
-      timeout: 60000,
-      onAfterReload: () =>
-        this.selectResourceTypeTab(authorization.resourceType),
-    });
+    const maxRetries = 3;
+    let lastError: Error | null = null;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        await this.createAuthorizationButton.click();
+        await expect(this.createAuthorizationModal).toBeVisible({
+          timeout: 15000,
+        });
+        await this.selectAuthorizationOwnerType({
+          ownerType: authorization.ownerType,
+        });
+        await this.selectAuthorizationOwner({
+          ownerId: authorization.ownerId,
+        });
+        await this.selectResourceType(authorization.resourceType);
+        await this.fillResourceId(authorization.resourceId);
+        await this.selectAccessPermissions(authorization.accessPermissions);
+        await this.createAuthorizationSubmitButton.click();
+        await expect(this.createAuthorizationModal).toBeHidden({
+          timeout: 15000,
+        });
+
+        await this.selectResourceTypeTab(authorization.resourceType);
+        const item = this.getAuthorizationCell(authorization.ownerId);
+        await waitForItemInList(this.page, item, {
+          timeout: 30000,
+          onAfterReload: () =>
+            this.selectResourceTypeTab(authorization.resourceType),
+        });
+        return;
+      } catch (error) {
+        lastError = error as Error;
+        if (attempt < maxRetries) {
+          await sleep(60000);
+          await this.page.reload();
+        }
+      }
+    }
+
+    throw new Error(
+      `Failed to create authorization for ${authorization.ownerId} after ${maxRetries} attempts. Last error: ${lastError?.message}`,
+    );
   }
 
   async selectResourceType(resourceType: string) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -164,33 +164,33 @@ export class IdentityAuthorizationsPage {
     resourceId: string;
     accessPermissions: string[];
   }) {
+    await this.createAuthorizationButton.click();
+    await expect(this.createAuthorizationModal).toBeVisible({
+      timeout: 15000,
+    });
+    await this.selectAuthorizationOwnerType({
+      ownerType: authorization.ownerType,
+    });
+    await this.selectAuthorizationOwner({
+      ownerId: authorization.ownerId,
+    });
+    await this.selectResourceType(authorization.resourceType);
+    await this.fillResourceId(authorization.resourceId);
+    await this.selectAccessPermissions(authorization.accessPermissions);
+    await this.createAuthorizationSubmitButton.click();
+    await expect(this.createAuthorizationModal).toBeHidden({
+      timeout: 15000,
+    });
     const maxRetries = 3;
     let lastError: Error | null = null;
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        await this.createAuthorizationButton.click();
-        await expect(this.createAuthorizationModal).toBeVisible({
-          timeout: 15000,
-        });
-        await this.selectAuthorizationOwnerType({
-          ownerType: authorization.ownerType,
-        });
-        await this.selectAuthorizationOwner({
-          ownerId: authorization.ownerId,
-        });
-        await this.selectResourceType(authorization.resourceType);
-        await this.fillResourceId(authorization.resourceId);
-        await this.selectAccessPermissions(authorization.accessPermissions);
-        await this.createAuthorizationSubmitButton.click();
-        await expect(this.createAuthorizationModal).toBeHidden({
-          timeout: 15000,
-        });
-
         await this.selectResourceTypeTab(authorization.resourceType);
         const item = this.getAuthorizationCell(authorization.ownerId);
         await waitForItemInList(this.page, item, {
           timeout: 30000,
+          clickNext: true,
           onAfterReload: () =>
             this.selectResourceTypeTab(authorization.resourceType),
         });
@@ -205,7 +205,7 @@ export class IdentityAuthorizationsPage {
     }
 
     throw new Error(
-      `Failed to create authorization for ${authorization.ownerId} after ${maxRetries} attempts. Last error: ${lastError?.message}`,
+      `Failed to verify authorization for ${authorization.ownerId} after ${maxRetries} attempts. Last error: ${lastError?.message}`,
     );
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupDetailsPage.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator, expect} from '@playwright/test';
+import {waitForItemInList} from 'utils/waitForItemInList';
+
+export class IdentityGroupDetailsPage {
+  private page: Page;
+  readonly assignedUsersList: Locator;
+  readonly assignUserButton: Locator;
+  readonly unassignUserButton: (rowName?: string) => Locator;
+  readonly assignUserModal: Locator;
+  readonly closeAssignUserModal: Locator;
+  readonly assignUserModalSearchField: Locator;
+  readonly assignUserModalSearchResult: Locator;
+  readonly assignUserModalCancelButton: Locator;
+  readonly assignUserModalAssignButton: Locator;
+  readonly unassignUserModal: Locator;
+  readonly closeUnassignUserModal: Locator;
+  readonly unassignUserModalCancelButton: Locator;
+  readonly unassignUserModalRemoveButton: Locator;
+  readonly emptyStateLocator: Locator;
+  readonly userCell: (name: string) => Locator;
+  readonly userRow: (userName: string) => Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.assignedUsersList = page.getByRole('table');
+    this.assignUserButton = page.getByRole('button', {
+      name: 'assign user',
+    });
+    this.unassignUserButton = (rowName) =>
+      this.assignedUsersList
+        .getByRole('row', {name: rowName})
+        .getByLabel('Remove');
+    this.assignUserModal = page.getByRole('dialog', {
+      name: 'Assign user',
+    });
+    this.closeAssignUserModal = this.assignUserModal.getByRole('button', {
+      name: 'Close',
+    });
+    this.assignUserModalSearchField =
+      this.assignUserModal.getByRole('searchbox');
+    this.assignUserModalSearchResult =
+      this.assignUserModal.getByRole('listbox');
+    this.assignUserModalCancelButton = this.assignUserModal.getByRole(
+      'button',
+      {
+        name: 'Cancel',
+      },
+    );
+    this.assignUserModalAssignButton = this.assignUserModal.getByRole(
+      'button',
+      {
+        name: 'assign user',
+      },
+    );
+    this.unassignUserModal = page.getByRole('dialog', {name: 'remove user'});
+    this.closeUnassignUserModal = this.unassignUserModal.getByRole('button', {
+      name: 'Close',
+    });
+    this.unassignUserModalCancelButton = this.unassignUserModal.getByRole(
+      'button',
+      {
+        name: 'Cancel',
+      },
+    );
+    this.unassignUserModalRemoveButton = this.unassignUserModal.getByRole(
+      'button',
+      {
+        name: 'remove user',
+      },
+    );
+    this.emptyStateLocator = page.getByText(
+      'No users assigned to this group yet',
+    );
+    this.userCell = (userID: string) =>
+      this.assignedUsersList.getByRole('cell', {name: userID, exact: true});
+    this.userRow = (userName: string) =>
+      this.page.getByRole('row').filter({hasText: userName});
+  }
+
+  async assignUserToGroup(user: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  }) {
+    await this.assignUserButton.click();
+    await this.assignUserModalSearchField.fill(user.username);
+    await this.assignUserModalSearchResult
+      .filter({
+        hasText: user.email,
+      })
+      .click();
+    await this.assignUserModalAssignButton.click();
+    const item = this.userCell(user.email);
+    await waitForItemInList(this.page, item, {timeout: 60000, clickNext: true});
+  }
+
+  async unassignUserFromGroup(userName: string): Promise<void> {
+    const userRow = this.userRow(userName);
+    await expect(userRow).toBeVisible({timeout: 30000});
+    await this.unassignUserButton(userName).click();
+    await this.unassignUserModalRemoveButton.click({timeout: 30000});
+    const item = this.userCell(userName);
+    await waitForItemInList(this.page, item, {
+      shouldBeVisible: false,
+      timeout: 60000,
+      clickNext: true,
+      emptyStateLocator: this.emptyStateLocator,
+    });
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
@@ -8,7 +8,6 @@
 
 import {Page, Locator, expect} from '@playwright/test';
 import {relativizePath, Paths} from 'utils/relativizePath';
-import {sleep} from 'utils/sleep';
 import {defaultAssertionOptions} from '../utils/constants';
 import {waitForItemInList} from '../utils/waitForItemInList';
 
@@ -36,10 +35,6 @@ export class IdentityGroupsPage {
   readonly deleteGroupModalCancelButton: Locator;
   readonly deleteGroupModalDeleteButton: Locator;
   readonly emptyStateLocator: Locator;
-  readonly assignUserButton: Locator;
-  readonly searchBox: Locator;
-  readonly searchBoxResult: Locator;
-  readonly assignUserButtonModal: Locator;
   readonly selectGroupRow: (name: string) => Locator;
   readonly groupCell: (name: string) => Locator;
   readonly groupsHeading: Locator;
@@ -129,12 +124,6 @@ export class IdentityGroupsPage {
       },
     );
     this.emptyStateLocator = page.getByText('No groups created yet');
-    this.assignUserButton = page.getByRole('button', {name: 'Assign user'});
-    this.searchBox = page.getByRole('searchbox');
-    this.searchBoxResult = page.getByRole('listitem');
-    this.assignUserButtonModal = page
-      .getByLabel('Assign user')
-      .getByRole('button', {name: 'Assign user'});
     this.groupsHeading = this.page.getByRole('heading', {name: 'Groups'});
   }
 
@@ -192,17 +181,5 @@ export class IdentityGroupsPage {
 
   async clickGroupId(groupName: string) {
     await this.selectGroupRow(groupName).click();
-  }
-
-  async assignUserToGroup(userName: string, userEmail: string) {
-    await this.assignUserButton.click();
-    await this.searchBox.fill(userName);
-    await this.searchBoxResult
-      .filter({
-        hasText: userEmail,
-      })
-      .click();
-    await this.assignUserButtonModal.click();
-    await sleep(8000);
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
@@ -27,6 +27,9 @@ export class IdentityHeader {
       .locator('nav a')
       .filter({hasText: /^Authorizations$/});
     this.usersTab = page.locator('nav a').filter({hasText: /^Users$/});
+    this.authorizationsTab = page
+      .locator('nav a')
+      .filter({hasText: /^Authorizations$/});
   }
 
   async logout() {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
@@ -6,17 +6,21 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Page, Locator} from '@playwright/test';
+import {Page, Locator, expect} from '@playwright/test';
+import {Paths, relativizePath} from 'utils/relativizePath';
 
 export class IdentityHeader {
+  readonly page: Page;
   readonly openSettingsButton: Locator;
   readonly logoutButton: Locator;
   readonly rolesTab: Locator;
   readonly tenantsTab: Locator;
   readonly authorizationsTab: Locator;
   readonly usersTab: Locator;
+  readonly groupsTab: Locator;
 
   constructor(page: Page) {
+    this.page = page;
     this.openSettingsButton = page.getByRole('button', {
       name: 'Open Settings',
     });
@@ -27,9 +31,7 @@ export class IdentityHeader {
       .locator('nav a')
       .filter({hasText: /^Authorizations$/});
     this.usersTab = page.locator('nav a').filter({hasText: /^Users$/});
-    this.authorizationsTab = page
-      .locator('nav a')
-      .filter({hasText: /^Authorizations$/});
+    this.groupsTab = page.locator('nav a').filter({hasText: /^Groups$/});
   }
 
   async logout() {
@@ -47,9 +49,14 @@ export class IdentityHeader {
 
   async navigateToAuthorizations() {
     await this.authorizationsTab.click();
+    await expect(this.page).toHaveURL(relativizePath(Paths.authorizations()));
   }
 
   async navigateToUsers() {
     await this.usersTab.click();
+  }
+
+  async navigateToGroups() {
+    await this.groupsTab.click();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/simpleProcessForIdentity.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/simpleProcessForIdentity.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_06afpkj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.35.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="identityProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1gx0k6g</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1gx0k6g" sourceRef="StartEvent_1" targetRef="identityUserTask" />
+    <bpmn:endEvent id="Event_0grafub">
+      <bpmn:incoming>Flow_0wmsgbl</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0wmsgbl" sourceRef="identityUserTask" targetRef="Event_0grafub" />
+    <bpmn:userTask id="identityUserTask">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1gx0k6g</bpmn:incoming>
+      <bpmn:outgoing>Flow_0wmsgbl</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="identityProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0grafub_di" bpmnElement="Event_0grafub">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0d3a5m9_di" bpmnElement="identityUserTask">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1gx0k6g_di" bpmnElement="Flow_1gx0k6g">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wmsgbl_di" bpmnElement="Flow_0wmsgbl">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
@@ -14,8 +14,16 @@ import {createTestData, createComponentAuthorization} from 'utils/constants';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {verifyAccess} from 'utils/accessVerification';
 import {waitForItemInList} from 'utils/waitForItemInList';
+import {createInstances, deploy} from 'utils/zeebeClient'; // Add these imports
 
 test.describe('Identity User Flows', () => {
+  // Add deployment setup before all tests
+  test.beforeAll(async () => {
+    await deploy(['./resources/simpleProcessForIdentity.bpmn']);
+    await sleep(500);
+    await createInstances('identityProcess', 1, 1);
+  });
+
   test.beforeEach(async ({loginPage, page}) => {
     await navigateToApp(page, 'identity');
     await loginPage.login('demo', 'demo');
@@ -216,6 +224,162 @@ test.describe('Identity User Flows', () => {
 
     await test.step(`Verify Operate access is denied`, async () => {
       await verifyAccess(page, false, 'operate');
+    });
+  });
+
+  test('New user can inherit permissions when assigned to a group', async ({
+    page,
+    identityGroupsPage,
+    identityAuthorizationsPage,
+    identityUsersPage,
+    identityHeader,
+    loginPage,
+    operateHomePage,
+    tasklistHeader,
+  }) => {
+    test.slow();
+    const testData = createTestData({
+      group: true,
+      user: true,
+    });
+    const TEST_GROUP = testData.group!;
+    const TEST_USER = testData.user!;
+
+    await test.step('Create test user', async () => {
+      await identityUsersPage.createUser({
+        username: TEST_USER.username,
+        password: TEST_USER.password,
+        email: TEST_USER.email!,
+        name: TEST_USER.name ?? TEST_USER.username,
+      });
+
+      const userName = identityUsersPage.userCell(TEST_USER.username);
+      await waitForItemInList(page, userName, {
+        timeout: 60000,
+        clickNext: true,
+      });
+    });
+
+    await test.step('Create test group with process permissions', async () => {
+      await identityGroupsPage.navigateToGroups();
+      await identityGroupsPage.createGroup(
+        TEST_GROUP.groupId,
+        TEST_GROUP.name,
+        TEST_GROUP.description,
+      );
+
+      const item = identityGroupsPage.groupCell(TEST_GROUP.groupId);
+      await waitForItemInList(page, item, {
+        clickNext: true,
+        timeout: 60000,
+        onAfterReload: async () => {
+          await identityGroupsPage.navigateToGroups();
+          await expect(identityGroupsPage.groupsList).toBeVisible({
+            timeout: 60000,
+          });
+        },
+      });
+    });
+
+    await test.step('Create authorization for the test group', async () => {
+      await identityHeader.navigateToAuthorizations();
+      await expect(page).toHaveURL(relativizePath(Paths.authorizations()));
+      const COMPONENT_AUTH = createComponentAuthorization(
+        {name: TEST_GROUP.name},
+        'Group',
+      );
+      await identityAuthorizationsPage.createAuthorization(COMPONENT_AUTH);
+    });
+
+    await test.step('Assign test user to group', async () => {
+      await identityGroupsPage.navigateToGroups();
+      await identityGroupsPage.clickGroupId(TEST_GROUP.groupId);
+      await identityGroupsPage.assignUserToGroup(
+        TEST_USER.username,
+        TEST_USER.email!,
+      );
+      await page.reload();
+    });
+
+    await test.step('Verify authorization was created', async () => {
+      await identityHeader.navigateToAuthorizations();
+      await identityAuthorizationsPage.clickResourceType('Component');
+
+      const authorizationItem = identityAuthorizationsPage.getAuthorizationCell(
+        TEST_GROUP.groupId,
+      );
+      await waitForItemInList(page, authorizationItem, {
+        shouldBeVisible: true,
+        timeout: 10000,
+        onAfterReload: () =>
+          identityAuthorizationsPage.selectResourceTypeTab('Component'),
+        clickNext: true,
+      });
+    });
+
+    await test.step('Verify test user can access Identity', async () => {
+      await identityHeader.logout();
+      await loginPage.login(TEST_USER.username, TEST_USER.password);
+      await expect(page).toHaveURL(new RegExp('identity'), {timeout: 10000});
+      await sleep(2000);
+      await verifyAccess(page, true);
+    });
+
+    await test.step('Verify test user can access Operate but cannot view process instances', async () => {
+      await page.goto(`${process.env.CORE_APPLICATION_URL}/operate`);
+      await operateHomePage.clickProcessesTab();
+      await expect(page.getByText('identityProcess')).not.toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step('Verify test user can access Tasklist but cannot view the userTask', async () => {
+      await page.goto(`${process.env.CORE_APPLICATION_URL}/tasklist`);
+      console.log('sero ' + page.url());
+      await expect(page).toHaveURL(new RegExp(`tasklist`));
+      await verifyAccess(page, true);
+      await expect(page.getByText('identityProcess')).not.toBeVisible({
+        timeout: 30000,
+      });
+      await tasklistHeader.logout();
+    });
+
+    await test.step('Login with demo user and create authorization for the group', async () => {
+      await navigateToApp(page, 'identity');
+      await loginPage.login('demo', 'demo');
+      await identityHeader.navigateToAuthorizations();
+      await identityAuthorizationsPage.createAuthorization({
+        ownerType: 'Group',
+        ownerId: TEST_GROUP.name,
+        resourceType: 'Authorization',
+        resourceId: '*',
+        accessPermissions: ['Read'],
+      });
+    });
+
+    await test.step('Verify authorization was created', async () => {
+      await identityAuthorizationsPage.clickResourceType('Authorization');
+      await identityAuthorizationsPage.assertAuthorizationExists(
+        TEST_GROUP.groupId,
+        'Group',
+        ['Read'],
+      );
+    });
+
+    await test.step('Verify test user can view process instances in Operate', async () => {
+      await page.goto(`${process.env.CORE_APPLICATION_URL}/operate`);
+      await operateHomePage.clickProcessesTab();
+      await expect(page.getByText('identityProcess').first()).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step('Verify test user can view the userTask in Tasklist', async () => {
+      await page.goto(`${process.env.CORE_APPLICATION_URL}/tasklist`);
+      await expect(page).toHaveURL(new RegExp(`tasklist`));
+      await expect(page.getByText('identityProcess').first()).toBeVisible({
+        timeout: 30000,
+      });
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
@@ -14,7 +14,8 @@ import {createTestData, createComponentAuthorization} from 'utils/constants';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {verifyAccess} from 'utils/accessVerification';
 import {waitForItemInList} from 'utils/waitForItemInList';
-import {createInstances, deploy} from 'utils/zeebeClient'; // Add these imports
+import {createInstances, deploy} from 'utils/zeebeClient';
+import {sleep} from 'utils/sleep';
 
 test.describe('Identity User Flows', () => {
   // Add deployment setup before all tests
@@ -260,14 +261,13 @@ test.describe('Identity User Flows', () => {
       });
     });
 
-    await test.step('Create test group with process permissions', async () => {
+    await test.step('Create test group', async () => {
       await identityGroupsPage.navigateToGroups();
       await identityGroupsPage.createGroup(
         TEST_GROUP.groupId,
         TEST_GROUP.name,
         TEST_GROUP.description,
       );
-
       const item = identityGroupsPage.groupCell(TEST_GROUP.groupId);
       await waitForItemInList(page, item, {
         clickNext: true,
@@ -284,11 +284,13 @@ test.describe('Identity User Flows', () => {
     await test.step('Create authorization for the test group', async () => {
       await identityHeader.navigateToAuthorizations();
       await expect(page).toHaveURL(relativizePath(Paths.authorizations()));
-      const COMPONENT_AUTH = createComponentAuthorization(
-        {name: TEST_GROUP.name},
-        'Group',
-      );
-      await identityAuthorizationsPage.createAuthorization(COMPONENT_AUTH);
+      await identityAuthorizationsPage.createAuthorization({
+        ownerType: 'Group',
+        ownerId: TEST_GROUP.name,
+        resourceType: 'Component',
+        resourceId: '*',
+        accessPermissions: ['Access'],
+      });
     });
 
     await test.step('Assign test user to group', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -135,6 +135,7 @@ test.describe('Groups functionalities', () => {
     identityGroupsPage,
     identityAuthorizationsPage,
     identityHeader,
+    identityGroupDetailsPage,
   }) => {
     const testData = createTestData({
       group: true,
@@ -161,7 +162,12 @@ test.describe('Groups functionalities', () => {
 
     await test.step('Assign user to group', async () => {
       await identityGroupsPage.clickGroupId(TEST_GROUP.name);
-      await identityGroupsPage.assignUserToGroup('lisa', 'lisa@example.com');
+      await identityGroupDetailsPage.assignUserToGroup({
+        username: 'lisa',
+        name: 'lisa',
+        email: 'lisa@example.com',
+        password: 'password',
+      });
       await page.reload();
     });
 


### PR DESCRIPTION
## Description
Added a new E2E test to verify that removing a user from a group properly revokes their inherited process definition permissions in both Operate and Tasklist applications as requested [here](https://github.com/camunda/camunda/issues/35041)

### Changes
- **New test**: `Admin user can remove Test user from TestGroup and revoke inherited process access`
- **Enhanced page objects**: Utilized `IdentityGroupDetailsPage` for user-group management operations
- Corrected the logic for `waitForItemInList`
-   Created `IdentityGroupDetailsPage`: For user assignment/removal operations
- **Test flow**:
  1. Create test user with component authorization
  2. Create test group with process definition permissions  
  3. Assign user to group using `identityGroupDetailsPage.assignUserToGroup()`
  4. Verify user can access processes in Operate/Tasklist
  5. Remove user from group using `identityGroupDetailsPage.unassignUserFromGroup()`
  6. Verify user loses access to processes



🧪 [Test Run](identity-e2e-Admin-user-can-remove-user-from-a-group)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
