### PR TITLE
fix: MessagingException thrown when channel is closed contains original Throwable

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingException.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingException.java
@@ -70,5 +70,9 @@ public class MessagingException extends IOException {
     public ConnectionClosed(final String message) {
       super(message);
     }
+
+    public ConnectionClosed(final String message, final Throwable exception) {
+      super(message, exception);
+    }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -863,7 +863,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
                     new MessagingException.ConnectionClosed(
                         String.format(
                             "Channel %s for address %s was closed unexpectedly before the request was handled",
-                            channel, address)));
+                            channel, address),
+                        onClose.cause()));
               }
             });
 


### PR DESCRIPTION
## Description
When a channel is closed prematurely, the original exception is never logged.
Adding it to the cause of `MessagingException` can help debugging logs when such error occurs.

## Checklist
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

