### PR TITLE
feat: getMappingRule

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -102,6 +102,7 @@ import io.camunda.client.api.fetch.DocumentContentGetRequest;
 import io.camunda.client.api.fetch.ElementInstanceGetRequest;
 import io.camunda.client.api.fetch.GroupGetRequest;
 import io.camunda.client.api.fetch.IncidentGetRequest;
+import io.camunda.client.api.fetch.MappingRuleGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetFormRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
@@ -1610,6 +1611,21 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   DeleteMappingRuleCommandStep1 newDeleteMappingRuleCommand(String mappingRuleId);
+
+  /**
+   * Request to get a mapping rule by mapping rule ID.
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newMappingRuleGetRequest("mappingRuleId")
+   *  .send();
+   * </pre>
+   *
+   * @param mappingRuleId the ID of the mapping rule
+   * @return a builder for the request to get a mapping rule
+   */
+  MappingRuleGetRequest newMappingRuleGetRequest(String mappingRuleId);
 
   /**
    * Command to assign a user to a group.

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/MappingRuleGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/MappingRuleGetRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.response.MappingRule;
+
+public interface MappingRuleGetRequest extends FinalCommandStep<MappingRule> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -113,6 +113,7 @@ import io.camunda.client.api.fetch.DocumentContentGetRequest;
 import io.camunda.client.api.fetch.ElementInstanceGetRequest;
 import io.camunda.client.api.fetch.GroupGetRequest;
 import io.camunda.client.api.fetch.IncidentGetRequest;
+import io.camunda.client.api.fetch.MappingRuleGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetFormRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
@@ -250,6 +251,7 @@ import io.camunda.client.impl.fetch.DocumentContentGetRequestImpl;
 import io.camunda.client.impl.fetch.ElementInstanceGetRequestImpl;
 import io.camunda.client.impl.fetch.GroupGetRequestImpl;
 import io.camunda.client.impl.fetch.IncidentGetRequestImpl;
+import io.camunda.client.impl.fetch.MappingRuleGetRequestImpl;
 import io.camunda.client.impl.fetch.ProcessDefinitionGetFormRequestImpl;
 import io.camunda.client.impl.fetch.ProcessDefinitionGetRequestImpl;
 import io.camunda.client.impl.fetch.ProcessDefinitionGetXmlRequestImpl;
@@ -1013,6 +1015,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public DeleteMappingRuleCommandStep1 newDeleteMappingRuleCommand(final String mappingRuleId) {
     return new DeleteMappingRuleCommandImpl(mappingRuleId, httpClient);
+  }
+
+  @Override
+  public MappingRuleGetRequest newMappingRuleGetRequest(final String mappingRuleId) {
+    return new MappingRuleGetRequestImpl(httpClient, mappingRuleId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/MappingRuleGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/MappingRuleGetRequestImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.fetch.MappingRuleGetRequest;
+import io.camunda.client.api.search.response.MappingRule;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.MappingRuleResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class MappingRuleGetRequestImpl implements MappingRuleGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final String mappingRuleId;
+
+  public MappingRuleGetRequestImpl(final HttpClient httpClient, final String mappingRuleId) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    this.mappingRuleId = mappingRuleId;
+  }
+
+  @Override
+  public FinalCommandStep<MappingRule> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<MappingRule> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("mappingRuleId", mappingRuleId);
+    final HttpCamundaFuture<MappingRule> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        "/mapping-rules/" + mappingRuleId,
+        httpRequestConfig.build(),
+        MappingRuleResult.class,
+        SearchResponseMapper::toMappingResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/mappingrule/GetMappingRuleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/mappingrule/GetMappingRuleTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.mappingrule;
+
+import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.MappingRule;
+import io.camunda.client.protocol.rest.MappingRuleResult;
+import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class GetMappingRuleTest extends ClientRestTest {
+
+  private static final String MAPPING_RULE_ID = "mappingRuleId";
+
+  @Test
+  void shouldGetMappingRule() {
+    // given
+    gatewayService.onMappingRuleRequest(
+        MAPPING_RULE_ID,
+        new MappingRuleResult()
+            .mappingRuleId(MAPPING_RULE_ID)
+            .claimName("role")
+            .claimValue("admin")
+            .name("Admin Mapping Rule"));
+
+    // when
+    final MappingRule result = client.newMappingRuleGetRequest(MAPPING_RULE_ID).send().join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    final RequestMethod method = RestGatewayService.getLastRequest().getMethod();
+    assertThat(requestPath).isEqualTo(REST_API_PATH + "/mapping-rules/" + MAPPING_RULE_ID);
+    assertThat(method).isEqualTo(RequestMethod.GET);
+
+    assertThat(result.getMappingRuleId()).isEqualTo(MAPPING_RULE_ID);
+    assertThat(result.getClaimName()).isEqualTo("role");
+    assertThat(result.getClaimValue()).isEqualTo("admin");
+    assertThat(result.getName()).isEqualTo("Admin Mapping Rule");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullMappingRuleId() {
+    // when / then
+    assertThatThrownBy(() -> client.newMappingRuleGetRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("mappingRuleId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyMappingRuleId() {
+    // when / then
+    assertThatThrownBy(() -> client.newMappingRuleGetRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("mappingRuleId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNotFoundMappingRule() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/mapping-rules/" + MAPPING_RULE_ID,
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(() -> client.newMappingRuleGetRequest(MAPPING_RULE_ID).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnForbiddenRequest() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/mapping-rules/" + MAPPING_RULE_ID,
+        () -> new ProblemDetail().title("Forbidden").status(403));
+
+    // when / then
+    assertThatThrownBy(() -> client.newMappingRuleGetRequest(MAPPING_RULE_ID).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 403: 'Forbidden'");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -37,6 +37,7 @@ public class RestGatewayPaths {
   private static final String URL_INCIDENT = REST_API_PATH + "/incidents/%s";
   private static final String URL_INCIDENT_RESOLUTION = REST_API_PATH + "/incidents/%s/resolution";
   private static final String URL_JOB_ACTIVATION = REST_API_PATH + "/jobs/activation";
+  private static final String URL_MAPPING_RULE = REST_API_PATH + "/mapping-rules/%s";
   private static final String URL_MAPPING_RULES = REST_API_PATH + "/mapping-rules";
   private static final String URL_MESSAGE_PUBLICATION = REST_API_PATH + "/messages/publication";
   private static final String URL_MESSAGE_CORRELATION = REST_API_PATH + "/messages/correlation";
@@ -231,6 +232,10 @@ public class RestGatewayPaths {
 
   public static String getMappingRulesUrl() {
     return URL_MAPPING_RULES;
+  }
+
+  public static String getMappingRuleUrl(final String mappingRuleId) {
+    return String.format(URL_MAPPING_RULE, mappingRuleId);
   }
 
   public static String getGroupsUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -38,6 +38,7 @@ import io.camunda.client.protocol.rest.GroupUpdateResult;
 import io.camunda.client.protocol.rest.IncidentResult;
 import io.camunda.client.protocol.rest.JobActivationResult;
 import io.camunda.client.protocol.rest.MappingRuleCreateResult;
+import io.camunda.client.protocol.rest.MappingRuleResult;
 import io.camunda.client.protocol.rest.MessageCorrelationResult;
 import io.camunda.client.protocol.rest.MessagePublicationResult;
 import io.camunda.client.protocol.rest.ProblemDetail;
@@ -237,6 +238,10 @@ public class RestGatewayService {
 
   public void onCreateMappingRuleRequest(final MappingRuleCreateResult response) {
     registerPost(RestGatewayPaths.getMappingRulesUrl(), response);
+  }
+
+  public void onMappingRuleRequest(final String mappingRuleId, final MappingRuleResult response) {
+    registerGet(RestGatewayPaths.getMappingRuleUrl(mappingRuleId), response);
   }
 
   public void onCreateGroupRequest(final GroupCreateResult response) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MappingRuleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MappingRuleAuthorizationIT.java
@@ -116,6 +116,26 @@ class MappingRuleAuthorizationIT {
   }
 
   @Test
+  void getMappingRuleShouldReturnForbiddenIfUnauthorized(
+      @Authenticated(UNAUTHORIZED) final CamundaClient camundaClient) {
+    assertThatThrownBy(() -> camundaClient.newMappingRuleGetRequest("mappingRule1").send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("403: 'Forbidden'");
+  }
+
+  @Test
+  void getMappingRuleShouldReturnMappingRuleIfAuthorized(
+      @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
+    // when - get the mapping rule (this should not throw an exception)
+    final var mappingRule = camundaClient.newMappingRuleGetRequest("mappingRule1").send().join();
+
+    // then
+    assertThat(mappingRule.getMappingRuleId()).isEqualTo("mappingRule1");
+    assertThat(mappingRule.getClaimName()).isEqualTo("test-name");
+    assertThat(mappingRule.getClaimValue()).isEqualTo("test-value");
+  }
+
+  @Test
   void deleteMappingRuleShouldDeleteMappingRuleIfAuthorized(
       @Authenticated(ADMIN) final CamundaClient camundaClient) throws Exception {
     // given - create a mapping rule specifically for deletion in this test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetMappingRuleIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetMappingRuleIntegrationTest.java
@@ -54,10 +54,7 @@ public class GetMappingRuleIntegrationTest {
             () -> {
               final MappingRule result =
                   camundaClient.newMappingRuleGetRequest(mappingRuleId).send().join();
-              assertThat(result.getMappingRuleId()).isEqualTo(mappingRuleId);
-              assertThat(result.getClaimName()).isEqualTo(claimName);
-              assertThat(result.getClaimValue()).isEqualTo(claimValue);
-              assertThat(result.getName()).isEqualTo(name);
+              assertThat(result).isNotNull();
             });
 
     // when - get the mapping rule
@@ -76,7 +73,7 @@ public class GetMappingRuleIntegrationTest {
     assertThatThrownBy(
             () ->
                 camundaClient
-                    .newMappingRuleGetRequest(Strings.newRandomValidIdentityId())
+                    .newMappingRuleGetRequest("non-existent-mapping-rule-id")
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetMappingRuleIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetMappingRuleIntegrationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.MappingRule;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import java.net.http.HttpClient;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+public class GetMappingRuleIntegrationTest {
+
+  private static CamundaClient camundaClient;
+
+  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+  @Test
+  void shouldGetMappingRule() {
+    // given
+    final var mappingRuleId = Strings.newRandomValidIdentityId();
+    final var claimName = "role";
+    final var claimValue = "admin";
+    final var name = "Admin Mapping Rule";
+
+    // create a mapping rule first
+    camundaClient
+        .newCreateMappingRuleCommand()
+        .mappingRuleId(mappingRuleId)
+        .claimName(claimName)
+        .claimValue(claimValue)
+        .name(name)
+        .send()
+        .join();
+
+    // wait for the mapping rule to be created and indexed
+    Awaitility.await("Mapping rule is created and indexed")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final MappingRule result =
+                  camundaClient.newMappingRuleGetRequest(mappingRuleId).send().join();
+              assertThat(result.getMappingRuleId()).isEqualTo(mappingRuleId);
+              assertThat(result.getClaimName()).isEqualTo(claimName);
+              assertThat(result.getClaimValue()).isEqualTo(claimValue);
+              assertThat(result.getName()).isEqualTo(name);
+            });
+
+    // when - get the mapping rule
+    final MappingRule result = camundaClient.newMappingRuleGetRequest(mappingRuleId).send().join();
+
+    // then
+    assertThat(result.getMappingRuleId()).isEqualTo(mappingRuleId);
+    assertThat(result.getClaimName()).isEqualTo(claimName);
+    assertThat(result.getClaimValue()).isEqualTo(claimValue);
+    assertThat(result.getName()).isEqualTo(name);
+  }
+
+  @Test
+  void shouldReturnNotFoundOnGettingNonExistentMappingRule() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newMappingRuleGetRequest(Strings.newRandomValidIdentityId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+}


### PR DESCRIPTION
## Description

Adds command for REST endpoint getMappingRule to Java Client.
Exposes the API `GET /v2/mapping-rules/:mappingRuleId`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35817
