### PR TITLE
[CPT] Improve message assertions

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -498,10 +498,9 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasActiveIncidents();
 
   /**
-   * Verifies that the process instance is currently waiting to receive one or more specified
-   * messages.
+   * Verifies that the process instance is waiting for a message with the given name.
    *
-   * <p>The assertion waits for the correct message subscription.
+   * <p>The assertion waits until a message subscription is created.
    *
    * @param messageName the name of the message
    * @return the assertion object
@@ -509,10 +508,10 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert isWaitingForMessage(final String messageName);
 
   /**
-   * Verifies that the process instance is currently waiting to receive one or more specified
-   * messages.
+   * Verifies that the process instance is waiting for a message with the given name and correlation
+   * key.
    *
-   * <p>The assertion waits for the correct message subscription.
+   * <p>The assertion waits until a message subscription is created.
    *
    * @param messageName the name of the message
    * @param correlationKey the message's correlation key
@@ -521,10 +520,9 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert isWaitingForMessage(final String messageName, final String correlationKey);
 
   /**
-   * Verifies that the process instance is not currently waiting to receive one or more specified
-   * messages.
+   * Verifies that the process instance is not waiting for a message with the given name.
    *
-   * <p>The assertion waits for a message subscription that may invalidate the assertion
+   * <p>The assertion waits until no message subscription exists.
    *
    * @param messageName the name of the message
    * @return the assertion object
@@ -532,10 +530,10 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert isNotWaitingForMessage(final String messageName);
 
   /**
-   * Verifies that the process instance is not currently waiting to receive one or more specified
-   * messages.
+   * Verifies that the process instance is not waiting for a message with the given name and
+   * correlation key.
    *
-   * <p>The assertion waits for a message subscription that may invalidate the assertion
+   * <p>The assertion waits until no message subscription exists.
    *
    * @param messageName the name of the message
    * @param correlationKey the message's correlation key

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -173,7 +173,7 @@ public class CamundaDataSource {
         .items();
   }
 
-  public List<CorrelatedMessage> getCorrelatedMessages(
+  public List<CorrelatedMessage> findCorrelatedMessages(
       final Consumer<CorrelatedMessageFilter> filter) {
     return client
         .newCorrelatedMessageSearchRequest()

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -161,7 +161,11 @@ public class CamundaDataSource {
     return client.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
   }
 
-  public List<MessageSubscription> getMessageSubscriptions(
+  public List<MessageSubscription> findMessageSubscriptions() {
+    return findMessageSubscriptions(filter -> {});
+  }
+
+  public List<MessageSubscription> findMessageSubscriptions(
       final Consumer<MessageSubscriptionFilter> filter) {
     return client
         .newMessageSubscriptionSearchRequest()

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -161,10 +161,6 @@ public class CamundaDataSource {
     return client.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
   }
 
-  public List<MessageSubscription> findMessageSubscriptions() {
-    return findMessageSubscriptions(filter -> {});
-  }
-
   public List<MessageSubscription> findMessageSubscriptions(
       final Consumer<MessageSubscriptionFilter> filter) {
     return client

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
@@ -140,7 +140,7 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
 
     awaitBehavior.untilAsserted(
         () ->
-            dataSource.getMessageSubscriptions(
+            dataSource.findMessageSubscriptions(
                 f -> filter.accept(f.processInstanceKey(processInstanceKey))),
         assertionCallback);
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
@@ -25,7 +25,6 @@ import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 
 public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscriptionAssertj, String> {
@@ -80,8 +79,8 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
         messageSubscriptions ->
             assertThat(messageSubscriptions)
                 .withFailMessage(
-                    "%s should have no active message subscription [message-name: '%s'], but the following subscriptions were active:\n%s",
-                    actual, messageName, formatMessageSubscriptions(messageSubscriptions))
+                    "%s should have no active message subscription [message-name: '%s'], but found <%d> active subscriptions.",
+                    actual, messageName, messageSubscriptions.size())
                 .isEmpty());
   }
 
@@ -98,11 +97,8 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
         messageSubscriptions ->
             assertThat(messageSubscriptions)
                 .withFailMessage(
-                    "%s should have no active message subscription [message-name: '%s', correlation-key: '%s'], but the following subscriptions were active:\n%s",
-                    actual,
-                    messageName,
-                    correlationKey,
-                    formatMessageSubscriptions(messageSubscriptions))
+                    "%s should have no active message subscription [message-name: '%s', correlation-key: '%s'], but found <%d> active subscriptions.",
+                    actual, messageName, correlationKey, messageSubscriptions.size())
                 .isEmpty());
   }
 
@@ -155,16 +151,5 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
             dataSource.findCorrelatedMessages(
                 f -> filter.accept(f.processInstanceKey(processInstanceKey))),
         assertionCallback);
-  }
-
-  private static String formatMessageSubscriptions(
-      final List<MessageSubscription> messageSubscriptions) {
-    return messageSubscriptions.stream()
-        .map(
-            subscription ->
-                String.format(
-                    "\t- name: '%s', correlation-key: '%s'",
-                    subscription.getMessageName(), subscription.getCorrelationKey()))
-        .collect(Collectors.joining("\n"));
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
@@ -152,7 +152,7 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
 
     awaitBehavior.untilAsserted(
         () ->
-            dataSource.getCorrelatedMessages(
+            dataSource.findCorrelatedMessages(
                 f -> filter.accept(f.processInstanceKey(processInstanceKey))),
         assertionCallback);
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
@@ -25,6 +25,7 @@ import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 
 public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscriptionAssertj, String> {
@@ -79,8 +80,8 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
         messageSubscriptions ->
             assertThat(messageSubscriptions)
                 .withFailMessage(
-                    "%s has an active message subscription [message-name: '%s'], but such a subscription was not expected.",
-                    actual, messageName)
+                    "%s should have no active message subscription [message-name: '%s'], but the following subscriptions were active:\n%s",
+                    actual, messageName, formatMessageSubscriptions(messageSubscriptions))
                 .isEmpty());
   }
 
@@ -97,8 +98,11 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
         messageSubscriptions ->
             assertThat(messageSubscriptions)
                 .withFailMessage(
-                    "%s has an active message subscription [message-name: '%s', correlation-key: '%s'], but such a subscription was not expected.",
-                    actual, messageName, correlationKey)
+                    "%s should have no active message subscription [message-name: '%s', correlation-key: '%s'], but the following subscriptions were active:\n%s",
+                    actual,
+                    messageName,
+                    correlationKey,
+                    formatMessageSubscriptions(messageSubscriptions))
                 .isEmpty());
   }
 
@@ -151,5 +155,16 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
             dataSource.getCorrelatedMessages(
                 f -> filter.accept(f.processInstanceKey(processInstanceKey))),
         assertionCallback);
+  }
+
+  private static String formatMessageSubscriptions(
+      final List<MessageSubscription> messageSubscriptions) {
+    return messageSubscriptions.stream()
+        .map(
+            subscription ->
+                String.format(
+                    "\t- name: '%s', correlation-key: '%s'",
+                    subscription.getMessageName(), subscription.getCorrelationKey()))
+        .collect(Collectors.joining("\n"));
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
@@ -17,8 +17,10 @@ package io.camunda.process.test.impl.testresult;
 
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.enums.IncidentState;
+import io.camunda.client.api.search.enums.MessageSubscriptionState;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import java.util.HashMap;
@@ -56,6 +58,7 @@ public class CamundaProcessTestResultCollector {
     result.setVariables(collectVariables(processInstanceKey));
     result.setActiveIncidents(collectActiveIncidents(processInstanceKey));
     result.setActiveElementInstances(collectActiveElementInstances(processInstanceKey));
+    result.setActiveMessageSubscriptions(collectActiveMessageSubscriptions(processInstanceKey));
 
     return result;
   }
@@ -81,5 +84,14 @@ public class CamundaProcessTestResultCollector {
   private List<ElementInstance> collectActiveElementInstances(final long processInstanceKey) {
     return dataSource.findElementInstances(
         filter -> filter.processInstanceKey(processInstanceKey).state(ElementInstanceState.ACTIVE));
+  }
+
+  private List<MessageSubscription> collectActiveMessageSubscriptions(
+      final long processInstanceKey) {
+    return dataSource.findMessageSubscriptions(
+        filter ->
+            filter
+                .processInstanceKey(processInstanceKey)
+                .messageSubscriptionState(MessageSubscriptionState.CREATED));
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultPrinter.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultPrinter.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.testresult;
 
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.client.api.search.response.ProcessInstance;
 import java.util.List;
 import java.util.Map;
@@ -75,7 +76,10 @@ public class CamundaProcessTestResultPrinter {
         + formatVariables(result.getVariables())
         + "\n\n"
         + "Active incidents:\n"
-        + formatIncidents(result.getActiveIncidents());
+        + formatIncidents(result.getActiveIncidents())
+        + "\n\n"
+        + "Active message subscriptions:\n"
+        + formatMessageSubscriptions(result.getActiveMessageSubscriptions());
   }
 
   private static String formatVariables(final Map<String, String> variables) {
@@ -125,5 +129,24 @@ public class CamundaProcessTestResultPrinter {
   private static String formatElementInstance(final ElementInstance elementInstance) {
     final String name = Optional.ofNullable(elementInstance.getElementName()).orElse("");
     return String.format("- '%s' [name: '%s']", elementInstance.getElementId(), name);
+  }
+
+  private static String formatMessageSubscriptions(
+      final List<MessageSubscription> messageSubscriptions) {
+    if (messageSubscriptions.isEmpty()) {
+      return NO_ENTRIES;
+    } else {
+      return messageSubscriptions.stream()
+          .map(CamundaProcessTestResultPrinter::formatMessageSubscription)
+          .collect(Collectors.joining("\n"));
+    }
+  }
+
+  private static String formatMessageSubscription(final MessageSubscription subscription) {
+    return String.format(
+        "- '%s' [message-name: '%s', correlation-key: '%s']",
+        subscription.getElementId(),
+        subscription.getMessageName(),
+        subscription.getCorrelationKey());
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/ProcessInstanceResult.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/ProcessInstanceResult.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.testresult;
 
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.client.api.search.response.ProcessInstance;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,6 +33,8 @@ public class ProcessInstanceResult {
   private List<Incident> activeIncidents = new ArrayList<>();
 
   private List<ElementInstance> activeElementInstances = new ArrayList<>();
+
+  private List<MessageSubscription> activeMessageSubscriptions = new ArrayList<>();
 
   public ProcessInstance getProcessInstance() {
     return processInstance;
@@ -63,5 +66,14 @@ public class ProcessInstanceResult {
 
   public void setActiveElementInstances(final List<ElementInstance> activeElementInstances) {
     this.activeElementInstances = activeElementInstances;
+  }
+
+  public List<MessageSubscription> getActiveMessageSubscriptions() {
+    return activeMessageSubscriptions;
+  }
+
+  public void setActiveMessageSubscriptions(
+      final List<MessageSubscription> activeMessageSubscriptions) {
+    this.activeMessageSubscriptions = activeMessageSubscriptions;
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -830,7 +830,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+      when(camundaDataSource.findMessageSubscriptions(filterCaptor.capture()))
           .thenReturn(
               Collections.singletonList(
                   new MessageSubscriptionImpl(new MessageSubscriptionResult())));
@@ -852,7 +852,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+      when(camundaDataSource.findMessageSubscriptions(filterCaptor.capture()))
           .thenReturn(
               Collections.singletonList(
                   new MessageSubscriptionImpl(new MessageSubscriptionResult())));
@@ -876,7 +876,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+      when(camundaDataSource.findMessageSubscriptions(filterCaptor.capture()))
           .thenReturn(Collections.emptyList());
 
       // then
@@ -897,7 +897,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+      when(camundaDataSource.findMessageSubscriptions(filterCaptor.capture()))
           .thenReturn(Collections.emptyList());
 
       // then
@@ -922,7 +922,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+      when(camundaDataSource.findMessageSubscriptions(filterCaptor.capture()))
           .thenReturn(Collections.emptyList())
           .thenReturn(Collections.emptyList())
           .thenReturn(Collections.emptyList())
@@ -950,7 +950,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+      when(camundaDataSource.findMessageSubscriptions(filterCaptor.capture()))
           .thenReturn(Collections.emptyList())
           .thenReturn(Collections.emptyList())
           .thenReturn(Collections.emptyList());
@@ -974,7 +974,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+      when(camundaDataSource.findMessageSubscriptions(filterCaptor.capture()))
           .thenReturn(Collections.emptyList());
 
       // then
@@ -996,7 +996,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+      when(camundaDataSource.findMessageSubscriptions(filterCaptor.capture()))
           .thenReturn(Collections.emptyList());
 
       // then
@@ -1018,7 +1018,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+      when(camundaDataSource.findMessageSubscriptions(filterCaptor.capture()))
           .thenReturn(
               Collections.singletonList(
                   new MessageSubscriptionImpl(
@@ -1046,7 +1046,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
+      when(camundaDataSource.findMessageSubscriptions(filterCaptor.capture()))
           .thenReturn(
               Collections.singletonList(
                   new MessageSubscriptionImpl(

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -1032,8 +1032,7 @@ public class ProcessInstanceAssertTest {
                   CamundaAssert.assertThatProcessInstance(processInstanceEvent)
                       .isNotWaitingForMessage("expected"))
           .hasMessage(
-              "Process instance [key: 1] should have no active message subscription [message-name: 'expected'], but the following subscriptions were active:\n"
-                  + "\t- name: 'expected', correlation-key: 'correlation-key'");
+              "Process instance [key: 1] should have no active message subscription [message-name: 'expected'], but found <1> active subscriptions.");
     }
 
     @Test
@@ -1060,8 +1059,7 @@ public class ProcessInstanceAssertTest {
                   CamundaAssert.assertThatProcessInstance(processInstanceEvent)
                       .isNotWaitingForMessage("expected", "correlation-key"))
           .hasMessage(
-              "Process instance [key: 1] should have no active message subscription [message-name: 'expected', correlation-key: 'correlation-key'], but the following subscriptions were active:\n"
-                  + "\t- name: 'expected', correlation-key: 'correlation-key'");
+              "Process instance [key: 1] should have no active message subscription [message-name: 'expected', correlation-key: 'correlation-key'], but found <1> active subscriptions.");
     }
   }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -1021,7 +1021,10 @@ public class ProcessInstanceAssertTest {
       when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
           .thenReturn(
               Collections.singletonList(
-                  new MessageSubscriptionImpl(new MessageSubscriptionResult())));
+                  new MessageSubscriptionImpl(
+                      new MessageSubscriptionResult()
+                          .messageName("expected")
+                          .correlationKey("correlation-key"))));
 
       // then
       Assertions.assertThatThrownBy(
@@ -1029,7 +1032,8 @@ public class ProcessInstanceAssertTest {
                   CamundaAssert.assertThatProcessInstance(processInstanceEvent)
                       .isNotWaitingForMessage("expected"))
           .hasMessage(
-              "Process instance [key: 1] has an active message subscription [message-name: 'expected'], but such a subscription was not expected.");
+              "Process instance [key: 1] should have no active message subscription [message-name: 'expected'], but the following subscriptions were active:\n"
+                  + "\t- name: 'expected', correlation-key: 'correlation-key'");
     }
 
     @Test
@@ -1045,7 +1049,10 @@ public class ProcessInstanceAssertTest {
       when(camundaDataSource.getMessageSubscriptions(filterCaptor.capture()))
           .thenReturn(
               Collections.singletonList(
-                  new MessageSubscriptionImpl(new MessageSubscriptionResult())));
+                  new MessageSubscriptionImpl(
+                      new MessageSubscriptionResult()
+                          .messageName("expected")
+                          .correlationKey("correlation-key"))));
 
       // then
       Assertions.assertThatThrownBy(
@@ -1053,7 +1060,8 @@ public class ProcessInstanceAssertTest {
                   CamundaAssert.assertThatProcessInstance(processInstanceEvent)
                       .isNotWaitingForMessage("expected", "correlation-key"))
           .hasMessage(
-              "Process instance [key: 1] has an active message subscription [message-name: 'expected', correlation-key: 'correlation-key'], but such a subscription was not expected.");
+              "Process instance [key: 1] should have no active message subscription [message-name: 'expected', correlation-key: 'correlation-key'], but the following subscriptions were active:\n"
+                  + "\t- name: 'expected', correlation-key: 'correlation-key'");
     }
   }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -1082,7 +1082,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getCorrelatedMessages(filterCaptor.capture()))
+      when(camundaDataSource.findCorrelatedMessages(filterCaptor.capture()))
           .thenReturn(
               Collections.singletonList(new CorrelatedMessageImpl(new CorrelatedMessageResult())));
 
@@ -1104,7 +1104,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getCorrelatedMessages(filterCaptor.capture()))
+      when(camundaDataSource.findCorrelatedMessages(filterCaptor.capture()))
           .thenReturn(
               Collections.singletonList(new CorrelatedMessageImpl(new CorrelatedMessageResult())));
 
@@ -1130,7 +1130,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getCorrelatedMessages(filterCaptor.capture()))
+      when(camundaDataSource.findCorrelatedMessages(filterCaptor.capture()))
           .thenReturn(Collections.emptyList())
           .thenReturn(Collections.emptyList())
           .thenReturn(Collections.emptyList())
@@ -1156,7 +1156,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getCorrelatedMessages(filterCaptor.capture()))
+      when(camundaDataSource.findCorrelatedMessages(filterCaptor.capture()))
           .thenReturn(Collections.emptyList());
 
       // then
@@ -1178,7 +1178,7 @@ public class ProcessInstanceAssertTest {
 
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
-      when(camundaDataSource.getCorrelatedMessages(filterCaptor.capture()))
+      when(camundaDataSource.findCorrelatedMessages(filterCaptor.capture()))
           .thenReturn(Collections.emptyList());
 
       // then

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/MessageSubscriptionBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/MessageSubscriptionBuilder.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.utils;
+
+import io.camunda.client.api.search.enums.MessageSubscriptionState;
+import io.camunda.client.api.search.response.MessageSubscription;
+
+public class MessageSubscriptionBuilder implements MessageSubscription {
+
+  private Long messageSubscriptionKey;
+  private String processDefinitionId;
+  private Long processDefinitionKey;
+  private Long processInstanceKey;
+  private String elementId;
+  private Long elementInstanceKey;
+  private String lastUpdatedDate;
+  private String messageName;
+  private String correlationKey;
+  private String tenantId;
+  private MessageSubscriptionState messageSubscriptionState;
+
+  @Override
+  public Long getMessageSubscriptionKey() {
+    return messageSubscriptionKey;
+  }
+
+  @Override
+  public String getProcessDefinitionId() {
+    return processDefinitionId;
+  }
+
+  @Override
+  public Long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  @Override
+  public Long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  @Override
+  public String getElementId() {
+    return elementId;
+  }
+
+  @Override
+  public Long getElementInstanceKey() {
+    return elementInstanceKey;
+  }
+
+  @Override
+  public MessageSubscriptionState getMessageSubscriptionState() {
+    return messageSubscriptionState;
+  }
+
+  @Override
+  public String getLastUpdatedDate() {
+    return lastUpdatedDate;
+  }
+
+  @Override
+  public String getMessageName() {
+    return messageName;
+  }
+
+  @Override
+  public String getCorrelationKey() {
+    return correlationKey;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public MessageSubscriptionBuilder setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setCorrelationKey(final String correlationKey) {
+    this.correlationKey = correlationKey;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setMessageName(final String messageName) {
+    this.messageName = messageName;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setLastUpdatedDate(final String lastUpdatedDate) {
+    this.lastUpdatedDate = lastUpdatedDate;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setMessageSubscriptionState(
+      final MessageSubscriptionState messageSubscriptionState) {
+    this.messageSubscriptionState = messageSubscriptionState;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setElementInstanceKey(final Long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setElementId(final String elementId) {
+    this.elementId = elementId;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setProcessInstanceKey(final Long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setProcessDefinitionKey(final Long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setProcessDefinitionId(final String processDefinitionId) {
+    this.processDefinitionId = processDefinitionId;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setMessageSubscriptionKey(final Long messageSubscriptionKey) {
+    this.messageSubscriptionKey = messageSubscriptionKey;
+    return this;
+  }
+
+  public MessageSubscription build() {
+    return this;
+  }
+
+  public static MessageSubscriptionBuilder newActiveMessageSubscription(
+      final String messageName, final String correlationKey) {
+    final MessageSubscriptionBuilder builder = new MessageSubscriptionBuilder();
+    builder.setMessageName(messageName);
+    builder.setCorrelationKey(correlationKey);
+    builder.setMessageSubscriptionState(MessageSubscriptionState.CREATED);
+    return builder;
+  }
+}


### PR DESCRIPTION
## Description

Some minor improvements for the message assertions. 

- Align the assertion failure messages
- Print the active message subscription in the test output
- Adjust the JavaDoc

## Related issues

follow-up of #23257, #23256
