### PR TITLE
[Backport stable/8.5] fix: correct zeebe incident events metric name

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
@@ -196,7 +196,7 @@ public enum EngineMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public String getName() {
-      return "zeebe.incidents.events.total";
+      return "zeebe.incident.events.total";
     }
 
     @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/IncidentMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/IncidentMetricsTest.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.camunda.zeebe.engine.metrics;
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/IncidentMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/IncidentMetricsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class IncidentMetricsTest {
+
+  private static final String PROCESS_ID = "process";
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldUpdateIncidentMetricsIfIncidentOccurs() {
+    // given - process with a call activity referencing a non-existing process
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .callActivity("call", a -> a.zeebeProcessId("non-existing"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when - create process instance that will cause an incident
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then - wait for incident to be created and verify metrics
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    assertThat(createdIncidentsMetric()).describedAs("Created incidents metric").isOne();
+    assertThat(pendingIncidentsMetric()).describedAs("Pending incidents metric").isOne();
+    assertThat(resolvedIncidentsMetric()).describedAs("Resolved incidents metric").isZero();
+  }
+
+  @Test
+  public void shouldUpdateIncidentMetricsIfIncidentIsResolved() {
+    // given - process with a call activity referencing a non-existing process
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .callActivity("call", a -> a.zeebeProcessId("non-existing"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when - cancel the process instance, resolving the incident
+    engine.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then - wait for process to be canceled and verify metrics
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+    assertThat(createdIncidentsMetric()).describedAs("Created incidents metric").isOne();
+    assertThat(pendingIncidentsMetric()).describedAs("Pending incidents metric").isZero();
+    assertThat(resolvedIncidentsMetric()).describedAs("Resolved incidents metric").isOne();
+  }
+
+  private Double createdIncidentsMetric() {
+    return engine
+        .getMeterRegistry()
+        .get("zeebe.incident.events.total")
+        .tag("action", "created")
+        .counter()
+        .count();
+  }
+
+  private Double pendingIncidentsMetric() {
+    return engine.getMeterRegistry().get("zeebe.pending.incidents.total").gauge().value();
+  }
+
+  private Double resolvedIncidentsMetric() {
+    return engine
+        .getMeterRegistry()
+        .get("zeebe.incident.events.total")
+        .tag("action", "resolved")
+        .counter()
+        .count();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/DefaultZeebeDbFactory.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/DefaultZeebeDbFactory.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.StatefulMeterRegistryProvider;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class DefaultZeebeDbFactory {
 
@@ -25,6 +26,6 @@ public final class DefaultZeebeDbFactory {
         new RocksDbConfiguration(),
         consistencyChecks,
         new AccessMetricsConfiguration(Kind.NONE, 1),
-        StatefulMeterRegistryProvider.defaultProvider());
+        StatefulMeterRegistryProvider.wrapping(new SimpleMeterRegistry(), null));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -263,7 +263,7 @@ public final class TestStreams {
     final var streamProcessorListeners = new ArrayList<StreamProcessorListener>();
     streamProcessorListenerOpt.ifPresent(streamProcessorListeners::add);
 
-    final var meterRegistry = new SimpleMeterRegistry();
+    final var meterRegistry = zeebeDb.getMeterRegistry();
     meterRegistry
         .config()
         .commonTags(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -51,7 +51,6 @@ import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileAlreadyExistsException;


### PR DESCRIPTION
# Description
Backport of #37900 to `stable/8.5`.

relates to #34342