### PR TITLE
feat: handle es/os meta properties

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/IndexMapping.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/IndexMapping.java
@@ -40,6 +40,7 @@ public record IndexMapping(
       final Map<String, Object> mappings =
           mapper.readValue(mappingsStream, nestedType).get("mappings");
       final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+      final Map<String, Object> metaProperties = (Map<String, Object>) mappings.get("_meta");
       final var dynamic = mappings.get("dynamic");
 
       return new IndexMapping.Builder()
@@ -48,6 +49,7 @@ public record IndexMapping(
               properties.entrySet().stream()
                   .map(IndexMappingProperty::createIndexMappingProperty)
                   .collect(Collectors.toSet()))
+          .metaProperties(metaProperties)
           .build();
     } catch (final IOException e) {
       throw new IllegalArgumentException(

--- a/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
@@ -43,6 +43,8 @@ public interface SearchEngineClient extends CloseableSilently {
 
   void putIndexLifeCyclePolicy(final String policyName, final String deletionMinAge);
 
+  void putIndexMeta(final String indexName, Map<String, Object> meta);
+
   boolean importersCompleted(
       final int partitionId, final List<IndexDescriptor> importPositionIndices);
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -32,6 +32,7 @@ import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.elasticsearch.indices.PutMappingRequest;
 import co.elastic.clients.elasticsearch.indices.get_index_template.IndexTemplateItem;
 import co.elastic.clients.elasticsearch.indices.put_index_template.IndexTemplateMapping;
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpSerializable;
 import co.elastic.clients.json.jackson.JacksonJsonpGenerator;
@@ -214,6 +215,19 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
       client.ilm().putLifecycle(request);
     } catch (final IOException e) {
       final var errMsg = String.format("Index lifecycle policy [%s] failed to PUT", policyName);
+      LOG.error(errMsg, e);
+      throw new SearchEngineException(errMsg, e);
+    }
+  }
+
+  @Override
+  public void putIndexMeta(final String indexName, final Map<String, Object> meta) {
+    final var request = putMetaMappingRequest(indexName, meta);
+
+    try {
+      client.indices().putMapping(request);
+    } catch (final IOException | ElasticsearchException e) {
+      final var errMsg = String.format("_meta PUT failed for %s", indexName);
       LOG.error(errMsg, e);
       throw new SearchEngineException(errMsg, e);
     }
@@ -592,6 +606,15 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
               + " from classpath.",
           e);
     }
+  }
+
+  private PutMappingRequest putMetaMappingRequest(
+      final String indexName, final Map<String, Object> meta) {
+    final var jsonMeta =
+        meta.entrySet().stream()
+            .map(entry -> Map.entry(entry.getKey(), JsonData.of(entry.getValue())))
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    return new PutMappingRequest.Builder().index(indexName).meta(jsonMeta).build();
   }
 
   @Override

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -612,8 +612,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
       final String indexName, final Map<String, Object> meta) {
     final var jsonMeta =
         meta.entrySet().stream()
-            .map(entry -> Map.entry(entry.getKey(), JsonData.of(entry.getValue())))
-            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+            .collect(Collectors.toMap(Entry::getKey, e -> JsonData.of(e.getValue())));
     return new PutMappingRequest.Builder().index(indexName).meta(jsonMeta).build();
   }
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -641,8 +641,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
       final String indexName, final Map<String, Object> meta) {
     final var jsonMeta =
         meta.entrySet().stream()
-            .map(entry -> Map.entry(entry.getKey(), JsonData.of(entry.getValue())))
-            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+            .collect(Collectors.toMap(Entry::getKey, e -> JsonData.of(e.getValue())));
     return new PutMappingRequest.Builder().index(indexName).meta(jsonMeta).build();
   }
 

--- a/schema-manager/src/test/java/io/camunda/search/schema/IndexMappingTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/IndexMappingTest.java
@@ -38,4 +38,30 @@ public class IndexMappingTest {
                 .typeDefinition(Map.of("type", "keyword"))
                 .build());
   }
+
+  @Test
+  void shouldReadIndexMappingsWithMetaFileCorrectly() {
+    // given
+    final var index = createTestIndexDescriptor("index_name", "/mappings_with_meta.json");
+
+    // when
+    final var indexMapping = IndexMapping.from(index, TestObjectMapper.objectMapper());
+
+    // then
+    assertThat(indexMapping.dynamic()).isEqualTo("strict");
+
+    assertThat(indexMapping.properties())
+        .containsExactlyInAnyOrder(
+            new IndexMappingProperty.Builder()
+                .name("hello")
+                .typeDefinition(Map.of("type", "text"))
+                .build(),
+            new IndexMappingProperty.Builder()
+                .name("world")
+                .typeDefinition(Map.of("type", "keyword"))
+                .build());
+
+    assertThat(indexMapping.metaProperties().entrySet())
+        .containsExactly(Map.entry("test_key", "test_value"));
+  }
 }

--- a/schema-manager/src/test/java/io/camunda/search/schema/IndexSchemaValidatorTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/IndexSchemaValidatorTest.java
@@ -270,6 +270,29 @@ public class IndexSchemaValidatorTest {
     assertThat(difference).isEmpty();
   }
 
+  @Test
+  void shouldIgnoreMetaProperty() throws IOException {
+    // given
+    final var mappings = jsonToIndexMappingProperties("/mappings.json", "qualified_name");
+
+    // when
+    final var index = createTestIndexDescriptor("qualified_name", "/mappings.json");
+
+    final var currentMappings =
+        Map.of(
+            index.getFullQualifiedName(),
+            new IndexMapping.Builder()
+                .indexName(index.getFullQualifiedName())
+                .properties(mappings.properties())
+                .dynamic("strict")
+                .metaProperties(Map.of("meta_key", "meta_value"))
+                .build());
+    // then
+    final var difference = VALIDATOR.validateIndexMappings(currentMappings, Set.of(index));
+
+    assertThat(difference).isEmpty();
+  }
+
   @SuppressWarnings("unchecked")
   private IndexMapping jsonToIndexMappingProperties(
       final String mappingsFileName, final String indexName) throws IOException {

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaTestUtil.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaTestUtil.java
@@ -101,6 +101,12 @@ public final class SchemaTestUtil {
                   Map.class);
       final var actualMappingsTree =
           TestObjectMapper.objectMapper().convertValue(mappings, Map.class);
+
+      // remove _meta for comparison as it is not part of the mapping validation as the diff
+      // is based only on the mapping properties
+      actualMappingsTree.remove("_meta");
+      expectedMappingsTree.remove("_meta");
+
       if (parseBoolean(actualMappingsTree.getOrDefault("dynamic", "false").toString())
           && parseBoolean(expectedMappingsTree.getOrDefault("dynamic", "false").toString())) {
         // if dynamic is true, skip mappings validation

--- a/schema-manager/src/test/resources/mappings_with_meta.json
+++ b/schema-manager/src/test/resources/mappings_with_meta.json
@@ -1,0 +1,16 @@
+{
+  "mappings": {
+    "_meta": {
+      "test_key" : "test_value"
+    },
+    "dynamic": "strict",
+    "properties": {
+      "hello": {
+        "type": "text"
+      },
+      "world": {
+        "type": "keyword"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Schema manager can be able to handle and update meta properties on index mappings. This is related to the 8.8 migration since we'd include a meta property to temporarily disable the Archiver.

The general handling and validation of meta properties must be present on `main` as well so as not to have validation issues on future updates. Also, it's an extension to the client capabilities.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Part of #38032
