### PR TITLE
fix: Elasticsearch Memory Leak

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -555,7 +555,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
                       return true;
                     } catch (final Exception e) {
                       LOG.warn("Failed to open exporter '{}'. Retrying...", container.getId());
-                      LOG.debug("Stacktrace:", e);
+                      LOG.debug(
+                          "Failed to open exporter '{}' => Stacktrace:", container.getId(), e);
                       return false;
                     }
                   },

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.VersionUtil;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
@@ -92,6 +93,19 @@ final class ElasticsearchExporterTest {
 
     // when
     assertThatCode(() -> exporter.open(controller)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldCloseElasticsearchClientIfExporterFailedToOpen() throws IOException {
+    // given
+    final ExporterTestController controller = mock(ExporterTestController.class);
+    doThrow(new RuntimeException("Failed opening exporter!")).when(controller).readMetadata();
+
+    // then
+    assertThatThrownBy(() -> exporter.open(controller))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Failed opening exporter!");
+    verify(client).close();
   }
 
   @Nested

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -64,19 +64,30 @@ public class OpensearchExporter implements Exporter {
   @Override
   public void open(final Controller controller) {
     this.controller = controller;
-    client = createClient();
+    try {
+      client = createClient();
+      recordCounters =
+          controller
+              .readMetadata()
+              .map(this::deserializeExporterMetadata)
+              .map(OpensearchExporterMetadata::getRecordCountersByValueType)
+              .filter(counters -> !counters.isEmpty())
+              .map(OpensearchRecordCounters::new)
+              .orElse(new OpensearchRecordCounters());
 
-    recordCounters =
-        controller
-            .readMetadata()
-            .map(this::deserializeExporterMetadata)
-            .map(OpensearchExporterMetadata::getRecordCountersByValueType)
-            .filter(counters -> !counters.isEmpty())
-            .map(OpensearchRecordCounters::new)
-            .orElse(new OpensearchRecordCounters());
-
-    scheduleDelayedFlush();
-    log.info("Exporter opened");
+      scheduleDelayedFlush();
+      log.info("Exporter opened");
+    } catch (final Exception ex) {
+      if (client != null) {
+        try {
+          client.close();
+          client = null;
+        } catch (final Exception e) {
+          log.warn("Failed to close the opensearch client", e);
+        }
+      }
+      throw ex;
+    }
   }
 
   @Override

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.VersionUtil;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
@@ -95,6 +96,19 @@ final class OpensearchExporterTest {
 
     // when
     assertThatCode(() -> exporter.open(controller)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldCloseOpensearchClientIfExporterFailedToOpen() throws IOException {
+    // given
+    final ExporterTestController controller = mock(ExporterTestController.class);
+    doThrow(new RuntimeException("Failed opening exporter!")).when(controller).readMetadata();
+
+    // then
+    assertThatThrownBy(() -> exporter.open(controller))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Failed opening exporter!");
+    verify(client).close();
   }
 
   @Test


### PR DESCRIPTION

## Description

When the elasticsearch exporter is used and if that fail to open successfully, the threadpools elastic client created is left dangling. Whilst the client object should get GC'ed, the underneath http client thread is a reactor event dispatch thread which seems to have is own stack and does not get properly cleaned unless we call the close method. Lack of this resulted in trying to create camunda exporters in a loop, and eventually no of threads for elasticsearch-rest-client exceeded over 20k threads and resulted in the app OOM'ing.

The bug that caused this is fixed in #37012 and it should not happen, but this is adding a guard for any possible future failures.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

https://github.com/camunda/camunda/issues/29146
