### PR TITLE
Revert "UC: add index config properties"

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
@@ -32,15 +32,6 @@ public abstract class SecondaryStorageDatabase {
   /** How many shards Elasticsearch uses for all Tasklist indices. */
   private int numberOfShards = 1;
 
-  /** How many replicas Elasticsearch uses for all indices. */
-  private int numberOfReplicas = 0;
-
-  /** Variable size threshold for the database configured as secondary storage. */
-  private int variableSizeThreshold = 8191;
-
-  /** Whether to wait for importers before proceeding. */
-  private boolean waitForImporters = true;
-
   public String getUrl() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         prefix() + ".url",
@@ -127,45 +118,6 @@ public abstract class SecondaryStorageDatabase {
     this.numberOfShards = numberOfShards;
   }
 
-  public int getNumberOfReplicas() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        prefix() + ".number-of-replicas",
-        numberOfReplicas,
-        Integer.class,
-        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
-        legacyNumberOfReplicasProperties());
-  }
-
-  public void setNumberOfReplicas(final int numberOfReplicas) {
-    this.numberOfReplicas = numberOfReplicas;
-  }
-
-  public int getVariableSizeThreshold() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        prefix() + ".variable-size-threshold",
-        variableSizeThreshold,
-        Integer.class,
-        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
-        legacyVariableSizeThresholdProperties());
-  }
-
-  public void setVariableSizeThreshold(final int variableSizeThreshold) {
-    this.variableSizeThreshold = variableSizeThreshold;
-  }
-
-  public boolean isWaitForImporters() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        prefix() + ".wait-for-importers",
-        waitForImporters,
-        Boolean.class,
-        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
-        legacyWaitForImportersProperties());
-  }
-
-  public void setWaitForImporters(final boolean waitForImporters) {
-    this.waitForImporters = waitForImporters;
-  }
-
   private String prefix() {
     return "camunda.data.secondary-storage." + databaseName().toLowerCase();
   }
