### PR TITLE
fix: disable all coercion to string

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -97,8 +97,11 @@ public class JacksonConfig {
         .modulesToInstall(new JavaTimeModule(), new Jdk8Module())
         .postConfigurer(
             om -> {
-              // this also prevents coercion for string target types
+              // this also prevents coercion for string target types from non-string types
               om.coercionConfigDefaults()
+                  .setCoercion(CoercionInputShape.Boolean, CoercionAction.Fail)
+                  .setCoercion(CoercionInputShape.Integer, CoercionAction.Fail)
+                  .setCoercion(CoercionInputShape.Float, CoercionAction.Fail)
                   .setCoercion(CoercionInputShape.String, CoercionAction.Fail);
             });
     gatewayRestObjectMapperCustomizer().accept(builder);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiJacksonConfigTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiJacksonConfigTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(value = {ProcessInstanceController.class})
+public class RestApiJacksonConfigTest extends RestApiConfigurationTest {
+
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+
+  @BeforeEach
+  void setUpServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"true", "false", "5", "5.5", "[1,2,3]"})
+  void shouldYieldBadRequestForQueryViolatingFilterTypeStringRequest(final String invalidValue) {
+    // given
+    final var request =
+        """
+            {
+                "filter": {
+                        "processDefinitionKey": %s
+                }
+            }"""
+            .formatted(invalidValue);
+    final var expectedResponse =
+        String.format(
+            """
+                {
+                  "type": "about:blank",
+                  "title": "Bad Request",
+                  "status": 400,
+                  "detail": "Request property [filter.processDefinitionKey] cannot be parsed",
+                  "instance": "%s"
+                }""",
+            PROCESS_INSTANCES_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"true", "false", "\"5\"", "5.5", "[1,2,3]"})
+  void shouldYieldBadRequestForQueryViolatingFilterTypeIntRequest(final String invalidValue) {
+    // given
+    final var request =
+        """
+            {
+                "filter": {
+                        "processDefinitionVersion": %s
+                }
+            }"""
+            .formatted(invalidValue);
+    final var expectedResponse =
+        String.format(
+            """
+                {
+                  "type": "about:blank",
+                  "title": "Bad Request",
+                  "status": 400,
+                  "detail": "Request property [filter.processDefinitionVersion] cannot be parsed",
+                  "instance": "%s"
+                }""",
+            PROCESS_INSTANCES_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class));
+  }
+}


### PR DESCRIPTION
## Description

Yet another follow-up as #37982 was not effective for coercions to string.

This also adds a test for rejecting number and string type violations.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37865
