### PR TITLE
feat: add secondary storage properties to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -22,6 +22,15 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   /** Name of the cluster */
   private String clusterName = databaseName().toLowerCase();
 
+  /** The date format for ES and OS */
+  private String dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
+
+  /** The socket timeout for ES and OS connector */
+  private Integer socketTimeout;
+
+  /** The connection timeout for ES and OS connector */
+  private Integer connectionTimeout;
+
   /** How many shards Elasticsearch uses for all Tasklist indices. */
   private int numberOfShards = 1;
 
@@ -217,6 +226,45 @@ public abstract class DocumentBasedSecondaryStorageDatabase
     this.incidentNotifier = incidentNotifier;
   }
 
+  public String getDateFormat() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".date-format",
+        dateFormat,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyDateFormatProperties());
+  }
+
+  public void setDateFormat(final String dateFormat) {
+    this.dateFormat = dateFormat;
+  }
+
+  public Integer getSocketTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".socket-timeout",
+        socketTimeout,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacySocketTimeoutProperties());
+  }
+
+  public void setSocketTimeout(final Integer socketTimeout) {
+    this.socketTimeout = socketTimeout;
+  }
+
+  public Integer getConnectionTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".connection-timeout",
+        connectionTimeout,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyConnectionTimeoutProperties());
+  }
+
+  public void setConnectionTimeout(final Integer connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
+  }
+
   private String prefix() {
     return "camunda.data.secondary-storage." + databaseName().toLowerCase();
   }
@@ -270,5 +318,32 @@ public abstract class DocumentBasedSecondaryStorageDatabase
     return Set.of(
         "camunda.database.index.numberOfShards",
         "zeebe.broker.exporters.camundaexporter.args.index.numberOfShards");
