### PR TITLE
[Backport stable/8.7] fix: do not set the commitIndex to be greater than biggest logIndex

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -529,8 +529,14 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    * @param commitIndex The commit index.
    * @return the previous commit index
    */
-  public long setCommitIndex(final long commitIndex) {
+  public long setCommitIndex(long commitIndex) {
     checkArgument(commitIndex >= 0, "commitIndex must be positive");
+
+    // Do not set the commitIndex to be greater than the events we persisted.
+    // In case of a heartbeat, the leader sends its commitIndex which may be greater than what's
+    // persisted in case we failed to persist a previous AppendEntries
+    commitIndex = Math.min(commitIndex, raftLog.getLastIndex());
+
     final long previousCommitIndex = this.commitIndex;
     if (commitIndex > previousCommitIndex) {
       this.commitIndex = commitIndex;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -760,12 +760,6 @@ public class PassiveRole extends InactiveRole {
     // Set the first commit index.
     raft.setFirstCommitIndex(request.commitIndex());
 
-    // Update the context commit and global indices.
-    final long previousCommitIndex = raft.setCommitIndex(commitIndex);
-    if (previousCommitIndex < commitIndex) {
-      log.trace("Committed entries up to index {}", commitIndex);
-    }
-
     try {
       //     Make sure all entries are flushed before ack to ensure we have persisted what we
       //     acknowledge
@@ -777,6 +771,12 @@ public class PassiveRole extends InactiveRole {
       // Flush failed, return error to the leader so we can retry.
       failAppend(request.prevLogIndex(), future);
       return;
+    }
+
+    // Update the context commit and global indices.
+    final long previousCommitIndex = raft.setCommitIndex(commitIndex);
+    if (previousCommitIndex < commitIndex) {
+      log.trace("Committed entries up to index {}", commitIndex);
     }
 
     // Return a successful append response.


### PR DESCRIPTION
# Description
Backport of #30354 to `stable/8.7`.

relates to #27852