### PR TITLE
test: decision definition

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/simpleDecisionTable1.dmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/simpleDecisionTable1.dmn
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="Definitions_1lja2g1" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Web Modeler" exporterVersion="b209cc3" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0" camunda:diagramRelationId="ac49db8f-d827-44bc-b0d3-c7c35105e38b">
+  <decision id="Decision_f6ej9i5" name="SingleTableDecision">
+    <decisionTable id="DecisionTable_159uxo7" hitPolicy="FIRST">
+      <input id="InputClause_1bnwsvl" label="User Status">
+        <inputExpression id="LiteralExpression_081uqdf" typeRef="string">
+          <text>userStatus</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0vy6xfo">
+          <text>"VIP","Regular"</text>
+        </inputValues>
+      </input>
+      <input id="InputClause_0adc4dq" label="Engagement Score">
+        <inputExpression id="LiteralExpression_15gdlmw" typeRef="number">
+          <text>CalculateEngagementScore</text>
+        </inputExpression>
+      </input>
+      <input id="Input_1" label="Is User under 18">
+        <inputExpression id="InputExpression_1" typeRef="boolean">
+          <text>under18</text>
+        </inputExpression>
+      </input>
+      <input id="InputClause_0nktm14" label="Student">
+        <inputExpression id="LiteralExpression_01f7vye" typeRef="boolean">
+          <text>isStudent</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Is Eligible for Upgrade" name="eligibleForUpgrade" typeRef="boolean" />
+      <rule id="DecisionRule_0zglss8">
+        <inputEntry id="UnaryTests_0egfog0">
+          <text>"VIP"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kr2l2z">
+          <text>&gt;= 25</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10aaazw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hcbm8g">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1u0rlpd">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0b2bzdh">
+        <inputEntry id="UnaryTests_1e9n3cs">
+          <text>"Regular"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0v86nfq">
+          <text>&lt;= 40</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_077hm7f">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dzlice">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1j4if3w">
+          <text>false</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_12fjlpy">
+        <inputEntry id="UnaryTests_1cbrb1t">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1g1canf">
+          <text>&gt;= 20</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mo4mz1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05zdqni">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0jc0p85">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_00u4fbr">
+        <inputEntry id="UnaryTests_1rr48dd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ck4fzk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qjpgnd">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1otucf9">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0rxnqop">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1sf1hjh">
+        <inputEntry id="UnaryTests_1huw4sj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fpql5y">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xp5pr9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1nbz77t">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_157lys4">
+          <text>false</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_f6ej9i5">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/simpleDecisionTable2.dmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/simpleDecisionTable2.dmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="Generations_DMN" name="Generations_DMN" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0" camunda:diagramRelationId="ad1a3ef3-e97e-4585-8517-2e0a3d759e6c">
+  <decision id="GenerationsDecision" name="GenerationsDecision">
+    <decisionTable id="DecisionTable_1qn3ngy" hitPolicy="FIRST">
+      <input id="Input_1" label="trainName" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>trainName</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="baseGenerationId" name="baseGenerationId" typeRef="string" biodi:width="503" />
+      <rule id="DecisionRule_1fp46ws">
+        <description>Camunda 8.4.5</description>
+        <inputEntry id="UnaryTests_0t72zos">
+          <text>"8.4"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_15y0ymj">
+          <text>"8.4-generation"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0u44ngh">
+        <description>Camunda 8.3.8</description>
+        <inputEntry id="UnaryTests_157bn2k">
+          <text>"8.5"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1rvyvhb">
+          <text>"8.5-generation"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0z5aeou">
+        <description>Camunda 8.2.26</description>
+        <inputEntry id="UnaryTests_0n7p6y1">
+          <text>"8.6"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0mfbbej">
+          <text>"8.6-generation"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0k6wq2l">
+        <description>Camunda 8.5.0</description>
+        <inputEntry id="UnaryTests_0r60kwl">
+          <text>"8.7"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0xx7km2">
+          <text>"8.7-generation"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1d9up3i">
+        <description>Camunda 8.6.0</description>
+        <inputEntry id="UnaryTests_06yeejc">
+          <text>"8.8"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1tpkkpu">
+          <text>"8.8-generation"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="GenerationsDecision">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definitions-api.tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definitions-api.tests.spec.ts
@@ -1,0 +1,888 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertRequiredFields,
+  assertUnauthorizedRequest,
+  assertPaginatedRequest,
+  assertNotFoundRequest,
+  assertEqualsForKeys,
+  assertBadRequest,
+  textXMLHeaders,
+} from '../../../utils/http';
+import {defaultAssertionOptions} from '../../../utils/constants';
+import {
+  decisionDefinitionRequiredFields,
+  EVALUATE_DECISION_EXPECTED_BODY,
+  EVALUATED_DECISION_EXPECTED_BODY,
+  evaluateDecisionRequiredFields,
+} from '../../../utils/beans/requestBeans';
+import {
+  assertDecisionDefinitionInResponse,
+  DECISION_DEFINITION_RESPONSE_FROM_DEPLOYMENT,
+  deployDecisionAndStoreResponse,
+} from '../../../utils/requestHelpers';
+import {DecisionDeployment} from '@camunda8/sdk/dist/c8/lib/C8Dto';
+import fs from 'fs';
+
+test.describe.parallel('Decision Definitions Search API Tests', () => {
+  const state: Record<string, unknown> = {};
+  let decisionDefinition1: DecisionDeployment;
+  let decisionDefinition2: DecisionDeployment;
+  let expectedBody1: Record<string, unknown>;
+  let expectedBody2: Record<string, unknown>;
+
+  test.beforeAll(async () => {
+    await deployDecisionAndStoreResponse(
+      state,
+      '1',
+      './resources/simpleDecisionTable1.dmn',
+    );
+    await deployDecisionAndStoreResponse(
+      state,
+      '2',
+      './resources/simpleDecisionTable2.dmn',
+    );
+    decisionDefinition1 = state['decisionDefinition1'] as DecisionDeployment;
+    decisionDefinition2 = state['decisionDefinition2'] as DecisionDeployment;
+    expectedBody1 =
+      DECISION_DEFINITION_RESPONSE_FROM_DEPLOYMENT(decisionDefinition1);
+    expectedBody2 =
+      DECISION_DEFINITION_RESPONSE_FROM_DEPLOYMENT(decisionDefinition2);
+  });
+
+  test('Search Decision Definitions', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/search', {}),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+
+      await assertPaginatedRequest(res, {
+        itemLengthGreaterThan: 0,
+        totalItemGreaterThan: 0,
+      });
+      const json = await res.json();
+      assertDecisionDefinitionInResponse(
+        json,
+        expectedBody1,
+        decisionDefinition1.decisionDefinitionKey as string,
+      );
+      assertDecisionDefinitionInResponse(
+        json,
+        expectedBody2,
+        decisionDefinition2.decisionDefinitionKey as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Decision Definitions by decisionDefinitionId', async ({
+    request,
+  }) => {
+    const filter = {
+      decisionDefinitionId: decisionDefinition1.decisionDefinitionId,
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/search', {}),
+        {
+          headers: jsonHeaders(),
+          data: {filter},
+        },
+      );
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertDecisionDefinitionInResponse(
+        json,
+        expectedBody1,
+        decisionDefinition1.decisionDefinitionKey as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Decision Definitions by name', async ({request}) => {
+    const filter = {
+      name: decisionDefinition1.name as string,
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/search', {}),
+        {
+          headers: jsonHeaders(),
+          data: {filter},
+        },
+      );
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertDecisionDefinitionInResponse(
+        json,
+        expectedBody1,
+        decisionDefinition1.decisionDefinitionKey as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Decision Definitions by version', async ({request}) => {
+    const filter = {
+      version: 1,
+    };
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/search', {}),
+        {
+          headers: jsonHeaders(),
+          data: {filter},
+        },
+      );
+
+      await assertPaginatedRequest(res, {
+        itemLengthGreaterThan: 1,
+        totalItemGreaterThan: 1,
+      });
+      const json = await res.json();
+      assertDecisionDefinitionInResponse(
+        json,
+        expectedBody1,
+        decisionDefinition1.decisionDefinitionKey as string,
+      );
+      assertDecisionDefinitionInResponse(
+        json,
+        expectedBody2,
+        decisionDefinition2.decisionDefinitionKey as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Decision Definitions by decisionRequirementsId', async ({
+    request,
+  }) => {
+    const filter = {
+      decisionRequirementsId:
+        decisionDefinition2.decisionRequirementsId as string,
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/search', {}),
+        {
+          headers: jsonHeaders(),
+          data: {filter},
+        },
+      );
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertDecisionDefinitionInResponse(
+        json,
+        expectedBody2,
+        decisionDefinition2.decisionDefinitionKey as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Decision Definitions by decisionDefinitionKey', async ({
+    request,
+  }) => {
+    const filter = {
+      decisionDefinitionKey:
+        decisionDefinition2.decisionDefinitionKey as string,
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/search', {}),
+        {
+          headers: jsonHeaders(),
+          data: {filter},
+        },
+      );
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertDecisionDefinitionInResponse(
+        json,
+        expectedBody2,
+        decisionDefinition2.decisionDefinitionKey as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Decision Definitions by decisionRequirementsKey', async ({
+    request,
+  }) => {
+    const filter = {
+      decisionRequirementsKey:
+        decisionDefinition1.decisionRequirementsKey as string,
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/search', {}),
+        {
+          headers: jsonHeaders(),
+          data: {filter},
+        },
+      );
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertDecisionDefinitionInResponse(
+        json,
+        expectedBody1,
+        decisionDefinition1.decisionDefinitionKey as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Decision Definitions by tenantId', async ({request}) => {
+    const filter = {
+      tenantId: '<default>',
+    };
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/search', {}),
+        {
+          headers: jsonHeaders(),
+          data: {filter},
+        },
+      );
+
+      await assertPaginatedRequest(res, {
+        itemLengthGreaterThan: 1,
+        totalItemGreaterThan: 1,
+      });
+      const json = await res.json();
+      assertDecisionDefinitionInResponse(
+        json,
+        expectedBody1,
+        decisionDefinition1.decisionDefinitionKey as string,
+      );
+      assertDecisionDefinitionInResponse(
+        json,
+        expectedBody2,
+        decisionDefinition2.decisionDefinitionKey as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Decision Definitions by multiple filters', async ({request}) => {
+    const filter = {
+      decisionRequirementsId:
+        decisionDefinition2.decisionRequirementsId as string,
+      decisionDefinitionId: decisionDefinition2.decisionDefinitionId as string,
+      name: decisionDefinition2.name as string,
+      version: decisionDefinition2.version as number,
+    };
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/search', {}),
+        {
+          headers: jsonHeaders(),
+          data: {filter},
+        },
+      );
+
+      await assertPaginatedRequest(res, {
+        itemsLengthEqualTo: 1,
+        totalItemsEqualTo: 1,
+      });
+      const json = await res.json();
+      assertDecisionDefinitionInResponse(
+        json,
+        expectedBody2,
+        decisionDefinition2.decisionDefinitionKey as string,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Decision Definitions - No Matching Item', async ({request}) => {
+    const filter = {decisionDefinitionId: 'non-existent-id'};
+
+    const res = await request.post(
+      buildUrl('/decision-definitions/search', {}),
+      {
+        headers: jsonHeaders(),
+        data: {filter},
+      },
+    );
+    await assertPaginatedRequest(res, {
+      itemsLengthEqualTo: 0,
+      totalItemsEqualTo: 0,
+    });
+  });
+
+  test('Search Decision Definitions Unauthorized', async ({request}) => {
+    const res = await request.post(
+      buildUrl('/decision-definitions/search', {}),
+      {
+        headers: {},
+        data: {},
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Get Decision Definition', async ({request}) => {
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl('/decision-definitions/{decisionDefinitionKey}', {
+          decisionDefinitionKey:
+            decisionDefinition1.decisionDefinitionKey as string,
+        }),
+        {headers: jsonHeaders()},
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, decisionDefinitionRequiredFields);
+      assertEqualsForKeys(
+        json,
+        expectedBody1,
+        decisionDefinitionRequiredFields,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Decision Definition Not Found', async ({request}) => {
+    const nonExistentKey = '11111';
+    const res = await request.get(
+      buildUrl('/decision-definitions/{decisionDefinitionKey}', {
+        decisionDefinitionKey: nonExistentKey,
+      }),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Decision Definition with key '${nonExistentKey}' not found`,
+    );
+  });
+
+  test('Get Decision Definition Bad Request', async ({request}) => {
+    const invalidKey = 'abc';
+    const res = await request.get(
+      buildUrl('/decision-definitions/{decisionDefinitionKey}', {
+        decisionDefinitionKey: invalidKey,
+      }),
+      {headers: jsonHeaders()},
+    );
+    await assertBadRequest(res, `Failed to convert 'decisionDefinitionKey'`);
+  });
+
+  test('Get Decision Definition Unauthorized', async ({request}) => {
+    const res = await request.get(
+      buildUrl('/decision-definitions/{decisionDefinitionKey}', {
+        decisionDefinitionKey:
+          decisionDefinition1.decisionDefinitionKey as string,
+      }),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Get Decision Definition XML', async ({request}) => {
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl('/decision-definitions/{decisionDefinitionKey}/xml', {
+          decisionDefinitionKey:
+            decisionDefinition1.decisionDefinitionKey as string,
+        }),
+        {headers: textXMLHeaders()},
+      );
+
+      expect(res.status()).toBe(200);
+      expect(await res.text()).toEqual(
+        fs.readFileSync('./resources/simpleDecisionTable1.dmn', 'utf-8'),
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Decision Definition XML Not Found', async ({request}) => {
+    const nonExistentKey = '11111';
+    const res = await request.get(
+      buildUrl('/decision-definitions/{decisionDefinitionKey}/xml', {
+        decisionDefinitionKey: nonExistentKey,
+      }),
+      {headers: jsonHeaders()},
+    );
+    await assertNotFoundRequest(
+      res,
+      `Decision Definition with key '${nonExistentKey}' not found`,
+    );
+  });
+
+  test('Get Decision Definition XML Bad Request', async ({request}) => {
+    const invalidKey = 'abc';
+    const res = await request.get(
+      buildUrl('/decision-definitions/{decisionDefinitionKey}/xml', {
+        decisionDefinitionKey: invalidKey,
+      }),
+      {headers: jsonHeaders()},
+    );
+    await assertBadRequest(res, `Failed to convert 'decisionDefinitionKey'`);
+  });
+
+  test('Get Decision Definition XML Unauthorized', async ({request}) => {
+    const res = await request.get(
+      buildUrl('/decision-definitions/{decisionDefinitionKey}/xml', {
+        decisionDefinitionKey:
+          decisionDefinition1.decisionDefinitionKey as string,
+      }),
+      {headers: {}},
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Evaluate Decision Definition by decisionDefinitionKey For Input 8.8', async ({
+    request,
+  }) => {
+    const matchedRule = {
+      output: '"8.8-generation"',
+      ruleId: 'DecisionRule_1d9up3i',
+      outputId: 'Output_1',
+      outputName: 'baseGenerationId',
+      outputValue: '"8.8-generation"',
+      input: [
+        {
+          inputId: 'Input_1',
+          inputName: 'trainName',
+          inputValue: '"8.8"',
+        },
+      ],
+      ruleIndex: 5,
+    };
+    const expectedBody = EVALUATE_DECISION_EXPECTED_BODY(
+      decisionDefinition2,
+      matchedRule.output,
+    );
+    const evaluatedDecisionExpectedBody = EVALUATED_DECISION_EXPECTED_BODY(
+      decisionDefinition2,
+      matchedRule,
+    );
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/evaluation'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            decisionDefinitionKey:
+              decisionDefinition2.decisionDefinitionKey as string,
+            variables: {
+              trainName: '8.8',
+            },
+          },
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, evaluateDecisionRequiredFields);
+      assertEqualsForKeys(json, expectedBody, Object.keys(expectedBody));
+      expect(json['evaluatedDecisions'].length).toBe(1);
+      const evaluatedDecisionActualBody = json['evaluatedDecisions'][0];
+      assertEqualsForKeys(
+        evaluatedDecisionActualBody,
+        evaluatedDecisionExpectedBody,
+        Object.keys(evaluatedDecisionExpectedBody),
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Evaluate Decision Definition by decisionDefinitionKey For Input 8.7', async ({
+    request,
+  }) => {
+    const matchedRule = {
+      output: '"8.7-generation"',
+      ruleId: 'DecisionRule_0k6wq2l',
+      outputId: 'Output_1',
+      outputName: 'baseGenerationId',
+      outputValue: '"8.7-generation"',
+      input: [
+        {inputId: 'Input_1', inputName: 'trainName', inputValue: '"8.7"'},
+      ],
+      ruleIndex: 4,
+    };
+    const expectedBody = EVALUATE_DECISION_EXPECTED_BODY(
+      decisionDefinition2,
+      matchedRule.output,
+    );
+    const evaluatedDecisionExpectedBody = EVALUATED_DECISION_EXPECTED_BODY(
+      decisionDefinition2,
+      matchedRule,
+    );
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/evaluation'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            decisionDefinitionKey:
+              decisionDefinition2.decisionDefinitionKey as string,
+            variables: {
+              trainName: '8.7',
+            },
+          },
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, evaluateDecisionRequiredFields);
+      assertEqualsForKeys(json, expectedBody, Object.keys(expectedBody));
+      expect(json['evaluatedDecisions'].length).toBe(1);
+      const evaluatedDecisionActualBody = json['evaluatedDecisions'][0];
+      assertEqualsForKeys(
+        evaluatedDecisionActualBody,
+        evaluatedDecisionExpectedBody,
+        Object.keys(evaluatedDecisionExpectedBody),
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Evaluate Decision Definition by decisionDefinitionKey For Input 8.6', async ({
+    request,
+  }) => {
+    const matchedRule = {
+      output: '"8.6-generation"',
+      ruleId: 'DecisionRule_0z5aeou',
+      outputId: 'Output_1',
+      outputName: 'baseGenerationId',
+      outputValue: '"8.6-generation"',
+      input: [
+        {inputId: 'Input_1', inputName: 'trainName', inputValue: '"8.6"'},
+      ],
+      ruleIndex: 3,
+    };
+    const expectedBody = EVALUATE_DECISION_EXPECTED_BODY(
+      decisionDefinition2,
+      matchedRule.output,
+    );
+    const evaluatedDecisionExpectedBody = EVALUATED_DECISION_EXPECTED_BODY(
+      decisionDefinition2,
+      matchedRule,
+    );
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/evaluation'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            decisionDefinitionKey:
+              decisionDefinition2.decisionDefinitionKey as string,
+            variables: {
+              trainName: '8.6',
+            },
+          },
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, evaluateDecisionRequiredFields);
+      assertEqualsForKeys(json, expectedBody, Object.keys(expectedBody));
+      expect(json['evaluatedDecisions'].length).toBe(1);
+      const evaluatedDecisionActualBody = json['evaluatedDecisions'][0];
+      assertEqualsForKeys(
+        evaluatedDecisionActualBody,
+        evaluatedDecisionExpectedBody,
+        Object.keys(evaluatedDecisionExpectedBody),
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Evaluate Decision Definition by decisionDefinitionKey For Non Existent Input', async ({
+    request,
+  }) => {
+    const nonExistentInput = '8.11111';
+    const matchedRule = {
+      output: 'null',
+      input: [
+        {
+          inputId: 'Input_1',
+          inputName: 'trainName',
+          inputValue: `"${nonExistentInput}"`,
+        },
+      ],
+      ruleIndex: 3,
+    };
+    const expectedBody = EVALUATE_DECISION_EXPECTED_BODY(
+      decisionDefinition2,
+      'null',
+    );
+    const evaluatedDecisionExpectedBody = EVALUATED_DECISION_EXPECTED_BODY(
+      decisionDefinition2,
+      matchedRule,
+      true,
+    );
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/evaluation'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            decisionDefinitionKey:
+              decisionDefinition2.decisionDefinitionKey as string,
+            variables: {
+              trainName: nonExistentInput,
+            },
+          },
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, evaluateDecisionRequiredFields);
+      assertEqualsForKeys(json, expectedBody, Object.keys(expectedBody));
+      expect(json['evaluatedDecisions'].length).toBe(1);
+      const evaluatedDecisionActualBody = json['evaluatedDecisions'][0];
+      assertEqualsForKeys(
+        evaluatedDecisionActualBody,
+        evaluatedDecisionExpectedBody,
+        Object.keys(evaluatedDecisionExpectedBody),
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Evaluate Decision Definition by decisionDefinitionId For Input With status VIP and Score 50', async ({
+    request,
+  }) => {
+    const matchedRule = {
+      output: 'true',
+      ruleId: 'DecisionRule_0zglss8',
+      outputId: 'Output_1',
+      outputName: 'Is Eligible for Upgrade',
+      outputValue: 'true',
+      ruleIndex: 1,
+      input: [
+        {
+          inputId: 'InputClause_1bnwsvl',
+          inputName: 'User Status',
+          inputValue: '"VIP"',
+        },
+        {
+          inputId: 'InputClause_0adc4dq',
+          inputName: 'Engagement Score',
+          inputValue: '50',
+        },
+        {
+          inputId: 'Input_1',
+          inputName: 'Is User under 18',
+          inputValue: 'null',
+        },
+        {
+          inputId: 'InputClause_0nktm14',
+          inputName: 'Student',
+          inputValue: 'null',
+        },
+      ],
+    };
+    const expectedBody = EVALUATE_DECISION_EXPECTED_BODY(
+      decisionDefinition1,
+      matchedRule.output,
+    );
+    const evaluatedDecisionExpectedBody = EVALUATED_DECISION_EXPECTED_BODY(
+      decisionDefinition1,
+      matchedRule,
+    );
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/evaluation'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            decisionDefinitionId:
+              decisionDefinition1.decisionDefinitionId as string,
+            variables: {
+              userStatus: 'VIP',
+              CalculateEngagementScore: 50,
+            },
+          },
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, evaluateDecisionRequiredFields);
+      assertEqualsForKeys(json, expectedBody, Object.keys(expectedBody));
+      expect(json['evaluatedDecisions'].length).toBe(1);
+      const evaluatedDecisionActualBody = json['evaluatedDecisions'][0];
+      assertEqualsForKeys(
+        evaluatedDecisionActualBody,
+        evaluatedDecisionExpectedBody,
+        Object.keys(evaluatedDecisionExpectedBody),
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Evaluate Decision Definition by decisionDefinitionId For Input With status Regular and Score 40', async ({
+    request,
+  }) => {
+    const matchedRule = {
+      output: 'false',
+      ruleId: 'DecisionRule_0b2bzdh',
+      outputId: 'Output_1',
+      outputName: 'Is Eligible for Upgrade',
+      outputValue: 'false',
+      ruleIndex: 2,
+      input: [
+        {
+          inputId: 'InputClause_1bnwsvl',
+          inputName: 'User Status',
+          inputValue: '"Regular"',
+        },
+        {
+          inputId: 'InputClause_0adc4dq',
+          inputName: 'Engagement Score',
+          inputValue: '40',
+        },
+        {
+          inputId: 'Input_1',
+          inputName: 'Is User under 18',
+          inputValue: 'null',
+        },
+        {
+          inputId: 'InputClause_0nktm14',
+          inputName: 'Student',
+          inputValue: 'null',
+        },
+      ],
+    };
+    const expectedBody = EVALUATE_DECISION_EXPECTED_BODY(
+      decisionDefinition1,
+      matchedRule.output,
+    );
+    const evaluatedDecisionExpectedBody = EVALUATED_DECISION_EXPECTED_BODY(
+      decisionDefinition1,
+      matchedRule,
+    );
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/evaluation'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            decisionDefinitionId:
+              decisionDefinition1.decisionDefinitionId as string,
+            variables: {
+              userStatus: 'Regular',
+              CalculateEngagementScore: 40,
+            },
+          },
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, evaluateDecisionRequiredFields);
+      assertEqualsForKeys(json, expectedBody, Object.keys(expectedBody));
+      expect(json['evaluatedDecisions'].length).toBe(1);
+      const evaluatedDecisionActualBody = json['evaluatedDecisions'][0];
+      assertEqualsForKeys(
+        evaluatedDecisionActualBody,
+        evaluatedDecisionExpectedBody,
+        Object.keys(evaluatedDecisionExpectedBody),
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Evaluate Decision Definition by decisionDefinitionId For Non Existent Input', async ({
+    request,
+  }) => {
+    const nonExistentInput = '8.11111';
+    const matchedRule = {
+      output: 'null',
+      input: [
+        {
+          inputId: 'Input_1',
+          inputName: 'trainName',
+          inputValue: `"${nonExistentInput}"`,
+        },
+      ],
+      ruleIndex: 3,
+    };
+    const expectedBody = EVALUATE_DECISION_EXPECTED_BODY(
+      decisionDefinition2,
+      'null',
+    );
+    const evaluatedDecisionExpectedBody = EVALUATED_DECISION_EXPECTED_BODY(
+      decisionDefinition2,
+      matchedRule,
+      true,
+    );
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/evaluation'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            decisionDefinitionId:
+              decisionDefinition2.decisionDefinitionId as string,
+            variables: {
+              trainName: nonExistentInput,
+            },
+          },
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, evaluateDecisionRequiredFields);
+      assertEqualsForKeys(json, expectedBody, Object.keys(expectedBody));
+      expect(json['evaluatedDecisions'].length).toBe(1);
+      const evaluatedDecisionActualBody = json['evaluatedDecisions'][0];
+      assertEqualsForKeys(
+        evaluatedDecisionActualBody,
+        evaluatedDecisionExpectedBody,
+        Object.keys(evaluatedDecisionExpectedBody),
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Evaluate Decision Definition Invalid Data', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/decision-definitions/evaluation'),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+
+      await assertBadRequest(
+        res,
+        'At least one of [decisionDefinitionId, decisionDefinitionKey] is required.',
+        'INVALID_ARGUMENT',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -21,6 +21,7 @@ import {
   mappingRuleIdFromKey,
 } from '../requestHelpers';
 import {APIRequestContext} from 'playwright-core';
+import {DecisionDeployment} from '@camunda8/sdk/dist/c8/lib/C8Dto';
 
 export const groupRequiredFields: string[] = ['groupId', 'name', 'description'];
 export const tenantRequiredFields: string[] = [
@@ -37,6 +38,30 @@ export const mappingRuleRequiredFields: string[] = [
 export const roleRequiredFields: string[] = ['roleId', 'name', 'description'];
 export const authorizedComponentRequiredFields: string[] = ['authorizationKey'];
 export const userRequiredFields: string[] = ['username', 'name', 'email'];
+export const decisionDefinitionRequiredFields: string[] = [
+  'decisionDefinitionId',
+  'name',
+  'version',
+  'decisionRequirementsId',
+  'tenantId',
+  'decisionDefinitionKey',
+  'decisionRequirementsKey',
+];
+export const evaluateDecisionRequiredFields: string[] = [
+  'decisionDefinitionId',
+  'decisionDefinitionName',
+  'decisionDefinitionVersion',
+  'decisionRequirementsId',
+  'output',
+  'failedDecisionDefinitionId',
+  'failureMessage',
+  'tenantId',
+  'decisionDefinitionKey',
+  'decisionRequirementsKey',
+  'decisionInstanceKey',
+  'decisionEvaluationKey',
+  'evaluatedDecisions',
+];
 export const authenticationRequiredFields: string[] = [
   'username',
   'displayName',
@@ -279,6 +304,67 @@ export function CREATE_ON_FLY_DOCUMENT_REQUEST_BODY_WITH_METADATA(
     ),
   );
   return form;
+}
+
+export function EVALUATE_DECISION_EXPECTED_BODY(
+  decision: DecisionDeployment,
+  output: string,
+) {
+  return {
+    decisionDefinitionId: decision.decisionDefinitionId,
+    decisionDefinitionName: decision.name,
+    decisionDefinitionVersion: decision.version,
+    decisionRequirementsId: decision.decisionRequirementsId,
+    output: output,
+    failedDecisionDefinitionId: '',
+    failureMessage: '',
+    tenantId: '<default>',
+    decisionDefinitionKey: decision.decisionDefinitionKey,
+    decisionRequirementsKey: decision.decisionRequirementsKey,
+  };
+}
+
+export function EVALUATED_DECISION_EXPECTED_BODY(
+  decision: DecisionDeployment,
+  matchedRuleOptions: {
+    output: string;
+    ruleId?: string;
+    outputId?: string;
+    outputName?: string;
+    outputValue?: string;
+    input: {
+      inputId: string;
+      inputName: string;
+      inputValue: string;
+    }[];
+    ruleIndex?: number;
+  },
+  emptyResults: boolean = false,
+) {
+  return {
+    decisionDefinitionId: decision.decisionDefinitionId,
+    decisionDefinitionName: decision.name,
+    decisionDefinitionVersion: decision.version,
+    output: matchedRuleOptions.output,
+    tenantId: '<default>',
+    matchedRules: emptyResults
+      ? []
+      : [
+          {
+            ruleId: matchedRuleOptions.ruleId,
+            ruleIndex: matchedRuleOptions.ruleIndex,
+            evaluatedOutputs: [
+              {
+                outputId: matchedRuleOptions.outputId,
+                outputName: matchedRuleOptions.outputName,
+                outputValue: matchedRuleOptions.outputValue,
+              },
+            ],
+          },
+        ],
+    evaluatedInputs: matchedRuleOptions.input,
+    decisionDefinitionKey: decision.decisionDefinitionKey,
+  };
 }
 
 export function CREATE_ON_FLY_MULTIPLE_DOCUMENTS_REQUEST_BODY(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -187,6 +187,16 @@ export function jsonHeaders(
   };
 }
 
+export function textXMLHeaders(
+  auth: string = credentials.accessToken,
+): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    Accept: 'text/xml',
+    ...authHeaders(auth),
+  };
+}
+
 export function defaultHeaders(): Record<string, string> {
   return {
     Accept: 'application/json',


### PR DESCRIPTION
## Description

Run: https://github.com/camunda/camunda/actions/runs/17770404618

- Implemented [search](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/search-decision-definitions/), [get](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/get-decision-definition/), and [evaluate](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/evaluate-decision/) decision requirement.

## DECISION DEFINITIONS API:
**Search Decision Definitions** (`POST /decision-definitions/search`)
- 200: Success (no filter; returns multiple definitions)
- 200: Success (filter by `decisionDefinitionId`; single result)
- 200: Success (filter by `name`; single result)
- 200: Success (filter by `version=1`; returns both definitions)
- 200: Success (filter by `decisionRequirementsId`; single result)
- 200: Success (filter by `decisionDefinitionKey`; single result)
- 200: Success (filter by `decisionRequirementsKey`; single result)
- 200: Success (filter by `tenantId=<default>`; returns both)
- 200: Success (multiple filters combined; single result)
- 200: Success (no matching item; empty list)
- 401: Unauthorized (missing auth headers)

**Get Decision Definition** (`GET /decision-definitions/{decisionDefinitionKey}`)
- 200: Success
- 404: Not Found (unknown numeric key)
- 400: Bad Request (non-numeric key → conversion failure)
- 401: Unauthorized (missing auth headers)

**Get Decision Definition XML** (`GET /decision-definitions/{decisionDefinitionKey}/xml`)
- 200: Success (returns original DMN XML)
- 404: Not Found (unknown numeric key)
- 400: Bad Request (non-numeric key → conversion failure)
- 401: Unauthorized (missing auth headers)

**Evaluate Decision Definition** (`POST /decision-definitions/evaluation`)
- 200: Success (by `decisionDefinitionKey` trainName `8.8` → output `"8.8-generation"`)
- 200: Success (by `decisionDefinitionKey` trainName `8.7` → output `"8.7-generation"`)
- 200: Success (by `decisionDefinitionKey` trainName `8.6` → output `"8.6-generation"`)
- 200: Success (by `decisionDefinitionKey` non-existent trainName → output `null`)
- 200: Success (by `decisionDefinitionId` userStatus `VIP`, score `50` → output `true`)
- 200: Success (by `decisionDefinitionId` userStatus `Regular`, score `40` → output `false`)
- 200: Success (by `decisionDefinitionId` non-existent trainName → output `null`)
- 400: Invalid body (missing both identifiers) → `INVALID_ARGUMENT` ("At least one of [decisionDefinitionId, decisionDefinitionKey] is required.")
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
