### PR TITLE
feat: client java + spring boot starter retry backoff config

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
@@ -161,7 +161,8 @@ public class AnnotationUtil {
               annotation.fetchAllVariables(),
               annotation.streamEnabled(),
               Duration.of(annotation.streamTimeout(), ChronoUnit.MILLIS),
-              annotation.maxRetries()));
+              annotation.maxRetries(),
+              Duration.of(annotation.retryBackoff(), ChronoUnit.MILLIS)));
     }
     return Optional.empty();
   }
@@ -188,7 +189,8 @@ public class AnnotationUtil {
               annotation.fetchAllVariables(),
               annotation.streamEnabled(),
               Duration.of(annotation.streamTimeout(), ChronoUnit.MILLIS),
-              annotation.maxRetries()));
+              annotation.maxRetries(),
+              Duration.ZERO));
     }
     return Optional.empty();
   }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/JobWorker.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/JobWorker.java
@@ -119,5 +119,5 @@ public @interface JobWorker {
   int maxRetries() default -1;
 
   /** Set the retry backoff for a job (in milliseconds) */
-  long retryBackoff() default 0L;
+  long retryBackoff() default -1L;
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/JobWorker.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/JobWorker.java
@@ -117,4 +117,7 @@ public @interface JobWorker {
 
   /** Set the max number of retries for a job */
   int maxRetries() default -1;
+
+  /** Set the retry backoff for a job (in milliseconds) */
+  long retryBackoff() default -1L;
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/JobWorker.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/JobWorker.java
@@ -119,5 +119,5 @@ public @interface JobWorker {
   int maxRetries() default -1;
 
   /** Set the retry backoff for a job (in milliseconds) */
-  long retryBackoff() default -1L;
+  long retryBackoff() default 0L;
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/value/JobWorkerValue.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/value/JobWorkerValue.java
@@ -35,7 +35,8 @@ public class JobWorkerValue {
   private Boolean forceFetchAllVariables;
   private Boolean streamEnabled;
   private Duration streamTimeout;
-  private Integer maxRetries;
+  private Integer maxRetries = 0;
+  private Duration retryBackoff;
 
   public JobWorkerValue() {}
 
@@ -54,7 +55,8 @@ public class JobWorkerValue {
       final Boolean forceFetchAllVariables,
       final Boolean streamEnabled,
       final Duration streamTimeout,
-      final Integer maxRetries) {
+      final Integer maxRetries,
+      final Duration retryBackoff) {
     this.type = type;
     this.name = name;
     this.timeout = timeout;
@@ -70,6 +72,7 @@ public class JobWorkerValue {
     this.streamEnabled = streamEnabled;
     this.streamTimeout = streamTimeout;
     this.maxRetries = maxRetries;
+    this.retryBackoff = retryBackoff;
   }
 
   public String getType() {
@@ -192,6 +195,14 @@ public class JobWorkerValue {
     this.maxRetries = maxRetries;
   }
 
+  public Duration getRetryBackoff() {
+    return retryBackoff;
+  }
+
+  public void setRetryBackoff(final Duration retryBackoff) {
+    this.retryBackoff = retryBackoff;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -209,14 +220,12 @@ public class JobWorkerValue {
         forceFetchAllVariables,
         streamEnabled,
         streamTimeout,
-        maxRetries);
+        maxRetries,
+        retryBackoff);
   }
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
@@ -235,7 +244,8 @@ public class JobWorkerValue {
         && Objects.equals(forceFetchAllVariables, that.forceFetchAllVariables)
         && Objects.equals(streamEnabled, that.streamEnabled)
         && Objects.equals(streamTimeout, that.streamTimeout)
-        && Objects.equals(maxRetries, that.maxRetries);
+        && Objects.equals(maxRetries, that.maxRetries)
+        && Objects.equals(retryBackoff, that.retryBackoff);
   }
 
   @Override
@@ -273,6 +283,8 @@ public class JobWorkerValue {
         + streamTimeout
         + ", maxRetries="
         + maxRetries
+        + ", retryBackoff="
+        + retryBackoff
         + '}';
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/DefaultJobExceptionHandlerSupplier.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/DefaultJobExceptionHandlerSupplier.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.jobhandling;
+
+import io.camunda.client.api.worker.JobExceptionHandler;
+import io.camunda.client.metrics.MetricsRecorder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultJobExceptionHandlerSupplier implements JobExceptionHandlerSupplier {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DefaultJobExceptionHandlerSupplier.class);
+  private final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy;
+  private final MetricsRecorder metricsRecorder;
+
+  public DefaultJobExceptionHandlerSupplier(
+      final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
+      final MetricsRecorder metricsRecorder) {
+    this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
+    this.metricsRecorder = metricsRecorder;
+  }
+
+  @Override
+  public JobExceptionHandler getJobExceptionHandler(
+      final JobExceptionHandlerSupplierContext context) {
+    return new SpringJobExceptionHandler(
+        context.jobWorkerValue(), metricsRecorder, commandExceptionHandlingStrategy);
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobExceptionHandlerSupplier.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobExceptionHandlerSupplier.java
@@ -16,17 +16,10 @@
 package io.camunda.client.jobhandling;
 
 import io.camunda.client.annotation.value.JobWorkerValue;
-import io.camunda.client.api.command.FinalCommandStep;
-import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.client.api.worker.JobClient;
+import io.camunda.client.api.worker.JobExceptionHandler;
 
-public interface JobExceptionHandlingStrategy {
-  void handleException(Exception exception, ExceptionHandlingContext context) throws Exception;
+public interface JobExceptionHandlerSupplier {
+  JobExceptionHandler getJobExceptionHandler(JobExceptionHandlerSupplierContext context);
 
-  record ExceptionHandlingContext(
-      JobClient jobClient, ActivatedJob job, JobWorkerValue jobWorkerValue) {}
-
-  interface CommandWrapperCreator {
-    CommandWrapper create(FinalCommandStep<?> command);
-  }
+  record JobExceptionHandlerSupplierContext(JobWorkerValue jobWorkerValue) {}
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/result/DocumentResultProcessorFailureHandlingStrategy.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/result/DocumentResultProcessorFailureHandlingStrategy.java
@@ -22,7 +22,7 @@ import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.exception.BpmnError;
 import io.camunda.client.exception.JobError;
 import io.camunda.client.jobhandling.DocumentContext;
-import io.camunda.client.jobhandling.JobExceptionHandlingStrategy;
+import io.camunda.client.jobhandling.JobExceptionHandlerSupplier;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -35,7 +35,7 @@ public interface DocumentResultProcessorFailureHandlingStrategy {
   /**
    * The method that will be invoked on failure. This method can throw runtime exception, including
    * {@link JobError} and {@link BpmnError} that will be respected and processed by a {@link
-   * JobExceptionHandlingStrategy}
+   * JobExceptionHandlerSupplier}
    *
    * @param context the context being available for handling the failure
    * @throws RuntimeException the exception that may be thrown

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientAllAutoConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientAllAutoConfiguration.java
@@ -22,8 +22,8 @@ import io.camunda.client.api.worker.BackoffSupplier;
 import io.camunda.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.client.jobhandling.DefaultCommandExceptionHandlingStrategy;
-import io.camunda.client.jobhandling.DefaultJobExceptionHandlingStrategy;
-import io.camunda.client.jobhandling.JobExceptionHandlingStrategy;
+import io.camunda.client.jobhandling.DefaultJobExceptionHandlerSupplier;
+import io.camunda.client.jobhandling.JobExceptionHandlerSupplier;
 import io.camunda.client.jobhandling.JobWorkerManager;
 import io.camunda.client.jobhandling.parameter.DefaultParameterResolverStrategy;
 import io.camunda.client.jobhandling.parameter.ParameterResolverStrategy;
@@ -100,10 +100,10 @@ public class CamundaClientAllAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public JobExceptionHandlingStrategy jobExceptionHandlingStrategy(
+  public JobExceptionHandlerSupplier jobExceptionHandlingStrategy(
       final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
       final MetricsRecorder metricsRecorder) {
-    return new DefaultJobExceptionHandlingStrategy(
+    return new DefaultJobExceptionHandlerSupplier(
         commandExceptionHandlingStrategy, metricsRecorder);
   }
 
@@ -114,14 +114,14 @@ public class CamundaClientAllAutoConfiguration {
       final ParameterResolverStrategy parameterResolverStrategy,
       final ResultProcessorStrategy resultProcessorStrategy,
       final BackoffSupplier backoffSupplier,
-      final JobExceptionHandlingStrategy jobExceptionHandlingStrategy) {
+      final JobExceptionHandlerSupplier jobExceptionHandlerSupplier) {
     return new JobWorkerManager(
         commandExceptionHandlingStrategy,
         metricsRecorder,
         parameterResolverStrategy,
         resultProcessorStrategy,
         backoffSupplier,
-        jobExceptionHandlingStrategy);
+        jobExceptionHandlerSupplier);
   }
 
   @Bean

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
@@ -195,6 +195,7 @@ public class SpringCamundaClientConfiguration implements CamundaClientConfigurat
   public int getMaxHttpConnections() {
     return camundaClientProperties.getMaxHttpConnections();
   }
+
   @Override
   public String toString() {
     return "SpringCamundaClientConfiguration{"

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
@@ -238,7 +238,7 @@ public class SpringCamundaClientConfiguration implements CamundaClientConfigurat
 
   @Override
   public String toString() {
-    return "CamundaClientConfigurationImpl{"
+    return "SpringCamundaClientConfiguration{"
         + "camundaClientProperties="
         + camundaClientProperties
         + ", jsonMapper="

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
@@ -181,7 +181,7 @@ public class SpringCamundaClientConfiguration implements CamundaClientConfigurat
   }
 
   @Override
-  public JobExceptionHandler getDefaultJobWorkerJobExceptionHandler() {
+  public JobExceptionHandler getDefaultJobWorkerExceptionHandler() {
     return JobExceptionHandler.createWithRetryBackoff(
         camundaClientProperties.getWorker().getDefaults().getRetryBackoff());
   }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
@@ -18,10 +18,10 @@ package io.camunda.client.spring.configuration;
 import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.worker.JobExceptionHandler;
 import io.camunda.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.client.spring.properties.CamundaClientProperties;
 import io.grpc.ClientInterceptor;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
@@ -181,6 +181,12 @@ public class SpringCamundaClientConfiguration implements CamundaClientConfigurat
   }
 
   @Override
+  public JobExceptionHandler getDefaultJobWorkerJobExceptionHandler() {
+    return JobExceptionHandler.createWithRetryBackoff(
+        camundaClientProperties.getWorker().getDefaults().getRetryBackoff());
+  }
+
+  @Override
   public boolean preferRestOverGrpc() {
     return camundaClientProperties.getPreferRestOverGrpc();
   }
@@ -189,53 +195,6 @@ public class SpringCamundaClientConfiguration implements CamundaClientConfigurat
   public int getMaxHttpConnections() {
     return camundaClientProperties.getMaxHttpConnections();
   }
-
-  private String composeGatewayAddress() {
-    final URI gatewayUrl = getGrpcAddress();
-    final int port = gatewayUrl.getPort();
-    final String host = gatewayUrl.getHost();
-
-    // port is set
-    if (port != -1) {
-      return composeAddressWithPort(host, port, "Gateway port is set");
-    }
-
-    // port is not set, attempting to use default
-    int defaultPort;
-    try {
-      defaultPort = gatewayUrl.toURL().getDefaultPort();
-    } catch (final MalformedURLException e) {
-      LOG.warn("Invalid gateway url: {}", gatewayUrl);
-      // could not get a default port, setting it to -1 and moving to the next statement
-      defaultPort = -1;
-    }
-    if (defaultPort != -1) {
-      return composeAddressWithPort(host, defaultPort, "Gateway port has default");
-    }
-
-    // do not use any port
-    LOG.debug("Gateway cannot be determined, address will be '{}'", host);
-    return host;
-  }
-
-  private String composeAddressWithPort(
-      final String host, final int port, final String debugMessage) {
-    final String gatewayAddress = host + ":" + port;
-    LOG.debug("{}, address will be '{}'", debugMessage, gatewayAddress);
-    return gatewayAddress;
-  }
-
-  private boolean composePlaintext() {
-    final String protocol = getGrpcAddress().getScheme();
-    return switch (protocol) {
-      case "http", "grpc" -> true;
-      case "https", "grpcs" -> false;
-      default ->
-          throw new IllegalStateException(
-              String.format("Unrecognized zeebe protocol '%s'", protocol));
-    };
-  }
-
   @Override
   public String toString() {
     return "SpringCamundaClientConfiguration{"

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientJobWorkerProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientJobWorkerProperties.java
@@ -91,6 +91,9 @@ public class CamundaClientJobWorkerProperties {
    */
   private Integer maxRetries;
 
+  /** The backoff before a retry of a failed job is possible. */
+  private Duration retryBackoff;
+
   /**
    * This instantiates the properties without any defaults. Intended to be used by {@link
    * CamundaClientWorkerProperties#getOverride()}.
@@ -113,6 +116,7 @@ public class CamundaClientJobWorkerProperties {
       pollInterval = DEFAULT_JOB_POLL_INTERVAL;
       name = DEFAULT_JOB_WORKER_NAME_VAR;
       streamEnabled = DEFAULT_STREAM_ENABLED;
+      retryBackoff = Duration.ZERO;
     }
   }
 
@@ -226,5 +230,13 @@ public class CamundaClientJobWorkerProperties {
 
   public void setMaxRetries(final Integer maxRetries) {
     this.maxRetries = maxRetries;
+  }
+
+  public Duration getRetryBackoff() {
+    return retryBackoff;
+  }
+
+  public void setRetryBackoff(final Duration retryBackoff) {
+    this.retryBackoff = retryBackoff;
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizer.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizer.java
@@ -171,6 +171,7 @@ public class PropertyBasedJobWorkerValueCustomizer implements JobWorkerValueCust
         source::getForceFetchAllVariables,
         target::setForceFetchAllVariables);
     copyProperty("maxRetries", overrideSource, source::getMaxRetries, target::setMaxRetries);
+    copyProperty("retryBackoff", overrideSource, source::getRetryBackoff, target::setRetryBackoff);
   }
 
   private <T> void copyProperty(

--- a/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -130,6 +130,10 @@
       "defaultValue": "PT0.1S"
     },
     {
+      "name": "camunda.client.worker.defaults.retry-backoff",
+      "defaultValue": "PT0S"
+    },
+    {
       "name": "camunda.client.worker.defaults.name",
       "defaultValue": "default"
     },

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/JobHandlerInvokingBeansTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/JobHandlerInvokingBeansTest.java
@@ -15,8 +15,8 @@
  */
 package io.camunda.client.jobhandling;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -27,16 +27,12 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.annotation.value.JobWorkerValue;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.CompleteJobCommandStep1;
-import io.camunda.client.api.command.FailJobCommandStep1;
-import io.camunda.client.api.command.FailJobCommandStep1.FailJobCommandStep2;
-import io.camunda.client.api.command.ThrowErrorCommandStep1;
-import io.camunda.client.api.command.ThrowErrorCommandStep1.ThrowErrorCommandStep2;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.CompleteJobResponse;
-import io.camunda.client.api.response.FailJobResponse;
-import io.camunda.client.api.response.ThrowErrorResponse;
 import io.camunda.client.api.worker.BackoffSupplier;
 import io.camunda.client.api.worker.JobClient;
+import io.camunda.client.exception.BpmnError;
+import io.camunda.client.exception.JobError;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.jobhandling.parameter.DefaultParameterResolverStrategy;
 import io.camunda.client.jobhandling.parameter.ParameterResolver;
@@ -76,8 +72,7 @@ public class JobHandlerInvokingBeansTest {
             commandExceptionHandlingStrategy(),
             metricsRecorder(),
             parameterResolvers(jobWorkerValue),
-            resultProcessor(jobWorkerValue),
-            jobExceptionHandlingStrategy());
+            resultProcessor(jobWorkerValue));
 
     final JobClient jobClient = mock(JobClient.class);
     final CompleteJobCommandStep1 completeJobCommandStep1 = mock(CompleteJobCommandStep1.class);
@@ -105,8 +100,7 @@ public class JobHandlerInvokingBeansTest {
             commandExceptionHandlingStrategy(),
             metricsRecorder(),
             parameterResolvers(jobWorkerValue),
-            resultProcessor(jobWorkerValue),
-            jobExceptionHandlingStrategy());
+            resultProcessor(jobWorkerValue));
 
     final JobClient jobClient = mock(JobClient.class);
     final ActivatedJob job = mock(ActivatedJob.class);
@@ -127,27 +121,13 @@ public class JobHandlerInvokingBeansTest {
             commandExceptionHandlingStrategy(),
             metricsRecorder(),
             parameterResolvers(jobWorkerValue),
-            resultProcessor(jobWorkerValue),
-            jobExceptionHandlingStrategy());
+            resultProcessor(jobWorkerValue));
 
     final JobClient jobClient = mock(JobClient.class);
-    final FailJobCommandStep1 failJobCommandStep1 = mock(FailJobCommandStep1.class);
-    final FailJobCommandStep2 failJobCommandStep2 = mock(FailJobCommandStep2.class);
-    final CamundaFuture<FailJobResponse> future = mock(CamundaFuture.class);
-    when(jobClient.newFailCommand(anyLong())).thenReturn(failJobCommandStep1);
-    when(failJobCommandStep1.retries(anyInt())).thenReturn(failJobCommandStep2);
-    when(failJobCommandStep2.errorMessage(any())).thenReturn(failJobCommandStep2);
-    when(failJobCommandStep2.retryBackoff(any())).thenReturn(failJobCommandStep2);
-    when(failJobCommandStep2.variables(any(JobResponse.class))).thenReturn(failJobCommandStep2);
-    when(failJobCommandStep2.send()).thenReturn(future);
-    when(future.thenApply(any())).thenReturn(mock(CompletionStage.class));
     final ActivatedJob job = mock(ActivatedJob.class);
-    when(job.getRetries()).thenReturn(3);
-    jobHandler.handle(jobClient, job);
-    verify(jobClient, times(0)).newCompleteCommand(anyLong());
-    verify(jobClient, times(1)).newFailCommand(anyLong());
-    verify(jobClient, times(0)).newThrowErrorCommand(anyLong());
-    verify(failJobCommandStep2, times(1)).send();
+    assertThatThrownBy(() -> jobHandler.handle(jobClient, job))
+        .isInstanceOf(JobError.class)
+        .hasMessage("test error");
   }
 
   @ParameterizedTest
@@ -162,27 +142,14 @@ public class JobHandlerInvokingBeansTest {
             commandExceptionHandlingStrategy(),
             metricsRecorder(),
             parameterResolvers(jobWorkerValue),
-            resultProcessor(jobWorkerValue),
-            jobExceptionHandlingStrategy());
+            resultProcessor(jobWorkerValue));
 
     final JobClient jobClient = mock(JobClient.class);
-    final ThrowErrorCommandStep1 throwErrorCommandStep1 = mock(ThrowErrorCommandStep1.class);
-    final ThrowErrorCommandStep2 throwErrorCommandStep2 = mock(ThrowErrorCommandStep2.class);
-    final CamundaFuture<ThrowErrorResponse> future = mock(CamundaFuture.class);
-    when(jobClient.newThrowErrorCommand(anyLong())).thenReturn(throwErrorCommandStep1);
-    when(throwErrorCommandStep1.errorCode(any())).thenReturn(throwErrorCommandStep2);
-    when(throwErrorCommandStep2.errorMessage(any())).thenReturn(throwErrorCommandStep2);
-    when(throwErrorCommandStep2.variables(any(JobResponse.class)))
-        .thenReturn(throwErrorCommandStep2);
-    when(throwErrorCommandStep2.send()).thenReturn(future);
-    when(future.thenApply(any())).thenReturn(mock(CompletionStage.class));
     final ActivatedJob job = mock(ActivatedJob.class);
-    when(job.getRetries()).thenReturn(3);
-    jobHandler.handle(jobClient, job);
-    verify(jobClient, times(0)).newCompleteCommand(anyLong());
-    verify(jobClient, times(0)).newFailCommand(anyLong());
-    verify(jobClient, times(1)).newThrowErrorCommand(anyLong());
-    verify(throwErrorCommandStep2, times(1)).send();
+    assertThatThrownBy(() -> jobHandler.handle(jobClient, job))
+        .isInstanceOf(BpmnError.class)
+        .hasMessage("[testCode] test message")
+        .hasFieldOrPropertyWithValue("errorCode", "testCode");
   }
 
   private static JobWorkerValue jobWorkerValue(final TestDimension testDimension) {
@@ -234,10 +201,5 @@ public class JobHandlerInvokingBeansTest {
         new DefaultResultProcessorStrategy(
             mock(CamundaClient.class), mock(DocumentResultProcessorFailureHandlingStrategy.class)),
         jobWorkerValue);
-  }
-
-  private static JobExceptionHandlingStrategy jobExceptionHandlingStrategy() {
-    return new DefaultJobExceptionHandlingStrategy(
-        commandExceptionHandlingStrategy(), metricsRecorder());
   }
 }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/SpringJobExceptionHandlerTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/SpringJobExceptionHandlerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.jobhandling;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.annotation.value.JobWorkerValue;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FailJobCommandStep1;
+import io.camunda.client.api.command.FailJobCommandStep1.FailJobCommandStep2;
+import io.camunda.client.api.command.ThrowErrorCommandStep1;
+import io.camunda.client.api.command.ThrowErrorCommandStep1.ThrowErrorCommandStep2;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.FailJobResponse;
+import io.camunda.client.api.response.ThrowErrorResponse;
+import io.camunda.client.api.worker.JobClient;
+import io.camunda.client.api.worker.JobExceptionHandler.JobExceptionHandlerContext;
+import io.camunda.client.exception.BpmnError;
+import io.camunda.client.exception.JobError;
+import io.camunda.client.metrics.DefaultNoopMetricsRecorder;
+import io.camunda.client.metrics.MetricsRecorder;
+import io.camunda.client.spring.test.util.JobWorkerPermutationsGenerator.JobResponse;
+import java.util.concurrent.CompletionStage;
+import org.junit.jupiter.api.Test;
+
+public class SpringJobExceptionHandlerTest {
+  @Test
+  void shouldHandleAnyException() {
+    final JobWorkerValue jobWorkerValue = new JobWorkerValue();
+    final MetricsRecorder metricsRecorder = new DefaultNoopMetricsRecorder();
+    final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy =
+        mock(CommandExceptionHandlingStrategy.class);
+    final SpringJobExceptionHandler handler =
+        new SpringJobExceptionHandler(
+            jobWorkerValue, metricsRecorder, commandExceptionHandlingStrategy);
+    final JobClient jobClient = mock(JobClient.class);
+    final FailJobCommandStep1 failJobCommandStep1 = mock(FailJobCommandStep1.class);
+    final FailJobCommandStep2 failJobCommandStep2 = mock(FailJobCommandStep2.class);
+    final CamundaFuture<FailJobResponse> future = mock(CamundaFuture.class);
+    when(jobClient.newFailCommand(anyLong())).thenReturn(failJobCommandStep1);
+    when(failJobCommandStep1.retries(anyInt())).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.errorMessage(any())).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.retryBackoff(any())).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.variables(any(JobResponse.class))).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.send()).thenReturn(future);
+    when(future.thenApply(any())).thenReturn(mock(CompletionStage.class));
+    final ActivatedJob job = mock(ActivatedJob.class);
+    when(job.getRetries()).thenReturn(3);
+    handler.handleJobException(new JobExceptionHandlerContext(jobClient, job, new Exception()));
+    verify(jobClient, times(0)).newCompleteCommand(anyLong());
+    verify(jobClient, times(1)).newFailCommand(anyLong());
+    verify(jobClient, times(0)).newThrowErrorCommand(anyLong());
+    verify(failJobCommandStep2, times(1)).send();
+  }
+
+  @Test
+  void shouldHandleJobError() {
+    final JobWorkerValue jobWorkerValue = new JobWorkerValue();
+    final MetricsRecorder metricsRecorder = new DefaultNoopMetricsRecorder();
+    final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy =
+        mock(CommandExceptionHandlingStrategy.class);
+    final SpringJobExceptionHandler handler =
+        new SpringJobExceptionHandler(
+            jobWorkerValue, metricsRecorder, commandExceptionHandlingStrategy);
+    final JobClient jobClient = mock(JobClient.class);
+    final FailJobCommandStep1 failJobCommandStep1 = mock(FailJobCommandStep1.class);
+    final FailJobCommandStep2 failJobCommandStep2 = mock(FailJobCommandStep2.class);
+    final CamundaFuture<FailJobResponse> future = mock(CamundaFuture.class);
+    when(jobClient.newFailCommand(anyLong())).thenReturn(failJobCommandStep1);
+    when(failJobCommandStep1.retries(anyInt())).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.errorMessage(any())).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.retryBackoff(any())).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.variables(any(JobResponse.class))).thenReturn(failJobCommandStep2);
+    when(failJobCommandStep2.send()).thenReturn(future);
+    when(future.thenApply(any())).thenReturn(mock(CompletionStage.class));
+    final ActivatedJob job = mock(ActivatedJob.class);
+    when(job.getRetries()).thenReturn(3);
+    handler.handleJobException(
+        new JobExceptionHandlerContext(jobClient, job, new JobError("test error")));
+    verify(jobClient, times(0)).newCompleteCommand(anyLong());
+    verify(jobClient, times(1)).newFailCommand(anyLong());
+    verify(jobClient, times(0)).newThrowErrorCommand(anyLong());
+    verify(failJobCommandStep2, times(1)).send();
+  }
+
+  @Test
+  void shouldHandleBpmnError() {
+    final JobWorkerValue jobWorkerValue = new JobWorkerValue();
+    final MetricsRecorder metricsRecorder = new DefaultNoopMetricsRecorder();
+    final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy =
+        mock(CommandExceptionHandlingStrategy.class);
+    final SpringJobExceptionHandler handler =
+        new SpringJobExceptionHandler(
+            jobWorkerValue, metricsRecorder, commandExceptionHandlingStrategy);
+    final JobClient jobClient = mock(JobClient.class);
+    final ThrowErrorCommandStep1 throwErrorCommandStep1 = mock(ThrowErrorCommandStep1.class);
+    final ThrowErrorCommandStep2 throwErrorCommandStep2 = mock(ThrowErrorCommandStep2.class);
+    final CamundaFuture<ThrowErrorResponse> future = mock(CamundaFuture.class);
+    when(jobClient.newThrowErrorCommand(anyLong())).thenReturn(throwErrorCommandStep1);
+    when(throwErrorCommandStep1.errorCode(any())).thenReturn(throwErrorCommandStep2);
+    when(throwErrorCommandStep2.errorMessage(any())).thenReturn(throwErrorCommandStep2);
+    when(throwErrorCommandStep2.variables(any(JobResponse.class)))
+        .thenReturn(throwErrorCommandStep2);
+    when(throwErrorCommandStep2.send()).thenReturn(future);
+    when(future.thenApply(any())).thenReturn(mock(CompletionStage.class));
+    final ActivatedJob job = mock(ActivatedJob.class);
+    when(job.getRetries()).thenReturn(3);
+    handler.handleJobException(
+        new JobExceptionHandlerContext(jobClient, job, new BpmnError("errorCode", "test error")));
+    verify(jobClient, times(0)).newCompleteCommand(anyLong());
+    verify(jobClient, times(0)).newFailCommand(anyLong());
+    verify(jobClient, times(1)).newThrowErrorCommand(anyLong());
+    verify(throwErrorCommandStep2, times(1)).send();
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/SpringCamundaClientConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/SpringCamundaClientConfigurationTest.java
@@ -77,6 +77,6 @@ public class SpringCamundaClientConfigurationTest {
     final SpringCamundaClientConfiguration camundaClientConfiguration =
         new SpringCamundaClientConfiguration(properties(), null, null, null, null, null);
     final String toStringOutput = camundaClientConfiguration.toString();
-    assertThat(toStringOutput).matches("CamundaClientConfigurationImpl\\{.*}");
+    assertThat(toStringOutput).matches("SpringCamundaClientConfiguration\\{.*}");
   }
 }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -113,6 +113,11 @@ public class AlignmentTest {
     GETTERS.put(
         "camunda.client.worker.defaults.stream-enabled",
         p -> p.getWorker().getDefaults().getStreamEnabled());
+    // camunda.client.worker.defaults.retry-backoff
+    GETTERS.put(
+        "camunda.client.worker.defaults.retry-backoff",
+        p -> p.getWorker().getDefaults().getRetryBackoff());
+    MAPPERS.put("camunda.client.worker.defaults.retry-backoff", p -> Duration.parse((String) p));
   }
 
   @Autowired CamundaClientProperties camundaClientProperties;

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
@@ -17,6 +17,7 @@ package io.camunda.client;
 
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CommandWithTenantStep;
+import io.camunda.client.api.worker.JobExceptionHandler;
 import io.camunda.client.api.worker.JobHandler;
 import io.camunda.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
 import io.grpc.ClientInterceptor;
