### PR TITLE
[Backport stable/8.8] fix: search clients proxy is not injected to broker when no embedded-gateway is configured

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -51,13 +51,11 @@ import io.camunda.search.os.clients.OpensearchSearchClient;
 import io.camunda.security.reader.ResourceAccessController;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
-import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnRestGatewayEnabled
 public class SearchClientDatabaseConfiguration {
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
@@ -96,12 +96,10 @@ import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.SequenceFlowTemplate;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
-import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnRestGatewayEnabled
 @ConditionalOnSecondaryStorageType({
   SecondaryStorageType.elasticsearch,
   SecondaryStorageType.opensearch

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -135,7 +135,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final SecurityConfiguration securityConfiguration,
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
-      final JwtDecoder jwtDecoder) {
+      final JwtDecoder jwtDecoder,
+      final SearchClientsProxy searchClientsProxy) {
 
     this(
         brokerInfo,
@@ -154,7 +155,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
         userServices,
         passwordEncoder,
         jwtDecoder,
-        null);
+        searchClientsProxy);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -115,7 +115,8 @@ public final class SystemContext {
       final SecurityConfiguration securityConfiguration,
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
-      final JwtDecoder jwtDecoder) {
+      final JwtDecoder jwtDecoder,
+      final SearchClientsProxy searchClientsProxy) {
     this(
         DEFAULT_SHUTDOWN_TIMEOUT,
         brokerCfg,
@@ -128,7 +129,7 @@ public final class SystemContext {
         userServices,
         passwordEncoder,
         jwtDecoder,
-        null);
+        searchClientsProxy);
   }
 
   private void initSystemContext() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.AtomixCluster;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -73,7 +74,8 @@ public final class SimpleBrokerStartTest {
                       new SecurityConfiguration(),
                       mock(UserServices.class),
                       mock(PasswordEncoder.class),
-                      mock(JwtDecoder.class));
+                      mock(JwtDecoder.class),
+                      mock(SearchClientsProxy.class));
               new Broker(systemContext, TEST_SPRING_BROKER_BRIDGE, emptyList());
             });
 
@@ -102,7 +104,8 @@ public final class SimpleBrokerStartTest {
             new SecurityConfiguration(),
             mock(UserServices.class),
             mock(PasswordEncoder.class),
-            mock(JwtDecoder.class));
+            mock(JwtDecoder.class),
+            mock(SearchClientsProxy.class));
 
     final var leaderLatch = new CountDownLatch(1);
     final var listener =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -77,7 +78,8 @@ class ApiMessagingServiceStepTest {
             new SecurityConfiguration(),
             mock(UserServices.class),
             mock(PasswordEncoder.class),
-            mock(JwtDecoder.class));
+            mock(JwtDecoder.class),
+            mock(SearchClientsProxy.class));
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -78,7 +79,8 @@ class CommandApiServiceStepTest {
             new SecurityConfiguration(),
             mock(UserServices.class),
             mock(PasswordEncoder.class),
-            mock(JwtDecoder.class));
+            mock(JwtDecoder.class),
+            mock(SearchClientsProxy.class));
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
     testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitorActor.class));
     testBrokerStartupContext.setGatewayBrokerTransport(mock(AtomixServerTransport.class));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStepTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -88,7 +89,8 @@ class EmbeddedGatewayServiceStepTest {
               new SecurityConfiguration(),
               mock(UserServices.class),
               mock(PasswordEncoder.class),
-              mock(JwtDecoder.class));
+              mock(JwtDecoder.class),
+              mock(SearchClientsProxy.class));
 
       final var port = SocketUtil.getNextAddress().getPort();
       final var commandApiCfg = TEST_BROKER_CONFIG.getGateway().getNetwork();
@@ -161,7 +163,8 @@ class EmbeddedGatewayServiceStepTest {
               new SecurityConfiguration(),
               mock(UserServices.class),
               mock(PasswordEncoder.class),
-              mock(JwtDecoder.class));
+              mock(JwtDecoder.class),
+              mock(SearchClientsProxy.class));
 
       testBrokerStartupContext.setEmbeddedGatewayService(mockEmbeddedGatewayService);
       shutdownFuture = CONCURRENCY_CONTROL.createFuture();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -70,7 +71,8 @@ class GatewayBrokerTransportStepTest {
             new SecurityConfiguration(),
             mock(UserServices.class),
             mock(PasswordEncoder.class),
-            mock(JwtDecoder.class));
+            mock(JwtDecoder.class),
+            mock(SearchClientsProxy.class));
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberConfig;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -100,7 +101,8 @@ class PartitionManagerStepTest {
               new SecurityConfiguration(),
               mock(UserServices.class),
               mock(PasswordEncoder.class),
-              mock(JwtDecoder.class));
+              mock(JwtDecoder.class),
+              mock(SearchClientsProxy.class));
       testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
       testBrokerStartupContext.setAdminApiService(mock(AdminApiRequestHandler.class));
       testBrokerStartupContext.setBrokerAdminService(mock(BrokerAdminServiceImpl.class));
@@ -202,7 +204,8 @@ class PartitionManagerStepTest {
               new SecurityConfiguration(),
               mock(UserServices.class),
               mock(PasswordEncoder.class),
-              mock(JwtDecoder.class));
+              mock(JwtDecoder.class),
+              mock(SearchClientsProxy.class));
 
       testBrokerStartupContext.setPartitionManager(mockPartitionManager);
       final ClusterConfigurationService mockClusterTopology =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -64,7 +65,8 @@ class RequestIdGeneratorStepTest {
             new SecurityConfiguration(),
             mock(UserServices.class),
             mock(PasswordEncoder.class),
-            mock(JwtDecoder.class));
+            mock(JwtDecoder.class),
+            mock(SearchClientsProxy.class));
     testBrokerStartupContext.setConcurrencyControl(spyConcurrencyControl);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -117,6 +117,7 @@ final class PartitionJoinTest {
             new SecurityConfiguration(),
             null,
             null,
+            null,
             null);
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -236,6 +236,7 @@ final class PartitionLeaveTest {
             SecurityConfigurations.unauthenticatedAndUnauthorized(),
             null,
             null,
+            null,
             null);
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.AtomixCluster;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -372,7 +373,8 @@ final class SystemContextTest {
         new SecurityConfiguration(),
         mock(UserServices.class),
         mock(PasswordEncoder.class),
-        mock(JwtDecoder.class));
+        mock(JwtDecoder.class),
+        mock(SearchClientsProxy.class));
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -253,6 +253,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
             SecurityConfigurations.unauthenticatedAndUnauthorized(),
             null,
             null,
+            null,
             null);
 
     final var additionalListeners = new ArrayList<>(Arrays.asList(listeners));


### PR DESCRIPTION
# Description
Backport of #37991 to `stable/8.8`.

relates to #38211