### PR TITLE
[Backport stable/8.8] fix: disable destroy method for proxy clients

### DIFF
--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestProxyConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestProxyConfiguration.java
@@ -32,7 +32,7 @@ public class CamundaProcessTestProxyConfiguration {
     return new CamundaClientProxy();
   }
 
-  @Bean
+  @Bean(destroyMethod = "")
   @Primary
   public CamundaClient proxiedCamundaClient(final CamundaClientProxy camundaClientProxy) {
     return (CamundaClient)
@@ -45,7 +45,7 @@ public class CamundaProcessTestProxyConfiguration {
     return new ZeebeClientProxy();
   }
 
-  @Bean
+  @Bean(destroyMethod = "")
   @Primary
   public ZeebeClient proxiedZeebeClient(final ZeebeClientProxy zeebeClientProxy) {
     return (ZeebeClient)


### PR DESCRIPTION
# Description
Backport of #38223 to `stable/8.8`.

relates to #31860