### PR TITLE
[Backport stable/8.8] Fix unassign group from tenant command to follow the agreed pattern

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2190,15 +2190,15 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newUnassignGroupFromTenantCommand(tenantId)
-   *   .groupId(groupId)
+   *   .newUnassignGroupFromTenantCommand()
+   *   .groupId("groupId")
+   *   .tenantId("tenantId")
    *   .send();
    * </pre>
    *
-   * @param tenantId the unique identifier of the tenant
    * @return a builder to configure and send the unassign group from tenant command
    */
-  UnassignGroupFromTenantCommandStep1 newUnassignGroupFromTenantCommand(String tenantId);
+  UnassignGroupFromTenantCommandStep1 newUnassignGroupFromTenantCommand();
 
   /**
    * Command to assign a client to a group.

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignGroupFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignGroupFromTenantCommandStep1.java
@@ -17,15 +17,28 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.UnassignGroupFromTenantResponse;
 
-public interface UnassignGroupFromTenantCommandStep1
-    extends FinalCommandStep<UnassignGroupFromTenantResponse> {
+public interface UnassignGroupFromTenantCommandStep1 {
 
   /**
    * Sets the group ID for the unassignment.
    *
    * @param groupId the ID of the group
-   * @return the builder for this command. Call {@link #send()} to complete the command and send it
-   *     to the broker.
+   * @return the builder for this command.
    */
