### PR TITLE
fix: return new CamundaClient for factory method

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
@@ -216,21 +216,24 @@ public class CamundaProcessTestContainerRuntime
 
   @Override
   public CamundaClientBuilderFactory getCamundaClientBuilderFactory() {
-    final CamundaClientBuilder client =
-        CamundaClient.newClientBuilder()
-            .restAddress(getCamundaRestApiAddress())
-            .grpcAddress(getCamundaGrpcApiAddress())
-            .defaultRequestTimeout(camundaClientRequestTimeout);
 
-    if (isMultitenancyEnabled) {
-      client.credentialsProvider(
-          CredentialsProvider.newBasicAuthCredentialsProviderBuilder()
-              .username(MultitenancyConfiguration.MULTITENANCY_USER_USERNAME)
-              .password(MultitenancyConfiguration.MULTITENANCY_USER_PASSWORD)
-              .build());
-    }
+    return () -> {
+      final CamundaClientBuilder client =
+          CamundaClient.newClientBuilder()
+              .restAddress(getCamundaRestApiAddress())
+              .grpcAddress(getCamundaGrpcApiAddress())
+              .defaultRequestTimeout(camundaClientRequestTimeout);
 
-    return () -> client;
+      if (isMultitenancyEnabled) {
+        client.credentialsProvider(
+            CredentialsProvider.newBasicAuthCredentialsProviderBuilder()
+                .username(MultitenancyConfiguration.MULTITENANCY_USER_USERNAME)
+                .password(MultitenancyConfiguration.MULTITENANCY_USER_PASSWORD)
+                .build());
+      }
+
+      return client;
+    };
   }
 
   public CamundaContainer getCamundaContainer() {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionMultitenancyIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionMultitenancyIT.java
@@ -39,7 +39,6 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -47,7 +46,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * This test is a combination of the ConnectorsIT and the ExtensionIT to ensure
  * that the new multitenancy configuration works with and without the connectors container.
  */
-@Disabled("The test cases are flaky. We need to improve the stability before enabling them again.")
 public class CamundaProcessTestExtensionMultitenancyIT {
 
   // The ID is part of the connector configuration in the BPMN element


### PR DESCRIPTION
## Description

The Multitenancy feature includes a test ensuring that the new setup works. However, one mistake was that I created a client and *then* returned it in the factory method instead of creating a new client every time. This made it so that the credentials of the previous test carried over to the next one causing errors. 

## Related issues

fixes #36147