@@ -233,6 +234,17 @@ public interface CamundaClientBuilder {
 
   /** Sets the maximum number of concurrent HTTP connections the client can open. */
   CamundaClientBuilder maxHttpConnections(int maxConnections);
+
+  /**
+   * A custom retryBackoffSupplier allows the client to determine the default retry backoff strategy
+   * that every job worker will apply unless configured otherwise. By default, a static retry
+   * backoff of <code>PT0S</code> is used.
+   *
+   * @param jobExceptionHandler the retry backoff supplier to retrieve the retry backoff for every
+   *     fail job command
+   * @return this builder for chaining
+   */
+  CamundaClientBuilder defaultJobWorkerExceptionHandler(JobExceptionHandler jobExceptionHandler);
 
   /**
    * @return a new {@link CamundaClient} with the provided configuration options.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientConfiguration.java
@@ -154,7 +154,7 @@ public interface CamundaClientConfiguration {
   /**
    * @see CamundaClientBuilder#defaultJobWorkerExceptionHandler(JobExceptionHandler)
    */
-  JobExceptionHandler getDefaultJobWorkerJobExceptionHandler();
+  JobExceptionHandler getDefaultJobWorkerExceptionHandler();
 
   /**
    * @see CamundaClientBuilder#preferRestOverGrpc(boolean)

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientConfiguration.java
@@ -16,6 +16,7 @@
 package io.camunda.client;
 
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.worker.JobExceptionHandler;
 import io.grpc.ClientInterceptor;
 import java.net.URI;
 import java.time.Duration;
@@ -149,6 +150,11 @@ public interface CamundaClientConfiguration {
    * @see CamundaClientBuilder#useDefaultRetryPolicy(boolean)
    */
   boolean useDefaultRetryPolicy();
+
+  /**
+   * @see CamundaClientBuilder#defaultJobWorkerExceptionHandler(JobExceptionHandler)
+   */
+  JobExceptionHandler getDefaultJobWorkerJobExceptionHandler();
 
   /**
    * @see CamundaClientBuilder#preferRestOverGrpc(boolean)

--- a/clients/java/src/main/java/io/camunda/client/api/worker/JobExceptionHandler.java
+++ b/clients/java/src/main/java/io/camunda/client/api/worker/JobExceptionHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.worker;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.impl.worker.JobExceptionHandlerImpl;
+import java.time.Duration;
+
+/**
+ * The {@link JobWorker} uses this interface to handle exceptions that are thrown from the {@link
+ * JobHandler#handle(JobClient, ActivatedJob)} method.
+ */
+@FunctionalInterface
+public interface JobExceptionHandler {
+  void handleJobException(JobExceptionHandlerContext context);
+
+  /**
+   * @return the default job exception handler
+   */
+  static JobExceptionHandler createDefault() {
+    return new JobExceptionHandlerImpl();
+  }
+
+  static JobExceptionHandler createWithRetryBackoff(final Duration retryBackoff) {
+    return new JobExceptionHandlerImpl(retryBackoff);
+  }
+
+  class JobExceptionHandlerContext {
+    private final JobClient jobClient;
+    private final ActivatedJob activatedJob;
+    private final Exception exception;
+
+    public JobExceptionHandlerContext(
+        final JobClient jobClient, final ActivatedJob activatedJob, final Exception exception) {
+      this.jobClient = jobClient;
+      this.activatedJob = activatedJob;
+      this.exception = exception;
+    }
+
+    public JobClient getJobClient() {
+      return jobClient;
+    }
+
+    public ActivatedJob getActivatedJob() {
+      return activatedJob;
+    }
+
+    public Exception getException() {
+      return exception;
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
@@ -243,6 +243,16 @@ public interface JobWorkerBuilderStep1 {
     JobWorkerBuilderStep3 metrics(final JobWorkerMetrics metrics);
 
     /**
+     * Sets the job exception handler to use for this worker. See {@link JobExceptionHandler} for
+     * more. Defaults to {@link
+     * io.camunda.client.CamundaClientBuilder#defaultJobWorkerExceptionHandler(JobExceptionHandler)}.
+     *
+     * @param jobExceptionHandler the retry backoff supplier to use
+     * @return the builder for this worker
+     */
+    JobWorkerBuilderStep3 jobExceptionHandler(JobExceptionHandler jobExceptionHandler);
+
+    /**
      * Open the worker and start to work on available tasks.
      *
      * @return the worker

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -260,7 +260,7 @@ public final class CamundaClientBuilderImpl
   }
 
   @Override
-  public JobExceptionHandler getDefaultJobWorkerJobExceptionHandler() {
+  public JobExceptionHandler getDefaultJobWorkerExceptionHandler() {
     return jobExceptionHandler;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -59,6 +59,7 @@ import io.camunda.client.CredentialsProvider;
 import io.camunda.client.LegacyZeebeClientProperties;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CommandWithTenantStep;
+import io.camunda.client.api.worker.JobExceptionHandler;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.client.impl.util.AddressUtil;
@@ -98,6 +99,8 @@ public final class CamundaClientBuilderImpl
   public static final Duration DEFAULT_JOB_POLL_INTERVAL = Duration.ofMillis(100);
   public static final boolean DEFAULT_STREAM_ENABLED = false;
   public static final int DEFAULT_MAX_HTTP_CONNECTIONS = 100;
+  public static final JobExceptionHandler DEFAULT_JOB_EXCEPTION_HANDLER =
+      JobExceptionHandler.createDefault();
   private static final String TENANT_ID_LIST_SEPARATOR = ",";
   private boolean applyEnvironmentVariableOverrides = true;
 
@@ -129,6 +132,7 @@ public final class CamundaClientBuilderImpl
   private boolean ownsJobWorkerExecutor;
   private boolean useDefaultRetryPolicy;
   private int maxHttpConnections = DEFAULT_MAX_HTTP_CONNECTIONS;
+  private JobExceptionHandler jobExceptionHandler = DEFAULT_JOB_EXCEPTION_HANDLER;
 
   @Override
   public URI getRestAddress() {
@@ -253,6 +257,11 @@ public final class CamundaClientBuilderImpl
   @Override
   public boolean useDefaultRetryPolicy() {
     return useDefaultRetryPolicy;
+  }
+
+  @Override
+  public JobExceptionHandler getDefaultJobWorkerJobExceptionHandler() {
+    return jobExceptionHandler;
   }
 
   @Override
@@ -585,6 +594,13 @@ public final class CamundaClientBuilderImpl
   @Override
   public CamundaClientBuilder preferRestOverGrpc(final boolean preferRestOverGrpc) {
     this.preferRestOverGrpc = preferRestOverGrpc;
+    return this;
+  }
+
+  @Override
+  public CamundaClientBuilder defaultJobWorkerExceptionHandler(
+      final JobExceptionHandler jobExceptionHandler) {
+    this.jobExceptionHandler = jobExceptionHandler;
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
@@ -33,6 +33,7 @@ import io.camunda.client.CredentialsProvider;
 import io.camunda.client.LegacyZeebeClientProperties;
 import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.worker.JobExceptionHandler;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.client.impl.util.AddressUtil;
 import io.grpc.ClientInterceptor;
@@ -292,6 +293,13 @@ public class CamundaClientCloudBuilderImpl
   @Override
   public CamundaClientBuilder preferRestOverGrpc(final boolean preferRestOverGrpc) {
     innerBuilder.preferRestOverGrpc(preferRestOverGrpc);
+    return this;
+  }
+
+  @Override
+  public CamundaClientBuilder defaultJobWorkerExceptionHandler(
+      final JobExceptionHandler jobExceptionHandler) {
+    innerBuilder.defaultJobWorkerExceptionHandler(jobExceptionHandler);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobExceptionHandlerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobExceptionHandlerImpl.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.worker;
+
+import io.camunda.client.api.command.FailJobCommandStep1.FailJobCommandStep2;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.worker.JobClient;
+import io.camunda.client.api.worker.JobExceptionHandler;
+import io.camunda.client.impl.Loggers;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Duration;
+import java.util.function.Function;
+import org.slf4j.Logger;
+
+public class JobExceptionHandlerImpl implements JobExceptionHandler {
+  public static final Function<JobExceptionHandlerContext, String> DEFAULT_ERROR_MESSAGE_PROVIDER =
+      ctx -> {
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter printWriter = new PrintWriter(stringWriter);
+        ctx.getException().printStackTrace(printWriter);
+        return stringWriter.toString();
+      };
+  public static final Function<JobExceptionHandlerContext, Integer> DEFAULT_RETRIES_PROVIDER =
+      ctx -> ctx.getActivatedJob().getRetries() - 1;
+  public static final Function<JobExceptionHandlerContext, Duration>
+      DEFAULT_RETRY_BACKOFF_SUPPLIER = ctx -> Duration.ZERO;
+  public static final Function<JobExceptionHandlerContext, Object> DEFAULT_VARIABLES_PROVIDER =
+      ctx -> null;
+
+  private static final Logger LOG = Loggers.JOB_WORKER_LOGGER;
+  private final Function<JobExceptionHandlerContext, String> errorMessageProvider;
+  private final Function<JobExceptionHandlerContext, Integer> retriesProvider;
+  private final Function<JobExceptionHandlerContext, Duration> retryBackoffProvider;
+  private final Function<JobExceptionHandlerContext, Object> variablesProvider;
+
+  public JobExceptionHandlerImpl(
+      final Function<JobExceptionHandlerContext, String> errorMessageProvider,
+      final Function<JobExceptionHandlerContext, Integer> retriesProvider,
+      final Function<JobExceptionHandlerContext, Duration> retryBackoffProvider,
+      final Function<JobExceptionHandlerContext, Object> variablesProvider) {
+    this.errorMessageProvider = errorMessageProvider;
+    this.retriesProvider = retriesProvider;
+    this.retryBackoffProvider = retryBackoffProvider;
+    this.variablesProvider = variablesProvider;
+  }
+
+  public JobExceptionHandlerImpl() {
+    this(
+        DEFAULT_ERROR_MESSAGE_PROVIDER,
+        DEFAULT_RETRIES_PROVIDER,
+        DEFAULT_RETRY_BACKOFF_SUPPLIER,
+        DEFAULT_VARIABLES_PROVIDER);
+  }
+
+  public JobExceptionHandlerImpl(final Duration retryBackoff) {
+    this(
+        DEFAULT_ERROR_MESSAGE_PROVIDER,
+        DEFAULT_RETRIES_PROVIDER,
+        ctx -> retryBackoff,
+        DEFAULT_VARIABLES_PROVIDER);
+  }
+
+  @Override
+  public void handleJobException(final JobExceptionHandlerContext context) {
+    final ActivatedJob job = context.getActivatedJob();
+    final Exception e = context.getException();
+    final JobClient jobClient = context.getJobClient();
+    LOG.warn(
+        "Worker {} failed to handle job with key {} of type {}, sending fail command to broker",
+        job.getWorker(),
+        job.getKey(),
+        job.getType(),
+        e);
+    final Object variables = variablesProvider.apply(context);
+    final FailJobCommandStep2 failJobCommandStep2 =
+        jobClient
+            .newFailCommand(job.getKey())
+            .retries(retriesProvider.apply(context))
+            .errorMessage(errorMessageProvider.apply(context))
+            .retryBackoff(retryBackoffProvider.apply(context));
+    if (variables != null) {
+      failJobCommandStep2.variables(variables);
+    }
+    failJobCommandStep2.send();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobExceptionHandlerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobExceptionHandlerImpl.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.client.impl.worker;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.client.api.command.FailJobCommandStep1.FailJobCommandStep2;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
@@ -52,10 +54,13 @@ public class JobExceptionHandlerImpl implements JobExceptionHandler {
       final Function<JobExceptionHandlerContext, Integer> retriesProvider,
       final Function<JobExceptionHandlerContext, Duration> retryBackoffProvider,
       final Function<JobExceptionHandlerContext, Object> variablesProvider) {
-    this.errorMessageProvider = errorMessageProvider;
-    this.retriesProvider = retriesProvider;
-    this.retryBackoffProvider = retryBackoffProvider;
-    this.variablesProvider = variablesProvider;
+    this.errorMessageProvider =
+        requireNonNull(errorMessageProvider, "errorMessageProvider must not be null");
+    this.retriesProvider = requireNonNull(retriesProvider, "retriesProvider must not be null");
+    this.retryBackoffProvider =
+        requireNonNull(retryBackoffProvider, "retryBackoffProvider must not be null");
+    this.variablesProvider =
+        requireNonNull(variablesProvider, "variablesProvider must not be null");
   }
 
   public JobExceptionHandlerImpl() {

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobRunnableFactoryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobRunnableFactoryImpl.java
@@ -17,10 +17,10 @@ package io.camunda.client.impl.worker;
 
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
+import io.camunda.client.api.worker.JobExceptionHandler;
+import io.camunda.client.api.worker.JobExceptionHandler.JobExceptionHandlerContext;
 import io.camunda.client.api.worker.JobHandler;
 import io.camunda.client.impl.Loggers;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import org.slf4j.Logger;
 
 public final class JobRunnableFactoryImpl implements JobRunnableFactory {
@@ -29,10 +29,15 @@ public final class JobRunnableFactoryImpl implements JobRunnableFactory {
 
   private final JobClient jobClient;
   private final JobHandler handler;
+  private final JobExceptionHandler jobExceptionHandler;
 
-  public JobRunnableFactoryImpl(final JobClient jobClient, final JobHandler handler) {
+  public JobRunnableFactoryImpl(
+      final JobClient jobClient,
+      final JobHandler handler,
+      final JobExceptionHandler jobExceptionHandler) {
     this.jobClient = jobClient;
     this.handler = handler;
+    this.jobExceptionHandler = jobExceptionHandler;
   }
 
   @Override
@@ -44,21 +49,7 @@ public final class JobRunnableFactoryImpl implements JobRunnableFactory {
     try {
       handler.handle(jobClient, job);
     } catch (final Exception e) {
-      LOG.warn(
-          "Worker {} failed to handle job with key {} of type {}, sending fail command to broker",
-          job.getWorker(),
-          job.getKey(),
-          job.getType(),
-          e);
-      final StringWriter stringWriter = new StringWriter();
-      final PrintWriter printWriter = new PrintWriter(stringWriter);
-      e.printStackTrace(printWriter);
-      final String message = stringWriter.toString();
-      jobClient
-          .newFailCommand(job.getKey())
-          .retries(job.getRetries() - 1)
-          .errorMessage(message)
-          .send();
+      jobExceptionHandler.handleJobException(new JobExceptionHandlerContext(jobClient, job, e));
     } finally {
       doneCallback.run();
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
@@ -79,7 +79,7 @@ public final class JobWorkerBuilderImpl
     requestTimeout = configuration.getDefaultRequestTimeout();
     enableStreaming = configuration.getDefaultJobWorkerStreamEnabled();
     defaultTenantIds = configuration.getDefaultJobWorkerTenantIds();
-    jobExceptionHandler = configuration.getDefaultJobWorkerJobExceptionHandler();
+    jobExceptionHandler = configuration.getDefaultJobWorkerExceptionHandler();
     customTenantIds = new ArrayList<>();
     backoffSupplier = DEFAULT_BACKOFF_SUPPLIER;
     streamingTimeout = DEFAULT_STREAMING_TIMEOUT;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a new functionality to camunda client and spring boot starter:

The way an exception is handled from a job handler is transferred to an interface.

This interface can be configured globally but also per-worker in the builder.

The spring boot starter takes advantage of this by uniting this with its own embedded exception handling and extending the default functionality.

At the same time, it takes advantage of the default implementation by applying a property `retry-backoff` that can be configured globally and per-worker.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
