### PR TITLE
feat: default number of ES replicas to 1.

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/config/IndexConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/IndexConfiguration.java
@@ -15,7 +15,7 @@ public class IndexConfiguration {
   private String zeebeIndexPrefix = "zeebe-record";
 
   private Integer numberOfShards = 1;
-  private Integer numberOfReplicas = 0;
+  private Integer numberOfReplicas = 1;
   private Integer templatePriority;
 
   private Map<String, Integer> replicasByIndexName = new HashMap<>();

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -509,7 +509,7 @@ public class SchemaManagerIT {
     final var initialTemplate =
         searchClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName());
 
-    assertThat(initialTemplate.at(replicaSettingPath).asInt()).isEqualTo(0);
+    assertThat(initialTemplate.at(replicaSettingPath).asInt()).isEqualTo(1);
     assertThat(initialTemplate.at(shardsSettingPath).asInt()).isEqualTo(1);
 
     // when
@@ -542,7 +542,7 @@ public class SchemaManagerIT {
 
     final var initialIndex = searchClientAdapter.getIndexAsNode(index.getFullQualifiedName());
 
-    assertThat(initialIndex.at(replicaSettingPath).asInt()).isEqualTo(0);
+    assertThat(initialIndex.at(replicaSettingPath).asInt()).isEqualTo(1);
     assertThat(initialIndex.at(shardsSettingPath).asInt()).isEqualTo(1);
 
     // when
@@ -678,7 +678,7 @@ public class SchemaManagerIT {
     final var initialTemplate =
         searchClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName());
 
-    assertThat(initialTemplate.at(replicaSettingPath).asInt()).isEqualTo(0);
+    assertThat(initialTemplate.at(replicaSettingPath).asInt()).isEqualTo(1);
     assertThat(initialTemplate.at(shardsSettingPath).asInt()).isEqualTo(1);
 
     indexTemplate.setMappingsClasspathFilename("/mappings-settings-replica-and-shards.json");
@@ -912,14 +912,14 @@ public class SchemaManagerIT {
     final String runtimeIndexName = indexTemplate.getFullQualifiedName();
     final var initialRuntimeIndex = searchClientAdapter.getIndexAsNode(runtimeIndexName);
 
-    assertThat(initialRuntimeIndex.at(replicaSettingPath).asInt()).isEqualTo(0);
+    assertThat(initialRuntimeIndex.at(replicaSettingPath).asInt()).isEqualTo(1);
     assertThat(initialRuntimeIndex.at(shardsSettingPath).asInt()).isEqualTo(1);
 
     final String archiveIndexName = indexTemplate.getIndexPattern().replace("*", "-archived");
     searchClientAdapter.index("123", archiveIndexName, Map.of("hello", "foo", "world", "bar"));
 
     final var initialArchiveIndex = searchClientAdapter.getIndexAsNode(archiveIndexName);
-    assertThat(initialArchiveIndex.at(replicaSettingPath).asInt()).isEqualTo(0);
+    assertThat(initialArchiveIndex.at(replicaSettingPath).asInt()).isEqualTo(1);
     assertThat(initialArchiveIndex.at(shardsSettingPath).asInt()).isEqualTo(1);
 
     // when


### PR DESCRIPTION
## Description

[Context](https://github.com/camunda/camunda/issues/35080#issuecomment-3284550610) 

The number of default replicas is getting changed to 1 in helm, but it should also be done as an application default as not all customers use the helm chart so those customers might still have default 0.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35080 
