### PR TITLE
[Backport stable/8.8] fix: make RoutingState backward compatible between 8.8 and 8.7

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -526,7 +526,7 @@ public class ProtoBufSerializer
         pendingOperations);
   }
 
-  private Optional<RoutingState> decodeRoutingState(final Topology.RoutingState routingState) {
+  Optional<RoutingState> decodeRoutingState(final Topology.RoutingState routingState) {
     if (routingState.equals(Topology.RoutingState.getDefaultInstance())) {
       return Optional.empty();
     } else {
@@ -573,7 +573,7 @@ public class ProtoBufSerializer
     };
   }
 
-  private Topology.RoutingState encodeRoutingState(final RoutingState routingState) {
+  Topology.RoutingState encodeRoutingState(final RoutingState routingState) {
     return Topology.RoutingState.newBuilder()
         .setVersion(routingState.version())
         .addAllActivePartitions(routingState.requestHandling().activePartitions())

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
@@ -69,8 +69,7 @@ public record RoutingState(
 
   private static void validatePartitionCount(final int partitionCount) {
     if (partitionCount < 1) {
-      throw new IllegalArgumentException(
-          "Partition count must be greater than %d".formatted(Protocol.START_PARTITION_ID));
+      throw new IllegalArgumentException("Partition count must be greater than or equal to 1");
     }
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -64,6 +65,13 @@ public record RoutingState(
   public static RoutingState initializeWithPartitionCount(final int partitionCount) {
     return new RoutingState(
         1, new AllPartitions(partitionCount), new MessageCorrelation.HashMod(partitionCount));
+  }
+
+  private static void validatePartitionCount(final int partitionCount) {
+    if (partitionCount < 1) {
+      throw new IllegalArgumentException(
+          "Partition count must be greater than %d".formatted(Protocol.START_PARTITION_ID));
+    }
   }
 
   private static void validatePartitionId(final int partitionId) {
@@ -120,6 +128,8 @@ public record RoutingState(
       public ActivePartitions {
         Objects.requireNonNull(additionalActivePartitions);
         Objects.requireNonNull(inactivePartitions);
+        validatePartitionCount(basePartitionCount);
+
         for (final int activePartition : additionalActivePartitions) {
           validatePartitionId(activePartition);
           if (inactivePartitions.contains(activePartition)) {
@@ -136,8 +146,7 @@ public record RoutingState(
 
       @Override
       public Set<Integer> activePartitions() {
-        final var all =
-            new HashSet<Integer>(basePartitionCount + additionalActivePartitions.size());
+        final var all = new TreeSet<Integer>();
         all.addAll(allPartitions(basePartitionCount));
         all.addAll(additionalActivePartitions);
         all.removeAll(inactivePartitions);

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -16,9 +16,10 @@ message ClusterTopology {
 }
 
 message RoutingState {
-  int64 version = 1;
-  RequestHandling requestHandling = 2;
+  int64  version = 1;
+  repeated sint32 activePartitions = 2 [deprecated=true];
   MessageCorrelation messageCorrelation = 3;
+  RequestHandling requestHandling = 4;
 }
 
 message RequestHandling {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
@@ -43,12 +43,6 @@ final class PersistedClusterConfigurationRandomizedPropertyTest {
     assertThat(updatedTopology).isEqualTo(persistedClusterTopology.getConfiguration());
     assertThat(PersistedClusterConfiguration.ofFile(topologyFile, serializer).getConfiguration())
         .usingRecursiveComparison()
-        // The type of generated `activePartitions` is `LinkedHashSet`, which AssertJ treats as an
-        // ordered collection. We are not interested in the order of the partitions, so we ignore
-        // it here.
-        .ignoringCollectionOrderInFields(
-            "routingState.value.requestHandling.additionalActivePartitions")
-        .ignoringCollectionOrderInFields("routingState.value.requestHandling.inactivePartitions")
         .isEqualTo(updatedTopology);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
@@ -34,12 +34,6 @@ final class ProtoBufSerializerPropertyTest {
     assertThat(decodedState.getClusterConfiguration())
         .describedAs("Decoded clusterTopology must be equal to initial one")
         .usingRecursiveComparison()
-        // The type of generated `activePartitions` is `LinkedHashSet`, which AssertJ treats as an
-        // ordered collection. We are not interested in the order of the partitions, so we ignore
-        // it here.
-        .ignoringCollectionOrderInFields(
-            "routingState.value.requestHandling.additionalActivePartitions")
-        .ignoringCollectionOrderInFields("routingState.value.requestHandling.inactivePartitions")
         .isEqualTo(clusterConfiguration);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -68,9 +68,9 @@ public final class ClusterTopologyDomain extends DomainContextBase {
 
   @Provide
   Arbitrary<RequestHandling> requestHandling() {
-    return Arbitraries.of(
-            ReflectUtil.implementationsOfSealedInterface(RequestHandling.class).toList())
-        .flatMap(Arbitraries::forType);
+    return Arbitraries.oneOf(
+        allPartitions().map(RequestHandling.class::cast),
+        activePartitions().map(RequestHandling.class::cast));
   }
 
   @Provide
@@ -81,8 +81,8 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   @Provide
   Arbitrary<ActivePartitions> activePartitions() {
     final var basePartitionCount = Arbitraries.integers().between(1, 3);
-    final var activePartitions = Arbitraries.integers().between(4, 8).set();
-    final var inactivePartitions = Arbitraries.integers().between(9, 12).set();
+    final var activePartitions = Arbitraries.integers().between(4, 8).list().map(TreeSet::new);
+    final var inactivePartitions = Arbitraries.integers().between(9, 12).list().map(TreeSet::new);
 
     return Combinators.combine(basePartitionCount, activePartitions, inactivePartitions)
         .as(ActivePartitions::new);


### PR DESCRIPTION
# Description
Backport of #38184 to `stable/8.8`.

BREAKING CHANGE:
This PR reverts a BREAKING CHANGE done in 8.8, so it's a BREAKING CHANGE.


relates to #38140