### PR TITLE
fix: align permission mapping to spec

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class StaticEntities {
 
@@ -34,10 +35,15 @@ public class StaticEntities {
           new CreateRoleRequest(OPERATIONS_ENGINEER_ROLE_ID, "Operations Engineer", ""),
           new CreateRoleRequest(TASK_USER_ROLE_ID, "Task User", ""),
           new CreateRoleRequest(VISITOR_ROLE_ID, "Visitor", ""));
-
   public static final List<CreateAuthorizationRequest> ROLE_PERMISSIONS =
       List.of(
           // DEVELOPER
+          new CreateAuthorizationRequest(
+              DEVELOPER_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.BATCH,
+              Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
           new CreateAuthorizationRequest(
               DEVELOPER_ROLE_ID,
               AuthorizationOwnerType.ROLE,
@@ -54,12 +60,6 @@ public class StaticEntities {
               DEVELOPER_ROLE_ID,
               AuthorizationOwnerType.ROLE,
               "*",
-              AuthorizationResourceType.PROCESS_DEFINITION,
-              AuthorizationResourceType.PROCESS_DEFINITION.getSupportedPermissionTypes()),
-          new CreateAuthorizationRequest(
-              DEVELOPER_ROLE_ID,
-              AuthorizationOwnerType.ROLE,
-              "*",
               AuthorizationResourceType.DECISION_DEFINITION,
               AuthorizationResourceType.DECISION_DEFINITION.getSupportedPermissionTypes()),
           new CreateAuthorizationRequest(
@@ -69,6 +69,12 @@ public class StaticEntities {
               AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
               AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION
                   .getSupportedPermissionTypes()),
+          new CreateAuthorizationRequest(
+              DEVELOPER_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.MESSAGE,
+              Set.of(PermissionType.READ)),
           new CreateAuthorizationRequest(
               DEVELOPER_ROLE_ID,
               AuthorizationOwnerType.ROLE,
@@ -79,26 +85,21 @@ public class StaticEntities {
               DEVELOPER_ROLE_ID,
               AuthorizationOwnerType.ROLE,
               "*",
+              AuthorizationResourceType.PROCESS_DEFINITION,
+              AuthorizationResourceType.PROCESS_DEFINITION.getSupportedPermissionTypes()),
+          // OPERATIONS ENGINEER
+          new CreateAuthorizationRequest(
+              OPERATIONS_ENGINEER_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
               AuthorizationResourceType.BATCH,
               Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
-          // OPERATIONS ENGINEER
           new CreateAuthorizationRequest(
               OPERATIONS_ENGINEER_ROLE_ID,
               AuthorizationOwnerType.ROLE,
               "operate",
               AuthorizationResourceType.COMPONENT,
               AuthorizationResourceType.COMPONENT.getSupportedPermissionTypes()),
-          new CreateAuthorizationRequest(
-              OPERATIONS_ENGINEER_ROLE_ID,
-              AuthorizationOwnerType.ROLE,
-              "*",
-              AuthorizationResourceType.PROCESS_DEFINITION,
-              Set.of(
-                  PermissionType.READ_PROCESS_DEFINITION,
-                  PermissionType.READ_PROCESS_INSTANCE,
-                  PermissionType.UPDATE_PROCESS_INSTANCE,
-                  PermissionType.CREATE_PROCESS_INSTANCE,
-                  PermissionType.DELETE_PROCESS_INSTANCE)),
           new CreateAuthorizationRequest(
               OPERATIONS_ENGINEER_ROLE_ID,
               AuthorizationOwnerType.ROLE,
@@ -116,19 +117,27 @@ public class StaticEntities {
               OPERATIONS_ENGINEER_ROLE_ID,
               AuthorizationOwnerType.ROLE,
               "*",
-              AuthorizationResourceType.RESOURCE,
-              Set.of(
-                  PermissionType.READ,
-                  PermissionType.DELETE_RESOURCE,
-                  PermissionType.DELETE_PROCESS,
-                  PermissionType.DELETE_DRD,
-                  PermissionType.DELETE_FORM)),
+              AuthorizationResourceType.MESSAGE,
+              Set.of(PermissionType.READ)),
           new CreateAuthorizationRequest(
               OPERATIONS_ENGINEER_ROLE_ID,
               AuthorizationOwnerType.ROLE,
               "*",
-              AuthorizationResourceType.BATCH,
-              Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
+              AuthorizationResourceType.RESOURCE,
+              AuthorizationResourceType.RESOURCE.getSupportedPermissionTypes().stream()
+                  .filter(p -> !p.equals(PermissionType.CREATE))
+                  .collect(Collectors.toSet())),
+          new CreateAuthorizationRequest(
+              OPERATIONS_ENGINEER_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.PROCESS_DEFINITION,
+              AuthorizationResourceType.PROCESS_DEFINITION.getSupportedPermissionTypes().stream()
+                  .filter(
+                      s ->
+                          !s.equals(PermissionType.READ_USER_TASK)
+                              && !s.equals(PermissionType.UPDATE_USER_TASK))
+                  .collect(Collectors.toSet())),
           // TASK USER
           new CreateAuthorizationRequest(
               TASK_USER_ROLE_ID,
@@ -144,9 +153,15 @@ public class StaticEntities {
               Set.of(
                   PermissionType.READ_PROCESS_DEFINITION,
                   PermissionType.READ_USER_TASK,
-                  PermissionType.UPDATE_USER_TASK,
-                  PermissionType.CREATE_PROCESS_INSTANCE)),
+                  PermissionType.CREATE_PROCESS_INSTANCE,
+                  PermissionType.UPDATE_USER_TASK)),
           // VISITOR
+          new CreateAuthorizationRequest(
+              VISITOR_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.BATCH,
+              Set.of(PermissionType.READ)),
           new CreateAuthorizationRequest(
               VISITOR_ROLE_ID,
               AuthorizationOwnerType.ROLE,
@@ -159,15 +174,6 @@ public class StaticEntities {
               "tasklist",
               AuthorizationResourceType.COMPONENT,
               AuthorizationResourceType.COMPONENT.getSupportedPermissionTypes()),
-          new CreateAuthorizationRequest(
-              VISITOR_ROLE_ID,
-              AuthorizationOwnerType.ROLE,
-              "*",
-              AuthorizationResourceType.PROCESS_DEFINITION,
-              Set.of(
-                  PermissionType.READ_PROCESS_DEFINITION,
-                  PermissionType.READ_PROCESS_INSTANCE,
-                  PermissionType.READ_USER_TASK)),
           new CreateAuthorizationRequest(
               VISITOR_ROLE_ID,
               AuthorizationOwnerType.ROLE,
@@ -185,8 +191,23 @@ public class StaticEntities {
               VISITOR_ROLE_ID,
               AuthorizationOwnerType.ROLE,
               "*",
-              AuthorizationResourceType.BATCH,
-              Set.of(PermissionType.READ)));
+              AuthorizationResourceType.MESSAGE,
+              Set.of(PermissionType.READ)),
+          new CreateAuthorizationRequest(
+              VISITOR_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.RESOURCE,
+              Set.of(PermissionType.READ)),
+          new CreateAuthorizationRequest(
+              VISITOR_ROLE_ID,
+              AuthorizationOwnerType.ROLE,
+              "*",
+              AuthorizationResourceType.PROCESS_DEFINITION,
+              Set.of(
+                  PermissionType.READ_PROCESS_DEFINITION,
+                  PermissionType.READ_PROCESS_INSTANCE,
+                  PermissionType.READ_USER_TASK)));
 
   public static List<CreateAuthorizationRequest> getZeebeClientPermissions(final String clientId) {
     return List.of(

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
@@ -206,20 +206,22 @@ public class StaticEntities {
                         ownerType,
                         "*",
                         AuthorizationResourceType.RESOURCE,
-                        Set.of(
-                            PermissionType.READ,
-                            PermissionType.DELETE_PROCESS,
-                            PermissionType.DELETE_DRD)),
+                        AuthorizationResourceType.RESOURCE.getSupportedPermissionTypes().stream()
+                            .filter(p -> !p.equals(PermissionType.CREATE))
+                            .collect(Collectors.toSet())),
                     new CreateAuthorizationRequest(
                         ownerId,
                         ownerType,
                         "*",
                         AuthorizationResourceType.PROCESS_DEFINITION,
-                        Set.of(
-                            PermissionType.READ_PROCESS_DEFINITION,
-                            PermissionType.READ_PROCESS_INSTANCE,
-                            PermissionType.UPDATE_PROCESS_INSTANCE,
-                            PermissionType.DELETE_PROCESS_INSTANCE)),
+                        AuthorizationResourceType.PROCESS_DEFINITION
+                            .getSupportedPermissionTypes()
+                            .stream()
+                            .filter(
+                                s ->
+                                    !s.equals(PermissionType.READ_USER_TASK)
+                                        && !s.equals(PermissionType.UPDATE_USER_TASK))
+                            .collect(Collectors.toSet())),
                     new CreateAuthorizationRequest(
                         ownerId,
                         ownerType,
@@ -231,11 +233,8 @@ public class StaticEntities {
                         ownerType,
                         "*",
                         AuthorizationResourceType.DECISION_DEFINITION,
-                        Set.of(
-                            PermissionType.READ_DECISION_DEFINITION,
-                            PermissionType.READ_DECISION_INSTANCE,
-                            PermissionType.CREATE_DECISION_INSTANCE,
-                            PermissionType.DELETE_DECISION_INSTANCE)))),
+                        AuthorizationResourceType.DECISION_DEFINITION
+                            .getSupportedPermissionTypes()))),
             new AuthEntry(
                 audiences.getTasklist() + ":read:*",
                 List.of(
@@ -245,12 +244,6 @@ public class StaticEntities {
                         TASKLIST_RESOURCE_ID,
                         AuthorizationResourceType.COMPONENT,
                         Set.of(PermissionType.ACCESS)),
-                    new CreateAuthorizationRequest(
-                        ownerId,
-                        ownerType,
-                        "*",
-                        AuthorizationResourceType.RESOURCE,
-                        Set.of(PermissionType.READ)),
                     new CreateAuthorizationRequest(
                         ownerId,
                         ownerType,
@@ -268,12 +261,6 @@ public class StaticEntities {
                         TASKLIST_RESOURCE_ID,
                         AuthorizationResourceType.COMPONENT,
                         Set.of(PermissionType.ACCESS)),
-                    new CreateAuthorizationRequest(
-                        ownerId,
-                        ownerType,
-                        "*",
-                        AuthorizationResourceType.RESOURCE,
-                        Set.of(PermissionType.READ)),
                     new CreateAuthorizationRequest(
                         ownerId,
                         ownerType,

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/saas/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
@@ -55,7 +55,7 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
     migrationHandler.migrate();
 
     final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, times(21)).createAuthorization(results.capture());
+    verify(authorizationServices, times(25)).createAuthorization(results.capture());
     final var requests = results.getAllValues();
     assertThat(requests).containsExactlyElementsOf(ROLE_PERMISSIONS);
   }
@@ -75,6 +75,6 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
     migrationHandler.migrate();
 
     // then
-    verify(authorizationServices, times(22)).createAuthorization(any());
+    verify(authorizationServices, times(26)).createAuthorization(any());
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandlerTest.java
@@ -163,12 +163,14 @@ public class ClientMigrationHandlerTest {
                 "*",
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 Set.of(
-                    PermissionType.UPDATE_USER_TASK,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
-                    PermissionType.UPDATE_PROCESS_INSTANCE,
                     PermissionType.CREATE_PROCESS_INSTANCE,
+                    PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
-                    PermissionType.READ_PROCESS_DEFINITION)),
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.UPDATE_USER_TASK,
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 "ClientTwo",
                 AuthorizationOwnerType.CLIENT,

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
@@ -167,7 +167,11 @@ public class KeycloakRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
+                    PermissionType.READ,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_RESOURCE)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -178,10 +182,13 @@ public class KeycloakRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 Set.of(
+                    PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
-                    PermissionType.UPDATE_PROCESS_INSTANCE)),
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -246,7 +253,6 @@ public class KeycloakRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ,
                     PermissionType.CREATE,
                     PermissionType.DELETE_FORM,
                     PermissionType.DELETE_PROCESS,

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
@@ -171,7 +171,11 @@ public class OidcRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
+                    PermissionType.READ,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_RESOURCE)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -182,10 +186,13 @@ public class OidcRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 Set.of(
+                    PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
-                    PermissionType.UPDATE_PROCESS_INSTANCE)),
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -250,7 +257,6 @@ public class OidcRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ,
                     PermissionType.CREATE,
                     PermissionType.DELETE_FORM,
                     PermissionType.DELETE_PROCESS,
