### PR TITLE
[CPT] test: Ignore CPT multi-tenancy tests

### DIFF
--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionMultitenancyIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionMultitenancyIT.java
@@ -39,6 +39,7 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * This test is a combination of the ConnectorsIT and the ExtensionIT to ensure
  * that the new multitenancy configuration works with and without the connectors container.
  */
+@Disabled("The test cases are flaky. We need to improve the stability before enabling them again.")
 public class CamundaProcessTestExtensionMultitenancyIT {
 
   // The ID is part of the connector configuration in the BPMN element


### PR DESCRIPTION
## Description

The CI reported that the CPT multi-tenancy tests are flaky. We need to ignore them until we improve the stability.

cc: @Christian-Broomfield 

## Related issues

Top 5 flakiest tests yesterday:
• 71x `CamundaProcessTestExtensionMultitenancyIT.multitenancyWithConnectorsEnabled`
• 71x `CamundaProcessTestExtensionMultitenancyIT.shouldCreateProcessWithoutTenants`

[CI report](https://camunda.slack.com/archives/C071KP5BTHB/p1757657465524259)