### PR TITLE
pg/38032-task-migration-disable-archiver

### DIFF
--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/TaskMigrationAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/TaskMigrationAdapter.java
@@ -44,5 +44,9 @@ public interface TaskMigrationAdapter {
 
   Set<ImportPositionEntity> getImportPositions() throws MigrationException;
 
+  void blockArchiving() throws MigrationException;
+
+  void resumeArchiving() throws MigrationException;
+
   void close() throws IOException;
 }

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -310,7 +310,7 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
     final var blockArchivingRequest =
         new PutMappingRequest.Builder()
             .index(importPositionIndex.getFullQualifiedName())
-            .meta(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(true))
+            .meta(SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY, JsonData.of(true))
             .build();
 
     try {
@@ -328,7 +328,7 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
     final var resumeArchivingRequest =
         new PutMappingRequest.Builder()
             .index(importPositionIndex.getFullQualifiedName())
-            .meta(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(false))
+            .meta(SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY, JsonData.of(false))
             .build();
 
     try {

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -31,7 +31,9 @@ import co.elastic.clients.elasticsearch.core.reindex.Source;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
+import co.elastic.clients.elasticsearch.indices.PutMappingRequest;
 import co.elastic.clients.elasticsearch.indices.UpdateAliasesRequest;
+import co.elastic.clients.json.JsonData;
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.commons.configuration.MigrationConfiguration;
 import io.camunda.migration.commons.storage.ProcessorStep;
@@ -43,6 +45,7 @@ import io.camunda.migration.task.adapter.TaskWithIndex;
 import io.camunda.migration.task.util.MigrationUtils;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.search.schema.SchemaManager;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
 import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
@@ -300,6 +303,42 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
         .map(Hit::source)
         .filter(Objects::nonNull)
         .collect(Collectors.toSet());
+  }
+
+  @Override
+  public void blockArchiving() throws MigrationException {
+    final var blockArchivingRequest =
+        new PutMappingRequest.Builder()
+            .index(importPositionIndex.getFullQualifiedName())
+            .meta(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(true))
+            .build();
+
+    try {
+      retryDecorator.decorate(
+          "Blocking archiving",
+          () -> client.indices().putMapping(blockArchivingRequest),
+          res -> !res.acknowledged());
+    } catch (final Exception e) {
+      throw new MigrationException("Unable to block archiver", e);
+    }
+  }
+
+  @Override
+  public void resumeArchiving() throws MigrationException {
+    final var resumeArchivingRequest =
+        new PutMappingRequest.Builder()
+            .index(importPositionIndex.getFullQualifiedName())
+            .meta(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(false))
+            .build();
+
+    try {
+      retryDecorator.decorate(
+          "Resuming archiving",
+          () -> client.indices().putMapping(resumeArchivingRequest),
+          res -> !res.acknowledged());
+    } catch (final Exception e) {
+      throw new MigrationException("Unable to resume archiver", e);
+    }
   }
 
   @Override

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
@@ -21,6 +21,7 @@ import io.camunda.migration.task.adapter.TaskWithIndex;
 import io.camunda.migration.task.util.MigrationUtils;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.os.OpensearchConnector;
+import io.camunda.search.schema.SchemaManager;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
 import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
@@ -60,6 +61,7 @@ import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.opensearch.client.opensearch.generic.Requests;
 import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
+import org.opensearch.client.opensearch.indices.PutMappingRequest;
 import org.opensearch.client.opensearch.indices.UpdateAliasesRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,12 +92,12 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
             .withRetryOnException(
                 e -> e instanceof IOException || e instanceof OpenSearchException);
 
-    legacyIndex = new TaskLegacyIndex(connectConfiguration.getIndexPrefix(), true);
-    destinationIndex = new TaskTemplate(connectConfiguration.getIndexPrefix(), true);
+    legacyIndex = new TaskLegacyIndex(connectConfiguration.getIndexPrefix(), false);
+    destinationIndex = new TaskTemplate(connectConfiguration.getIndexPrefix(), false);
     migrationIndex =
-        new TasklistMigrationRepositoryIndex(connectConfiguration.getIndexPrefix(), true);
+        new TasklistMigrationRepositoryIndex(connectConfiguration.getIndexPrefix(), false);
     importPositionIndex =
-        new TasklistImportPositionIndex(connectConfiguration.getIndexPrefix(), true);
+        new TasklistImportPositionIndex(connectConfiguration.getIndexPrefix(), false);
     this.retentionConfiguration = retentionConfiguration;
   }
 
@@ -303,6 +305,42 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
         .map(Hit::source)
         .filter(Objects::nonNull)
         .collect(Collectors.toSet());
+  }
+
+  @Override
+  public void blockArchiving() throws MigrationException {
+    final var blockArchivingRequest =
+        new PutMappingRequest.Builder()
+            .index(importPositionIndex.getFullQualifiedName())
+            .meta(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(true))
+            .build();
+
+    try {
+      retryDecorator.decorate(
+          "Blocking archiving",
+          () -> client.indices().putMapping(blockArchivingRequest),
+          res -> !res.acknowledged());
+    } catch (final Exception e) {
+      throw new MigrationException("Unable to block archiver", e);
+    }
+  }
+
+  @Override
+  public void resumeArchiving() throws MigrationException {
+    final var resumeArchivingRequest =
+        new PutMappingRequest.Builder()
+            .index(importPositionIndex.getFullQualifiedName())
+            .meta(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(false))
+            .build();
+
+    try {
+      retryDecorator.decorate(
+          "Resuming archiving",
+          () -> client.indices().putMapping(resumeArchivingRequest),
+          res -> !res.acknowledged());
+    } catch (final Exception e) {
+      throw new MigrationException("Unable to resume archiver", e);
+    }
   }
 
   @Override

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
@@ -312,7 +312,7 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
     final var blockArchivingRequest =
         new PutMappingRequest.Builder()
             .index(importPositionIndex.getFullQualifiedName())
