### PR TITLE
UC: add index config properties

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -9,7 +9,9 @@ package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
@@ -24,6 +26,15 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   /** How many shards Elasticsearch uses for all Tasklist indices. */
   private int numberOfShards = 1;
+
+  /** Per-index replica overrides. */
+  private Map<String, Integer> numberOfReplicasPerIndex = new HashMap<>();
+
+  /** Per-index shard overrides. */
+  private Map<String, Integer> numberOfShardsPerIndex = new HashMap<>();
+
+  /** Template priority for index templates. */
+  private Integer templatePriority;
 
   @NestedConfigurationProperty private Security security = new Security(databaseName());
 
@@ -217,6 +228,45 @@ public abstract class DocumentBasedSecondaryStorageDatabase
     this.incidentNotifier = incidentNotifier;
   }
 
+  public Map<String, Integer> getNumberOfReplicasPerIndex() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".number-of-replicas-per-index",
+        numberOfReplicasPerIndex,
+        Map.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyReplicasByIndexNameProperties());
+  }
+
+  public void setNumberOfReplicasPerIndex(final Map<String, Integer> numberOfReplicasPerIndex) {
+    this.numberOfReplicasPerIndex = numberOfReplicasPerIndex;
+  }
+
+  public Map<String, Integer> getNumberOfShardsPerIndex() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".number-of-shards-per-index",
+        numberOfShardsPerIndex,
+        Map.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyShardsByIndexNameProperties());
+  }
+
+  public void setNumberOfShardsPerIndex(final Map<String, Integer> numberOfShardsPerIndex) {
+    this.numberOfShardsPerIndex = numberOfShardsPerIndex;
+  }
+
+  public Integer getTemplatePriority() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".template-priority",
+        templatePriority,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyTemplatePriorityProperties());
+  }
+
+  public void setTemplatePriority(final Integer templatePriority) {
+    this.templatePriority = templatePriority;
+  }
+
   private String prefix() {
     return "camunda.data.secondary-storage." + databaseName().toLowerCase();
   }
@@ -270,5 +320,23 @@ public abstract class DocumentBasedSecondaryStorageDatabase
     return Set.of(
         "camunda.database.index.numberOfShards",
         "zeebe.broker.exporters.camundaexporter.args.index.numberOfShards");
