### PR TITLE
El aws config

### DIFF
--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
@@ -30,6 +30,7 @@ public class ConnectConfiguration {
   private SecurityConfiguration security = new SecurityConfiguration();
   private String indexPrefix = "";
   private List<PluginConfiguration> interceptorPlugins = new ArrayList<>();
+  private boolean isAwsEnabled = false;
 
   /** Use {@link ConnectConfiguration#getTypeEnum()} */
   @Deprecated
@@ -39,6 +40,14 @@ public class ConnectConfiguration {
 
   public void setType(final String type) {
     this.type = type;
+  }
+
+  public boolean isAwsEnabled() {
+    return isAwsEnabled;
+  }
+
+  public void setAwsEnabled(final boolean awsEnabled) {
+    isAwsEnabled = awsEnabled;
   }
 
   public DatabaseType getTypeEnum() {

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -93,7 +93,7 @@ public final class OpensearchConnector {
   }
 
   private OpenSearchTransport createTransport(final ConnectConfiguration configuration) {
-    if (shouldCreateAWSBasedTransport()) {
+    if (configuration.isAwsEnabled() && shouldCreateAWSBasedTransport()) {
       return createAWSBasedTransport(configuration);
     } else {
       return createDefaultTransport(configuration);

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -93,7 +93,7 @@ public final class OpensearchConnector {
   }
 
   private OpenSearchTransport createTransport(final ConnectConfiguration configuration) {
-    if (configuration.isAwsEnabled() && shouldCreateAWSBasedTransport()) {
+    if (shouldCreateAWSBasedTransport()) {
       return createAWSBasedTransport(configuration);
     } else {
       return createDefaultTransport(configuration);
@@ -137,7 +137,7 @@ public final class OpensearchConnector {
   }
 
   private boolean shouldCreateAWSBasedTransport() {
-    if (credentialsProvider == null) {
+    if (credentialsProvider == null || !configuration.isAwsEnabled()) {
       return false;
     }
 


### PR DESCRIPTION
## Description

The opensearch connector should use basic auth without checking for AWS credentials.

## Related issues

relates to https://github.com/camunda/camunda/issues/32007