-            .meta(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(true))
+            .meta(SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY, JsonData.of(true))
             .build();
 
     try {
@@ -330,7 +330,7 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
     final var resumeArchivingRequest =
         new PutMappingRequest.Builder()
             .index(importPositionIndex.getFullQualifiedName())
-            .meta(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(false))
+            .meta(SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY, JsonData.of(false))
             .build();
 
     try {

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/TaskMigrationPartialUpdatesIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/TaskMigrationPartialUpdatesIT.java
@@ -369,8 +369,8 @@ public class TaskMigrationPartialUpdatesIT extends UserTaskMigrationHelper {
             "/"
                 + tasklistImportPositionIndex.getFullQualifiedName()
                 + "/mappings/_meta/"
-                + SchemaManager.ARCHIVING_BLOCKED_META_KEY);
-    return blockedPropertyNode.isMissingNode() ? false : blockedPropertyNode.asBoolean();
+                + SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY);
+    return !blockedPropertyNode.isMissingNode() && blockedPropertyNode.asBoolean();
   }
 
   private void assertTasksAreInCorrectIndices(final CamundaMigrator migrator) {

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/TaskMigrationPartialUpdatesIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/TaskMigrationPartialUpdatesIT.java
@@ -1,0 +1,467 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.migration;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.camunda.it.migration.usertask.UserTaskMigrationHelper;
+import io.camunda.it.migration.util.CamundaMigrator;
+import io.camunda.it.migration.util.MigrationITExtension;
+import io.camunda.migration.commons.configuration.ConfigurationType;
+import io.camunda.migration.commons.configuration.MigrationConfiguration;
+import io.camunda.migration.commons.configuration.MigrationProperties;
+import io.camunda.migration.task.TaskMigrator;
+import io.camunda.migration.task.adapter.TaskLegacyIndex;
+import io.camunda.search.clients.core.SearchQueryHit;
+import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.schema.SchemaManager;
+import io.camunda.search.schema.config.RetentionConfiguration;
+import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
+import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.lang3.exception.UncheckedException;
+import org.apache.commons.lang3.tuple.Pair;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@Tag("multi-db-test")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@TestMethodOrder(OrderAnnotation.class)
+public class TaskMigrationPartialUpdatesIT extends UserTaskMigrationHelper {
+  private static final Map<Long, TaskData> PI_TASKS = new HashMap<>();
+  private static final List<Long> ARCHIVING_BACKLOG = new ArrayList<>();
+  private static final long ONE_DAY_MILLIS = ChronoUnit.DAYS.getDuration().toMillis();
+  private static final long WAIT_PERIOD_BEFORE_ARCHIVING_SECONDS = 5;
+  private static final long CLOCK_STEP_MILLIS = (WAIT_PERIOD_BEFORE_ARCHIVING_SECONDS + 1) * 1000;
+  private static final int TASK_COUNT = 20;
+  private static Instant clock =
+      Instant.now().minus(TASK_COUNT, ChronoUnit.DAYS).truncatedTo(ChronoUnit.MILLIS);
+  private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+  private static TaskLegacyIndex legacyIndex;
+  private static TaskTemplate taskIndex;
+
+  @RegisterExtension
+  static final MigrationITExtension PROVIDER =
+      new MigrationITExtension()
+          .withBeforeUpgradeConsumer((db, migrator) -> preconditions(migrator))
+          .withCamundaExporterArgsOverride(
+              args -> {
+                ((Map) args.get("history"))
+                    .put("waitPeriodBeforeArchiving", WAIT_PERIOD_BEFORE_ARCHIVING_SECONDS + "s");
+                ((Map) args.get("history")).put("delayBetweenRuns", "1000");
+              })
+          .withUpgradeSystemPropertyOverrides(Map.of("zeebe.clock.controlled", "true"))
+          .withInitialEnvOverrides(
+              Map.of(
+                  "ZEEBE_CLOCK_CONTROLLED",
+                  "true",
+                  "CAMUNDA_TASKLIST_ARCHIVER_WAITPERIODBEFOREARCHIVING",
+                  WAIT_PERIOD_BEFORE_ARCHIVING_SECONDS + "s"));
+
+  @Test
+  void shouldCompleteMigrationWithPartialData(final CamundaMigrator migrator)
+      throws IOException, InterruptedException {
+
+    // Archiver should be blocked on 8.8 startup
+    final var tasklistImportPositionIndex =
+        new TasklistImportPositionIndex(migrator.getIndexPrefix(), migrator.isElasticsearch());
+    assertArchiverState(tasklistImportPositionIndex, true);
+
+    // Pin clock to last known time
+    pinClock(migrator.getActuatorUrl() + "/clock", clock.toEpochMilli());
+
+    // Perform Assignment and Completion of User Tasks - Resulting in partial documents
+    PI_TASKS.entrySet().stream()
+        .filter(e -> !e.getValue().completed)
+        .filter(e -> e.getValue().implementation.equals(TaskImplementation.ZEEBE_USER_TASK))
+        .forEach(e -> tryAssignAndCompleteTask(migrator, e.getValue()));
+
+    // Start Task Migration
+    startTaskMigration(migrator);
+
+    // Archiver should be unblocked when migration completes
+    assertArchiverState(tasklistImportPositionIndex, false);
+
+    waitForTasksToBeArchived(taskIndex.getFullQualifiedName(), migrator, ARCHIVING_BACKLOG, 60);
+    assertTasksAreInCorrectIndices(migrator);
+
+    generateState(migrator, migrator.getActuatorUrl() + "/clock");
+    // Ensure that all other tasks can be completed and archived normally
+    PI_TASKS.values().stream()
+        .filter(task -> !task.completed)
+        .forEach(task -> tryAssignAndCompleteTask(migrator, task));
+    waitForTasksToBeArchived(
+        taskIndex.getFullQualifiedName(), migrator, PI_TASKS.keySet().stream().toList(), 60);
+  }
+
+  private void startTaskMigration(final CamundaMigrator migrator) {
+    final var connectConfiguration = new ConnectConfiguration();
+    connectConfiguration.setUrl(PROVIDER.getDatabaseUrl());
+    connectConfiguration.setType(migrator.isElasticsearch() ? "elasticsearch" : "opensearch");
+    connectConfiguration.setIndexPrefix(migrator.getIndexPrefix());
+
+    final var migrationConfiguration = new MigrationConfiguration();
+    migrationConfiguration.setBatchSize(1);
+
+    final var migrationProperties = new MigrationProperties();
+    migrationProperties.setMigration(Map.of(ConfigurationType.TASKS, migrationConfiguration));
+
+    // Run the Task Migration
+    Executors.newSingleThreadExecutor()
+        .submit(
+            () ->
+                new TaskMigrator(
+                        connectConfiguration,
+                        migrationProperties,
+                        new SimpleMeterRegistry(),
+                        new RetentionConfiguration())
+                    .call());
+  }
+
+  private static void preconditions(final CamundaMigrator migrator) {
+    try {
+      final String actuatorUrl = migrator.getActuatorUrl() + "/clock";
+      legacyIndex = new TaskLegacyIndex(migrator.getIndexPrefix(), migrator.isElasticsearch());
+      taskIndex = new TaskTemplate(migrator.getIndexPrefix(), migrator.isElasticsearch());
+      pinClock(actuatorUrl, clock.toEpochMilli());
+      dataSetup(migrator);
+    } catch (final IOException | InterruptedException ignored) {
+      // ignored
+    }
+  }
+
+  private static void dataSetup(final CamundaMigrator migrator)
+      throws IOException, InterruptedException {
+
+    final String actuatorUrl = migrator.getActuatorUrl() + "/clock";
+
+    final var jobWorkerProcessDefinitionKey = deployProcess(migrator.getCamundaClient(), t -> t);
+    PROCESS_DEFINITION_KEYS.put(TaskImplementation.JOB_WORKER, jobWorkerProcessDefinitionKey);
+
+    final var zeebeProcessDefinitionKey =
+        deployProcess(migrator.getCamundaClient(), AbstractUserTaskBuilder::zeebeUserTask);
+    PROCESS_DEFINITION_KEYS.put(TaskImplementation.ZEEBE_USER_TASK, zeebeProcessDefinitionKey);
+
+    // Run User Tasks
+    generateState87(migrator, actuatorUrl);
+  }
+
+  private static void generateState87(final CamundaMigrator migrator, final String clockActuatorUrl)
+      throws IOException, InterruptedException {
+    final List<Long> waitForArchival = new ArrayList<>();
+
+    for (int i = 0; i < TASK_COUNT; i++) {
+      final TaskImplementation implementation =
+          i % 2 == 0 ? TaskImplementation.JOB_WORKER : TaskImplementation.ZEEBE_USER_TASK;
+      final var processInstanceKey =
+          startProcessInstance(
+              migrator.getCamundaClient(), PROCESS_DEFINITION_KEYS.get(implementation));
+      final var taskKey = waitForTaskToBeImportedReturningId(migrator, processInstanceKey);
+      PI_TASKS.put(
+          processInstanceKey,
+          new TaskData(implementation, processInstanceKey, taskKey, false, clock, false, false));
+
+      if (waitForArchival.size() <= TASK_COUNT / 2) {
+        assignAndComplete87Task(migrator, taskKey);
+        waitForArchival.add(taskKey);
+      }
+      if (i % 2 != 0) {
+        clock = clock.plus(ONE_DAY_MILLIS, ChronoUnit.MILLIS);
+        progressClock(clockActuatorUrl, ONE_DAY_MILLIS);
+      }
+    }
+    clock = clock.plus(CLOCK_STEP_MILLIS, ChronoUnit.MILLIS);
+    progressClock(clockActuatorUrl, CLOCK_STEP_MILLIS);
+    waitForTasksToBeArchived(legacyIndex.getFullQualifiedName(), migrator, waitForArchival, 120);
+  }
+
+  private void generateState(final CamundaMigrator migrator, final String clockActuatorUrl)
+      throws IOException, InterruptedException {
+
+    for (int i = 0; i < TASK_COUNT; i++) {
+      final TaskImplementation implementation =
+          i % 2 == 0 ? TaskImplementation.JOB_WORKER : TaskImplementation.ZEEBE_USER_TASK;
+      final var processInstanceKey =
+          startProcessInstance(
+              migrator.getCamundaClient(), PROCESS_DEFINITION_KEYS.get(implementation));
+      final var taskKey = waitFor88CreatedTaskToBeImportedReturningId(migrator, processInstanceKey);
+      PI_TASKS.put(
+          processInstanceKey,
+          new TaskData(implementation, processInstanceKey, taskKey, false, clock, true, false));
+
+      if (i % 2 != 0) {
+        clock = clock.plus(ONE_DAY_MILLIS, ChronoUnit.MILLIS);
+        progressClock(clockActuatorUrl, ONE_DAY_MILLIS);
+      }
+    }
+  }
+
+  private static void assignAndComplete87Task(final CamundaMigrator migrator, final long taskKey) {
+    assignUserTask(migrator, String.valueOf(taskKey), "demo");
+
+    completeUserTask(migrator, String.valueOf(taskKey));
+
+    final var entry =
+        PI_TASKS.entrySet().stream()
+            .filter(e -> e.getValue().taskKey() == taskKey)
+            .findFirst()
+            .orElseThrow();
+    PI_TASKS.compute(
+        entry.getKey(),
+        (k, currentTaskData) ->
+            new TaskData(
+                currentTaskData.implementation,
+                currentTaskData.processInstanceKey,
+                entry.getValue().taskKey,
+                true,
+                currentTaskData.date,
+                currentTaskData.startedAfterUpgrade,
+                false));
+  }
+
+  private void tryAssignAndCompleteTask(final CamundaMigrator migrator, final TaskData taskData) {
+    if (Math.random() > 0.6) {
+      if (taskData.implementation.equals(TaskImplementation.ZEEBE_USER_TASK)) {
+        migrator
+            .getCamundaClient()
+            .newAssignUserTaskCommand(taskData.taskKey)
+            .assignee("demo")
+            .send()
+            .join();
+
+        migrator.getCamundaClient().newCompleteUserTaskCommand(taskData.taskKey).send().join();
+
+      } else {
+        var res =
+            migrator
+                .getTasklistClient()
+                .withAuthentication("demo", "demo")
+                .assignUserTask(taskData.taskKey, "demo");
+        assertThat(res.statusCode()).isEqualTo(200);
+        res =
+            migrator
+                .getTasklistClient()
+                .withAuthentication("demo", "demo")
+                .completeUserTask(taskData.taskKey);
+        assertThat(res.statusCode()).isEqualTo(200);
+      }
+      ARCHIVING_BACKLOG.add(taskData.taskKey);
+      final var entry =
+          PI_TASKS.entrySet().stream()
+              .filter(e -> e.getValue().taskKey() == taskData.taskKey())
+              .findFirst()
+              .orElseThrow();
+      PI_TASKS.compute(
+          entry.getKey(),
+          (k, currentTaskData) ->
+              new TaskData(
+                  currentTaskData.implementation,
+                  currentTaskData.processInstanceKey,
+                  entry.getValue().taskKey,
+                  true,
+                  clock,
+                  currentTaskData.startedAfterUpgrade,
+                  true));
+    }
+
+    clock = clock.plus(CLOCK_STEP_MILLIS, ChronoUnit.MILLIS);
+    try {
+      progressClock(migrator.getActuatorUrl() + "/clock", CLOCK_STEP_MILLIS);
+    } catch (final IOException | InterruptedException e) {
+      throw new UncheckedException(e);
+    }
+  }
+
+  // Use plain HTTP to pin the clock as 8.8 Actuator is not compatible with 8.7
+  private static void pinClock(final String actuatorUrl, final long epochMilli)
+      throws IOException, InterruptedException {
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(actuatorUrl + "/pin"))
+            .header("Content-Type", "application/json")
+            .POST(
+                HttpRequest.BodyPublishers.ofString(
+                    String.format("{\"epochMilli\":\"%s\"}", epochMilli)))
+            .build();
+
+    HTTP_CLIENT.send(request, BodyHandlers.discarding());
+  }
+
+  // Use plain HTTP to progress the clock as 8.8 Actuator is not compatible with 8.7
+  private static void progressClock(final String actuatorUrl, final long offsetMilli)
+      throws IOException, InterruptedException {
+
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(actuatorUrl + "/add"))
+            .header("Content-Type", "application/json")
+            .POST(
+                HttpRequest.BodyPublishers.ofString(
+                    String.format("{\"offsetMilli\":\"%s\"}", offsetMilli)))
+            .build();
+
+    HTTP_CLIENT.send(request, BodyHandlers.discarding());
+  }
+
+  private void assertArchiverState(
+      final TasklistImportPositionIndex tasklistImportPositionIndex, final boolean blocked) {
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              try {
+                assertThat(fetchArchiverBlockedProperty(tasklistImportPositionIndex))
+                    .withFailMessage("Expected Archiver to have state blocked:" + blocked)
+                    .isEqualTo(blocked);
+              } catch (final IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+            });
+  }
+
+  private boolean fetchArchiverBlockedProperty(
+      final TasklistImportPositionIndex tasklistImportPositionIndex)
+      throws IOException, InterruptedException {
+    final var httpReq =
+        HttpRequest.newBuilder()
+            .uri(
+                URI.create(
+                    PROVIDER.getDatabaseUrl()
+                        + "/"
+                        + tasklistImportPositionIndex.getFullQualifiedName()
+                        + "/_mapping"))
+            .build();
+    final var res = HTTP_CLIENT.send(httpReq, BodyHandlers.ofString());
+    final var node = OBJECT_MAPPER.readTree(res.body());
+    final var blockedPropertyNode =
+        node.at(
+            "/"
+                + tasklistImportPositionIndex.getFullQualifiedName()
+                + "/mappings/_meta/"
+                + SchemaManager.ARCHIVING_BLOCKED_META_KEY);
+    return blockedPropertyNode.isMissingNode() ? false : blockedPropertyNode.asBoolean();
+  }
+
+  private void assertTasksAreInCorrectIndices(final CamundaMigrator migrator) {
+    final var taskIndex = new TaskTemplate(migrator.getIndexPrefix(), migrator.isElasticsearch());
+    PI_TASKS.forEach(
+        (key, value) -> {
+          final var taskEntityIndexPair = awaitTaskPresentInSingleIndex(migrator, value);
+          final var completionDate = value.date.atZone(ZoneId.systemDefault()).toLocalDate();
+          if (value.completed) {
+            if (!value.completedAfterUpgrade) {
+              final var indexName =
+                  String.format(
+                      "%s%d-%02d-%02d",
+                      taskIndex.getFullQualifiedName(),
+                      completionDate.getYear(),
+                      completionDate.getMonthValue(),
+                      completionDate.getDayOfMonth());
+              assertThat(taskEntityIndexPair.getKey()).isEqualTo(indexName);
+            } else {
+              assertThat(taskEntityIndexPair.getKey())
+                  .isNotEqualTo(taskIndex.getFullQualifiedName());
+            }
+          } else {
+            assertThat(taskEntityIndexPair.getKey()).isEqualTo(taskIndex.getFullQualifiedName());
+          }
+
+          assertThat(taskEntityIndexPair.getValue())
+              .withFailMessage(
+                  "Found %s when expecting %s in %s",
+                  taskEntityIndexPair.getValue(), value, taskEntityIndexPair.getKey())
+              .extracting(
+                  TaskEntity::getKey,
+                  TaskEntity::getAssignee,
+                  TaskEntity::getImplementation,
+                  TaskEntity::getCompletionTime)
+              .containsExactly(
+                  value.taskKey,
+                  value.completed ? "demo" : null,
+                  value.implementation(),
+                  value.completed() ? taskEntityIndexPair.getValue().getCompletionTime() : null);
+          if (value.completed()) {
+            assertThat(taskEntityIndexPair.getValue().getCompletionTime()).isNotNull();
+          } else {
+            assertThat(taskEntityIndexPair.getValue().getCompletionTime()).isNull();
+          }
+        });
+  }
+
+  private Pair<String, TaskEntity> awaitTaskPresentInSingleIndex(
+      final CamundaMigrator migrator, final TaskData taskData) {
+    final var taskIndex = new TaskTemplate(migrator.getIndexPrefix(), migrator.isElasticsearch());
+    final var search =
+        SearchQueryRequest.of(
+            s ->
+                s.query(SearchQueryBuilders.term(TaskTemplate.KEY, taskData.taskKey))
+                    .index(taskIndex.getFullQualifiedName() + "*"));
+
+    final var tuple = new AtomicReference<Pair<String, TaskEntity>>();
+
+    Awaitility.await("Wait for task to be present only on one index")
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .atMost(Duration.ofMinutes(1))
+        .untilAsserted(
+            () -> taskData,
+            (task) -> {
+              final var searchResponse =
+                  migrator.getSearchClient().search(search, TaskEntity.class);
+              assertThat(searchResponse.hits().size())
+                  .withFailMessage(
+                      "Expected task %s to be in exactly 1 index but found %d. Task exists in indices: %s",
+                      taskData,
+                      searchResponse.hits().size(),
+                      searchResponse.hits().stream().map(SearchQueryHit::index).distinct().toList())
+                  .isOne();
+              final var taskEntity =
+                  searchResponse.hits().stream().findFirst().map(SearchQueryHit::source);
+              assertThat(taskEntity).isPresent();
+              tuple.set(
+                  Pair.of(
+                      searchResponse.hits().stream().findFirst().get().index(), taskEntity.get()));
+            });
+    return tuple.get();
+  }
+
+  private record TaskData(
+      TaskImplementation implementation,
+      long processInstanceKey,
+      long taskKey,
+      boolean completed,
+      Instant date,
+      boolean startedAfterUpgrade,
+      boolean completedAfterUpgrade) {}
+}

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -17,6 +17,7 @@ import io.camunda.search.schema.exceptions.SearchEngineException;
 import io.camunda.search.schema.metrics.SchemaManagerMetrics;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
 import io.camunda.zeebe.util.retry.RetryDecorator;
 import java.util.Collection;
 import java.util.Collections;
