### PR TITLE
Add summarizers for FORM records in CompactRecordLogger

### DIFF
--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -127,6 +127,7 @@ import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.protocol.record.value.deployment.Resource;
@@ -296,6 +297,7 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.IDENTITY_SETUP, this::summarizeIdentitySetup);
     valueLoggers.put(ValueType.SCALE, this::summarizeScale);
     valueLoggers.put(ValueType.CHECKPOINT, this::summarizeCheckpoint);
+    valueLoggers.put(ValueType.FORM, this::summarizeForm);
   }
 
   public CompactRecordLogger(final Collection<Record<?>> records) {
@@ -1697,6 +1699,19 @@ public class CompactRecordLogger {
         .formatted(value.getCheckpointId(), formatPosition(value.getCheckpointPosition()));
   }
 
+  private String summarizeForm(final Record<?> record) {
+    final var value = (Form) record.getValue();
+    return summarizeDeploymentMetadata(
+            value,
+            value.getResourceName(),
+            value.getFormId(),
+            value.getFormKey(),
+            value.getVersion(),
+            value.getVersionTag(),
+            value.isDuplicate())
+        .toString();
+  }
+
   private StringBuilder summarizeDeploymentMetadata(
       final TenantOwned value,
       final String resourceName,
@@ -1705,6 +1720,7 @@ public class CompactRecordLogger {
       final int version,
       final String versionTag,
       final boolean duplicate) {
+
     final StringBuilder result = new StringBuilder();
 
     result

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
@@ -33,18 +33,7 @@ class CompactRecordLoggerTest {
   }
 
   @ParameterizedTest(name = "has compact logging for {0}")
-  @EnumSource(
-      value = ValueType.class,
-      // Excluding ValueTypes not yet supported by CompactRecordLogger.
-      // They will be covered in follow-up PRs as part of:
-      // https://github.com/camunda/camunda/issues/31825.
-      //
-      // When you introduce a new ValueType, please avoid excluding new Value Types here.
-      // Instead, please add a new value logger to CompactRecordLogger.valueLoggers.
-      mode = EnumSource.Mode.EXCLUDE,
-      names = {
-        "FORM",
-      })
+  @EnumSource(ValueType.class)
   public void shouldHaveCompactLoggerForValueType(final ValueType valueType) {
     assertThat(compactRecordLogger.getSupportedValueTypes())
         .as(


### PR DESCRIPTION
## Description

This PR introduces compact value-specific logging in `CompactRecordLogger` for the following record types:
- `FORM`

Additionally, the logging has been edited and unified for the following additional record types:
- `DECISION_REQUIREMENTS`
- `PROCESS`
- `RESOUCE`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Closes #31825