### PR TITLE
[Backport stable/8.8] fix: ensure groups claim value is included in broker request auth

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/service/NoDBMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/NoDBMembershipService.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.authentication.service;
 
+import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
+
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.OidcGroupsLoader;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -39,11 +41,14 @@ public class NoDBMembershipService implements MembershipService {
       final String clientId)
       throws OAuth2AuthenticationException {
     final boolean groupsClaimPresent = StringUtils.hasText(groupsClaim);
-    final Set<String> groups =
-        groupsClaimPresent
-            ? new HashSet<>(oidcGroupsLoader.load(tokenClaims))
-            : Collections.emptySet();
+    final Set<String> groups;
 
+    if (groupsClaimPresent) {
+      groups = new HashSet<>(oidcGroupsLoader.load(tokenClaims));
+      authenticatedClaims.put(USER_GROUPS_CLAIMS, groups.stream().toList());
+    } else {
+      groups = Collections.emptySet();
+    }
     return CamundaAuthentication.of(
         a ->
             a.user(username)

--- a/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterNoDbTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterNoDbTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.authentication.converter;
 
+import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -91,6 +92,8 @@ public class TokenClaimsConverterNoDbTest {
     assertThat(result).isNotNull();
     assertThat(result.authenticatedUsername()).isEqualTo("testuser");
     assertThat(result.authenticatedGroupIds()).containsExactlyInAnyOrder("group1", "group2");
+    assertThat((List<String>) result.claims().get(USER_GROUPS_CLAIMS))
+        .containsExactlyInAnyOrder("group1", "group2");
     // In no-db mode, no secondary storage access, so these should be empty
     assertThat(result.authenticatedRoleIds()).isEmpty();
     assertThat(result.authenticatedTenantIds()).isEmpty();
@@ -110,6 +113,7 @@ public class TokenClaimsConverterNoDbTest {
     assertThat(result).isNotNull();
     assertThat(result.authenticatedUsername()).isEqualTo("testuser");
     assertThat(result.authenticatedGroupIds()).isEmpty();
+    assertThat((List<String>) result.claims().get(USER_GROUPS_CLAIMS)).isEmpty();
   }
 
   @Test
@@ -146,5 +150,6 @@ public class TokenClaimsConverterNoDbTest {
     assertThat(result).isNotNull();
     assertThat(result.authenticatedUsername()).isEqualTo("testuser");
     assertThat(result.authenticatedGroupIds()).isEmpty();
+    assertThat((List<String>) result.claims().get(USER_GROUPS_CLAIMS)).isEmpty();
   }
 }


### PR DESCRIPTION
# Description
Backport of #38236 to `stable/8.8`.

relates to #38251