### PR TITLE
[Backport stable/8.8] feat: added correlated message assertions

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -503,10 +503,10 @@ public interface ProcessInstanceAssert {
    *
    * <p>The assertion waits for the correct message subscription.
    *
-   * @param expectedMessageName the name of the message
+   * @param messageName the name of the message
    * @return the assertion object
    */
-  ProcessInstanceAssert isWaitingForMessage(final String expectedMessageName);
+  ProcessInstanceAssert isWaitingForMessage(final String messageName);
 
   /**
    * Verifies that the process instance is currently waiting to receive one or more specified
@@ -514,12 +514,11 @@ public interface ProcessInstanceAssert {
    *
    * <p>The assertion waits for the correct message subscription.
    *
-   * @param expectedMessageName the name of the message
+   * @param messageName the name of the message
    * @param correlationKey the message's correlation key
    * @return the assertion object
    */
-  ProcessInstanceAssert isWaitingForMessage(
-      final String expectedMessageName, final String correlationKey);
+  ProcessInstanceAssert isWaitingForMessage(final String messageName, final String correlationKey);
 
   /**
    * Verifies that the process instance is not currently waiting to receive one or more specified
@@ -527,10 +526,10 @@ public interface ProcessInstanceAssert {
    *
    * <p>The assertion waits for a message subscription that may invalidate the assertion
    *
-   * @param expectedMessageName the name of the message
+   * @param messageName the name of the message
    * @return the assertion object
    */
-  ProcessInstanceAssert isNotWaitingForMessage(final String expectedMessageName);
+  ProcessInstanceAssert isNotWaitingForMessage(final String messageName);
 
   /**
    * Verifies that the process instance is not currently waiting to receive one or more specified
@@ -538,10 +537,31 @@ public interface ProcessInstanceAssert {
    *
    * <p>The assertion waits for a message subscription that may invalidate the assertion
    *
-   * @param expectedMessageName the name of the message
+   * @param messageName the name of the message
    * @param correlationKey the message's correlation key
    * @return the assertion object
    */
   ProcessInstanceAssert isNotWaitingForMessage(
-      final String expectedMessageName, final String correlationKey);
+      final String messageName, final String correlationKey);
+
+  /**
+   * Verifies that the process instance has received and successfully correlated a message.
+   *
+   * <p>The assertion waits for the correlated message.
+   *
+   * @param messageName the name of the message
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasCorrelatedMessage(final String messageName);
+
+  /**
+   * Verifies that the process instance has received and successfully correlated a message.
+   *
+   * <p>The assertion waits for the correlated message.
+   *
+   * @param messageName the name of the message
+   * @param correlationKey the message's correlation key
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasCorrelatedMessage(final String messageName, final String correlationKey);
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.impl.assertions;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.filter.CorrelatedMessageFilter;
 import io.camunda.client.api.search.filter.DecisionInstanceFilter;
 import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.filter.IncidentFilter;
@@ -24,6 +25,7 @@ import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.filter.UserTaskFilter;
 import io.camunda.client.api.search.filter.VariableFilter;
 import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.CorrelatedMessage;
 import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Incident;
@@ -159,16 +161,24 @@ public class CamundaDataSource {
     return client.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
   }
 
-  public List<MessageSubscription> getMessageSubscriptions() {
-    return getMessageSubscriptions(filter -> {});
-  }
-
   public List<MessageSubscription> getMessageSubscriptions(
       final Consumer<MessageSubscriptionFilter> filter) {
     return client
         .newMessageSubscriptionSearchRequest()
         .filter(filter)
         .sort(sort -> sort.lastUpdatedDate().asc())
+        .page(DEFAULT_PAGE_REQUEST)
+        .send()
+        .join()
+        .items();
+  }
+
+  public List<CorrelatedMessage> getCorrelatedMessages(
+      final Consumer<CorrelatedMessageFilter> filter) {
+    return client
+        .newCorrelatedMessageSearchRequest()
+        .filter(filter)
+        .sort(sort -> sort.correlationTime().asc())
         .page(DEFAULT_PAGE_REQUEST)
         .send()
         .join()

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
@@ -17,7 +17,7 @@ package io.camunda.process.test.impl.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.client.api.search.enums.MessageSubscriptionType;
+import io.camunda.client.api.search.enums.MessageSubscriptionState;
 import io.camunda.client.api.search.filter.CorrelatedMessageFilter;
 import io.camunda.client.api.search.filter.MessageSubscriptionFilter;
 import io.camunda.client.api.search.response.CorrelatedMessage;
@@ -48,7 +48,7 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
         filter ->
             filter
                 .messageName(messageName)
-                .messageSubscriptionType(MessageSubscriptionType.CREATED),
+                .messageSubscriptionState(MessageSubscriptionState.CREATED),
         messageSubscriptions ->
             assertThat(messageSubscriptions)
                 .withFailMessage(
@@ -91,7 +91,7 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
         processInstanceKey,
         filter ->
             filter
-                .messageSubscriptionType(MessageSubscriptionType.CREATED)
+                .messageSubscriptionState(MessageSubscriptionState.CREATED)
                 .messageName(messageName)
                 .correlationKey(correlationKey),
         messageSubscriptions ->

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/MessageSubscriptionAssertj.java
@@ -17,7 +17,10 @@ package io.camunda.process.test.impl.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.client.api.search.enums.MessageSubscriptionType;
+import io.camunda.client.api.search.filter.CorrelatedMessageFilter;
 import io.camunda.client.api.search.filter.MessageSubscriptionFilter;
+import io.camunda.client.api.search.response.CorrelatedMessage;
 import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import java.util.List;
@@ -38,63 +41,92 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
     this.awaitBehavior = awaitBehavior;
   }
 
-  public void isWaitingForMessage(final long processInstanceKey, final String expectedMessageName) {
+  public void isWaitingForMessage(final long processInstanceKey, final String messageName) {
 
     awaitMessageSubscription(
         processInstanceKey,
-        f -> f.messageName(expectedMessageName),
+        filter ->
+            filter
+                .messageName(messageName)
+                .messageSubscriptionType(MessageSubscriptionType.CREATED),
         messageSubscriptions ->
             assertThat(messageSubscriptions)
                 .withFailMessage(
                     "%s should have an active message subscription [message-name: '%s'], but no such subscription was found.",
-                    actual, expectedMessageName)
+                    actual, messageName)
                 .isNotEmpty());
   }
 
   public void isWaitingForMessage(
-      final long processInstanceKey,
-      final String expectedMessageName,
-      final String correlationKey) {
+      final long processInstanceKey, final String messageName, final String correlationKey) {
 
     awaitMessageSubscription(
         processInstanceKey,
-        f -> f.messageName(expectedMessageName).correlationKey(correlationKey),
+        f -> f.messageName(messageName).correlationKey(correlationKey),
         messageSubscriptions ->
             assertThat(messageSubscriptions)
                 .withFailMessage(
                     "%s should have a message subscription [message-name: '%s', correlation-key: '%s'], but no such subscription was found.",
-                    actual, expectedMessageName, correlationKey)
+                    actual, messageName, correlationKey)
                 .isNotEmpty());
   }
 
-  public void isNotWaitingForMessage(
-      final long processInstanceKey, final String expectedMessageName) {
+  public void isNotWaitingForMessage(final long processInstanceKey, final String messageName) {
 
     awaitMessageSubscription(
         processInstanceKey,
-        f -> f.messageName(expectedMessageName),
+        f -> f.messageName(messageName),
         messageSubscriptions ->
             assertThat(messageSubscriptions)
                 .withFailMessage(
                     "%s has an active message subscription [message-name: '%s'], but such a subscription was not expected.",
-                    actual, expectedMessageName)
+                    actual, messageName)
                 .isEmpty());
   }
 
   public void isNotWaitingForMessage(
-      final long processInstanceKey,
-      final String expectedMessageName,
-      final String correlationKey) {
+      final long processInstanceKey, final String messageName, final String correlationKey) {
 
     awaitMessageSubscription(
         processInstanceKey,
-        f -> f.messageName(expectedMessageName).correlationKey(correlationKey),
+        filter ->
+            filter
+                .messageSubscriptionType(MessageSubscriptionType.CREATED)
+                .messageName(messageName)
+                .correlationKey(correlationKey),
         messageSubscriptions ->
             assertThat(messageSubscriptions)
                 .withFailMessage(
                     "%s has an active message subscription [message-name: '%s', correlation-key: '%s'], but such a subscription was not expected.",
-                    actual, expectedMessageName, correlationKey)
+                    actual, messageName, correlationKey)
                 .isEmpty());
+  }
+
+  public void hasCorrelatedMessage(final long processInstanceKey, final String messageName) {
+
+    awaitCorrelatedMessages(
+        processInstanceKey,
+        filter -> filter.messageName(messageName),
+        correlatedMessages ->
+            assertThat(correlatedMessages)
+                .withFailMessage(
+                    "%s should have at least one correlated message [message-name: '%s'], but found none.",
+                    actual, messageName)
+                .isNotEmpty());
+  }
+
+  public void hasCorrelatedMessage(
+      final long processInstanceKey, final String messageName, final String correlationKey) {
+
+    awaitCorrelatedMessages(
+        processInstanceKey,
+        filter -> filter.messageName(messageName).correlationKey(correlationKey),
+        correlatedMessages ->
+            assertThat(correlatedMessages)
+                .withFailMessage(
+                    "%s should have at least one correlated message [message-name: '%s', correlation-key: '%s'], but found none.",
+                    actual, messageName, correlationKey)
+                .isNotEmpty());
   }
 
   private void awaitMessageSubscription(
@@ -105,6 +137,18 @@ public class MessageSubscriptionAssertj extends AbstractAssert<MessageSubscripti
     awaitBehavior.untilAsserted(
         () ->
             dataSource.getMessageSubscriptions(
+                f -> filter.accept(f.processInstanceKey(processInstanceKey))),
+        assertionCallback);
+  }
+
+  private void awaitCorrelatedMessages(
+      final long processInstanceKey,
+      final Consumer<CorrelatedMessageFilter> filter,
+      final Consumer<List<CorrelatedMessage>> assertionCallback) {
+
+    awaitBehavior.untilAsserted(
+        () ->
+            dataSource.getCorrelatedMessages(
                 f -> filter.accept(f.processInstanceKey(processInstanceKey))),
         assertionCallback);
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -353,30 +353,44 @@ public class ProcessInstanceAssertj
   }
 
   @Override
-  public ProcessInstanceAssert isWaitingForMessage(final String expectedMessageName) {
-    messageSubscriptionAssertj.isWaitingForMessage(getProcessInstanceKey(), expectedMessageName);
+  public ProcessInstanceAssert isWaitingForMessage(final String messageName) {
+    messageSubscriptionAssertj.isWaitingForMessage(getProcessInstanceKey(), messageName);
     return this;
   }
 
   @Override
   public ProcessInstanceAssert isWaitingForMessage(
-      final String expectedMessageName, final String correlationKey) {
+      final String messageName, final String correlationKey) {
     messageSubscriptionAssertj.isWaitingForMessage(
-        getProcessInstanceKey(), expectedMessageName, correlationKey);
+        getProcessInstanceKey(), messageName, correlationKey);
     return this;
   }
 
   @Override
-  public ProcessInstanceAssert isNotWaitingForMessage(final String expectedMessageName) {
-    messageSubscriptionAssertj.isNotWaitingForMessage(getProcessInstanceKey(), expectedMessageName);
+  public ProcessInstanceAssert isNotWaitingForMessage(final String messageName) {
+    messageSubscriptionAssertj.isNotWaitingForMessage(getProcessInstanceKey(), messageName);
     return this;
   }
 
   @Override
   public ProcessInstanceAssert isNotWaitingForMessage(
-      final String expectedMessageName, final String correlationKey) {
+      final String messageName, final String correlationKey) {
     messageSubscriptionAssertj.isNotWaitingForMessage(
-        getProcessInstanceKey(), expectedMessageName, correlationKey);
+        getProcessInstanceKey(), messageName, correlationKey);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasCorrelatedMessage(final String messageName) {
+    messageSubscriptionAssertj.hasCorrelatedMessage(getProcessInstanceKey(), messageName);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasCorrelatedMessage(
+      final String messageName, final String correlationKey) {
+    messageSubscriptionAssertj.hasCorrelatedMessage(
+        getProcessInstanceKey(), messageName, correlationKey);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -29,12 +29,15 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.response.ProcessInstanceResult;
+import io.camunda.client.api.search.filter.CorrelatedMessageFilter;
 import io.camunda.client.api.search.filter.MessageSubscriptionFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.Variable;
+import io.camunda.client.impl.search.response.CorrelatedMessageImpl;
 import io.camunda.client.impl.search.response.MessageSubscriptionImpl;
+import io.camunda.client.protocol.rest.CorrelatedMessageResult;
 import io.camunda.client.protocol.rest.MessageSubscriptionResult;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
@@ -65,8 +68,6 @@ public class ProcessInstanceAssertTest {
 
   private static final long PROCESS_INSTANCE_KEY = 1L;
   private static final String BPMN_PROCESS_ID = "process";
-  private static final String START_DATE = "2024-07-01T09:45:00";
-  private static final String END_DATE = "2024-07-01T10:00:00";
 
   @Mock private CamundaDataSource camundaDataSource;
   @Mock private ProcessInstanceEvent processInstanceEvent;
@@ -1034,6 +1035,132 @@ public class ProcessInstanceAssertTest {
                       .isNotWaitingForMessage("expected", "correlation-key"))
           .hasMessage(
               "Process instance [key: 1] has an active message subscription [message-name: 'expected', correlation-key: 'correlation-key'], but such a subscription was not expected.");
+    }
+  }
+
+  @Nested
+  class CorrelatedMessages {
+
+    @Captor private ArgumentCaptor<Consumer<CorrelatedMessageFilter>> filterCaptor;
+
+    @Mock(answer = Answers.RETURNS_SELF)
+    private CorrelatedMessageFilter correlatedMessageFilter;
+
+    @Test
+    void shouldFindCorrelatedMessage() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getCorrelatedMessages(filterCaptor.capture()))
+          .thenReturn(
+              Collections.singletonList(new CorrelatedMessageImpl(new CorrelatedMessageResult())));
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasCorrelatedMessage("expected");
+
+      filterCaptor.getValue().accept(correlatedMessageFilter);
+      verify(correlatedMessageFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(correlatedMessageFilter).messageName("expected");
+    }
+
+    @Test
+    void shouldFindCorrelatedMessageWithCorrelationKey() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getCorrelatedMessages(filterCaptor.capture()))
+          .thenReturn(
+              Collections.singletonList(new CorrelatedMessageImpl(new CorrelatedMessageResult())));
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasCorrelatedMessage("expected", "correlation-key");
+
+      filterCaptor.getValue().accept(correlatedMessageFilter);
+      verify(correlatedMessageFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(correlatedMessageFilter).messageName("expected");
+      verify(correlatedMessageFilter).correlationKey("correlation-key");
+    }
+
+    @Test
+    void shouldAwaitCorrelatedMessage() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.emptyList())
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getCorrelatedMessages(filterCaptor.capture()))
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.emptyList())
+          .thenReturn(Collections.emptyList())
+          .thenReturn(
+              Collections.singletonList(new CorrelatedMessageImpl(new CorrelatedMessageResult())));
+
+      // then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasCorrelatedMessage("expected");
+
+      filterCaptor.getValue().accept(correlatedMessageFilter);
+      verify(correlatedMessageFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(correlatedMessageFilter).messageName("expected");
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldErrorIfNoCorrelatedMessageWasFound() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getCorrelatedMessages(filterCaptor.capture()))
+          .thenReturn(Collections.emptyList());
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .hasCorrelatedMessage("expected"))
+          .hasMessage(
+              "Process instance [key: 1] should have at least one correlated message [message-name: 'expected'], but found none.");
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldErrorIfNoCorrelatedMessageWasFoundWithCorrelationKey() {
+      // given
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getCorrelatedMessages(filterCaptor.capture()))
+          .thenReturn(Collections.emptyList());
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .hasCorrelatedMessage("expected", "correlation-key"))
+          .hasMessage(
+              "Process instance [key: 1] should have at least one correlated message [message-name: 'expected', correlation-key: 'correlation-key'], but found none.");
     }
   }
 }

--- a/testing/camunda-process-test-java/src/test/resources/processInstanceAssertMessageAssertIT/await-message.bpmn
+++ b/testing/camunda-process-test-java/src/test/resources/processInstanceAssertMessageAssertIT/await-message.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=1" target="eventId" />
+          <zeebe:output source="=&#34;1&#34;" target="eventId" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_0yffp2u</bpmn:outgoing>


### PR DESCRIPTION
# Description
Backport of #37897 to `stable/8.8`.

relates to #23291