### PR TITLE
refactor: provide broker request authorization

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -103,6 +103,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-auth</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
@@ -7,15 +7,10 @@
  */
 package io.camunda.authentication.converter;
 
-import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_CLIENT_ID;
-import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
-import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
-
 import io.camunda.authentication.service.MembershipService;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.OidcPrincipalLoader;
 import io.camunda.security.configuration.SecurityConfiguration;
-import java.util.HashMap;
 import java.util.Map;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
@@ -42,25 +37,13 @@ public class TokenClaimsConverter {
     final var username = principals.username();
     final var clientId = principals.clientId();
 
-    // will be used when sending a broker request
-    final var authenticatedClaims = new HashMap<String, Object>();
-    authenticatedClaims.put(USER_TOKEN_CLAIMS, tokenClaims);
-
     if (username == null && clientId == null) {
       throw new OAuth2AuthenticationException(
           new OAuth2Error(OAuth2ErrorCodes.INVALID_CLIENT),
           "Neither username claim (%s) nor clientId claim (%s) could be found in the claims. Please check your OIDC configuration."
               .formatted(usernameClaim, clientIdClaim));
     }
-    if (username != null) {
-      authenticatedClaims.put(AUTHORIZED_USERNAME, username);
-    }
 
-    if (clientId != null) {
-      authenticatedClaims.put(AUTHORIZED_CLIENT_ID, clientId);
-    }
-
-    return membershipService.resolveMemberships(
-        tokenClaims, authenticatedClaims, username, clientId);
+    return membershipService.resolveMemberships(tokenClaims, username, clientId);
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverter.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.authentication.converter;
 
-import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
 import static io.camunda.zeebe.protocol.record.value.EntityType.GROUP;
 import static io.camunda.zeebe.protocol.record.value.EntityType.ROLE;
 import static io.camunda.zeebe.protocol.record.value.EntityType.USER;
@@ -22,7 +21,6 @@ import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -95,7 +93,6 @@ public class UsernamePasswordAuthenticationTokenConverter
             a.user(username)
                 .roleIds(roles.stream().toList())
                 .groupIds(groups.stream().toList())
-                .tenants(tenants)
-                .claims(Map.of(AUTHORIZED_USERNAME, username)));
+                .tenants(tenants));
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.authentication.service;
 
-import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
 import static io.camunda.zeebe.protocol.record.value.EntityType.GROUP;
 import static io.camunda.zeebe.protocol.record.value.EntityType.MAPPING_RULE;
 
@@ -34,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 @Service
 @Primary
