### PR TITLE
Adding `~` char to default ID regex

### DIFF
--- a/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
@@ -12,8 +12,8 @@ import java.util.regex.Pattern;
 
 public class SecurityConfiguration {
 
-  /** 1 or more alphanumeric characters, '_', '@', '.', '+', or '-'. */
-  public static final String DEFAULT_ID_REGEX = "^[a-zA-Z0-9_@.+-]+$";
+  /** 1 or more alphanumeric characters, '_', '@', '.', '+', '-' or '~'. */
+  public static final String DEFAULT_ID_REGEX = "^[a-zA-Z0-9_~@.+-]+$";
 
   private AuthenticationConfiguration authentication = new AuthenticationConfiguration();
   private AuthorizationsConfiguration authorizations = new AuthorizationsConfiguration();

--- a/security/security-core/src/test/java/io/camunda/security/configuration/SecurityConfigurationTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/configuration/SecurityConfigurationTest.java
@@ -21,10 +21,10 @@ class SecurityConfigurationTest {
     final String pattern = securityConfiguration.getIdValidationPattern();
 
     // when
-    final String idWithSpecialCharTilda = "id_with_special_char~";
+    final String idWithSpecialCharTilde = "id_with_special_char~";
 
     // then
-    assertThat(idWithSpecialCharTilda.matches(pattern)).isTrue();
+    assertThat(idWithSpecialCharTilde.matches(pattern)).isTrue();
   }
 
   @Test

--- a/security/security-core/src/test/java/io/camunda/security/configuration/SecurityConfigurationTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/configuration/SecurityConfigurationTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SecurityConfigurationTest {
+
+  SecurityConfiguration securityConfiguration = new SecurityConfiguration();
+
+  @Test
+  void shouldAcceptValidPattern() {
+    // given
+    final String pattern = securityConfiguration.getIdValidationPattern();
+
+    // when
+    final String idWithSpecialCharTilda = "id_with_special_char~";
+
+    // then
+    assertThat(idWithSpecialCharTilda.matches(pattern)).isTrue();
+  }
+
+  @Test
+  void shouldDenyInvalidPattern() {
+    // given
+    final String pattern = securityConfiguration.getIdValidationPattern();
+
+    // when
+    final String idWithNotAllowedSpecialChar = "id_with_not_allowed_special_char!";
+
+    // then
+    assertThat(idWithNotAllowedSpecialChar.matches(pattern)).isFalse();
+  }
+}

--- a/security/security-core/src/test/java/io/camunda/security/configuration/SecurityConfigurationTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/configuration/SecurityConfigurationTest.java
@@ -16,7 +16,7 @@ class SecurityConfigurationTest {
   SecurityConfiguration securityConfiguration = new SecurityConfiguration();
 
   @Test
-  void shouldAcceptValidPattern() {
+  void shouldAcceptIdWithTilde() {
     // given
     final String pattern = securityConfiguration.getIdValidationPattern();
 
@@ -28,7 +28,7 @@ class SecurityConfigurationTest {
   }
 
   @Test
-  void shouldDenyInvalidPattern() {
+  void shouldDenyIdWithExclamationMark() {
     // given
     final String pattern = securityConfiguration.getIdValidationPattern();
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
@@ -67,7 +67,16 @@ class SetupControllerTest extends RestControllerTest {
 
   @ParameterizedTest
   @ValueSource(
-      strings = {"foo", "Foo", "foo@bar.baz", "f_oo@bar.baz", "foo123", "foo-", "foo+bar@baz.bir"})
+      strings = {
+        "foo",
+        "foo~",
+        "Foo",
+        "foo@bar.baz",
+        "f_oo@bar.baz",
+        "foo123",
+        "foo-",
+        "foo+bar@baz.bir"
+      })
   void createAdminUserShouldReturnCreated(final String username) {
     final var dto = validCreateUserRequest(username);
     final var userRecord =
@@ -317,9 +326,9 @@ class SetupControllerTest extends RestControllerTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
-        "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<",
-        "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
+        "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=", "foo{",
+        "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<", "foo>",
+        "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
       })
   void shouldRejectUserCreationWithIllegalCharactersInUsername(final String username) {
     // given

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -80,7 +80,7 @@ public class TenantControllerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"foo", "Foo", "foo123", "foo_", "foo.", "foo@"})
+    @ValueSource(strings = {"foo", "foo~", "Foo", "foo123", "foo_", "foo.", "foo@"})
     void createTenantShouldReturnAccepted(final String id) {
       // given
       final var tenantName = "Test Tenant";
@@ -194,9 +194,9 @@ public class TenantControllerTest {
     @ParameterizedTest
     @ValueSource(
         strings = {
-          "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
-          "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<",
-          "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
+          "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=", "foo{",
+          "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<", "foo>",
+          "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
         })
     void shouldRejectTenantCreationWithIllegalCharactersInId(final String id) {
       // given

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -227,7 +227,7 @@ public class GroupControllerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"foo", "Foo", "foo123", "foo_", "foo.", "foo@"})
+    @ValueSource(strings = {"foo", "foo~", "Foo", "foo123", "foo_", "foo.", "foo@"})
     void shouldAcceptCreateGroupRequest(final String groupId) {
       // given
       final var groupName = "testGroup";
@@ -379,9 +379,9 @@ public class GroupControllerTest {
     @ParameterizedTest
     @ValueSource(
         strings = {
-          "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
-          "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<",
-          "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
+          "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=", "foo{",
+          "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<", "foo>",
+          "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
         })
     void shouldRejectGroupCreationWithIllegalCharactersInId(final String groupId) {
       // when then
@@ -547,9 +547,7 @@ public class GroupControllerTest {
 
     @ParameterizedTest
     @ValueSource(
-        strings = {
-          "foo~", "foo!", "foo$", "foo&", "foo*", "foo(", "foo)", "foo=", "foo:", "foo'", "foo,"
-        })
+        strings = {"foo!", "foo$", "foo&", "foo*", "foo(", "foo)", "foo=", "foo:", "foo'", "foo,"})
     void shouldRejectGroupUpdateWithIllegalCharactersInId(final String groupId) {
       // when then
       final var path = "%s/%s".formatted(GROUP_BASE_URL, groupId);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleControllerTest.java
@@ -53,7 +53,7 @@ public class MappingRuleControllerTest extends RestControllerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"foo", "Foo", "foo123", "foo_", "foo.", "foo@"})
+  @ValueSource(strings = {"foo", "foo~", "Foo", "foo123", "foo_", "foo.", "foo@"})
   void createMappingRuleRuleShouldReturnCreated(final String id) {
     // given
     final var dto = validCreateMappingRuleRuleDTO();
@@ -251,9 +251,9 @@ public class MappingRuleControllerTest extends RestControllerTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
-        "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<",
-        "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
+        "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=", "foo{",
+        "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<", "foo>",
+        "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
       })
   void shouldRejectMappingRuleCreationWithIllegalCharactersInId(final String id) {
     // given

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -73,7 +73,7 @@ public class RoleControllerTest extends RestControllerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"foo", "Foo", "foo123", "foo_", "foo.", "foo@"})
+  @ValueSource(strings = {"foo", "foo~", "Foo", "foo123", "foo_", "foo.", "foo@"})
   void createRoleShouldReturnCreated(final String roleId) {
     // given
     final var roleName = "Test Role";
@@ -233,9 +233,9 @@ public class RoleControllerTest extends RestControllerTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
-        "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<",
-        "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
+        "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=", "foo{",
+        "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<", "foo>",
+        "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
       })
   void shouldRejectRoleCreationWithIllegalCharactersInId(final String roleId) {
     // when then

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -73,6 +73,7 @@ public class UserControllerTest {
         strings = {
           "foo",
           "Foo",
+          "foo~",
           "foo@bar.baz",
           "f_oo@bar.baz",
           "foo123",
@@ -309,9 +310,9 @@ public class UserControllerTest {
     @ParameterizedTest
     @ValueSource(
         strings = {
-          "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
-          "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<",
-          "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
+          "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=", "foo{",
+          "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'", "foo<", "foo>",
+          "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
         })
     void shouldRejectUserCreationWithIllegalCharactersInUsername(final String username) {
       // given


### PR DESCRIPTION
Adding `~` char to default ID regex

Motivation:
It is not possible to set the default ID pattern so that it fits every possible IdP, but we can include already known chars into it. Also, please note that users can override the default pattern if they need to.

If we can determine the format and chars used for client IDs, then we can make that part of the default pattern (as it is done it this PR). I am not adding extra chars in order to make the change minimal.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37665
