### PR TITLE
[Backport stable/8.6] fix: do not set the commitIndex to be greater than biggest logIndex

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -532,8 +532,14 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    * @param commitIndex The commit index.
    * @return the previous commit index
    */
-  public long setCommitIndex(final long commitIndex) {
+  public long setCommitIndex(long commitIndex) {
     checkArgument(commitIndex >= 0, "commitIndex must be positive");
+
+    // Do not set the commitIndex to be greater than the events we persisted.
+    // In case of a heartbeat, the leader sends its commitIndex which may be greater than what's
+    // persisted in case we failed to persist a previous AppendEntries
+    commitIndex = Math.min(commitIndex, raftLog.getLastIndex());
+
     final long previousCommitIndex = this.commitIndex;
     if (commitIndex > previousCommitIndex) {
       this.commitIndex = commitIndex;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -548,9 +548,21 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
         // leader counts itself in quorum, so in order to commit the leader must persist
         raftLog.flush();
       }
+<<<<<<< HEAD
       final long configurationIndex = cluster.getConfiguration().index();
       if (configurationIndex > previousCommitIndex && configurationIndex <= commitIndex) {
         cluster.commitCurrentConfiguration();
+=======
+      raftLog.setCommitIndex(commitIndex);
+      this.commitIndex = commitIndex;
+      meta.storeCommitIndex(commitIndex);
+      final var clusterConfig = cluster.getConfiguration();
+      if (clusterConfig != null) {
+        final long configurationIndex = clusterConfig.index();
+        if (configurationIndex > previousCommitIndex && configurationIndex <= commitIndex) {
+          cluster.commitCurrentConfiguration();
+        }
+>>>>>>> b494f4b4 (refactor: merge checks on commitIndex/raftLog.getLastIndex())
       }
       replicationMetrics.setCommitIndex(commitIndex);
       notifyCommitListeners(commitIndex);


### PR DESCRIPTION
# Description
Backport of #30354 to `stable/8.6`.

relates to #27852