### PR TITLE
[Backport stable/8.8] fix: failing to create user due to broken API call

### DIFF
--- a/identity/client/src/utility/api/users/index.ts
+++ b/identity/client/src/utility/api/users/index.ts
@@ -50,7 +50,7 @@ export const getUserDetails: ApiDefinition<
 type CreateUserParams = { password: string } & User;
 
 export const createUser: ApiDefinition<undefined, CreateUserParams> = (user) =>
-  apiPost(USERS_ENDPOINT, { ...user, enabled: true });
+  apiPost(USERS_ENDPOINT, { ...user });
 
 type UpdateUserParams = { password?: string } & User;
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
@@ -33,8 +33,7 @@ test.describe('Identity User Flows', () => {
     await cleanupUsers(request, createdUsernames);
   });
 
-  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
-  test.skip('Admin user can delete user', async ({
+  test('Admin user can delete user', async ({
     page,
     loginPage,
     identityUsersPage,
@@ -79,9 +78,8 @@ test.describe('Identity User Flows', () => {
     });
   });
 
-  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
   // eslint-disable-next-line playwright/expect-expect
-  test.skip('Brand new user cannot access any OC cluster apps', async ({
+  test('Brand new user cannot access any OC cluster apps', async ({
     page,
     loginPage,
     identityUsersPage,
@@ -120,8 +118,7 @@ test.describe('Identity User Flows', () => {
     });
   });
 
-  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
-  test.skip('Admin user can grant and revoke component authorization for user', async ({
+  test('Admin user can grant and revoke component authorization for user', async ({
     page,
     loginPage,
     identityUsersPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -67,8 +67,7 @@ test.describe.serial('authorizations CRUD', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
-  test.skip('create user authorization', async ({
+  test('create user authorization', async ({
     page,
     identityUsersPage,
     identityRolesPage,
@@ -119,8 +118,7 @@ test.describe.serial('authorizations CRUD', () => {
     });
   });
 
-  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
-  test.skip('create component authorization', async ({
+  test('create component authorization for a role', async ({
     identityUsersPage,
     identityAuthorizationsPage,
     identityHeader,
@@ -139,8 +137,7 @@ test.describe.serial('authorizations CRUD', () => {
     });
   });
 
-  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
-  test.skip('delete an authorization', async ({
+  test('delete component authorization for role', async ({
     page,
     identityHeader,
     loginPage,
@@ -213,8 +210,7 @@ test.describe('authorization scenarios', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
-  test.skip('create component authorization for a user', async ({
+  test('create component authorization for a user', async ({
     page,
     identityUsersPage,
     identityAuthorizationsPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/create-new-user.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/create-new-user.spec.ts
@@ -29,8 +29,7 @@ test.describe.parallel('login page', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
-  test.skip('Create new Test user', async ({page, identityUsersPage}) => {
+  test('Create new Test user', async ({page, identityUsersPage}) => {
     const testData = createTestData({user: true});
     const testUser = testData.user!;
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -130,8 +130,7 @@ test.describe('Groups functionalities', () => {
     }
   });
 
-  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
-  test.skip('As an Admin user can create a group with particular permissions and assign it to Test user', async ({
+  test('As an Admin user can create a group with particular permissions and assign it to Test user', async ({
     page,
     identityGroupsPage,
     identityAuthorizationsPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
@@ -42,8 +42,7 @@ test.describe.serial('users CRUD', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
-  test.skip('create a user', async ({identityUsersPage, page}) => {
+  test('create a user', async ({identityUsersPage, page}) => {
     await expect(identityUsersPage.userCell('demo@example.com')).toBeVisible();
     await identityUsersPage.createUser(NEW_USER);
     await waitForItemInList(page, identityUsersPage.userCell(NEW_USER.email), {
@@ -52,8 +51,7 @@ test.describe.serial('users CRUD', () => {
     });
   });
 
-  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
-  test.skip('edit a user', async ({identityUsersPage, page}) => {
+  test('edit a user', async ({identityUsersPage, page}) => {
     await identityUsersPage.editUser(NEW_USER, EDITED_USER);
     const item = identityUsersPage.userCell(EDITED_USER.email);
     await waitForItemInList(page, item, {
@@ -62,8 +60,7 @@ test.describe.serial('users CRUD', () => {
     });
   });
 
-  // Skipped due to bug #38094: https://github.com/camunda/camunda/issues/38094
-  test.skip('delete a user', async ({identityUsersPage, page}) => {
+  test('delete a user', async ({identityUsersPage, page}) => {
     const item = identityUsersPage.userCell(EDITED_USER.email);
     await identityUsersPage.deleteUser(EDITED_USER);
 


### PR DESCRIPTION
# Description
Backport of #38162 to `stable/8.8`.

relates to #38094