@@ -47,7 +45,7 @@ public class DefaultMembershipService implements MembershipService {
   private final RoleServices roleServices;
   private final GroupServices groupServices;
   private final OidcGroupsLoader oidcGroupsLoader;
-  private final String groupsClaim;
+  private final boolean isGroupsClaimConfigured;
 
   public DefaultMembershipService(
       final MappingRuleServices mappingRuleServices,
@@ -59,16 +57,15 @@ public class DefaultMembershipService implements MembershipService {
     this.tenantServices = tenantServices;
     this.roleServices = roleServices;
     this.groupServices = groupServices;
-    groupsClaim = securityConfiguration.getAuthentication().getOidc().getGroupsClaim();
-    oidcGroupsLoader = new OidcGroupsLoader(groupsClaim);
+    oidcGroupsLoader =
+        new OidcGroupsLoader(securityConfiguration.getAuthentication().getOidc().getGroupsClaim());
+    isGroupsClaimConfigured =
+        securityConfiguration.getAuthentication().getOidc().isGroupsClaimConfigured();
   }
 
   @Override
   public CamundaAuthentication resolveMemberships(
-      final Map<String, Object> tokenClaims,
-      final Map<String, Object> authenticatedClaims,
-      final String username,
-      final String clientId)
+      final Map<String, Object> tokenClaims, final String username, final String clientId)
       throws OAuth2AuthenticationException {
     final var ownerTypeToIds = new HashMap<EntityType, Set<String>>();
     if (username != null) {
@@ -92,10 +89,8 @@ public class DefaultMembershipService implements MembershipService {
     }
 
     final Set<String> groups;
-    final boolean groupsClaimPresent = StringUtils.hasText(groupsClaim);
-    if (groupsClaimPresent) {
+    if (isGroupsClaimConfigured) {
       groups = new HashSet<>(oidcGroupsLoader.load(tokenClaims));
-      authenticatedClaims.put(USER_GROUPS_CLAIMS, groups.stream().toList());
     } else {
       groups =
           groupServices
@@ -138,6 +133,6 @@ public class DefaultMembershipService implements MembershipService {
                 .groupIds(groups.stream().toList())
                 .mappingRule(mappingRules.stream().toList())
                 .tenants(tenants)
-                .claims(authenticatedClaims));
+                .claims(tokenClaims));
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/service/MembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/MembershipService.java
@@ -24,9 +24,6 @@ public interface MembershipService {
    * @param tokenClaims the raw claims extracted from the authentication token (e.g., JWT/OIDC
    *     token). These are used for matching against mapping rules and extracting groups from the
    *     token itself
-   * @param authenticatedClaims mutable map that will be enriched with authentication context (e.g.,
-   *     AUTHORIZED_USERNAME, AUTHORIZED_CLIENT_ID, USER_TOKEN_CLAIMS). These claims are passed to
-   *     the broker for authorization decisions
    * @param username the username to resolve memberships for
    * @param clientId the client ID to resolve memberships for
    * @return a {@link CamundaAuthentication} containing the resolved groups, roles, tenants, and
@@ -35,9 +32,6 @@ public interface MembershipService {
    *     resolution fails
    */
   CamundaAuthentication resolveMemberships(
-      Map<String, Object> tokenClaims,
-      Map<String, Object> authenticatedClaims,
-      String username,
-      String clientId)
+      Map<String, Object> tokenClaims, String username, String clientId)
       throws OAuth2AuthenticationException;
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigParameterizedTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigParameterizedTest.java
@@ -104,7 +104,13 @@ public class BasicAuthWebSecurityConfigParameterizedTest {
     @Bean
     public UserServices userServices() {
       return new UserServices(
-          null, null, null, null, null, new ApiServicesExecutorProvider(ForkJoinPool.commonPool()));
+          null,
+          null,
+          null,
+          null,
+          null,
+          new ApiServicesExecutorProvider(ForkJoinPool.commonPool()),
+          null);
     }
 
     @Bean

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
@@ -75,17 +75,17 @@ public class WebSecurityConfigTestContext {
 
   @Bean
   public RoleServices createRoleServices(final ApiServicesExecutorProvider executorProvider) {
-    return new RoleServices(null, null, null, null, executorProvider);
+    return new RoleServices(null, null, null, null, executorProvider, null);
   }
 
   @Bean
   public GroupServices createGroupServices(final ApiServicesExecutorProvider executorProvider) {
-    return new GroupServices(null, null, null, null, executorProvider);
+    return new GroupServices(null, null, null, null, executorProvider, null);
   }
 
   @Bean
   public TenantServices createTenantServices(final ApiServicesExecutorProvider executorProvider) {
-    return new TenantServices(null, null, null, null, executorProvider);
+    return new TenantServices(null, null, null, null, executorProvider, null);
   }
 
   @Bean

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
@@ -24,7 +24,7 @@ public class WebSecurityOidcTestContext {
   @Bean
   public MappingRuleServices createMappingRuleServices(
       final ApiServicesExecutorProvider executorProvider) {
-    return new MappingRuleServices(null, null, null, null, executorProvider);
+    return new MappingRuleServices(null, null, null, null, executorProvider, null);
   }
 
   @Bean

--- a/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterNoDbTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterNoDbTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.authentication.converter;
 
-import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -92,8 +91,7 @@ public class TokenClaimsConverterNoDbTest {
     assertThat(result).isNotNull();
     assertThat(result.authenticatedUsername()).isEqualTo("testuser");
     assertThat(result.authenticatedGroupIds()).containsExactlyInAnyOrder("group1", "group2");
-    assertThat((List<String>) result.claims().get(USER_GROUPS_CLAIMS))
-        .containsExactlyInAnyOrder("group1", "group2");
+    assertThat(result.claims()).isEqualTo(claims);
     // In no-db mode, no secondary storage access, so these should be empty
     assertThat(result.authenticatedRoleIds()).isEmpty();
     assertThat(result.authenticatedTenantIds()).isEmpty();
@@ -113,7 +111,7 @@ public class TokenClaimsConverterNoDbTest {
     assertThat(result).isNotNull();
     assertThat(result.authenticatedUsername()).isEqualTo("testuser");
     assertThat(result.authenticatedGroupIds()).isEmpty();
-    assertThat((List<String>) result.claims().get(USER_GROUPS_CLAIMS)).isEmpty();
+    assertThat(result.claims()).isEqualTo(claims);
   }
 
   @Test
@@ -150,6 +148,6 @@ public class TokenClaimsConverterNoDbTest {
     assertThat(result).isNotNull();
     assertThat(result.authenticatedUsername()).isEqualTo("testuser");
     assertThat(result.authenticatedGroupIds()).isEmpty();
-    assertThat((List<String>) result.claims().get(USER_GROUPS_CLAIMS)).isEmpty();
+    assertThat(result.claims()).isEqualTo(claims);
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterTest.java
@@ -8,10 +8,7 @@
 package io.camunda.authentication.converter;
 
 import static io.camunda.security.auth.OidcGroupsLoader.DERIVED_GROUPS_ARE_NOT_STRING_ARRAY;
-import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_CLIENT_ID;
-import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
 import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
-import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
@@ -143,8 +140,7 @@ public class TokenClaimsConverterTest {
       // then
       assertThat(camundaAuthentication).isNotNull();
       assertThat(camundaAuthentication.authenticatedClientId()).isEqualTo("app-1");
-      assertThat(camundaAuthentication.claims()).containsEntry(AUTHORIZED_CLIENT_ID, "app-1");
-      assertThat(camundaAuthentication.claims()).containsEntry(USER_TOKEN_CLAIMS, claims);
+      assertThat(camundaAuthentication.claims()).isEqualTo(claims);
     }
   }
 
@@ -276,8 +272,7 @@ public class TokenClaimsConverterTest {
       // then
       assertThat(authentication).isNotNull();
       assertThat(authentication.authenticatedUsername()).isEqualTo("foo@camunda.test");
-      assertThat(authentication.claims()).containsEntry(AUTHORIZED_USERNAME, "foo@camunda.test");
-      assertThat(authentication.claims()).containsEntry(USER_TOKEN_CLAIMS, claims);
+      assertThat(authentication.claims()).isEqualTo(claims);
       assertThat(authentication.authenticatedMappingRuleIds())
           .containsExactlyInAnyOrder("test-id", "test-id-2");
       assertThat(authentication.authenticatedRoleIds())
@@ -370,6 +365,7 @@ public class TokenClaimsConverterTest {
       when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
       when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn("sub");
       when(oidcAuthenticationConfiguration.getClientIdClaim()).thenReturn("not-tested");
+      when(oidcAuthenticationConfiguration.isGroupsClaimConfigured()).thenReturn(true);
       when(oidcAuthenticationConfiguration.getGroupsClaim()).thenReturn(GROUPS_CLAIM);
       when(mappingRuleServices.withAuthentication(any(CamundaAuthentication.class)))
           .thenReturn(mappingRuleServices);
@@ -409,8 +405,7 @@ public class TokenClaimsConverterTest {
       // then
       assertThat(authentication.authenticatedGroupIds())
           .containsExactlyInAnyOrder(GROUP1_NAME, GROUP2_NAME);
-      assertThat((List<String>) authentication.claims().get(USER_GROUPS_CLAIMS))
-          .containsExactlyInAnyOrder(GROUP1_NAME, GROUP2_NAME);
+      assertThat(authentication.claims()).isEqualTo(claims);
     }
 
     @Test
@@ -434,8 +429,7 @@ public class TokenClaimsConverterTest {
 
       // then
       assertThat(authentication.authenticatedGroupIds()).containsExactly(GROUP1_NAME);
-      assertThat((List<String>) authentication.claims().get(USER_GROUPS_CLAIMS))
-          .containsExactly(GROUP1_NAME);
+      assertThat(authentication.claims()).isEqualTo(claims);
     }
 
     @Test

--- a/authentication/src/test/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/UsernamePasswordAuthenticationTokenConverterTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.authentication.converter;
 
-import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -143,7 +142,7 @@ public class UsernamePasswordAuthenticationTokenConverterTest {
   }
 
   @Test
-  void authenticationContainsUsernameClaim() {
+  void authenticationClaimsAreNull() {
     // given
     final var authentication = getUsernamePasswordAuthentication("test-user", "test-password");
 
@@ -151,7 +150,7 @@ public class UsernamePasswordAuthenticationTokenConverterTest {
     final var camundaAuthentication = authenticationConverter.convert(authentication);
 
     // then
-    assertThat(camundaAuthentication.claims()).containsEntry(AUTHORIZED_USERNAME, "test-user");
+    assertThat(camundaAuthentication.claims()).isNull();
   }
 
   private Authentication getUsernamePasswordAuthentication(

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -32,6 +32,7 @@ import io.camunda.search.clients.UserSearchClient;
 import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.clients.VariableSearchClient;
 import io.camunda.search.clients.reader.AuthorizationReader;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.service.AdHocSubProcessActivityServices;
@@ -79,13 +80,25 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class CamundaServicesConfiguration {
 
   @Bean
+  public BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter(
+      final SecurityConfiguration securityConfiguration) {
+    return new BrokerRequestAuthorizationConverter(securityConfiguration);
+  }
+
+  @Bean
   public UsageMetricsServices usageMetricsServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final UsageMetricsSearchClient usageMetricsSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new UsageMetricsServices(
-        brokerClient, securityContextProvider, usageMetricsSearchClient, null, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        usageMetricsSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -94,14 +107,16 @@ public class CamundaServicesConfiguration {
       final SecurityContextProvider securityContextProvider,
       final ActivateJobsHandler<JobActivationResult> activateJobsHandler,
       final JobSearchClient jobSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new JobServices<>(
         brokerClient,
         securityContextProvider,
         activateJobsHandler,
         jobSearchClient,
         null,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -110,14 +125,16 @@ public class CamundaServicesConfiguration {
       final SecurityContextProvider securityContextProvider,
       final DecisionDefinitionSearchClient decisionDefinitionSearchClient,
       final DecisionRequirementsServices decisionRequirementsServices,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new DecisionDefinitionServices(
         brokerClient,
         securityContextProvider,
         decisionDefinitionSearchClient,
         decisionRequirementsServices,
         null,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -125,13 +142,15 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final DecisionInstanceSearchClient decisionInstanceSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new DecisionInstanceServices(
         brokerClient,
         securityContextProvider,
         decisionInstanceSearchClient,
         null,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -140,14 +159,16 @@ public class CamundaServicesConfiguration {
       final SecurityContextProvider securityContextProvider,
       final ProcessDefinitionSearchClient processDefinitionSearchClient,
       final FormServices formServices,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new ProcessDefinitionServices(
         brokerClient,
         securityContextProvider,
         processDefinitionSearchClient,
         formServices,
         null,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -157,7 +178,8 @@ public class CamundaServicesConfiguration {
       final ProcessInstanceSearchClient processInstanceSearchClient,
       final SequenceFlowSearchClient sequenceFlowSearchClient,
       final IncidentServices incidentServices,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new ProcessInstanceServices(
         brokerClient,
         securityContextProvider,
@@ -165,7 +187,8 @@ public class CamundaServicesConfiguration {
         sequenceFlowSearchClient,
         incidentServices,
         null,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -173,13 +196,15 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final DecisionRequirementSearchClient decisionRequirementSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new DecisionRequirementsServices(
         brokerClient,
         securityContextProvider,
         decisionRequirementSearchClient,
         null,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -188,23 +213,30 @@ public class CamundaServicesConfiguration {
       final SecurityContextProvider securityContextProvider,
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient,
       final ProcessCache processCache,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new ElementInstanceServices(
         brokerClient,
         securityContextProvider,
         flowNodeInstanceSearchClient,
         processCache,
         null,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
   public AdHocSubProcessActivityServices adHocSubProcessActivityServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new AdHocSubProcessActivityServices(
-        brokerClient, securityContextProvider, null, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -212,9 +244,15 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final IncidentSearchClient incidentSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new IncidentServices(
-        brokerClient, securityContextProvider, incidentSearchClient, null, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        incidentSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -222,9 +260,15 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final RoleSearchClient roleSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new RoleServices(
-        brokerClient, securityContextProvider, roleSearchClient, null, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        roleSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -232,9 +276,15 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final TenantSearchClient tenantSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new TenantServices(
-        brokerClient, securityContextProvider, tenantSearchClient, null, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        tenantSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -242,9 +292,15 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final GroupSearchClient groupSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new GroupServices(
-        brokerClient, securityContextProvider, groupSearchClient, null, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        groupSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -253,14 +309,16 @@ public class CamundaServicesConfiguration {
       final SecurityContextProvider securityContextProvider,
       final UserSearchClient userSearchClient,
       final PasswordEncoder passwordEncoder,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new UserServices(
         brokerClient,
         securityContextProvider,
         userSearchClient,
         null,
         passwordEncoder,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -272,7 +330,8 @@ public class CamundaServicesConfiguration {
       final ElementInstanceServices elementInstanceServices,
       final VariableServices variableServices,
       final ProcessCache processCache,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new UserTaskServices(
         brokerClient,
         securityContextProvider,
@@ -282,7 +341,8 @@ public class CamundaServicesConfiguration {
         variableServices,
         processCache,
         null,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -290,9 +350,15 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final VariableSearchClient variableSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new VariableServices(
-        brokerClient, securityContextProvider, variableSearchClient, null, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        variableSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -300,13 +366,15 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final CorrelatedMessageSearchClient correlatedMessageSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new MessageServices(
         brokerClient,
         securityContextProvider,
         correlatedMessageSearchClient,
         null,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -315,7 +383,8 @@ public class CamundaServicesConfiguration {
       final SecurityContextProvider securityContextProvider,
       final AuthorizationChecker authorizationChecker,
       final SecurityConfiguration securityConfiguration,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new DocumentServices(
         brokerClient,
         securityContextProvider,
@@ -323,7 +392,8 @@ public class CamundaServicesConfiguration {
         new SimpleDocumentStoreRegistry(new EnvironmentConfigurationLoader()),
         authorizationChecker,
         securityConfiguration,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -331,33 +401,57 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final AuthorizationSearchClient authorizationSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new AuthorizationServices(
-        brokerClient, securityContextProvider, authorizationSearchClient, null, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        authorizationSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
   public ClockServices clockServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final ApiServicesExecutorProvider executorProvider) {
-    return new ClockServices(brokerClient, securityContextProvider, null, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    return new ClockServices(
+        brokerClient,
+        securityContextProvider,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
   public ResourceServices resourceServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final ApiServicesExecutorProvider executorProvider) {
-    return new ResourceServices(brokerClient, securityContextProvider, null, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    return new ResourceServices(
+        brokerClient,
+        securityContextProvider,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
   public SignalServices signalServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final ApiServicesExecutorProvider executorProvider) {
-    return new SignalServices(brokerClient, securityContextProvider, null, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    return new SignalServices(
+        brokerClient,
+        securityContextProvider,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -365,9 +459,15 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final BatchOperationSearchClient batchOperationSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new BatchOperationServices(
-        brokerClient, securityContextProvider, batchOperationSearchClient, null, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        batchOperationSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -375,9 +475,15 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final FormSearchClient formSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new FormServices(
-        brokerClient, securityContextProvider, formSearchClient, null, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        formSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -385,9 +491,15 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final MappingRuleSearchClient mappingRuleSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new MappingRuleServices(
-        brokerClient, securityContextProvider, mappingRuleSearchClient, null, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        mappingRuleSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean
@@ -395,13 +507,15 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final MessageSubscriptionSearchClient messageSubscriptionSearchClient,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new MessageSubscriptionServices(
         brokerClient,
         securityContextProvider,
         messageSubscriptionSearchClient,
         null,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -120,7 +121,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             userServices,
             passwordEncoder,
             jwtDecoder,
-            searchClientsProxy);
+            searchClientsProxy,
+            new BrokerRequestAuthorizationConverter(securityConfiguration));
     springBrokerBridge.registerShutdownHelper(
         errorCode -> shutdownHelper.initiateShutdown(errorCode));
     broker =

--- a/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+import static io.camunda.security.entity.AuthenticationMethod.OIDC;
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_ANONYMOUS_USER;
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_CLIENT_ID;
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
+import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
+import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
+
+import io.camunda.security.configuration.SecurityConfiguration;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BrokerRequestAuthorizationConverter {
+
+  private final boolean isGroupsClaimConfigured;
+
+  public BrokerRequestAuthorizationConverter(final SecurityConfiguration securityConfiguration) {
+    isGroupsClaimConfigured = isGroupsClaimConfigured(securityConfiguration);
+  }
+
+  protected boolean isGroupsClaimConfigured(final SecurityConfiguration securityConfiguration) {
+    final var authenticationConfiguration = securityConfiguration.getAuthentication();
+    return authenticationConfiguration.getMethod() == OIDC
+        && authenticationConfiguration.getOidc().isGroupsClaimConfigured();
+  }
+
+  public Map<String, Object> convert(final CamundaAuthentication authentication) {
+    if (authentication.isAnonymous()) {
+      return Map.of(AUTHORIZED_ANONYMOUS_USER, true);
+    }
+
+    final var authorization = new HashMap<String, Object>();
+    final var username = authentication.authenticatedUsername();
+    final var clientId = authentication.authenticatedClientId();
+    final var groups = authentication.authenticatedGroupIds();
+    final var claims = authentication.claims();
+
+    if (username != null) {
+      authorization.put(AUTHORIZED_USERNAME, username);
+    }
+
+    if (clientId != null) {
+      authorization.put(AUTHORIZED_CLIENT_ID, clientId);
+    }
+
+    if (isGroupsClaimConfigured) {
+      authorization.put(USER_GROUPS_CLAIMS, groups);
+    }
+
+    if (claims != null) {
+      authorization.put(USER_TOKEN_CLAIMS, claims);
+    }
+
+    return authorization;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -184,6 +184,10 @@ public class OidcAuthenticationConfiguration {
     this.groupsClaim = groupsClaim;
   }
 
+  public boolean isGroupsClaimConfigured() {
+    return groupsClaim != null && !groupsClaim.isBlank();
+  }
+
   public String getClientAuthenticationMethod() {
     return clientAuthenticationMethod;
   }

--- a/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+import static io.camunda.security.entity.AuthenticationMethod.OIDC;
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_ANONYMOUS_USER;
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_CLIENT_ID;
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
+import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
+import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class BrokerRequestAuthorizationConverterTest {
+
+  @Test
+  void shouldContainAnonymousClaim() {
+    // given
+    final var authentication = CamundaAuthentication.anonymous();
+    final var converter = new BrokerRequestAuthorizationConverter(new SecurityConfiguration());
+
+    // when
+    final var brokerRequestAuth = converter.convert(authentication);
+
+    // then
+    assertThat(brokerRequestAuth).hasSize(1);
+    assertThat(brokerRequestAuth).containsEntry(AUTHORIZED_ANONYMOUS_USER, true);
+  }
+
+  @Test
+  void shouldContainUsername() {
+    // given
+    final var authentication = CamundaAuthentication.of(b -> b.user("foo"));
+    final var converter = new BrokerRequestAuthorizationConverter(new SecurityConfiguration());
+
+    // when
+    final var brokerRequestAuth = converter.convert(authentication);
+
+    // then
+    assertThat(brokerRequestAuth).hasSize(1);
+    assertThat(brokerRequestAuth).containsEntry(AUTHORIZED_USERNAME, "foo");
+  }
+
+  @Test
+  void shouldContainClientID() {
+    // given
+    final var authentication = CamundaAuthentication.of(b -> b.clientId("foo"));
+    final var converter = new BrokerRequestAuthorizationConverter(new SecurityConfiguration());
+
+    // when
+    final var brokerRequestAuth = converter.convert(authentication);
+
+    // then
+    assertThat(brokerRequestAuth).hasSize(1);
+    assertThat(brokerRequestAuth).containsEntry(AUTHORIZED_CLIENT_ID, "foo");
+  }
+
+  @Test
+  void shouldContainTokenClaims() {
+    // given
+    final Map<String, Object> claims = Map.of("sub", "foo");
+    final var authentication = CamundaAuthentication.of(b -> b.claims(claims));
+    final var converter = new BrokerRequestAuthorizationConverter(new SecurityConfiguration());
+
+    // when
+    final var brokerRequestAuth = converter.convert(authentication);
+
+    // then
+    assertThat(brokerRequestAuth).hasSize(1);
+    assertThat(brokerRequestAuth).containsEntry(USER_TOKEN_CLAIMS, claims);
+  }
+
+  @Test
+  void shouldContainGroupsIfClaimConfigured() {
+    // given
+    final var groups = List.of("group1", "group2");
+    final var authentication = CamundaAuthentication.of(b -> b.groupIds(groups));
+
+    final var oidcConfiguration = new OidcAuthenticationConfiguration();
+    oidcConfiguration.setGroupsClaim("groups");
+    final var securityConfiguration = new SecurityConfiguration();
+    securityConfiguration.getAuthentication().setOidc(oidcConfiguration);
+    securityConfiguration.getAuthentication().setMethod(OIDC);
+
+    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
+
+    // when
+    final var brokerRequestAuth = converter.convert(authentication);
+
+    // then
+    assertThat(brokerRequestAuth).hasSize(1);
+    assertThat(brokerRequestAuth).containsEntry(USER_GROUPS_CLAIMS, groups);
+  }
+
+  @Test
+  void shouldIgnoreGroupsIfAuthenticationMethodNotOIDC() {
+    // given
+    final var groups = List.of("group1", "group2");
+    final var authentication = CamundaAuthentication.of(b -> b.groupIds(groups));
+
+    final var oidcConfiguration = new OidcAuthenticationConfiguration();
+    oidcConfiguration.setGroupsClaim("groups");
+    final var securityConfiguration = new SecurityConfiguration();
+    securityConfiguration.getAuthentication().setOidc(oidcConfiguration);
+
+    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
+
+    // when
+    final var brokerRequestAuth = converter.convert(authentication);
+
+    // then
+    assertThat(brokerRequestAuth).hasSize(0);
+  }
+
+  @Test
+  void shouldIgnoreGroupsIfClaimNotConfigured() {
+    // given
+    final var groups = List.of("group1", "group2");
+    final var authentication = CamundaAuthentication.of(b -> b.groupIds(groups));
+
+    final var converter = new BrokerRequestAuthorizationConverter(new SecurityConfiguration());
+
+    // when
+    final var brokerRequestAuth = converter.convert(authentication);
+
+    // then
+    assertThat(brokerRequestAuth).hasSize(0);
+  }
+}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -82,6 +82,11 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-protocol</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-auth</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.agrona</groupId>

--- a/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.service;
 
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
-import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateAdHocSubProcessActivityRequest;
@@ -23,15 +23,25 @@ public class AdHocSubProcessActivityServices extends ApiServices<AdHocSubProcess
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override
   public AdHocSubProcessActivityServices withAuthentication(
       final CamundaAuthentication authentication) {
     return new AdHocSubProcessActivityServices(
-        brokerClient, securityContextProvider, authentication, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public CompletableFuture<AdHocSubProcessInstructionRecord> activateActivities(

--- a/service/src/main/java/io/camunda/service/ApiServices.java
+++ b/service/src/main/java/io/camunda/service/ApiServices.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service;
 
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.security.SecurityContextProvider;
@@ -28,18 +29,21 @@ public abstract class ApiServices<T extends ApiServices<T>> {
   protected final SecurityContextProvider securityContextProvider;
   protected final CamundaAuthentication authentication;
   protected final ApiServicesExecutorProvider executorProvider;
+  protected final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
   private final ExecutorService executor;
 
   protected ApiServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this.brokerClient = brokerClient;
     this.securityContextProvider = securityContextProvider;
     this.authentication = authentication;
     this.executorProvider = executorProvider;
     executor = executorProvider.getExecutor();
+    this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
   }
 
   public abstract T withAuthentication(final CamundaAuthentication authentication);
@@ -56,7 +60,9 @@ public abstract class ApiServices<T extends ApiServices<T>> {
 
   protected <R> CompletableFuture<BrokerResponse<R>> sendBrokerRequestWithFullResponse(
       final BrokerRequest<R> brokerRequest) {
-    brokerRequest.setAuthorization(authentication.claims());
+    final var brokerRequestAuthorization =
+        brokerRequestAuthorizationConverter.convert(authentication);
+    brokerRequest.setAuthorization(brokerRequestAuthorization);
     return brokerClient
         .sendRequest(brokerRequest)
         .handleAsync(

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -14,6 +14,7 @@ import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -40,8 +41,14 @@ public class AuthorizationServices
       final SecurityContextProvider securityContextProvider,
       final AuthorizationSearchClient authorizationSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.authorizationSearchClient = authorizationSearchClient;
   }
 
@@ -52,7 +59,8 @@ public class AuthorizationServices
         securityContextProvider,
         authorizationSearchClient,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/BatchOperationServices.java
+++ b/service/src/main/java/io/camunda/service/BatchOperationServices.java
@@ -17,6 +17,7 @@ import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -41,8 +42,14 @@ public final class BatchOperationServices
       final SecurityContextProvider securityContextProvider,
       final BatchOperationSearchClient batchOperationSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.batchOperationSearchClient = batchOperationSearchClient;
   }
 
@@ -53,7 +60,8 @@ public final class BatchOperationServices
         securityContextProvider,
         batchOperationSearchClient,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/ClockServices.java
+++ b/service/src/main/java/io/camunda/service/ClockServices.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service;
 
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -21,14 +22,24 @@ public final class ClockServices extends ApiServices<ClockServices> {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override
   public ClockServices withAuthentication(final CamundaAuthentication authentication) {
     return new ClockServices(
-        brokerClient, securityContextProvider, authentication, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public CompletableFuture<ClockRecord> pinClock(final long pinnedEpoch) {

--- a/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
@@ -15,6 +15,7 @@ import io.camunda.search.clients.DecisionDefinitionSearchClient;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
@@ -43,8 +44,14 @@ public final class DecisionDefinitionServices
       final DecisionDefinitionSearchClient decisionDefinitionSearchClient,
       final DecisionRequirementsServices decisionRequirementServices,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.decisionDefinitionSearchClient = decisionDefinitionSearchClient;
     this.decisionRequirementServices = decisionRequirementServices;
   }
@@ -57,7 +64,8 @@ public final class DecisionDefinitionServices
         decisionDefinitionSearchClient,
         decisionRequirementServices,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -16,6 +16,7 @@ import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -32,8 +33,14 @@ public final class DecisionInstanceServices
       final SecurityContextProvider securityHandler,
       final DecisionInstanceSearchClient decisionInstanceSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityHandler, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityHandler,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.decisionInstanceSearchClient = decisionInstanceSearchClient;
   }
 
@@ -44,7 +51,8 @@ public final class DecisionInstanceServices
         securityContextProvider,
         decisionInstanceSearchClient,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   /**

--- a/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -33,8 +34,14 @@ public final class DecisionRequirementsServices
       final SecurityContextProvider securityContextProvider,
       final DecisionRequirementSearchClient decisionRequirementSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.decisionRequirementSearchClient = decisionRequirementSearchClient;
   }
 
@@ -46,7 +53,8 @@ public final class DecisionRequirementsServices
         securityContextProvider,
         decisionRequirementSearchClient,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -18,6 +18,7 @@ import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreRecord;
 import io.camunda.document.store.SimpleDocumentStoreRegistry;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
@@ -51,8 +52,14 @@ public class DocumentServices extends ApiServices<DocumentServices> {
       final SimpleDocumentStoreRegistry registry,
       final AuthorizationChecker authorizationChecker,
       final SecurityConfiguration securityConfig,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.registry = registry;
     this.authorizationChecker = authorizationChecker;
     this.securityConfig = securityConfig;
@@ -67,7 +74,8 @@ public class DocumentServices extends ApiServices<DocumentServices> {
         registry,
         authorizationChecker,
         securityConfig,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   /** Will return a failed future for any error returned by the store */

--- a/service/src/main/java/io/camunda/service/ElementInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ElementInstanceServices.java
@@ -14,6 +14,7 @@ import io.camunda.search.clients.FlowNodeInstanceSearchClient;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.service.cache.ProcessCache;
@@ -40,8 +41,14 @@ public final class ElementInstanceServices
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient,
       final ProcessCache processCache,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.flowNodeInstanceSearchClient = flowNodeInstanceSearchClient;
     this.processCache = processCache;
   }
@@ -54,7 +61,8 @@ public final class ElementInstanceServices
         flowNodeInstanceSearchClient,
         processCache,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/FormServices.java
+++ b/service/src/main/java/io/camunda/service/FormServices.java
@@ -12,6 +12,7 @@ import io.camunda.search.entities.FormEntity;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -27,15 +28,26 @@ public final class FormServices extends SearchQueryService<FormServices, FormQue
       final SecurityContextProvider securityContextProvider,
       final FormSearchClient formSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.formSearchClient = formSearchClient;
   }
 
   @Override
   public FormServices withAuthentication(final CamundaAuthentication authentication) {
     return new FormServices(
-        brokerClient, securityContextProvider, formSearchClient, authentication, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        formSearchClient,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -39,8 +40,14 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
       final SecurityContextProvider securityContextProvider,
       final GroupSearchClient groupSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.groupSearchClient = groupSearchClient;
   }
 
@@ -69,7 +76,12 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
   @Override
   public GroupServices withAuthentication(final CamundaAuthentication authentication) {
     return new GroupServices(
-        brokerClient, securityContextProvider, groupSearchClient, authentication, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        groupSearchClient,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public CompletableFuture<GroupRecord> createGroup(final GroupDTO groupDTO) {

--- a/service/src/main/java/io/camunda/service/IncidentServices.java
+++ b/service/src/main/java/io/camunda/service/IncidentServices.java
@@ -15,6 +15,7 @@ import io.camunda.search.clients.IncidentSearchClient;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -35,8 +36,14 @@ public class IncidentServices
       final SecurityContextProvider securityContextProvider,
       final IncidentSearchClient incidentSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.incidentSearchClient = incidentSearchClient;
   }
 
@@ -63,7 +70,8 @@ public class IncidentServices
         securityContextProvider,
         incidentSearchClient,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public IncidentEntity getByKey(final Long key) {

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -13,6 +13,7 @@ import io.camunda.search.clients.JobSearchClient;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -42,8 +43,14 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final ActivateJobsHandler<T> activateJobsHandler,
       final JobSearchClient jobSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.activateJobsHandler = activateJobsHandler;
     this.jobSearchClient = jobSearchClient;
   }
@@ -56,7 +63,8 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
         activateJobsHandler,
         jobSearchClient,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public void activateJobs(
@@ -70,7 +78,9 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
             .setTimeout(request.timeout())
             .setWorker(request.worker())
             .setVariables(request.fetchVariable());
-    brokerRequest.setAuthorization(authentication.claims());
+    final var brokerRequestAuthorization =
+        brokerRequestAuthorizationConverter.convert(authentication);
+    brokerRequest.setAuthorization(brokerRequestAuthorization);
     activateJobsHandler.activateJobs(
         brokerRequest, responseObserver, cancelationHandlerConsumer, request.requestTimeout());
   }

--- a/service/src/main/java/io/camunda/service/MappingRuleServices.java
+++ b/service/src/main/java/io/camunda/service/MappingRuleServices.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.SearchQueryBase.AbstractQueryBuilder;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.MappingRuleMatcher;
 import io.camunda.service.search.core.SearchQueryService;
@@ -38,8 +39,14 @@ public class MappingRuleServices
       final SecurityContextProvider securityContextProvider,
       final MappingRuleSearchClient mappingRuleSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.mappingRuleSearchClient = mappingRuleSearchClient;
   }
 
@@ -61,7 +68,8 @@ public class MappingRuleServices
         securityContextProvider,
         mappingRuleSearchClient,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public CompletableFuture<MappingRuleRecord> createMappingRule(final MappingRuleDTO request) {

--- a/service/src/main/java/io/camunda/service/MessageServices.java
+++ b/service/src/main/java/io/camunda/service/MessageServices.java
@@ -13,6 +13,7 @@ import io.camunda.search.clients.CorrelatedMessageSearchClient;
 import io.camunda.search.entities.CorrelatedMessageEntity;
 import io.camunda.search.query.CorrelatedMessageQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -35,15 +36,26 @@ public final class MessageServices
       final SecurityContextProvider securityContextProvider,
       final CorrelatedMessageSearchClient searchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.searchClient = searchClient;
   }
 
   @Override
   public MessageServices withAuthentication(final CamundaAuthentication authentication) {
     return new MessageServices(
-        brokerClient, securityContextProvider, searchClient, authentication, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        searchClient,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public CompletableFuture<MessageCorrelationRecord> correlateMessage(

--- a/service/src/main/java/io/camunda/service/MessageSubscriptionServices.java
+++ b/service/src/main/java/io/camunda/service/MessageSubscriptionServices.java
@@ -13,6 +13,7 @@ import io.camunda.search.clients.MessageSubscriptionSearchClient;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -29,8 +30,14 @@ public class MessageSubscriptionServices
       final SecurityContextProvider securityContextProvider,
       final MessageSubscriptionSearchClient searchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.searchClient = searchClient;
   }
 
@@ -49,6 +56,11 @@ public class MessageSubscriptionServices
   public MessageSubscriptionServices withAuthentication(
       final CamundaAuthentication authentication) {
     return new MessageSubscriptionServices(
-        brokerClient, securityContextProvider, searchClient, authentication, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        searchClient,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 }

--- a/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
@@ -17,6 +17,7 @@ import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -37,8 +38,14 @@ public class ProcessDefinitionServices
       final ProcessDefinitionSearchClient processDefinitionSearchClient,
       final FormServices formServices,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.processDefinitionSearchClient = processDefinitionSearchClient;
     this.formServices = formServices;
   }
@@ -73,7 +80,8 @@ public class ProcessDefinitionServices
         processDefinitionSearchClient,
         formServices,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public ProcessDefinitionEntity getByKey(final Long processDefinitionKey) {

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -24,6 +24,7 @@ import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SequenceFlowQuery;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -74,8 +75,14 @@ public final class ProcessInstanceServices
       final SequenceFlowSearchClient sequenceFlowSearchClient,
       final IncidentServices incidentServices,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.processInstanceSearchClient = processInstanceSearchClient;
     this.sequenceFlowSearchClient = sequenceFlowSearchClient;
     this.incidentServices = incidentServices;
@@ -90,7 +97,8 @@ public final class ProcessInstanceServices
         sequenceFlowSearchClient,
         incidentServices,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/ResourceServices.java
+++ b/service/src/main/java/io/camunda/service/ResourceServices.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service;
 
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -25,14 +26,24 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override
   public ResourceServices withAuthentication(final CamundaAuthentication authentication) {
     return new ResourceServices(
-        brokerClient, securityContextProvider, authentication, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public CompletableFuture<DeploymentRecord> deployResources(

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.RoleMemberEntity;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -40,8 +41,14 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
       final SecurityContextProvider securityContextProvider,
       final RoleSearchClient roleSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.roleSearchClient = roleSearchClient;
   }
 
@@ -93,7 +100,12 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
   @Override
   public RoleServices withAuthentication(final CamundaAuthentication authentication) {
     return new RoleServices(
-        brokerClient, securityContextProvider, roleSearchClient, authentication, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        roleSearchClient,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public CompletableFuture<RoleRecord> createRole(final CreateRoleRequest request) {

--- a/service/src/main/java/io/camunda/service/SignalServices.java
+++ b/service/src/main/java/io/camunda/service/SignalServices.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service;
 
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -22,14 +23,24 @@ public class SignalServices extends ApiServices<SignalServices> {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override
   public SignalServices withAuthentication(final CamundaAuthentication authentication) {
     return new SignalServices(
-        brokerClient, securityContextProvider, authentication, executorProvider);
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public CompletableFuture<BrokerResponse<SignalRecord>> broadcastSignal(

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -39,8 +40,14 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
       final SecurityContextProvider securityContextProvider,
       final TenantSearchClient tenantSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.tenantSearchClient = tenantSearchClient;
   }
 
@@ -72,7 +79,8 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
         securityContextProvider,
         tenantSearchClient,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public CompletableFuture<TenantRecord> createTenant(final TenantRequest request) {

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -35,8 +36,14 @@ public final class UsageMetricsServices
       final SecurityContextProvider securityContextProvider,
       final UsageMetricsSearchClient usageMetricsSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.usageMetricsSearchClient = usageMetricsSearchClient;
   }
 
@@ -70,6 +77,7 @@ public final class UsageMetricsServices
         securityContextProvider,
         usageMetricsSearchClient,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 }

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -14,6 +14,7 @@ import io.camunda.search.clients.UserSearchClient;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UserQuery;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -38,8 +39,14 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
       final UserSearchClient userSearchClient,
       final CamundaAuthentication authentication,
       final PasswordEncoder passwordEncoder,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.userSearchClient = userSearchClient;
     this.passwordEncoder = passwordEncoder;
   }
@@ -63,7 +70,8 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
         userSearchClient,
         authentication,
         passwordEncoder,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public CompletableFuture<UserRecord> createUser(final UserDTO request) {

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -20,6 +20,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.UserTaskQuery.Builder;
 import io.camunda.search.query.VariableQuery;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.service.cache.ProcessCache;
@@ -64,8 +65,14 @@ public final class UserTaskServices
       final VariableServices variableServices,
       final ProcessCache processCache,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.userTaskSearchClient = userTaskSearchClient;
     this.formServices = formServices;
     this.elementInstanceServices = elementInstanceServices;
@@ -84,7 +91,8 @@ public final class UserTaskServices
         variableServices,
         processCache,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/VariableServices.java
+++ b/service/src/main/java/io/camunda/service/VariableServices.java
@@ -14,6 +14,7 @@ import io.camunda.search.clients.VariableSearchClient;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.VariableQuery;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -29,8 +30,14 @@ public final class VariableServices
       final SecurityContextProvider securityContextProvider,
       final VariableSearchClient variableSearchClient,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
     this.variableSearchClient = variableSearchClient;
   }
 
@@ -41,7 +48,8 @@ public final class VariableServices
         securityContextProvider,
         variableSearchClient,
         authentication,
-        executorProvider);
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
@@ -10,6 +10,7 @@ package io.camunda.service.search.core;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.query.SearchQueryBase;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.ApiServices;
 import io.camunda.service.ApiServicesExecutorProvider;
@@ -25,8 +26,14 @@ public abstract class SearchQueryService<T extends ApiServices<T>, Q extends Sea
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final CamundaAuthentication authentication,
-      final ApiServicesExecutorProvider executorProvider) {
-    super(brokerClient, securityContextProvider, authentication, executorProvider);
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
   }
 
   public abstract SearchQueryResult<D> search(final Q query);

--- a/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
@@ -7,11 +7,14 @@
  */
 package io.camunda.service;
 
+import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
@@ -32,6 +35,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Mock.Strictness;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,18 +55,29 @@ public class AdHocSubProcessActivityServicesTest {
   @Mock private BrokerClient brokerClient;
   @Mock private SecurityContextProvider securityContextProvider;
   @Mock private ApiServicesExecutorProvider executorProvider;
+
+  @Mock(strictness = Strictness.LENIENT)
+  private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
+
   @Captor private ArgumentCaptor<BrokerActivateAdHocSubProcessActivityRequest> requestCaptor;
 
   private AdHocSubProcessActivityServices services;
 
   @BeforeEach
   public void before() {
+    final Map<String, Object> tokenClaims = Map.of("claim", "value");
     final CamundaAuthentication authentication =
-        CamundaAuthentication.of(b -> b.claims(Map.of("claim", "value")));
+        CamundaAuthentication.of(b -> b.claims(tokenClaims));
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
+    when(brokerRequestAuthorizationConverter.convert(eq(authentication)))
+        .thenReturn(Map.of(USER_TOKEN_CLAIMS, tokenClaims));
     services =
         new AdHocSubProcessActivityServices(
-            brokerClient, securityContextProvider, authentication, executorProvider);
+            brokerClient,
+            securityContextProvider,
+            authentication,
+            executorProvider,
+            brokerRequestAuthorizationConverter);
   }
 
   @Test
@@ -110,7 +125,7 @@ public class AdHocSubProcessActivityServicesTest {
     // then
     assertThat(result).isEqualTo(expectedResponse);
     assertThat(requestCaptor.getValue().getAuthorization().getClaims())
-        .containsExactly(entry("claim", "value"));
+        .containsExactly(entry(USER_TOKEN_CLAIMS, Map.of("claim", "value")));
   }
 
   @Test
@@ -118,6 +133,8 @@ public class AdHocSubProcessActivityServicesTest {
     // given
     final CamundaAuthentication newAuthentication =
         CamundaAuthentication.of(b -> b.claims(Map.of("newClaim", "newValue")));
+    when(brokerRequestAuthorizationConverter.convert(eq(newAuthentication)))
+        .thenReturn(Map.of(USER_TOKEN_CLAIMS, Map.of("newClaim", "newValue")));
 
     // when
     when(brokerClient.sendRequest(requestCaptor.capture()))
@@ -131,7 +148,7 @@ public class AdHocSubProcessActivityServicesTest {
     // then
     assertThat(newServices).isNotSameAs(services);
     assertThat(requestCaptor.getValue().getAuthorization().getClaims())
-        .containsExactly(entry("newClaim", "newValue"));
+        .containsExactly(entry(USER_TOKEN_CLAIMS, Map.of("newClaim", "newValue")));
   }
 
   @ParameterizedTest

--- a/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
@@ -37,7 +37,8 @@ public class AuthorizationServiceTest {
             mock(SecurityContextProvider.class),
             client,
             null,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
@@ -53,7 +53,8 @@ public final class DecisionDefinitionServiceTest {
             client,
             decisionRequirementServices,
             null,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -45,7 +45,8 @@ class DecisionInstanceServiceTest {
             mock(SecurityContextProvider.class),
             client,
             null,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
@@ -43,7 +43,8 @@ public final class DecisionRequirementsServiceTest {
             mock(SecurityContextProvider.class),
             client,
             null,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/DocumentServicesTest.java
+++ b/service/src/test/java/io/camunda/service/DocumentServicesTest.java
@@ -62,7 +62,8 @@ public class DocumentServicesTest {
             registry,
             authorizationChecker,
             securityConfiguration,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
 
     final var authorizationConfiguration = new AuthorizationsConfiguration();
     authorizationConfiguration.setEnabled(false);

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -53,7 +53,8 @@ public final class ElementInstanceServiceTest {
             client,
             processCache,
             null,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
 
     when(client.withSecurityContext(any())).thenReturn(client);
     when(processCache.getCacheItems(any())).thenReturn(ProcessCacheResult.EMPTY);

--- a/service/src/test/java/io/camunda/service/FormServiceTest.java
+++ b/service/src/test/java/io/camunda/service/FormServiceTest.java
@@ -35,7 +35,8 @@ public final class FormServiceTest {
             mock(SecurityContextProvider.class),
             client,
             null,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.service;
 
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -18,6 +20,7 @@ import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
@@ -33,6 +36,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ForkJoinPool;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +49,7 @@ public class GroupServiceTest {
   private CamundaAuthentication authentication;
   private StubbedBrokerClient stubbedBrokerClient;
   private ApiServicesExecutorProvider executorProvider;
+  private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
   @BeforeEach
   public void before() {
@@ -54,13 +59,17 @@ public class GroupServiceTest {
     when(client.withSecurityContext(any())).thenReturn(client);
     executorProvider = mock(ApiServicesExecutorProvider.class);
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
+    brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
+    when(brokerRequestAuthorizationConverter.convert(eq(authentication)))
+        .thenReturn(Map.of(AUTHORIZED_USERNAME, authentication.authenticatedUsername()));
     services =
         new GroupServices(
             stubbedBrokerClient,
             mock(SecurityContextProvider.class),
             client,
             authentication,
-            executorProvider);
+            executorProvider,
+            brokerRequestAuthorizationConverter);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -42,7 +42,8 @@ public final class IncidentServiceTest {
             mock(SecurityContextProvider.class),
             client,
             null,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/JobServiceTest.java
+++ b/service/src/test/java/io/camunda/service/JobServiceTest.java
@@ -37,7 +37,8 @@ public class JobServiceTest {
             null,
             client,
             null,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/MappingRuleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingRuleServicesTest.java
@@ -20,6 +20,7 @@ import io.camunda.search.filter.MappingRuleFilter;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.MappingRuleServices.MappingRuleDTO;
 import io.camunda.service.security.SecurityContextProvider;
@@ -50,6 +51,7 @@ public class MappingRuleServicesTest {
   private StubbedBrokerClient stubbedBrokerClient;
   private SearchQueryResult<MappingRuleEntity> result;
   private ApiServicesExecutorProvider executorProvider;
+  private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
   @BeforeEach
   public void before() {
@@ -65,13 +67,15 @@ public class MappingRuleServicesTest {
         ArgumentCaptor.forClass(BrokerMappingRuleUpdateRequest.class);
     executorProvider = mock(ApiServicesExecutorProvider.class);
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
+    brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
     services =
         new MappingRuleServices(
             stubbedBrokerClient,
             mock(SecurityContextProvider.class),
             client,
             authentication,
-            executorProvider);
+            executorProvider,
+            brokerRequestAuthorizationConverter);
   }
 
   @Test
@@ -142,7 +146,8 @@ public class MappingRuleServicesTest {
             mock(SecurityContextProvider.class),
             client,
             testAuthentication,
-            executorProvider);
+            executorProvider,
+            brokerRequestAuthorizationConverter);
 
     final var mappingRuleRecord = new MappingRuleRecord();
     mappingRuleRecord.setMappingRuleId("id");
@@ -170,7 +175,8 @@ public class MappingRuleServicesTest {
             mock(SecurityContextProvider.class),
             client,
             testAuthentication,
-            executorProvider);
+            executorProvider,
+            brokerRequestAuthorizationConverter);
 
     final var mappingRuleRecord = new MappingRuleRecord();
     mappingRuleRecord.setMappingRuleId("id");

--- a/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
@@ -36,7 +36,8 @@ public class MessageSubscriptionServiceTest {
             mock(SecurityContextProvider.class),
             client,
             null,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -32,6 +32,7 @@ import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SequenceFlowQuery;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
@@ -65,6 +66,7 @@ public final class ProcessInstanceServiceTest {
   private CamundaAuthentication authentication;
   private BrokerClient brokerClient;
   private ApiServicesExecutorProvider executorProvider;
+  private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
   @BeforeEach
   public void before() {
@@ -81,6 +83,7 @@ public final class ProcessInstanceServiceTest {
     brokerClient = mock(BrokerClient.class);
     executorProvider = mock(ApiServicesExecutorProvider.class);
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
+    brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
     services =
         new ProcessInstanceServices(
             brokerClient,
@@ -89,7 +92,8 @@ public final class ProcessInstanceServiceTest {
             sequenceFlowSearchClient,
             incidentServices,
             authentication,
-            executorProvider);
+            executorProvider,
+            brokerRequestAuthorizationConverter);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -19,6 +19,7 @@ import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.RoleMemberRequest;
@@ -46,6 +47,7 @@ public class RoleServicesTest {
   private CamundaAuthentication authentication;
   private StubbedBrokerClient stubbedBrokerClient;
   private ApiServicesExecutorProvider executorProvider;
+  private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
   @BeforeEach
   public void before() {
@@ -55,13 +57,15 @@ public class RoleServicesTest {
     when(client.withSecurityContext(any())).thenReturn(client);
     executorProvider = mock(ApiServicesExecutorProvider.class);
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
+    brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
     services =
         new RoleServices(
             stubbedBrokerClient,
             mock(SecurityContextProvider.class),
             client,
             authentication,
-            executorProvider);
+            executorProvider,
+            brokerRequestAuthorizationConverter);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -20,6 +20,7 @@ import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.TenantServices.TenantMemberRequest;
 import io.camunda.service.TenantServices.TenantRequest;
@@ -50,6 +51,7 @@ public class TenantServiceTest {
   private final TenantEntity tenantEntity =
       new TenantEntity(100L, "tenant-id", "Tenant name", "Tenant description");
   private ApiServicesExecutorProvider executorProvider;
+  private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
   @BeforeEach
   public void before() {
@@ -60,13 +62,15 @@ public class TenantServiceTest {
     when(client.withSecurityContext(any())).thenReturn(client);
     executorProvider = mock(ApiServicesExecutorProvider.class);
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
+    brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
     services =
         new TenantServices(
             stubbedBrokerClient,
             mock(SecurityContextProvider.class),
             client,
             authentication,
-            executorProvider);
+            executorProvider,
+            brokerRequestAuthorizationConverter);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -40,7 +40,8 @@ public final class UsageMetricsServiceTest {
             mock(SecurityContextProvider.class),
             client,
             null,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/UserServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserServiceTest.java
@@ -19,6 +19,7 @@ import io.camunda.search.entities.UserEntity;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -40,6 +41,7 @@ public class UserServiceTest {
   private UserSearchClient client;
   private BrokerClient brokerClient;
   private CamundaAuthentication authentication;
+  private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
   @BeforeEach
   public void before() {
@@ -51,6 +53,7 @@ public class UserServiceTest {
     userDeleteRequestArgumentCaptor = ArgumentCaptor.forClass(BrokerUserDeleteRequest.class);
     final ApiServicesExecutorProvider executorProvider = mock(ApiServicesExecutorProvider.class);
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
+    brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
     services =
         new UserServices(
             brokerClient,
@@ -58,7 +61,8 @@ public class UserServiceTest {
             client,
             authentication,
             passwordEncoder,
-            executorProvider);
+            executorProvider,
+            brokerRequestAuthorizationConverter);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -70,7 +70,8 @@ public class UserTaskServiceTest {
             variableServices,
             processCache,
             null,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
 
     when(client.withSecurityContext(any())).thenReturn(client);
     when(formServices.withAuthentication(any(CamundaAuthentication.class)))

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -45,7 +45,8 @@ public class VariableServiceTest {
             mock(SecurityContextProvider.class),
             client,
             null,
-            mock(ApiServicesExecutorProvider.class));
+            mock(ApiServicesExecutorProvider.class),
+            null);
   }
 
   @Test

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -90,7 +90,8 @@ public final class Broker implements AutoCloseable {
             systemContext.getUserServices(),
             systemContext.getPasswordEncoder(),
             systemContext.getJwtDecoder(),
-            systemContext.getSearchClientsProxy());
+            systemContext.getSearchClientsProxy(),
+            systemContext.getBrokerRequestAuthorizationConverter());
 
     brokerStartupActor = new BrokerStartupActor(startupContext);
     scheduler.submitActor(brokerStartupActor);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.bootstrap;
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -140,4 +141,6 @@ public interface BrokerStartupContext {
   SnapshotApiRequestHandler getSnapshotApiRequestHandler();
 
   void setSnapshotApiRequestHandler(SnapshotApiRequestHandler snapshotApiRequestHandler);
+
+  BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -13,6 +13,7 @@ import static java.util.Objects.requireNonNull;
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -67,6 +68,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
   private final SearchClientsProxy searchClientsProxy;
+  private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
   private ConcurrencyControl concurrencyControl;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor;
@@ -99,7 +101,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
-      final SearchClientsProxy searchClientsProxy) {
+      final SearchClientsProxy searchClientsProxy,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
 
     this.brokerInfo = requireNonNull(brokerInfo);
     this.configuration = requireNonNull(configuration);
@@ -118,6 +121,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.jwtDecoder = jwtDecoder;
     this.searchClientsProxy = searchClientsProxy;
     partitionListeners.addAll(additionalPartitionListeners);
+    this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
   }
 
   @VisibleForTesting
@@ -136,7 +140,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
-      final SearchClientsProxy searchClientsProxy) {
+      final SearchClientsProxy searchClientsProxy,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
 
     this(
         brokerInfo,
@@ -155,7 +160,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
         userServices,
         passwordEncoder,
         jwtDecoder,
-        searchClientsProxy);
+        searchClientsProxy,
+        brokerRequestAuthorizationConverter);
   }
 
   @Override
@@ -402,5 +408,10 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   public void setSnapshotApiRequestHandler(
       final SnapshotApiRequestHandler snapshotApiRequestHandler) {
     this.snapshotApiRequestHandler = snapshotApiRequestHandler;
+  }
+
+  @Override
+  public BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter() {
+    return brokerRequestAuthorizationConverter;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -50,7 +50,8 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext.getMeterRegistry(),
             brokerStartupContext.getBrokerClient(),
             brokerStartupContext.getSecurityConfiguration(),
-            brokerStartupContext.getSearchClientsProxy());
+            brokerStartupContext.getSearchClientsProxy(),
+            brokerStartupContext.getBrokerRequestAuthorizationConverter());
     concurrencyControl.run(
         () -> {
           try {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -13,6 +13,7 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.primitive.partition.impl.DefaultPartitionManagementService;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
@@ -100,7 +101,8 @@ public final class PartitionManagerImpl
       final MeterRegistry meterRegistry,
       final BrokerClient brokerClient,
       final SecurityConfiguration securityConfig,
-      final SearchClientsProxy searchClientsProxy) {
+      final SearchClientsProxy searchClientsProxy,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this.brokerCfg = brokerCfg;
     this.concurrencyControl = concurrencyControl;
     this.actorSchedulingService = actorSchedulingService;
@@ -135,7 +137,8 @@ public final class PartitionManagerImpl
             topologyManager,
             featureFlags,
             securityConfig,
-            searchClientsProxy);
+            searchClientsProxy,
+            brokerRequestAuthorizationConverter);
     managementService =
         new DefaultPartitionManagementService(
             clusterServices.getMembershipService(), clusterServices.getCommunicationService());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.partitioning.startup;
 
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
@@ -120,6 +121,7 @@ public final class ZeebePartitionFactory {
   private final List<PartitionRaftListener> partitionRaftListeners;
   private final SecurityConfiguration securityConfig;
   private final SearchClientsProxy searchClientsProxy;
+  private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
   public ZeebePartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -137,7 +139,8 @@ public final class ZeebePartitionFactory {
       final TopologyManagerImpl topologyManager,
       final FeatureFlags featureFlags,
       final SecurityConfiguration securityConfig,
-      final SearchClientsProxy searchClientsProxy) {
+      final SearchClientsProxy searchClientsProxy,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
@@ -154,6 +157,7 @@ public final class ZeebePartitionFactory {
     this.featureFlags = featureFlags;
     this.securityConfig = securityConfig;
     this.searchClientsProxy = searchClientsProxy;
+    this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
   }
 
   public ZeebePartition constructPartition(
@@ -268,7 +272,8 @@ public final class ZeebePartitionFactory {
           partitionCommandSender,
           featureFlags,
           jobStreamer,
-          searchClientsProxy);
+          searchClientsProxy,
+          brokerRequestAuthorizationConverter);
     };
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirect
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.backup.azure.AzureBackupStore;
@@ -77,6 +78,7 @@ public final class SystemContext {
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
   private final SearchClientsProxy searchClientsProxy;
+  private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
   public SystemContext(
       final Duration shutdownTimeout,
@@ -90,7 +92,8 @@ public final class SystemContext {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
-      final SearchClientsProxy searchClientsProxy) {
+      final SearchClientsProxy searchClientsProxy,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this.shutdownTimeout = shutdownTimeout;
     this.brokerCfg = brokerCfg;
     this.identityConfiguration = identityConfiguration;
@@ -103,6 +106,7 @@ public final class SystemContext {
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
     this.searchClientsProxy = searchClientsProxy;
+    this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
     initSystemContext();
   }
 
@@ -116,7 +120,8 @@ public final class SystemContext {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
-      final SearchClientsProxy searchClientsProxy) {
+      final SearchClientsProxy searchClientsProxy,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this(
         DEFAULT_SHUTDOWN_TIMEOUT,
         brokerCfg,
@@ -129,7 +134,8 @@ public final class SystemContext {
         userServices,
         passwordEncoder,
         jwtDecoder,
-        searchClientsProxy);
+        searchClientsProxy,
+        brokerRequestAuthorizationConverter);
   }
 
   private void initSystemContext() {
@@ -482,5 +488,9 @@ public final class SystemContext {
 
   public SearchClientsProxy getSearchClientsProxy() {
     return searchClientsProxy;
+  }
+
+  public BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter() {
+    return brokerRequestAuthorizationConverter;
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -75,7 +76,8 @@ public final class SimpleBrokerStartTest {
                       mock(UserServices.class),
                       mock(PasswordEncoder.class),
                       mock(JwtDecoder.class),
-                      mock(SearchClientsProxy.class));
+                      mock(SearchClientsProxy.class),
+                      mock(BrokerRequestAuthorizationConverter.class));
               new Broker(systemContext, TEST_SPRING_BROKER_BRIDGE, emptyList());
             });
 
@@ -105,7 +107,8 @@ public final class SimpleBrokerStartTest {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
-            mock(SearchClientsProxy.class));
+            mock(SearchClientsProxy.class),
+            mock(BrokerRequestAuthorizationConverter.class));
 
     final var leaderLatch = new CountDownLatch(1);
     final var listener =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -79,7 +80,8 @@ class ApiMessagingServiceStepTest {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
-            mock(SearchClientsProxy.class));
+            mock(SearchClientsProxy.class),
+            mock(BrokerRequestAuthorizationConverter.class));
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -80,7 +81,8 @@ class CommandApiServiceStepTest {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
-            mock(SearchClientsProxy.class));
+            mock(SearchClientsProxy.class),
+            mock(BrokerRequestAuthorizationConverter.class));
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
     testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitorActor.class));
     testBrokerStartupContext.setGatewayBrokerTransport(mock(AtomixServerTransport.class));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStepTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -90,7 +91,8 @@ class EmbeddedGatewayServiceStepTest {
               mock(UserServices.class),
               mock(PasswordEncoder.class),
               mock(JwtDecoder.class),
-              mock(SearchClientsProxy.class));
+              mock(SearchClientsProxy.class),
+              mock(BrokerRequestAuthorizationConverter.class));
 
       final var port = SocketUtil.getNextAddress().getPort();
       final var commandApiCfg = TEST_BROKER_CONFIG.getGateway().getNetwork();
@@ -164,7 +166,8 @@ class EmbeddedGatewayServiceStepTest {
               mock(UserServices.class),
               mock(PasswordEncoder.class),
               mock(JwtDecoder.class),
-              mock(SearchClientsProxy.class));
+              mock(SearchClientsProxy.class),
+              mock(BrokerRequestAuthorizationConverter.class));
 
       testBrokerStartupContext.setEmbeddedGatewayService(mockEmbeddedGatewayService);
       shutdownFuture = CONCURRENCY_CONTROL.createFuture();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -72,7 +73,8 @@ class GatewayBrokerTransportStepTest {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
-            mock(SearchClientsProxy.class));
+            mock(SearchClientsProxy.class),
+            mock(BrokerRequestAuthorizationConverter.class));
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -18,6 +18,7 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberConfig;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -102,7 +103,8 @@ class PartitionManagerStepTest {
               mock(UserServices.class),
               mock(PasswordEncoder.class),
               mock(JwtDecoder.class),
-              mock(SearchClientsProxy.class));
+              mock(SearchClientsProxy.class),
+              mock(BrokerRequestAuthorizationConverter.class));
       testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
       testBrokerStartupContext.setAdminApiService(mock(AdminApiRequestHandler.class));
       testBrokerStartupContext.setBrokerAdminService(mock(BrokerAdminServiceImpl.class));
@@ -205,7 +207,8 @@ class PartitionManagerStepTest {
               mock(UserServices.class),
               mock(PasswordEncoder.class),
               mock(JwtDecoder.class),
-              mock(SearchClientsProxy.class));
+              mock(SearchClientsProxy.class),
+              mock(BrokerRequestAuthorizationConverter.class));
 
       testBrokerStartupContext.setPartitionManager(mockPartitionManager);
       final ClusterConfigurationService mockClusterTopology =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -66,7 +67,8 @@ class RequestIdGeneratorStepTest {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
-            mock(SearchClientsProxy.class));
+            mock(SearchClientsProxy.class),
+            mock(BrokerRequestAuthorizationConverter.class));
     testBrokerStartupContext.setConcurrencyControl(spyConcurrencyControl);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -118,6 +118,7 @@ final class PartitionJoinTest {
             null,
             null,
             null,
+            null,
             null);
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -237,6 +237,7 @@ final class PartitionLeaveTest {
             null,
             null,
             null,
+            null,
             null);
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -374,7 +375,8 @@ final class SystemContextTest {
         mock(UserServices.class),
         mock(PasswordEncoder.class),
         mock(JwtDecoder.class),
-        mock(SearchClientsProxy.class));
+        mock(SearchClientsProxy.class),
+        mock(BrokerRequestAuthorizationConverter.class));
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -254,6 +254,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
             null,
             null,
             null,
+            null,
             null);
 
     final var additionalListeners = new ArrayList<>(Arrays.asList(listeners));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing;
 import static io.camunda.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
@@ -90,7 +91,8 @@ public final class EngineProcessors {
       final InterPartitionCommandSender interPartitionCommandSender,
       final FeatureFlags featureFlags,
       final JobStreamer jobStreamer,
-      final SearchClientsProxy searchClientsProxy) {
+      final SearchClientsProxy searchClientsProxy,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
     final var keyGenerator = processingState.getKeyGenerator();
@@ -336,7 +338,8 @@ public final class EngineProcessors {
         config,
         partitionId,
         routingInfo,
-        batchOperationMetrics);
+        batchOperationMetrics,
+        brokerRequestAuthorizationConverter);
 
     UsageMetricsProcessors.addUsageMetricsProcessors(
         typedRecordProcessors, config, clock, processingState, writers, keyGenerator);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.batchoperation;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.CancelProcessInstanceBatchOperationExecutor;
@@ -50,20 +51,28 @@ public final class BatchOperationSetupProcessors {
       final EngineConfiguration engineConfiguration,
       final int partitionId,
       final RoutingInfo routingInfo,
-      final BatchOperationMetrics batchOperationMetrics) {
+      final BatchOperationMetrics batchOperationMetrics,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     final var batchExecutionHandlers =
         Map.of(
             BatchOperationType.CANCEL_PROCESS_INSTANCE,
-            new CancelProcessInstanceBatchOperationExecutor(writers.command()),
+            new CancelProcessInstanceBatchOperationExecutor(
+                writers.command(), brokerRequestAuthorizationConverter),
             BatchOperationType.RESOLVE_INCIDENT,
             new ResolveIncidentBatchOperationExecutor(
-                writers.command(), processingState.getIncidentState()),
+                writers.command(),
+                processingState.getIncidentState(),
+                brokerRequestAuthorizationConverter),
             BatchOperationType.MIGRATE_PROCESS_INSTANCE,
             new MigrateProcessInstanceBatchOperationExecutor(
-                writers.command(), processingState.getBatchOperationState()),
+                writers.command(),
+                processingState.getBatchOperationState(),
+                brokerRequestAuthorizationConverter),
             BatchOperationType.MODIFY_PROCESS_INSTANCE,
             new ModifyProcessInstanceBatchOperationExecutor(
-                writers.command(), processingState.getElementInstanceState()));
+                writers.command(),
+                processingState.getElementInstanceState(),
+                brokerRequestAuthorizationConverter));
 
     final var batchOperationInitializer =
         new BatchOperationInitializer(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/CancelProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/CancelProcessInstanceBatchOperationExecutor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.batchoperation.handlers;
 
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -20,15 +21,21 @@ public class CancelProcessInstanceBatchOperationExecutor implements BatchOperati
       LoggerFactory.getLogger(CancelProcessInstanceBatchOperationExecutor.class);
 
   final TypedCommandWriter commandWriter;
+  private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
-  public CancelProcessInstanceBatchOperationExecutor(final TypedCommandWriter commandWriter) {
+  public CancelProcessInstanceBatchOperationExecutor(
+      final TypedCommandWriter commandWriter,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this.commandWriter = commandWriter;
+    this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
   }
 
   @Override
   public void execute(final long itemKey, final PersistedBatchOperation batchOperation) {
     LOGGER.trace("Cancelling process instance with key '{}'", itemKey);
 
+    final var authentication = batchOperation.getAuthentication();
+    final var claims = brokerRequestAuthorizationConverter.convert(authentication);
     final var command = new ProcessInstanceRecord();
     command.setProcessInstanceKey(itemKey);
     commandWriter.appendFollowUpCommand(
@@ -36,8 +43,6 @@ public class CancelProcessInstanceBatchOperationExecutor implements BatchOperati
         ProcessInstanceIntent.CANCEL,
         command,
         FollowUpCommandMetadata.of(
-            b ->
-                b.batchOperationReference(batchOperation.getKey())
-                    .claims(batchOperation.getAuthentication().claims())));
+            b -> b.batchOperationReference(batchOperation.getKey()).claims(claims)));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.perf;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
@@ -86,7 +88,8 @@ public final class TestEngine {
                             interPartitionCommandSender,
                             featureFlags,
                             JobStreamer.noop(),
-                            SearchClientsProxy.noop())
+                            SearchClientsProxy.noop(),
+                            new BrokerRequestAuthorizationConverter(new SecurityConfiguration()))
                         .withListener(
                             new ProcessingExporterTransistor(
                                 testStreams.getLogStream(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -18,6 +18,7 @@ import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
@@ -62,6 +63,8 @@ abstract class AbstractBatchOperationTest {
 
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
   protected final SearchClientsProxy searchClientsProxy = Mockito.mock(SearchClientsProxy.class);
+  protected final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter =
+      Mockito.mock(BrokerRequestAuthorizationConverter.class);
 
   @Rule
   public final EngineRule engine =
@@ -79,7 +82,8 @@ abstract class AbstractBatchOperationTest {
                   cfg.setBatchOperationQueryPageSize(DEFAULT_QUERY_PAGE_SIZE)
                       .setBatchOperationQueryRetryMax(2)
                       .setBatchOperationQueryRetryInitialDelay(Duration.ofMillis(100)))
-          .withSearchClientsProxy(searchClientsProxy);
+          .withSearchClientsProxy(searchClientsProxy)
+          .withBrokerRequestAuthorizationConverter(brokerRequestAuthorizationConverter);
 
   @Before
   public void setUp() {
@@ -109,6 +113,7 @@ abstract class AbstractBatchOperationTest {
     DirectBuffer authenticationBuffer = null;
     if (claims != null) {
       authenticationBuffer = convertToBuffer(CamundaAuthentication.of(b -> b.claims(claims)));
+      when(brokerRequestAuthorizationConverter.convert(any())).thenReturn(claims);
     }
 
     return engine
@@ -148,6 +153,7 @@ abstract class AbstractBatchOperationTest {
     DirectBuffer authenticationBuffer = null;
     if (claims != null) {
       authenticationBuffer = convertToBuffer(CamundaAuthentication.of(b -> b.claims(claims)));
+      when(brokerRequestAuthorizationConverter.convert(any())).thenReturn(claims);
     }
 
     return engine
@@ -211,6 +217,7 @@ abstract class AbstractBatchOperationTest {
     DirectBuffer authenticationBuffer = null;
     if (claims != null) {
       authenticationBuffer = convertToBuffer(CamundaAuthentication.of(b -> b.claims(claims)));
+      when(brokerRequestAuthorizationConverter.convert(any())).thenReturn(claims);
     }
 
     return engine
@@ -254,6 +261,7 @@ abstract class AbstractBatchOperationTest {
     DirectBuffer authenticationBuffer = null;
     if (claims != null) {
       authenticationBuffer = convertToBuffer(CamundaAuthentication.of(b -> b.claims(claims)));
+      when(brokerRequestAuthorizationConverter.convert(any())).thenReturn(claims);
     }
 
     return engine

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
@@ -129,6 +130,7 @@ public final class EngineRule extends ExternalResource {
       cfg -> cfg.getAuthorizations().setEnabled(false);
   private Consumer<EngineConfiguration> engineConfigModifier = cfg -> {};
   private SearchClientsProxy searchClientsProxy;
+  private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
   private Optional<RoutingState> initialRoutingState = Optional.empty();
 
   private EngineRule(final int partitionCount) {
@@ -265,6 +267,12 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
+  public EngineRule withBrokerRequestAuthorizationConverter(
+      final BrokerRequestAuthorizationConverter authorizationConverter) {
+    brokerRequestAuthorizationConverter = authorizationConverter;
+    return this;
+  }
+
   public EngineRule withInitializeRoutingState(final boolean initializeRoutingState) {
     this.initializeRoutingState = initializeRoutingState;
     return this;
@@ -334,7 +342,8 @@ public final class EngineRule extends ExternalResource {
                         interPartitionCommandSender,
                         featureFlags,
                         jobStreamer,
-                        searchClientsProxy)
+                        searchClientsProxy,
+                        brokerRequestAuthorizationConverter)
                     .withListener(
                         new ProcessingExporterTransistor(
                             environmentRule.getLogStream(partitionId)));

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -85,7 +85,7 @@ public sealed interface AuthenticationHandler {
       }
 
       var context = Context.current();
-      if (oidcAuthenticationConfiguration.getGroupsClaim() != null) {
+      if (oidcAuthenticationConfiguration.isGroupsClaimConfigured()) {
         try {
           context = context.withValue(GROUPS_CLAIMS, oidcGroupsLoader.load(token.getClaims()));
         } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -12,8 +12,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.jayway.jsonpath.JsonPath;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.ApiServicesExecutorProvider;
 import io.camunda.service.JobServices;
 import io.camunda.service.security.SecurityContextProvider;
@@ -433,7 +435,8 @@ public class JobControllerLongPollingTest extends RestControllerTest {
           activateJobsHandler,
           null,
           null,
-          new ApiServicesExecutorProvider(1, 1, 1, 1));
+          new ApiServicesExecutorProvider(1, 1, 1, 1),
+          new BrokerRequestAuthorizationConverter(new SecurityConfiguration()));
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -12,8 +12,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.jayway.jsonpath.JsonPath;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.ApiServicesExecutorProvider;
 import io.camunda.service.JobServices;
 import io.camunda.service.security.SecurityContextProvider;
@@ -423,7 +425,8 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
           activateJobsHandler,
           null,
           null,
-          new ApiServicesExecutorProvider(1, 1, 1, 1));
+          new ApiServicesExecutorProvider(1, 1, 1, 1),
+          new BrokerRequestAuthorizationConverter(new SecurityConfiguration()));
     }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -384,6 +384,7 @@ public class ClusteringRule extends ExternalResource {
             null,
             null,
             null,
+            null,
             null);
 
     final Broker broker =


### PR DESCRIPTION
## Description

Before these changes, when creating a `CamundaAuthentication,` specific claims must be provided to submit a broker request. When forgotten, it may behave differently (in terms of authorization) depending on what is missing with which authentication method.

This pull resolves the tight coupling of both concerns, meaning:
1. The authentication-relevant properties must be provided when creating a `CamundaAuthentication`. It is not needed to provide specific claims to submit a broker request.
2. Instead, in `BrokerRequestAuthorizationConverter`, the `CamundaAuthentication` is converted into a broker request authorization object (i.e., a Map) that extracts the relevant information from the given authentication that the broker needs. That way, that concern is centralized and implemented once, and there is no need to re-implement it in different places.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36036