@@ -219,24 +171,6 @@ public abstract class SecondaryStorageDatabase {
     return Set.of(
         "camunda.database.index.numberOfShards",
         "zeebe.broker.exporters.camundaexporter.args.index.numberOfShards");
-  }
-
-  private Set<String> legacyNumberOfReplicasProperties() {
-    return Set.of(
-        "camunda.database.index.numberOfReplicas",
-        "zeebe.broker.exporters.camundaexporter.args.index.numberOfReplicas");
-  }
-
-  private Set<String> legacyVariableSizeThresholdProperties() {
-    return Set.of(
-        "camunda.database.index.variableSizeThreshold",
-        "zeebe.broker.exporters.camundaexporter.args.index.variableSizeThreshold");
-  }
-
-  private Set<String> legacyWaitForImportersProperties() {
-    return Set.of(
-        "camunda.database.index.shouldWaitForImporters",
-        "zeebe.broker.exporters.camundaexporter.args.index.shouldWaitForImporters");
   }
 
   protected abstract String databaseName();

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -549,9 +549,6 @@ public class BrokerBasedPropertiesOverride {
 
     setArg(args, "connect.indexPrefix", database.getIndexPrefix());
     setArg(args, "index.numberOfShards", database.getNumberOfShards());
-    setArg(args, "index.numberOfReplicas", database.getNumberOfReplicas());
-    setArg(args, "index.variableSizeThreshold", database.getVariableSizeThreshold());
-    setArg(args, "index.shouldWaitForImporters", database.isWaitForImporters());
   }
 
   @SuppressWarnings("unchecked")

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
@@ -56,9 +56,6 @@ public class SearchEngineIndexPropertiesOverride {
             : secondaryStorage.getOpensearch();
 
     override.setNumberOfShards(database.getNumberOfShards());
-    override.setNumberOfReplicas(database.getNumberOfReplicas());
-    override.setVariableSizeThreshold(database.getVariableSizeThreshold());
-    override.setShouldWaitForImporters(database.isWaitForImporters());
 
     return override;
   }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -48,9 +48,6 @@ public class SecondaryStorageElasticsearchTest {
   private static final String EXPECTED_PASSWORD = "testPassword";
 
   private static final int EXPECTED_NUMBER_OF_SHARDS = 3;
-  private static final int EXPECTED_NUMBER_OF_REPLICAS = 2;
-  private static final int EXPECTED_VARIABLE_SIZE_THRESHOLD = 5000;
-  private static final boolean EXPECTED_WAIT_FOR_IMPORTERS = false;
 
   @Nested
   @TestPropertySource(
@@ -61,14 +58,7 @@ public class SecondaryStorageElasticsearchTest {
         "camunda.data.secondary-storage.elasticsearch.password=" + EXPECTED_PASSWORD,
         "camunda.data.secondary-storage.elasticsearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
         "camunda.data.secondary-storage.elasticsearch.index-prefix=" + EXPECTED_INDEX_PREFIX,
-        "camunda.data.secondary-storage.elasticsearch.number-of-shards="
-            + EXPECTED_NUMBER_OF_SHARDS,
-        "camunda.data.secondary-storage.elasticsearch.number-of-replicas="
-            + EXPECTED_NUMBER_OF_REPLICAS,
-        "camunda.data.secondary-storage.elasticsearch.variable-size-threshold="
-            + EXPECTED_VARIABLE_SIZE_THRESHOLD,
-        "camunda.data.secondary-storage.elasticsearch.wait-for-importers="
-            + EXPECTED_WAIT_FOR_IMPORTERS
+        "camunda.data.secondary-storage.elasticsearch.number-of-shards=" + EXPECTED_NUMBER_OF_SHARDS
       })
   class WithOnlyUnifiedConfigSet {
     final OperateProperties operateProperties;
@@ -138,16 +128,8 @@ public class SecondaryStorageElasticsearchTest {
       assertThat(exporterConfiguration.getConnect().getPassword()).isEqualTo(EXPECTED_PASSWORD);
       assertThat(exporterConfiguration.getConnect().getIndexPrefix())
           .isEqualTo(EXPECTED_INDEX_PREFIX);
-      assertThat(exporterConfiguration.getConnect().getClusterName())
-          .isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
-      assertThat(exporterConfiguration.getIndex().getNumberOfReplicas())
-          .isEqualTo(EXPECTED_NUMBER_OF_REPLICAS);
-      assertThat(exporterConfiguration.getIndex().getVariableSizeThreshold())
-          .isEqualTo(EXPECTED_VARIABLE_SIZE_THRESHOLD);
-      assertThat(exporterConfiguration.getIndex().shouldWaitForImporters())
-          .isEqualTo(EXPECTED_WAIT_FOR_IMPORTERS);
     }
 
     @Test
@@ -161,12 +143,6 @@ public class SecondaryStorageElasticsearchTest {
     void testCamundaSearchEngineIndexProperties() {
       assertThat(searchEngineIndexProperties.getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
-      assertThat(searchEngineIndexProperties.getNumberOfReplicas())
-          .isEqualTo(EXPECTED_NUMBER_OF_REPLICAS);
-      assertThat(searchEngineIndexProperties.getVariableSizeThreshold())
-          .isEqualTo(EXPECTED_VARIABLE_SIZE_THRESHOLD);
-      assertThat(searchEngineIndexProperties.shouldWaitForImporters())
-          .isEqualTo(EXPECTED_WAIT_FOR_IMPORTERS);
     }
   }
 
@@ -220,21 +196,6 @@ public class SecondaryStorageElasticsearchTest {
         "camunda.data.secondary-storage.elasticsearch.number-of-shards="
             + EXPECTED_NUMBER_OF_SHARDS,
         "camunda.database.index.numberOfShards=" + EXPECTED_NUMBER_OF_SHARDS,
-
-        // number of replicas
-        "camunda.data.secondary-storage.elasticsearch.number-of-replicas="
-            + EXPECTED_NUMBER_OF_REPLICAS,
-        "camunda.database.index.numberOfReplicas=" + EXPECTED_NUMBER_OF_REPLICAS,
-
-        // variable size threshold
-        "camunda.data.secondary-storage.elasticsearch.variable-size-threshold="
-            + EXPECTED_VARIABLE_SIZE_THRESHOLD,
-        "camunda.database.index.variableSizeThreshold=" + EXPECTED_VARIABLE_SIZE_THRESHOLD,
-
-        // wait for importers
-        "camunda.data.secondary-storage.elasticsearch.wait-for-importers="
-            + EXPECTED_WAIT_FOR_IMPORTERS,
-        "camunda.database.index.shouldWaitForImporters=" + EXPECTED_WAIT_FOR_IMPORTERS,
       })
   class WithNewAndLegacySet {
     final OperateProperties operateProperties;
@@ -310,12 +271,6 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
-      assertThat(exporterConfiguration.getIndex().getNumberOfReplicas())
-          .isEqualTo(EXPECTED_NUMBER_OF_REPLICAS);
-      assertThat(exporterConfiguration.getIndex().getVariableSizeThreshold())
-          .isEqualTo(EXPECTED_VARIABLE_SIZE_THRESHOLD);
-      assertThat(exporterConfiguration.getIndex().shouldWaitForImporters())
-          .isEqualTo(EXPECTED_WAIT_FOR_IMPORTERS);
     }
 
     @Test
@@ -332,12 +287,6 @@ public class SecondaryStorageElasticsearchTest {
     void testCamundaSearchEngineIndexProperties() {
       assertThat(searchEngineIndexProperties.getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
-      assertThat(searchEngineIndexProperties.getNumberOfReplicas())
-          .isEqualTo(EXPECTED_NUMBER_OF_REPLICAS);
-      assertThat(searchEngineIndexProperties.getVariableSizeThreshold())
-          .isEqualTo(EXPECTED_VARIABLE_SIZE_THRESHOLD);
-      assertThat(searchEngineIndexProperties.shouldWaitForImporters())
-          .isEqualTo(EXPECTED_WAIT_FOR_IMPORTERS);
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -48,9 +48,6 @@ public class SecondaryStorageOpensearchTest {
   private static final String EXPECTED_PASSWORD = "testPassword";
 
   private static final int EXPECTED_NUMBER_OF_SHARDS = 3;
-  private static final int EXPECTED_NUMBER_OF_REPLICAS = 2;
-  private static final int EXPECTED_VARIABLE_SIZE_THRESHOLD = 5000;
-  private static final boolean EXPECTED_WAIT_FOR_IMPORTERS = false;
 
   @Nested
   @TestPropertySource(
@@ -61,13 +58,7 @@ public class SecondaryStorageOpensearchTest {
         "camunda.data.secondary-storage.opensearch.password=" + EXPECTED_PASSWORD,
         "camunda.data.secondary-storage.opensearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
         "camunda.data.secondary-storage.opensearch.index-prefix=" + EXPECTED_INDEX_PREFIX,
-        "camunda.data.secondary-storage.opensearch.number-of-shards=" + EXPECTED_NUMBER_OF_SHARDS,
-        "camunda.data.secondary-storage.opensearch.number-of-replicas="
-            + EXPECTED_NUMBER_OF_REPLICAS,
-        "camunda.data.secondary-storage.opensearch.variable-size-threshold="
-            + EXPECTED_VARIABLE_SIZE_THRESHOLD,
-        "camunda.data.secondary-storage.opensearch.wait-for-importers="
-            + EXPECTED_WAIT_FOR_IMPORTERS
+        "camunda.data.secondary-storage.opensearch.number-of-shards=" + EXPECTED_NUMBER_OF_SHARDS
       })
   class WithOnlyUnifiedConfigSet {
     final OperateProperties operateProperties;
@@ -139,12 +130,6 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_INDEX_PREFIX);
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
-      assertThat(exporterConfiguration.getIndex().getNumberOfReplicas())
-          .isEqualTo(EXPECTED_NUMBER_OF_REPLICAS);
-      assertThat(exporterConfiguration.getIndex().getVariableSizeThreshold())
-          .isEqualTo(EXPECTED_VARIABLE_SIZE_THRESHOLD);
-      assertThat(exporterConfiguration.getIndex().shouldWaitForImporters())
-          .isEqualTo(EXPECTED_WAIT_FOR_IMPORTERS);
     }
 
     @Test
@@ -160,12 +145,6 @@ public class SecondaryStorageOpensearchTest {
     void testCamundaSearchEngineIndexProperties() {
       assertThat(searchEngineIndexProperties.getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
-      assertThat(searchEngineIndexProperties.getNumberOfReplicas())
-          .isEqualTo(EXPECTED_NUMBER_OF_REPLICAS);
-      assertThat(searchEngineIndexProperties.getVariableSizeThreshold())
-          .isEqualTo(EXPECTED_VARIABLE_SIZE_THRESHOLD);
-      assertThat(searchEngineIndexProperties.shouldWaitForImporters())
-          .isEqualTo(EXPECTED_WAIT_FOR_IMPORTERS);
     }
   }
 
@@ -218,21 +197,6 @@ public class SecondaryStorageOpensearchTest {
         // number of shards
         "camunda.data.secondary-storage.opensearch.number-of-shards=" + EXPECTED_NUMBER_OF_SHARDS,
         "camunda.database.index.numberOfShards=" + EXPECTED_NUMBER_OF_SHARDS,
-
-        // number of replicas
-        "camunda.data.secondary-storage.opensearch.number-of-replicas="
-            + EXPECTED_NUMBER_OF_REPLICAS,
-        "camunda.database.index.numberOfReplicas=" + EXPECTED_NUMBER_OF_REPLICAS,
-
-        // variable size threshold
-        "camunda.data.secondary-storage.opensearch.variable-size-threshold="
-            + EXPECTED_VARIABLE_SIZE_THRESHOLD,
-        "camunda.database.index.variableSizeThreshold=" + EXPECTED_VARIABLE_SIZE_THRESHOLD,
-
-        // wait for importers
-        "camunda.data.secondary-storage.opensearch.wait-for-importers="
-            + EXPECTED_WAIT_FOR_IMPORTERS,
-        "camunda.database.index.shouldWaitForImporters=" + EXPECTED_WAIT_FOR_IMPORTERS,
       })
   class WithNewAndLegacySet {
     final OperateProperties operateProperties;
@@ -308,12 +272,6 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_CLUSTER_NAME);
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
-      assertThat(exporterConfiguration.getIndex().getNumberOfReplicas())
-          .isEqualTo(EXPECTED_NUMBER_OF_REPLICAS);
-      assertThat(exporterConfiguration.getIndex().getVariableSizeThreshold())
-          .isEqualTo(EXPECTED_VARIABLE_SIZE_THRESHOLD);
-      assertThat(exporterConfiguration.getIndex().shouldWaitForImporters())
-          .isEqualTo(EXPECTED_WAIT_FOR_IMPORTERS);
     }
 
     @Test
@@ -332,12 +290,6 @@ public class SecondaryStorageOpensearchTest {
     void testCamundaSearchEngineIndexProperties() {
       assertThat(searchEngineIndexProperties.getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
-      assertThat(searchEngineIndexProperties.getNumberOfReplicas())
-          .isEqualTo(EXPECTED_NUMBER_OF_REPLICAS);
-      assertThat(searchEngineIndexProperties.getVariableSizeThreshold())
-          .isEqualTo(EXPECTED_VARIABLE_SIZE_THRESHOLD);
-      assertThat(searchEngineIndexProperties.shouldWaitForImporters())
-          .isEqualTo(EXPECTED_WAIT_FOR_IMPORTERS);
     }
   }
 }


### PR DESCRIPTION
Reverts camunda/camunda#38051 due to several complaints, e.g. https://camunda.slack.com/archives/C08MRKHJ0CD/p1758010985305019.

This code break `8.9-SNAPSHOT` deployments which can occur in E2E or integration tests.

The change must be re-merged after Controller and Helm Chart changes apply.