### PR TITLE
feat: add retention to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Retention.java
+++ b/configuration/src/main/java/io/camunda/configuration/Retention.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH;
+
+import java.util.Set;
+
+public class Retention {
+
+  private static final String PREFIX = "camunda.data.secondary-storage.retention";
+  private static final Set<String> LEGACY_ENABLED_PROPERTIES =
+      Set.of(
+          "camunda.database.retention.enabled",
+          "zeebe.broker.exporters.camundaexporter.args.history.retention.enabled");
+  private static final Set<String> LEGACY_MINIMUM_AGE_PROPERTIES =
+      Set.of(
+          "camunda.database.retention.minimumAge",
+          "zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge");
+
+  /** if true, the ILM Policy is created and applied to the index templates */
+  private boolean enabled = false;
+
+  /** defines how old the data must be, before the data is deleted as a duration */
+  private String minimumAge = "30d";
+
+  public boolean isEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enabled",
+        enabled,
+        Boolean.class,
+        SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_ENABLED_PROPERTIES);
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getMinimumAge() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".minimum-age",
+        minimumAge,
+        String.class,
+        SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_MINIMUM_AGE_PROPERTIES);
+  }
+
+  public void setMinimumAge(final String minimumAge) {
+    this.minimumAge = minimumAge;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
@@ -21,6 +21,9 @@ public class SecondaryStorage {
           "camunda.tasklist.database",
           "zeebe.broker.exporters.camundaexporter.args.connect.type");
 
+  /** Configuration for retention behavior */
+  private Retention retention = new Retention();
+
   /** Determines the type of the secondary storage database. */
   private SecondaryStorage.SecondaryStorageType type = SecondaryStorageType.elasticsearch;
 
@@ -29,6 +32,14 @@ public class SecondaryStorage {
 
   /** Stores the Elasticsearch configuration, when type is set to 'elasticsearch'. */
   private Opensearch opensearch = new Opensearch();
+
+  public Retention getRetention() {
+    return retention;
+  }
+
+  public void setRetention(final Retention retention) {
+    this.retention = retention;
+  }
 
   public SecondaryStorageType getType() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
@@ -39,7 +50,7 @@ public class SecondaryStorage {
         LEGACY_TYPE_PROPERTIES);
   }
 
-  public void setType(SecondaryStorageType type) {
+  public void setType(final SecondaryStorageType type) {
     this.type = type;
   }
 
@@ -47,7 +58,7 @@ public class SecondaryStorage {
     return elasticsearch;
   }
 
-  public void setElasticsearch(Elasticsearch elasticsearch) {
+  public void setElasticsearch(final Elasticsearch elasticsearch) {
     this.elasticsearch = elasticsearch;
   }
 
@@ -55,7 +66,7 @@ public class SecondaryStorage {
     return opensearch;
   }
 
-  public void setOpensearch(Opensearch opensearch) {
+  public void setOpensearch(final Opensearch opensearch) {
     this.opensearch = opensearch;
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -22,7 +22,6 @@ import io.camunda.configuration.PrimaryStorage;
 import io.camunda.configuration.S3;
 import io.camunda.configuration.SasToken;
 import io.camunda.configuration.SecondaryStorage;
-import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.SecondaryStorageDatabase;
 import io.camunda.configuration.Ssl;
 import io.camunda.configuration.UnifiedConfiguration;
@@ -500,14 +499,17 @@ public class BrokerBasedPropertiesOverride {
         unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
 
     final SecondaryStorageDatabase database;
-    if (SecondaryStorageType.elasticsearch == secondaryStorage.getType()) {
-      database =
-          unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getElasticsearch();
-    } else if (SecondaryStorageType.opensearch == secondaryStorage.getType()) {
-      database = unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getOpensearch();
-    } else {
-      // RDBMS and NONE are not supported.
-      return;
+    switch (secondaryStorage.getType()) {
+      case elasticsearch ->
+          database =
+              unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getElasticsearch();
+      case opensearch ->
+          database =
+              unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getOpensearch();
+      default -> {
+        // RDBMS and NONE are not supported.
+        return;
+      }
     }
 
     /* Load exporter config map */
@@ -533,6 +535,10 @@ public class BrokerBasedPropertiesOverride {
     // it is possible to have an exporter with no args defined
     final Map<String, Object> args =
         exporter.getArgs() == null ? new LinkedHashMap<>() : exporter.getArgs();
+
+    setArg(args, "history.retention.enabled", secondaryStorage.getRetention().isEnabled());
+    setArg(args, "history.retention.minimumAge", secondaryStorage.getRetention().getMinimumAge());
+
     setArg(args, "connect.type", secondaryStorage.getType().name());
     setArg(args, "connect.url", database.getUrl());
     setArg(args, "connect.clusterName", database.getClusterName());

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineRetentionPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineRetentionPropertiesOverride.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import io.camunda.configuration.Retention;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beans.LegacySearchEngineRetentionProperties;
+import io.camunda.configuration.beans.SearchEngineRetentionProperties;
+import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@EnableConfigurationProperties(LegacySearchEngineRetentionProperties.class)
+@DependsOn("unifiedConfigurationHelper")
+@ConditionalOnSecondaryStorageType({
+  SecondaryStorageType.elasticsearch,
+  SecondaryStorageType.opensearch
+})
+public class SearchEngineRetentionPropertiesOverride {
+
+  private final UnifiedConfiguration unifiedConfiguration;
+  private final LegacySearchEngineRetentionProperties legacySearchEngineRetentionProperties;
+
+  public SearchEngineRetentionPropertiesOverride(
+      @Autowired final UnifiedConfiguration unifiedConfiguration,
+      @Autowired
+          final LegacySearchEngineRetentionProperties legacySearchEngineRetentionProperties) {
+    this.unifiedConfiguration = unifiedConfiguration;
+    this.legacySearchEngineRetentionProperties = legacySearchEngineRetentionProperties;
+  }
+
+  @Bean
+  @Primary
+  public SearchEngineRetentionProperties searchEngineRetentionProperties() {
+    final SearchEngineRetentionProperties override = new SearchEngineRetentionProperties();
+    BeanUtils.copyProperties(legacySearchEngineRetentionProperties, override);
+
+    final Retention retention =
+        unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getRetention();
+
+    override.setEnabled(retention.isEnabled());
+    override.setMinimumAge(retention.getMinimumAge());
+
+    return override;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beans/LegacySearchEngineRetentionProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/LegacySearchEngineRetentionProperties.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.search.schema.config.RetentionConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("camunda.database.retention")
+public class LegacySearchEngineRetentionProperties extends RetentionConfiguration {}

--- a/configuration/src/main/java/io/camunda/configuration/beans/SearchEngineRetentionProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/SearchEngineRetentionProperties.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.search.schema.config.RetentionConfiguration;
+
+public class SearchEngineRetentionProperties extends RetentionConfiguration {}

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRetentionTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRetentionTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.beans.SearchEngineRetentionProperties;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.search.schema.config.RetentionConfiguration;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@ActiveProfiles({"broker"})
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  BrokerBasedPropertiesOverride.class,
+  SearchEngineRetentionPropertiesOverride.class
+})
+public class SecondaryStorageRetentionTest {
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.retention.enabled=true",
+        "camunda.data.secondary-storage.retention.minimum-age=60d",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerBasedProperties;
+    final SearchEngineRetentionProperties searchEngineRetentionProperties;
+
+    WithOnlyUnifiedConfigSet(
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final SearchEngineRetentionProperties searchEngineRetentionProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.searchEngineRetentionProperties = searchEngineRetentionProperties;
+    }
+
+    @Test
+    void testCamundaDataSecondaryStorageCamundaExporterProperties() {
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNotNull();
+
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToExporterConfiguration(args);
+      assertThat(exporterConfiguration.getHistory().getRetention())
+          .returns(true, RetentionConfiguration::isEnabled)
+          .returns("60d", RetentionConfiguration::getMinimumAge);
+    }
+
+    @Test
+    void testCamundaSearchEngineRetentionProperties() {
+      assertThat(searchEngineRetentionProperties)
+          .returns(true, SearchEngineRetentionProperties::isEnabled)
+          .returns("60d", SearchEngineRetentionProperties::getMinimumAge);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // enabled
+        "camunda.data.secondary-storage.retention.enabled=true",
+        "camunda.database.retention.enabled=true",
+        // minimum-age
+        "camunda.data.secondary-storage.retention.minimum-age=60d",
+        "camunda.database.retention.minimumAge=60d",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+    final SearchEngineRetentionProperties searchEngineRetentionProperties;
+
+    WithNewAndLegacySet(
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final SearchEngineRetentionProperties searchEngineRetentionProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.searchEngineRetentionProperties = searchEngineRetentionProperties;
+    }
+
+    @Test
+    void testCamundaDataSecondaryStorageCamundaExporterProperties() {
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNotNull();
+
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToExporterConfiguration(args);
+      assertThat(exporterConfiguration.getHistory().getRetention())
+          .returns(true, RetentionConfiguration::isEnabled)
+          .returns("60d", RetentionConfiguration::getMinimumAge);
+    }
+
+    @Test
+    void testCamundaSearchEngineRetentionProperties() {
+      assertThat(searchEngineRetentionProperties)
+          .returns(true, SearchEngineRetentionProperties::isEnabled)
+          .returns("60d", SearchEngineRetentionProperties::getMinimumAge);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -15,6 +15,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.webapps.backup.BackupRepository;
@@ -98,6 +99,7 @@ public class StandaloneBackupManager implements CommandLineRunner {
             UnifiedConfiguration.class,
             SearchEngineConnectPropertiesOverride.class,
             SearchEngineIndexPropertiesOverride.class,
+            SearchEngineRetentionPropertiesOverride.class,
             // ---
             BackupManagerConfiguration.class,
             StandaloneBackupManager.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBroker.java
@@ -17,6 +17,7 @@ import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import org.springframework.boot.SpringBootConfiguration;
 
@@ -39,6 +40,7 @@ public class StandaloneBroker {
                 IdleStrategyPropertiesOverride.class,
                 SearchEngineConnectPropertiesOverride.class,
                 SearchEngineIndexPropertiesOverride.class,
+                SearchEngineRetentionPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 GatewayRestPropertiesOverride.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -24,6 +24,7 @@ import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.identity.IdentityModuleConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
@@ -69,6 +70,7 @@ public class StandaloneCamunda {
                 GatewayRestPropertiesOverride.class,
                 SearchEngineConnectPropertiesOverride.class,
                 SearchEngineIndexPropertiesOverride.class,
+                SearchEngineRetentionPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 OperateModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneGateway.java
@@ -15,6 +15,7 @@ import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
 import org.springframework.boot.SpringBootConfiguration;
 
@@ -35,6 +36,7 @@ public class StandaloneGateway {
                 GatewayBasedPropertiesOverride.class,
                 SearchEngineConnectPropertiesOverride.class,
                 SearchEngineIndexPropertiesOverride.class,
+                SearchEngineRetentionPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 GatewayModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneOperate.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneOperate.java
@@ -18,6 +18,7 @@ import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import java.util.HashMap;
@@ -54,6 +55,7 @@ public class StandaloneOperate {
                 GatewayRestPropertiesOverride.class,
                 SearchEngineConnectPropertiesOverride.class,
                 SearchEngineIndexPropertiesOverride.class,
+                SearchEngineRetentionPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 OperateModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
@@ -15,6 +15,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beans.LegacyBrokerBasedProperties;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
@@ -86,6 +87,7 @@ public class StandaloneSchemaManager implements CommandLineRunner {
             UnifiedConfiguration.class,
             SearchEngineConnectPropertiesOverride.class,
             SearchEngineIndexPropertiesOverride.class,
+            SearchEngineRetentionPropertiesOverride.class,
             // ---
             StandaloneSchemaManagerConfiguration.class)
         .initializers(new StandaloneSchemaManagerInitializer())

--- a/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
@@ -17,6 +17,7 @@ import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -49,6 +50,7 @@ public class StandaloneTasklist {
                 GatewayRestPropertiesOverride.class,
                 SearchEngineConnectPropertiesOverride.class,
                 SearchEngineIndexPropertiesOverride.class,
+                SearchEngineRetentionPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 TasklistModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -7,15 +7,14 @@
  */
 package io.camunda.application.commons.search;
 
-import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineRetentionProperties;
 import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.configuration.beans.SearchEngineIndexProperties;
+import io.camunda.configuration.beans.SearchEngineRetentionProperties;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.connect.configuration.DatabaseType;
-import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.search.schema.config.SchemaManagerConfiguration;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.zeebe.broker.Broker;
@@ -34,7 +33,6 @@ import org.springframework.context.annotation.Configuration;
   SecondaryStorageType.opensearch
 })
 @EnableConfigurationProperties({
-  SearchEngineRetentionProperties.class,
   SearchEngineSchemaManagerProperties.class,
 })
 public class SearchEngineDatabaseConfiguration {
@@ -71,9 +69,6 @@ public class SearchEngineDatabaseConfiguration {
                 .retention(searchEngineRetentionProperties)
                 .schemaManager(searchEngineSchemaManagerProperties));
   }
-
-  @ConfigurationProperties("camunda.database.retention")
-  public static final class SearchEngineRetentionProperties extends RetentionConfiguration {}
 
   @ConfigurationProperties("camunda.database.schema-manager")
   public static final class SearchEngineSchemaManagerProperties extends SchemaManagerConfiguration {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
@@ -14,6 +14,7 @@ import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import org.springframework.boot.SpringApplication;
@@ -44,6 +45,7 @@ import org.springframework.context.annotation.Import;
   GatewayBasedPropertiesOverride.class,
   SearchEngineConnectPropertiesOverride.class,
   SearchEngineIndexPropertiesOverride.class,
+  SearchEngineRetentionPropertiesOverride.class
 })
 public class TestApplication {
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
@@ -14,6 +14,7 @@ import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.operate.util.TestApplication;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -53,6 +54,7 @@ import org.springframework.context.annotation.Import;
   UnifiedConfiguration.class,
   SearchEngineConnectPropertiesOverride.class,
   SearchEngineIndexPropertiesOverride.class,
+  SearchEngineRetentionPropertiesOverride.class,
   OperatePropertiesOverride.class,
   GatewayBasedPropertiesOverride.class,
   GatewayRestPropertiesOverride.class,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
@@ -87,7 +87,7 @@ final class StandaloneBackupManagerIT {
           .withProperty("camunda.database.password", ADMIN_PASSWORD)
           .withProperty("camunda.data.secondary-storage.elasticsearch.username", ADMIN_USER)
           .withProperty("camunda.data.secondary-storage.elasticsearch.password", ADMIN_PASSWORD)
-          .withProperty("camunda.database.retention.enabled", "true");
+          .withProperty("camunda.data.secondary-storage.retention.enabled", true);
 
   // Configure the Camunda single application with restricted access to the Elasticsearch
   @TestZeebe(autoStart = false)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
@@ -76,7 +76,7 @@ final class StandaloneSchemaManagerIT {
           .withProperty("camunda.database.password", ADMIN_PASSWORD)
           .withProperty("camunda.data.secondary-storage.elasticsearch.username", ADMIN_USER)
           .withProperty("camunda.data.secondary-storage.elasticsearch.password", ADMIN_PASSWORD)
-          .withProperty("camunda.database.retention.enabled", "true");
+          .withProperty("camunda.data.secondary-storage.retention.enabled", "true");
 
   @TestZeebe(autoStart = false)
   final TestCamundaApplication camunda =

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -23,6 +23,7 @@ import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.identity.IdentityModuleConfiguration;
@@ -77,6 +78,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         OperatePropertiesOverride.class,
         SearchEngineConnectPropertiesOverride.class,
         SearchEngineIndexPropertiesOverride.class,
+        SearchEngineRetentionPropertiesOverride.class,
         GatewayRestPropertiesOverride.class,
         // ---
         CommonsModuleConfiguration.class,

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
@@ -16,6 +16,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator.NoopHealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
@@ -34,6 +35,7 @@ public class TestStandaloneBackupManager
         UnifiedConfiguration.class,
         SearchEngineConnectPropertiesOverride.class,
         SearchEngineIndexPropertiesOverride.class,
+        SearchEngineRetentionPropertiesOverride.class,
         // ---
         BackupManagerConfiguration.class,
         StandaloneBackupManager.class);

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -95,6 +95,11 @@ public class MultiDbConfigurator {
     elasticsearchProperties.put("camunda.database.retention.minimumAge", "0s");
     elasticsearchProperties.put(CREATE_SCHEMA_PROPERTY, true);
 
+    /* Unified Config */
+    elasticsearchProperties.put(
+        "camunda.data.secondary-storage.retention.enabled", Boolean.toString(retentionEnabled));
+    elasticsearchProperties.put("camunda.data.secondary-storage.retention.minimum-age", "0s");
+
     testApplication.withAdditionalProperties(elasticsearchProperties);
 
     testApplication.withExporter(
@@ -215,6 +220,9 @@ public class MultiDbConfigurator {
     /* Unified Config */
     opensearchProperties.put("camunda.data.secondary-storage.opensearch.username", userName);
     opensearchProperties.put("camunda.data.secondary-storage.opensearch.password", userPassword);
+    opensearchProperties.put(
+        "camunda.data.secondary-storage.retention.enabled", Boolean.toString(retentionEnabled));
+    opensearchProperties.put("camunda.data.secondary-storage.retention.minimum-age", "0s");
 
     testApplication.withAdditionalProperties(opensearchProperties);
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModuleIntegrationTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModuleIntegrationTest.java
@@ -11,6 +11,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.apps.modules.ModulesTestApplication;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +29,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       UnifiedConfiguration.class,
       SearchEngineConnectPropertiesOverride.class,
       SearchEngineIndexPropertiesOverride.class,
+      SearchEngineRetentionPropertiesOverride.class
     },
     properties = {
       TasklistProperties.PREFIX + ".elasticsearch.createSchema = false",

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
@@ -14,6 +14,7 @@ import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
@@ -52,6 +53,7 @@ import org.springframework.context.annotation.Profile;
   GatewayBasedPropertiesOverride.class,
   SearchEngineConnectPropertiesOverride.class,
   SearchEngineIndexPropertiesOverride.class,
+  SearchEngineRetentionPropertiesOverride.class
 })
 public class TestApplication {
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -20,9 +20,11 @@ import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.configuration.beans.SearchEngineIndexProperties;
+import io.camunda.configuration.beans.SearchEngineRetentionProperties;
 import io.camunda.security.configuration.ConfiguredMappingRule;
 import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.security.configuration.InitializationConfiguration;
@@ -65,7 +67,8 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
         UnifiedConfiguration.class,
         GatewayRestPropertiesOverride.class,
         SearchEngineConnectPropertiesOverride.class,
-        SearchEngineIndexPropertiesOverride.class);
+        SearchEngineIndexPropertiesOverride.class,
+        SearchEngineRetentionPropertiesOverride.class);
 
     config = new BrokerBasedProperties();
 
@@ -339,6 +342,11 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
         "searchEngineIndexProperties",
         searchEngineIndexProperties,
         SearchEngineIndexProperties.class);
+    final var searchEngineRetentionProperties = new SearchEngineRetentionProperties();
+    withBean(
+        "searchEngineRetentionProperties",
+        searchEngineRetentionProperties,
+        SearchEngineRetentionProperties.class);
     // enable schema creation as ES is used in the current tests
     withCreateSchema(true);
     return this;

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -20,6 +20,7 @@ import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
@@ -46,6 +47,7 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
         IdleStrategyPropertiesOverride.class,
         SearchEngineConnectPropertiesOverride.class,
         SearchEngineIndexPropertiesOverride.class,
+        SearchEngineRetentionPropertiesOverride.class,
         // ---
         GatewayModuleConfiguration.class,
         CommonsModuleConfiguration.class);


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.data.secondary-storage.retention in unified config.

The legacy properties are:
camunda.database.retention.enabled
zeebe.broker.exporters.camundaexporter.args.history.retention.enabled
camunda.database.retention.minimumAge
zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge

The new properties are:
camunda.data.secondary-storage.retention.enabled
camunda.data.secondary-storage.retention.minimum-age

Backwards compatibility is supported only if new and legacy values match.

## Checklist

- [x] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [x] The new property fields are documented in the code
## Related issues

related to #34902 