### PR TITLE
feat: enable partition scaling feature by default

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
@@ -164,16 +164,6 @@ final class FeatureFlagsCfgTest {
   }
 
   @Test
-  void shouldDisablePartitionScalingByDefault() {
-    // when
-    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
-    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
-
-    // then
-    assertThat(featureFlagsCfg.isEnablePartitionScaling()).isFalse();
-  }
-
-  @Test
   void shouldSetEnablePartitionScalingFromConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -45,7 +45,7 @@ public final class FeatureFlags {
   private static final boolean ENABLE_MSG_TTL_CHECKER_ASYNC = false;
   private static final boolean ENABLE_DUE_DATE_CHECKER_ASYNC = false;
   private static final boolean ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR = true;
-  private static final boolean ENABLE_PARTITION_SCALING = false;
+  private static final boolean ENABLE_PARTITION_SCALING = true;
   private static final boolean ENABLE_IDENTITY_SETUP = true;
   private static final boolean ENABLE_MESSAGE_BODY_ON_EXPIRED = false;
 

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
@@ -22,7 +22,7 @@ class FeatureFlagsTest {
     assertThat(sut.yieldingDueDateChecker()).isTrue();
     assertThat(sut.enableActorMetrics()).isFalse();
     assertThat(sut.enableMessageTTLCheckerAsync()).isFalse();
-    assertThat(sut.enablePartitionScaling()).isFalse();
+    assertThat(sut.enablePartitionScaling()).isTrue();
     assertThat(sut.enableMessageBodyOnExpired()).isFalse();
   }
 


### PR DESCRIPTION
## Description

Enable partition scaling by default. We want to ship this feature by default in 8.8. The feature flag will be removed later.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #34197 
