### PR TITLE
Fix rest client connection handling

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/ApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/ApiEntityConsumer.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.http;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.impl.http.TypedApiEntityConsumer.JsonApiEntityConsumer;
 import io.camunda.client.impl.http.TypedApiEntityConsumer.RawApiEntityConsumer;
+import io.camunda.client.impl.http.TypedApiEntityConsumer.TextStreamJsonApiEntityConsumer;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -70,6 +71,8 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
       entityConsumer = new RawApiEntityConsumer<>(true, chunkSize);
     } else if (ContentType.APPLICATION_JSON.isSameMimeType(contentType)) {
       entityConsumer = new JsonApiEntityConsumer<>(json, type, true);
+    } else if (ContentType.TEXT_EVENT_STREAM.isSameMimeType(contentType)) {
+      entityConsumer = new TextStreamJsonApiEntityConsumer<>(json, type, true);
     } else {
       final boolean isResponse =
           String.class.equals(type)

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
@@ -84,7 +84,7 @@ public final class HttpClient implements AutoCloseable {
 
   @Override
   public void close() throws Exception {
-    client.close(CloseMode.GRACEFUL);
+    client.close(CloseMode.IMMEDIATE);
     try {
       client.awaitShutdown(shutdownTimeout);
     } catch (final InterruptedException e) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
@@ -104,10 +104,8 @@ public class LongPollingActivateJobsTest {
     assertThat(response.getJobs()).hasSize(expectedJobsCount);
   }
 
-  // TODO: the REST use case is currently not working, see
-  // https://github.com/camunda/camunda/issues/19883
   @ParameterizedTest
-  @ValueSource(booleans = {false})
+  @ValueSource(booleans = {true, false})
   public void shouldActivateJobForOpenRequest(final boolean useRest, final TestInfo testInfo)
       throws InterruptedException {
     // given
@@ -163,6 +161,7 @@ public class LongPollingActivateJobsTest {
           .jobType(jobType)
           .maxJobsToActivate(5)
           .workerName("closed-" + i)
+          .timeout(Duration.ofMillis(500))
           .send();
 
       Thread.sleep(100);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Here are the key points to consider (also similar in commit messages):

* SseEmitter catches client connection close only when writing the response. That means  jobs can still be returned to the closed connection.. If the job is activated without a timeout, it might never be activated. We might need to think of solutions where we should make returned jobs activatable immediately without considering the job timeout.
* For backward compatibility, we need to convert SSE formatted "text/event-stream" content to JSON. Added a new consumer to achieve the desired backward compatibility. However, having a new endpoint or extending existing endpoint to support returning "text/event-stream" content type is just another viable option.
* In test, job activation timeout is added to the closed requests to make the job activatable again by worker "open". As mentioned in the fist point, this is required. Because jobs are returned to the controller, but they are not written to the response as client is closed. For returned job to become available again, timeout needs to expire, so worker "open" can pick it and write to the response.
* HttpClient now closes immediately instead of gracefully. If we do not have immediate http client shutdown, SseEmitter knows about connection close only later, so it writes the job response to the closed worker. To properly/timely listen http closes, connection must be closed immediately.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #19883
