### PR TITLE
feat: improved error messages for when clock api is disabled and fail fast if remote runtime is unhealthy

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/HttpClientUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/HttpClientUtil.java
@@ -21,7 +21,7 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 
 public class HttpClientUtil {
 
-  public static String getReponseAsString(final ClassicHttpResponse response) {
+  public static String getResponseAsString(final ClassicHttpResponse response) {
     return Optional.ofNullable(response.getEntity())
         .map(
             entity -> {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntime.java
@@ -98,22 +98,36 @@ public class CamundaProcessTestRemoteRuntime implements CamundaProcessTestRuntim
   }
 
   private void checkConnectionToRemoteRuntime() {
+    final Topology topology = queryRemoteRuntimeHealth();
+
+    final boolean isHealthy =
+        topology.getBrokers().stream()
+            .flatMap(brokerInfo -> brokerInfo.getPartitions().stream())
+            .map(PartitionInfo::getHealth)
+            .allMatch(PartitionBrokerHealth.HEALTHY::equals);
+    final boolean hasAtLeastOnePartition =
+        topology.getBrokers().stream()
+            .anyMatch(brokerInfo -> !brokerInfo.getPartitions().isEmpty());
+
+    if (isHealthy && hasAtLeastOnePartition) {
+      LOGGER.info("Remote Camunda runtime connected. [version: {}]", topology.getGatewayVersion());
+    } else if (!isHealthy) {
+      final String errorMessage =
+          String.format("Remote Camunda runtime is unhealthy. [topology: %s]", topology);
+      throw new RemoteRuntimeUnhealthyException(errorMessage);
+    } else {
+      final String errorMessage =
+          String.format(
+              "Remote Camunda runtime has zero available partitions. Please check the remote runtime logs for errors. [topology: %s",
+              topology);
+      throw new RemoteRuntimeHasNoAvailablePartitionsException(errorMessage);
+    }
+  }
+
+  private Topology queryRemoteRuntimeHealth() {
     try (final CamundaClient camundaClient = getCamundaClientBuilderFactory().get().build()) {
-      final Topology topology = camundaClient.newTopologyRequest().send().join();
 
-      final boolean isHealthy =
-          topology.getBrokers().stream()
-              .flatMap(brokerInfo -> brokerInfo.getPartitions().stream())
-              .map(PartitionInfo::getHealth)
-              .allMatch(PartitionBrokerHealth.HEALTHY::equals);
-
-      if (isHealthy) {
-        LOGGER.info(
-            "Remote Camunda runtime connected. [version: {}]", topology.getGatewayVersion());
-      } else {
-        LOGGER.warn("Remote Camunda runtime is unhealthy. [topology: {}]", topology);
-      }
-
+      return camundaClient.newTopologyRequest().send().join();
     } catch (final Exception e) {
       throw new RuntimeException("Failed to connect to remote Camunda runtime.", e);
     }
@@ -130,5 +144,19 @@ public class CamundaProcessTestRemoteRuntime implements CamundaProcessTestRuntim
   @Override
   public void close() throws Exception {
     // nothing to close. the runtime is managed remotely.
+  }
+
+  public static class RemoteRuntimeUnhealthyException extends IllegalStateException {
+
+    public RemoteRuntimeUnhealthyException(final String message) {
+      super(message);
+    }
+  }
+
+  public static class RemoteRuntimeHasNoAvailablePartitionsException extends IllegalStateException {
+
+    public RemoteRuntimeHasNoAvailablePartitionsException(final String message) {
+      super(message);
+    }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntime.java
@@ -118,7 +118,7 @@ public class CamundaProcessTestRemoteRuntime implements CamundaProcessTestRuntim
     } else {
       final String errorMessage =
           String.format(
-              "Remote Camunda runtime has zero available partitions. Please check the remote runtime logs for errors. [topology: %s",
+              "Remote Camunda runtime has zero available partitions. Please check the remote runtime logs for errors. [topology: %s]",
               topology);
       throw new RemoteRuntimeHasNoAvailablePartitionsException(errorMessage);
     }


### PR DESCRIPTION
## Description

Improves the error message a user may see when attempting to call the Clock endpoint, but the endpoint is disabled. Also added a fail-fast condition if the health check of a remote runtime inidicates that it's unhealthy.

## Related issues

closes #36203