### PR TITLE
fix: ensure completing retry of join request to a single member cluster

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -51,8 +51,7 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -86,6 +85,7 @@ public final class ControllableRaftContexts {
       new HashMap<>();
   private final Map<MemberId, DeterministicSingleThreadContext> deterministicExecutors =
       new HashMap<>();
+  private final Map<MemberId, CompletableFuture<?>> futuresToFailOnClose = new HashMap<>();
 
   private Path directory;
   private Random random;
@@ -126,12 +126,22 @@ public final class ControllableRaftContexts {
     if (nodeCount > 0) {
       createRaftContexts(nodeCount, random);
     }
-    joinRaftServers();
-    electionTimeout = getRaftContext(0).getElectionTimeout();
-    heartbeatTimeout = getRaftContext(0).getHeartbeatInterval();
+    bootstrapAllRaftServers();
+  }
 
-    // expecting 0 to be the leader
-    tickHeartbeatTimeout(0);
+  public void setup(
+      final Path directory, final Random random, final Collection<Integer> bootstrapServerIds)
+      throws Exception {
+    this.directory = directory;
+    this.random = random;
+    if (nodeCount > 0) {
+      createRaftContexts(nodeCount, random);
+    }
+    final var bootstrapMembers =
+        bootstrapServerIds.stream()
+            .map(i -> MemberId.from(String.valueOf(i)))
+            .collect(Collectors.toSet());
+    bootstrapRaftServers(bootstrapMembers);
   }
 
   public void shutdown() throws IOException {
@@ -148,15 +158,23 @@ public final class ControllableRaftContexts {
     MicrometerUtil.close(meterRegistry);
   }
 
-  private void joinRaftServers() throws InterruptedException, ExecutionException, TimeoutException {
+  private void bootstrapAllRaftServers()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    bootstrapRaftServers(raftServers.keySet());
+  }
+
+  private void bootstrapRaftServers(final Collection<MemberId> bootstrapServers)
+      throws ExecutionException, InterruptedException, TimeoutException {
     final Set<CompletableFuture<Void>> futures = new HashSet<>();
-    final var servers = getRaftServers();
-    final var serverIds = new ArrayList<>(servers.keySet());
+    final var servers =
+        getRaftServers().entrySet().stream()
+            .filter(e -> bootstrapServers.contains(e.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    servers.forEach(
+        (memberId, raftContext) ->
+            futures.add(raftContext.getCluster().bootstrap(bootstrapServers)));
     final long electionTimeout =
         servers.get(MemberId.from(String.valueOf(0))).getElectionTimeout().toMillis();
-    Collections.sort(serverIds);
-    servers.forEach(
-        (memberId, raftContext) -> futures.add(raftContext.getCluster().bootstrap(serverIds)));
 
     runUntilDone(0);
     // trigger election on 0 so that 0 is initially the leader
@@ -170,6 +188,12 @@ public final class ControllableRaftContexts {
       runUntilDone();
     }
     joinFuture.get(1, TimeUnit.SECONDS);
+
+    this.electionTimeout = getRaftContext(0).getElectionTimeout();
+    heartbeatTimeout = getRaftContext(0).getHeartbeatInterval();
+
+    // expecting 0 to be the leader
+    tickHeartbeatTimeout(0);
   }
 
   private void createRaftContexts(final int nodeCount, final Random random) {
@@ -379,18 +403,38 @@ public final class ControllableRaftContexts {
   }
 
   public void restart(final MemberId memberId) {
-    {
-      final var raftcontext = raftServers.get(memberId);
-      raftcontext.getThreadContext().execute(raftcontext::close);
-      runUntilDone(memberId);
-    }
+    final var raftcontext = raftServers.get(memberId);
+    raftcontext.getThreadContext().execute(raftcontext::close);
+    runUntilDone(memberId);
     deterministicExecutors.remove(memberId).close();
     snapshotStores.get(memberId).close();
     MicrometerUtil.close(meterRegistries.get(memberId));
+    futuresToFailOnClose.computeIfPresent(
+        memberId,
+        (ignore, future) -> {
+          future.completeExceptionally(new RuntimeException("Shutting down"));
+          return null;
+        });
+
     final var newContext = createRaftContextForMember(random, Integer.parseInt(memberId.id()));
     try (final var ignored = MDC.putCloseable("actor-scheduler", memberId.toString())) {
       newContext.getCluster().bootstrap(raftServers.keySet());
     }
+  }
+
+  public CompletableFuture<Void> join(
+      final MemberId memberId, final Collection<MemberId> otherMembers) {
+    final var raftcontext = raftServers.get(memberId);
+    raftcontext.getThreadContext().execute(raftcontext::close);
+    runUntilDone(memberId);
+
+    deterministicExecutors.remove(memberId).close();
+    snapshotStores.get(memberId).close();
+    MicrometerUtil.close(meterRegistries.get(memberId));
+    createRaftContextForMember(random, Integer.parseInt(memberId.id()));
+    final var future = raftServers.get(memberId).getCluster().join(otherMembers);
+    futuresToFailOnClose.put(memberId, future);
+    return future;
   }
 
   // This is a different from other operations, as it restarts the node and force operations on

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.EdgeCasesMode;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.PropertyDefaults;
+import net.jqwik.api.Provide;
+import net.jqwik.api.ShrinkingMode;
+import net.jqwik.api.lifecycle.AfterTry;
+import net.jqwik.api.lifecycle.BeforeProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@PropertyDefaults(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+public class RandomizedRaftJoinTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RandomizedRaftJoinTest.class);
+  private static final int OPERATION_SIZE = 1000;
+
+  private ControllableRaftContexts raftContexts;
+  private Path raftDataDirectory;
+  private MemberId member0;
+  private MemberId member1;
+  private List<RaftOperation> operationsWithRestarts;
+
+  @BeforeProperty
+  public void initMembers() {
+    // Initialize the two member IDs for the 2-node cluster
+    member0 = MemberId.from("0");
+    member1 = MemberId.from("1");
+    // Create ControllableRaftContexts with 2 nodes
+    raftContexts = new ControllableRaftContexts(2);
+    operationsWithRestarts = RaftOperation.getRaftOperationsWithRestarts();
+  }
+
+  @AfterTry
+  public void shutDownRaftNodes() throws IOException {
+    if (raftContexts != null) {
+      raftContexts.shutdown();
+    }
+    if (raftDataDirectory != null) {
+      FileUtil.deleteFolder(raftDataDirectory);
+      raftDataDirectory = null;
+    }
+  }
+
+  @Property
+  void joinCompletes(
+      @ForAll("raftOperations") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
+    setUpRaftNodes(new Random(seed));
+
+    var joinFuture = raftContexts.join(member1, Set.of(member0));
+
+    // given - when there are failures such as message loss
+    final var memberIter = raftMembers.iterator();
+    for (final RaftOperation operation : raftOperations) {
+      final MemberId member = memberIter.next();
+      LOG.info("{} on {}", operation, member);
+      operation.run(raftContexts, member);
+      if (joinFuture.isCompletedExceptionally()) {
+        // retry join
+        LOG.info("Join failed. Retrying...");
+        joinFuture = raftContexts.join(member1, Set.of(member0));
+      }
+    }
+
+    raftContexts.runUntilDone();
+    raftContexts.processAllMessage();
+    raftContexts.tickHeartbeatTimeout();
+
+    // when - no more message loss or restarts
+
+    LOG.info("Stopping failures, waiting for join to complete");
+
+    // hoping that 2000 iterations are enough to complete the join process
+    int maxStepsToReplicateEntries = 10100;
+    while (!((joinFuture.isDone() && !joinFuture.isCompletedExceptionally())
+            && raftContexts.allMembersAreReady()
+            && raftContexts.hasLeaderAtTheLatestTerm())
+        && maxStepsToReplicateEntries-- > 0) {
+
+      if (joinFuture.isCompletedExceptionally()) {
+        // retry join
+        LOG.info("Join failed. Retrying...");
+        joinFuture = raftContexts.join(member1, Set.of(member0));
+      }
+
+      raftContexts.runUntilDone();
+      raftContexts.processAllMessage();
+      raftContexts.tickHeartbeatTimeout();
+    }
+
+    // then
+    assertThat(joinFuture).describedAs("Join of member 1 should be completed").isCompleted();
+    assertThat(raftContexts.hasLeaderAtTheLatestTerm()).describedAs("There is a leader").isTrue();
+    raftContexts.assertAllMembersAreReady();
+  }
+
+  private void setUpRaftNodes(final Random random) throws Exception {
+    // Create temporary directory for raft data
+    raftDataDirectory = Files.createTempDirectory(null);
+
+    // Bootstrap only with member 0 (single node cluster initially)
+    raftContexts.setup(raftDataDirectory, random, Set.of(0));
+
+    LOG.info("Set up 2-node raft cluster, bootstrapped with member 0 only");
+  }
+
+  @Provide
+  Arbitrary<List<RaftOperation>> raftOperations() {
+    final var operation = Arbitraries.of(operationsWithRestarts);
+    return operation.list().ofSize(OPERATION_SIZE);
+  }
+
+  @Provide
+  Arbitrary<List<MemberId>> raftMembers() {
+    final var members = Arbitraries.of(member0, member1);
+    return members.list().ofSize(OPERATION_SIZE);
+  }
+
+  @Provide
+  Arbitrary<Long> seeds() {
+    return Arbitraries.longs();
+  }
+}


### PR DESCRIPTION
## Description

Added a randomized test for joining a new member to an single member cluster. This tests identified several scenarios where a  retry of join would not complete. 

The fixes includes the following: 
1. The joining member starts in a PASSIVE role to ensure it can respond to requests from the other member. This is required when the other member has started the re-configure process, but this member did not receive the entries to commit before the restart.
2. If the joining member has already partially or fully committed the configuration changes, then on restart it should start with that configuration to ensure that it is an active member of the cluster so that the other member can become the leader and complete the re-configuration process. 
3. The leader should identify duplicate join request instead of failing the request. This is required so that the joining member stays active to complete the re-configuration steps.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37892 
