### PR TITLE
fix: add RoleValidator and use jwt decoder in ID token filter

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/oauth/RoleValidator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/oauth/RoleValidator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.oauth;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class RoleValidator implements OAuth2TokenValidator<Jwt> {
+
+  static final String ORGANIZATION_CLAIM_KEY = "https://camunda.com/orgs";
+  private static final Logger LOG = LoggerFactory.getLogger(RoleValidator.class);
+
+  private final List<String> allowedRoles;
+
+  public RoleValidator(final List<String> allowedRoles) {
+    this.allowedRoles = Objects.requireNonNull(allowedRoles, "allowedRoles must not be null");
+  }
+
+  @Override
+  public OAuth2TokenValidatorResult validate(final Jwt token) {
+    final var claimValue = token.getClaims().get(ORGANIZATION_CLAIM_KEY);
+    if (claimValue == null) {
+      LOG.debug("Rejected token: missing organization claim '{}'", ORGANIZATION_CLAIM_KEY);
+      return OAuth2TokenValidatorResult.failure(
+          new OAuth2Error(
+              OAuth2ErrorCodes.INVALID_TOKEN,
+              "Token does not contain required organization claim for Optimize access.",
+              null));
+    }
+
+    if (claimValue instanceof final Collection<?> claimedOrgs) {
+      if (hasAllowedRole(claimedOrgs)) {
+        return OAuth2TokenValidatorResult.success();
+      }
+    }
+
+    LOG.debug(
+        "Rejected token with organizations '{}', required roles: {}", claimValue, allowedRoles);
+    return OAuth2TokenValidatorResult.failure(
+        new OAuth2Error(
+            OAuth2ErrorCodes.INVALID_TOKEN,
+            "Token does not contain required organization role for Optimize access. Required roles: %s"
+                .formatted(allowedRoles),
+            null));
+  }
+
+  private boolean hasAllowedRole(final Collection<?> claimedOrgs) {
+    for (final Object claimedOrg : claimedOrgs) {
+      if (claimedOrg instanceof final Map<?, ?> orgDetails) {
+        final Object rolesObj = orgDetails.get("roles");
+        if (rolesObj instanceof final Collection<?> userRoles) {
+          for (final Object userRole : userRoles) {
+            if (userRole instanceof String && allowedRoles.contains(userRole)) {
+              LOG.debug("User has allowed role '{}' for Optimize access", userRole);
+              return true;
+            }
+          }
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/oauth/RoleValidatorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/oauth/RoleValidatorTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+class RoleValidatorTest {
+
+  private final List<String> allowedRoles = Arrays.asList("admin", "analyst", "owner");
+  private final RoleValidator validator = new RoleValidator(allowedRoles);
+
+  @Test
+  void shouldFailWhenTokenHasNoOrganizationClaim() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+  }
+
+  @Test
+  void shouldSucceedWhenUserHasAllowedRole() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    final Map<String, Object> org = new HashMap<>();
+    org.put("id", "org1");
+    org.put("roles", Arrays.asList("admin", "developer"));
+    claims.put("https://camunda.com/orgs", List.of(org));
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldSucceedWhenUserHasAllowedRoleInAnyOrg() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    final Map<String, Object> org1 = new HashMap<>();
+    org1.put("id", "org1");
+    org1.put("roles", List.of("developer"));
+    final Map<String, Object> org2 = new HashMap<>();
+    org2.put("id", "org2");
+    org2.put("roles", List.of("analyst"));
+    claims.put("https://camunda.com/orgs", Arrays.asList(org1, org2));
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldFailWhenUserHasNoAllowedRole() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    final Map<String, Object> org = new HashMap<>();
+    org.put("id", "org1");
+    org.put("roles", Arrays.asList("developer", "viewer"));
+    claims.put("https://camunda.com/orgs", List.of(org));
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+    assertThat(result.getErrors().iterator().next().getErrorCode()).isEqualTo("invalid_token");
+  }
+
+  @Test
+  void shouldFailWhenOrganizationHasNoRoles() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    final Map<String, Object> org = new HashMap<>();
+    org.put("id", "org1");
+    org.put("roles", Collections.emptyList());
+    claims.put("https://camunda.com/orgs", List.of(org));
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+  }
+
+  @Test
+  void shouldFailWhenOrganizationClaimIsEmpty() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    claims.put("https://camunda.com/orgs", Collections.emptyList());
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+  }
+
+  @Test
+  void shouldFailWhenOrganizationClaimHasInvalidStructure() {
+    // given
+    final Jwt token = mock(Jwt.class);
+    final Map<String, Object> claims = new HashMap<>();
+    claims.put("https://camunda.com/orgs", "invalid-structure");
+    when(token.getClaims()).thenReturn(claims);
+
+    // when
+    final OAuth2TokenValidatorResult result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+  }
+}


### PR DESCRIPTION
## Description

- Initial problem : users are able to access Optimize even though they're missing roles
- Recent fix : #37039 introduced a `RoleValidator` and added existing validators to a new `idTokenDecoderFactory` which runs upon initial Oauth login. This ensures the claims are checked once before issuing an Optimize token. Unfortunately it resulted in a 404 backend error which broke Optimize entirely on SaaS, see [slack](https://camunda.slack.com/archives/C08G19SQ1BM/p1756223369323499)
- Investigation : after adding extensive logs, we found out that Optimize is actually [correctly validating roles](https://camunda.slack.com/archives/C08G19SQ1BM/p1757673746725609?thread_ts=1756223369.323499&cid=C08G19SQ1BM) with the recent fix but was trying to read Audience claim which turns out not to be present in the ID token 
```
An error occurred while attempting to decode the Jwt: The required audience is missing at org.springframework.security.oauth2.client.oidc.authentication.OidcAuthorizationCodeAuthenticationProvider.getJwt
```
- Final fix : In this PR, I'm only keeping RoleValidator inside the ID token decoder. I have validated the changes on this custom cluster : https://console.cloud.ultrawombat.com/org/12f6e8ce-c60b-4d28-ba92-45b55622319f/cluster/b3fb8ea6-0bbf-48ac-baff-273fe7eaeb83. The RoleValidator logs indicate that the roles are initially validated. I also tried a docker image with invalid authorized roles (see [cluster](https://console.cloud.ultrawombat.com/org/12f6e8ce-c60b-4d28-ba92-45b55622319f/cluster/d0c37dae-2ef9-4013-ba8b-cd3b9ecb6cd5)) and we're getting a 401 error (both when clicking on Optimize and when trying to access it from the app switcher top-left)

## Related issues

related to #31600
