### PR TITLE
[CPT] feat: Improve process instance selector description

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceSelectors.java
@@ -47,7 +47,7 @@ public class ProcessInstanceSelectors {
    * @param parentProcessInstanceKey the key of the parent instance
    * @return the selector
    */
-  public static ProcessInstanceSelector byParentProcesInstanceKey(
+  public static ProcessInstanceSelector byParentProcessInstanceKey(
       final long parentProcessInstanceKey) {
     return new ParentProcessInstanceKeySelector(parentProcessInstanceKey);
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceSelectors.java
@@ -91,7 +91,7 @@ public class ProcessInstanceSelectors {
 
     @Override
     public String describe() {
-      return String.format("parent key: %s", parentProcessInstanceKey);
+      return String.format("parent process instance key: %s", parentProcessInstanceKey);
     }
 
     @Override

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -808,7 +808,7 @@ public class ProcessInstanceAssertTest {
                           byParentProcesInstanceKey(PARENT_PROCESS_KEY))
                       .isCreated())
           .hasMessage(
-              "Process instance [parent key: %d] should be created but was not created.",
+              "Process instance [parent process instance key: %d] should be created but was not created.",
               PARENT_PROCESS_KEY);
     }
   }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -16,7 +16,7 @@
 package io.camunda.process.test.api;
 
 import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
-import static io.camunda.process.test.api.assertions.ProcessInstanceSelectors.byParentProcesInstanceKey;
+import static io.camunda.process.test.api.assertions.ProcessInstanceSelectors.byParentProcessInstanceKey;
 import static io.camunda.process.test.utils.ProcessInstanceBuilder.newActiveChildProcessInstance;
 import static io.camunda.process.test.utils.ProcessInstanceBuilder.newActiveProcessInstance;
 import static org.mockito.ArgumentMatchers.any;
@@ -750,7 +750,7 @@ public class ProcessInstanceAssertTest {
                   newActiveChildProcessInstance(PROCESS_INSTANCE_KEY, PARENT_PROCESS_KEY).build()));
 
       // then
-      CamundaAssert.assertThatProcessInstance(byParentProcesInstanceKey(PARENT_PROCESS_KEY))
+      CamundaAssert.assertThatProcessInstance(byParentProcessInstanceKey(PARENT_PROCESS_KEY))
           .isCreated();
     }
 
@@ -766,7 +766,7 @@ public class ProcessInstanceAssertTest {
       when(camundaDataSource.findProcessInstances(any())).thenReturn(searchResult);
 
       // then
-      CamundaAssert.assertThatProcessInstance(byParentProcesInstanceKey(PARENT_PROCESS_KEY))
+      CamundaAssert.assertThatProcessInstance(byParentProcessInstanceKey(PARENT_PROCESS_KEY))
           .isCreated();
 
       final ProcessInstance firstChildProcessInstance = searchResult.get(0);
@@ -787,7 +787,7 @@ public class ProcessInstanceAssertTest {
       when(camundaDataSource.findProcessInstances(any())).thenReturn(searchResult);
 
       // then
-      CamundaAssert.assertThatProcessInstance(byParentProcesInstanceKey(PARENT_PROCESS_KEY))
+      CamundaAssert.assertThatProcessInstance(byParentProcessInstanceKey(PARENT_PROCESS_KEY))
           .isCreated();
 
       final ProcessInstance firstChildProcessInstance = searchResult.get(0);
@@ -805,7 +805,7 @@ public class ProcessInstanceAssertTest {
       Assertions.assertThatThrownBy(
               () ->
                   CamundaAssert.assertThatProcessInstance(
-                          byParentProcesInstanceKey(PARENT_PROCESS_KEY))
+                          byParentProcessInstanceKey(PARENT_PROCESS_KEY))
                       .isCreated())
           .hasMessage(
               "Process instance [parent process instance key: %d] should be created but was not created.",


### PR DESCRIPTION
## Description

- Update the description to be more precise about the behavior. There are multiple keys for a process instance. 
- Fix a type in the selector method name 

## Related issues

follow-up of https://github.com/camunda/camunda/issues/36410