### PR TITLE
[Backport stable/8.8] fix: do not set the commitIndex to be greater than biggest logIndex

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -572,7 +572,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
               "Failed to commit index %s because of a flush error: %s", commitIndex, e);
         }
       }
-      raftLog.setCommitIndex(Math.min(commitIndex, raftLog.getLastIndex()));
+      raftLog.setCommitIndex(commitIndex);
       this.commitIndex = commitIndex;
       meta.storeCommitIndex(commitIndex);
       final var clusterConfig = cluster.getConfiguration();

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -762,12 +762,6 @@ public class PassiveRole extends InactiveRole {
     // Set the first commit index.
     raft.setFirstCommitIndex(request.commitIndex(), lastLogIndex);
 
-    // Update the context commit and global indices.
-    final long previousCommitIndex = raft.setCommitIndex(commitIndex);
-    if (previousCommitIndex < commitIndex) {
-      log.trace("Committed entries up to index {}", commitIndex);
-    }
-
     try {
       //     Make sure all entries are flushed before ack to ensure we have persisted what we
       //     acknowledge
@@ -779,6 +773,12 @@ public class PassiveRole extends InactiveRole {
       // Flush failed, return error to the leader so we can retry.
       failAppend(request.prevLogIndex(), future);
       return;
+    }
+
+    // Update the context commit and global indices.
+    final long previousCommitIndex = raft.setCommitIndex(commitIndex);
+    if (previousCommitIndex < commitIndex) {
+      log.trace("Committed entries up to index {}", commitIndex);
     }
 
     // Return a successful append response.


### PR DESCRIPTION
# Description
Backport of #30354 to `stable/8.8`.

relates to #27852