### PR TITLE
Run archunit tests in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -909,7 +909,7 @@ jobs:
 
   archunit-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    name: "General - ArchUnit Tests"
+    name: "General / Unit - ArchUnit"
     needs: [ detect-changes ]
     timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
@@ -954,7 +954,7 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
-          name: "General - ArchUnit Tests"
+          name: "General / Unit - ArchUnit"
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -907,6 +907,71 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  archunit-tests:
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    name: "General - ArchUnit Tests"
+    needs: [ detect-changes ]
+    timeout-minutes: 10
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    runs-on: gcp-perf-core-16-default
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: archunit-tests
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -Dquickly
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
+      - name: Maven Test Build
+        shell: bash
+        # Modules in zeebe, operate, tasklist, and optimize are skipped as they have dedicated unit test jobs
+        #
+        # we use the verify goal here as flaky test extraction is bound to the post-integration-test
+        # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
+        run: >
+          ./mvnw -B --no-snapshot-updates
+          -D skipITs -D skipQaBuild=false -D skipChecks
+          -P skipFrontendBuild
+          -pl :camunda-archunit-tests
+          -am
+          -Dtest='*ArchTest'
+          -Dsurefire.failIfNoSpecifiedTests=false
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      # TODO: We edited the job up until the point. The remainder is copied from the general UTs still
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
+        with:
+          name: "General - [UT]"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: "General"
+          detailed_junit_flaky_tests: true
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+
   docker-checks:
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true'
     name: "Docker / Tool / Checks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -942,8 +942,8 @@ jobs:
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
         run: >
           ./mvnw -B --no-snapshot-updates
-          -D skipITs -D skipQaBuild=false -D skipChecks
-          -P skipFrontendBuild
+          -D skipITs -D skipQaBuild=false -D skipChecks -Dsurefire.rerunFailingTestsCount=3
+          -P skipFrontendBuild,extract-flaky-tests
           -pl :camunda-archunit-tests
           -am
           -Dtest='*ArchTest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -946,7 +946,6 @@ jobs:
           -Dsurefire.failIfNoSpecifiedTests=false
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
-      # TODO: We edited the job up until the point. The remainder is copied from the general UTs still
       - name: Analyze Test Runs
         id: analyze-test-run
         if: always()
@@ -957,7 +956,7 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
-          name: "General - [UT]"
+          name: "General - ArchUnit Tests"
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1291,6 +1291,7 @@ jobs:
       checks: read
     needs: # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
+      - archunit-tests
       - build-platform-frontend
       - client-components
       - commitlint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -932,8 +932,6 @@ jobs:
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build
         shell: bash
-        # Modules in zeebe, operate, tasklist, and optimize are skipped as they have dedicated unit test jobs
-        #
         # we use the verify goal here as flaky test extraction is bound to the post-integration-test
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
         run: >
@@ -969,7 +967,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
 
   docker-checks:
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ defaults:
 env:
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
-  TEST_PRODUCT: Camunda
 
 jobs:
   detect-changes:
@@ -917,6 +916,7 @@ jobs:
     runs-on: gcp-perf-core-16-default
     env:
       TEST_OWNER: General
+      TEST_PRODUCT: Camunda
       TEST_TYPE: Unit
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ defaults:
 env:
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
+  TEST_PRODUCT: Camunda
 
 jobs:
   detect-changes:
@@ -914,10 +915,15 @@ jobs:
     timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
+    env:
+      TEST_OWNER: General
+      TEST_TYPE: Unit
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
       - uses: actions/checkout@v4
+      - name: Log Test Details
+        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
       - uses: ./.github/actions/setup-build
         with:
           maven-cache-key-modifier: archunit-tests

