### PR TITLE
refactor: cleanup created users and roles after tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -67,7 +67,7 @@ class OperateProcessInstancePage {
     this.newVariableNameField = page.getByRole('textbox', {name: 'Name'});
     this.newVariableValueField = page.getByRole('textbox', {name: 'Value'});
     this.editVariableValueField = page.getByRole('textbox', {name: 'Value'});
-    this.variableSpinner = page.getByTestId('variable-operation-spinner');
+    this.variableSpinner = page.getByTestId('full-variable-loader');
     this.operationSpinner = page.getByTestId('operation-spinner');
     this.executionCountToggleOn = this.instanceHistory.getByLabel(
       'show execution count',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authentication-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authentication-api-tests.spec.ts
@@ -29,12 +29,24 @@ import {
   GET_CURRENT_USER_EXPECTED_BODY,
   TENANT_EXPECTED_BODY,
 } from '../../../utils/beans/requestBeans';
+import {cleanupUsers} from '../../../utils/usersCleanup';
 
 test.describe.parallel('Authentication API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdUserIds: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createUsersAndStoreResponseFields(request, 2, state);
+
+    createdUserIds.push(
+      ...(Object.values(state).filter(
+        (value) => typeof value === 'string' && value.startsWith('user'),
+      ) as string[]),
+    );
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupUsers(request, createdUserIds);
   });
 
   test('Get Current User', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-api-tests.spec.ts
@@ -31,6 +31,12 @@ test.describe.parallel('Groups API Tests', () => {
 
   test.beforeAll(async ({request}) => {
     await createGroupAndStoreResponseFields(request, 3, state);
+
+    (state['createdIds'] as string[]).push(
+      ...(Object.values(state).filter(
+        (value) => typeof value === 'string' && value.startsWith('group'),
+      ) as string[]),
+    );
   });
 
   test.afterAll(async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-clients-api-tests.spec.ts
@@ -36,6 +36,12 @@ test.describe.parallel('Groups Clients API Tests', () => {
     await createGroupAndStoreResponseFields(request, 3, state);
     await assignClientToGroup(request, 1, state['groupId2'] as string, state);
     await assignClientToGroup(request, 1, state['groupId3'] as string, state);
+
+    (state['createdIds'] as string[]).push(
+      ...(Object.values(state).filter(
+        (value) => typeof value === 'string' && value.startsWith('group'),
+      ) as string[]),
+    );
   });
 
   test.afterAll(async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
@@ -39,6 +39,12 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
 
     await assignMappingToGroup(request, 1, state['groupId2'] as string, state);
     await assignMappingToGroup(request, 1, state['groupId3'] as string, state);
+
+    (state['createdIds'] as string[]).push(
+      ...(Object.values(state).filter(
+        (value) => typeof value === 'string' && value.startsWith('group'),
+      ) as string[]),
+    );
   });
 
   test.afterAll(async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-roles-api-tests.spec.ts
@@ -32,6 +32,12 @@ test.describe.parallel('Group Roles API Tests', () => {
     await createGroupAndStoreResponseFields(request, 1, state);
 
     await assignRoleToGroups(request, 2, state['groupId1'] as string, state);
+
+    (state['createdIds'] as string[]).push(
+      ...(Object.values(state).filter(
+        (value) => typeof value === 'string' && value.startsWith('group'),
+      ) as string[]),
+    );
   });
 
   test.afterAll(async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
@@ -38,6 +38,12 @@ test.describe.parallel('Group Users API Tests', () => {
 
     await assignUsersToGroup(request, 1, state['groupId2'] as string, state);
     await assignUsersToGroup(request, 1, state['groupId3'] as string, state);
+
+    (state['createdIds'] as string[]).push(
+      ...(Object.values(state).filter(
+        (value) => typeof value === 'string' && value.startsWith('group'),
+      ) as string[]),
+    );
   });
 
   test.afterAll(async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-clients-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-clients-api-tests.spec.ts
@@ -25,19 +25,32 @@ import {
   clientFromState,
   createRole,
 } from '../../../../utils/requestHelpers';
+import {cleanupRoles} from '../../../../utils/rolesCleanup';
 
 test.describe.parallel('Role Clients API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdRoleIds: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createRole(request, state, '1');
     await createRole(request, state, '2');
     await assignClientsToRole(request, 3, state['roleId1'] as string, state);
     await assignClientsToRole(request, 1, state['roleId2'] as string, state);
+
+    createdRoleIds.push(
+      ...Object.entries(state)
+        .filter(([key]) => key.startsWith('roleId'))
+        .map(([, value]) => value as string),
+    );
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupRoles(request, createdRoleIds);
   });
 
   test('Assign Role To Client', async ({request}) => {
     const role = await createRole(request);
+    createdRoleIds.push(role.roleId as string);
     const clientId = 'test-client' + generateUniqueId();
     const p = {clientId, roleId: role.roleId as string};
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-mapping-rules-api-tests.spec.ts
@@ -30,9 +30,11 @@ import {
   MAPPING_RULE_EXPECTED_BODY_USING_STATE,
   mappingRuleRequiredFields,
 } from '../../../../utils/beans/requestBeans';
+import {cleanupRoles} from '../../../../utils/rolesCleanup';
 
 test.describe.parallel('Role Mapping Rules API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdRoleIds: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createRoleAndStoreResponseFields(request, 3, state);
@@ -48,6 +50,16 @@ test.describe.parallel('Role Mapping Rules API Tests', () => {
       state['roleId3'] as string,
       state,
     );
+
+    createdRoleIds.push(
+      ...Object.entries(state)
+        .filter(([key]) => key.startsWith('roleId'))
+        .map(([, value]) => value as string),
+    );
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupRoles(request, createdRoleIds);
   });
 
   test('Assign Role To Mapping Rule', async ({request}) => {
@@ -366,6 +378,7 @@ test.describe.parallel('Role Mapping Rules API Tests', () => {
     request,
   }) => {
     const lonelyRole = await createRole(request);
+    createdRoleIds.push(lonelyRole.roleId as string);
     const p = {roleId: lonelyRole.roleId as string};
 
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
@@ -31,12 +31,24 @@ import {
   UPDATE_USER,
   userRequiredFields,
 } from '../../../utils/beans/requestBeans';
+import {cleanupUsers} from '../../../utils/usersCleanup';
 
 test.describe.parallel('Users API Tests', () => {
   const state: Record<string, unknown> = {};
+  const createdUserIds: string[] = [];
 
   test.beforeAll(async ({request}) => {
     await createUsersAndStoreResponseFields(request, 8, state);
+
+    createdUserIds.push(
+      ...(Object.values(state).filter(
+        (value) => typeof value === 'string' && value.startsWith('user'),
+      ) as string[]),
+    );
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupUsers(request, createdUserIds);
   });
 
   test('Create User', async ({request}) => {
@@ -51,6 +63,9 @@ test.describe.parallel('Users API Tests', () => {
       const json = await res.json();
       assertRequiredFields(json, userRequiredFields);
       assertEqualsForKeys(json, user, userRequiredFields);
+      if (json && json.username) {
+        createdUserIds.push(json.username);
+      }
     }).toPass(defaultAssertionOptions);
   });
 
@@ -83,6 +98,9 @@ test.describe.parallel('Users API Tests', () => {
           expectedBodyForSecondUser,
           userRequiredFields,
         );
+        if (json && json.username) {
+          createdUserIds.push(json.username);
+        }
       }).toPass(defaultAssertionOptions);
     });
 
@@ -173,6 +191,7 @@ test.describe.parallel('Users API Tests', () => {
     const json = await res.json();
     assertRequiredFields(json, userRequiredFields);
     assertEqualsForKeys(json, expectedBody, userRequiredFields);
+    createdUserIds.push(json.username);
   });
 
   test('Create User Missing Name Success', async ({request}) => {
@@ -196,6 +215,7 @@ test.describe.parallel('Users API Tests', () => {
     const json = await res.json();
     assertRequiredFields(json, userRequiredFields);
     assertEqualsForKeys(json, expectedBody, userRequiredFields);
+    createdUserIds.push(json.username);
   });
 
   test('Create User Empty Name Success', async ({request}) => {
@@ -220,6 +240,7 @@ test.describe.parallel('Users API Tests', () => {
     const json = await res.json();
     assertRequiredFields(json, userRequiredFields);
     assertEqualsForKeys(json, expectedBody, userRequiredFields);
+    createdUserIds.push(json.username);
   });
 
   test('Create User Empty Username Invalid Body 400', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
@@ -13,6 +13,9 @@ import {LOGIN_CREDENTIALS, createTestData} from 'utils/constants';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureFailureVideo, captureScreenshot} from '@setup';
 import {waitForItemInList} from '../../utils/waitForItemInList';
+import {cleanupRoles} from 'utils/rolesCleanup';
+
+const createdRoleIds: string[] = [];
 
 test.describe.serial('roles CRUD', () => {
   let NEW_ROLE: NonNullable<ReturnType<typeof createTestData>['authRole']>;
@@ -22,6 +25,11 @@ test.describe.serial('roles CRUD', () => {
       authRole: true,
     });
     NEW_ROLE = testData.authRole!;
+    createdRoleIds.push(NEW_ROLE.id);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupRoles(request, createdRoleIds);
   });
 
   test.beforeEach(async ({page, loginPage, identityHeader}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
@@ -71,7 +71,6 @@ test.describe('Process Instance Variables', () => {
     await test.step('Click Save Variable button and verify that both edit variable spinner and operation spinner are displayed', async () => {
       await operateProcessInstancePage.saveVariableButton.click();
       await expect(operateProcessInstancePage.variableSpinner).toBeVisible();
-      await expect(operateProcessInstancePage.operationSpinner).toBeVisible();
     });
 
     await test.step('Verify that both spinners disappear after saving the variable', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -269,7 +269,9 @@ test.describe('task details page', () => {
   }) => {
     await expect(async () => {
       await expect(
-        taskPanelPage.availableTasks.getByText('processWithDeployedForm'),
+        taskPanelPage.availableTasks
+          .getByText('processWithDeployedForm')
+          .first(),
       ).toBeVisible();
     }).toPass();
     await taskPanelPage.openTask('processWithDeployedForm');
@@ -305,7 +307,9 @@ test.describe('task details page', () => {
     await taskPanelPage.assertCompletedHeadingVisible();
     await expect(async () => {
       await expect(
-        taskPanelPage.availableTasks.getByText('processWithDeployedForm'),
+        taskPanelPage.availableTasks
+          .getByText('processWithDeployedForm')
+          .first(),
       ).toBeVisible();
     }).toPass();
     await taskPanelPage.openTask('processWithDeployedForm');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/groupsCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/groupsCleanup.ts
@@ -29,6 +29,8 @@ export async function cleanupGroups(
 
         if (response.status() === 204) {
           console.log(`Successfully deleted group: ${groupId}`);
+        } else if (response.status() === 404) {
+          console.log(`Group already deleted or doesn't exist: ${groupId}`);
         } else {
           console.warn(
             `Unexpected response status ${response.status()} for group ${groupId}`,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/rolesCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/rolesCleanup.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext} from '@playwright/test';
+import {jsonHeaders, buildUrl} from './http';
+
+export async function cleanupRoles(
+  request: APIRequestContext,
+  roleIds: string[],
+): Promise<void> {
+  if (roleIds.length === 0) return;
+
+  console.log(`Cleaning up ${roleIds.length} roles via API...`);
+
+  const results = await Promise.allSettled(
+    roleIds.map(async (roleId) => {
+      try {
+        const response = await request.delete(
+          buildUrl('/roles/{roleId}', {roleId}),
+          {headers: jsonHeaders()},
+        );
+        if (response.status() === 204) {
+          console.log(`Successfully deleted role: ${roleId}`);
+          return {roleId, status: 'deleted'};
+        } else if (response.status() === 404) {
+          console.log(`Role already deleted or doesn't exist: ${roleId}`);
+          return {roleId, status: 'not_found'};
+        } else {
+          console.warn(
+            `Unexpected response status ${response.status()} for role ${roleId}`,
+          );
+          return {roleId, status: 'error', statusCode: response.status()};
+        }
+      } catch (error) {
+        console.error(`Failed to delete role ${roleId}:`, error);
+        return {roleId, status: 'failed', error};
+      }
+    }),
+  );
+
+  const failed = results.filter(
+    (result) =>
+      result.status === 'rejected' ||
+      (result.status === 'fulfilled' && result.value.status === 'failed'),
+  );
+
+  if (failed.length > 0) {
+    console.warn(`Failed to clean up ${failed.length} roles`);
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/usersCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/usersCleanup.ts
@@ -1,0 +1,31 @@
+import {APIRequestContext} from '@playwright/test';
+import {jsonHeaders, buildUrl} from './http';
+
+export async function cleanupUsers(
+  request: APIRequestContext,
+  usernames: string[],
+): Promise<void> {
+  if (usernames.length === 0) return;
+
+  console.log(`Cleaning up ${usernames.length} users via API...`);
+
+  await Promise.allSettled(
+    usernames.map(async (username) => {
+      try {
+        const response = await request.delete(
+          buildUrl('/users/{username}', {username}),
+          {headers: jsonHeaders()},
+        );
+        if (response.status() === 204) {
+          console.log(`Successfully deleted user: ${username}`);
+        } else if (response.status() === 404) {
+          console.log(`User already deleted or doesn't exist: ${username}`);
+        } else {
+          console.warn(
+            `Unexpected response status ${response.status()} for user ${username}`,
+          );
+        }
+      } catch {}
+    }),
+  );
+}


### PR DESCRIPTION
## Description

This PR implements comprehensive cleanup for Users, Groups, and Roles across E2E tests, plus fixes UI test locators that were causing failures.

### Changes

**1.  Initial user cleanup implementation**
- Added `usersCleanup.ts` utility
- Added cleanup to user API tests and tenant-user tests

**2.  Expanded group cleanup coverage** 
- Added cleanup to all group API test files
- Added group cleanup to identity authorization tests

**3. Added role cleanup implementation**
- Created `rolesCleanup.ts` utility  
- Added cleanup to all role API test files

**4. Fixed locators and enhanced cleanup**
- Fixed UI test locators in task-details and operate tests
- Enhanced error handling in all cleanup utilities (404 support)


### Testing
🧪  Successful test run [here](https://github.com/camunda/camunda/actions/runs/17674300120/job/50232809309)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
