### PR TITLE
feat: bubble JsonProcessingException to the caller so that assertion errors are more informative

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -214,8 +214,14 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
           } catch (final JsonMappingException e) {
             final String failureMessage =
                 String.format(
-                    "%s should have a variable '%s' of type '%s', but was: '%s'",
-                    actual, variableName, variableValueType.getName(), actualVariable);
+                    "%s should have a variable '%s' of type '%s', but the JSON mapping failed:\n"
+                        + "Error: %s\n"
+                        + "Reason: %s",
+                    actual,
+                    variableName,
+                    variableValueType.getName(),
+                    e.getMessage(),
+                    e.getCause());
 
             fail(failureMessage);
           }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -212,16 +212,17 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
                 actual, variableName, e.getMessage());
 
           } catch (final JsonMappingException e) {
+            final Throwable reason =
+                Optional.ofNullable(e.getCause())
+                    .map(cause -> Optional.ofNullable(cause.getCause()).orElse(cause))
+                    .orElse(e);
+
             final String failureMessage =
                 String.format(
                     "%s should have a variable '%s' of type '%s', but the JSON mapping failed:\n"
                         + "Error: %s\n"
                         + "Reason: %s",
-                    actual,
-                    variableName,
-                    variableValueType.getName(),
-                    e.getMessage(),
-                    e.getCause());
+                    actual, variableName, variableValueType.getName(), e.getMessage(), reason);
 
             fail(failureMessage);
           }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -777,10 +777,10 @@ public class VariableAssertTest {
                           COMPLEX_VARIABLE_KEY,
                           List.class,
                           result -> Assertions.assertThat(result).hasSize(5)))
-          .hasMessage(
-              "Process instance [key: 1] should have a variable 'complex' of type 'java.util.List', but was: '"
-                  + jsonMapper.readJson(COMPLEX_VARIABLE_VALUE)
-                  + "'");
+          .hasMessageContainingAll(
+              "Process instance [key: 1] should have a variable 'complex' of type 'java.util.List', but the JSON mapping failed:\n",
+              "Error: Failed to read JSON: '" + COMPLEX_VARIABLE_VALUE + "'\n",
+              "Reason: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.util.ArrayList<java.lang.Object>` from Object value (token `JsonToken.START_OBJECT`)");
     }
 
     @Test


### PR DESCRIPTION
## Description

The JSON mapping for variables could sometimes fail because of e.g. incorrectly specified goal types. However, these errors weren't reported in the assertion message.

## Related issues

closes #37608
