### PR TITLE
feat: task migration apply lifecycle policy to old runtime index

### DIFF
--- a/migration/commons/src/main/java/io/camunda/migration/commons/configuration/MigrationConfiguration.java
+++ b/migration/commons/src/main/java/io/camunda/migration/commons/configuration/MigrationConfiguration.java
@@ -15,6 +15,8 @@ public class MigrationConfiguration {
   private Duration importerFinishedTimeout = Duration.ofMinutes(1);
   private Duration timeout = Duration.ofHours(2);
   private MigrationRetryConfiguration retry = new MigrationRetryConfiguration();
+  // Only used by Task migration
+  private String legacyIndexRetentionAge = "30d";
 
   public int getBatchSize() {
     return batchSize;
@@ -46,6 +48,14 @@ public class MigrationConfiguration {
 
   public void setTimeout(final Duration timeout) {
     this.timeout = timeout;
+  }
+
+  public String getLegacyIndexRetentionAge() {
+    return legacyIndexRetentionAge;
+  }
+
+  public void setLegacyIndexRetentionAge(final String legacyIndexRetentionAge) {
+    this.legacyIndexRetentionAge = legacyIndexRetentionAge;
   }
 
   public static class MigrationRetryConfiguration extends RetryConfiguration {

--- a/migration/task-migration/pom.xml
+++ b/migration/task-migration/pom.xml
@@ -44,6 +44,10 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/TaskMigrationAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/TaskMigrationAdapter.java
@@ -17,6 +17,7 @@ import java.util.Set;
 public interface TaskMigrationAdapter {
   String TASK_MIGRATION_STEP_ID = VersionUtil.getVersion() + "-1";
   String TASK_MIGRATION_STEP_TYPE = "processorStep";
+  String LEGACY_INDEX_RETENTION_POLICY_NAME = "task-migration-retention-policy";
 
   boolean migrationIndexExists() throws MigrationException;
 

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -29,6 +29,8 @@ import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.core.reindex.Destination;
 import co.elastic.clients.elasticsearch.core.reindex.Source;
 import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.ilm.DeleteAction;
+import co.elastic.clients.elasticsearch.ilm.PutLifecycleRequest;
 import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.elasticsearch.indices.UpdateAliasesRequest;
@@ -141,6 +143,9 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
   @Override
   public void reindexLegacyMainIndex() throws MigrationException {
     reindex(legacyIndex.getFullQualifiedName(), destinationIndex.getFullQualifiedName());
+    if (retentionConfiguration.isEnabled()) {
+      applyLegacyIndexRetentionPolicy();
+    }
   }
 
   @Override
@@ -485,5 +490,65 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
       }
     }
     return Objects.requireNonNull(sorted.getLast().id());
+  }
+
+  ///  Forked from io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient()
+
+  private void applyLegacyIndexRetentionPolicy() {
+    createPolicy();
+    applyPolicy();
+  }
+
+  private void applyPolicy() {
+    try {
+      client
+          .indices()
+          .putSettings(
+              r ->
+                  r.index(legacyIndex.getFullQualifiedName())
+                      .settings(
+                          s ->
+                              s.index(
+                                  i ->
+                                      i.lifecycle(
+                                          l -> l.name(LEGACY_INDEX_RETENTION_POLICY_NAME)))));
+    } catch (final IOException e) {
+      final var message =
+          "Failed to apply index lifecycle policy '%s' to '%s' index"
+              .formatted(LEGACY_INDEX_RETENTION_POLICY_NAME, legacyIndex.getFullQualifiedName());
+      LOG.error(message, e);
+      throw new MigrationException(message, e);
+    }
+  }
+
+  private void createPolicy() {
+    final PutLifecycleRequest request = putLifecycleRequest();
+    try {
+      client.ilm().putLifecycle(request);
+    } catch (final IOException e) {
+      final var errMsg =
+          String.format(
+              "Index lifecycle policy [%s] failed to PUT", LEGACY_INDEX_RETENTION_POLICY_NAME);
+      LOG.error(errMsg, e);
+      throw new MigrationException(errMsg, e);
+    }
+  }
+
+  private PutLifecycleRequest putLifecycleRequest() {
+    return new PutLifecycleRequest.Builder()
+        .name(LEGACY_INDEX_RETENTION_POLICY_NAME)
+        .policy(
+            policy ->
+                policy.phases(
+                    phase ->
+                        phase.delete(
+                            del ->
+                                del.minAge(
+                                        m ->
+                                            m.time(
+                                                migrationConfiguration
+                                                    .getLegacyIndexRetentionAge()))
+                                    .actions(a -> a.delete(DeleteAction.of(d -> d))))))
+        .build();
   }
 }

--- a/migration/task-migration/src/main/resources/opensearch-legacy-runtime-index-policy.json
+++ b/migration/task-migration/src/main/resources/opensearch-legacy-runtime-index-policy.json
@@ -1,0 +1,29 @@
+{
+  "policy": {
+    "description": "Legacy Task runtime index policy",
+    "default_state": "archived",
+    "states": [
+      {
+        "name": "archived",
+        "actions": [],
+        "transitions": [
+          {
+            "state_name": "deleted",
+            "conditions": {
+              "min_index_age": "$MIN_INDEX_AGE"
+            }
+          }
+        ]
+      },
+      {
+        "name": "deleted",
+        "actions": [
+          {
+            "delete": {}
+          }
+        ],
+        "transitions": []
+      }
+    ]
+  }
+}

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/SearchAndCreateTaskMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/SearchAndCreateTaskMigrationIT.java
@@ -215,8 +215,8 @@ public class SearchAndCreateTaskMigrationIT extends UserTaskMigrationHelper {
       final var response = HTTP_CLIENT.send(request, BodyHandlers.ofString());
       final JsonNode jsonResponse = OBJECT_MAPPER.readTree(response.body());
       final var policy = jsonResponse.at("/" + datedIndex + "/settings/index/lifecycle");
-      assertThat(policy.isMissingNode()).isFalse();
       assertThat(policy).isNotNull();
+      assertThat(policy.isMissingNode()).isFalse();
       assertThat(policy.get("name").asText()).isNotBlank();
     } catch (final Exception e) {
       fail("Failed to get ILM policy for index: " + datedIndex, e);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Task migration should apply an ILM/ISM lifecycle policy to the old `tasklist-task-8.5.0_` index for it to be deleted after a defined period, defaults to 30 days.

Instead of deleting the runtime index, we maintain it in case of any issues that have occurred during the migration that did not cause it to fail.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37837
