### PR TITLE
[Backport stable/8.5] fix: synthesize missing ruleId to prevent NPE during decision evaluation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -33,9 +33,12 @@ import io.camunda.zeebe.util.collection.Tuple;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DecisionBehavior {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(DecisionBehavior.class);
   private static final DecisionInfo UNKNOWN_DECISION_INFO = new DecisionInfo(-1L, -1);
   private static final String SYNTHESIZED_RULE_ID_PREFIX = "ZB_SYNTH_RULE_ID";
   private static final String SYNTHESIZED_RULE_ID_TEMPLATE = "%s_%s_v%s_r%s";
@@ -197,12 +200,24 @@ public class DecisionBehavior {
       final MatchedRule matchedRule, final EvaluatedDecisionRecord evaluatedDecisionRecord) {
 
     final var matchedRuleRecord = evaluatedDecisionRecord.matchedRules().add();
+    final boolean ruleIdMissing = StringUtils.isBlank(matchedRule.ruleId());
     final var ruleId =
         getOrSynthesizeRuleId(
             evaluatedDecisionRecord.getDecisionId(),
             evaluatedDecisionRecord.getDecisionVersion(),
             matchedRule);
     matchedRuleRecord.setRuleId(ruleId).setRuleIndex(matchedRule.ruleIndex());
+
+    if (ruleIdMissing) {
+      LOGGER.warn(
+          "DMN evaluation: matched rule without id in decision '{}' (version {}, rule index {}). "
+              + "Synthesized surrogate ruleId '{}'. "
+              + "To eliminate this warning, add an 'id' attribute to the <rule> and deploy a new DMN version.",
+          evaluatedDecisionRecord.getDecisionId(),
+          evaluatedDecisionRecord.getDecisionVersion(),
+          matchedRule.ruleIndex(),
+          ruleId);
+    }
 
     matchedRule
         .evaluatedOutputs()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -32,10 +32,13 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
+import org.apache.commons.lang3.StringUtils;
 
 public class DecisionBehavior {
 
   private static final DecisionInfo UNKNOWN_DECISION_INFO = new DecisionInfo(-1L, -1);
+  private static final String SYNTHESIZED_RULE_ID_PREFIX = "ZB_SYNTH_RULE_ID";
+  private static final String SYNTHESIZED_RULE_ID_TEMPLATE = "%s_%s_v%s_r%s";
   private final DecisionEngine decisionEngine;
   private final DecisionState decisionState;
   private final ProcessEngineMetrics metrics;
@@ -194,11 +197,35 @@ public class DecisionBehavior {
       final MatchedRule matchedRule, final EvaluatedDecisionRecord evaluatedDecisionRecord) {
 
     final var matchedRuleRecord = evaluatedDecisionRecord.matchedRules().add();
-    matchedRuleRecord.setRuleId(matchedRule.ruleId()).setRuleIndex(matchedRule.ruleIndex());
+    final var ruleId =
+        getOrSynthesizeRuleId(
+            evaluatedDecisionRecord.getDecisionId(),
+            evaluatedDecisionRecord.getDecisionVersion(),
+            matchedRule);
+    matchedRuleRecord.setRuleId(ruleId).setRuleIndex(matchedRule.ruleIndex());
 
     matchedRule
         .evaluatedOutputs()
         .forEach(evaluatedOutput -> addOutputToEvaluationEvent(evaluatedOutput, matchedRuleRecord));
+  }
+
+  /**
+   * Returns the original ruleId if present; otherwise synthesizes a deterministic surrogate:
+   * {prefix}_{decisionId}_v{decisionVersion}_r{ruleIndex}
+   *
+   * <p>Deterministic per deployed decision version and rule index (no timestamps/randomness).
+   * Static prefix makes it obvious this was synthesized by the engine.
+   */
+  private static String getOrSynthesizeRuleId(
+      final String decisionId, final int decisionVersion, final MatchedRule rule) {
+
+    final var ruleId = rule.ruleId();
+    if (StringUtils.isNotBlank(ruleId)) {
+      return ruleId;
+    }
+
+    return SYNTHESIZED_RULE_ID_TEMPLATE.formatted(
+        SYNTHESIZED_RULE_ID_PREFIX, decisionId, decisionVersion, rule.ruleIndex());
   }
 
   private void addInputToEvaluationEvent(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
@@ -618,4 +618,68 @@ public final class BusinessRuleTaskTest {
         .hasDecisionRequirementsKey(lastDeployedDecisionRequirements.getDecisionRequirementsKey())
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
+
+  @Test
+  public void shouldEvaluateBusinessRuleTaskWithSynthesizedRuleIdWhenMissing() {
+    // given
+    final String decisionId = "shippingDecision";
+    final String resultVar = "shippingType";
+
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .businessRuleTask(
+                TASK_ID, t -> t.zeebeCalledDecisionId(decisionId).zeebeResultVariable(resultVar))
+            .endEvent()
+            .done();
+
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource("/dmn/decision-table-with-missing-ruleId.dmn")
+        .withXmlResource(process)
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("amount", 300).create();
+
+    // then (decision evaluation event exists and is successful)
+    final var decisionEvaluationRecordValue =
+        RecordingExporter.decisionEvaluationRecords(DecisionEvaluationIntent.EVALUATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withDecisionId(decisionId)
+            .getFirst()
+            .getValue();
+
+    assertThat(decisionEvaluationRecordValue)
+        .hasDecisionId(decisionId)
+        .hasDecisionOutput("\"EXPRESS\"")
+        .hasDecisionVersion(1);
+
+    // verify matched rule: index 2 and synthesized ruleId
+    final var evaluatedDecision =
+        decisionEvaluationRecordValue.getEvaluatedDecisions().stream()
+            .filter(d -> decisionId.equals(d.getDecisionId()))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(evaluatedDecision.getMatchedRules())
+        .singleElement()
+        .satisfies(
+            matchedRule -> {
+              assertThat(matchedRule.getRuleIndex()).isEqualTo(2);
+              assertThat(matchedRule.getRuleId())
+                  .isEqualTo("ZB_SYNTH_RULE_ID_shippingDecision_v1_r2");
+            });
+
+    // result variable written by the business rule task
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withScopeKey(processInstanceKey)
+                .withName(resultVar)
+                .getFirst()
+                .getValue())
+        .hasValue("\"EXPRESS\"");
+  }
 }

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-missing-ruleId.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-missing-ruleId.dmn
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  - Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  - one or more contributor license agreements. See the NOTICE file distributed
+  - with this work for additional information regarding copyright ownership.
+  - Licensed under the Camunda License 1.0. You may not use this file
+  - except in compliance with the Camunda License 1.0.
+  -->
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+  xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1whs8i1" name="DRD"
+  namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.36.1"
+  modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <decision id="shippingDecision" name="Shipping decision">
+    <decisionTable id="shippingTable" hitPolicy="FIRST">
+      <input id="Input_1" label="Amount">
+        <inputExpression id="InputExpression_1" typeRef="number">
+          <text>amount</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Shipping" name="shipping" typeRef="string">
+        <outputValues id="UnaryTests_0dlr7qd">
+          <text>"STANDARD","EXPRESS"</text>
+        </outputValues>
+      </output>
+      <!-- Rule with ID (safe) -->
+      <rule id="rule_1_standard">
+        <inputEntry id="UnaryTests_0upjivp">
+          <text>&lt;= 100</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1pkzjur">
+          <text>"STANDARD"</text>
+        </outputEntry>
+      </rule>
+      <!-- Rule WITHOUT id on purpose -->
+      <rule>
+        <inputEntry id="UnaryTests_1pqn5oz">
+          <text>&gt; 100</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_17do8e0">
+          <text>"EXPRESS"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="shipping_decision">
+        <dc:Bounds height="80" width="180" x="160" y="100"/>
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
# Description
Backport of #37992 to `stable/8.5`.

relates to #36900