### PR TITLE
[CPT] Remove client config options

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -529,17 +529,6 @@ public class CamundaProcessTestExtension
   }
 
   /**
-   * Configure the request timeout for the Camunda Client
-   *
-   * @param requestTimeout time to wait before the request times out
-   * @return the extension builder
-   */
-  public CamundaProcessTestExtension withClientRequestTimeout(final Duration requestTimeout) {
-    runtimeBuilder.withCamundaClientRequestTimeout(requestTimeout);
-    return this;
-  }
-
-  /**
    * Specifies process definition keys that should be excluded from coverage analysis. These
    * processes will not be considered when calculating coverage metrics.
    *

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -16,7 +16,6 @@
 package io.camunda.process.test.api;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.process.test.api.coverage.ProcessCoverage;
 import io.camunda.process.test.api.coverage.ProcessCoverageBuilder;
@@ -526,18 +525,6 @@ public class CamundaProcessTestExtension
   public CamundaProcessTestExtension withRemoteConnectorsRestApiAddress(
       final URI remoteConnectorsRestApiAddress) {
     runtimeBuilder.withRemoteConnectorsRestApiAddress(remoteConnectorsRestApiAddress);
-    return this;
-  }
-
-  /**
-   * Provide a custom credentials provider for a remote Camunda runtime.
-   *
-   * @param credentialsProvider the credentials provider for the remote runtime.
-   * @return the extension builder
-   */
-  public CamundaProcessTestExtension withRemoteCamundaClientCredentialsProvider(
-      final CredentialsProvider credentialsProvider) {
-    runtimeBuilder.withCredentialsProvider(credentialsProvider);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
@@ -74,7 +74,6 @@ public class CamundaProcessTestContainerRuntime
 
   private final boolean isMultiTenancyEnabled;
   private final boolean connectorsEnabled;
-  private final Duration camundaClientRequestTimeout;
 
   CamundaProcessTestContainerRuntime(
       final CamundaProcessTestRuntimeBuilder builder, final ContainerFactory containerFactory) {
@@ -82,7 +81,6 @@ public class CamundaProcessTestContainerRuntime
 
     isMultiTenancyEnabled = builder.isMultiTenancyEnabled();
     connectorsEnabled = builder.isConnectorsEnabled();
-    camundaClientRequestTimeout = builder.getCamundaClientRequestTimeout();
 
     network = Network.newNetwork();
     camundaContainer = createCamundaContainer(network, builder);
@@ -222,8 +220,7 @@ public class CamundaProcessTestContainerRuntime
       final CamundaClientBuilder client =
           CamundaClient.newClientBuilder()
               .restAddress(getCamundaRestApiAddress())
-              .grpcAddress(getCamundaGrpcApiAddress())
-              .defaultRequestTimeout(camundaClientRequestTimeout);
+              .grpcAddress(getCamundaGrpcApiAddress());
 
       if (isMultiTenancyEnabled) {
         client.credentialsProvider(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.process.test.impl.runtime;
 
-import io.camunda.client.CredentialsProvider;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.impl.containers.ContainerFactory;
@@ -236,13 +235,6 @@ public class CamundaProcessTestRuntimeBuilder {
   public CamundaProcessTestRuntimeBuilder withRemoteConnectorsRestApiAddress(
       final URI remoteConnectorsRestApiAddress) {
     this.remoteConnectorsRestApiAddress = remoteConnectorsRestApiAddress;
-    return this;
-  }
-
-  public CamundaProcessTestRuntimeBuilder withCredentialsProvider(
-      final CredentialsProvider credentialsProvider) {
-    remoteCamundaClientBuilderFactory =
-        () -> remoteCamundaClientBuilderFactory.get().credentialsProvider(credentialsProvider);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -19,7 +19,6 @@ import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.impl.containers.ContainerFactory;
 import java.net.URI;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -73,8 +72,6 @@ public class CamundaProcessTestRuntimeBuilder {
   private CamundaProcessTestRuntimeMode runtimeMode =
       CamundaProcessTestRuntimeDefaults.RUNTIME_MODE;
 
-  private Duration camundaClientRequestTimeout =
-      CamundaProcessTestRuntimeDefaults.CAMUNDA_CLIENT_REQUEST_TIMEOUT;
   private CamundaClientBuilderFactory remoteCamundaClientBuilderFactory =
       CamundaProcessTestRuntimeDefaults.CAMUNDA_CLIENT_BUILDER_FACTORY;
 
@@ -212,14 +209,6 @@ public class CamundaProcessTestRuntimeBuilder {
     return this;
   }
 
-  public CamundaProcessTestRuntimeBuilder withCamundaClientRequestTimeout(
-      final Duration requestTimeout) {
-    camundaClientRequestTimeout = requestTimeout;
-    remoteCamundaClientBuilderFactory =
-        () -> remoteCamundaClientBuilderFactory.get().defaultRequestTimeout(requestTimeout);
-    return this;
-  }
-
   public CamundaProcessTestRuntimeBuilder withRemoteCamundaClientBuilderFactory(
       final CamundaClientBuilderFactory remoteCamundaClientBuilderFactory) {
     this.remoteCamundaClientBuilderFactory = remoteCamundaClientBuilderFactory;
@@ -345,9 +334,5 @@ public class CamundaProcessTestRuntimeBuilder {
 
   public URI getRemoteConnectorsRestApiAddress() {
     return remoteConnectorsRestApiAddress;
-  }
-
-  public Duration getCamundaClientRequestTimeout() {
-    return camundaClientRequestTimeout;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -82,10 +82,9 @@ public class CamundaProcessTestRuntimeDefaults {
 
   public static final URI REMOTE_CLIENT_GRPC_ADDRESS = PROPERTIES_UTIL.getRemoteClientGrpcAddress();
   public static final URI REMOTE_CLIENT_REST_ADDRESS = PROPERTIES_UTIL.getRemoteClientRestAddress();
+
   public static final CamundaClientBuilderFactory CAMUNDA_CLIENT_BUILDER_FACTORY =
       PROPERTIES_UTIL.getCamundaClientBuilderFactory();
-  public static final Duration CAMUNDA_CLIENT_REQUEST_TIMEOUT =
-      PROPERTIES_UTIL.getCamundaClientRequestTimeout();
 
   public static final boolean MULTI_TENANCY_ENABLED = PROPERTIES_UTIL.isMultiTenancyEnabled();
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
@@ -25,7 +25,6 @@ import io.camunda.process.test.impl.runtime.properties.RemoteRuntimeProperties;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -199,10 +198,6 @@ public final class ContainerRuntimePropertiesUtil {
 
   public URI getRemoteClientRestAddress() {
     return remoteRuntimeProperties.getRemoteClientProperties().getRestAddress();
-  }
-
-  public Duration getCamundaClientRequestTimeout() {
-    return remoteRuntimeProperties.getRemoteClientProperties().getRequestTimeout();
   }
 
   public CamundaProcessTestRuntimeMode getRuntimeMode() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeClientProperties.java
@@ -26,20 +26,16 @@ import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import io.camunda.process.test.impl.runtime.util.CptCredentialsProviderConfigurer;
 import java.net.URI;
-import java.time.Duration;
 import java.util.Properties;
 
 public class RemoteRuntimeClientProperties {
   public static final String PROPERTY_NAME_MODE = "remote.client.mode";
   public static final String PROPERTY_NAME_GRPC_ADDRESS = "remote.client.grpcAddress";
   public static final String PROPERTY_NAME_REST_ADDRESS = "remote.client.restAddress";
-  public static final String PROPERTY_NAME_CAMUNDA_CLIENT_REQUEST_TIMEOUT =
-      "remote.client.requestTimeout";
 
   private final ClientMode mode;
   private final URI grpcAddress;
   private final URI restAddress;
-  private final Duration requestTimeout;
 
   private final RemoteRuntimeClientCloudProperties remoteRuntimeClientCloudProperties;
   private final RemoteRuntimeClientAuthProperties remoteRuntimeClientAuthProperties;
@@ -86,19 +82,6 @@ public class RemoteRuntimeClientProperties {
                 return CamundaProcessTestRuntimeDefaults.REMOTE_CLIENT_REST_ADDRESS;
               }
             });
-
-    requestTimeout =
-        getPropertyOrDefault(
-            properties,
-            PROPERTY_NAME_CAMUNDA_CLIENT_REQUEST_TIMEOUT,
-            v -> {
-              try {
-                return Duration.parse(v);
-              } catch (final Throwable t) {
-                return CamundaProcessTestRuntimeDefaults.DEFAULT_CAMUNDA_CLIENT_REQUEST_TIMEOUT;
-              }
-            },
-            CamundaProcessTestRuntimeDefaults.DEFAULT_CAMUNDA_CLIENT_REQUEST_TIMEOUT);
   }
 
   public ClientMode getMode() {
@@ -113,10 +96,6 @@ public class RemoteRuntimeClientProperties {
     return restAddress;
   }
 
-  public Duration getRequestTimeout() {
-    return requestTimeout;
-  }
-
   public RemoteRuntimeClientCloudProperties getCloudProperties() {
     return remoteRuntimeClientCloudProperties;
   }
@@ -126,8 +105,7 @@ public class RemoteRuntimeClientProperties {
   }
 
   public CamundaClientBuilderFactory getClientBuilderFactory() {
-    final CamundaClientBuilder camundaClientBuilder =
-        createCamundaClient(mode).defaultRequestTimeout(requestTimeout);
+    final CamundaClientBuilder camundaClientBuilder = createCamundaClient(mode);
 
     if (CamundaProcessTestRuntimeDefaults.REMOTE_CLIENT_GRPC_ADDRESS != null) {
       camundaClientBuilder.grpcAddress(

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
@@ -18,13 +18,11 @@ package io.camunda.process.test.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientConfiguration;
-import io.camunda.client.impl.NoopCredentialsProvider;
 import io.camunda.process.test.api.coverage.ProcessCoverage;
 import io.camunda.process.test.api.coverage.ProcessCoverageBuilder;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
@@ -273,8 +271,7 @@ public class JunitExtensionTest {
             .withCamundaEnv("env-3", "test-3")
             .withCamundaExposedPort(100)
             .withCamundaExposedPort(200)
-            .withClientRequestTimeout(Duration.ofHours(1))
-            .withRemoteCamundaClientCredentialsProvider(new NoopCredentialsProvider());
+            .withClientRequestTimeout(Duration.ofHours(1));
 
     // when
     extension.beforeAll(extensionContext);
@@ -293,7 +290,6 @@ public class JunitExtensionTest {
     verify(camundaRuntimeBuilder).withCamundaExposedPort(200);
 
     verify(camundaRuntimeBuilder).withCamundaClientRequestTimeout(Duration.ofHours(1));
-    verify(camundaRuntimeBuilder, times(1)).withCredentialsProvider(any());
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
@@ -34,7 +34,6 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import java.lang.reflect.Field;
 import java.net.URI;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -270,8 +269,7 @@ public class JunitExtensionTest {
             .withCamundaEnv(camundaEnvVars)
             .withCamundaEnv("env-3", "test-3")
             .withCamundaExposedPort(100)
-            .withCamundaExposedPort(200)
-            .withClientRequestTimeout(Duration.ofHours(1));
+            .withCamundaExposedPort(200);
 
     // when
     extension.beforeAll(extensionContext);
@@ -288,8 +286,6 @@ public class JunitExtensionTest {
 
     verify(camundaRuntimeBuilder).withCamundaExposedPort(100);
     verify(camundaRuntimeBuilder).withCamundaExposedPort(200);
-
-    verify(camundaRuntimeBuilder).withCamundaClientRequestTimeout(Duration.ofHours(1));
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.containers.ConnectorsContainer;
 import io.camunda.process.test.impl.containers.ContainerFactory;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -225,7 +224,6 @@ public class CamundaProcessTestContainerRuntimeTest {
         .withConnectorsSecrets(connectorSecrets)
         .withConnectorsSecret(additionalConnectorSecretKey, additionalConnectorSecretValue)
         .withConnectorsLogger("custom-logger")
-        .withCamundaClientRequestTimeout(Duration.ofHours(1))
         .build();
 
     // then

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -56,7 +56,6 @@ public class ContainerRuntimePropertiesUtilTest {
     assertThat(propertiesUtil.getConnectorsDockerImageName())
         .isEqualTo("camunda/connectors-bundle");
     assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("SNAPSHOT");
-    assertThat(propertiesUtil.getCamundaClientRequestTimeout()).hasSeconds(10);
   }
 
   @Test
@@ -320,7 +319,6 @@ public class ContainerRuntimePropertiesUtilTest {
       assertThat(propertiesUtil.getConnectorsDockerImageName())
           .isEqualTo("camunda/connectors-bundle");
       assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("8.8.3");
-      assertThat(propertiesUtil.getCamundaClientRequestTimeout()).hasHours(1);
 
       final RemoteRuntimeClientCloudProperties cloudProps =
           propertiesUtil

--- a/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
@@ -39,7 +39,6 @@ remote.camundaMonitoringApiAddress=http://0.0.0.0:8080
 remote.connectorsRestApiAddress=http://0.0.0.0:8085
 remote.client.grpcAddress=http://0.0.0.0:8088
 remote.client.restAddress=http://0.0.0.0:8089
-remote.client.requestTimeout=PT1H
 remote.client.cloud.clusterId=clusterId
 remote.client.cloud.region=region
 

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
@@ -36,9 +36,6 @@ public class CamundaSpringProcessTestRuntimeBuilder {
     final CamundaProcessTestRuntimeMode runtimeMode = runtimeConfiguration.getRuntimeMode();
     runtimeBuilder.withRuntimeMode(runtimeMode);
 
-    runtimeBuilder.withCamundaClientRequestTimeout(
-        runtimeConfiguration.getRemote().getClient().getRequestTimeout());
-
     if (runtimeMode == CamundaProcessTestRuntimeMode.MANAGED || runtimeMode == null) {
       configureManagedRuntime(runtimeBuilder, runtimeConfiguration);
 
@@ -96,14 +93,15 @@ public class CamundaSpringProcessTestRuntimeBuilder {
         runtimeConfiguration.getRemote().getClient();
 
     final CamundaClientBuilder clientBuilder = createCamundaClientBuilder(remoteClientProperties);
-    clientBuilder.defaultRequestTimeout(
-        runtimeConfiguration.getRemote().getClient().getRequestTimeout());
 
     if (remoteClientProperties.getRestAddress() != null) {
       clientBuilder.restAddress(remoteClientProperties.getRestAddress());
     }
     if (remoteClientProperties.getGrpcAddress() != null) {
       clientBuilder.grpcAddress(remoteClientProperties.getGrpcAddress());
+    }
+    if (remoteClientProperties.getRequestTimeout() != null) {
+      clientBuilder.defaultRequestTimeout(remoteClientProperties.getRequestTimeout());
     }
 
     return () -> clientBuilder;

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
@@ -67,7 +67,6 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     assertThat(runtimeBuilder.getCamundaExposedPorts()).isEmpty();
 
     assertThat(runtimeBuilder.isConnectorsEnabled()).isFalse();
-    assertThat(runtimeBuilder.getCamundaClientRequestTimeout()).hasSeconds(10);
   }
 
   @Test
@@ -89,8 +88,6 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     runtimeConfiguration.setCamundaLoggerName("io.camunda.custom.logger.name");
     runtimeConfiguration.setConnectorsLoggerName("io.camunda.custom.logger.name");
 
-    runtimeConfiguration.getRemote().getClient().setRequestTimeout(Duration.ofHours(1));
-
     // when
     CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
 
@@ -101,7 +98,6 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     assertThat(runtimeBuilder.getCamundaExposedPorts()).isEqualTo(camundaExposedPorts);
     assertThat(runtimeBuilder.getCamundaLoggerName()).isEqualTo("io.camunda.custom.logger.name");
     assertThat(runtimeBuilder.getConnectorsLoggerName()).isEqualTo("io.camunda.custom.logger.name");
-    assertThat(runtimeBuilder.getCamundaClientRequestTimeout()).isEqualTo(Duration.ofHours(1));
   }
 
   @Test


### PR DESCRIPTION
## Description

- Remove the setter for the remote credential provider in favor of the more generic remote client builder factory.
- Remove the setter for the client request timeout in favor of the more generic client customization option that we should add as part of https://github.com/camunda/camunda/issues/35308.

The intention is to increase the maintainability by favoring generic or implicit configuration options over specific properties. The assumption is that the configuration of the `requestTimeout` is an edge case. 

## Related issues

follow-up of https://github.com/camunda/camunda/pull/37239
