### PR TITLE
[CPT] Complete user task by BPMN element ID

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
@@ -170,19 +170,19 @@ public interface CamundaProcessTestContext {
       final String jobType, final String errorCode, final Map<String, Object> variables);
 
   /**
-   * Completes a user task with the specified task name.
+   * Completes a user task with the given BPMN element ID.
    *
-   * @param taskName the name of the user task to complete
+   * @param elementId the BPMN element ID of the user task to complete
    */
-  void completeUserTask(final String taskName);
+  void completeUserTask(final String elementId);
 
   /**
-   * Completes a user task with the specified task name and sets the provided variables.
+   * Completes a user task with the given BPMN element ID and sets the provided variables.
    *
-   * @param taskName the name of the user task to complete
+   * @param elementId the BPMN element ID of the user task to complete
    * @param variables a map of variables to set when completing the user task
    */
-  void completeUserTask(final String taskName, final Map<String, Object> variables);
+  void completeUserTask(final String elementId, final Map<String, Object> variables);
 
   /**
    * Completes a user task that matches the specified selector.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -259,7 +259,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
 
           assertThat(userTask)
               .withFailMessage(
-                  "Expected to complete user task [%s] but no job is available.",
+                  "Expected to complete user task [%s] but no user task is available.",
                   userTaskSelector.describe())
               .isPresent();
         });

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -38,7 +38,7 @@ import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -158,7 +158,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
 
   @Override
   public void mockChildProcess(final String childProcessId) {
-    mockChildProcess(childProcessId, new HashMap<>());
+    mockChildProcess(childProcessId, Collections.emptyMap());
   }
 
   @Override
@@ -185,7 +185,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
 
   @Override
   public void completeJob(final String jobType) {
-    completeJob(jobType, new HashMap<>());
+    completeJob(jobType, Collections.emptyMap());
   }
 
   @Override
@@ -203,7 +203,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
 
   @Override
   public void throwBpmnErrorFromJob(final String jobType, final String errorCode) {
-    throwBpmnErrorFromJob(jobType, errorCode, new HashMap<>());
+    throwBpmnErrorFromJob(jobType, errorCode, Collections.emptyMap());
   }
 
   @Override
@@ -223,7 +223,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
 
   @Override
   public void completeUserTask(final String elementId) {
-    completeUserTask(UserTaskSelectors.byElementId(elementId), new HashMap<>());
+    completeUserTask(UserTaskSelectors.byElementId(elementId), Collections.emptyMap());
   }
 
   @Override
@@ -233,7 +233,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
 
   @Override
   public void completeUserTask(final UserTaskSelector userTaskSelector) {
-    completeUserTask(userTaskSelector, new HashMap<>());
+    completeUserTask(userTaskSelector, Collections.emptyMap());
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -222,13 +222,13 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   }
 
   @Override
-  public void completeUserTask(final String taskName) {
-    completeUserTask(UserTaskSelectors.byTaskName(taskName), new HashMap<>());
+  public void completeUserTask(final String elementId) {
+    completeUserTask(UserTaskSelectors.byElementId(elementId), new HashMap<>());
   }
 
   @Override
-  public void completeUserTask(final String taskName, final Map<String, Object> variables) {
-    completeUserTask(UserTaskSelectors.byTaskName(taskName), variables);
+  public void completeUserTask(final String elementId, final Map<String, Object> variables) {
+    completeUserTask(UserTaskSelectors.byElementId(elementId), variables);
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -333,7 +333,7 @@ public class CamundaProcessTestContextIT {
     variables.put("abc", 123);
 
     // When
-    processTestContext.completeUserTask("user-task", variables);
+    processTestContext.completeUserTask("user-task-1", variables);
 
     // Then
     assertThatProcessInstance(processInstanceEvent).isCompleted();

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -316,7 +316,7 @@ public class CamundaProcessTestContextIT {
         client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
 
     // When
-    processTestContext.completeUserTask("user-task");
+    processTestContext.completeUserTask("user-task-1");
 
     // Then
     assertThatProcessInstance(processInstanceEvent).isCompleted();

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -452,7 +452,7 @@ public class CamundaProcessTestContextIT {
             () ->
                 processTestContext.completeUserTask(UserTaskSelectors.byElementId("unknown-task")))
         .hasMessage(
-            "Expected to complete user task [elementId: unknown-task] but no job is available.");
+            "Expected to complete user task [elementId: unknown-task] but no user task is available.");
   }
 
   @Test


### PR DESCRIPTION
## Description

Change the utility behavior to complete a user task by BPMN element ID instead of the task name. This change aligns the utility method with the rest of the API that uses the element ID consistently. 

:warning: This PR changes the current behavior and could break process tests that rely on the behavior of previous alpha versions.

## Related issues

closes https://github.com/camunda/camunda/issues/38111