-  UnassignGroupFromTenantCommandStep1 groupId(String groupId);
+  UnassignGroupFromTenantCommandStep2 groupId(String groupId);
+
+  interface UnassignGroupFromTenantCommandStep2 {
+
+    /**
+     * Sets the tenant ID.
+     *
+     * @param tenantId the ID of the tenant
+     * @return the builder for this command. Call {@link UnassignGroupFromTenantCommandStep3#send()}
+     *     to complete the command and send it to the broker.
+     */
+    UnassignGroupFromTenantCommandStep3 tenantId(String tenantId);
+  }
+
+  interface UnassignGroupFromTenantCommandStep3
+      extends FinalCommandStep<UnassignGroupFromTenantResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -1178,9 +1178,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public UnassignGroupFromTenantCommandStep1 newUnassignGroupFromTenantCommand(
-      final String tenantId) {
-    return new UnassignGroupFromTenantCommandImpl(httpClient, tenantId);
+  public UnassignGroupFromTenantCommandStep1 newUnassignGroupFromTenantCommand() {
+    return new UnassignGroupFromTenantCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignGroupFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignGroupFromTenantCommandImpl.java
@@ -18,6 +18,8 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignGroupFromTenantCommandStep1;
+import io.camunda.client.api.command.UnassignGroupFromTenantCommandStep1.UnassignGroupFromTenantCommandStep2;
+import io.camunda.client.api.command.UnassignGroupFromTenantCommandStep1.UnassignGroupFromTenantCommandStep3;
 import io.camunda.client.api.response.UnassignGroupFromTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -27,21 +29,29 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class UnassignGroupFromTenantCommandImpl
-    implements UnassignGroupFromTenantCommandStep1 {
+    implements UnassignGroupFromTenantCommandStep1,
+        UnassignGroupFromTenantCommandStep2,
+        UnassignGroupFromTenantCommandStep3 {
+
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
-  private final String tenantId;
+  private String tenantId;
   private String groupId;
 
-  public UnassignGroupFromTenantCommandImpl(final HttpClient httpClient, final String tenantId) {
+  public UnassignGroupFromTenantCommandImpl(final HttpClient httpClient) {
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
-    this.tenantId = tenantId;
   }
 
   @Override
-  public UnassignGroupFromTenantCommandStep1 groupId(final String groupId) {
+  public UnassignGroupFromTenantCommandStep2 groupId(final String groupId) {
     this.groupId = groupId;
+    return this;
+  }
+
+  @Override
+  public UnassignGroupFromTenantCommandStep3 tenantId(final String tenantId) {
+    this.tenantId = tenantId;
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/tenant/UnassignGroupFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/UnassignGroupFromTenantTest.java
@@ -33,7 +33,7 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
   @Test
   void shouldUnassignGroupFromTenant() {
     // when
-    client.newUnassignGroupFromTenantCommand(TENANT_ID).groupId(GROUP_ID).send().join();
+    client.newUnassignGroupFromTenantCommand().groupId(GROUP_ID).tenantId(TENANT_ID).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
@@ -51,7 +51,12 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
     // when / then
     assertThatThrownBy(
             () ->
-                client.newUnassignGroupFromTenantCommand(TENANT_ID).groupId(GROUP_ID).send().join())
+                client
+                    .newUnassignGroupFromTenantCommand()
+                    .groupId(GROUP_ID)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -66,7 +71,12 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
     // when / then
     assertThatThrownBy(
             () ->
-                client.newUnassignGroupFromTenantCommand(TENANT_ID).groupId(GROUP_ID).send().join())
+                client
+                    .newUnassignGroupFromTenantCommand()
+                    .groupId(GROUP_ID)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -81,7 +91,12 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
     // when / then
     assertThatThrownBy(
             () ->
-                client.newUnassignGroupFromTenantCommand(TENANT_ID).groupId(GROUP_ID).send().join())
+                client
+                    .newUnassignGroupFromTenantCommand()
+                    .groupId(GROUP_ID)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -96,7 +111,12 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
     // when / then
     assertThatThrownBy(
             () ->
-                client.newUnassignGroupFromTenantCommand(TENANT_ID).groupId(GROUP_ID).send().join())
+                client
+                    .newUnassignGroupFromTenantCommand()
+                    .groupId(GROUP_ID)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
@@ -64,7 +64,12 @@ class UnassignGroupFromTenantTest {
   void shouldUnassignGroupFromTenant() {
     // when
     final UnassignGroupFromTenantResponse response =
-        client.newUnassignGroupFromTenantCommand(tenantId).groupId(groupId).send().join();
+        client
+            .newUnassignGroupFromTenantCommand()
+            .groupId(groupId)
+            .tenantId(tenantId)
+            .send()
+            .join();
 
     // then
     assertThat(response).isNotNull().isInstanceOf(UnassignGroupFromTenantResponse.class);
@@ -85,8 +90,9 @@ class UnassignGroupFromTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignGroupFromTenantCommand(nonExistentTenantId)
+                    .newUnassignGroupFromTenantCommand()
                     .groupId(groupId)
+                    .tenantId(nonExistentTenantId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -108,7 +114,12 @@ class UnassignGroupFromTenantTest {
         .join();
 
     // when
-    client.newUnassignGroupFromTenantCommand(tenantId).groupId(nonExistentGroupId).send().join();
+    client
+        .newUnassignGroupFromTenantCommand()
+        .groupId(nonExistentGroupId)
+        .tenantId(tenantId)
+        .send()
+        .join();
 
     // then
     ZeebeAssertHelper.assertGroupUnassignedFromTenant(
@@ -129,8 +140,9 @@ class UnassignGroupFromTenantTest {
             () ->
                 client
                     // Group key is not assigned
-                    .newUnassignGroupFromTenantCommand(tenantId)
+                    .newUnassignGroupFromTenantCommand()
                     .groupId(nonAssignedGroupId)
+                    .tenantId(tenantId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -144,7 +156,13 @@ class UnassignGroupFromTenantTest {
   void shouldRejectIfMissingTenantId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUnassignGroupFromTenantCommand(null).groupId(groupId).send().join())
+            () ->
+                client
+                    .newUnassignGroupFromTenantCommand()
+                    .groupId(groupId)
+                    .tenantId(null)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be null");
   }
@@ -153,7 +171,13 @@ class UnassignGroupFromTenantTest {
   void shouldRejectIfEmptyTenantId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUnassignGroupFromTenantCommand("").groupId(groupId).send().join())
+            () ->
+                client
+                    .newUnassignGroupFromTenantCommand()
+                    .groupId(groupId)
+                    .tenantId("")
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be empty");
   }
@@ -162,7 +186,13 @@ class UnassignGroupFromTenantTest {
   void shouldRejectIfMissingGroupId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUnassignGroupFromTenantCommand(tenantId).groupId(null).send().join())
+            () ->
+                client
+                    .newUnassignGroupFromTenantCommand()
+                    .groupId(null)
+                    .tenantId(tenantId)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("groupId must not be null");
   }
@@ -171,7 +201,13 @@ class UnassignGroupFromTenantTest {
   void shouldRejectIfEmptyGroupId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUnassignGroupFromTenantCommand(tenantId).groupId("").send().join())
+            () ->
+                client
+                    .newUnassignGroupFromTenantCommand()
+                    .groupId("")
+                    .tenantId(tenantId)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("groupId must not be empty");
   }


### PR DESCRIPTION
# Description
Backport of #37835 to `stable/8.8`.

relates to #37871