### PR TITLE
fix: configure `ResourceAccessController` beans regardless of having the gateway embedded

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
@@ -22,10 +22,12 @@ import io.camunda.security.reader.ResourceAccessController;
 import io.camunda.security.reader.ResourceAccessProvider;
 import io.camunda.security.reader.TenantAccessProvider;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
+@ConditionalOnWebApplication
 @ConditionalOnSecondaryStorageEnabled
 public class ResourceAccessControllerConfiguration {
 

--- a/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
@@ -22,12 +22,10 @@ import io.camunda.security.reader.ResourceAccessController;
 import io.camunda.security.reader.ResourceAccessProvider;
 import io.camunda.security.reader.TenantAccessProvider;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
-import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnRestGatewayEnabled
 @ConditionalOnSecondaryStorageEnabled
 public class ResourceAccessControllerConfiguration {
 

--- a/dist/src/main/java/io/camunda/application/commons/security/AuthorizationCheckerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/AuthorizationCheckerConfiguration.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.security;
+
+import io.camunda.search.clients.reader.AuthorizationReader;
+import io.camunda.security.impl.AuthorizationChecker;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class AuthorizationCheckerConfiguration {
+  @Bean
+  public AuthorizationChecker authorizationChecker(final AuthorizationReader authorizationReader) {
+    return new AuthorizationChecker(authorizationReader);
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -31,7 +31,6 @@ import io.camunda.search.clients.UsageMetricsSearchClient;
 import io.camunda.search.clients.UserSearchClient;
 import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.clients.VariableSearchClient;
-import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
@@ -521,11 +520,6 @@ public class CamundaServicesConfiguration {
   @Bean
   public SecurityContextProvider securityContextProvider() {
     return new SecurityContextProvider();
-  }
-
-  @Bean
-  public AuthorizationChecker authorizationChecker(final AuthorizationReader authorizationReader) {
-    return new AuthorizationChecker(authorizationReader);
   }
 
   @Bean


### PR DESCRIPTION
## Description

Similar to #38211, In `production` environments for some customers, the gateway runs standalone in a separate deployment that can scale separately, and the broker runs without exposing an `embedded` gateway.

But we will still need the `ResourceAccessControllers` to be injected to the broker, to be able to authorize batch operation items queries in the client providers.

## Related issues

closes #38214
