### PR TITLE
fix: incorrect Swagger BasicAuth Visibility And 'Enable Swagger' Toggle Inconsistencies

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/OpenApiConfigurer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/OpenApiConfigurer.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.gateway.rest.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 
 /**
@@ -39,15 +38,4 @@ public abstract class OpenApiConfigurer {
    * @return the API description text
    */
   public abstract String getApiDescription();
-
-  /**
-   * Adds bearer authentication to the OpenAPI specification. This is common for both SaaS and
-   * Self-Managed deployments.
-   *
-   * @param openApi the OpenAPI object to configure
-   */
-  protected final void addBearerAuthentication(final OpenAPI openApi) {
-    openApi.getComponents().addSecuritySchemes(BEARER_SECURITY_SCHEMA_NAME, BEARER_SECURITY_SCHEMA);
-    openApi.addSecurityItem(new SecurityRequirement().addList(BEARER_SECURITY_SCHEMA_NAME));
-  }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/SaaSOpenApiConfigurer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/SaaSOpenApiConfigurer.java
@@ -9,14 +9,20 @@ package io.camunda.zeebe.gateway.rest.config;
 
 import io.camunda.security.ConditionalOnSaaSConfigured;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
+@Primary
 @Configuration
 @ConditionalOnSaaSConfigured
-@Primary
+@EnableConfigurationProperties(OpenApiConfigurationProperties.class)
 public class SaaSOpenApiConfigurer extends OpenApiConfigurer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SaaSOpenApiConfigurer.class);
@@ -25,7 +31,12 @@ public class SaaSOpenApiConfigurer extends OpenApiConfigurer {
   public void configureSecurity(final OpenAPI openApi) {
     LOGGER.debug("Configuring OpenAPI security for SaaS deployment");
 
-    addBearerAuthentication(openApi);
+    openApi
+        .getComponents()
+        .setSecuritySchemes(
+            new LinkedHashMap<>(Map.of(BEARER_SECURITY_SCHEMA_NAME, BEARER_SECURITY_SCHEMA)));
+
+    openApi.setSecurity(List.of(new SecurityRequirement().addList(BEARER_SECURITY_SCHEMA_NAME)));
   }
 
   @Override

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/SelfManagedOpenApiConfigurer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/SelfManagedOpenApiConfigurer.java
@@ -10,10 +10,7 @@ package io.camunda.zeebe.gateway.rest.config;
 import io.camunda.security.ConditionalOnSelfManagedConfigured;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -25,21 +22,11 @@ import org.springframework.context.annotation.Configuration;
 public class SelfManagedOpenApiConfigurer extends OpenApiConfigurer {
 
   public static final String BASIC_SECURITY_SCHEMA_NAME = "basicAuth";
-  public static final SecurityScheme BASIC_SECURITY_SCHEMA =
-      new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("basic");
   private static final Logger LOGGER = LoggerFactory.getLogger(SelfManagedOpenApiConfigurer.class);
 
   @Override
   public void configureSecurity(final OpenAPI openApi) {
     LOGGER.debug("Configuring OpenAPI security for Self-Managed deployment");
-
-    openApi
-        .getComponents()
-        .setSecuritySchemes(
-            new LinkedHashMap<>(
-                Map.of(
-                    BEARER_SECURITY_SCHEMA_NAME, BEARER_SECURITY_SCHEMA,
-                    BASIC_SECURITY_SCHEMA_NAME, BASIC_SECURITY_SCHEMA)));
 
     openApi.setSecurity(
         List.of(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/SelfManagedOpenApiConfigurer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/SelfManagedOpenApiConfigurer.java
@@ -11,6 +11,9 @@ import io.camunda.security.ConditionalOnSelfManagedConfigured;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -30,9 +33,18 @@ public class SelfManagedOpenApiConfigurer extends OpenApiConfigurer {
   public void configureSecurity(final OpenAPI openApi) {
     LOGGER.debug("Configuring OpenAPI security for Self-Managed deployment");
 
-    addBearerAuthentication(openApi);
-    openApi.getComponents().addSecuritySchemes(BASIC_SECURITY_SCHEMA_NAME, BASIC_SECURITY_SCHEMA);
-    openApi.addSecurityItem(new SecurityRequirement().addList(BASIC_SECURITY_SCHEMA_NAME));
+    openApi
+        .getComponents()
+        .setSecuritySchemes(
+            new LinkedHashMap<>(
+                Map.of(
+                    BEARER_SECURITY_SCHEMA_NAME, BEARER_SECURITY_SCHEMA,
+                    BASIC_SECURITY_SCHEMA_NAME, BASIC_SECURITY_SCHEMA)));
+
+    openApi.setSecurity(
+        List.of(
+            new SecurityRequirement().addList(BEARER_SECURITY_SCHEMA_NAME),
+            new SecurityRequirement().addList(BASIC_SECURITY_SCHEMA_NAME)));
   }
 
   @Override


### PR DESCRIPTION
## Description

We're using all components from rest-api-yaml when [parsing](https://github.com/camunda/camunda/blob/3e1ff3fb792a40bd161cf9037f35468e996426f3/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/OpenApiYamlLoader.java#L87) the yaml and the security schemes are only appended instead of overwriting [here](https://github.com/camunda/camunda/blob/667fa6adf2ce4f37a738ea2c9e989b579c9fe469/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/SaaSOpenApiConfigurer.java#L28). The fix is to overwrite the security schemes inside the configurer implementations.

SM has this [config properties](https://github.com/camunda/camunda/blob/667fa6adf2ce4f37a738ea2c9e989b579c9fe469/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/SelfManagedOpenApiConfigurer.java#L21) but not [SaaS](https://github.com/camunda/camunda/blob/667fa6adf2ce4f37a738ea2c9e989b579c9fe469/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/SaaSOpenApiConfigurer.java#L20) so disable Swagger didn't work in SaaS

## Related issues

closes #38206