--- a/qa/archunit-tests/src/test/java/io/camunda/ArchTestsArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/ArchTestsArchTest.java
@@ -21,7 +21,9 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 /**
  * ArchUnit rules related to arch tests themselves.
  *
- * <p>Checks proper naming conventions and placement of arch test classes and fields.
+ * <p>We require arch tests to be named *ArchTest and be located in the qa/archunit-tests module.
+ * Other tests should not be named *ArchTest. This ensures that we can easily identify arch tests by
+ * name when running them in CI.
  */
 @AnalyzeClasses(packages = "io.camunda", importOptions = ImportOption.OnlyIncludeTests.class)
 public final class ArchTestsArchTest {

--- a/qa/archunit-tests/src/test/java/io/camunda/ArchTestsArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/ArchTestsArchTest.java
@@ -21,7 +21,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 /**
  * ArchUnit rules related to arch tests themselves.
  *
- * Checks proper naming conventions and placement of arch test classes and fields.
+ * <p>Checks proper naming conventions and placement of arch test classes and fields.
  */
 @AnalyzeClasses(packages = "io.camunda", importOptions = ImportOption.OnlyIncludeTests.class)
 public final class ArchTestsArchTest {
@@ -52,9 +52,11 @@ public final class ArchTestsArchTest {
                 public void check(final JavaClass item, final ConditionEvents events) {
                   if (item.getFields().stream()
                       .noneMatch(field -> field.isAnnotatedWith(ArchTest.class))) {
-                    events.add(violated(item,
-                        String.format("Class '%s' does not contain arch tests",
-                            item.getSimpleName())));
+                    events.add(
+                        violated(
+                            item,
+                            String.format(
+                                "Class '%s' does not contain arch tests", item.getSimpleName())));
                   }
                 }
               })
@@ -71,9 +73,12 @@ public final class ArchTestsArchTest {
                 public void check(final JavaClass item, final ConditionEvents events) {
                   final String classPath = item.getSource().get().getUri().getPath();
                   if (!classPath.contains(QA_MODULE_PATH)) {
-                    events.add(violated(item,
-                        String.format("Class '%s' located in '%s' instead of inside '%s'",
-                            item.getSimpleName(), classPath, QA_MODULE_PATH)));
+                    events.add(
+                        violated(
+                            item,
+                            String.format(
+                                "Class '%s' located in '%s' instead of inside '%s'",
+                                item.getSimpleName(), classPath, QA_MODULE_PATH)));
                   }
                 }
               })

--- a/qa/archunit-tests/src/test/java/io/camunda/ArchTestsArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/ArchTestsArchTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+
+/**
+ * ArchUnit rules related to arch tests themselves.
+ *
+ * Checks proper naming conventions and placement of arch test classes and fields.
+ */
+@AnalyzeClasses(packages = "io.camunda", importOptions = ImportOption.OnlyIncludeTests.class)
+public final class ArchTestsArchTest {
+
+  /** Matches any class name that ends with "ArchTest". */
+  static final String NAMING_CONVENTION = ".*ArchTest$";
+
+  static final String QA_MODULE_PATH = "qa/archunit-tests";
+
+  @ArchTest
+  static final ArchRule REQUIRE_ARCH_TESTS_TO_BE_IN_CLASSES_NAMED_ARCH_TEST =
+      ArchRuleDefinition.fields()
+          .that()
+          .areAnnotatedWith(ArchTest.class)
+          .should()
+          .beDeclaredInClassesThat()
+          .haveNameMatching(NAMING_CONVENTION)
+          .because("Arch tests should only be declared in classes named *ArchTest");
+
+  @ArchTest
+  static final ArchRule REQUIRE_CLASSES_NAMED_ARCH_TEST_TO_ACTUALLY_BE_ARCH_TESTS =
+      ArchRuleDefinition.classes()
+          .that()
+          .haveNameMatching(NAMING_CONVENTION)
+          .should(
+              new ArchCondition<>("contain at least one field annotated @ArchTest") {
+                @Override
+                public void check(final JavaClass item, final ConditionEvents events) {
+                  if (item.getFields().stream()
+                      .noneMatch(field -> field.isAnnotatedWith(ArchTest.class))) {
+                    events.add(violated(item,
+                        String.format("Class '%s' does not contain arch tests",
+                            item.getSimpleName())));
+                  }
+                }
+              })
+          .because("Classes named *ArchTest should actually contain arch tests");
+
+  @ArchTest
+  static final ArchRule REQUIRE_ARCH_TESTS_TO_BE_IN_THE_QA_MODULE =
+      ArchRuleDefinition.classes()
+          .that()
+          .haveNameMatching(NAMING_CONVENTION)
+          .should(
+              new ArchCondition<>("belong to class named *ArchTest") {
+                @Override
+                public void check(final JavaClass item, final ConditionEvents events) {
+                  final String classPath = item.getSource().get().getUri().getPath();
+                  if (!classPath.contains(QA_MODULE_PATH)) {
+                    events.add(violated(item,
+                        String.format("Class '%s' located in '%s' instead of inside '%s'",
+                            item.getSimpleName(), classPath, QA_MODULE_PATH)));
+                  }
+                }
+              })
+          .because("Arch tests should be located in the camunda-archunit-tests module");
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We have added a new job to the ci.yml. The job is supposed to run the tests in the archunit package of the qa module.

A challenge here is that these archunit tests should run against the whole codebase. As a result we must build the entire codebase (`-am` flag), yet we only want to run the archunit tests (`-Dtest='*ArchTest'`). The downside of this -Dtest
 flag is that all archunit tests must follow this naming pattern. On a positive note, this will ensure that archunit
 tests in a different module that follow this naming pattern still get run.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37176
