### PR TITLE
[Backport main] refactor: use both start and end time in usage metric migration

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -605,14 +605,15 @@
       <column name="TENANT_ID" type="VARCHAR(255)">
         <constraints primaryKey="true"/>
       </column>
-      <column name="EVENT_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="START_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="END_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
       <column name="EVENT_TYPE" type="INTEGER"/>
       <column name="EVENT_VALUE" type="BIGINT"/>
       <column name="PARTITION_ID" type="NUMBER"/>
     </createTable>
 
-    <createIndex tableName="${prefix}USAGE_METRIC" indexName="${prefix}IDX_USAGE_METRIC_EVENT_TIME">
-      <column name="EVENT_TIME"/>
+    <createIndex tableName="${prefix}USAGE_METRIC" indexName="${prefix}IDX_USAGE_METRIC_END_TIME">
+      <column name="END_TIME"/>
     </createIndex>
 
     <createTable tableName="${prefix}USAGE_METRIC_TU">
@@ -622,15 +623,16 @@
       <column name="TENANT_ID" type="VARCHAR(255)">
         <constraints primaryKey="true"/>
       </column>
-      <column name="EVENT_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="START_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="END_TIME" type="TIMESTAMP WITH TIME ZONE(3)"/>
       <column name="ASSIGNEE_HASH" type="BIGINT">
         <constraints primaryKey="true"/>
       </column>
       <column name="PARTITION_ID" type="NUMBER"/>
     </createTable>
 
-    <createIndex tableName="${prefix}USAGE_METRIC_TU" indexName="${prefix}IDX_USAGE_METRIC_TU_EVENT_TIME">
-      <column name="EVENT_TIME"/>
+    <createIndex tableName="${prefix}USAGE_METRIC_TU" indexName="${prefix}IDX_USAGE_METRIC_TU_END_TIME">
+      <column name="END_TIME"/>
     </createIndex>
 
     <modifySql dbms="mariadb">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UsageMetricDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UsageMetricDbModel.java
