### PR TITLE
fix: skip RBA relevant role permissions when enabled

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/IdentityMigrationProperties.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/IdentityMigrationProperties.java
@@ -31,6 +31,7 @@ public class IdentityMigrationProperties {
   private ClusterProperties cluster = new ClusterProperties();
   private OidcProperties oidc = new OidcProperties();
   private Integer backpressureDelay = 5000;
+  private boolean resourceAuthorizationsEnabled = false;
 
   public ManagementIdentityProperties getManagementIdentity() {
     return managementIdentity;
@@ -86,6 +87,14 @@ public class IdentityMigrationProperties {
 
   public void setBackpressureDelay(final Integer backpressureDelay) {
     this.backpressureDelay = backpressureDelay;
+  }
+
+  public boolean isResourceAuthorizationsEnabled() {
+    return resourceAuthorizationsEnabled;
+  }
+
+  public void setResourceAuthorizationsEnabled(final boolean resourceAuthorizationsEnabled) {
+    this.resourceAuthorizationsEnabled = resourceAuthorizationsEnabled;
   }
 
   public enum Mode {

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ResourceBasedAuthorizationConstants.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ResourceBasedAuthorizationConstants.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity.config;
+
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import java.util.Set;
+
+public final class ResourceBasedAuthorizationConstants {
+  public static final Set<AuthorizationResourceType> RBA_IRRELEVANT_RESOURCE_TYPES =
+      Set.of(
+          AuthorizationResourceType.AUTHORIZATION,
+          AuthorizationResourceType.COMPONENT,
+          AuthorizationResourceType.GROUP,
+          AuthorizationResourceType.ROLE,
+          AuthorizationResourceType.USER,
+          AuthorizationResourceType.TENANT,
+          AuthorizationResourceType.SYSTEM);
+
+  private ResourceBasedAuthorizationConstants() {}
+}

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
@@ -54,7 +54,7 @@ public class KeycloakRoleMigrationHandlerTest {
   private final RoleServices roleServices;
   private final AuthorizationServices authorizationServices;
 
-  private final RoleMigrationHandler roleMigrationHandler;
+  private RoleMigrationHandler roleMigrationHandler;
 
   public KeycloakRoleMigrationHandlerTest(
       @Mock final ManagementIdentityClient managementIdentityClient,
@@ -269,6 +269,120 @@ public class KeycloakRoleMigrationHandlerTest {
                     PermissionType.UPDATE_USER_TASK,
                     PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.DELETE_PROCESS_INSTANCE)));
+  }
+
+  @Test
+  public void shouldMigrateRolesAndAuthorizationsExceptRBARelevantResourceTypes() {
+    // given
+    final var migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setResourceAuthorizationsEnabled(true);
+    roleMigrationHandler =
+        new RoleMigrationHandler(
+            CamundaAuthentication.none(),
+            managementIdentityClient,
+            roleServices,
+            authorizationServices,
+            migrationProperties);
+
+    when(managementIdentityClient.fetchRoles())
+        .thenReturn(
+            List.of(
+                new Role("Role 1", "Description for Role 1"),
+                new Role(
+                    "Role@Name#With$Special%Chars", "Description for Role with special chars")));
+    when(roleServices.createRole(any()))
+        .thenReturn(CompletableFuture.completedFuture(new RoleRecord()));
+    when(managementIdentityClient.fetchPermissions(any()))
+        .thenReturn(
+            List.of(
+                new Permission("read", "camunda-identity-resource-server"),
+                new Permission("read:users", "camunda-identity-resource-server"),
+                new Permission("write", "camunda-identity-resource-server"),
+                new Permission("read:*", "operate-api"),
+                new Permission("write:*", "operate-api")))
+        .thenReturn(
+            List.of(
+                new Permission("read:*", "tasklist-api"),
+                new Permission("write:*", "tasklist-api"),
+                new Permission("write:*", "zeebe-api")));
+    when(authorizationServices.createAuthorization(any()))
+        .thenReturn(CompletableFuture.completedFuture(new AuthorizationRecord()));
+
+    // when
+    roleMigrationHandler.migrate();
+
+    // then
+    final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
+    verify(authorizationServices, times(9)).createAuthorization(results.capture());
+    final var authorizationRequests = results.getAllValues();
+    assertThat(authorizationRequests)
+        .extracting(
+            CreateAuthorizationRequest::ownerId,
+            CreateAuthorizationRequest::ownerType,
+            CreateAuthorizationRequest::resourceType,
+            CreateAuthorizationRequest::permissionTypes)
+        .containsExactlyInAnyOrder(
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.USER,
+                Set.of(PermissionType.READ)),
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.COMPONENT,
+                Set.of(PermissionType.ACCESS)),
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.ROLE,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE,
+                    PermissionType.CREATE)),
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.COMPONENT,
+                Set.of(PermissionType.ACCESS)),
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.GROUP,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.CREATE,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE)),
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.AUTHORIZATION,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.CREATE,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE)),
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.TENANT,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.CREATE,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE)),
+            tuple(
+                "role@name_with_special_chars",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.SYSTEM,
+                Set.of(PermissionType.READ, PermissionType.UPDATE)),
+            tuple(
+                "role@name_with_special_chars",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.COMPONENT,
+                Set.of(PermissionType.ACCESS)));
   }
 
   @Test


### PR DESCRIPTION
## Description

When RBA is enabled in 8.7, roles should not get granted wildcard authorizations process or definition related resource types.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38227
