### PR TITLE
fix: make RoutingState backward compatible between 8.8 and 8.7

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -537,7 +537,7 @@ public class ProtoBufSerializer
         pendingOperations);
   }
 
-  private Optional<RoutingState> decodeRoutingState(final Topology.RoutingState routingState) {
+  Optional<RoutingState> decodeRoutingState(final Topology.RoutingState routingState) {
     if (routingState.equals(Topology.RoutingState.getDefaultInstance())) {
       return Optional.empty();
     } else {
@@ -584,7 +584,7 @@ public class ProtoBufSerializer
     };
   }
 
-  private Topology.RoutingState encodeRoutingState(final RoutingState routingState) {
+  Topology.RoutingState encodeRoutingState(final RoutingState routingState) {
     return Topology.RoutingState.newBuilder()
         .setVersion(routingState.version())
         .addAllActivePartitions(routingState.requestHandling().activePartitions())

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -66,6 +66,7 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import io.camunda.zeebe.util.Either;
 import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -543,12 +544,15 @@ public class ProtoBufSerializer
       return Optional.of(
           new RoutingState(
               routingState.getVersion(),
-              decodeRequestHandling(routingState.getRequestHandling()),
+              decodeRequestHandling(
+                  routingState.getRequestHandling(), routingState.getActivePartitionsList()),
               decodeMessageCorrelation(routingState.getMessageCorrelation())));
     }
   }
 
-  private RequestHandling decodeRequestHandling(final Topology.RequestHandling requestHandling) {
+  private RequestHandling decodeRequestHandling(
+      final Topology.RequestHandling requestHandling,
+      @Deprecated(forRemoval = true) final List<Integer> activePartitionList) {
     return switch (requestHandling.getStrategyCase()) {
       case ALLPARTITIONS ->
           new RequestHandling.AllPartitions(requestHandling.getAllPartitions().getPartitionCount());
@@ -558,7 +562,15 @@ public class ProtoBufSerializer
               new TreeSet<>(
                   requestHandling.getActivePartitions().getAdditionalActivePartitionsList()),
               new TreeSet<>(requestHandling.getActivePartitions().getInactivePartitionsList()));
-      case STRATEGY_NOT_SET -> throw new IllegalArgumentException("Unknown request handling type");
+      case STRATEGY_NOT_SET -> {
+        // This fallback is used during the transition from 8.7 to 8.8, as RequestHandling was
+        // introduced in 8.8. It can be removed in 8.9
+        if (activePartitionList.isEmpty()) {
+          throw new IllegalArgumentException("Unknown request handling type");
+        } else {
+          yield new RequestHandling.AllPartitions(activePartitionList.size());
+        }
+      }
     };
   }
 
@@ -575,6 +587,7 @@ public class ProtoBufSerializer
   private Topology.RoutingState encodeRoutingState(final RoutingState routingState) {
     return Topology.RoutingState.newBuilder()
         .setVersion(routingState.version())
+        .addAllActivePartitions(routingState.requestHandling().activePartitions())
         .setRequestHandling(encodeRequestHandling(routingState.requestHandling()))
         .setMessageCorrelation(encodeMessageCorrelation(routingState.messageCorrelation()))
         .build();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
@@ -69,8 +69,7 @@ public record RoutingState(
 
   private static void validatePartitionCount(final int partitionCount) {
     if (partitionCount < 1) {
-      throw new IllegalArgumentException(
-          "Partition count must be greater than %d".formatted(Protocol.START_PARTITION_ID));
+      throw new IllegalArgumentException("Partition count must be greater than or equal to 1");
     }
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -64,6 +65,13 @@ public record RoutingState(
   public static RoutingState initializeWithPartitionCount(final int partitionCount) {
     return new RoutingState(
         1, new AllPartitions(partitionCount), new MessageCorrelation.HashMod(partitionCount));
+  }
+
+  private static void validatePartitionCount(final int partitionCount) {
+    if (partitionCount < 1) {
+      throw new IllegalArgumentException(
+          "Partition count must be greater than %d".formatted(Protocol.START_PARTITION_ID));
+    }
   }
 
   private static void validatePartitionId(final int partitionId) {
@@ -120,6 +128,8 @@ public record RoutingState(
       public ActivePartitions {
         Objects.requireNonNull(additionalActivePartitions);
         Objects.requireNonNull(inactivePartitions);
+        validatePartitionCount(basePartitionCount);
+
         for (final int activePartition : additionalActivePartitions) {
           validatePartitionId(activePartition);
           if (inactivePartitions.contains(activePartition)) {
@@ -136,8 +146,7 @@ public record RoutingState(
 
       @Override
       public Set<Integer> activePartitions() {
-        final var all =
-            new HashSet<Integer>(basePartitionCount + additionalActivePartitions.size());
+        final var all = new TreeSet<Integer>();
         all.addAll(allPartitions(basePartitionCount));
         all.addAll(additionalActivePartitions);
         all.removeAll(inactivePartitions);

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -17,9 +17,10 @@ message ClusterTopology {
 }
 
 message RoutingState {
-  int64 version = 1;
-  RequestHandling requestHandling = 2;
+  int64  version = 1;
+  repeated sint32 activePartitions = 2 [deprecated=true];
   MessageCorrelation messageCorrelation = 3;
+  RequestHandling requestHandling = 4;
 }
 
 message RequestHandling {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
@@ -43,12 +43,6 @@ final class PersistedClusterConfigurationRandomizedPropertyTest {
     assertThat(updatedTopology).isEqualTo(persistedClusterTopology.getConfiguration());
     assertThat(PersistedClusterConfiguration.ofFile(topologyFile, serializer).getConfiguration())
         .usingRecursiveComparison()
-        // The type of generated `activePartitions` is `LinkedHashSet`, which AssertJ treats as an
-        // ordered collection. We are not interested in the order of the partitions, so we ignore
-        // it here.
-        .ignoringCollectionOrderInFields(
-            "routingState.value.requestHandling.additionalActivePartitions")
-        .ignoringCollectionOrderInFields("routingState.value.requestHandling.inactivePartitions")
         .isEqualTo(updatedTopology);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
@@ -34,12 +34,6 @@ final class ProtoBufSerializerPropertyTest {
     assertThat(decodedState.getClusterConfiguration())
         .describedAs("Decoded clusterTopology must be equal to initial one")
         .usingRecursiveComparison()
-        // The type of generated `activePartitions` is `LinkedHashSet`, which AssertJ treats as an
-        // ordered collection. We are not interested in the order of the partitions, so we ignore
-        // it here.
-        .ignoringCollectionOrderInFields(
-            "routingState.value.requestHandling.additionalActivePartitions")
-        .ignoringCollectionOrderInFields("routingState.value.requestHandling.inactivePartitions")
         .isEqualTo(clusterConfiguration);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -70,9 +70,9 @@ public final class ClusterTopologyDomain extends DomainContextBase {
 
   @Provide
   Arbitrary<RequestHandling> requestHandling() {
-    return Arbitraries.of(
-            ReflectUtil.implementationsOfSealedInterface(RequestHandling.class).toList())
-        .flatMap(Arbitraries::forType);
+    return Arbitraries.oneOf(
+        allPartitions().map(RequestHandling.class::cast),
+        activePartitions().map(RequestHandling.class::cast));
   }
 
   @Provide
@@ -83,8 +83,8 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   @Provide
   Arbitrary<ActivePartitions> activePartitions() {
     final var basePartitionCount = Arbitraries.integers().between(1, 3);
-    final var activePartitions = Arbitraries.integers().between(4, 8).set();
-    final var inactivePartitions = Arbitraries.integers().between(9, 12).set();
+    final var activePartitions = Arbitraries.integers().between(4, 8).list().map(TreeSet::new);
+    final var inactivePartitions = Arbitraries.integers().between(9, 12).list().map(TreeSet::new);
 
     return Combinators.combine(basePartitionCount, activePartitions, inactivePartitions)
         .as(ActivePartitions::new);


### PR DESCRIPTION
## Description
BREAKING CHANGE:
This PR reverts a  **BREAKING CHANGE** introduced in 8.8.
In 8.8 an incompatibility between RoutingState has been introduced by reusing the field with id 2 for a new field, therefore introduce an incompatibility between the two formats.

A fallback to the previous field has been introduced to be able to deserialize correctly messages generated by 8.7. 

Some property tests reported errors, mostly related to generating `RequestHandling` classes with `basePartitionCount=-1` which is not a valid value. However, the validation for that field was missing.

I also noticed that the value `basePartitionCount = -1` should not have been "generated" at all, since `Arbitrary` for `RequestHandling.AllPartitions` should have produced only positive values. 
By making the `Arbitrary<RequestHandling>` explicitly refer to our custom instances, the error vanished.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38140
