### PR TITLE
ci: seperate Node version manager tool upgrades from NPM group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -301,8 +301,7 @@
     },
     {
       "matchManagers": [
-        "npm",
-        "nvm"
+        "npm"
       ],
       "matchPackageNames": [
         "*"


### PR DESCRIPTION
## Description

This PR allows bumping Node tool versions without having frontend knowledge regarding other NPM dependencies.

This is relevant for https://github.com/camunda/camunda/pull/38019 where dozens of NPM dependencies (that require frontend knowledge in case of build failures) are grouped together in one PR with one Node version upgrade (that can in many cases be automerged and requires more devops knowledge).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to https://github.com/camunda/camunda/issues/36956