+  }
+
+  private Set<String> legacyDateFormatProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.dateFormat",
+        "camunda.operate." + dbName + ".dateFormat",
+        "camunda.tasklist." + dbName + ".dateFormat",
+        "zeebe.broker.exporters.camundaexporter.args.connect.dateFormat");
+  }
+
+  private Set<String> legacySocketTimeoutProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.socketTimeout",
+        "camunda.operate." + dbName + ".socketTimeout",
+        "camunda.tasklist." + dbName + ".socketTimeout",
+        "zeebe.broker.exporters.camundaexporter.args.connect.socketTimeout");
+  }
+
+  private Set<String> legacyConnectionTimeoutProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.connectionTimeout",
+        "camunda.operate." + dbName + ".connectionTimeout",
+        "camunda.tasklist." + dbName + ".connectionTimeout",
+        "zeebe.broker.exporters.camundaexporter.args.connect.connectionTimeout");
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -659,6 +659,9 @@ public class BrokerBasedPropertiesOverride {
     setArg(args, "connect.type", secondaryStorage.getType().name());
     setArg(args, "connect.url", database.getUrl());
     setArg(args, "connect.clusterName", database.getClusterName());
+    setArg(args, "connect.dateFormat", database.getDateFormat());
+    setArg(args, "connect.socketTimeout", database.getSocketTimeout());
+    setArg(args, "connect.connectTimeout", database.getConnectionTimeout());
 
     // Add security configuration mapping
     if (database.getSecurity() != null) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -86,6 +86,11 @@ public class OperatePropertiesOverride {
     override.getElasticsearch().setPassword(database.getElasticsearch().getPassword());
     override.getElasticsearch().setClusterName(database.getElasticsearch().getClusterName());
     override.getElasticsearch().setIndexPrefix(database.getElasticsearch().getIndexPrefix());
+    override.getElasticsearch().setDateFormat(database.getElasticsearch().getDateFormat());
+    override.getElasticsearch().setSocketTimeout(database.getElasticsearch().getSocketTimeout());
+    override
+        .getElasticsearch()
+        .setConnectTimeout(database.getElasticsearch().getConnectionTimeout());
 
     populateFromSecurity(
         database.getElasticsearch().getSecurity(),
@@ -107,6 +112,9 @@ public class OperatePropertiesOverride {
     override.getOpensearch().setPassword(database.getOpensearch().getPassword());
     override.getOpensearch().setClusterName(database.getOpensearch().getClusterName());
     override.getOpensearch().setIndexPrefix(database.getOpensearch().getIndexPrefix());
+    override.getOpensearch().setDateFormat(database.getOpensearch().getDateFormat());
+    override.getOpensearch().setSocketTimeout(database.getOpensearch().getSocketTimeout());
+    override.getOpensearch().setConnectTimeout(database.getOpensearch().getConnectionTimeout());
 
     populateFromSecurity(
         database.getOpensearch().getSecurity(),

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -66,10 +66,8 @@ public class SearchEngineConnectPropertiesOverride {
       case elasticsearch:
         {
           database = secondaryStorage.getElasticsearch();
-          override.setClusterName(
-              ((DocumentBasedSecondaryStorageDatabase) database).getClusterName());
-          override.setIndexPrefix(
-              ((DocumentBasedSecondaryStorageDatabase) database).getIndexPrefix());
+          populateFromDocumentBasedSecondaryStorageDatabase(
+              (DocumentBasedSecondaryStorageDatabase) database, override);
           break;
         }
       case rdbms:
@@ -80,10 +78,8 @@ public class SearchEngineConnectPropertiesOverride {
       default:
         {
           database = secondaryStorage.getOpensearch();
-          override.setClusterName(
-              ((DocumentBasedSecondaryStorageDatabase) database).getClusterName());
-          override.setIndexPrefix(
-              ((DocumentBasedSecondaryStorageDatabase) database).getIndexPrefix());
+          populateFromDocumentBasedSecondaryStorageDatabase(
+              (DocumentBasedSecondaryStorageDatabase) database, override);
           break;
         }
     }
@@ -98,6 +94,16 @@ public class SearchEngineConnectPropertiesOverride {
     override.setPassword(database.getPassword());
 
     return override;
+  }
+
+  private void populateFromDocumentBasedSecondaryStorageDatabase(
+      final DocumentBasedSecondaryStorageDatabase database,
+      final SearchEngineConnectProperties override) {
+    override.setClusterName(database.getClusterName());
+    override.setDateFormat(database.getDateFormat());
+    override.setSocketTimeout(database.getSocketTimeout());
+    override.setConnectTimeout(database.getConnectionTimeout());
+    override.setIndexPrefix(database.getIndexPrefix());
   }
 
   private void populateFromSecurity(final SearchEngineConnectProperties override) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -81,6 +81,11 @@ public class TasklistPropertiesOverride {
     override.getElasticsearch().setPassword(database.getElasticsearch().getPassword());
     override.getElasticsearch().setClusterName(database.getElasticsearch().getClusterName());
     override.getElasticsearch().setIndexPrefix(database.getElasticsearch().getIndexPrefix());
+    override.getElasticsearch().setDateFormat(database.getElasticsearch().getDateFormat());
+    override.getElasticsearch().setSocketTimeout(database.getElasticsearch().getSocketTimeout());
+    override
+        .getElasticsearch()
+        .setConnectTimeout(database.getElasticsearch().getConnectionTimeout());
 
     populateFromSecurity(
         database.getElasticsearch().getSecurity(),
@@ -102,6 +107,9 @@ public class TasklistPropertiesOverride {
     override.getOpenSearch().setPassword(database.getOpensearch().getPassword());
     override.getOpenSearch().setClusterName(database.getOpensearch().getClusterName());
     override.getOpenSearch().setIndexPrefix(database.getOpensearch().getIndexPrefix());
+    override.getOpenSearch().setDateFormat(database.getOpensearch().getDateFormat());
+    override.getOpenSearch().setSocketTimeout(database.getOpensearch().getSocketTimeout());
+    override.getOpenSearch().setConnectTimeout(database.getOpensearch().getConnectionTimeout());
 
     populateFromSecurity(
         database.getOpensearch().getSecurity(),

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -42,6 +42,9 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 })
 public class SecondaryStorageElasticsearchTest {
   private static final String EXPECTED_CLUSTER_NAME = "sample-cluster";
+  private static final String EXPECTED_DATE_FORMAT = "date-format";
+  private static final int EXPECTED_SOCKET_TIMEOUT = 20;
+  private static final int EXPECTED_CONNECTION_TIMEOUT = 30;
   private static final String EXPECTED_INDEX_PREFIX = "sample-index-prefix";
 
   private static final String EXPECTED_USERNAME = "testUsername";
@@ -95,6 +98,10 @@ public class SecondaryStorageElasticsearchTest {
             + EXPECTED_NUMBER_OF_SHARDS,
         "camunda.data.secondary-storage.elasticsearch.history.process-instance-enabled="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
+        "camunda.data.secondary-storage.elasticsearch.date-format=" + EXPECTED_DATE_FORMAT,
+        "camunda.data.secondary-storage.elasticsearch.socket-timeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.data.secondary-storage.elasticsearch.connection-timeout="
+            + EXPECTED_CONNECTION_TIMEOUT,
         "camunda.data.secondary-storage.elasticsearch.history.els-rollover-date-format="
             + EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT,
         "camunda.data.secondary-storage.elasticsearch.history.rollover-interval="
@@ -160,6 +167,7 @@ public class SecondaryStorageElasticsearchTest {
       final String expectedUrl = "http://expected-url:4321";
 
       assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
+
       assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
       assertThat(operateProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
       assertThat(operateProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
@@ -167,6 +175,12 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(operateProperties.getElasticsearch().getIndexPrefix())
           .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(operateProperties.getElasticsearch().getDateFormat())
+          .isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(operateProperties.getElasticsearch().getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(operateProperties.getElasticsearch().getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
     }
 
     @Test
@@ -175,11 +189,20 @@ public class SecondaryStorageElasticsearchTest {
       final String expectedUrl = "http://expected-url:4321";
 
       assertThat(tasklistProperties.getDatabase()).isEqualTo(expectedTasklistDatabaseType);
+
       assertThat(tasklistProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
       assertThat(tasklistProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
       assertThat(tasklistProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(tasklistProperties.getElasticsearch().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(tasklistProperties.getElasticsearch().getIndexPrefix())
           .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(tasklistProperties.getElasticsearch().getDateFormat())
+          .isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(tasklistProperties.getElasticsearch().getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(tasklistProperties.getElasticsearch().getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
     }
 
     @Test
@@ -200,6 +223,15 @@ public class SecondaryStorageElasticsearchTest {
       assertThat(exporterConfiguration.getConnect().getPassword()).isEqualTo(EXPECTED_PASSWORD);
       assertThat(exporterConfiguration.getConnect().getIndexPrefix())
           .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(exporterConfiguration.getConnect().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(exporterConfiguration.getConnect().getDateFormat())
+          .isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(exporterConfiguration.getConnect().getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(exporterConfiguration.getConnect().getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+
       assertThat(exporterConfiguration.getConnect().getClusterName())
           .isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
@@ -252,6 +284,12 @@ public class SecondaryStorageElasticsearchTest {
       assertThat(searchEngineConnectProperties.getType().toLowerCase()).isEqualTo("elasticsearch");
       assertThat(searchEngineConnectProperties.getUrl()).isEqualTo("http://expected-url:4321");
       assertThat(searchEngineConnectProperties.getIndexPrefix()).isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(searchEngineConnectProperties.getClusterName()).isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(searchEngineConnectProperties.getDateFormat()).isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(searchEngineConnectProperties.getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(searchEngineConnectProperties.getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
     }
 
     @Test
@@ -340,6 +378,7 @@ public class SecondaryStorageElasticsearchTest {
         "camunda.database.password=" + EXPECTED_PASSWORD,
         "camunda.operate.elasticsearch.password=" + EXPECTED_PASSWORD,
         "camunda.tasklist.elasticsearch.password=" + EXPECTED_PASSWORD,
+
         // NOTE: In the following blocks, the camundaExporter doesn't have to be configured, as
         //  it is default with StandaloneCamunda. Any attempt of configuration will fail unless
         //  the className is also configured.
@@ -350,6 +389,22 @@ public class SecondaryStorageElasticsearchTest {
         "camunda.tasklist.elasticsearch.clusterName=" + EXPECTED_CLUSTER_NAME,
         "camunda.operate.elasticsearch.clusterName=" + EXPECTED_CLUSTER_NAME,
         "camunda.operate.elasticsearch.url=http://matching-url:4321",
+        // date format
+        "camunda.data.secondary-storage.elasticsearch.date-format=" + EXPECTED_DATE_FORMAT,
+        "camunda.data.dateFormat=" + EXPECTED_DATE_FORMAT,
+        "camunda.tasklist.elasticsearch.dateFormat=" + EXPECTED_DATE_FORMAT,
+        "camunda.operate.elasticsearch.dateFormat=" + EXPECTED_DATE_FORMAT,
+        // socket timeout
+        "camunda.data.secondary-storage.elasticsearch.socket-timeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.data.socketTimeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.tasklist.elasticsearch.socketTimeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.operate.elasticsearch.socketTimeout=" + EXPECTED_SOCKET_TIMEOUT,
+        // connection timeout
+        "camunda.data.secondary-storage.elasticsearch.connection-timeout="
+            + EXPECTED_CONNECTION_TIMEOUT,
+        "camunda.data.connectTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
+        "camunda.tasklist.elasticsearch.connectTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
+        "camunda.operate.elasticsearch.connectTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
 
         // NOTE: In the following blocks, the camundaExporter doesn't have to be configured, as
         //  it is default with StandaloneCamunda. Any attempt of configuration will fail unless
@@ -392,6 +447,7 @@ public class SecondaryStorageElasticsearchTest {
       final String expectedUrl = "http://matching-url:4321";
 
       assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
+
       assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
       assertThat(operateProperties.getElasticsearch().getClusterName())
           .isEqualTo(EXPECTED_CLUSTER_NAME);
@@ -399,6 +455,12 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_INDEX_PREFIX);
       assertThat(operateProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
       assertThat(operateProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(operateProperties.getElasticsearch().getDateFormat())
+          .isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(operateProperties.getElasticsearch().getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(operateProperties.getElasticsearch().getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
     }
 
     @Test
@@ -407,6 +469,7 @@ public class SecondaryStorageElasticsearchTest {
       final String expectedUrl = "http://matching-url:4321";
 
       assertThat(tasklistProperties.getDatabase()).isEqualTo(expectedTasklistDatabaseType);
+
       assertThat(tasklistProperties.getElasticsearch().getUrl()).isEqualTo(expectedUrl);
       assertThat(tasklistProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
       assertThat(tasklistProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
@@ -414,6 +477,12 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_INDEX_PREFIX);
       assertThat(tasklistProperties.getElasticsearch().getClusterName())
           .isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(tasklistProperties.getElasticsearch().getDateFormat())
+          .isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(tasklistProperties.getElasticsearch().getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(tasklistProperties.getElasticsearch().getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
     }
 
     @Test
@@ -436,6 +505,13 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_INDEX_PREFIX);
       assertThat(exporterConfiguration.getConnect().getClusterName())
           .isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(exporterConfiguration.getConnect().getDateFormat())
+          .isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(exporterConfiguration.getConnect().getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(exporterConfiguration.getConnect().getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
     }
@@ -448,6 +524,11 @@ public class SecondaryStorageElasticsearchTest {
       assertThat(searchEngineConnectProperties.getClusterName()).isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(searchEngineConnectProperties.getUsername()).isEqualTo(EXPECTED_USERNAME);
       assertThat(searchEngineConnectProperties.getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(searchEngineConnectProperties.getDateFormat()).isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(searchEngineConnectProperties.getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(searchEngineConnectProperties.getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -42,6 +42,9 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 })
 public class SecondaryStorageOpensearchTest {
   private static final String EXPECTED_CLUSTER_NAME = "sample-cluster";
+  private static final String EXPECTED_DATE_FORMAT = "date-format";
+  private static final int EXPECTED_SOCKET_TIMEOUT = 20;
+  private static final int EXPECTED_CONNECTION_TIMEOUT = 30;
   private static final String EXPECTED_INDEX_PREFIX = "sample-index-prefix";
 
   private static final String EXPECTED_USERNAME = "testUsername";
@@ -94,6 +97,10 @@ public class SecondaryStorageOpensearchTest {
         "camunda.data.secondary-storage.opensearch.number-of-shards=" + EXPECTED_NUMBER_OF_SHARDS,
         "camunda.data.secondary-storage.opensearch.history.process-instance-enabled="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
+        "camunda.data.secondary-storage.opensearch.date-format=" + EXPECTED_DATE_FORMAT,
+        "camunda.data.secondary-storage.opensearch.socket-timeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.data.secondary-storage.opensearch.connection-timeout="
+            + EXPECTED_CONNECTION_TIMEOUT,
         "camunda.data.secondary-storage.opensearch.history.els-rollover-date-format="
             + EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT,
         "camunda.data.secondary-storage.opensearch.history.rollover-interval="
@@ -159,6 +166,7 @@ public class SecondaryStorageOpensearchTest {
       final String expectedUrl = "http://expected-url:4321";
 
       assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
+
       assertThat(operateProperties.getOpensearch().getUrl()).isEqualTo(expectedUrl);
       assertThat(operateProperties.getOpensearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
       assertThat(operateProperties.getOpensearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
@@ -166,6 +174,11 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(operateProperties.getOpensearch().getIndexPrefix())
           .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(operateProperties.getOpensearch().getDateFormat()).isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(operateProperties.getOpensearch().getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(operateProperties.getOpensearch().getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
     }
 
     @Test
@@ -174,11 +187,20 @@ public class SecondaryStorageOpensearchTest {
       final String expectedUrl = "http://expected-url:4321";
 
       assertThat(tasklistProperties.getDatabase()).isEqualTo(expectedTasklistDatabaseType);
+
       assertThat(tasklistProperties.getOpenSearch().getUrl()).isEqualTo(expectedUrl);
       assertThat(tasklistProperties.getOpenSearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
       assertThat(tasklistProperties.getOpenSearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(tasklistProperties.getOpenSearch().getClusterName())
+          .isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(tasklistProperties.getOpenSearch().getIndexPrefix())
           .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(tasklistProperties.getOpenSearch().getDateFormat())
+          .isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(tasklistProperties.getOpenSearch().getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(tasklistProperties.getOpenSearch().getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
     }
 
     @Test
@@ -197,8 +219,16 @@ public class SecondaryStorageOpensearchTest {
       assertThat(exporterConfiguration.getConnect().getUrl()).isEqualTo(expectedUrl);
       assertThat(exporterConfiguration.getConnect().getUsername()).isEqualTo(EXPECTED_USERNAME);
       assertThat(exporterConfiguration.getConnect().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(exporterConfiguration.getConnect().getClusterName());
       assertThat(exporterConfiguration.getConnect().getIndexPrefix())
           .isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(exporterConfiguration.getConnect().getDateFormat())
+          .isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(exporterConfiguration.getConnect().getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(exporterConfiguration.getConnect().getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
       assertThat(exporterConfiguration.getHistory().isProcessInstanceEnabled())
@@ -251,6 +281,12 @@ public class SecondaryStorageOpensearchTest {
       assertThat(searchEngineConnectProperties.getType().toLowerCase()).isEqualTo(expectedType);
       assertThat(searchEngineConnectProperties.getUrl()).isEqualTo("http://expected-url:4321");
       assertThat(searchEngineConnectProperties.getIndexPrefix()).isEqualTo(EXPECTED_INDEX_PREFIX);
+      assertThat(searchEngineConnectProperties.getClusterName()).isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(searchEngineConnectProperties.getDateFormat()).isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(searchEngineConnectProperties.getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(searchEngineConnectProperties.getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
     }
 
     @Test
@@ -338,6 +374,7 @@ public class SecondaryStorageOpensearchTest {
         "camunda.database.password=" + EXPECTED_PASSWORD,
         "camunda.operate.opensearch.password=" + EXPECTED_PASSWORD,
         "camunda.tasklist.opensearch.password=" + EXPECTED_PASSWORD,
+
         // NOTE: In the following blocks, the camundaExporter doesn't have to be configured, as
         //  it is default with StandaloneCamunda. Any attempt of configuration will fail unless
         //  the className is also configured.
@@ -348,6 +385,22 @@ public class SecondaryStorageOpensearchTest {
         "camunda.tasklist.opensearch.clusterName=" + EXPECTED_CLUSTER_NAME,
         "camunda.operate.opensearch.clusterName=" + EXPECTED_CLUSTER_NAME,
         "camunda.operate.opensearch.url=http://matching-url:4321",
+        // date format
+        "camunda.data.secondary-storage.opensearch.date-format=" + EXPECTED_DATE_FORMAT,
+        "camunda.data.dateFormat=" + EXPECTED_DATE_FORMAT,
+        "camunda.tasklist.opensearch.dateFormat=" + EXPECTED_DATE_FORMAT,
+        "camunda.operate.opensearch.dateFormat=" + EXPECTED_DATE_FORMAT,
+        // socket timeout
+        "camunda.data.secondary-storage.opensearch.socket-timeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.data.socketTimeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.tasklist.opensearch.socketTimeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.operate.opensearch.socketTimeout=" + EXPECTED_SOCKET_TIMEOUT,
+        // connection timeout
+        "camunda.data.secondary-storage.opensearch.connection-timeout="
+            + EXPECTED_CONNECTION_TIMEOUT,
+        "camunda.data.socketConnectTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
+        "camunda.tasklist.opensearch.connectTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
+        "camunda.operate.opensearch.connectTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
 
         // NOTE: In the following blocks, the camundaExporter doesn't have to be configured, as
         //  it is default with StandaloneCamunda. Any attempt of configuration will fail unless
@@ -389,6 +442,7 @@ public class SecondaryStorageOpensearchTest {
       final String expectedUrl = "http://matching-url:4321";
 
       assertThat(operateProperties.getDatabase()).isEqualTo(expectedOperateDatabaseType);
+
       assertThat(operateProperties.getOpensearch().getUrl()).isEqualTo(expectedUrl);
       assertThat(operateProperties.getOpensearch().getClusterName())
           .isEqualTo(EXPECTED_CLUSTER_NAME);
@@ -396,6 +450,11 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_INDEX_PREFIX);
       assertThat(operateProperties.getOpensearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
       assertThat(operateProperties.getOpensearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(operateProperties.getOpensearch().getDateFormat()).isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(operateProperties.getOpensearch().getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(operateProperties.getOpensearch().getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
     }
 
     @Test
@@ -404,6 +463,7 @@ public class SecondaryStorageOpensearchTest {
       final String expectedUrl = "http://matching-url:4321";
 
       assertThat(tasklistProperties.getDatabase()).isEqualTo(expectedTasklistDatabaseType);
+
       assertThat(tasklistProperties.getOpenSearch().getUrl()).isEqualTo(expectedUrl);
       assertThat(tasklistProperties.getOpenSearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
       assertThat(tasklistProperties.getOpenSearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
@@ -411,6 +471,12 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_INDEX_PREFIX);
       assertThat(tasklistProperties.getOpenSearch().getClusterName())
           .isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(tasklistProperties.getOpenSearch().getDateFormat())
+          .isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(tasklistProperties.getOpenSearch().getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(tasklistProperties.getOpenSearch().getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
     }
 
     @Test
@@ -433,6 +499,13 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_INDEX_PREFIX);
       assertThat(exporterConfiguration.getConnect().getClusterName())
           .isEqualTo(EXPECTED_CLUSTER_NAME);
+      assertThat(exporterConfiguration.getConnect().getDateFormat())
+          .isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(exporterConfiguration.getConnect().getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(exporterConfiguration.getConnect().getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
     }
@@ -447,6 +520,11 @@ public class SecondaryStorageOpensearchTest {
       assertThat(searchEngineConnectProperties.getClusterName()).isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(searchEngineConnectProperties.getUsername()).isEqualTo(EXPECTED_USERNAME);
       assertThat(searchEngineConnectProperties.getPassword()).isEqualTo(EXPECTED_PASSWORD);
+      assertThat(searchEngineConnectProperties.getDateFormat()).isEqualTo(EXPECTED_DATE_FORMAT);
+      assertThat(searchEngineConnectProperties.getSocketTimeout())
+          .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
+      assertThat(searchEngineConnectProperties.getConnectTimeout())
+          .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
     }
 
     @Test

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/properties/PropertiesTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/properties/PropertiesTest.java
@@ -49,7 +49,8 @@ public class PropertiesTest {
     assertThat(tasklistProperties.getElasticsearch().getClusterName()).isEqualTo("clusterName");
     assertThat(tasklistProperties.getElasticsearch().getHost()).isEqualTo("localhost");
     assertThat(tasklistProperties.getElasticsearch().getPort()).isEqualTo(9200);
-    assertThat(tasklistProperties.getElasticsearch().getDateFormat()).isEqualTo("yyyy-MM-dd");
+    assertThat(tasklistProperties.getElasticsearch().getDateFormat())
+        .isEqualTo("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
     assertThat(tasklistProperties.getElasticsearch().getBatchSize()).isEqualTo(111);
     assertThat(tasklistProperties.getZeebe().getGatewayAddress()).isEqualTo("someZeebeHost:999");
   }

--- a/tasklist/qa/integration-tests/src/test/resources/config/application-test-properties.yml
+++ b/tasklist/qa/integration-tests/src/test/resources/config/application-test-properties.yml
@@ -9,7 +9,7 @@ camunda:
   # ---
   tasklist:
     elasticsearch:
-      dateFormat: yyyy-MM-dd
+      dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZZ
       batchSize: 111
     zeebe:
       gatewayAddress: someZeebeHost:999

--- a/tasklist/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/tasklist/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -10,7 +10,7 @@ camunda:
 
 camunda.tasklist:
   elasticsearch:
-    dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZ
+    dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZZ
   zeebe:
     gatewayAddress: localhost:26500
     worker: tasklist


### PR DESCRIPTION
## Description

This PR MUST NOT BE MERGED until the dependent teams have implemented the properties, as these properties introduce breaking changes

This PR adds the properties from section camunda.data.secondary-storage.elasticsearch/opensearch in unified config.

Must not be merged

The legacy properties are:
camunda.database.dateFormat
camunda.tasklist.elasticsearch.dateFormat
camunda.tasklist.opensearch.dateFormat
zeebe.broker.exporters.camundaexporter.args.connect.dateFormat
camunda.database.socketTimeout
camunda.tasklist.elasticsearch.socketTimeout
camunda.tasklist.opensearch.socketTimeout
zeebe.broker.exporters.camundaexporter.args.connect.socketTimeout
camunda.database.connectTimeout
camunda.tasklist.elasticsearch.connectTimeout
camunda.tasklist.opensearch.connectTimeout
zeebe.broker.exporters.camundaexporter.args.connect.connectTimeout

The new properties are:
camunda.data.secondary-storage.elasticsearch.date-format
camunda.data.secondary-storage.elasticsearch.socket-timeout
camunda.data.secondary-storage.elasticsearch.connection-timeout
camunda.data.secondary-storage.opensearch.date-format
camunda.data.secondary-storage.opensearch.socket-timeout
camunda.data.secondary-storage.opensearch.connection-timeout

Backwards compatibility is not supported. That means, new properties need to be available and must match with legacy values.
## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34902