@@ -489,7 +495,11 @@ public class OidcRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
+                    PermissionType.READ,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_RESOURCE)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -500,10 +510,13 @@ public class OidcRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 Set.of(
+                    PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
-                    PermissionType.UPDATE_PROCESS_INSTANCE)),
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -568,7 +581,6 @@ public class OidcRoleMigrationHandlerTest {
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ,
                     PermissionType.CREATE,
                     PermissionType.DELETE_FORM,
                     PermissionType.DELETE_PROCESS,

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -261,7 +261,11 @@ public class KeycloakIdentityMigrationIT {
                 "operate",
                 ResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
+                    PermissionType.READ,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_RESOURCE)),
             tuple(
                 "operate",
                 ResourceType.DECISION_DEFINITION,
@@ -279,10 +283,13 @@ public class KeycloakIdentityMigrationIT {
                 "operate",
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
+                    PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
+                    PermissionType.READ_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
-                    PermissionType.READ_PROCESS_INSTANCE)),
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 "operate",
                 ResourceType.BATCH,
@@ -320,8 +327,6 @@ public class KeycloakIdentityMigrationIT {
                     PermissionType.UPDATE_USER_TASK,
                     PermissionType.READ_PROCESS_DEFINITION)),
             tuple("tasklist", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)),
-            tuple("tasklist", ResourceType.RESOURCE, Set.of(PermissionType.READ)),
-            tuple("tasklist", ResourceType.RESOURCE, Set.of(PermissionType.READ)),
             tuple(
                 "identity",
                 ResourceType.GROUP,

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
@@ -228,7 +228,11 @@ public class OidcIdentityMigrationIT {
                 "operate",
                 ResourceType.RESOURCE,
                 Set.of(
-                    PermissionType.READ, PermissionType.DELETE_PROCESS, PermissionType.DELETE_DRD)),
+                    PermissionType.READ,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_RESOURCE)),
             tuple(
                 "operate",
                 ResourceType.DECISION_DEFINITION,
@@ -246,10 +250,13 @@ public class OidcIdentityMigrationIT {
                 "operate",
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
+                    PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
-                    PermissionType.DELETE_PROCESS_INSTANCE,
+                    PermissionType.READ_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
-                    PermissionType.READ_PROCESS_INSTANCE)),
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 "operate",
                 ResourceType.BATCH,
