### PR TITLE
Add tenant and authorization checks on job push

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -108,6 +109,7 @@ public class JobStreamAuthorizationIT {
     deployResource(adminClient, "service_tasks_v2.bpmn", modelInstance, TENANT_B);
   }
 
+  @Disabled("We don't have a broker mechanism to reject unauthorized job streams yet")
   @Test
   public void shouldNotOpenStreamWhenNotAssignedToAllTenants(
       @Authenticated("admin") final CamundaClient adminClient,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
@@ -61,7 +61,7 @@ public class JobStreamAuthorizationIT {
   private static final String PROCESS_ID_2 = "service_tasks_v2";
   private static final String JOB_TYPE = "taskA";
 
-  private static final Set<Long> startedProcessInstances = new HashSet<>();
+  private static final Set<Long> STARTED_PROCESS_INSTANCES = new HashSet<>();
 
   @UserDefinition
   private static final TestUser ADMIN_USER =
@@ -118,9 +118,9 @@ public class JobStreamAuthorizationIT {
   @AfterEach
   void cleanUp(@Authenticated("admin") final CamundaClient adminClient) {
     // cancel all process instances to ensure no jobs are left in the system
-    startedProcessInstances.forEach(
+    STARTED_PROCESS_INSTANCES.forEach(
         processInstanceKey -> cancelProcessInstance(adminClient, processInstanceKey));
-    startedProcessInstances.clear();
+    STARTED_PROCESS_INSTANCES.clear();
   }
 
   @Disabled("We don't have a broker mechanism to reject unauthorized job streams yet")
@@ -255,7 +255,7 @@ public class JobStreamAuthorizationIT {
             .tenantId(tenant)
             .send()
             .join();
-    startedProcessInstances.add(instanceCreated.getProcessInstanceKey());
+    STARTED_PROCESS_INSTANCES.add(instanceCreated.getProcessInstanceKey());
   }
 
   private static void cancelProcessInstance(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class JobStreamAuthorizationIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.client.api.search.enums.PermissionType.CREATE;
+import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.UPDATE;
+import static io.camunda.client.api.search.enums.PermissionType.UPDATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
+import static io.camunda.client.api.search.enums.ResourceType.TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class JobStreamAuthorizationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthorizationsEnabled()
+          .withAuthenticatedAccess();
+
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+  private static final String PROCESS_ID_1 = "service_tasks_v1";
+  private static final String PROCESS_ID_2 = "service_tasks_v2";
+  private static final String JOB_TYPE = "taskA";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER =
+      new TestUser(
+          "admin",
+          "password",
+          List.of(
+              new Permissions(TENANT, CREATE, List.of("*")),
+              new Permissions(TENANT, UPDATE, List.of("*")),
+              new Permissions(RESOURCE, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser("user1", "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER2_USER =
+      new TestUser(
+          "user2",
+          "password",
+          List.of(
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(PROCESS_ID_2)),
+              new Permissions(PROCESS_DEFINITION, UPDATE_PROCESS_INSTANCE, List.of(PROCESS_ID_2))));
+
+  @BeforeAll
+  static void setUp(@Authenticated("admin") final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+
+    assignUserToTenant(adminClient, "admin", TENANT_A);
+    assignUserToTenant(adminClient, "admin", TENANT_B);
+    // user1 is only assigned to tenantA, but isn't authorized to handle any resources
+    assignUserToTenant(adminClient, "user1", TENANT_A);
+    // user2 is assigned to tenantA AND tenant B BUT is authorized to handle only PROCESS_2 on
+    // tenantB
+    assignUserToTenant(adminClient, "user2", TENANT_A);
+    assignUserToTenant(adminClient, "user2", TENANT_B);
+
+    deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
+    deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);
+
+    final var modelInstance =
+        Bpmn.createExecutableProcess(PROCESS_ID_2)
+            .startEvent()
+            .serviceTask(JOB_TYPE, t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    deployResource(adminClient, "service_tasks_v2.bpmn", modelInstance, TENANT_B);
+  }
+
+  @Test
+  public void shouldNotOpenStreamWhenNotAssignedToAllTenants(
+      @Authenticated("admin") final CamundaClient adminClient,
+      @Authenticated("user1") final CamundaClient camundaClient) {
+    // given
+    // a job set for collecting jobs in the client
+    final var jobCollector = new HashSet<ActivatedJob>();
+    // and a job stream command created by the user1 client, with their authorizations
+    final var command =
+        camundaClient
+            .newStreamJobsCommand()
+            .jobType(JOB_TYPE)
+            .consumer(job -> jobCollector.add(job))
+            .tenantIds(TENANT_A, TENANT_B);
+
+    // when
+    // a stream is opened
+    assertThatThrownBy(() -> command.send().cancel(true))
+        // then
+        .hasMessageContaining(
+            "Expected to find authorizations for all tenants, but found only for tenants: [tenantA]");
+  }
+
+  @Test
+  public void shouldReceiveNoJobsWhenNotAuthorized(
+      @Authenticated("admin") final CamundaClient adminClient,
+      @Authenticated("user1") final CamundaClient camundaClient) {
+    // given
+    // a job set for collecting jobs in the client
+    final var jobCollector = new HashSet<ActivatedJob>();
+    // and a job stream created by the user1 client, with their authorizations
+    final var stream =
+        camundaClient
+            .newStreamJobsCommand()
+            .jobType(JOB_TYPE)
+            .consumer(job -> jobCollector.add(job))
+            .tenantId(TENANT_A)
+            .send();
+
+    // when
+    // two process instances with jobs are created (one for each tenant)
+    try {
+      startProcessInstance(adminClient, PROCESS_ID_1, TENANT_A);
+      startProcessInstance(adminClient, PROCESS_ID_1, TENANT_B);
+      waitForJobsBeingExported(adminClient, 2, PROCESS_ID_1);
+
+      // then
+      // expect that  the camunda client of user1 receives no job
+      assertThat(jobCollector).isEmpty();
+    } finally {
+      // ensure that the stream is closed
+      stream.cancel(true);
+    }
+  }
+
+  @Test
+  public void shouldReceiveOnlyAuthorizedJobs(
+      @Authenticated("admin") final CamundaClient adminClient,
+      @Authenticated("user2") final CamundaClient camundaClient) {
+    // given
+    // a job set for collecting jobs in the client
+    final var jobCollector = new HashSet<ActivatedJob>();
+    // and a job stream created by the user1 client, with their authorizations
+    final var stream =
+        camundaClient
+            .newStreamJobsCommand()
+            .jobType(JOB_TYPE)
+            .consumer(job -> jobCollector.add(job))
+            .tenantIds(TENANT_A, TENANT_B)
+            .send();
+
+    // when
+    // two process instances with jobs are created (one for each tenant)
+    try {
+      startProcessInstance(adminClient, PROCESS_ID_1, TENANT_A);
+      startProcessInstance(adminClient, PROCESS_ID_1, TENANT_B);
+      startProcessInstance(adminClient, PROCESS_ID_2, TENANT_B);
+      waitForJobsBeingExported(adminClient, 3, PROCESS_ID_1, PROCESS_ID_2);
+
+      // then
+      // expect that  the camunda client of user2 receives one job
+      assertThat(jobCollector).hasSize(1);
+      assertThat(jobCollector.iterator().next().getTenantId()).isEqualTo(TENANT_B);
+    } finally {
+      // ensure that the stream is closed
+      stream.cancel(true);
+    }
+  }
+
+  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient camundaClient, final String username, final String tenant) {
+    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
+  }
+
+  private static void deployResource(
+      final CamundaClient camundaClient, final String resourceName, final String tenant) {
+    camundaClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void deployResource(
+      final CamundaClient camundaClient,
+      final String resourceName,
+      final BpmnModelInstance modelInstance,
+      final String tenant) {
+    camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(modelInstance, resourceName)
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void startProcessInstance(
+      final CamundaClient camundaClient, final String processId, final String tenant) {
+    camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void waitForJobsBeingExported(
+      final CamundaClient camundaClient, final int expectedJobs, final String... resourceIds) {
+    Awaitility.await("should receive data from secondary storage")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      camundaClient
+                          .newJobSearchRequest()
+                          .filter(filter -> filter.processDefinitionId(fn -> fn.in(resourceIds)))
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(expectedJobs);
+            });
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Collection;
+import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
@@ -122,7 +123,11 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
     mutable.wrap(buffer);
 
     return new ImmutableJobActivationPropertiesImpl(
-        mutable.worker(), mutable.timeout(), mutable.fetchVariables(), mutable.tenantIds());
+        mutable.worker(),
+        mutable.timeout(),
+        mutable.fetchVariables(),
+        mutable.tenantIds(),
+        mutable.authorizations());
   }
 
   @Override
@@ -134,7 +139,8 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
       DirectBuffer worker,
       long timeout,
       Collection<DirectBuffer> fetchVariables,
-      Collection<String> tenantIds)
+      Collection<String> tenantIds,
+      Map<String, Object> authorizations)
       implements JobActivationProperties {
 
     @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -127,7 +127,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
         mutable.timeout(),
         mutable.fetchVariables(),
         mutable.tenantIds(),
-        mutable.authorizations());
+        mutable.claims());
   }
 
   @Override
@@ -140,7 +140,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
       long timeout,
       Collection<DirectBuffer> fetchVariables,
       Collection<String> tenantIds,
-      Map<String, Object> authorizations)
+      Map<String, Object> claims)
       implements JobActivationProperties {
 
     @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/CachesCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/CachesCfg.java
@@ -15,6 +15,8 @@ public final class CachesCfg implements ConfigurationEntry {
   private int formCacheCapacity = EngineConfiguration.DEFAULT_FORM_CACHE_CAPACITY;
   private int processCacheCapacity = EngineConfiguration.DEFAULT_PROCESS_CACHE_CAPACITY;
   private int resourceCacheCapacity = EngineConfiguration.DEFAULT_PROCESS_CACHE_CAPACITY;
+  private int authorizationsCacheCapacity =
+      EngineConfiguration.DEFAULT_AUTHORIZATIONS_CACHE_CAPACITY;
 
   public int getDrgCacheCapacity() {
     return drgCacheCapacity;
@@ -48,6 +50,14 @@ public final class CachesCfg implements ConfigurationEntry {
     this.resourceCacheCapacity = resourceCacheCapacity;
   }
 
+  public int getAuthorizationsCacheCapacity() {
+    return authorizationsCacheCapacity;
+  }
+
+  public void setAuthorizationsCacheCapacity(final int authorizationsCacheCapacity) {
+    this.authorizationsCacheCapacity = authorizationsCacheCapacity;
+  }
+
   @Override
   public String toString() {
     return "CachesCfg{"
@@ -59,6 +69,8 @@ public final class CachesCfg implements ConfigurationEntry {
         + processCacheCapacity
         + ", resourceCacheCapacity="
         + resourceCacheCapacity
+        + ", authorizationsCacheCapacity="
+        + authorizationsCacheCapacity
         + '}';
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -127,6 +127,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setFormCacheCapacity(caches.getFormCacheCapacity())
         .setResourceCacheCapacity(caches.getResourceCacheCapacity())
         .setProcessCacheCapacity(caches.getProcessCacheCapacity())
+        .setAuthorizationsCacheCapacity(caches.getAuthorizationsCacheCapacity())
         .setJobsTimeoutCheckerPollingInterval(jobs.getTimeoutCheckerPollingInterval())
         .setJobsTimeoutCheckerBatchLimit(jobs.getTimeoutCheckerBatchLimit())
         .setValidatorsResultsOutputMaxSize(validators.getResultsOutputMaxSize())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -23,6 +23,7 @@ public final class EngineConfiguration {
   public static final int DEFAULT_DRG_CACHE_CAPACITY = 1000;
   public static final int DEFAULT_FORM_CACHE_CAPACITY = 1000;
   public static final int DEFAULT_PROCESS_CACHE_CAPACITY = 1000;
+  public static final int DEFAULT_AUTHORIZATIONS_CACHE_CAPACITY = 1000;
   public static final Duration DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL = Duration.ofSeconds(1);
   public static final int DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT = Integer.MAX_VALUE;
   public static final int DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE = 12 * 1024;
@@ -57,6 +58,7 @@ public final class EngineConfiguration {
   private int formCacheCapacity = DEFAULT_FORM_CACHE_CAPACITY;
   private int resourceCacheCapacity = DEFAULT_FORM_CACHE_CAPACITY;
   private int processCacheCapacity = DEFAULT_FORM_CACHE_CAPACITY;
+  private int authorizationsCacheCapacity = DEFAULT_AUTHORIZATIONS_CACHE_CAPACITY;
 
   private Duration jobsTimeoutCheckerPollingInterval = DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
   private int jobsTimeoutCheckerBatchLimit = DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT;
@@ -139,6 +141,15 @@ public final class EngineConfiguration {
 
   public EngineConfiguration setProcessCacheCapacity(final int processCacheCapacity) {
     this.processCacheCapacity = processCacheCapacity;
+    return this;
+  }
+
+  public int getAuthorizationsCacheCapacity() {
+    return authorizationsCacheCapacity;
+  }
+
+  public EngineConfiguration setAuthorizationsCacheCapacity(final int authorizationsCacheCapacity) {
+    this.authorizationsCacheCapacity = authorizationsCacheCapacity;
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -128,7 +128,8 @@ public final class EngineProcessors {
     final var decisionBehavior =
         new DecisionBehavior(
             DecisionEngineFactory.createDecisionEngine(), processingState, processEngineMetrics);
-    final var authCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
+    final var authCheckBehavior =
+        new AuthorizationCheckBehavior(processingState, securityConfig, config);
     final var asyncRequestBehavior =
         new AsyncRequestBehavior(processingState.getKeyGenerator(), writers.state());
     final var transientProcessMessageSubscriptionState =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -150,7 +150,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             writers,
             processingState.getKeyGenerator(),
             jobMetrics,
-            clock);
+            clock,
+            authCheckBehavior);
 
     multiInstanceInputCollectionBehavior =
         new MultiInstanceInputCollectionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -170,12 +170,8 @@ public class BpmnJobActivationBehavior {
     }
 
     final var authorizations = jobActivationProperties.authorizations();
-    // get authorized tenant IDs
-    // TODO: add cache to avoid repeated calls for same command
     final var authorizedTenantIds =
         authorizationCheckBehavior.getAuthorizedTenantIds(authorizations);
-    // get authorized process IDs
-    // TODO: add cache to avoid repeated calls for same command
     final var authorizedProcessIds =
         authorizationCheckBehavior.getAllAuthorizedScopes(
             new AuthorizationRequest(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -176,6 +176,7 @@ public class BpmnJobActivationBehavior {
                 .authorizationClaims(claims)
                 .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
                 .permissionType(PermissionType.UPDATE_PROCESS_INSTANCE)
+                .addAuthorizationScope(AuthorizationScope.id(jobRecord.getBpmnProcessId()))
                 .tenantId(ownerTenantId)
                 .build())
         .isRight(); // we only care if the job stream is authorized, not why it isn't

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.job.JobVariablesCollector;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer.JobStream;
@@ -21,10 +23,14 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJobImpl;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.time.InstantSource;
 import java.util.Optional;
+import java.util.Set;
 import org.agrona.concurrent.UnsafeBuffer;
 
 /**
@@ -46,6 +52,7 @@ public class BpmnJobActivationBehavior {
   private final KeyGenerator keyGenerator;
   private final JobProcessingMetrics jobMetrics;
   private final InstantSource clock;
+  private final AuthorizationCheckBehavior authorizationCheckBehavior;
 
   public BpmnJobActivationBehavior(
       final JobStreamer jobStreamer,
@@ -53,7 +60,8 @@ public class BpmnJobActivationBehavior {
       final Writers writers,
       final KeyGenerator keyGenerator,
       final JobProcessingMetrics jobMetrics,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     this.jobStreamer = jobStreamer;
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;
@@ -61,6 +69,7 @@ public class BpmnJobActivationBehavior {
     stateWriter = writers.state();
     sideEffectWriter = writers.sideEffect();
     this.clock = clock;
+    authorizationCheckBehavior = authCheckBehavior;
   }
 
   public void publishWork(final long jobKey, final JobRecord jobRecord) {
@@ -69,11 +78,10 @@ public class BpmnJobActivationBehavior {
 
     final String jobType = wrappedJobRecord.getType();
     final JobKind jobKind = wrappedJobRecord.getJobKind();
-    final String tenantId = wrappedJobRecord.getTenantId();
     final Optional<JobStream> optionalJobStream =
         jobStreamer.streamFor(
             wrappedJobRecord.getTypeBuffer(),
-            jobActivationProperties -> jobActivationProperties.tenantIds().contains(tenantId));
+            jobActivationProperties -> isAuthorized(jobActivationProperties, wrappedJobRecord));
 
     if (optionalJobStream.isPresent()) {
       final JobStream jobStream = optionalJobStream.get();
@@ -149,5 +157,40 @@ public class BpmnJobActivationBehavior {
     final var jobCopyBuffer = new UnsafeBuffer(bytes);
     jobRecord.write(jobCopyBuffer, 0);
     jobRecordClone.wrap(jobCopyBuffer, 0, jobRecord.getLength());
+  }
+
+  private boolean isAuthorized(
+      final JobActivationProperties jobActivationProperties, final JobRecord jobRecord) {
+
+    final var ownerTenantId = jobRecord.getTenantId();
+    final var tenantIds = jobActivationProperties.tenantIds().stream().toList();
+    if (!tenantIds.contains(ownerTenantId)) {
+      // don't push jobs to workers that don't request them from the job's tenant
+      return false;
+    }
+
+    final var authorizations = jobActivationProperties.authorizations();
+    // get authorized tenant IDs
+    // TODO: add cache to avoid repeated calls for same command
+    final var authorizedTenantIds =
+        authorizationCheckBehavior.getAuthorizedTenantIds(authorizations);
+    // get authorized process IDs
+    // TODO: add cache to avoid repeated calls for same command
+    final var authorizedProcessIds =
+        authorizationCheckBehavior.getAllAuthorizedScopes(
+            new AuthorizationRequest(
+                authorizations,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.UPDATE_PROCESS_INSTANCE,
+                ownerTenantId));
+
+    return authorizedTenantIds.isAuthorizedForTenantIds(tenantIds)
+        && isAuthorizedForJob(jobRecord, authorizedProcessIds);
+  }
+
+  private boolean isAuthorizedForJob(
+      final JobRecord jobRecord, final Set<AuthorizationScope> authorizedProcessIds) {
+    return authorizedProcessIds.contains(AuthorizationScope.WILDCARD)
+        || authorizedProcessIds.contains(AuthorizationScope.id(jobRecord.getBpmnProcessId()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -771,7 +771,7 @@ public final class AuthorizationCheckBehavior {
           isTenantOwnedResource,
           tenantId,
           Collections.unmodifiableSet(authorizationScopes),
-          false,
+          true,
           RecordMetadataDecoder.batchOperationReferenceNullValue());
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -64,7 +64,7 @@ public final class AuthorizationCheckBehavior {
   private final boolean multiTenancyEnabled;
 
   private final LoadingCache<AuthorizationRequestMetadata, Either<Rejection, Void>>
-      authorizationScopeCache;
+      authorizationsCache;
 
   public AuthorizationCheckBehavior(
       final ProcessingState processingState,
@@ -76,7 +76,7 @@ public final class AuthorizationCheckBehavior {
     authorizationsEnabled = securityConfig.getAuthorizations().isEnabled();
     multiTenancyEnabled = securityConfig.getMultiTenancy().isChecksEnabled();
 
-    authorizationScopeCache =
+    authorizationsCache =
         CacheBuilder.newBuilder()
             .maximumSize(config.getAuthorizationsCacheCapacity())
             .build(
@@ -122,7 +122,7 @@ public final class AuthorizationCheckBehavior {
    */
   public Either<Rejection, Void> isAuthorized(final AuthorizationRequestMetadata request) {
     try {
-      return authorizationScopeCache.get(request);
+      return authorizationsCache.get(request);
     } catch (final ExecutionException e) {
       return Either.left(
           new Rejection(
@@ -606,8 +606,8 @@ public final class AuthorizationCheckBehavior {
     return MappingRuleMatcher.matchingRules(mappingRuleState.getAll().stream(), claims);
   }
 
-  public void clearAuthorizationScopeCache() {
-    authorizationScopeCache.invalidateAll();
+  public void clearAuthorizationsCache() {
+    authorizationsCache.invalidateAll();
   }
 
   public record AuthorizationRequestMetadata(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -105,10 +105,11 @@ public final class AuthorizationCheckBehavior {
   // Helper methods
   private boolean shouldSkipAuthorization(final AuthorizationRequest request) {
     return (!authorizationsEnabled && !multiTenancyEnabled)
-        || (!request.getCommand().hasRequestMetadata()
+        || (request.isCommandAuthorization()
+            && !request.getCommand().hasRequestMetadata()
             && request.getCommand().getBatchOperationReference()
                 == batchOperationReferenceNullValue())
-        || isAuthorizedAnonymousUser(request.getCommand());
+        || isAuthorizedAnonymousUser(request.getAuthorizationClaims());
   }
 
   private AuthorizationResult checkPrimaryAuthorization(
@@ -180,7 +181,7 @@ public final class AuthorizationCheckBehavior {
           owners.stream()
               .noneMatch(
                   entity ->
-                      getAuthorizedTenantIds(request.command, entityType, entity)
+                      getAuthorizedTenantIds(request.getAuthorizationClaims(), entityType, entity)
                           .anyMatch(request.tenantId::equals));
       if (notAssignedToTenant) {
         final var rejectionType =
@@ -217,7 +218,7 @@ public final class AuthorizationCheckBehavior {
             .flatMap(
                 entityId ->
                     getAuthorizedScopes(
-                        request.command,
+                        request.getAuthorizationClaims(),
                         entityType,
                         entityId,
                         request.getResourceType(),
@@ -294,37 +295,37 @@ public final class AuthorizationCheckBehavior {
    * requests and commands anonymously. This is helpful especially if the gateway, for example,
    * already checks authorizations and tenancy.
    */
-  private boolean isAuthorizedAnonymousUser(final TypedRecord<?> command) {
-    final var authorizationClaims = command.getAuthorizations();
+  private boolean isAuthorizedAnonymousUser(final Map<String, Object> authorizationClaims) {
     final var authorizedAnonymousUserClaim =
         authorizationClaims.get(Authorization.AUTHORIZED_ANONYMOUS_USER);
     return Optional.ofNullable(authorizedAnonymousUserClaim).map(Boolean.class::cast).orElse(false);
   }
 
   private Optional<String> getUsername(final AuthorizationRequest request) {
-    return getUsername(request.getCommand());
+    return getUsername(request.getAuthorizationClaims());
   }
 
-  private Optional<String> getUsername(final TypedRecord<?> command) {
-    return Optional.ofNullable(
-        (String) command.getAuthorizations().get(Authorization.AUTHORIZED_USERNAME));
+  private Optional<String> getUsername(final Map<String, Object> authorizationClaims) {
+    return Optional.ofNullable((String) authorizationClaims.get(Authorization.AUTHORIZED_USERNAME));
   }
 
   private Optional<String> getClientId(final AuthorizationRequest request) {
-    return getClientId(request.getCommand());
+    return getClientId(request.getAuthorizationClaims());
   }
 
-  private Optional<String> getClientId(final TypedRecord<?> command) {
+  private Optional<String> getClientId(final Map<String, Object> authorizationClaims) {
     return Optional.ofNullable(
-        (String) command.getAuthorizations().get(Authorization.AUTHORIZED_CLIENT_ID));
+        (String) authorizationClaims.get(Authorization.AUTHORIZED_CLIENT_ID));
   }
 
   private Stream<String> getAuthorizedTenantIds(
-      final TypedRecord<?> command, final EntityType entityType, final String entityId) {
+      final Map<String, Object> authorizations,
+      final EntityType entityType,
+      final String entityId) {
     return Stream.concat(
         membershipState.getMemberships(entityType, entityId, RelationType.TENANT).stream(),
         Stream.concat(
-            fetchGroups(command, entityType, entityId).stream()
+            fetchGroups(authorizations, entityType, entityId).stream()
                 .flatMap(
                     groupId ->
                         Stream.concat(
@@ -349,7 +350,7 @@ public final class AuthorizationCheckBehavior {
   }
 
   public Set<AuthorizationScope> getAllAuthorizedScopes(final AuthorizationRequest request) {
-    if (!authorizationsEnabled || isAuthorizedAnonymousUser(request.getCommand())) {
+    if (!authorizationsEnabled || isAuthorizedAnonymousUser(request.getAuthorizationClaims())) {
       return Set.of(AuthorizationScope.WILDCARD);
     }
 
@@ -358,7 +359,7 @@ public final class AuthorizationCheckBehavior {
     final var optionalClientId = getClientId(request);
     if (optionalClientId.isPresent()) {
       getAuthorizedScopes(
-              request.command,
+              request.getAuthorizationClaims(),
               EntityType.CLIENT,
               optionalClientId.get(),
               request.getResourceType(),
@@ -371,7 +372,7 @@ public final class AuthorizationCheckBehavior {
           .map(
               username ->
                   getAuthorizedScopes(
-                      request.command,
+                      request.getAuthorizationClaims(),
                       EntityType.USER,
                       username,
                       request.getResourceType(),
@@ -384,7 +385,7 @@ public final class AuthorizationCheckBehavior {
         .flatMap(
             mappingRule ->
                 getAuthorizedScopes(
-                    request.command,
+                    request.getAuthorizationClaims(),
                     EntityType.MAPPING_RULE,
                     mappingRule.getMappingRuleId(),
                     request.getResourceType(),
@@ -409,7 +410,7 @@ public final class AuthorizationCheckBehavior {
   }
 
   private Stream<AuthorizationScope> getAuthorizedScopes(
-      final TypedRecord<?> command,
+      final Map<String, Object> authorizationClaims,
       final EntityType ownerType,
       final String ownerId,
       final AuthorizationResourceType resourceType,
@@ -436,7 +437,7 @@ public final class AuthorizationCheckBehavior {
                         AuthorizationOwnerType.ROLE, roleId, resourceType, permissionType)
                         .stream());
     final var viaGroups =
-        fetchGroups(command, ownerType, ownerId).stream()
+        fetchGroups(authorizationClaims, ownerType, ownerId).stream()
             .<AuthorizationScope>mapMulti(
                 (groupId, stream) -> {
                   getDirectAuthorizedAuthorizationScopes(
@@ -456,9 +457,9 @@ public final class AuthorizationCheckBehavior {
   }
 
   private List<String> fetchGroups(
-      final TypedRecord<?> command, final EntityType ownerType, final String ownerId) {
+      final Map<String, Object> authorizations, final EntityType ownerType, final String ownerId) {
     final List<String> groupsClaims =
-        (List<String>) command.getAuthorizations().get(Authorization.USER_GROUPS_CLAIMS);
+        (List<String>) authorizations.get(Authorization.USER_GROUPS_CLAIMS);
     if (groupsClaims != null) {
       return groupsClaims;
     }
@@ -489,7 +490,11 @@ public final class AuthorizationCheckBehavior {
   }
 
   public AuthorizedTenants getAuthorizedTenantIds(final TypedRecord<?> command) {
-    if (isAuthorizedAnonymousUser(command)) {
+    return getAuthorizedTenantIds(command.getAuthorizations());
+  }
+
+  public AuthorizedTenants getAuthorizedTenantIds(final Map<String, Object> authorizations) {
+    if (isAuthorizedAnonymousUser(authorizations)) {
       return AuthorizedTenants.ANONYMOUS;
     }
 
@@ -498,26 +503,26 @@ public final class AuthorizationCheckBehavior {
     }
 
     final var authorizedTenants = new HashSet<String>();
-    getUsername(command)
+    getUsername(authorizations)
         .ifPresent(
             username ->
                 authorizedTenants.addAll(
-                    getAuthorizedTenantIds(command, EntityType.USER, username)
+                    getAuthorizedTenantIds(authorizations, EntityType.USER, username)
                         .collect(Collectors.toSet())));
 
-    getClientId(command)
+    getClientId(authorizations)
         .ifPresent(
             clientId ->
                 authorizedTenants.addAll(
-                    getAuthorizedTenantIds(command, EntityType.CLIENT, clientId)
+                    getAuthorizedTenantIds(authorizations, EntityType.CLIENT, clientId)
                         .collect(Collectors.toSet())));
 
     final var tenantsOfMappingRule =
-        getPersistedMappingRules(command)
+        getPersistedMappingRules(authorizations)
             .flatMap(
                 mappingRule ->
                     getAuthorizedTenantIds(
-                        command, EntityType.MAPPING_RULE, mappingRule.getMappingRuleId()))
+                        authorizations, EntityType.MAPPING_RULE, mappingRule.getMappingRuleId()))
             .collect(Collectors.toSet());
     authorizedTenants.addAll(tenantsOfMappingRule);
 
@@ -526,33 +531,39 @@ public final class AuthorizationCheckBehavior {
 
   private Stream<PersistedMappingRule> getPersistedMappingRules(
       final AuthorizationRequest request) {
-    return getPersistedMappingRules(request.getCommand());
+    return getPersistedMappingRules(request.getAuthorizationClaims());
   }
 
-  private Stream<PersistedMappingRule> getPersistedMappingRules(final TypedRecord<?> command) {
+  private Stream<PersistedMappingRule> getPersistedMappingRules(
+      final Map<String, Object> authorizations) {
     final var claims =
         (Map<String, Object>)
-            command.getAuthorizations().getOrDefault(Authorization.USER_TOKEN_CLAIMS, Map.of());
+            authorizations.getOrDefault(Authorization.USER_TOKEN_CLAIMS, Map.of());
     return MappingRuleMatcher.matchingRules(mappingRuleState.getAll().stream(), claims);
   }
 
   public static final class AuthorizationRequest {
     private final TypedRecord<?> command;
+    private final Map<String, Object> authorizationClaims;
     private final AuthorizationResourceType resourceType;
     private final PermissionType permissionType;
     private final Set<AuthorizationScope> authorizationScopes;
     private final String tenantId;
     private final boolean isNewResource;
     private final boolean isTenantOwnedResource;
+    private final boolean isCommandAuthorization;
 
     public AuthorizationRequest(
         final TypedRecord<?> command,
+        final Map<String, Object> authorizationClaims,
         final AuthorizationResourceType resourceType,
         final PermissionType permissionType,
         final String tenantId,
         final boolean isNewResource,
-        final boolean isTenantOwnedResource) {
+        final boolean isTenantOwnedResource,
+        final boolean isCommandAuthorization) {
       this.command = command;
+      this.authorizationClaims = authorizationClaims;
       this.resourceType = resourceType;
       this.permissionType = permissionType;
       authorizationScopes = new HashSet<>();
@@ -560,6 +571,7 @@ public final class AuthorizationCheckBehavior {
       this.tenantId = tenantId;
       this.isNewResource = isNewResource;
       this.isTenantOwnedResource = isTenantOwnedResource;
+      this.isCommandAuthorization = isCommandAuthorization;
     }
 
     public AuthorizationRequest(
@@ -568,7 +580,7 @@ public final class AuthorizationCheckBehavior {
         final PermissionType permissionType,
         final String tenantId,
         final boolean isNewResource) {
-      this(command, resourceType, permissionType, tenantId, isNewResource, true);
+      this(command, null, resourceType, permissionType, tenantId, isNewResource, true, true);
     }
 
     public AuthorizationRequest(
@@ -576,14 +588,22 @@ public final class AuthorizationCheckBehavior {
         final AuthorizationResourceType resourceType,
         final PermissionType permissionType,
         final String tenantId) {
-      this(command, resourceType, permissionType, tenantId, false, true);
+      this(command, null, resourceType, permissionType, tenantId, false, true, true);
+    }
+
+    public AuthorizationRequest(
+        final Map<String, Object> authorizationClaims,
+        final AuthorizationResourceType resourceType,
+        final PermissionType permissionType,
+        final String tenantId) {
+      this(null, authorizationClaims, resourceType, permissionType, tenantId, false, true, false);
     }
 
     public AuthorizationRequest(
         final TypedRecord<?> command,
         final AuthorizationResourceType resourceType,
         final PermissionType permissionType) {
-      this(command, resourceType, permissionType, null, false, false);
+      this(command, null, resourceType, permissionType, null, false, false, true);
     }
 
     public TypedRecord<?> getCommand() {
@@ -606,6 +626,10 @@ public final class AuthorizationCheckBehavior {
       return isTenantOwnedResource;
     }
 
+    public boolean isCommandAuthorization() {
+      return isCommandAuthorization;
+    }
+
     public AuthorizationRequest addAuthorizationScope(final AuthorizationScope authorizationScope) {
       authorizationScopes.add(authorizationScope);
       return this;
@@ -614,6 +638,10 @@ public final class AuthorizationCheckBehavior {
     public AuthorizationRequest addResourceId(final String resourceId) {
       authorizationScopes.add(AuthorizationScope.of(resourceId));
       return this;
+    }
+
+    public Map<String, Object> getAuthorizationClaims() {
+      return isCommandAuthorization ? command.getAuthorizations() : authorizationClaims;
     }
 
     public Set<AuthorizationScope> getAuthorizationScopes() {
@@ -675,8 +703,6 @@ public final class AuthorizationCheckBehavior {
 
   private record AuthorizationRejection(
       Rejection rejection, AuthorizationRejectionType authorizationRejectionType) {}
-
-  private record UserTokenClaim(String claimName, String claimValue) {}
 
   private enum AuthorizationRejectionType {
     TENANT,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -30,7 +31,9 @@ public class AuthorizationCreateProcessor
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
+  private final SideEffectWriter sideEffectWriter;
   private final PermissionsBehavior permissionsBehavior;
+  private final AuthorizationCheckBehavior authorizationCheckBehavior;
   private final UserState userState;
 
   public AuthorizationCreateProcessor(
@@ -44,6 +47,8 @@ public class AuthorizationCreateProcessor
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
+    sideEffectWriter = writers.sideEffect();
+    authorizationCheckBehavior = authCheckBehavior;
     permissionsBehavior = new PermissionsBehavior(processingState, authCheckBehavior);
     userState = processingState.getUserState();
   }
@@ -75,9 +80,15 @@ public class AuthorizationCreateProcessor
         .mappingRuleExists(command.getValue())
         .flatMap(permissionsBehavior::permissionsAlreadyExist)
         .ifRightOrLeft(
-            ignored ->
-                stateWriter.appendFollowUpEvent(
-                    command.getKey(), AuthorizationIntent.CREATED, command.getValue()),
+            ignored -> {
+              stateWriter.appendFollowUpEvent(
+                  command.getKey(), AuthorizationIntent.CREATED, command.getValue());
+              sideEffectWriter.appendSideEffect(
+                  () -> {
+                    authorizationCheckBehavior.clearAuthorizationScopeCache();
+                    return true;
+                  });
+            },
             rejection ->
                 rejectionWriter.appendRejection(command, rejection.type(), rejection.reason()));
 
@@ -96,5 +107,10 @@ public class AuthorizationCreateProcessor
         .withKey(key)
         .inQueue(DistributionQueue.IDENTITY.getQueueId())
         .distribute(command);
+    sideEffectWriter.appendSideEffect(
+        () -> {
+          authorizationCheckBehavior.clearAuthorizationScopeCache();
+          return true;
+        });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -85,7 +85,7 @@ public class AuthorizationCreateProcessor
                   command.getKey(), AuthorizationIntent.CREATED, command.getValue());
               sideEffectWriter.appendSideEffect(
                   () -> {
-                    authorizationCheckBehavior.clearAuthorizationScopeCache();
+                    authorizationCheckBehavior.clearAuthorizationsCache();
                     return true;
                   });
             },
@@ -109,7 +109,7 @@ public class AuthorizationCreateProcessor
         .distribute(command);
     sideEffectWriter.appendSideEffect(
         () -> {
-          authorizationCheckBehavior.clearAuthorizationScopeCache();
+          authorizationCheckBehavior.clearAuthorizationsCache();
           return true;
         });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -84,7 +84,7 @@ public class AuthorizationDeleteProcessor
                   command.getValue());
               sideEffectWriter.appendSideEffect(
                   () -> {
-                    authorizationCheckBehavior.clearAuthorizationScopeCache();
+                    authorizationCheckBehavior.clearAuthorizationsCache();
                     return true;
                   });
             },
@@ -111,7 +111,7 @@ public class AuthorizationDeleteProcessor
         authorizationKey, AuthorizationIntent.DELETED, command.getValue(), command);
     sideEffectWriter.appendSideEffect(
         () -> {
-          authorizationCheckBehavior.clearAuthorizationScopeCache();
+          authorizationCheckBehavior.clearAuthorizationsCache();
           return true;
         });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.engine.processing.identity.PermissionsBehavior.AU
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -30,6 +31,8 @@ public class AuthorizationUpdateProcessor
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
+  private final SideEffectWriter sideEffectWriter;
+  private final AuthorizationCheckBehavior authorizationCheckBehavior;
   private final PermissionsBehavior permissionsBehavior;
 
   public AuthorizationUpdateProcessor(
@@ -43,6 +46,8 @@ public class AuthorizationUpdateProcessor
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
+    sideEffectWriter = writers.sideEffect();
+    authorizationCheckBehavior = authCheckBehavior;
     permissionsBehavior = new PermissionsBehavior(processingState, authCheckBehavior);
   }
 
@@ -79,11 +84,17 @@ public class AuthorizationUpdateProcessor
                 permissionsBehavior.authorizationExists(
                     s, AUTHORIZATION_DOES_NOT_EXIST_ERROR_MESSAGE_UPDATE))
         .ifRightOrLeft(
-            ignored ->
-                stateWriter.appendFollowUpEvent(
-                    command.getValue().getAuthorizationKey(),
-                    AuthorizationIntent.UPDATED,
-                    command.getValue()),
+            ignored -> {
+              stateWriter.appendFollowUpEvent(
+                  command.getValue().getAuthorizationKey(),
+                  AuthorizationIntent.UPDATED,
+                  command.getValue());
+              sideEffectWriter.appendSideEffect(
+                  () -> {
+                    authorizationCheckBehavior.clearAuthorizationsCache();
+                    return true;
+                  });
+            },
             rejection ->
                 rejectionWriter.appendRejection(command, rejection.type(), rejection.reason()));
 
@@ -107,5 +118,10 @@ public class AuthorizationUpdateProcessor
         AuthorizationIntent.UPDATED,
         authorizationRecord,
         command);
+    sideEffectWriter.appendSideEffect(
+        () -> {
+          authorizationCheckBehavior.clearAuthorizationsCache();
+          return true;
+        });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -113,7 +113,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     responseWriter.writeEventOnCommand(tenantKey, TenantIntent.ENTITY_ADDED, record, command);
     sideEffectWriter.appendSideEffect(
         () -> {
-          authCheckBehavior.clearTenantIdCache();
+          authCheckBehavior.clearAuthorizationsCache();
           return true;
         });
 
@@ -130,7 +130,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       stateWriter.appendFollowUpEvent(command.getKey(), TenantIntent.ENTITY_ADDED, record);
       sideEffectWriter.appendSideEffect(
           () -> {
-            authCheckBehavior.clearTenantIdCache();
+            authCheckBehavior.clearAuthorizationsCache();
             return true;
           });
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -103,7 +103,7 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     responseWriter.writeEventOnCommand(tenantKey, TenantIntent.ENTITY_REMOVED, record, command);
     sideEffectWriter.appendSideEffect(
         () -> {
-          authCheckBehavior.clearTenantIdCache();
+          authCheckBehavior.clearAuthorizationsCache();
           return true;
         });
 
@@ -117,7 +117,7 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
           command.getKey(), TenantIntent.ENTITY_REMOVED, command.getValue());
       sideEffectWriter.appendSideEffect(
           () -> {
-            authCheckBehavior.clearTenantIdCache();
+            authCheckBehavior.clearAuthorizationsCache();
             return true;
           });
     }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.state.appliers.AuthorizationCreatedApplier;
@@ -70,9 +71,11 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
   public void before() {
     final var securityConfig = new SecurityConfiguration();
     final var authConfig = new AuthorizationsConfiguration();
+    final var engineConfig = new EngineConfiguration();
     authConfig.setEnabled(true);
     securityConfig.setAuthorizations(authConfig);
-    authorizationCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
+    authorizationCheckBehavior =
+        new AuthorizationCheckBehavior(processingState, securityConfig, engineConfig);
 
     userCreatedApplier = new UserCreatedApplier(processingState.getUserState());
     mappingRuleCreatedApplier =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -122,6 +122,28 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
   }
 
   @Test
+  void shouldCreateAuthorizationRequestWithoutCommand() {
+    // given
+    final var user = createUser();
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
+    final var tenantId = createAndAssignTenant(user.getUsername(), EntityType.USER);
+    final Map<String, Object> authorizationClaims = Map.of(AUTHORIZED_USERNAME, user.getUsername());
+
+    // when
+    final var request =
+        new AuthorizationRequest(authorizationClaims, resourceType, permissionType, tenantId)
+            .addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    assertThat(authorized.isRight()).isTrue();
+  }
+
+  @Test
   void shouldBeAuthorizedForUserTenantThroughGroup() {
     // given
     final var user = createUser();
@@ -369,7 +391,8 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType, null, false, false)
+        new AuthorizationRequest(
+                command, null, resourceType, permissionType, null, false, false, true)
             .addResourceId(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -125,28 +125,6 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
   }
 
   @Test
-  void shouldCreateAuthorizationRequestWithoutCommand() {
-    // given
-    final var user = createUser();
-    final var resourceType = AuthorizationResourceType.RESOURCE;
-    final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
-    final var tenantId = createAndAssignTenant(user.getUsername(), EntityType.USER);
-    final Map<String, Object> authorizationClaims = Map.of(AUTHORIZED_USERNAME, user.getUsername());
-
-    // when
-    final var request =
-        new AuthorizationRequest(authorizationClaims, resourceType, permissionType, tenantId)
-            .addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
-
-    // then
-    assertThat(authorized.isRight()).isTrue();
-  }
-
-  @Test
   void shouldBeAuthorizedForUserTenantThroughGroup() {
     // given
     final var user = createUser();
@@ -394,8 +372,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
 
     // when
     final var request =
-        new AuthorizationRequest(
-                command, null, resourceType, permissionType, null, false, false, true)
+        new AuthorizationRequest(command, resourceType, permissionType, null, false, false)
             .addResourceId(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
@@ -79,12 +80,14 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
   void before() {
     final var securityConfig = new SecurityConfiguration();
     final var authConfig = new AuthorizationsConfiguration();
+    final var engineConfig = new EngineConfiguration();
     authConfig.setEnabled(true);
     securityConfig.setAuthorizations(authConfig);
     final var multiTenancyConfig = new MultiTenancyConfiguration();
     multiTenancyConfig.setChecksEnabled(true);
     securityConfig.setMultiTenancy(multiTenancyConfig);
-    authorizationCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
+    authorizationCheckBehavior =
+        new AuthorizationCheckBehavior(processingState, securityConfig, engineConfig);
 
     userCreatedApplier = new UserCreatedApplier(processingState.getUserState());
     mappingRuleCreatedApplier =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.state.appliers.AuthorizationCreatedApplier;
@@ -72,9 +73,11 @@ final class AuthorizationCheckBehaviorTest {
   public void before() {
     final var securityConfig = new SecurityConfiguration();
     final var authConfig = new AuthorizationsConfiguration();
+    final var engineConfig = new EngineConfiguration();
     authConfig.setEnabled(true);
     securityConfig.setAuthorizations(authConfig);
-    authorizationCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
+    authorizationCheckBehavior =
+        new AuthorizationCheckBehavior(processingState, securityConfig, engineConfig);
 
     userCreatedApplier = new UserCreatedApplier(processingState.getUserState());
     mappingRuleCreatedApplier =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessorTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.*;
 
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -59,7 +60,8 @@ class BatchOperationSuspendProcessorTest {
     when(state.getBatchOperationState()).thenReturn(batchOperationState);
 
     final var authCheckBehavior = mock(AuthorizationCheckBehavior.class);
-    when(authCheckBehavior.isAuthorized(any())).thenReturn(Either.right(null));
+    when(authCheckBehavior.isAuthorized(any(AuthorizationRequest.class)))
+        .thenReturn(Either.right(null));
 
     when(keyGenerator.nextKey()).thenReturn(1L);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -61,7 +61,9 @@ final class JobBatchCollectorTest {
   void beforeEach() {
     final var authorizationCheckBehavior =
         new AuthorizationCheckBehavior(
-            state, SecurityConfigurations.unauthenticatedAndUnauthorized());
+            state,
+            SecurityConfigurations.unauthenticatedAndUnauthorized(),
+            new EngineConfiguration());
     collector = new JobBatchCollector(state, lengthEvaluator, authorizationCheckBehavior);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenancyActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenancyActivatableJobsPushTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
 import static io.camunda.zeebe.test.util.record.RecordingExporter.jobBatchRecords;
 import static io.camunda.zeebe.test.util.record.RecordingExporter.records;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.util.Strings;
@@ -42,7 +44,12 @@ public class MultiTenancyActivatableJobsPushTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition().withJobStreamer(JOB_STREAMER);
+      EngineRule.singlePartition()
+          .withJobStreamer(JOB_STREAMER)
+          .withSecurityConfig(
+              config -> {
+                config.getMultiTenancy().setChecksEnabled(true);
+              });
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
@@ -58,21 +65,41 @@ public class MultiTenancyActivatableJobsPushTest {
     final DirectBuffer worker = BufferUtil.wrapString("test");
     final Map<String, Object> variables = Map.of("a", "valA", "b", "valB", "c", "valC");
     final long timeout = 30000L;
+    final String username = Strings.newRandomValidIdentityId();
     final String tenantIdA = "tenant-a";
-    final String tenantIdB = "tenant-a";
+    final String tenantIdB = "tenant-b";
 
-    final JobActivationPropertiesImpl jobActivationProperties =
+    ENGINE.tenant().newTenant().withTenantId(tenantIdA).create();
+    ENGINE.tenant().newTenant().withTenantId(tenantIdB).create();
+    ENGINE.user().newUser(username).create();
+    ENGINE
+        .tenant()
+        .addEntity(tenantIdA)
+        .withEntityId(username)
+        .withEntityType(EntityType.USER)
+        .add();
+    final Map<String, Object> authorizationClaims = Map.of(AUTHORIZED_USERNAME, username);
+
+    final JobActivationPropertiesImpl jobActivationPropertiesA =
         new JobActivationPropertiesImpl()
             .setWorker(worker, 0, worker.capacity())
             .setTimeout(timeout)
             .setFetchVariables(
-                List.of(new StringValue("a"), new StringValue("b"), new StringValue("c")));
-    final var jobStreamA =
-        JOB_STREAMER.addJobStream(
-            jobTypeBuffer, jobActivationProperties.setTenantIds(List.of(tenantIdA)));
-    final var jobStreamB =
-        JOB_STREAMER.addJobStream(
-            jobTypeBuffer, jobActivationProperties.setTenantIds(List.of(tenantIdB)));
+                List.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
+            .setAuthorizations(authorizationClaims)
+            .setTenantIds(List.of(tenantIdA));
+
+    final JobActivationPropertiesImpl jobActivationPropertiesB =
+        new JobActivationPropertiesImpl()
+            .setWorker(worker, 0, worker.capacity())
+            .setTimeout(timeout)
+            .setFetchVariables(
+                List.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
+            .setAuthorizations(authorizationClaims)
+            .setTenantIds(List.of(tenantIdB));
+
+    final var jobStreamA = JOB_STREAMER.addJobStream(jobTypeBuffer, jobActivationPropertiesA);
+    final var jobStreamB = JOB_STREAMER.addJobStream(jobTypeBuffer, jobActivationPropertiesB);
 
     final int activationCount = 1;
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenancyActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenancyActivatableJobsPushTest.java
@@ -86,7 +86,7 @@ public class MultiTenancyActivatableJobsPushTest {
             .setTimeout(timeout)
             .setFetchVariables(
                 List.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
-            .setAuthorizations(authorizationClaims)
+            .setClaims(authorizationClaims)
             .setTenantIds(List.of(tenantIdA));
 
     final JobActivationPropertiesImpl jobActivationPropertiesB =
@@ -95,7 +95,7 @@ public class MultiTenancyActivatableJobsPushTest {
             .setTimeout(timeout)
             .setFetchVariables(
                 List.of(new StringValue("a"), new StringValue("b"), new StringValue("c")))
-            .setAuthorizations(authorizationClaims)
+            .setClaims(authorizationClaims)
             .setTenantIds(List.of(tenantIdB));
 
     final var jobStreamA = JOB_STREAMER.addJobStream(jobTypeBuffer, jobActivationPropertiesA);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.metrics.DistributionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
@@ -94,7 +95,8 @@ public final class MessageStreamProcessorTest {
           final var processingState = processingContext.getProcessingState();
           final var scheduledTaskState = processingContext.getScheduledTaskStateFactory();
           final var mockAuthCheckBehavior = mock(AuthorizationCheckBehavior.class);
-          when(mockAuthCheckBehavior.isAuthorized(any())).thenReturn(Either.right(null));
+          when(mockAuthCheckBehavior.isAuthorized(any(AuthorizationRequest.class)))
+              .thenReturn(Either.right(null));
           MessageEventProcessors.addMessageProcessors(
               1,
               mock(BpmnBehaviors.class),

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -170,7 +170,8 @@ public final class EndpointManager {
       final ServerCallStreamObserver<ActivatedJob> responseObserver) {
     try {
       final JobActivationProperties brokerRequest =
-          RequestMapper.toJobActivationProperties(request);
+          RequestMapper.toJobActivationProperties(request, getClaims());
+
       streamJobsHandler.handle(request.getType(), brokerRequest, responseObserver);
     } catch (final Exception e) {
       responseObserver.onError(e);
@@ -489,6 +490,12 @@ public final class EndpointManager {
 
     final BrokerRequest<BrokerResponseT> brokerRequest = requestMapper.apply(grpcRequest);
 
+    brokerRequest.setAuthorization(getClaims());
+
+    return brokerRequest;
+  }
+
+  private Map<String, Object> getClaims() throws Exception {
     final Map<String, Object> claims = new HashMap<>();
 
     // retrieve the user claims from the context and add them to the authorization if present
@@ -514,9 +521,7 @@ public final class EndpointManager {
       claims.put(Authorization.USER_GROUPS_CLAIMS, groupsClaims);
     }
 
-    brokerRequest.setAuthorization(claims);
-
-    return brokerRequest;
+    return claims;
   }
 
   private <BrokerResponseT, GrpcResponseT> void consumeResponse(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -416,7 +416,7 @@ public final class RequestMapper extends RequestUtil {
         .setTimeout(request.getTimeout())
         .setFetchVariables(request.getFetchVariableList().stream().map(StringValue::new).toList())
         .setTenantIds(tenantIds)
-        .setAuthorizations(claims);
+        .setClaims(claims);
 
     return jobActivationProperties;
   }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -63,6 +63,7 @@ import io.camunda.zeebe.protocol.record.value.JobResultType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.agrona.DirectBuffer;
@@ -403,7 +404,7 @@ public final class RequestMapper extends RequestUtil {
   }
 
   public static JobActivationProperties toJobActivationProperties(
-      final StreamActivatedJobsRequest request) {
+      final StreamActivatedJobsRequest request, final Map<String, Object> claims) {
 
     List<String> tenantIds = request.getTenantIdsList();
     tenantIds = ensureTenantIdsSet("StreamActivatedJobs", tenantIds);
@@ -414,7 +415,8 @@ public final class RequestMapper extends RequestUtil {
         .setWorker(worker, 0, worker.capacity())
         .setTimeout(request.getTimeout())
         .setFetchVariables(request.getFetchVariableList().stream().map(StringValue::new).toList())
-        .setTenantIds(tenantIds);
+        .setTenantIds(tenantIds)
+        .setAuthorizations(claims);
 
     return jobActivationProperties;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.stream.job;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
+import java.util.Map;
 import org.agrona.DirectBuffer;
 
 /**
@@ -48,4 +49,19 @@ public interface JobActivationProperties extends BufferWriter {
    * @return the identifiers of the tenants for which to activate jobs
    */
   Collection<String> tenantIds();
+
+  /**
+   * Returns the authorization data of the user that triggered the creation of this stream. The
+   * following entries may be available:
+   *
+   * <ul>
+   *   <li>Key: <code>authorized_tenants</code>; Value: a List of Strings defining the user's
+   *       authorized tenants.
+   *   <li>Key: <code>authorized_user_key</code>; Value: the Long representation of the
+   *       authenticated user's key
+   * </ul>
+   *
+   * @return a Map of authorization data for this record or an empty Map if not set.
+   */
+  Map<String, Object> authorizations();
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
@@ -51,17 +51,17 @@ public interface JobActivationProperties extends BufferWriter {
   Collection<String> tenantIds();
 
   /**
-   * Returns the authorization data of the user that triggered the creation of this stream. The
-   * following entries may be available:
+   * Returns the claim data of the user that triggered the creation of this stream. The following
+   * entries may be available:
    *
    * <ul>
    *   <li>Key: <code>authorized_tenants</code>; Value: a List of Strings defining the user's
    *       authorized tenants.
-   *   <li>Key: <code>authorized_user_key</code>; Value: the Long representation of the
-   *       authenticated user's key
+   *   <li>Key: <code>authorized_username</code>; Value: the Long representation of the
+   *       authenticated user's username
    * </ul>
    *
    * @return a Map of authorization data for this record or an empty Map if not set.
    */
-  Map<String, Object> authorizations();
+  Map<String, Object> claims();
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
@@ -30,7 +30,7 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
   private final ArrayProperty<StringValue> tenantIdsProp =
       new ArrayProperty<>(
           "tenantIds", () -> new StringValue(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
-  private final DocumentProperty authorizationsProp = new DocumentProperty("authorizations");
+  private final DocumentProperty claimsProp = new DocumentProperty("claims");
 
   public JobActivationPropertiesImpl() {
     super(5);
@@ -38,7 +38,7 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
         .declareProperty(timeoutProp)
         .declareProperty(fetchVariablesProp)
         .declareProperty(tenantIdsProp)
-        .declareProperty(authorizationsProp);
+        .declareProperty(claimsProp);
   }
 
   public JobActivationPropertiesImpl setWorker(
@@ -85,12 +85,12 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
   }
 
   @Override
-  public Map<String, Object> authorizations() {
-    return MsgPackConverter.convertToMap(authorizationsProp.getValue());
+  public Map<String, Object> claims() {
+    return MsgPackConverter.convertToMap(claimsProp.getValue());
   }
 
-  public JobActivationPropertiesImpl setAuthorizations(final Map<String, Object> authorizations) {
-    authorizationsProp.setValue(getDocumentOrEmpty(authorizations));
+  public JobActivationPropertiesImpl setClaims(final Map<String, Object> authorizations) {
+    claimsProp.setValue(getDocumentOrEmpty(authorizations));
     return this;
   }
 
@@ -98,12 +98,5 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
     return value == null || value.isEmpty()
         ? DocumentValue.EMPTY_DOCUMENT
         : new UnsafeBuffer(MsgPackConverter.convertToMsgPack(value));
-  }
-
-  public void wrap(final JobActivationPropertiesImpl other) {
-    workerProp.setValue(other.workerProp.getValue());
-    timeoutProp.setValue(other.timeoutProp.getValue());
-    other.fetchVariablesProp.forEach(v -> fetchVariablesProp.add().wrap(v));
-    other.tenantIdsProp.forEach(t -> tenantIdsProp.add().wrap(t));
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
@@ -9,13 +9,18 @@ package io.camunda.zeebe.protocol.impl.stream.job;
 
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
+import java.util.Map;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public class JobActivationPropertiesImpl extends UnpackedObject implements JobActivationProperties {
   private final StringProperty workerProp = new StringProperty("worker", "");
@@ -25,13 +30,15 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
   private final ArrayProperty<StringValue> tenantIdsProp =
       new ArrayProperty<>(
           "tenantIds", () -> new StringValue(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+  private final DocumentProperty authorizationsProp = new DocumentProperty("authorizations");
 
   public JobActivationPropertiesImpl() {
-    super(4);
+    super(5);
     declareProperty(workerProp)
         .declareProperty(timeoutProp)
         .declareProperty(fetchVariablesProp)
-        .declareProperty(tenantIdsProp);
+        .declareProperty(tenantIdsProp)
+        .declareProperty(authorizationsProp);
   }
 
   public JobActivationPropertiesImpl setWorker(
@@ -75,5 +82,28 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
   @Override
   public Collection<String> tenantIds() {
     return tenantIdsProp.stream().map(StringValue::toString).toList();
+  }
+
+  @Override
+  public Map<String, Object> authorizations() {
+    return MsgPackConverter.convertToMap(authorizationsProp.getValue());
+  }
+
+  public JobActivationPropertiesImpl setAuthorizations(final Map<String, Object> authorizations) {
+    authorizationsProp.setValue(getDocumentOrEmpty(authorizations));
+    return this;
+  }
+
+  protected DirectBuffer getDocumentOrEmpty(final Map<String, Object> value) {
+    return value == null || value.isEmpty()
+        ? DocumentValue.EMPTY_DOCUMENT
+        : new UnsafeBuffer(MsgPackConverter.convertToMsgPack(value));
+  }
+
+  public void wrap(final JobActivationPropertiesImpl other) {
+    workerProp.setValue(other.workerProp.getValue());
+    timeoutProp.setValue(other.timeoutProp.getValue());
+    other.fetchVariablesProp.forEach(v -> fetchVariablesProp.add().wrap(v));
+    other.tenantIdsProp.forEach(t -> tenantIdsProp.add().wrap(t));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Ensure that tenant and authorization checks are performed when jobs are pushed.

TODO:
- [x] Add authorization caching on job stream check
- [x] The acceptance test might be flaky as the jobs are never completed, so they might time out and be pushed again. I need to handle that before the PR is merged.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37455
