### PR TITLE
Add conditional automated test instructions to Bug Report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -164,3 +164,26 @@ body:
       description: Add the support ticket- or other links here if applicable.
     validations:
       required: false
+  - type: textarea
+    id: automated-test-impact
+    attributes:
+      label: Automated Test Impact
+      description: |
+        Does this bug impact an automated test suite? If so:
+
+        **For the Cross Component Test Suite:**  
+        This issue breaks a test case in the Cross Component Test Suite [Add link to the respective test case here]. Before you consider the fix as done, please check if the respective test case passes. To trigger the full test suite, follow the directions here: [GitHub Actions for Testing](https://github.com/camunda/c8-cross-component-e2e-tests/blob/main/README.md#github-actions-for-testing).
+
+        **For the Orchestration Cluster Test Suite:**  
+        This issue breaks a test case in the C8 Orchestration Cluster Test Suite [Add link to the respective test case here]. The test suite can be triggered automatically via PRs.  
+
+        Note: PR-triggered test runs only cover the components affected by the PR. Cross-component flows, or flows involving other components, are executed only during nightly builds and release runs. To trigger the full test suite, follow the directions here: [GitHub Actions for Testing](https://github.com/camunda/camunda/blob/main/qa/c8-orchestration-cluster-e2e-test-suite/README.md#running-the-on-demand-workflow).
+
+        **General note:**  
+        The automated test cases on E2E level might not provide enough test coverage to verify if the fix works 100%. Ensure the fix is covered by a sufficient regression test. Conduct manual testing if required. Until this bug is fixed, the affected test will be skipped. Once the fix passes, create a PR in the respective test suite to re-enable the test.
+    validations:
+      required: false
+    conditions:
+      - field: labels
+        value: qa/automation-found
+

--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -183,7 +183,4 @@ body:
         The automated test cases on E2E level might not provide enough test coverage to verify if the fix works 100%. Ensure the fix is covered by a sufficient regression test. Conduct manual testing if required. Until this bug is fixed, the affected test will be skipped. Once the fix passes, create a PR in the respective test suite to re-enable the test.
     validations:
       required: false
-    conditions:
-      - field: labels
-        value: qa/automation-found
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

When reporting bugs which impact any of the automatedThis PR updates the Bug Report template to include a conditional Automated Test Impact field that appears only when the qa/automation-found label is applied.

The field provides guidance for:

Cross Component Test Suite

Orchestration Cluster Test Suite

Skipping/re-enabling affected tests

Links to trigger the full test suites

This ensures contributors are aware of automated test impacts only when relevant.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