+  }
+
+  private Set<String> legacyReplicasByIndexNameProperties() {
+    return Set.of(
+        "camunda.database.index.replicasByIndexName",
+        "zeebe.broker.exporters.camundaexporter.args.index.replicasByIndexName");
+  }
+
+  private Set<String> legacyShardsByIndexNameProperties() {
+    return Set.of(
+        "camunda.database.index.shardsByIndexName",
+        "zeebe.broker.exporters.camundaexporter.args.index.shardsByIndexName");
+  }
+
+  private Set<String> legacyTemplatePriorityProperties() {
+    return Set.of(
+        "camunda.database.index.templatePriority",
+        "zeebe.broker.exporters.camundaexporter.args.index.templatePriority");
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -675,6 +675,15 @@ public class BrokerBasedPropertiesOverride {
 
     setArg(args, "connect.indexPrefix", database.getIndexPrefix());
     setArg(args, "index.numberOfShards", database.getNumberOfShards());
+    if (database.getTemplatePriority() != null) {
+      setArg(args, "index.templatePriority", database.getTemplatePriority());
+    }
+    if (!database.getNumberOfReplicasPerIndex().isEmpty()) {
+      setArg(args, "index.replicasByIndexName", database.getNumberOfReplicasPerIndex());
+    }
+    if (!database.getNumberOfShardsPerIndex().isEmpty()) {
+      setArg(args, "index.shardsByIndexName", database.getNumberOfShardsPerIndex());
+    }
 
     setArg(
         args, "history.processInstanceEnabled", database.getHistory().isProcessInstanceEnabled());

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
@@ -56,7 +56,13 @@ public class SearchEngineIndexPropertiesOverride {
             : secondaryStorage.getOpensearch();
 
     override.setNumberOfShards(database.getNumberOfShards());
-
+    override.setTemplatePriority(database.getTemplatePriority());
+    if (!database.getNumberOfReplicasPerIndex().isEmpty()) {
+      override.setReplicasByIndexName(database.getNumberOfReplicasPerIndex());
+    }
+    if (!database.getNumberOfShardsPerIndex().isEmpty()) {
+      override.setShardsByIndexName(database.getNumberOfShardsPerIndex());
+    }
     return override;
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -49,6 +49,10 @@ public class SecondaryStorageElasticsearchTest {
 
   private static final int EXPECTED_NUMBER_OF_SHARDS = 3;
 
+  private static final int EXPECTED_TEMPLATE_PRIORITY = 100;
+  private static final Map<String, Integer> EXPECTED_REPLICAS_BY_INDEX_NAME = Map.of("my-index", 3);
+  private static final Map<String, Integer> EXPECTED_SHARDS_BY_INDEX_NAME = Map.of("my-index", 2);
+
   private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
   private static final String EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "foo";
   private static final String EXPECTED_HISTORY_ROLLOVER_INTERVAL = "5d";
@@ -93,6 +97,10 @@ public class SecondaryStorageElasticsearchTest {
         "camunda.data.secondary-storage.elasticsearch.index-prefix=" + EXPECTED_INDEX_PREFIX,
         "camunda.data.secondary-storage.elasticsearch.number-of-shards="
             + EXPECTED_NUMBER_OF_SHARDS,
+        "camunda.data.secondary-storage.elasticsearch.template-priority="
+            + EXPECTED_TEMPLATE_PRIORITY,
+        "camunda.data.secondary-storage.elasticsearch.number-of-replicas-per-index.my-index=3",
+        "camunda.data.secondary-storage.elasticsearch.number-of-shards-per-index.my-index=2",
         "camunda.data.secondary-storage.elasticsearch.history.process-instance-enabled="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
         "camunda.data.secondary-storage.elasticsearch.history.els-rollover-date-format="
@@ -245,6 +253,12 @@ public class SecondaryStorageElasticsearchTest {
       assertThat(exporterConfiguration.getBulk().getSize()).isEqualTo(EXPECTED_BULK_SIZE);
       assertThat(exporterConfiguration.getBulk().getMemoryLimit())
           .isEqualTo(EXPECTED_BULK_MEMORY_LIMIT);
+      assertThat(exporterConfiguration.getIndex().getTemplatePriority())
+          .isEqualTo(EXPECTED_TEMPLATE_PRIORITY);
+      assertThat(exporterConfiguration.getIndex().getReplicasByIndexName())
+          .isEqualTo(EXPECTED_REPLICAS_BY_INDEX_NAME);
+      assertThat(exporterConfiguration.getIndex().getShardsByIndexName())
+          .isEqualTo(EXPECTED_SHARDS_BY_INDEX_NAME);
     }
 
     @Test
@@ -258,6 +272,12 @@ public class SecondaryStorageElasticsearchTest {
     void testCamundaSearchEngineIndexProperties() {
       assertThat(searchEngineIndexProperties.getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
+      assertThat(searchEngineIndexProperties.getTemplatePriority())
+          .isEqualTo(EXPECTED_TEMPLATE_PRIORITY);
+      assertThat(searchEngineIndexProperties.getReplicasByIndexName())
+          .isEqualTo(EXPECTED_REPLICAS_BY_INDEX_NAME);
+      assertThat(searchEngineIndexProperties.getShardsByIndexName())
+          .isEqualTo(EXPECTED_SHARDS_BY_INDEX_NAME);
     }
   }
 
@@ -365,6 +385,22 @@ public class SecondaryStorageElasticsearchTest {
         "camunda.data.secondary-storage.elasticsearch.number-of-shards="
             + EXPECTED_NUMBER_OF_SHARDS,
         "camunda.database.index.numberOfShards=" + EXPECTED_NUMBER_OF_SHARDS,
+
+        // template priority
+        "camunda.data.secondary-storage.elasticsearch.template-priority="
+            + EXPECTED_TEMPLATE_PRIORITY,
+        "camunda.database.index.templatePriority=" + EXPECTED_TEMPLATE_PRIORITY,
+
+        // template priority
+        "camunda.data.secondary-storage.elasticsearch.template-priority="
+            + EXPECTED_TEMPLATE_PRIORITY,
+        "camunda.database.index.templatePriority=" + EXPECTED_TEMPLATE_PRIORITY,
+
+        // per-index overrides
+        "camunda.data.secondary-storage.elasticsearch.number-of-replicas-per-index.my-index=3",
+        "camunda.database.index.replicasByIndexName.my-index=3",
+        "camunda.data.secondary-storage.elasticsearch.number-of-shards-per-index.my-index=2",
+        "camunda.database.index.shardsByIndexName.my-index=2",
       })
   class WithNewAndLegacySet {
     final OperateProperties operateProperties;
@@ -438,6 +474,12 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
+      assertThat(exporterConfiguration.getIndex().getTemplatePriority())
+          .isEqualTo(EXPECTED_TEMPLATE_PRIORITY);
+      assertThat(exporterConfiguration.getIndex().getReplicasByIndexName())
+          .isEqualTo(EXPECTED_REPLICAS_BY_INDEX_NAME);
+      assertThat(exporterConfiguration.getIndex().getShardsByIndexName())
+          .isEqualTo(EXPECTED_SHARDS_BY_INDEX_NAME);
     }
 
     @Test
@@ -454,6 +496,12 @@ public class SecondaryStorageElasticsearchTest {
     void testCamundaSearchEngineIndexProperties() {
       assertThat(searchEngineIndexProperties.getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
+      assertThat(searchEngineIndexProperties.getTemplatePriority())
+          .isEqualTo(EXPECTED_TEMPLATE_PRIORITY);
+      assertThat(searchEngineIndexProperties.getReplicasByIndexName())
+          .isEqualTo(EXPECTED_REPLICAS_BY_INDEX_NAME);
+      assertThat(searchEngineIndexProperties.getShardsByIndexName())
+          .isEqualTo(EXPECTED_SHARDS_BY_INDEX_NAME);
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -48,6 +48,9 @@ public class SecondaryStorageOpensearchTest {
   private static final String EXPECTED_PASSWORD = "testPassword";
 
   private static final int EXPECTED_NUMBER_OF_SHARDS = 3;
+  private static final int EXPECTED_TEMPLATE_PRIORITY = 100;
+  private static final Map<String, Integer> EXPECTED_REPLICAS_BY_INDEX_NAME = Map.of("my-index", 3);
+  private static final Map<String, Integer> EXPECTED_SHARDS_BY_INDEX_NAME = Map.of("my-index", 2);
 
   private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
   private static final String EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "foo";
@@ -92,6 +95,9 @@ public class SecondaryStorageOpensearchTest {
         "camunda.data.secondary-storage.opensearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
         "camunda.data.secondary-storage.opensearch.index-prefix=" + EXPECTED_INDEX_PREFIX,
         "camunda.data.secondary-storage.opensearch.number-of-shards=" + EXPECTED_NUMBER_OF_SHARDS,
+        "camunda.data.secondary-storage.opensearch.template-priority=" + EXPECTED_TEMPLATE_PRIORITY,
+        "camunda.data.secondary-storage.opensearch.number-of-replicas-per-index.my-index=3",
+        "camunda.data.secondary-storage.opensearch.number-of-shards-per-index.my-index=2",
         "camunda.data.secondary-storage.opensearch.history.process-instance-enabled="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
         "camunda.data.secondary-storage.opensearch.history.els-rollover-date-format="
@@ -201,6 +207,12 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_INDEX_PREFIX);
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
+      assertThat(exporterConfiguration.getIndex().getTemplatePriority())
+          .isEqualTo(EXPECTED_TEMPLATE_PRIORITY);
+      assertThat(exporterConfiguration.getIndex().getReplicasByIndexName())
+          .isEqualTo(EXPECTED_REPLICAS_BY_INDEX_NAME);
+      assertThat(exporterConfiguration.getIndex().getShardsByIndexName())
+          .isEqualTo(EXPECTED_SHARDS_BY_INDEX_NAME);
       assertThat(exporterConfiguration.getHistory().isProcessInstanceEnabled())
           .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
       assertThat(exporterConfiguration.getHistory().getElsRolloverDateFormat())
@@ -257,6 +269,12 @@ public class SecondaryStorageOpensearchTest {
     void testCamundaSearchEngineIndexProperties() {
       assertThat(searchEngineIndexProperties.getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
+      assertThat(searchEngineIndexProperties.getTemplatePriority())
+          .isEqualTo(EXPECTED_TEMPLATE_PRIORITY);
+      assertThat(searchEngineIndexProperties.getReplicasByIndexName())
+          .isEqualTo(EXPECTED_REPLICAS_BY_INDEX_NAME);
+      assertThat(searchEngineIndexProperties.getShardsByIndexName())
+          .isEqualTo(EXPECTED_SHARDS_BY_INDEX_NAME);
     }
   }
 
@@ -362,6 +380,20 @@ public class SecondaryStorageOpensearchTest {
         // number of shards
         "camunda.data.secondary-storage.opensearch.number-of-shards=" + EXPECTED_NUMBER_OF_SHARDS,
         "camunda.database.index.numberOfShards=" + EXPECTED_NUMBER_OF_SHARDS,
+
+        // template priority
+        "camunda.data.secondary-storage.opensearch.template-priority=" + EXPECTED_TEMPLATE_PRIORITY,
+        "camunda.database.index.templatePriority=" + EXPECTED_TEMPLATE_PRIORITY,
+
+        // template priority
+        "camunda.data.secondary-storage.opensearch.template-priority=" + EXPECTED_TEMPLATE_PRIORITY,
+        "camunda.database.index.templatePriority=" + EXPECTED_TEMPLATE_PRIORITY,
+
+        // per-index overrides
+        "camunda.data.secondary-storage.opensearch.number-of-replicas-per-index.my-index=3",
+        "camunda.database.index.replicasByIndexName.my-index=3",
+        "camunda.data.secondary-storage.opensearch.number-of-shards-per-index.my-index=2",
+        "camunda.database.index.shardsByIndexName.my-index=2",
       })
   class WithNewAndLegacySet {
     final OperateProperties operateProperties;
@@ -435,6 +467,12 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
+      assertThat(exporterConfiguration.getIndex().getTemplatePriority())
+          .isEqualTo(EXPECTED_TEMPLATE_PRIORITY);
+      assertThat(exporterConfiguration.getIndex().getReplicasByIndexName())
+          .isEqualTo(EXPECTED_REPLICAS_BY_INDEX_NAME);
+      assertThat(exporterConfiguration.getIndex().getShardsByIndexName())
+          .isEqualTo(EXPECTED_SHARDS_BY_INDEX_NAME);
     }
 
     @Test
@@ -453,6 +491,12 @@ public class SecondaryStorageOpensearchTest {
     void testCamundaSearchEngineIndexProperties() {
       assertThat(searchEngineIndexProperties.getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
+      assertThat(searchEngineIndexProperties.getTemplatePriority())
+          .isEqualTo(EXPECTED_TEMPLATE_PRIORITY);
+      assertThat(searchEngineIndexProperties.getReplicasByIndexName())
+          .isEqualTo(EXPECTED_REPLICAS_BY_INDEX_NAME);
+      assertThat(searchEngineIndexProperties.getShardsByIndexName())
+          .isEqualTo(EXPECTED_SHARDS_BY_INDEX_NAME);
     }
   }
 


### PR DESCRIPTION
## Description

UC: add index config properties

Should be included in wave 1 migration.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38121
