### PR TITLE
test: skip tests until bugs are fixed

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-api-tests.spec.ts
@@ -24,28 +24,11 @@ import {defaultAssertionOptions} from '../../../../utils/constants';
 test.describe('Correlate Message API Tests', () => {
   const state: Record<string, unknown> = {};
 
-  test.beforeAll(async ({request}) => {
+  test.beforeAll(async () => {
     await deploy(['./resources/messageCatchEvent3.bpmn']);
-    await createInstances('messageCatchEvent3', 1, 1);
-    await expect(async () => {
-      const res = await request.post(
-        buildUrl('/message-subscriptions/search'),
-        {
-          headers: jsonHeaders(),
-          data: {},
-        },
-      );
-
-      expect(res.status()).toBe(200);
-      const json = await res.json();
-      expect(json.page.totalItems).toBeGreaterThan(1);
-      const matchingItem = json.items.find(
-        (it: {processDefinitionId: string}) =>
-          it.processDefinitionId === 'messageCatchEvent3',
-      );
-      expect(matchingItem).toBeDefined();
-      state['processInstanceKey'] = matchingItem['processInstanceKey'];
-    }).toPass(defaultAssertionOptions);
+    const processes = await createInstances('messageCatchEvent3', 1, 1);
+    expect(processes.length).toBe(1);
+    state['processInstanceKey'] = processes[0].processInstanceKey;
   });
 
   test('Correlate Message Unauthorized', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
@@ -152,7 +152,8 @@ test.describe.parallel('Users API Tests', () => {
     await assertBadRequest(res, 'No password provided', 'INVALID_ARGUMENT');
   });
 
-  test('Create User Missing Email Success', async ({request}) => {
+  // Skipped due to bug 37720: https://github.com/camunda/camunda/issues/37720
+  test.skip('Create User Missing Email Success', async ({request}) => {
     const body = {
       username: `username-${generateUniqueId()}`,
       name: 'user',
@@ -175,7 +176,8 @@ test.describe.parallel('Users API Tests', () => {
     assertEqualsForKeys(json, expectedBody, userRequiredFields);
   });
 
-  test('Create User Missing Name Success', async ({request}) => {
+  // Skipped due to bug 37720: https://github.com/camunda/camunda/issues/37720
+  test.skip('Create User Missing Name Success', async ({request}) => {
     const body = {
       username: `username-${generateUniqueId()}`,
       email: 'user@example.com',
@@ -315,7 +317,8 @@ test.describe.parallel('Users API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Update User Missing Name Success', async ({request}) => {
+  // Skipped due to bug 37720: https://github.com/camunda/camunda/issues/37720
+  test.skip('Update User Missing Name Success', async ({request}) => {
     const p = {username: state['username6'] as string};
     const requestBody = {
       email: `updated-${generateUniqueId()}-email@example.com`,
@@ -338,7 +341,8 @@ test.describe.parallel('Users API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Update User Missing Email Success', async ({request}) => {
+  // Skipped due to bug 37720: https://github.com/camunda/camunda/issues/37720
+  test.skip('Update User Missing Email Success', async ({request}) => {
     const p = {username: state['username7'] as string};
     const requestBody = {
       name: `updated-${generateUniqueId()}-name`,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -56,7 +56,6 @@ export const licenseRequiredFields: string[] = [
 export const messageSubscriptionRequiredFields = [
   'messageSubscriptionKey',
   'processDefinitionId',
-  'processDefinitionKey',
   'processInstanceKey',
   'elementId',
   'elementInstanceKey',


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- Skip tests until bugs are fixed by teams.
- `processDefinitionKey` is not a required field anymore. 
- use processInstanceKEy from client response

Run: https://github.com/camunda/camunda/actions/runs/17672224630/

The other fixes will be applied in [this PR](https://github.com/camunda/camunda/pull/38036#event-19660004425) 
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