@@ -27,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.agrona.LangUtil;
@@ -34,8 +36,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SchemaManager {
-
   public static final int INDEX_CREATION_TIMEOUT_SECONDS = 60;
+  public static final String ARCHIVING_BLOCKED_META_KEY = "archivingBlocked";
   private static final Logger LOG = LoggerFactory.getLogger(SchemaManager.class);
   private final SearchEngineClient searchEngineClient;
   private final Collection<IndexDescriptor> allIndexDescriptors;
@@ -46,6 +48,7 @@ public class SchemaManager {
   private final ExecutorService virtualThreadExecutor;
   private final RetryDecorator retryDecorator;
   private final SchemaManagerMetrics schemaManagerMetrics;
+  private boolean isGreenfield = true;
 
   public SchemaManager(
       final SearchEngineClient searchEngineClient,
@@ -203,9 +206,14 @@ public class SchemaManager {
                         virtualThreadExecutor))
             .toArray(CompletableFuture[]::new);
 
-    // We need to wait for the completion, to make sure all indices has been created successfully
-    // Doing this in parallel is still speeding up the bootstrap time
-    joinOnFutures(futures);
+    if (isGreenfield) {
+      joinOnFutures(futures);
+    } else {
+      // If it's not a greenfield installation (i.e. not all indices are missing),
+      // we need to make sure that the archiverBlocked meta is set on the ListView index
+      // if it's missing
+      joinOnFutures(futures, applyArchiverBlockedMetaIfMissing());
+    }
   }
 
   private List<IndexDescriptor> getMissingIndices(
@@ -226,6 +234,7 @@ public class SchemaManager {
       return;
     }
     final var missingIndexTemplates = getMissingIndexTemplates(indexTemplateDescriptors);
+    isGreenfield = missingIndexTemplates.size() == indexTemplateDescriptors.size();
     LOG.info("Found '{}' missing index templates", missingIndexTemplates.size());
     final var futures =
         missingIndexTemplates.stream()
@@ -277,6 +286,44 @@ public class SchemaManager {
     }
   }
 
+  private Supplier<CompletableFuture<?>> applyArchiverBlockedMetaIfMissing() {
+    return () -> {
+      // only apply if ListViewTemplate is part of the descriptors
+      if (allIndexDescriptors.stream().noneMatch(TasklistImportPositionIndex.class::isInstance)) {
+        return CompletableFuture.completedFuture(null);
+      }
+      final var tasklistImportPositionIndex =
+          indexOnlyDescriptors.stream()
+              .filter(TasklistImportPositionIndex.class::isInstance)
+              .findFirst();
+
+      if (tasklistImportPositionIndex.isEmpty()) {
+        return CompletableFuture.failedFuture(
+            new IllegalStateException("No ImportPositionIndex found."));
+      }
+      final var indexName = tasklistImportPositionIndex.get().getFullQualifiedName();
+      if (blockedArchiverMetaIsMissing(indexName)) {
+        LOG.debug("Brownfield installation detected. Disabling flagging archiver as blocked.");
+        return CompletableFuture.runAsync(
+            () ->
+                searchEngineClient.putIndexMeta(
+                    indexName, Map.of(ARCHIVING_BLOCKED_META_KEY, true)),
+            virtualThreadExecutor);
+      }
+      return CompletableFuture.completedFuture(null);
+    };
+  }
+
+  private boolean blockedArchiverMetaIsMissing(final String operateImportPositionIndex) {
+    final var mappings =
+        searchEngineClient.getMappings(operateImportPositionIndex, MappingSource.INDEX);
+    return mappings.get(operateImportPositionIndex).metaProperties() == null
+        || !mappings
+            .get(operateImportPositionIndex)
+            .metaProperties()
+            .containsKey(ARCHIVING_BLOCKED_META_KEY);
+  }
+
   /**
    * Join on given futures with {@link SchemaManager#INDEX_CREATION_TIMEOUT_SECONDS} as timeout.
    *
@@ -288,6 +335,25 @@ public class SchemaManager {
   private void joinOnFutures(final CompletableFuture<?>[] futures) {
     try {
       CompletableFuture.allOf(futures).get(INDEX_CREATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (final Exception e) {
+      LangUtil.rethrowUnchecked(e);
+    }
+  }
+
+  /**
+   * Join on given futures with {@link SchemaManager#INDEX_CREATION_TIMEOUT_SECONDS} as timeout.
+   * After all futures are completed, the {@code andThen} supplier is called and joined on with the
+   * same timeout.
+   *
+   * @param futures futures that be joined on
+   * @param andThen supplier that is called after all futures are completed
+   */
+  private void joinOnFutures(
+      final CompletableFuture<?>[] futures, final Supplier<CompletableFuture<?>> andThen) {
+    try {
+      CompletableFuture.allOf(futures)
+          .thenCompose(ignored -> andThen.get())
+          .get(INDEX_CREATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     } catch (final Exception e) {
       LangUtil.rethrowUnchecked(e);
     }

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -1565,13 +1565,14 @@ public class SchemaManagerIT {
 
     // verify _meta property is not added
     assertThat(indexNode.get("mappings").get("_meta")).isNotNull();
-    assertThat(indexNode.get("mappings").get("_meta").get(SchemaManager.ARCHIVING_BLOCKED_META_KEY))
+    assertThat(
+            indexNode.get("mappings").get("_meta").get(SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY))
         .isNotNull();
     assertThat(
             indexNode
                 .get("mappings")
                 .get("_meta")
-                .get(SchemaManager.ARCHIVING_BLOCKED_META_KEY)
+                .get(SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY)
                 .asBoolean())
         .isTrue();
   }

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.schema;
 
+import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.CONFIG_PREFIX;
 import static io.camunda.search.schema.utils.SchemaTestUtil.createSchemaManager;
 import static io.camunda.search.schema.utils.SchemaTestUtil.createTestIndexDescriptor;
 import static io.camunda.search.schema.utils.SchemaTestUtil.createTestTemplateDescriptor;
@@ -43,6 +44,7 @@ import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
 import io.camunda.zeebe.test.util.junit.RegressionTestTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
@@ -1496,6 +1498,82 @@ public class SchemaManagerIT {
     // verify template pattern matches the created index
     assertThat(retrievedTemplate.at("/index_template/index_patterns").toString())
         .contains(indexTemplate.getIndexPattern());
+  }
+
+  @TestTemplate
+  void shouldNotAppendMetaPropertyOnGreenfield(
+      final SearchEngineConfiguration config, final SearchClientAdapter searchClientAdapter)
+      throws IOException {
+    // given - no template or index exist
+    final var tasklistImportPositionIndex =
+        new TasklistImportPositionIndex(
+            CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
+
+    // when - start schema manager with spy to track index creation
+    final SearchEngineClient spySearchEngineClient = spy(searchEngineClientFromConfig(config));
+    final var schemaManager =
+        new SchemaManager(
+            spySearchEngineClient,
+            Set.of(tasklistImportPositionIndex),
+            Set.of(indexTemplate),
+            config,
+            objectMapper);
+
+    schemaManager.startup();
+
+    // then - verify the index was created
+    final var indexNode =
+        searchClientAdapter.getIndexAsNode(tasklistImportPositionIndex.getFullQualifiedName());
+
+    // verify that schema manager did create the template
+    verify(spySearchEngineClient).createIndexTemplate(any(), any(), eq(true));
+
+    // verify that schema manager did create the index
+    verify(spySearchEngineClient, times(2)).createIndex(any(), any());
+
+    // verify _meta property is not added
+    assertThat(indexNode.get("mappings").get("_meta")).isNull();
+  }
+
+  @TestTemplate
+  void shouldAppendMetaPropertyOnBrownfieldDeployment(
+      final SearchEngineConfiguration config, final SearchClientAdapter searchClientAdapter)
+      throws IOException {
+    // given - create only the template first (without the index)
+    final SearchEngineClient searchEngineClient = searchEngineClientFromConfig(config);
+    final var tasklistImportPositionIndex =
+        new TasklistImportPositionIndex(
+            CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
+    searchEngineClient.createIndexTemplate(indexTemplate, new IndexConfiguration(), true);
+    searchEngineClient.createIndex(tasklistImportPositionIndex, new IndexConfiguration());
+
+    // when - start schema manager with spy to track index creation
+    final SearchEngineClient spySearchEngineClient = spy(searchEngineClientFromConfig(config));
+    final var schemaManager =
+        new SchemaManager(
+            spySearchEngineClient,
+            Set.of(tasklistImportPositionIndex),
+            Set.of(indexTemplate),
+            config,
+            objectMapper);
+
+    schemaManager.startup();
+
+    // then - verify the index was created
+    final var indexNode =
+        searchClientAdapter.getIndexAsNode(tasklistImportPositionIndex.getFullQualifiedName());
+
+    // verify _meta property is not added
+    assertThat(indexNode.get("mappings").get("_meta")).isNotNull();
+    assertThat(indexNode.get("mappings").get("_meta").get(SchemaManager.ARCHIVING_BLOCKED_META_KEY))
+        .isNotNull();
+    assertThat(
+            indexNode
+                .get("mappings")
+                .get("_meta")
+                .get(SchemaManager.ARCHIVING_BLOCKED_META_KEY)
+                .asBoolean())
+        .isTrue();
   }
 
   private String retentionMinAge(final JsonNode policyNode) {

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.search.schema;
 
-import static io.camunda.search.schema.SchemaManager.ARCHIVING_BLOCKED_META_KEY;
+import static io.camunda.search.schema.SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY;
 import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.ELASTICSEARCH_NETWORK_ALIAS;
 import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.OPENSEARCH_NETWORK_ALIAS;
 import static io.camunda.search.schema.utils.SchemaTestUtil.assertMappingsMatch;
@@ -193,8 +193,8 @@ class SchemaUpdateIT {
             // We only include the meta property on the runtime index on update
             if (indexName.equals(matchingIndexDescriptor.getFullQualifiedName())) {
               assertThat(meta).isNotNull();
-              assertThat(meta.get(ARCHIVING_BLOCKED_META_KEY)).isNotNull();
-              assertThat(meta.get(ARCHIVING_BLOCKED_META_KEY).asBoolean()).isTrue();
+              assertThat(meta.get(PI_ARCHIVING_BLOCKED_META_KEY)).isNotNull();
+              assertThat(meta.get(PI_ARCHIVING_BLOCKED_META_KEY).asBoolean()).isTrue();
             } else {
               assertThat(meta).isNull();
             }

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.schema;
 
+import static io.camunda.search.schema.SchemaManager.ARCHIVING_BLOCKED_META_KEY;
 import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.ELASTICSEARCH_NETWORK_ALIAS;
 import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.OPENSEARCH_NETWORK_ALIAS;
 import static io.camunda.search.schema.utils.SchemaTestUtil.assertMappingsMatch;
@@ -20,6 +21,7 @@ import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.time.Duration;
@@ -185,6 +187,18 @@ class SchemaUpdateIT {
           // validate index aliases
           assertThat(index.get("aliases").fieldNames().next())
               .isEqualTo(matchingIndexDescriptor.getAlias());
+
+          if (matchingIndexDescriptor instanceof TasklistImportPositionIndex) {
+            final var meta = index.get("mappings").get("_meta");
+            // We only include the meta property on the runtime index on update
+            if (indexName.equals(matchingIndexDescriptor.getFullQualifiedName())) {
+              assertThat(meta).isNotNull();
+              assertThat(meta.get(ARCHIVING_BLOCKED_META_KEY)).isNotNull();
+              assertThat(meta.get(ARCHIVING_BLOCKED_META_KEY).asBoolean()).isTrue();
+            } else {
+              assertThat(meta).isNull();
+            }
+          }
         });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -80,6 +80,7 @@ import io.camunda.exporter.handlers.batchoperation.listview.ListViewFromProcessI
 import io.camunda.exporter.handlers.operation.OperationFromIncidentHandler;
 import io.camunda.exporter.handlers.operation.OperationFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.operation.OperationFromVariableDocumentHandler;
+import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -350,6 +351,11 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   @Override
   public <T extends IndexTemplateDescriptor> T getIndexTemplateDescriptor(
       final Class<T> descriptorClass) {
+    return indexDescriptors.get(descriptorClass);
+  }
+
+  @Override
+  public <T extends AbstractIndexDescriptor> T getIndexDescriptor(final Class<T> descriptorClass) {
     return indexDescriptors.get(descriptorClass);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -13,6 +13,7 @@ import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
@@ -51,6 +52,13 @@ public interface ExporterResourceProvider {
    * @param <T> the expected descriptor type
    */
   <T extends IndexTemplateDescriptor> T getIndexTemplateDescriptor(Class<T> descriptorClass);
+
+  /**
+   * @param descriptorClass the expected descriptor type
+   * @return the index descriptor instance for the given class.
+   * @param <T> the expected descriptor type
+   */
+  <T extends AbstractIndexDescriptor> T getIndexDescriptor(Class<T> descriptorClass);
 
   /**
    * @return A {@link Set} of {@link ExportHandler} to be registered with the exporter

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -36,6 +36,7 @@ import io.camunda.exporter.tasks.incident.OpenSearchIncidentUpdateRepository;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
@@ -239,6 +240,8 @@ public final class BackgroundTaskManagerFactory {
         resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
     final var batchOperationTemplate =
         resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
+    final var tasklistImportPositionIndex =
+        resourceProvider.getIndexDescriptor(TasklistImportPositionIndex.class);
     return switch (ConnectionTypes.from(config.getConnect().getType())) {
       case ELASTICSEARCH -> {
         final var connector = new ElasticsearchConnector(config.getConnect());
@@ -249,6 +252,7 @@ public final class BackgroundTaskManagerFactory {
             config.getConnect().getIndexPrefix(),
             listViewTemplate.getFullQualifiedName(),
             batchOperationTemplate.getFullQualifiedName(),
+            tasklistImportPositionIndex.getFullQualifiedName(),
             config.getIndex().getZeebeIndexPrefix(),
             connector.createAsyncClient(),
             executor,
@@ -264,6 +268,7 @@ public final class BackgroundTaskManagerFactory {
             config.getConnect().getIndexPrefix(),
             listViewTemplate.getFullQualifiedName(),
             batchOperationTemplate.getFullQualifiedName(),
+            tasklistImportPositionIndex.getFullQualifiedName(),
             config.getIndex().getZeebeIndexPrefix(),
             connector.createAsyncClient(),
             executor,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -12,6 +12,7 @@ import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.OpensearchRepository;
+import io.camunda.search.schema.SchemaManager;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.exporter.api.ExporterException;
 import io.micrometer.core.instrument.Timer;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -48,6 +50,7 @@ import org.opensearch.client.opensearch.core.reindex.Source;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.opensearch.client.opensearch.generic.Requests;
+import org.opensearch.client.opensearch.indices.IndexState;
 import org.slf4j.Logger;
 
 public final class OpenSearchArchiverRepository extends OpensearchRepository
@@ -68,6 +71,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   private final String indexPrefix;
   private final String processInstanceIndex;
   private final String batchOperationIndex;
+  private final String archiverBlockedMetaIndex;
   private final CamundaExporterMetrics metrics;
   private final OpenSearchGenericClient genericClient;
   private String lastHistoricalArchiverDate = null;
@@ -80,6 +84,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final String indexPrefix,
       final String processInstanceIndex,
       final String batchOperationIndex,
+      final String archiverBlockedMetaIndex,
       final String zeebeIndexPrefix,
       @WillCloseWhenClosed final OpenSearchAsyncClient client,
       final Executor executor,
@@ -92,6 +97,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     this.indexPrefix = indexPrefix;
     this.processInstanceIndex = processInstanceIndex;
     this.batchOperationIndex = batchOperationIndex;
+    this.archiverBlockedMetaIndex = archiverBlockedMetaIndex;
     this.metrics = metrics;
     this.zeebeIndexPrefix = zeebeIndexPrefix;
 
@@ -100,6 +106,15 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
   @Override
   public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
+    try {
+      if (archivingIsBlocked()) {
+        logger.debug("Archiving is currently blocked.");
+        return CompletableFuture.completedFuture(new ArchiveBatch(null, List.of()));
+      }
+    } catch (final IOException e) {
+      return CompletableFuture.failedFuture(
+          new ExporterException("Failed to determine if archiving is blocked:", e));
+    }
     final var request = createFinishedInstancesSearchRequest();
 
     final var timer = Timer.start();
@@ -208,6 +223,28 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     } catch (final IOException e) {
       return CompletableFuture.failedFuture(e);
     }
+  }
+
+  private boolean archivingIsBlocked() throws IOException {
+    return client
+        .indices()
+        .get(r -> r.index(archiverBlockedMetaIndex))
+        .join()
+        .result()
+        .getOrDefault(
+            archiverBlockedMetaIndex,
+            IndexState.of(
+                state ->
+                    state.mappings(
+                        m ->
+                            m.meta(
+                                Map.of(
+                                    SchemaManager.ARCHIVING_BLOCKED_META_KEY,
+                                    JsonData.of(false))))))
+        .mappings()
+        .meta()
+        .getOrDefault(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(false))
+        .to(Boolean.class);
   }
 
   private Query finishedProcessInstancesQuery(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -374,7 +374,7 @@ final class ElasticsearchArchiverRepositoryIT {
             mapping ->
                 mapping
                     .index(archiverBlockedIndex)
-                    .meta(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(true)));
+                    .meta(SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY, JsonData.of(true)));
     // when
     final var result = repository.getProcessInstancesNextBatch();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -16,10 +16,12 @@ import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.ilm.Phase;
 import co.elastic.clients.elasticsearch.indices.IndexSettingsLifecycle;
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.search.schema.SchemaManager;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
@@ -69,6 +71,7 @@ final class ElasticsearchArchiverRepositoryIT {
   private final String zeebeIndexPrefix = "zeebe-record";
   private final String processInstanceIndex = "process-instance-" + UUID.randomUUID();
   private final String batchOperationIndex = "batch-operation-" + UUID.randomUUID();
+  private final String archiverBlockedIndex = "import-position-" + UUID.randomUUID();
   private final String zeebeIndex = zeebeIndexPrefix + "-" + UUID.randomUUID();
   private final ElasticsearchClient testClient = new ElasticsearchClient(transport);
 
@@ -344,6 +347,45 @@ final class ElasticsearchArchiverRepositoryIT {
   }
 
   @Test
+  void shouldGetEmptyProcessInstancesNextBatchWhenBlocked() throws IOException {
+    // given - 4 documents, where 2 is on a different partition, 3 is the wrong join relation type,
+    // and 4 was finished too recently: we then expect only 1 to be returned
+    final var now = Instant.now();
+    final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(
+            new TestProcessInstance(
+                "1", twoHoursAgo, ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION, 1),
+            new TestProcessInstance(
+                "2", twoHoursAgo, ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION, 2),
+            new TestProcessInstance("3", twoHoursAgo, ListViewTemplate.ACTIVITIES_JOIN_RELATION, 1),
+            new TestProcessInstance(
+                "4", now.toString(), ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION, 1));
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    createProcessInstanceIndex();
+    documents.forEach(doc -> index(processInstanceIndex, doc));
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+    testClient
+        .indices()
+        .putMapping(
+            mapping ->
+                mapping
+                    .index(archiverBlockedIndex)
+                    .meta(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(true)));
+    // when
+    final var result = repository.getProcessInstancesNextBatch();
+
+    // then - we expect only the first document created two hours ago to be returned
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    final var batch = result.join();
+    assertThat(batch.ids()).isEmpty();
+    assertThat(batch.finishDate()).isNull();
+  }
+
+  @Test
   void shouldGetBatchOperationsNextBatch() throws IOException {
     // given - 3 documents, two of which were created over an hour ago, one of which was created
     final var now = Instant.now();
@@ -549,6 +591,7 @@ final class ElasticsearchArchiverRepositoryIT {
         indexPrefix,
         processInstanceIndex,
         batchOperationIndex,
+        archiverBlockedIndex,
         zeebeIndexPrefix,
         client,
         Runnable::run,
@@ -578,6 +621,7 @@ final class ElasticsearchArchiverRepositoryIT {
                         ListViewTemplate.JOIN_RELATION,
                         joinRelationProp)));
     testClient.indices().create(r -> r.index(processInstanceIndex).mappings(properties));
+    testClient.indices().create(r -> r.index(archiverBlockedIndex));
   }
 
   private void createBatchOperationIndex() throws IOException {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -71,6 +71,7 @@ final class ElasticsearchArchiverRepositoryTest {
         "instance",
         "batch",
         "zeebe-record",
+        "import-position",
         client,
         Runnable::run,
         metrics,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -369,7 +369,7 @@ final class OpenSearchArchiverRepositoryIT {
             mapping ->
                 mapping
                     .index(archiverBlockedIndex)
-                    .meta(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(true)));
+                    .meta(SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY, JsonData.of(true)));
     // when
     final var result = repository.getProcessInstancesNextBatch();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.schema.SchemaManager;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.search.schema.opensearch.OpensearchEngineClient;
 import io.camunda.search.test.utils.SearchDBExtension;
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.client.RestClient;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -79,6 +81,8 @@ final class OpenSearchArchiverRepositoryIT {
       ARCHIVER_IDX_PREFIX + "process-instance-" + UUID.randomUUID();
   private final String batchOperationIndex =
       ARCHIVER_IDX_PREFIX + "batch-operation-" + UUID.randomUUID();
+  private final String archiverBlockedIndex =
+      ARCHIVER_IDX_PREFIX + "import-position-" + UUID.randomUUID();
   private final OpenSearchClient testClient = createOpenSearchClient();
   private final String zeebeIndexPrefix = "zeebe-record";
   private final String zeebeIndex = zeebeIndexPrefix + "-" + UUID.randomUUID();
@@ -338,6 +342,45 @@ final class OpenSearchArchiverRepositoryIT {
   }
 
   @Test
+  void shouldGetEmptyProcessInstancesNextBatchWhenBlocked() throws IOException {
+    // given - 4 documents, where 2 is on a different partition, 3 is the wrong join relation type,
+    // and 4 was finished too recently: we then expect only 1 to be returned
+    final var now = Instant.now();
+    final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(
+            new TestProcessInstance(
+                "1", twoHoursAgo, ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION, 1),
+            new TestProcessInstance(
+                "2", twoHoursAgo, ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION, 2),
+            new TestProcessInstance("3", twoHoursAgo, ListViewTemplate.ACTIVITIES_JOIN_RELATION, 1),
+            new TestProcessInstance(
+                "4", now.toString(), ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION, 1));
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    createProcessInstanceIndex();
+    documents.forEach(doc -> index(processInstanceIndex, doc));
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+    testClient
+        .indices()
+        .putMapping(
+            mapping ->
+                mapping
+                    .index(archiverBlockedIndex)
+                    .meta(SchemaManager.ARCHIVING_BLOCKED_META_KEY, JsonData.of(true)));
+    // when
+    final var result = repository.getProcessInstancesNextBatch();
+
+    // then - we expect only the first document created two hours ago to be returned
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    final var batch = result.join();
+    assertThat(batch.ids()).isEmpty();
+    assertThat(batch.finishDate()).isNull();
+  }
+
+  @Test
   void shouldGetBatchOperationsNextBatch() throws IOException {
     // given - 3 documents, two of which were created over an hour ago, one of which was created
     final var now = Instant.now();
@@ -591,6 +634,7 @@ final class OpenSearchArchiverRepositoryIT {
         connectConfiguration.getIndexPrefix(),
         processInstanceIndex,
         batchOperationIndex,
+        archiverBlockedIndex,
         zeebeIndexPrefix,
         client,
         Runnable::run,
@@ -615,6 +659,7 @@ final class OpenSearchArchiverRepositoryIT {
                         ListViewTemplate.JOIN_RELATION,
                         joinRelationProp)));
     testClient.indices().create(r -> r.index(processInstanceIndex).mappings(properties));
+    testClient.indices().create(r -> r.index(archiverBlockedIndex));
   }
 
   private RestClientTransport createRestClient() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -69,6 +69,7 @@ final class OpenSearchArchiverRepositoryTest {
         "testPrefix",
         "instance",
         "batch",
+        "import-position",
         "zeebe-record",
         client,
         Runnable::run,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Archiver can be disabled during brownfield rollout of 8.8. The following sequence of events is to happen for brownfield deployments of 8.8:
- SchemaManager detects brownfield deployment and sets `archivingBlocked` meta property to the `tasklist-import-position` index
- Archiver rounds pick this property up and do not initiate the archiving process
- Tasklist Task index migration starts and upon completion it re-enables the archiver by resetting the property

For greenfield deployments nothing changes, the property is not needed and migrations will not run.

This is to tackle the  contention between Archiver, CamundaExporter and the Tasklist Task migration all required to perform actions on the same indices. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38032