@@ -287,8 +294,6 @@ public class OidcIdentityMigrationIT {
                     PermissionType.UPDATE_USER_TASK,
                     PermissionType.READ_PROCESS_DEFINITION)),
             tuple("tasklist", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)),
-            tuple("tasklist", ResourceType.RESOURCE, Set.of(PermissionType.READ)),
-            tuple("tasklist", ResourceType.RESOURCE, Set.of(PermissionType.READ)),
             tuple(
                 "identity",
                 ResourceType.GROUP,

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -275,7 +275,7 @@ public class SaaSIdentityMigrationIT {
   }
 
   @Test
-  public void canMigratePermissions() throws URISyntaxException, IOException, InterruptedException {
+  public void canMigratePermissions() {
     // when
     migration.start();
 
@@ -370,6 +370,12 @@ public class SaaSIdentityMigrationIT {
                 ResourceType.BATCH,
                 Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
             tuple(
+                DEVELOPER_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.MESSAGE,
+                Set.of(PermissionType.READ)),
+            tuple(
                 OPERATIONS_ENGINEER_ROLE_ID,
                 OwnerType.ROLE,
                 "operate",
@@ -381,10 +387,12 @@ public class SaaSIdentityMigrationIT {
                 "*",
                 ResourceType.PROCESS_DEFINITION,
                 Set.of(
+                    PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE,
-                    PermissionType.CREATE_PROCESS_INSTANCE,
+                    PermissionType.MODIFY_PROCESS_INSTANCE,
+                    PermissionType.CANCEL_PROCESS_INSTANCE,
                     PermissionType.DELETE_PROCESS_INSTANCE)),
             tuple(
                 OPERATIONS_ENGINEER_ROLE_ID,
@@ -419,6 +427,12 @@ public class SaaSIdentityMigrationIT {
                 "*",
                 ResourceType.BATCH,
                 Set.of(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE)),
+            tuple(
+                OPERATIONS_ENGINEER_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.MESSAGE,
+                Set.of(PermissionType.READ)),
             tuple(
                 TASK_USER_ROLE_ID,
                 OwnerType.ROLE,
@@ -475,6 +489,18 @@ public class SaaSIdentityMigrationIT {
                 OwnerType.ROLE,
                 "*",
                 ResourceType.BATCH,
+                Set.of(PermissionType.READ)),
+            tuple(
+                VISITOR_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.MESSAGE,
+                Set.of(PermissionType.READ)),
+            tuple(
+                VISITOR_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.RESOURCE,
                 Set.of(PermissionType.READ)));
   }
 


### PR DESCRIPTION
## Description

This adapts the permission migration to be aligned with the current state of the spec:
* [SaaS Role permission mapping spec](https://docs.google.com/document/d/1XqG9Y9SXvakwcJ7ZheE8lgd6X0PMWSuyH4IbYTzLYeE/edit?pli=1&tab=t.0#bookmark=id.xx922nas68kh)
* [SM permission mapping spec](https://docs.google.com/document/d/1XqG9Y9SXvakwcJ7ZheE8lgd6X0PMWSuyH4IbYTzLYeE/edit?pli=1&tab=t.0#bookmark=kix.lqp4lg18i3nl)

Generally these changes were applied

SaaS-ADDED:
* DEVELOPER:Message:*:READ
* OPERATIONS ENGINEER:PROCESS_DEFINITION:*: MODIFY_PROCESS_INSTANCE, CANCEL_PROCESS_INSTANCE
* OPERATIONS ENGINEER:Message:*:READ
* VISITOR:Message:*:READ
* VISITOR:Resource:*:READ 

SM-ADDED:
* OPERATE-WRITE:RESOURCE:*: DELETE_RESOURCE
* OPERATE-WRITE:PROCESS_DEFINITION:*: MODIFY_PROCESS_INSTANCE, CANCEL_PROCESS_INSTANCE

SM-REMOVED:
* TASKLIST-READ:RESOURCE:*:READ
* TASKLIST-WRITE:RESOURCE:*:READ

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).