### PR TITLE
deps: upgrade maven surefire plugin to 3.5.4

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -338,16 +338,6 @@
       "addLabels": [
         "automerge"
       ]
-    },
-    {
-      "description": "Skip maven-surefire-plugin updates, as 3.5.3 version has a bug preventing ArchUnit tests from running. https://issues.apache.org/jira/browse/SUREFIRE-2298",
-      "matchManagers": [
-        "maven"
-      ],
-      "matchPackageNames": [
-        "org.apache.maven.plugins:maven-surefire-plugin"
-      ],
-      "enabled": false
     }
   ],
   "dockerfile": {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -66,7 +66,7 @@
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.8.0-alpha8</version.identity>
     <version.instancio>5.5.0</version.instancio>
-    <version.surefire>3.5.3</version.surefire>
+    <version.surefire>3.5.4</version.surefire>
     <version.jackson>2.19.2</version.jackson>
     <version.junit>5.13.4</version.junit>
     <version.junit4>4.13.2</version.junit4>
@@ -223,7 +223,7 @@
     <plugin.version.shade>3.6.0</plugin.version.shade>
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
     <plugin.version.spotbugs>4.9.3.2</plugin.version.spotbugs>
-    <plugin.version.surefire>3.5.2</plugin.version.surefire>
+    <plugin.version.surefire>3.5.4</plugin.version.surefire>
     <plugin.version.versions>2.18.0</plugin.version.versions>
     <plugin.version.frontend-maven>1.15.1</plugin.version.frontend-maven>
     <plugin.version.maven-source>3.3.1</plugin.version.maven-source>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -66,7 +66,6 @@
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.8.0-alpha8</version.identity>
     <version.instancio>5.5.0</version.instancio>
-    <version.surefire>3.5.4</version.surefire>
     <version.jackson>2.19.2</version.jackson>
     <version.junit>5.13.4</version.junit>
     <version.junit4>4.13.2</version.junit4>
@@ -1188,7 +1187,7 @@
       <dependency>
         <groupId>org.apache.maven.surefire</groupId>
         <artifactId>surefire-shared-utils</artifactId>
-        <version>${version.surefire}</version>
+        <version>${plugin.version.surefire}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
We downgraded the version to 3.5.2 in https://github.com/camunda/camunda/pull/36115, as 3.5.3 was causing that ArchUnit tests were not run by maven in the CI 

Now https://github.com/apache/maven-surefire/issues/2601 is solved, and released in 3.5.4


Example of run ArchUnit test
```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.01 s -- in io.camunda.operate.OperateQualifiedBeansArchTest
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