@@ -12,7 +12,8 @@ import java.time.OffsetDateTime;
 
 public record UsageMetricDbModel(
     long key,
-    OffsetDateTime eventTime,
+    OffsetDateTime startTime,
+    OffsetDateTime endTime,
     String tenantId,
     EventTypeDbModel eventType,
     Long value,
@@ -29,7 +30,8 @@ public record UsageMetricDbModel(
   public static class Builder implements ObjectBuilder<UsageMetricDbModel> {
 
     private long key;
-    private OffsetDateTime eventTime;
+    private OffsetDateTime startTime;
+    private OffsetDateTime endTime;
     private String tenantId;
     private EventTypeDbModel eventType;
     private Long value;
@@ -40,8 +42,13 @@ public record UsageMetricDbModel(
       return this;
     }
 
-    public Builder eventTime(final OffsetDateTime eventTime) {
-      this.eventTime = eventTime;
+    public Builder startTime(final OffsetDateTime startTime) {
+      this.startTime = startTime;
+      return this;
+    }
+
+    public Builder endTime(final OffsetDateTime endTime) {
+      this.endTime = endTime;
       return this;
     }
 
@@ -67,7 +74,8 @@ public record UsageMetricDbModel(
 
     @Override
     public UsageMetricDbModel build() {
-      return new UsageMetricDbModel(key, eventTime, tenantId, eventType, value, partitionId);
+      return new UsageMetricDbModel(
+          key, startTime, endTime, tenantId, eventType, value, partitionId);
     }
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UsageMetricTUDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UsageMetricTUDbModel.java
@@ -11,7 +11,12 @@ import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 
 public record UsageMetricTUDbModel(
-    long key, OffsetDateTime eventTime, String tenantId, long assigneeHash, int partitionId) {
+    long key,
+    OffsetDateTime startTime,
+    OffsetDateTime endTime,
+    String tenantId,
+    long assigneeHash,
+    int partitionId) {
 
   public String getId() {
     return key + "_" + tenantId;
@@ -24,7 +29,8 @@ public record UsageMetricTUDbModel(
   public static class Builder implements ObjectBuilder<UsageMetricTUDbModel> {
 
     private long key;
-    private OffsetDateTime eventTime;
+    private OffsetDateTime startTime;
+    private OffsetDateTime endTime;
     private String tenantId;
     private long assigneeHash;
     private int partitionId;
@@ -34,8 +40,13 @@ public record UsageMetricTUDbModel(
       return this;
     }
 
-    public Builder eventTime(final OffsetDateTime eventTime) {
-      this.eventTime = eventTime;
+    public Builder startTime(final OffsetDateTime startTime) {
+      this.startTime = startTime;
+      return this;
+    }
+
+    public Builder endTime(final OffsetDateTime endTime) {
+      this.endTime = endTime;
       return this;
     }
 
@@ -56,7 +67,7 @@ public record UsageMetricTUDbModel(
 
     @Override
     public UsageMetricTUDbModel build() {
-      return new UsageMetricTUDbModel(key, eventTime, tenantId, assigneeHash, partitionId);
+      return new UsageMetricTUDbModel(key, startTime, endTime, tenantId, assigneeHash, partitionId);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/UsageMetricMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UsageMetricMapper.xml
@@ -65,10 +65,10 @@
         </foreach>
       </if>
       <if test="filter.startTime != null">
-        AND EVENT_TIME &gt;= #{filter.startTime}
+        AND END_TIME &gt;= #{filter.startTime}
       </if>
       <if test="filter.endTime != null">
-        AND EVENT_TIME &lt; #{filter.endTime}
+        AND END_TIME &lt; #{filter.endTime}
       </if>
       <if test="filter.tenantId != null">
         AND TENANT_ID = #{filter.tenantId}
@@ -78,13 +78,15 @@
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.UsageMetricDbModel">
     INSERT INTO ${prefix}USAGE_METRIC (USAGE_METRIC_KEY,
-                                       EVENT_TIME,
+                                       START_TIME,
+                                       END_TIME,
                                        TENANT_ID,
                                        EVENT_TYPE,
                                        EVENT_VALUE,
                                        PARTITION_ID)
     VALUES (#{key},
-            #{eventTime, jdbcType=TIMESTAMP},
+            #{startTime, jdbcType=TIMESTAMP},
+            #{endTime, jdbcType=TIMESTAMP},
             #{tenantId},
             #{eventType, typeHandler=io.camunda.db.rdbms.sql.typehandler.UsageMetricEventTypeTypeHandler},
             #{value},
@@ -97,7 +99,7 @@
     DELETE
     FROM ${prefix}USAGE_METRIC
     WHERE PARTITION_ID = #{partitionId}
-      AND EVENT_TIME &lt; #{cleanupDate}
+      AND END_TIME &lt; #{cleanupDate}
     LIMIT #{limit}
   </delete>
   <delete flushCache="true"
@@ -109,7 +111,7 @@
     WHERE rowid IN (SELECT rowid
                     FROM ${prefix}USAGE_METRIC
                     WHERE PARTITION_ID = #{partitionId}
-                      AND EVENT_TIME &lt; #{cleanupDate}
+                      AND END_TIME &lt; #{cleanupDate}
                       AND ROWNUM &lt;= #{limit})
   </delete>
   <delete flushCache="true"
@@ -121,7 +123,7 @@
     WHERE ctid IN (SELECT ctid
                    FROM ${prefix}USAGE_METRIC
                    WHERE PARTITION_ID = #{partitionId}
-                     AND EVENT_TIME &lt; #{cleanupDate}
+                     AND END_TIME &lt; #{cleanupDate}
                    LIMIT #{limit})
   </delete>
 

--- a/db/rdbms/src/main/resources/mapper/UsageMetricTUMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UsageMetricTUMapper.xml
@@ -52,10 +52,10 @@
   <sql id="usageMetricStatisticsFilter">
     <where>
       <if test="filter.startTime != null">
-        AND EVENT_TIME &gt;= #{filter.startTime}
+        AND END_TIME &gt;= #{filter.startTime}
       </if>
       <if test="filter.endTime != null">
-        AND EVENT_TIME &lt; #{filter.endTime}
+        AND END_TIME &lt; #{filter.endTime}
       </if>
       <if test="filter.tenantId != null">
         AND TENANT_ID = #{filter.tenantId}
@@ -65,12 +65,14 @@
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.UsageMetricTUDbModel">
     INSERT INTO ${prefix}USAGE_METRIC_TU (USAGE_METRIC_KEY,
-                                          EVENT_TIME,
+                                          START_TIME,
+                                          END_TIME,
                                           TENANT_ID,
                                           ASSIGNEE_HASH,
                                           PARTITION_ID)
     VALUES (#{key},
-            #{eventTime, jdbcType=TIMESTAMP},
+            #{startTime, jdbcType=TIMESTAMP},
+            #{endTime, jdbcType=TIMESTAMP},
             #{tenantId},
             #{assigneeHash},
             #{partitionId})
@@ -82,7 +84,7 @@
     DELETE
     FROM ${prefix}USAGE_METRIC_TU
     WHERE PARTITION_ID = #{partitionId}
-      AND EVENT_TIME &lt; #{cleanupDate} LIMIT #{limit}
+      AND END_TIME &lt; #{cleanupDate} LIMIT #{limit}
   </delete>
 
   <delete flushCache="true"
@@ -94,7 +96,7 @@
     WHERE rowid IN (SELECT rowid
                     FROM ${prefix}USAGE_METRIC_TU
                     WHERE PARTITION_ID = #{partitionId}
-                      AND EVENT_TIME &lt; #{cleanupDate}
+                      AND END_TIME &lt; #{cleanupDate}
                       AND ROWNUM &lt;= #{limit})
   </delete>
 
@@ -107,7 +109,7 @@
     WHERE ctid IN (SELECT ctid
                    FROM ${prefix}USAGE_METRIC_TU
                    WHERE PARTITION_ID = #{partitionId}
-                     AND EVENT_TIME &lt; #{cleanupDate}
+                     AND END_TIME &lt; #{cleanupDate}
       LIMIT #{limit})
   </delete>
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchMetricsStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchMetricsStore.java
@@ -45,7 +45,7 @@ public class ElasticsearchMetricsStore implements MetricsStore {
   public Long retrieveProcessInstanceCount(
       final OffsetDateTime startTime, final OffsetDateTime endTime, final String tenantId) {
     Query query =
-        Query.whereEquals(EVENT_TYPE, RPI.name()).and(range(EVENT_TIME, startTime, endTime));
+        Query.whereEquals(EVENT_TYPE, RPI.name()).and(range(END_TIME, startTime, endTime));
 
     if (tenantId != null) {
       query = query.and(whereEquals(TENANT_ID, tenantId));
@@ -66,7 +66,7 @@ public class ElasticsearchMetricsStore implements MetricsStore {
   public Long retrieveDecisionInstanceCount(
       final OffsetDateTime startTime, final OffsetDateTime endTime, final String tenantId) {
     Query query =
-        Query.whereEquals(EVENT_TYPE, EDI.name()).and(range(EVENT_TIME, startTime, endTime));
+        Query.whereEquals(EVENT_TYPE, EDI.name()).and(range(END_TIME, startTime, endTime));
     if (tenantId != null) {
       query = query.and(whereEquals(TENANT_ID, tenantId));
     }
@@ -117,7 +117,8 @@ public class ElasticsearchMetricsStore implements MetricsStore {
         .setId(String.format(ID_PATTERN, key, tenantId))
         .setEventType(RPI)
         .setEventValue(1L)
-        .setEventTime(timestamp)
+        .setStartTime(timestamp)
+        .setEndTime(timestamp)
         .setTenantId(tenantId)
         .setPartitionId(partitionId);
   }
@@ -131,7 +132,8 @@ public class ElasticsearchMetricsStore implements MetricsStore {
         .setId(String.format(ID_PATTERN, key, tenantId))
         .setEventType(EDI)
         .setEventValue(1L)
-        .setEventTime(timestamp)
+        .setStartTime(timestamp)
+        .setEndTime(timestamp)
         .setTenantId(tenantId)
         .setPartitionId(partitionId);
   }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchMetricsStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchMetricsStore.java
@@ -12,7 +12,7 @@ import static io.camunda.operate.store.opensearch.dsl.QueryDSL.and;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.gteLte;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.term;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
-import static io.camunda.webapps.schema.descriptors.index.UsageMetricIndex.EVENT_TIME;
+import static io.camunda.webapps.schema.descriptors.index.UsageMetricIndex.END_TIME;
 import static io.camunda.webapps.schema.descriptors.index.UsageMetricIndex.EVENT_TYPE;
 import static io.camunda.webapps.schema.descriptors.index.UsageMetricIndex.EVENT_VALUE;
 import static io.camunda.webapps.schema.descriptors.index.UsageMetricIndex.TENANT_ID;
@@ -76,7 +76,7 @@ public class OpensearchMetricsStore implements MetricsStore {
   @Override
   public Long retrieveProcessInstanceCount(
       final OffsetDateTime startTime, final OffsetDateTime endTime, final String tenantId) {
-    var query = and(gteLte(EVENT_TIME, startTime, endTime), term(EVENT_TYPE, RPI.name()));
+    var query = and(gteLte(END_TIME, startTime, endTime), term(EVENT_TYPE, RPI.name()));
     if (tenantId != null) {
       query = and(query, term(TENANT_ID, tenantId));
     }
@@ -92,7 +92,7 @@ public class OpensearchMetricsStore implements MetricsStore {
   @Override
   public Long retrieveDecisionInstanceCount(
       final OffsetDateTime startTime, final OffsetDateTime endTime, final String tenantId) {
-    var query = and(term(EVENT_TYPE, EDI.name()), gteLte(EVENT_TIME, startTime, endTime));
+    var query = and(term(EVENT_TYPE, EDI.name()), gteLte(END_TIME, startTime, endTime));
     if (tenantId != null) {
       query = and(query, term(TENANT_ID, tenantId));
     }
@@ -141,7 +141,8 @@ public class OpensearchMetricsStore implements MetricsStore {
         .setId(String.format(ID_PATTERN, key, tenantId))
         .setEventType(RPI)
         .setEventValue(1L)
-        .setEventTime(timestamp)
+        .setStartTime(timestamp)
+        .setEndTime(timestamp)
         .setTenantId(tenantId)
         .setPartitionId(partitionId);
   }
@@ -155,7 +156,8 @@ public class OpensearchMetricsStore implements MetricsStore {
         .setId(String.format(ID_PATTERN, key, tenantId))
         .setEventType(EDI)
         .setEventValue(1L)
-        .setEventTime(timestamp)
+        .setStartTime(timestamp)
+        .setEndTime(timestamp)
         .setTenantId(tenantId)
         .setPartitionId(partitionId);
   }

--- a/operate/webapp/src/test/java/io/camunda/operate/elasticsearch/reader/MetricReaderTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/elasticsearch/reader/MetricReaderTest.java
@@ -8,7 +8,7 @@
 package io.camunda.operate.elasticsearch.reader;
 
 import static io.camunda.operate.store.elasticsearch.dao.Query.range;
-import static io.camunda.webapps.schema.descriptors.index.UsageMetricIndex.EVENT_TIME;
+import static io.camunda.webapps.schema.descriptors.index.UsageMetricIndex.END_TIME;
 import static io.camunda.webapps.schema.descriptors.index.UsageMetricIndex.EVENT_TYPE;
 import static io.camunda.webapps.schema.descriptors.index.UsageMetricIndex.EVENT_VALUE;
 import static io.camunda.webapps.schema.entities.metrics.UsageMetricsEventType.EDI;
@@ -72,7 +72,7 @@ public class MetricReaderTest {
 
     final Query expected =
         Query.whereEquals(EVENT_TYPE, RPI.name())
-            .and(range(EVENT_TIME, oneHourBefore, now))
+            .and(range(END_TIME, oneHourBefore, now))
             .aggregate(MetricsStore.PROCESS_INSTANCES_AGG_NAME, EVENT_VALUE);
     final Query calledValue = entityCaptor.getValue();
     assertThat(calledValue).isEqualTo(expected);
@@ -123,7 +123,7 @@ public class MetricReaderTest {
 
     final Query expected =
         Query.whereEquals(EVENT_TYPE, EDI.name())
-            .and(range(EVENT_TIME, oneHourBefore, now))
+            .and(range(END_TIME, oneHourBefore, now))
             .aggregate(MetricsStore.DECISION_INSTANCES_AGG_NAME, EVENT_VALUE);
     final Query calledValue = entityCaptor.getValue();
     assertThat(calledValue).isEqualTo(expected);

--- a/operate/webapp/src/test/java/io/camunda/operate/elasticsearch/writer/MetricWriterTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/elasticsearch/writer/MetricWriterTest.java
@@ -50,7 +50,8 @@ public class MetricWriterTest {
                 .setId(ID_PATTERN.formatted(key, tenantId))
                 .setEventType(RPI)
                 .setEventValue(1L)
-                .setEventTime(now)
+                .setStartTime(now)
+                .setEndTime(now)
                 .setTenantId(tenantId)
                 .setPartitionId(0));
   }
@@ -73,7 +74,8 @@ public class MetricWriterTest {
                 .setId(ID_PATTERN.formatted(key, tenantId))
                 .setEventType(EDI)
                 .setEventValue(1L)
-                .setEventTime(now)
+                .setStartTime(now)
+                .setEndTime(now)
                 .setTenantId(tenantId)
                 .setPartitionId(0));
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usagemetrics/UsageMetricsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usagemetrics/UsageMetricsIT.java
@@ -72,7 +72,8 @@ public class UsageMetricsIT {
     usageMetricWriter.create(
         new UsageMetricDbModel.Builder()
             .key(CommonFixtures.nextKey())
-            .eventTime(time)
+            .startTime(time)
+            .endTime(time)
             .tenantId(tenantId)
             .eventType(eventType)
             .value(value)
@@ -88,7 +89,8 @@ public class UsageMetricsIT {
     usageMetricTUWriter.create(
         new UsageMetricTUDbModel.Builder()
             .key(CommonFixtures.nextKey())
-            .eventTime(time)
+            .startTime(time)
+            .endTime(time)
             .tenantId(tenantId)
             .assigneeHash(value)
             .partitionId(PARTITION_ID.intValue())

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsFilterTransformer.java
@@ -32,7 +32,7 @@ public class UsageMetricsFilterTransformer extends IndexFilterTransformer<UsageM
     final var queries =
         new ArrayList<>(
             dateTimeOperations(
-                UsageMetricIndex.EVENT_TIME,
+                UsageMetricIndex.END_TIME,
                 List.of(Operation.gte(filter.startTime()), Operation.lt(filter.endTime()))));
 
     if (filter.tenantId() != null) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsTUFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsTUFilterTransformer.java
@@ -32,7 +32,7 @@ public class UsageMetricsTUFilterTransformer extends IndexFilterTransformer<Usag
     final var queries =
         new ArrayList<>(
             dateTimeOperations(
-                UsageMetricTUIndex.EVENT_TIME,
+                UsageMetricTUIndex.END_TIME,
                 List.of(Operation.gte(filter.startTime()), Operation.lt(filter.endTime()))));
 
     if (filter.tenantId() != null) {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UsageMetricsQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UsageMetricsQueryTransformerTest.java
@@ -33,7 +33,7 @@ public final class UsageMetricsQueryTransformerTest extends AbstractTransformerT
       assertThat(rangeQuery)
           .extracting("field", "gte", "lt")
           .containsExactly(
-              "eventTime", "2021-01-01T00:00:00.000+0000", "2023-01-01T00:00:00.000+0000");
+              "endTime", "2021-01-01T00:00:00.000+0000", "2023-01-01T00:00:00.000+0000");
     };
   }
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
@@ -10,7 +10,7 @@ package io.camunda.tasklist.store.elasticsearch;
 import static io.camunda.tasklist.util.ElasticsearchUtil.AGGREGATION_TERMS_SIZE;
 import static io.camunda.tasklist.util.ElasticsearchUtil.LENIENT_EXPAND_OPEN_IGNORE_THROTTLED;
 import static io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex.ASSIGNEE_HASH;
-import static io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex.EVENT_TIME;
+import static io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex.END_TIME;
 import static io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex.TENANT_ID;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 
@@ -83,7 +83,7 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
       final OffsetDateTime startTime, final OffsetDateTime endTime, final String tenantId) {
 
     final BoolQueryBuilder boolQuery =
-        boolQuery().must(QueryBuilders.rangeQuery(EVENT_TIME).gte(startTime).lte(endTime));
+        boolQuery().must(QueryBuilders.rangeQuery(END_TIME).gte(startTime).lte(endTime));
 
     if (tenantId != null) {
       boolQuery.must(QueryBuilders.termQuery(TENANT_ID, tenantId));
@@ -142,7 +142,8 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
     final long assigneeHash = HashUtil.getStringHashValue(task.getAssignee());
     return new UsageMetricsTUEntity()
         .setId(String.format(TU_ID_PATTERN, task.getKey(), tenantId, assigneeHash))
-        .setEventTime(task.getCreationTime())
+        .setStartTime(task.getCreationTime())
+        .setEndTime(task.getCreationTime())
         .setAssigneeHash(assigneeHash)
         .setTenantId(tenantId)
         .setPartitionId(task.getPartitionId());

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
@@ -9,7 +9,7 @@ package io.camunda.tasklist.store.opensearch;
 
 import static io.camunda.tasklist.util.OpenSearchUtil.AGGREGATION_TERMS_SIZE;
 import static io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex.ASSIGNEE_HASH;
-import static io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex.EVENT_TIME;
+import static io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex.END_TIME;
 
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
@@ -81,7 +81,7 @@ public class TaskMetricsStoreOpenSearch implements TaskMetricsStore {
         new Builder()
             .range(
                 r -> {
-                  r.field(EVENT_TIME);
+                  r.field(END_TIME);
 
                   if (startTime != null) {
                     r.gte(JsonData.of(startTime));
@@ -155,7 +155,8 @@ public class TaskMetricsStoreOpenSearch implements TaskMetricsStore {
     final long assigneeHash = HashUtil.getStringHashValue(task.getAssignee());
     return new UsageMetricsTUEntity()
         .setId(String.format(TU_ID_PATTERN, task.getKey(), tenantId, assigneeHash))
-        .setEventTime(task.getCreationTime())
+        .setStartTime(task.getCreationTime())
+        .setEndTime(task.getCreationTime())
         .setAssigneeHash(assigneeHash)
         .setTenantId(tenantId)
         .setPartitionId(task.getPartitionId());

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearchTest.java
@@ -12,7 +12,7 @@ import static io.camunda.tasklist.store.elasticsearch.TaskMetricsStoreElasticSea
 import static io.camunda.tasklist.util.ElasticsearchUtil.AGGREGATION_TERMS_SIZE;
 import static io.camunda.tasklist.util.ElasticsearchUtil.LENIENT_EXPAND_OPEN_IGNORE_THROTTLED;
 import static io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex.ASSIGNEE_HASH;
-import static io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex.EVENT_TIME;
+import static io.camunda.webapps.schema.descriptors.index.UsageMetricTUIndex.END_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
@@ -83,7 +83,8 @@ public class TaskMetricsStoreElasticSearchTest {
         new UsageMetricsTUEntity()
             .setId(String.format(TU_ID_PATTERN, task.getKey(), task.getTenantId(), assigneeHash))
             .setAssigneeHash(assigneeHash)
-            .setEventTime(now)
+            .setStartTime(now)
+            .setEndTime(now)
             .setTenantId("<default>")
             .setPartitionId(0);
     final var indexResponse = mock(IndexResponse.class);
@@ -160,7 +161,7 @@ public class TaskMetricsStoreElasticSearchTest {
   private SearchRequest buildSearchRequest(
       final OffsetDateTime now, final OffsetDateTime oneHourBefore) {
     final BoolQueryBuilder rangeQuery =
-        boolQuery().must(QueryBuilders.rangeQuery(EVENT_TIME).gte(oneHourBefore).lte(now));
+        boolQuery().must(QueryBuilders.rangeQuery(END_TIME).gte(oneHourBefore).lte(now));
     final TermsAggregationBuilder aggregation =
         AggregationBuilders.terms(ASSIGNEE).field(ASSIGNEE_HASH).size(AGGREGATION_TERMS_SIZE);
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/UsageMetricIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/UsageMetricIndex.java
@@ -17,7 +17,8 @@ public class UsageMetricIndex extends AbstractIndexDescriptor implements Prio5Ba
   public static final String INDEX_VERSION = "8.8.0";
 
   public static final String ID = "id";
-  public static final String EVENT_TIME = "eventTime";
+  public static final String START_TIME = "startTime";
+  public static final String END_TIME = "endTime";
   public static final String EVENT_TYPE = "eventType";
   public static final String EVENT_VALUE = "eventValue";
   public static final String TENANT_ID = "tenantId";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/UsageMetricTUIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/UsageMetricTUIndex.java
@@ -20,7 +20,8 @@ public class UsageMetricTUIndex extends AbstractIndexDescriptor implements Prio5
   public static final String ID = "id";
   public static final String TENANT_ID = IndexDescriptor.TENANT_ID;
   public static final String PARTITION_ID = "partitionId";
-  public static final String EVENT_TIME = "eventTime";
+  public static final String START_TIME = "startTime";
+  public static final String END_TIME = "endTime";
   public static final String ASSIGNEE_HASH = "assigneeHash";
 
   public UsageMetricTUIndex(final String indexPrefix, final boolean isElasticsearch) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/metrics/UsageMetricsEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/metrics/UsageMetricsEntity.java
@@ -19,7 +19,8 @@ public final class UsageMetricsEntity
         TenantOwned {
 
   private String id;
-  private OffsetDateTime eventTime;
+  private OffsetDateTime startTime;
+  private OffsetDateTime endTime;
   private UsageMetricsEventType eventType;
   private Long eventValue;
   private String tenantId;
@@ -36,12 +37,21 @@ public final class UsageMetricsEntity
     return this;
   }
 
-  public OffsetDateTime getEventTime() {
-    return eventTime;
+  public OffsetDateTime getStartTime() {
+    return startTime;
   }
 
-  public UsageMetricsEntity setEventTime(final OffsetDateTime eventTime) {
-    this.eventTime = eventTime;
+  public UsageMetricsEntity setStartTime(final OffsetDateTime startTime) {
+    this.startTime = startTime;
+    return this;
+  }
+
+  public OffsetDateTime getEndTime() {
+    return endTime;
+  }
+
+  public UsageMetricsEntity setEndTime(final OffsetDateTime endTime) {
+    this.endTime = endTime;
     return this;
   }
 
@@ -86,7 +96,7 @@ public final class UsageMetricsEntity
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, eventTime, eventType, eventValue, tenantId, partitionId);
+    return Objects.hash(id, startTime, endTime, eventType, eventValue, tenantId, partitionId);
   }
 
   @Override
@@ -99,7 +109,8 @@ public final class UsageMetricsEntity
     }
     final var that = (UsageMetricsEntity) obj;
     return Objects.equals(id, that.id)
-        && Objects.equals(eventTime, that.eventTime)
+        && Objects.equals(startTime, that.startTime)
+        && Objects.equals(endTime, that.endTime)
         && Objects.equals(eventType, that.eventType)
         && Objects.equals(eventValue, that.eventValue)
         && Objects.equals(tenantId, that.tenantId)
@@ -108,7 +119,7 @@ public final class UsageMetricsEntity
 
   @Override
   public String toString() {
-    return "UsageMetricsEntity[id=%s, eventTime=%s, eventType=%s, eventValue=%d, tenantId=%s, partitionId=%d]"
-        .formatted(id, eventTime, eventType, eventValue, tenantId, partitionId);
+    return "UsageMetricsEntity[id=%s, startTime=%s, endTime=%s, eventType=%s, eventValue=%d, tenantId=%s, partitionId=%d]"
+        .formatted(id, startTime, endTime, eventType, eventValue, tenantId, partitionId);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/metrics/UsageMetricsTUEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/metrics/UsageMetricsTUEntity.java
@@ -19,14 +19,15 @@ public class UsageMetricsTUEntity
         TenantOwned {
 
   private String id;
-  private OffsetDateTime eventTime;
+  private OffsetDateTime startTime;
+  private OffsetDateTime endTime;
   private Long assigneeHash;
   private String tenantId;
   private int partitionId;
 
   @Override
   public int hashCode() {
-    return Objects.hash(tenantId, eventTime, assigneeHash, partitionId);
+    return Objects.hash(tenantId, startTime, endTime, assigneeHash, partitionId);
   }
 
   @Override
@@ -38,29 +39,15 @@ public class UsageMetricsTUEntity
     return Objects.equals(id, that.id)
         && Objects.equals(tenantId, that.tenantId)
         && Objects.equals(partitionId, that.partitionId)
-        && Objects.equals(eventTime, that.eventTime)
+        && Objects.equals(startTime, that.startTime)
+        && Objects.equals(endTime, that.endTime)
         && Objects.equals(assigneeHash, that.assigneeHash);
   }
 
   @Override
   public String toString() {
-    return "UsageMetricsTUEntity{"
-        + "id='"
-        + id
-        + '\''
-        + ", tenantId='"
-        + tenantId
-        + '\''
-        + ", partitionId='"
-        + partitionId
-        + '\''
-        + ", eventTime="
-        + eventTime
-        + '\''
-        + ", assigneeHash='"
-        + assigneeHash
-        + '\''
-        + '}';
+    return "UsageMetricsTUEntity{id='%s', startTime=%s, endTime=%s, assigneeHash=%d, tenantId='%s', partitionId=%d}"
+        .formatted(id, startTime, endTime, assigneeHash, tenantId, partitionId);
   }
 
   @Override
@@ -84,12 +71,21 @@ public class UsageMetricsTUEntity
     return this;
   }
 
-  public OffsetDateTime getEventTime() {
-    return eventTime;
+  public OffsetDateTime getStartTime() {
+    return startTime;
   }
 
-  public UsageMetricsTUEntity setEventTime(final OffsetDateTime eventTime) {
-    this.eventTime = eventTime;
+  public UsageMetricsTUEntity setStartTime(final OffsetDateTime startTime) {
+    this.startTime = startTime;
+    return this;
+  }
+
+  public OffsetDateTime getEndTime() {
+    return endTime;
+  }
+
+  public UsageMetricsTUEntity setEndTime(final OffsetDateTime endTime) {
+    this.endTime = endTime;
     return this;
   }
 

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-usage-metric-tu.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-usage-metric-tu.json
@@ -11,7 +11,11 @@
       "partitionId": {
         "type": "integer"
       },
-      "eventTime": {
+      "startTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "endTime": {
         "format": "date_time || epoch_millis",
         "type": "date"
       },

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-usage-metric.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-usage-metric.json
@@ -5,7 +5,11 @@
       "id": {
         "type": "keyword"
       },
-      "eventTime": {
+      "startTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "endTime": {
         "format": "date_time || epoch_millis",
         "type": "date"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-usage-metric-tu.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-usage-metric-tu.json
@@ -11,7 +11,11 @@
       "partitionId": {
         "type": "integer"
       },
-      "eventTime": {
+      "startTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "endTime": {
         "format": "date_time || epoch_millis",
         "type": "date"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-usage-metric.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-usage-metric.json
@@ -5,7 +5,11 @@
       "id": {
         "type": "keyword"
       },
-      "eventTime": {
+      "startTime": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "endTime": {
         "format": "date_time || epoch_millis",
         "type": "date"
       },

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UsageMetricHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UsageMetricHandler.java
@@ -78,6 +78,7 @@ public record UsageMetricHandler(String indexName, String tuIndexName)
 
     final var recordKey = record.getKey();
     final var partitionId = record.getPartitionId();
+    final var startTime = DateUtil.toOffsetDateTime(recordValue.getStartTime());
     final var endTime = DateUtil.toOffsetDateTime(recordValue.getEndTime());
     final var collection = usageMetricsBatch.variables();
     final var tuCollection = usageMetricsBatch.tuVariables();
@@ -88,7 +89,7 @@ public record UsageMetricHandler(String indexName, String tuIndexName)
             (tenantId, counter) ->
                 collection.add(
                     createUsageMetricEntity(
-                        recordKey, partitionId, endTime, tenantId, eventType, counter)));
+                        recordKey, partitionId, startTime, endTime, tenantId, eventType, counter)));
 
     recordValue
         .getSetValues()
@@ -98,7 +99,7 @@ public record UsageMetricHandler(String indexName, String tuIndexName)
                     .map(
                         setValue ->
                             createUsageMetricTUEntity(
-                                recordKey, partitionId, endTime, tenantId, setValue))
+                                recordKey, partitionId, startTime, endTime, tenantId, setValue))
                     .forEach(tuCollection::add));
   }
 
@@ -127,7 +128,8 @@ public record UsageMetricHandler(String indexName, String tuIndexName)
   private UsageMetricsEntity createUsageMetricEntity(
       final long recordKey,
       final int partitionId,
-      final OffsetDateTime timestamp,
+      final OffsetDateTime startTime,
+      final OffsetDateTime endTime,
       final String tenantId,
       final UsageMetricsEventType eventType,
       final Long eventValue) {
@@ -136,7 +138,8 @@ public record UsageMetricHandler(String indexName, String tuIndexName)
         .setId(String.format(ID_PATTERN, recordKey, tenantId))
         .setPartitionId(partitionId)
         .setTenantId(tenantId)
-        .setEventTime(timestamp)
+        .setStartTime(startTime)
+        .setEndTime(endTime)
         .setEventType(eventType)
         .setEventValue(eventValue);
   }
@@ -144,7 +147,8 @@ public record UsageMetricHandler(String indexName, String tuIndexName)
   private UsageMetricsTUEntity createUsageMetricTUEntity(
       final long recordKey,
       final int partitionId,
-      final OffsetDateTime timestamp,
+      final OffsetDateTime startTime,
+      final OffsetDateTime endTime,
       final String tenantId,
       final long assigneeHash) {
 
@@ -152,7 +156,8 @@ public record UsageMetricHandler(String indexName, String tuIndexName)
         .setId(String.format(TU_ID_PATTERN, recordKey, tenantId, assigneeHash))
         .setPartitionId(partitionId)
         .setTenantId(tenantId)
-        .setEventTime(timestamp)
+        .setStartTime(startTime)
+        .setEndTime(endTime)
         .setAssigneeHash(assigneeHash);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UsageMetricHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UsageMetricHandlerTest.java
@@ -147,7 +147,10 @@ class UsageMetricHandlerTest {
             String.format(ID_PATTERN, EVENT_KEY, TENANT_2),
             String.format(ID_PATTERN, EVENT_KEY, TENANT_3));
     assertThat(variables)
-        .extracting(UsageMetricsEntity::getEventTime)
+        .extracting(UsageMetricsEntity::getEndTime)
+        .contains(DateUtil.toOffsetDateTime(now));
+    assertThat(variables)
+        .extracting(UsageMetricsEntity::getStartTime)
         .contains(DateUtil.toOffsetDateTime(now));
     assertThat(variables)
         .extracting(UsageMetricsEntity::getEventType)
@@ -195,7 +198,10 @@ class UsageMetricHandlerTest {
             String.format(TU_ID_PATTERN, EVENT_KEY, TENANT_3, ASSIGNEE_HASH_1),
             String.format(TU_ID_PATTERN, EVENT_KEY, TENANT_3, ASSIGNEE_HASH_2));
     assertThat(tuVariables)
-        .extracting(UsageMetricsTUEntity::getEventTime)
+        .extracting(UsageMetricsTUEntity::getEndTime)
+        .contains(DateUtil.toOffsetDateTime(now));
+    assertThat(tuVariables)
+        .extracting(UsageMetricsTUEntity::getStartTime)
         .contains(DateUtil.toOffsetDateTime(now));
     assertThat(tuVariables)
         .extracting(UsageMetricsTUEntity::getPartitionId)
@@ -242,7 +248,10 @@ class UsageMetricHandlerTest {
             String.format(ID_PATTERN, EVENT_KEY, TENANT_1),
             String.format(ID_PATTERN, EVENT_KEY, TENANT_2));
     assertThat(variables)
-        .extracting(UsageMetricsEntity::getEventTime)
+        .extracting(UsageMetricsEntity::getEndTime)
+        .contains(DateUtil.toOffsetDateTime(now));
+    assertThat(variables)
+        .extracting(UsageMetricsEntity::getStartTime)
         .contains(DateUtil.toOffsetDateTime(now));
     assertThat(variables).extracting(UsageMetricsEntity::getPartitionId).containsOnly(PARTITION_ID);
     assertThat(variables)
@@ -257,7 +266,10 @@ class UsageMetricHandlerTest {
             String.format(TU_ID_PATTERN, EVENT_KEY, TENANT_3, ASSIGNEE_HASH_1),
             String.format(TU_ID_PATTERN, EVENT_KEY, TENANT_3, ASSIGNEE_HASH_2));
     assertThat(tuVariables)
-        .extracting(UsageMetricsTUEntity::getEventTime)
+        .extracting(UsageMetricsTUEntity::getEndTime)
+        .contains(DateUtil.toOffsetDateTime(now));
+    assertThat(tuVariables)
+        .extracting(UsageMetricsTUEntity::getStartTime)
         .contains(DateUtil.toOffsetDateTime(now));
     assertThat(tuVariables)
         .extracting(UsageMetricsTUEntity::getPartitionId)
@@ -297,20 +309,23 @@ class UsageMetricHandlerTest {
     verifyNoMoreInteractions(mockRequest);
   }
 
-  private ArrayList<UsageMetricsEntity> composeUsageMetrics(final long now, Long... eventValues) {
+  private ArrayList<UsageMetricsEntity> composeUsageMetrics(
+      final long now, final Long... eventValues) {
     return new ArrayList<>(
         List.of(
             new UsageMetricsEntity()
                 .setId(String.format(ID_PATTERN, EVENT_KEY, TENANT_1))
                 .setPartitionId(PARTITION_ID)
-                .setEventTime(DateUtil.toOffsetDateTime(now))
+                .setStartTime(DateUtil.toOffsetDateTime(now))
+                .setEndTime(DateUtil.toOffsetDateTime(now))
                 .setEventType(UsageMetricsEventType.RPI)
                 .setEventValue(eventValues[0]),
             new UsageMetricsEntity()
                 .setId(String.format(ID_PATTERN, EVENT_KEY, TENANT_2))
                 .setEventType(UsageMetricsEventType.RPI)
                 .setPartitionId(PARTITION_ID)
-                .setEventTime(DateUtil.toOffsetDateTime(now))
+                .setStartTime(DateUtil.toOffsetDateTime(now))
+                .setEndTime(DateUtil.toOffsetDateTime(now))
                 .setEventValue(eventValues[1])));
   }
 
@@ -321,13 +336,15 @@ class UsageMetricHandlerTest {
                 .setId(String.format(TU_ID_PATTERN, EVENT_KEY, TENANT_1, ASSIGNEE_HASH_1))
                 .setPartitionId(PARTITION_ID)
                 .setTenantId(TENANT_1)
-                .setEventTime(DateUtil.toOffsetDateTime(now))
+                .setStartTime(DateUtil.toOffsetDateTime(now))
+                .setEndTime(DateUtil.toOffsetDateTime(now))
                 .setAssigneeHash(ASSIGNEE_HASH_1),
             new UsageMetricsTUEntity()
                 .setId(String.format(TU_ID_PATTERN, EVENT_KEY, TENANT_2, ASSIGNEE_HASH_2))
                 .setPartitionId(PARTITION_ID)
                 .setTenantId(TENANT_2)
-                .setEventTime(DateUtil.toOffsetDateTime(now))
+                .setStartTime(DateUtil.toOffsetDateTime(now))
+                .setEndTime(DateUtil.toOffsetDateTime(now))
                 .setAssigneeHash(ASSIGNEE_HASH_2)));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UsageMetricExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UsageMetricExportHandler.java
@@ -57,6 +57,7 @@ public record UsageMetricExportHandler(
       return new Tuple<>(List.of(), List.of());
     }
 
+    final var startTime = DateUtil.toOffsetDateTime(value.getStartTime());
     final var endTime = DateUtil.toOffsetDateTime(value.getEndTime());
     final var recordKey = usageMetricRecordValue.getKey();
     final var partitionId = usageMetricRecordValue.getPartitionId();
@@ -69,15 +70,29 @@ public record UsageMetricExportHandler(
         .forEach(
             (key, val) ->
                 usageMetricList.add(
-                    new UsageMetricDbModel(recordKey, endTime, key, eventType, val, partitionId)));
+                    new UsageMetricDbModel.Builder()
+                        .key(recordKey)
+                        .startTime(startTime)
+                        .endTime(endTime)
+                        .tenantId(key)
+                        .eventType(eventType)
+                        .value(val)
+                        .partitionId(partitionId)
+                        .build()));
     value.getSetValues().entrySet().stream()
         .flatMap(
             entry ->
                 entry.getValue().stream()
                     .map(
                         val ->
-                            new UsageMetricTUDbModel(
-                                recordKey, endTime, entry.getKey(), val, partitionId)))
+                            new UsageMetricTUDbModel.Builder()
+                                .key(recordKey)
+                                .startTime(startTime)
+                                .endTime(endTime)
+                                .tenantId(entry.getKey())
+                                .assigneeHash(val)
+                                .partitionId(partitionId)
+                                .build()))
         .forEach(usageMetricTUList::add);
 
     return new Tuple<>(usageMetricList, usageMetricTUList);


### PR DESCRIPTION
# Description
Backport of #37542 to `main`.

relates to camunda/camunda#37454