### PR TITLE
refactor: skip create users test cases due to bug #38094

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
@@ -10,7 +10,7 @@ import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {relativizePath, Paths} from 'utils/relativizePath';
-import {createTestData, createComponentAuthorization} from 'utils/constants';
+import {createTestData} from 'utils/constants';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {verifyAccess} from 'utils/accessVerification';
 import {waitForItemInList} from 'utils/waitForItemInList';
@@ -33,7 +33,8 @@ test.describe('Identity User Flows', () => {
     await cleanupUsers(request, createdUsernames);
   });
 
-  test('Admin user can delete user', async ({
+  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
+  test.skip('Admin user can delete user', async ({
     page,
     loginPage,
     identityUsersPage,
@@ -78,8 +79,9 @@ test.describe('Identity User Flows', () => {
     });
   });
 
+  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
   // eslint-disable-next-line playwright/expect-expect
-  test('Brand new user cannot access any OC cluster apps', async ({
+  test.skip('Brand new user cannot access any OC cluster apps', async ({
     page,
     loginPage,
     identityUsersPage,
@@ -118,7 +120,8 @@ test.describe('Identity User Flows', () => {
     });
   });
 
-  test('Admin user can grant and revoke component authorization for user', async ({
+  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
+  test.skip('Admin user can grant and revoke component authorization for user', async ({
     page,
     loginPage,
     identityUsersPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -73,7 +73,8 @@ test.describe.serial('component authorizations CRUD', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('create user authorization', async ({
+  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
+  test.skip('create user authorization', async ({
     page,
     identityUsersPage,
     identityRolesPage,
@@ -123,7 +124,8 @@ test.describe.serial('component authorizations CRUD', () => {
     });
   });
 
-  test('create component authorization for a role', async ({
+  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
+  test.skip('create component authorization for a role', async ({
     identityUsersPage,
     identityAuthorizationsPage,
     identityHeader,
@@ -142,7 +144,8 @@ test.describe.serial('component authorizations CRUD', () => {
     });
   });
 
-  test('delete component authorization for role', async ({
+  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
+  test.skip('delete component authorization for role', async ({
     page,
     identityHeader,
     loginPage,
@@ -215,7 +218,8 @@ test.describe('authorization scenarios', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('create component authorization for a user', async ({
+  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
+  test.skip('create component authorization for a user', async ({
     page,
     identityUsersPage,
     identityAuthorizationsPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/create-new-user.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/create-new-user.spec.ts
@@ -29,7 +29,8 @@ test.describe.parallel('login page', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('Create new Test user', async ({page, identityUsersPage}) => {
+  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
+  test.skip('Create new Test user', async ({page, identityUsersPage}) => {
     const testData = createTestData({user: true});
     const testUser = testData.user!;
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -130,7 +130,8 @@ test.describe('Groups functionalities', () => {
     }
   });
 
-  test('As an Admin user can create a group with particular permissions and assign it to Test user', async ({
+  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
+  test.skip('As an Admin user can create a group with particular permissions and assign it to Test user', async ({
     page,
     identityGroupsPage,
     identityAuthorizationsPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
@@ -42,7 +42,8 @@ test.describe.serial('users CRUD', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('create a user', async ({identityUsersPage, page}) => {
+  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
+  test.skip('create a user', async ({identityUsersPage, page}) => {
     await expect(identityUsersPage.userCell('demo@example.com')).toBeVisible();
     await identityUsersPage.createUser(NEW_USER);
     await waitForItemInList(page, identityUsersPage.userCell(NEW_USER.email), {
@@ -51,7 +52,8 @@ test.describe.serial('users CRUD', () => {
     });
   });
 
-  test('edit a user', async ({identityUsersPage, page}) => {
+  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
+  test.skip('edit a user', async ({identityUsersPage, page}) => {
     await identityUsersPage.editUser(NEW_USER, EDITED_USER);
     const item = identityUsersPage.userCell(EDITED_USER.email);
     await waitForItemInList(page, item, {
@@ -60,7 +62,8 @@ test.describe.serial('users CRUD', () => {
     });
   });
 
-  test('delete a user', async ({identityUsersPage, page}) => {
+  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
+  test.skip('delete a user', async ({identityUsersPage, page}) => {
     const item = identityUsersPage.userCell(EDITED_USER.email);
     await identityUsersPage.deleteUser(EDITED_USER);
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Skipping identity test cases that creates users due to bug  #38094 
❗ Identity-e2e flow fails to build due to configurations that needs to be updated as reported [here](https://camunda.slack.com/archives/C08MRKHJ0CD/p1757931902194169)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
