### PR TITLE
fix: rework prefix migration

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandalonePrefixMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandalonePrefixMigration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.application;
 
+import static io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
+
 import io.camunda.application.commons.migration.PrefixMigrationHelper;
 import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
@@ -46,6 +48,9 @@ public class StandalonePrefixMigration implements CommandLineRunner {
     // To ensure that debug logging performed using java.util.logging is routed into Log4j 2
     MainSupport.putSystemPropertyIfAbsent(
         "java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+
+    // Disable 8.8 Schema Manager during the prefix migration
+    MainSupport.putSystemPropertyIfAbsent(CREATE_SCHEMA_PROPERTY, "false");
 
     final SpringApplication application =
         new SpringApplicationBuilder()

--- a/dist/src/main/java/io/camunda/application/commons/migration/PrefixMigrationHelper.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/PrefixMigrationHelper.java
@@ -7,10 +7,11 @@
  */
 package io.camunda.application.commons.migration;
 
+import io.camunda.application.StandalonePrefixMigration.OperateIndexPrefixPropertiesOverride;
+import io.camunda.application.StandalonePrefixMigration.TasklistIndexPrefixPropertiesOverride;
 import io.camunda.migration.commons.storage.MigrationRepositoryIndex;
 import io.camunda.migration.commons.storage.TasklistMigrationRepositoryIndex;
 import io.camunda.migration.task.adapter.TaskLegacyIndex;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.search.connect.es.ElasticsearchConnector;
@@ -18,7 +19,6 @@ import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.search.schema.PrefixMigrationClient;
 import io.camunda.search.schema.elasticsearch.ElasticsearchPrefixMigrationClient;
 import io.camunda.search.schema.opensearch.OpensearchPrefixMigrationClient;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
@@ -91,19 +91,19 @@ public final class PrefixMigrationHelper {
   private PrefixMigrationHelper() {}
 
   public static void runPrefixMigration(
-      final OperateProperties operateProperties,
-      final TasklistProperties tasklistProperties,
+      final OperateIndexPrefixPropertiesOverride operateProperties,
+      final TasklistIndexPrefixPropertiesOverride tasklistProperties,
       final ConnectConfiguration connectConfiguration) {
     final var isElasticsearch = connectConfiguration.getTypeEnum() == DatabaseType.ELASTICSEARCH;
 
     final var operatePrefix =
         isElasticsearch
-            ? operateProperties.getElasticsearch().getIndexPrefix()
-            : operateProperties.getOpensearch().getIndexPrefix();
+            ? operateProperties.elasticsearchIndexPrefix()
+            : operateProperties.opensearchIndexPrefix();
     final var tasklistPrefix =
         isElasticsearch
-            ? tasklistProperties.getElasticsearch().getIndexPrefix()
-            : tasklistProperties.getOpenSearch().getIndexPrefix();
+            ? tasklistProperties.elasticsearchIndexPrefix()
+            : tasklistProperties.opensearchIndexPrefix();
 
     final var executor = Executors.newVirtualThreadPerTaskExecutor();
 
@@ -120,8 +120,7 @@ public final class PrefixMigrationHelper {
 
   private static PrefixMigrationClient getPrefixMigrationClient(
       final ConnectConfiguration connectConfiguration) {
-    if (connectConfiguration.getTypeEnum() == DatabaseType.ELASTICSEARCH) {
-
+    if (connectConfiguration.getTypeEnum().isElasticSearch()) {
       return new ElasticsearchPrefixMigrationClient(
           new ElasticsearchConnector(connectConfiguration).createClient());
     } else {

--- a/qa/migration-tests/pom.xml
+++ b/qa/migration-tests/pom.xml
@@ -184,11 +184,6 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>tasklist-common</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>webapps-schema</artifactId>
       <scope>test</scope>
     </dependency>
@@ -235,11 +230,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>operate-webapp</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>operate-common</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -13,12 +13,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.application.StandalonePrefixMigration.OperateIndexPrefixPropertiesOverride;
+import io.camunda.application.StandalonePrefixMigration.TasklistIndexPrefixPropertiesOverride;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.it.migration.util.PrefixMigrationUtils;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.cluster.TestRestOperateClient;
 import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
@@ -30,7 +31,6 @@ import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.search.schema.SchemaManager;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.qa.util.cluster.TestPrefixMigrationApp;
 import java.io.IOException;
@@ -300,15 +300,11 @@ public class PrefixMigrationIT {
 
   private void prefixMigration(
       final String oldOperatePrefix, final String oldTasklistPrefix, final String newPrefix) {
-    final var operate = new OperateProperties();
-    final var tasklist = new TasklistProperties();
+    final var operate =
+        new OperateIndexPrefixPropertiesOverride(oldOperatePrefix, oldOperatePrefix);
+    final var tasklist =
+        new TasklistIndexPrefixPropertiesOverride(oldTasklistPrefix, oldTasklistPrefix);
     final var connect = new SearchEngineConnectProperties();
-
-    operate.getElasticsearch().setIndexPrefix(oldOperatePrefix);
-    operate.getOpensearch().setIndexPrefix(oldOperatePrefix);
-
-    tasklist.getElasticsearch().setIndexPrefix(oldTasklistPrefix);
-    tasklist.getOpenSearch().setIndexPrefix(oldTasklistPrefix);
 
     connect.setIndexPrefix(newPrefix);
     if (currentMultiDbDatabaseType() == DatabaseType.ES) {

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/PrefixMigrationUtils.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/PrefixMigrationUtils.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.migration.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import io.camunda.application.commons.migration.PrefixMigrationHelper;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.search.connect.os.OpensearchConnector;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.opensearch.client.opensearch.OpenSearchClient;
+
+public class PrefixMigrationUtils {
+
+  public static void generateDatedIndicesElasticsearch(
+      final ConnectConfiguration configuration,
+      final IndexDescriptors descriptors,
+      final String oldTasklistPrefix,
+      final String oldOperatePrefix,
+      final String suffixNow,
+      final String suffixYesterday) {
+    final var client = new ElasticsearchConnector(configuration).createClient();
+
+    PrefixMigrationHelper.TASKLIST_INDICES_TO_MIGRATE.stream()
+        .map(
+            cls ->
+                PrefixMigrationHelper.getDescriptor(
+                    cls,
+                    descriptors,
+                    configuration.getIndexPrefix(),
+                    configuration.getTypeEnum().isElasticSearch()))
+        .filter(IndexTemplateDescriptor.class::isInstance)
+        .forEach(
+            template -> {
+              try {
+                final var indexName =
+                    "%s-%s-%s_"
+                        .formatted(
+                            oldTasklistPrefix, template.getIndexName(), template.getVersion());
+                client.indices().create(r -> r.index(indexName + suffixNow));
+                client.indices().create(r -> r.index(indexName + suffixYesterday));
+              } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+              }
+            });
+
+    PrefixMigrationHelper.OPERATE_INDICES_TO_MIGRATE.stream()
+        .map(
+            cls ->
+                PrefixMigrationHelper.getDescriptor(
+                    cls,
+                    descriptors,
+                    configuration.getIndexPrefix(),
+                    configuration.getTypeEnum().isElasticSearch()))
+        .filter(IndexTemplateDescriptor.class::isInstance)
+        .forEach(
+            template -> {
+              try {
+                final var indexName =
+                    "%s-%s-%s_"
+                        .formatted(
+                            oldOperatePrefix, template.getIndexName(), template.getVersion());
+                client.indices().create(r -> r.index(indexName + suffixNow));
+                client.indices().create(r -> r.index(indexName + suffixYesterday));
+              } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+              }
+            });
+  }
+
+  public static void generateDatedIndicesOpensearch(
+      final ConnectConfiguration configuration,
+      final IndexDescriptors descriptors,
+      final String oldTasklistPrefix,
+      final String oldOperatePrefix,
+      final String suffixNow,
+      final String suffixYesterday) {
+    final var client = new OpensearchConnector(configuration).createClient();
+
+    PrefixMigrationHelper.TASKLIST_INDICES_TO_MIGRATE.stream()
+        .map(
+            cls ->
+                PrefixMigrationHelper.getDescriptor(
+                    cls,
+                    descriptors,
+                    configuration.getIndexPrefix(),
+                    configuration.getTypeEnum().isElasticSearch()))
+        .filter(IndexTemplateDescriptor.class::isInstance)
+        .forEach(
+            template -> {
+              try {
+                final var indexName =
+                    "%s-%s-%s_"
+                        .formatted(
+                            oldTasklistPrefix, template.getIndexName(), template.getVersion());
+                client.indices().create(r -> r.index(indexName + suffixNow));
+                client.indices().create(r -> r.index(indexName + suffixYesterday));
+              } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+              }
+            });
+
+    PrefixMigrationHelper.OPERATE_INDICES_TO_MIGRATE.stream()
+        .map(
+            cls ->
+                PrefixMigrationHelper.getDescriptor(
+                    cls,
+                    descriptors,
+                    configuration.getIndexPrefix(),
+                    configuration.getTypeEnum().isElasticSearch()))
+        .filter(IndexTemplateDescriptor.class::isInstance)
+        .forEach(
+            template -> {
+              try {
+                final var indexName =
+                    "%s-%s-%s_"
+                        .formatted(
+                            oldOperatePrefix, template.getIndexName(), template.getVersion());
+                client.indices().create(r -> r.index(indexName + suffixNow));
+                client.indices().create(r -> r.index(indexName + suffixYesterday));
+              } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+              }
+            });
+  }
+
+  public static Map<String, List<String>> inverseAliases(
+      final Map<String, Set<String>> aliasesMap) {
+    return aliasesMap.entrySet().stream()
+        .flatMap(
+            entry -> {
+              final String indexName = entry.getKey();
+              return entry.getValue().stream().map(aliasName -> Map.entry(aliasName, indexName));
+            })
+        .collect(
+            Collectors.groupingBy(
+                Map.Entry::getKey, Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
+  }
+
+  public static Map<String, Set<String>> getAliasIndexMap(
+      final ElasticsearchClient client, final String aliasPrefix) throws IOException {
+    return client.indices().getAlias(a -> a.name(aliasPrefix)).result().entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().aliases().keySet()));
+  }
+
+  public static Map<String, Set<String>> getAliasIndexMap(
+      final OpenSearchClient client, final String aliasPrefix) throws IOException {
+    return client.indices().getAlias(a -> a.name(aliasPrefix)).result().entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().aliases().keySet()));
+  }
+
+  public static void verifyIndexAliasMappings(
+      final String newPrefix,
+      final Map<String, Set<String>> tasklistAliases,
+      final IndexDescriptors descriptors,
+      final Map<String, Set<String>> operateAliases,
+      final Map<String, Set<String>> oldTasklistAliases,
+      final Map<String, Set<String>> oldOperateAliases) {
+
+    // Assert that all expected Tasklist aliases are matched to the new indices
+    final var inverseTasklistAliases = PrefixMigrationUtils.inverseAliases(tasklistAliases);
+    PrefixMigrationHelper.TASKLIST_INDICES_TO_MIGRATE.forEach(
+        descriptorCls -> {
+          final var descriptor =
+              PrefixMigrationHelper.getDescriptor(descriptorCls, descriptors, newPrefix, true);
+          assertThat(tasklistAliases).containsKey(descriptor.getFullQualifiedName());
+          assertThat(inverseTasklistAliases).containsKey(descriptor.getAlias());
+          if (descriptor instanceof IndexTemplateDescriptor) {
+            assertThat(inverseTasklistAliases.get(descriptor.getAlias())).hasSize(3);
+          } else {
+            assertThat(inverseTasklistAliases.get(descriptor.getAlias())).hasSize(1);
+          }
+        });
+
+    // Assert that all expected Operate aliases are matched to the new indices
+    final var inverseOperateAliases = PrefixMigrationUtils.inverseAliases(operateAliases);
+    PrefixMigrationHelper.OPERATE_INDICES_TO_MIGRATE.forEach(
+        descriptorCls -> {
+          final var descriptor =
+              PrefixMigrationHelper.getDescriptor(descriptorCls, descriptors, newPrefix, true);
+          assertThat(operateAliases).containsKey(descriptor.getFullQualifiedName());
+          assertThat(inverseOperateAliases).containsKey(descriptor.getAlias());
+          if (descriptor instanceof IndexTemplateDescriptor) {
+            assertThat(inverseOperateAliases.get(descriptor.getAlias())).hasSize(3);
+          } else {
+            assertThat(inverseOperateAliases.get(descriptor.getAlias())).hasSize(1);
+          }
+        });
+
+    // Assert that no old indices are referenced in the new alias mappings
+    descriptors
+        .all()
+        .forEach(
+            desc -> assertThat(oldTasklistAliases).doesNotContainKey(desc.getFullQualifiedName()));
+
+    descriptors
+        .all()
+        .forEach(
+            desc -> assertThat(oldOperateAliases).doesNotContainKey(desc.getFullQualifiedName()));
+  }
+}

--- a/schema-manager/src/main/java/io/camunda/search/schema/PrefixMigrationClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/PrefixMigrationClient.java
@@ -8,13 +8,16 @@
 package io.camunda.search.schema;
 
 import io.camunda.search.schema.utils.CloneResult;
-import io.camunda.search.schema.utils.ReindexResult;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public interface PrefixMigrationClient {
-  ReindexResult reindex(String source, String destination);
 
-  CloneResult clone(String source, String destination);
+  List<String> getIndicesInAlias(String alias);
 
-  List<String> getAllHistoricIndices(String prefix);
+  CompletableFuture<CloneResult> cloneAndDeleteIndex(
+      final String source,
+      final String sourceAlias,
+      final String destination,
+      final String destinationAlias);
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchPrefixMigrationClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchPrefixMigrationClient.java
@@ -7,20 +7,15 @@
  */
 package io.camunda.search.schema.elasticsearch;
 
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch._types.OpType;
-import co.elastic.clients.elasticsearch.cat.indices.IndicesRecord;
-import co.elastic.clients.elasticsearch.core.ReindexRequest;
-import co.elastic.clients.elasticsearch.indices.Alias;
-import co.elastic.clients.elasticsearch.indices.ExistsRequest;
-import co.elastic.clients.json.JsonData;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch.indices.update_aliases.Action;
 import io.camunda.search.schema.PrefixMigrationClient;
 import io.camunda.search.schema.utils.CloneResult;
-import io.camunda.search.schema.utils.ReindexResult;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
+import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,82 +23,82 @@ public class ElasticsearchPrefixMigrationClient implements PrefixMigrationClient
   private static final Logger LOG =
       LoggerFactory.getLogger(ElasticsearchPrefixMigrationClient.class);
 
-  private static final String DATE_REGEX_FOR_INDICES = "\\d{4}-\\d{2}-\\d{2}";
   private final ElasticsearchClient client;
+  private final ElasticsearchAsyncClient asyncClient;
 
   public ElasticsearchPrefixMigrationClient(final ElasticsearchClient client) {
     this.client = client;
+    asyncClient = new ElasticsearchAsyncClient(client._transport(), client._transportOptions());
   }
 
   @Override
-  public ReindexResult reindex(final String src, final String dest) {
-    final var reindexRequest =
-        new ReindexRequest.Builder()
-            .source(s -> s.index(src))
-            .dest(d -> d.index(dest).opType(OpType.Create))
-            .build();
-
+  public List<String> getIndicesInAlias(final String alias) {
     try {
-      final ExistsRequest existRequest = new ExistsRequest.Builder().index(src).build();
-      if (client.indices().exists(existRequest).value()) {
-        LOG.info("Reindexing [{}] into [{}]", src, dest);
-        client.reindex(reindexRequest);
+      final var aliasMatches =
+          client.indices().getAlias(g -> g.name(alias)).result().keySet().stream().toList();
+      LOG.info("Found {} indices for alias '{}'", aliasMatches, alias);
+      return aliasMatches;
+    } catch (final ElasticsearchException esx) {
+      if (esx.status() == 404) {
+        LOG.warn("No indices for alias '{}' exist", alias);
+        return List.of();
       }
-      return new ReindexResult(true, src, dest, null);
-
-    } catch (final IOException e) {
-      LOG.error("Failed to reindex [{}] into [{}]", src, dest, e);
-      return new ReindexResult(false, src, dest, e);
-    }
-  }
-
-  @Override
-  public CloneResult clone(final String source, final String destination) {
-    try {
-      LOG.info("Cloning [{}] to [{}]", source, destination);
-      markIndexReadOnly(source);
-      cloneIndex(source, destination);
-      return new CloneResult(true, source, destination, null);
-    } catch (final IOException e) {
-      LOG.error("Error migrating index [{}] to [{}]", source, destination, e);
-      return new CloneResult(false, source, destination, e);
-    }
-  }
-
-  @Override
-  public List<String> getAllHistoricIndices(final String prefix) {
-    try {
-      return client.cat().indices(i -> i.index(prefix + "*")).valueBody().stream()
-          .map(IndicesRecord::index)
-          .filter(index -> Pattern.matches(".*" + DATE_REGEX_FOR_INDICES + "$", index))
-          .toList();
-    } catch (final IOException e) {
-      LOG.error("Failed to get all historic indices for prefix [{}]", prefix, e);
+      LOG.error("Failed to get all aliased indices for alias [{}]", alias, esx);
       throw new IllegalStateException(
-          "Failed to retrieve historic indices for prefix [" + prefix + "]", e);
+          "Failed to retrieve aliased indices for alias [" + alias + "]", esx);
+    } catch (final IOException e) {
+      LOG.error("Failed to get all aliased indices for alias [{}]", alias, e);
+      throw new IllegalStateException(
+          "Failed to retrieve aliased indices for alias [" + alias + "]", e);
     }
   }
 
-  private void markIndexReadOnly(final String index) throws IOException {
-    client
+  @Override
+  public CompletableFuture<CloneResult> cloneAndDeleteIndex(
+      final String source,
+      final String sourceAlias,
+      final String destination,
+      final String destinationAlias) {
+    return asyncClient
         .indices()
-        .putSettings(r -> r.index(index).settings(s -> s.index(i -> i.blocks(b -> b.write(true)))));
-  }
-
-  private void cloneIndex(final String src, final String target) throws IOException {
-    final var targetAlias = target.replaceAll(DATE_REGEX_FOR_INDICES, "alias");
-    client
-        .indices()
-        .clone(
-            c ->
-                c.index(src)
-                    .target(target)
-                    .settings(
-                        Map.of(
-                            "index.blocks.write",
-                            JsonData.of(false),
-                            "number_of_replicas",
-                            JsonData.of(0)))
-                    .aliases(targetAlias, new Alias.Builder().build()));
+        .putSettings(r -> r.index(source).settings(s -> s.index(i -> i.blocks(b -> b.write(true)))))
+        .thenCompose(
+            ignore -> {
+              LOG.info("Marked index [{}] as read-only", source);
+              return asyncClient.indices().clone(c -> c.index(source).target(destination));
+            })
+        .thenCompose(
+            ignore -> {
+              LOG.info("Cloned index [{}] to [{}]", source, destination);
+              return asyncClient
+                  .indices()
+                  .updateAliases(
+                      u ->
+                          u.actions(
+                              Action.of(
+                                  a -> a.remove(rm -> rm.index(destination).alias(sourceAlias))),
+                              Action.of(
+                                  a ->
+                                      a.add(
+                                          add ->
+                                              add.index(destination)
+                                                  .alias(destinationAlias)
+                                                  .isWriteIndex(false)))));
+            })
+        .thenCompose(
+            ignore -> {
+              LOG.info("Updated aliases for [{}] index", destination);
+              return asyncClient.indices().delete(d -> d.index(source));
+            })
+        .thenApply(
+            ignore -> {
+              LOG.info("Deleted index [{}]", source);
+              return new CloneResult(true, source, destination, null);
+            })
+        .exceptionally(
+            throwable -> {
+              LOG.error("Failed to migrate index [{}] to [{}]", source, destination, throwable);
+              return new CloneResult(false, source, destination, throwable);
+            });
   }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchPrefixMigrationClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchPrefixMigrationClient.java
@@ -9,98 +9,118 @@ package io.camunda.search.schema.opensearch;
 
 import io.camunda.search.schema.PrefixMigrationClient;
 import io.camunda.search.schema.utils.CloneResult;
-import io.camunda.search.schema.utils.ReindexResult;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-import org.opensearch.client.json.JsonData;
+import java.util.concurrent.CompletableFuture;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch._types.OpType;
-import org.opensearch.client.opensearch.cat.indices.IndicesRecord;
-import org.opensearch.client.opensearch.core.ReindexRequest;
-import org.opensearch.client.opensearch.indices.Alias;
-import org.opensearch.client.opensearch.indices.ExistsRequest;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch.indices.update_aliases.Action;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class OpensearchPrefixMigrationClient implements PrefixMigrationClient {
   private static final Logger LOG = LoggerFactory.getLogger(OpensearchPrefixMigrationClient.class);
-  private static final String DATE_REGEX_FOR_INDICES = "\\d{4}-\\d{2}-\\d{2}";
   private final OpenSearchClient client;
+  private final OpenSearchAsyncClient asyncClient;
 
   public OpensearchPrefixMigrationClient(final OpenSearchClient client) {
     this.client = client;
+    asyncClient = new OpenSearchAsyncClient(client._transport(), client._transportOptions());
   }
 
   @Override
-  public ReindexResult reindex(final String src, final String dest) {
-    final var reindexRequest =
-        new ReindexRequest.Builder()
-            .source(s -> s.index(src))
-            .dest(d -> d.index(dest).opType(OpType.Create))
-            .build();
-
+  public List<String> getIndicesInAlias(final String alias) {
     try {
-      final var existRequest = new ExistsRequest.Builder().index(src).build();
-      if (client.indices().exists(existRequest).value()) {
-        LOG.info("Reindexing [{}] into [{}]", src, dest);
-        client.reindex(reindexRequest);
+      final var aliasMatches =
+          client.indices().getAlias(g -> g.name(alias)).result().keySet().stream().toList();
+      LOG.info("Found {} indices for alias '{}'", aliasMatches, alias);
+      return aliasMatches;
+    } catch (final OpenSearchException esx) {
+      if (esx.status() == 404) {
+        LOG.warn("No indices for alias '{}' exist", alias);
+        return List.of();
       }
-      return new ReindexResult(true, src, dest, null);
-    } catch (final IOException e) {
-      LOG.error("Failed to reindex [{}] into [{}]", src, dest, e);
-      return new ReindexResult(false, src, dest, e);
-    }
-  }
-
-  @Override
-  public CloneResult clone(final String source, final String destination) {
-    try {
-      LOG.info("Cloning [{}] to [{}]", source, destination);
-      markIndexReadOnly(source);
-      cloneIndex(source, destination);
-      return new CloneResult(true, source, destination, null);
-    } catch (final IOException e) {
-      LOG.error("Error migrating index [{}] to [{}]", source, destination, e);
-      return new CloneResult(false, source, destination, e);
-    }
-  }
-
-  @Override
-  public List<String> getAllHistoricIndices(final String prefix) {
-    try {
-      return client.cat().indices(i -> i.index(prefix + "*")).valueBody().stream()
-          .map(IndicesRecord::index)
-          .filter(index -> Pattern.matches(".*" + DATE_REGEX_FOR_INDICES + "$", index))
-          .toList();
-    } catch (final IOException e) {
-      LOG.error("Failed to get all historic indices for prefix [{}]", prefix, e);
+      LOG.error("Failed to get all aliased indices for alias [{}]", alias, esx);
       throw new IllegalStateException(
-          "Failed to retrieve historic indices for prefix [" + prefix + "]", e);
+          "Failed to retrieve aliased indices for alias [" + alias + "]", esx);
+    } catch (final IOException e) {
+      LOG.error("Failed to get all aliased indices for alias [{}]", alias, e);
+      throw new IllegalStateException(
+          "Failed to retrieve aliased indices for alias [" + alias + "]", e);
     }
   }
 
-  private void markIndexReadOnly(final String index) throws IOException {
-    client
-        .indices()
-        .putSettings(r -> r.index(index).settings(s -> s.index(i -> i.blocks(b -> b.write(true)))));
-  }
-
-  private void cloneIndex(final String src, final String target) throws IOException {
-    final var targetAlias = target.replaceAll(DATE_REGEX_FOR_INDICES, "alias");
-    client
-        .indices()
-        .clone(
-            c ->
-                c.index(src)
-                    .target(target)
-                    .settings(
-                        Map.of(
-                            "index.blocks.write",
-                            JsonData.of(false),
-                            "number_of_replicas",
-                            JsonData.of(0)))
-                    .aliases(targetAlias, new Alias.Builder().build()));
+  @Override
+  public CompletableFuture<CloneResult> cloneAndDeleteIndex(
+      final String source,
+      final String sourceAlias,
+      final String destination,
+      final String destinationAlias) {
+    try {
+      return asyncClient
+          .indices()
+          .putSettings(
+              r -> r.index(source).settings(s -> s.index(i -> i.blocks(b -> b.write(true)))))
+          .thenCompose(
+              ignore -> {
+                LOG.info("Marked index [{}] as read-only", source);
+                try {
+                  return asyncClient.indices().clone(c -> c.index(source).target(destination));
+                } catch (final IOException e) {
+                  throw new IllegalStateException("Failed to clone index [" + source + "]", e);
+                }
+              })
+          .thenCompose(
+              ignore -> {
+                LOG.info("Successfully cloned [{}] to [{}]", source, destination);
+                try {
+                  return asyncClient
+                      .indices()
+                      .updateAliases(
+                          u ->
+                              u.actions(
+                                  Action.of(
+                                      a ->
+                                          a.remove(rm -> rm.index(destination).alias(sourceAlias))),
+                                  Action.of(
+                                      a ->
+                                          a.add(
+                                              add ->
+                                                  add.index(destination)
+                                                      .alias(destinationAlias)
+                                                      .isWriteIndex(false)))));
+                } catch (final IOException e) {
+                  throw new IllegalStateException(
+                      "Failed to update aliases for indices [" + source + ", " + destination + "]",
+                      e);
+                }
+              })
+          .thenCompose(
+              ignore -> {
+                LOG.info("Successfully updated aliases for [{}] index", destination);
+                try {
+                  return asyncClient.indices().delete(d -> d.index(source));
+                } catch (final IOException e) {
+                  throw new IllegalStateException("Failed to delete index [" + source + "]", e);
+                }
+              })
+          .thenApply(
+              ignore -> {
+                LOG.info("Successfully deleted source index [{}]", source);
+                return new CloneResult(true, source, destination, null);
+              })
+          .exceptionally(
+              throwable -> {
+                LOG.error(
+                    "Failed to clone and delete index [{}] to [{}]",
+                    source,
+                    destination,
+                    throwable);
+                return new CloneResult(false, source, destination, throwable);
+              });
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -251,16 +251,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>tasklist-common</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>operate-common</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda.migration</groupId>
       <artifactId>identity-migration</artifactId>
     </dependency>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestPrefixMigrationApp.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestPrefixMigrationApp.java
@@ -9,11 +9,11 @@ package io.camunda.zeebe.qa.util.cluster;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.application.StandalonePrefixMigration;
+import io.camunda.application.StandalonePrefixMigration.OperateIndexPrefixPropertiesOverride;
+import io.camunda.application.StandalonePrefixMigration.TasklistIndexPrefixPropertiesOverride;
 import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration;
 import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
-import io.camunda.operate.property.OperateProperties;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.restore.RestoreApp;
 import org.springframework.boot.WebApplicationType;
@@ -24,8 +24,8 @@ public final class TestPrefixMigrationApp extends TestSpringApplication<TestPref
 
   public TestPrefixMigrationApp(
       final SearchEngineConnectProperties connectConfiguration,
-      final TasklistProperties tasklistProperties,
-      final OperateProperties operateProperties) {
+      final TasklistIndexPrefixPropertiesOverride tasklistProperties,
+      final OperateIndexPrefixPropertiesOverride operateProperties) {
     super(StandalonePrefixMigration.class, SearchEngineDatabaseConfiguration.class);
 
     final var disableSchemaCreation = new SearchEngineSchemaManagerProperties();
@@ -36,8 +36,14 @@ public final class TestPrefixMigrationApp extends TestSpringApplication<TestPref
             "searchEngineSchemaManagerProperties",
             disableSchemaCreation,
             SearchEngineSchemaManagerProperties.class)
-        .withBean("tasklistProperties", tasklistProperties, TasklistProperties.class)
-        .withBean("operateProperties", operateProperties, OperateProperties.class);
+        .withBean(
+            "tasklistIndexPrefixPropertiesOverride",
+            tasklistProperties,
+            TasklistIndexPrefixPropertiesOverride.class)
+        .withBean(
+            "operateIndexPrefixPropertiesOverride",
+            operateProperties,
+            OperateIndexPrefixPropertiesOverride.class);
   }
 
   @Override

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestPrefixMigrationApp.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestPrefixMigrationApp.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.qa.util.cluster;
 import io.atomix.cluster.MemberId;
 import io.camunda.application.StandalonePrefixMigration;
 import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration;
+import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.tasklist.property.TasklistProperties;
@@ -27,7 +28,14 @@ public final class TestPrefixMigrationApp extends TestSpringApplication<TestPref
       final OperateProperties operateProperties) {
     super(StandalonePrefixMigration.class, SearchEngineDatabaseConfiguration.class);
 
+    final var disableSchemaCreation = new SearchEngineSchemaManagerProperties();
+    disableSchemaCreation.setCreateSchema(false);
+
     withBean("connectConfiguration", connectConfiguration, SearchEngineConnectProperties.class)
+        .withBean(
+            "searchEngineSchemaManagerProperties",
+            disableSchemaCreation,
+            SearchEngineSchemaManagerProperties.class)
         .withBean("tasklistProperties", tasklistProperties, TasklistProperties.class)
         .withBean("operateProperties", operateProperties, OperateProperties.class);
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Rework PrefixMigration to:
- Not start the SchemaManager as it's supposed to run on 8.7
- Clone indices based on their Alias from the _new_ descriptors expected
- Make use of ES/OS Async clients to chain the requests per index for updating settings, cloning, updating aliases and finally deleting the old index
- Override `TasklistProperties` and `OperateProperties` that are being validated by the Unified Config with custom properties just for the migration. The previous ones, have their values replaced from the new `CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_INDEXPREFIX` which for the Prefix migration corresponds to the unified prefix

Since it relies on the Aliases to find the required indices this means that the migration can be retried without side effects.

Still WiP need to make some adjustments

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38032
closes #38068 
