### PR TITLE
[Backport stable/8.8] feat: improved error messages for when clock api is disabled and fail fast if remote runtime is unhealthy

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/CamundaManagementClient.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/CamundaManagementClient.java
@@ -32,6 +32,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
@@ -65,7 +66,7 @@ public class CamundaManagementClient {
 
       return Instant.parse(clockResponseDto.getInstant());
     } catch (final Exception e) {
-      throw new RuntimeException("Failed to resolve the current time", e);
+      throw new RuntimeException(timerBasedErrorMessage(e), e);
     }
   }
 
@@ -81,7 +82,7 @@ public class CamundaManagementClient {
 
       sendRequest(request);
     } catch (final Exception e) {
-      throw new RuntimeException("Failed to increase the time", e);
+      throw new RuntimeException(timerBasedErrorMessage(e), e);
     }
   }
 
@@ -98,8 +99,15 @@ public class CamundaManagementClient {
     try {
       sendRequest(request);
     } catch (final Exception e) {
-      throw new RuntimeException("Failed to reset the time", e);
+      throw new RuntimeException(timerBasedErrorMessage(e), e);
     }
+  }
+
+  private String timerBasedErrorMessage(final Exception e) {
+    return e.getMessage().contains("code: " + HttpStatus.SC_FORBIDDEN)
+        ? "Failed to increase the time. Please double-check that the Clock endpoint is enabled by "
+            + "setting 'zeebe-clock-controlled' to true."
+        : "Failed to increase the time.";
   }
 
   /**
@@ -179,9 +187,9 @@ public class CamundaManagementClient {
             throw new RuntimeException(
                 String.format(
                     "Request failed. [code: %d, message: %s]",
-                    response.getCode(), HttpClientUtil.getReponseAsString(response)));
+                    response.getCode(), HttpClientUtil.getResponseAsString(response)));
           }
-          return HttpClientUtil.getReponseAsString(response);
+          return HttpClientUtil.getResponseAsString(response);
         });
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/HttpClientUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/HttpClientUtil.java
@@ -21,7 +21,7 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 
 public class HttpClientUtil {
 
-  public static String getReponseAsString(final ClassicHttpResponse response) {
+  public static String getResponseAsString(final ClassicHttpResponse response) {
     return Optional.ofNullable(response.getEntity())
         .map(
             entity -> {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntime.java
@@ -109,7 +109,7 @@ public class CamundaProcessTestRemoteRuntime implements CamundaProcessTestRuntim
     } else {
       final String errorMessage =
           String.format(
-              "Remote Camunda runtime has zero available partitions. Please check the remote runtime logs for errors. [topology: %s",
+              "Remote Camunda runtime has zero available partitions. Please check the remote runtime logs for errors. [topology: %s]",
               topology);
       throw new RemoteRuntimeHasNoAvailablePartitionsException(errorMessage);
     }


### PR DESCRIPTION
# Description
Backport of #38197 to `stable/8.8`.

relates to #36203