### PR TITLE
[Backport stable/8.8] build: add testing/.gitignore to exclude node modules

### DIFF
--- a/testing/.gitignore
+++ b/testing/.gitignore
@@ -1,0 +1,3 @@
+camunda-process-test-coverage-frontend/node/*
+camunda-process-test-coverage-frontend/node_modules/*
+camunda-process-test-java/src/main/resources/coverage/*


### PR DESCRIPTION
# Description
Backport of #38252 to `stable/8.8`.

relates to 