### PR TITLE
fix: synthesize missing ruleId to prevent NPE during decision evaluation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -33,9 +33,12 @@ import io.camunda.zeebe.util.collection.Tuple;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DecisionBehavior {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(DecisionBehavior.class);
   private static final DecisionInfo UNKNOWN_DECISION_INFO = new DecisionInfo(-1L, -1);
   private static final String SYNTHESIZED_RULE_ID_PREFIX = "ZB_SYNTH_RULE_ID";
   private static final String SYNTHESIZED_RULE_ID_TEMPLATE = "%s_%s_v%s_r%s";
@@ -233,12 +236,24 @@ public class DecisionBehavior {
       final MatchedRule matchedRule, final EvaluatedDecisionRecord evaluatedDecisionRecord) {
 
     final var matchedRuleRecord = evaluatedDecisionRecord.matchedRules().add();
+    final boolean ruleIdMissing = StringUtils.isBlank(matchedRule.ruleId());
     final var ruleId =
         getOrSynthesizeRuleId(
             evaluatedDecisionRecord.getDecisionId(),
             evaluatedDecisionRecord.getDecisionVersion(),
             matchedRule);
     matchedRuleRecord.setRuleId(ruleId).setRuleIndex(matchedRule.ruleIndex());
+
+    if (ruleIdMissing) {
+      LOGGER.warn(
+          "DMN evaluation: matched rule without id in decision '{}' (version {}, rule index {}). "
+              + "Synthesized surrogate ruleId '{}'. "
+              + "To eliminate this warning, add an 'id' attribute to the <rule> and deploy a new DMN version.",
+          evaluatedDecisionRecord.getDecisionId(),
+          evaluatedDecisionRecord.getDecisionVersion(),
+          matchedRule.ruleIndex(),
+          ruleId);
+    }
 
     matchedRule
         .evaluatedOutputs()

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-missing-ruleId.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-missing-ruleId.dmn
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  - Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  - one or more contributor license agreements. See the NOTICE file distributed
+  - with this work for additional information regarding copyright ownership.
+  - Licensed under the Camunda License 1.0. You may not use this file
+  - except in compliance with the Camunda License 1.0.
+  -->
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+  xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1whs8i1" name="DRD"
+  namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.36.1"
+  modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <decision id="shippingDecision" name="Shipping decision">
+    <decisionTable id="shippingTable" hitPolicy="FIRST">
+      <input id="Input_1" label="Amount">
+        <inputExpression id="InputExpression_1" typeRef="number">
+          <text>amount</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Shipping" name="shipping" typeRef="string">
+        <outputValues id="UnaryTests_0dlr7qd">
+          <text>"STANDARD","EXPRESS"</text>
+        </outputValues>
+      </output>
+      <!-- Rule with ID (safe) -->
+      <rule id="rule_1_standard">
+        <inputEntry id="UnaryTests_0upjivp">
+          <text>&lt;= 100</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1pkzjur">
+          <text>"STANDARD"</text>
+        </outputEntry>
+      </rule>
+      <!-- Rule WITHOUT id on purpose -->
+      <rule>
+        <inputEntry id="UnaryTests_1pqn5oz">
+          <text>&gt; 100</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_17do8e0">
+          <text>"EXPRESS"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="shipping_decision">
+        <dc:Bounds height="80" width="180" x="160" y="100"/>
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
## Description

This PR prevents a `NullPointerException` during `DecisionEvaluation` event construction when a matched decision-table rule lacks `ruleId`. The engine now synthesizes a deterministic, prefixed surrogate id and proceeds to emit the evaluation event.

### What changes for users
- Evaluations no longer fail with NPE if a rule is missing `ruleId`; events are written normally.
- A stable, engine-generated id is used for such rules:
  `ZB_SYNTH_RULE_ID_{decisionId}_v{decisionVersion}_r{ruleIndex}`.
- A WARN log is emitted to nudge model authors to add explicit rule ids and redeploy.

### Rationale
The model can still evaluate correctly; the failure previously happened only while building the `DecisionEvaluation` event. Synthesizing a deterministic id preserves observability and avoids breaking existing deployments, while signaling the misconfiguration via logs.

### Compatibility & backports
- No API or schema changes; behavior backward compatible.
- Safe to port to previous 8.x versions.

### Follow-up
A separate PR will add deployment-time DMN validation to reject decision tables with missing rule ids.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36900
