### PR TITLE
fix: stabilize Resource Authorization identity migration tests

### DIFF
--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/AbstractKeycloakIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/AbstractKeycloakIdentityMigrationIT.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.migration;
+
+import static io.camunda.it.migration.IdentityMigrationTestUtil.CAMUNDA_IDENTITY_RESOURCE_SERVER;
+import static io.camunda.it.migration.IdentityMigrationTestUtil.IDENTITY_CLIENT;
+import static io.camunda.it.migration.IdentityMigrationTestUtil.IDENTITY_CLIENT_SECRET;
+import static io.camunda.it.migration.IdentityMigrationTestUtil.externalIdentityUrl;
+import static io.camunda.it.migration.IdentityMigrationTestUtil.externalKeycloakUrl;
+import static io.camunda.zeebe.qa.util.cluster.TestZeebePort.CLUSTER;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.client.CamundaClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
+import io.camunda.migration.identity.config.IdentityMigrationProperties.Mode;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneIdentityMigration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@ZeebeIntegration
+@Testcontainers(parallel = true)
+public abstract class AbstractKeycloakIdentityMigrationIT {
+
+  @TestZeebe(autoStart = false)
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withAdditionalProfile("identity")
+          .withBasicAuth()
+          .withAuthorizationsEnabled();
+
+  @Container
+  private static final ElasticsearchContainer ELASTIC = IdentityMigrationTestUtil.getElastic();
+
+  @Container
+  private static final KeycloakContainer KEYCLOAK = IdentityMigrationTestUtil.getKeycloak();
+
+  @Container
+  private static final GenericContainer<?> POSTGRES = IdentityMigrationTestUtil.getPostgres();
+
+  private static final GenericContainer<?> IDENTITY =
+      IdentityMigrationTestUtil.getManagementIdentitySMKeycloak(KEYCLOAK, POSTGRES)
+          // this triggers the setup of the default roles for operate, tasklist and zeebe
+          .withEnv("KEYCLOAK_INIT_OPERATE_SECRET", "operate")
+          .withEnv("KEYCLOAK_INIT_OPERATE_ROOT_URL", "http://localhost:8081")
+          .withEnv("KEYCLOAK_INIT_TASKLIST_SECRET", "tasklist")
+          .withEnv("KEYCLOAK_INIT_TASKLIST_ROOT_URL", "http://localhost:8081")
+          .withEnv("KEYCLOAK_INIT_ZEEBE_NAME", "zeebe")
+          // create groups
+          .withEnv("KEYCLOAK_GROUPS_0_NAME", "groupA")
+          .withEnv("KEYCLOAK_GROUPS_1_NAME", "groupB")
+          .withEnv("KEYCLOAK_GROUPS_2_NAME", "groupC")
+          // create users and assign them to groups and roles
+          .withEnv("KEYCLOAK_USERS_0_EMAIL", "user0@email.com")
+          .withEnv("KEYCLOAK_USERS_0_FIRST-NAME", "user0")
+          .withEnv("KEYCLOAK_USERS_0_LAST-NAME", "user0")
+          .withEnv("KEYCLOAK_USERS_0_USERNAME", "user0")
+          .withEnv("KEYCLOAK_USERS_0_PASSWORD", "password")
+          .withEnv("KEYCLOAK_USERS_0_GROUPS_0", "groupA")
+          .withEnv("KEYCLOAK_USERS_0_GROUPS_1", "groupB")
+          .withEnv("KEYCLOAK_USERS_0_ROLES_0", "Identity")
+          .withEnv("KEYCLOAK_USERS_0_ROLES_1", "Operate")
+          .withEnv("KEYCLOAK_USERS_0_ROLES_2", "Tasklist")
+          .withEnv("KEYCLOAK_USERS_0_ROLES_3", "Zeebe")
+          .withEnv("KEYCLOAK_USERS_1_EMAIL", "user1@email.com")
+          .withEnv("KEYCLOAK_USERS_1_FIRST-NAME", "user1")
+          .withEnv("KEYCLOAK_USERS_1_LAST-NAME", "user1")
+          .withEnv("KEYCLOAK_USERS_1_USERNAME", "user1")
+          .withEnv("KEYCLOAK_USERS_1_PASSWORD", "password")
+          .withEnv("KEYCLOAK_USERS_1_GROUPS_0", "groupC")
+          .withEnv("KEYCLOAK_USERS_1_ROLES_0", "Zeebe")
+          // assign authorizations to groups
+          .withEnv("IDENTITY_AUTHORIZATIONS_0_GROUP_NAME", "groupA")
+          .withEnv("IDENTITY_AUTHORIZATIONS_0_RESOURCE_KEY", "*")
+          .withEnv("IDENTITY_AUTHORIZATIONS_0_RESOURCE_TYPE", "process-definition")
+          .withEnv("IDENTITY_AUTHORIZATIONS_0_PERMISSIONS_0", "READ")
+          .withEnv("IDENTITY_AUTHORIZATIONS_0_PERMISSIONS_1", "DELETE")
+          .withEnv("IDENTITY_AUTHORIZATIONS_1_GROUP_NAME", "groupB")
+          .withEnv("IDENTITY_AUTHORIZATIONS_1_RESOURCE_KEY", "*")
+          .withEnv("IDENTITY_AUTHORIZATIONS_1_RESOURCE_TYPE", "decision-definition")
+          .withEnv("IDENTITY_AUTHORIZATIONS_1_PERMISSIONS_0", "READ")
+          .withEnv("IDENTITY_AUTHORIZATIONS_1_PERMISSIONS_1", "DELETE")
+          // assign authorizations to users
+          .withEnv("IDENTITY_AUTHORIZATIONS_2_USERNAME", "user0")
+          .withEnv("IDENTITY_AUTHORIZATIONS_2_RESOURCE_KEY", "*")
+          .withEnv("IDENTITY_AUTHORIZATIONS_2_RESOURCE_TYPE", "process-definition")
+          .withEnv("IDENTITY_AUTHORIZATIONS_2_PERMISSIONS_0", "READ")
+          .withEnv("IDENTITY_AUTHORIZATIONS_2_PERMISSIONS_1", "UPDATE_PROCESS_INSTANCE")
+          .withEnv("IDENTITY_AUTHORIZATIONS_3_USERNAME", "user1")
+          .withEnv("IDENTITY_AUTHORIZATIONS_3_RESOURCE_KEY", "*")
+          .withEnv("IDENTITY_AUTHORIZATIONS_3_RESOURCE_TYPE", "decision-definition")
+          .withEnv("IDENTITY_AUTHORIZATIONS_3_PERMISSIONS_0", "READ")
+          .withEnv("IDENTITY_AUTHORIZATIONS_3_PERMISSIONS_1", "DELETE")
+          // tenant
+          .withEnv("IDENTITY_TENANTS_0_NAME", "tenant 1")
+          .withEnv("IDENTITY_TENANTS_0_TENANT-ID", "tenant1")
+          .withEnv("IDENTITY_TENANTS_0_MEMBERS_0_TYPE", "GROUP")
+          .withEnv("IDENTITY_TENANTS_0_MEMBERS_0_GROUP-NAME", "groupA")
+          .withEnv("IDENTITY_TENANTS_0_MEMBERS_1_TYPE", "USER")
+          .withEnv("IDENTITY_TENANTS_0_MEMBERS_1_USERNAME", "user0")
+          .withEnv("IDENTITY_TENANTS_0_MEMBERS_2_TYPE", "APPLICATION")
+          .withEnv("IDENTITY_TENANTS_0_MEMBERS_2_APPLICATION-ID", IDENTITY_CLIENT)
+          .withEnv("IDENTITY_TENANTS_1_NAME", "tenant 2")
+          .withEnv("IDENTITY_TENANTS_1_TENANT-ID", "tenant2")
+          .withEnv("IDENTITY_TENANTS_1_MEMBERS_0_TYPE", "GROUP")
+          .withEnv("IDENTITY_TENANTS_1_MEMBERS_0_GROUP-NAME", "groupB")
+          .withEnv("IDENTITY_TENANTS_1_MEMBERS_1_TYPE", "USER")
+          .withEnv("IDENTITY_TENANTS_1_MEMBERS_1_USERNAME", "user1")
+          .withEnv("IDENTITY_TENANTS_1_MEMBERS_2_TYPE", "APPLICATION")
+          .withEnv("IDENTITY_TENANTS_1_MEMBERS_2_APPLICATION-ID", IDENTITY_CLIENT)
+          // public client to be ignored
+          .withEnv("KEYCLOAK_CLIENTS_1_NAME", "console")
+          .withEnv("KEYCLOAK_CLIENTS_1_ID", "console")
+          .withEnv("KEYCLOAK_CLIENTS_1_ROOT_URL", "http://console.camunda.com")
+          .withEnv("KEYCLOAK_CLIENTS_1_TYPE", "public")
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPort(8082)
+                  .forPath("/actuator/health/readiness")
+                  .allowInsecure()
+                  .forStatusCode(200)
+                  .withReadTimeout(Duration.ofSeconds(10))
+                  .withStartupTimeout(Duration.ofMinutes(5)));
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  protected TestStandaloneIdentityMigration migration;
+  protected CamundaClient client;
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  @BeforeAll
+  static void init() {
+    BROKER
+        .withCamundaExporter("http://" + ELASTIC.getHttpHostAddress())
+        .withProperty(
+            "camunda.data.secondary-storage.elasticsearch.url",
+            "http://" + ELASTIC.getHttpHostAddress())
+        .start();
+
+    IDENTITY
+        .withEnv(
+            "IDENTITY_AUTH_PROVIDER_ISSUER_URL",
+            "http://localhost:%d/realms/camunda-platform".formatted(KEYCLOAK.getMappedPort(8080)))
+        .start();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    BROKER.stop();
+    IDENTITY.stop();
+  }
+
+  @BeforeEach
+  public void setup() throws Exception {
+    // given
+    final IdentityMigrationProperties migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.setMode(Mode.KEYCLOAK);
+    migrationProperties.getManagementIdentity().setBaseUrl(externalIdentityUrl(IDENTITY));
+    migrationProperties
+        .getManagementIdentity()
+        .setIssuerBackendUrl(externalKeycloakUrl(KEYCLOAK) + "/realms/camunda-platform/");
+    migrationProperties.getManagementIdentity().setIssuerType("KEYCLOAK");
+    migrationProperties.getManagementIdentity().setClientId(IDENTITY_CLIENT);
+    migrationProperties.getManagementIdentity().setClientSecret(IDENTITY_CLIENT_SECRET);
+    migrationProperties.getManagementIdentity().setAudience(CAMUNDA_IDENTITY_RESOURCE_SERVER);
+    migrationProperties
+        .getCluster()
+        .setInitialContactPoints(List.of("localhost:" + BROKER.mappedPort(CLUSTER)));
+    migration = new TestStandaloneIdentityMigration(migrationProperties);
+
+    client = BROKER.newClientBuilder().build();
+  }
+
+  @AfterEach
+  void tearDown() {
+    migration.close();
+  }
+
+  protected GroupsTenantResponse searchGroupsInTenant(
+      final String restAddress, final String tenantId)
+      throws URISyntaxException, IOException, InterruptedException {
+    final var encodedCredentials =
+        Base64.getEncoder().encodeToString("%s:%s".formatted("demo", "demo").getBytes());
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(
+                new URI("%s%s".formatted(restAddress, "v2/tenants/" + tenantId + "/groups/search")))
+            .POST(HttpRequest.BodyPublishers.ofString(""))
+            .header("Authorization", "Basic %s".formatted(encodedCredentials))
+            .build();
+
+    final HttpResponse<String> response =
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    return OBJECT_MAPPER.readValue(response.body(), GroupsTenantResponse.class);
+  }
+
+  protected ClientsTenantResponse searchClientsInTenant(
+      final String restAddress, final String tenantId)
+      throws URISyntaxException, IOException, InterruptedException {
+    final var encodedCredentials =
+        Base64.getEncoder().encodeToString("%s:%s".formatted("demo", "demo").getBytes());
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(
+                new URI(
+                    "%s%s".formatted(restAddress, "v2/tenants/" + tenantId + "/clients/search")))
+            .POST(HttpRequest.BodyPublishers.ofString(""))
+            .header("Authorization", "Basic %s".formatted(encodedCredentials))
+            .build();
+
+    final HttpResponse<String> response =
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    return OBJECT_MAPPER.readValue(response.body(), ClientsTenantResponse.class);
+  }
+
+  protected record GroupsTenantResponse(List<TenantGroup> items) {}
+
+  protected record TenantGroup(String groupId) {}
+
+  protected record ClientsTenantResponse(List<TenantClient> items) {}
+
+  protected record TenantClient(String clientId) {}
+}

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/AbstractSaaSIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/AbstractSaaSIdentityMigrationIT.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.migration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static io.camunda.it.migration.IdentityMigrationTestUtil.CAMUNDA_IDENTITY_RESOURCE_SERVER;
+import static io.camunda.it.migration.IdentityMigrationTestUtil.IDENTITY_CLIENT;
+import static io.camunda.it.migration.IdentityMigrationTestUtil.IDENTITY_CLIENT_SECRET;
+import static io.camunda.it.migration.IdentityMigrationTestUtil.externalIdentityUrl;
+import static io.camunda.zeebe.qa.util.cluster.TestZeebePort.CLUSTER;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.camunda.client.CamundaClient;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneIdentityMigration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.text.MessageFormat;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@WireMockTest
+@ZeebeIntegration
+@Testcontainers(parallel = true)
+public abstract class AbstractSaaSIdentityMigrationIT {
+
+  public static final String CONSOLE_CLIENT_ID = "client-id";
+  public static final String CONSOLE_CLIENT_SECRET = "client-secret";
+  public static final String CONSOLE_AUDIENCE = "test-audience";
+
+  @TestZeebe(autoStart = false)
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  private static final String AUTH_TOKEN_BODY =
+      """
+      {
+          "client_id":"%s",
+          "client_secret":"%s",
+          "audience":"%s",
+          "grant_type":"client_credentials"
+        }
+      """;
+  private static final String TOKEN = loadFixture("jwt-identity-client.txt");
+
+  @Container
+  private static final ElasticsearchContainer ELASTIC = IdentityMigrationTestUtil.getElastic();
+
+  @Container
+  private static final GenericContainer<?> POSTGRES = IdentityMigrationTestUtil.getPostgres();
+
+  private static final GenericContainer<?> IDENTITY =
+      IdentityMigrationTestUtil.getManagementIdentitySaaS(POSTGRES)
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPort(8082)
+                  .forPath("/actuator/health/readiness")
+                  .allowInsecure()
+                  .forStatusCode(200)
+                  .withReadTimeout(Duration.ofSeconds(10))
+                  .withStartupTimeout(Duration.ofMinutes(5)));
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  protected TestStandaloneIdentityMigration migration;
+  protected CamundaClient client;
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  @BeforeAll
+  static void init(final WireMockRuntimeInfo wmRuntimeInfo) {
+    BROKER
+        .withCamundaExporter("http://" + ELASTIC.getHttpHostAddress())
+        .withProperty(
+            "camunda.data.secondary-storage.elasticsearch.url",
+            "http://" + ELASTIC.getHttpHostAddress())
+        .start();
+
+    org.testcontainers.Testcontainers.exposeHostPorts(wmRuntimeInfo.getHttpPort());
+    IDENTITY.withEnv(
+        "IDENTITY_AUTH_PROVIDER_BACKEND_URL",
+        "http://host.testcontainers.internal:%d/".formatted(wmRuntimeInfo.getHttpPort()));
+    IDENTITY.withEnv(
+        "IDENTITY_AUTH_PROVIDER_ISSUER_URL",
+        "http://host.testcontainers.internal:%d/".formatted(wmRuntimeInfo.getHttpPort()));
+    IDENTITY.start();
+  }
+
+  @BeforeEach
+  public void setup(final WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    // given
+    stubConsoleClient();
+
+    final IdentityMigrationProperties migrationProperties = new IdentityMigrationProperties();
+    migrationProperties.getManagementIdentity().setBaseUrl(externalIdentityUrl(IDENTITY));
+    migrationProperties.getManagementIdentity().setIssuerBackendUrl(wmRuntimeInfo.getHttpBaseUrl());
+    migrationProperties.getManagementIdentity().setIssuerType("AUTH0");
+    migrationProperties.getManagementIdentity().setClientId(IDENTITY_CLIENT);
+    migrationProperties.getManagementIdentity().setClientSecret(IDENTITY_CLIENT_SECRET);
+    migrationProperties.getManagementIdentity().setAudience(CAMUNDA_IDENTITY_RESOURCE_SERVER);
+    // Console properties
+    migrationProperties.setOrganizationId("org123");
+    migrationProperties.getConsole().setBaseUrl(wmRuntimeInfo.getHttpBaseUrl());
+    migrationProperties
+        .getConsole()
+        .setIssuerBackendUrl(wmRuntimeInfo.getHttpBaseUrl() + "/oauth/token");
+    migrationProperties.getConsole().setClientId(CONSOLE_CLIENT_ID);
+    migrationProperties.getConsole().setClientSecret(CONSOLE_CLIENT_SECRET);
+    migrationProperties.getConsole().setAudience(CONSOLE_AUDIENCE);
+    migrationProperties.getConsole().setClusterId("cluster123");
+    migrationProperties.getConsole().setInternalClientId("client123");
+
+    migration =
+        new TestStandaloneIdentityMigration(migrationProperties)
+            .withAppConfig(
+                config -> {
+                  config
+                      .getCluster()
+                      .setInitialContactPoints(List.of("localhost:" + BROKER.mappedPort(CLUSTER)));
+                });
+
+    client = BROKER.newClientBuilder().build();
+  }
+
+  @AfterAll
+  static void cleanup() {
+    BROKER.stop();
+    IDENTITY.stop();
+  }
+
+  @AfterEach
+  public void afterEach() {
+    if (migration != null) {
+      migration.close();
+    }
+    if (client != null) {
+      client.close();
+    }
+  }
+
+  protected void createAuthorizations()
+      throws IOException, InterruptedException, URISyntaxException {
+    final HttpRequest request1 =
+        HttpRequest.newBuilder()
+            .uri(new URI("%s%s".formatted(externalIdentityUrl(IDENTITY), "/api/authorizations")))
+            .PUT(
+                HttpRequest.BodyPublishers.ofString(
+                    """
+                    {
+                       "entityId": "user0",
+                       "entityType": "USER",
+                       "resourceKey": "my-test-resource",
+                       "resourceType": "process-definition",
+                       "permissions":[
+                          "READ",
+                          "DELETE",
+                          "UPDATE_PROCESS_INSTANCE",
+                          "DELETE_PROCESS_INSTANCE",
+                          "START_PROCESS_INSTANCE"
+                       ],
+                       "organizationId": "org123"
+                    }
+                    """))
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer %s".formatted(TOKEN))
+            .build();
+
+    final HttpRequest request2 =
+        HttpRequest.newBuilder()
+            .uri(new URI("%s%s".formatted(externalIdentityUrl(IDENTITY), "/api/authorizations")))
+            .PUT(
+                HttpRequest.BodyPublishers.ofString(
+                    """
+                    {
+                       "entityId": "user1",
+                       "entityType": "USER",
+                       "resourceKey": "another-test-resource",
+                       "resourceType": "decision-definition",
+                       "permissions":[
+                          "READ",
+                          "DELETE"
+                       ],
+                       "organizationId": "org123"
+                    }
+                    """))
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer %s".formatted(TOKEN))
+            .build();
+
+    httpClient.send(request1, HttpResponse.BodyHandlers.ofString());
+    httpClient.send(request2, HttpResponse.BodyHandlers.ofString());
+  }
+
+  protected void createGroups() throws IOException, InterruptedException, URISyntaxException {
+    final var groupsNames = List.of("groupA", "groupB", "groupC");
+    for (final String groupName : groupsNames) {
+      createGroup(groupName);
+    }
+  }
+
+  protected void createGroup(final String groupName)
+      throws IOException, InterruptedException, URISyntaxException {
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(new URI("%s%s".formatted(externalIdentityUrl(IDENTITY), "/api/groups")))
+            .POST(
+                HttpRequest.BodyPublishers.ofString(
+                    """
+                    {
+                      "name": "%s",
+                      "organizationId": "org123"
+                    }
+                    """
+                        .formatted(groupName)))
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer %s".formatted(TOKEN))
+            .build();
+
+    httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  protected void assignGroupsToUsers()
+      throws IOException, URISyntaxException, InterruptedException {
+    final var groupIds =
+        getGroups().stream().map(io.camunda.migration.identity.dto.Group::id).toList();
+    assignGroupToUser(groupIds.getFirst(), "user0");
+    assignGroupToUser(groupIds.get(1), "user0");
+    assignGroupToUser(groupIds.getLast(), "user1");
+  }
+
+  protected void assignGroupToUser(final String groupId, final String userId)
+      throws IOException, InterruptedException, URISyntaxException {
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(
+                new URI(
+                    "%s%s"
+                        .formatted(
+                            externalIdentityUrl(IDENTITY),
+                            "/api/groups/%s/users".formatted(groupId))))
+            .POST(
+                HttpRequest.BodyPublishers.ofString(
+                    """
+                    {
+                      "userId": "%s",
+                      "organizationId": "org123"
+                    }
+                    """
+                        .formatted(userId)))
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer %s".formatted(TOKEN))
+            .build();
+
+    httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  protected List<io.camunda.migration.identity.dto.Group> getGroups()
+      throws IOException, InterruptedException, URISyntaxException {
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(
+                new URI(
+                    "%s%s"
+                        .formatted(
+                            externalIdentityUrl(IDENTITY), "/api/groups?organizationId=org123")))
+            .GET()
+            .header("Authorization", "Bearer %s".formatted(TOKEN))
+            .build();
+
+    final HttpResponse<String> response =
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    return OBJECT_MAPPER.readValue(response.body(), new TypeReference<>() {});
+  }
+
+  protected static void stubConsoleClient() {
+    // IDENTITY
+    stubFor(
+        get("/.well-known/jwks.json")
+            .willReturn(
+                ok().withHeader("Content-Type", "application/json")
+                    .withBody(loadFixture("jwks.json"))));
+
+    // console auth token
+    stubFor(
+        post(urlEqualTo("/oauth/token"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(
+                WireMock.equalToJson(
+                    AUTH_TOKEN_BODY.formatted(
+                        CONSOLE_CLIENT_ID, CONSOLE_CLIENT_SECRET, CONSOLE_AUDIENCE)))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"access_token\": \"" + TOKEN + "\"}")));
+
+    // management identity auth token
+    stubFor(
+        post(urlEqualTo("/oauth/token"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(
+                WireMock.equalToJson(
+                    AUTH_TOKEN_BODY.formatted(
+                        IDENTITY_CLIENT, IDENTITY_CLIENT_SECRET, CAMUNDA_IDENTITY_RESOURCE_SERVER)))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"access_token\": \"" + TOKEN + "\"}")));
+
+    // CONSOLE
+    final String endpoint =
+        MessageFormat.format(
+            "/external/organizations/{0}/clusters/{1}/migrationData/{2}",
+            "org123", "cluster123", "client123");
+
+    final String responseJson =
+        """
+        {
+          "members": [
+            {
+              "userId": "user0",
+              "roles": ["owner", "developer"],
+              "email": "user0@email.com",
+              "name": "John Doe"
+            },
+            {
+              "userId": "user1",
+              "roles": ["owner", "developer"],
+              "email": "user1@email.com",
+              "name": "John Doe"
+            }
+          ],
+          "clients": [
+            {
+              "name": "console-client",
+              "clientId": "client123",
+              "permissions": ["Operate", "Zeebe"]
+            },
+            {
+              "name": "Tasklist",
+              "clientId": "tasklist-client",
+              "permissions": ["Tasklist"]
+             }
+          ]
+        }
+        """;
+
+    stubFor(
+        get(urlEqualTo(endpoint))
+            .withHeader("Authorization", equalTo("Bearer " + TOKEN))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(responseJson)));
+  }
+
+  protected static String loadFixture(final String filename) {
+    try (final InputStream inputStream =
+        AbstractSaaSIdentityMigrationIT.class
+            .getClassLoader()
+            .getResourceAsStream("identity-migration/" + filename)) {
+      return new BufferedReader(new InputStreamReader(inputStream))
+          .lines()
+          .collect(Collectors.joining("\n"));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -7,19 +7,10 @@
  */
 package io.camunda.it.migration;
 
-import static io.camunda.it.migration.IdentityMigrationTestUtil.CAMUNDA_IDENTITY_RESOURCE_SERVER;
 import static io.camunda.it.migration.IdentityMigrationTestUtil.IDENTITY_CLIENT;
-import static io.camunda.it.migration.IdentityMigrationTestUtil.IDENTITY_CLIENT_SECRET;
-import static io.camunda.it.migration.IdentityMigrationTestUtil.externalIdentityUrl;
-import static io.camunda.it.migration.IdentityMigrationTestUtil.externalKeycloakUrl;
-import static io.camunda.zeebe.qa.util.cluster.TestZeebePort.CLUSTER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import dasniko.testcontainers.keycloak.KeycloakContainer;
-import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
@@ -28,193 +19,15 @@ import io.camunda.client.api.search.response.Role;
 import io.camunda.client.api.search.response.RoleUser;
 import io.camunda.client.api.search.response.Tenant;
 import io.camunda.client.api.search.response.TenantUser;
-import io.camunda.migration.identity.config.IdentityMigrationProperties;
-import io.camunda.migration.identity.config.IdentityMigrationProperties.Mode;
-import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import io.camunda.zeebe.qa.util.cluster.TestStandaloneIdentityMigration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.Base64;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.AutoClose;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@ZeebeIntegration
-@Testcontainers(parallel = true)
-public class KeycloakIdentityMigrationIT {
-
-  @TestZeebe(autoStart = false)
-  static final TestStandaloneBroker BROKER =
-      new TestStandaloneBroker()
-          .withAdditionalProfile("identity")
-          .withBasicAuth()
-          .withAuthorizationsEnabled();
-
-  @Container
-  private static final ElasticsearchContainer ELASTIC = IdentityMigrationTestUtil.getElastic();
-
-  @Container
-  private static final KeycloakContainer KEYCLOAK = IdentityMigrationTestUtil.getKeycloak();
-
-  @Container
-  private static final GenericContainer<?> POSTGRES = IdentityMigrationTestUtil.getPostgres();
-
-  private static final GenericContainer<?> IDENTITY =
-      IdentityMigrationTestUtil.getManagementIdentitySMKeycloak(KEYCLOAK, POSTGRES)
-          // this triggers the setup of the default roles for operate, tasklist and zeebe
-          .withEnv("KEYCLOAK_INIT_OPERATE_SECRET", "operate")
-          .withEnv("KEYCLOAK_INIT_OPERATE_ROOT_URL", "http://localhost:8081")
-          .withEnv("KEYCLOAK_INIT_TASKLIST_SECRET", "tasklist")
-          .withEnv("KEYCLOAK_INIT_TASKLIST_ROOT_URL", "http://localhost:8081")
-          .withEnv("KEYCLOAK_INIT_ZEEBE_NAME", "zeebe")
-          // create groups
-          .withEnv("KEYCLOAK_GROUPS_0_NAME", "groupA")
-          .withEnv("KEYCLOAK_GROUPS_1_NAME", "groupB")
-          .withEnv("KEYCLOAK_GROUPS_2_NAME", "groupC")
-          // create users and assign them to groups and roles
-          .withEnv("KEYCLOAK_USERS_0_EMAIL", "user0@email.com")
-          .withEnv("KEYCLOAK_USERS_0_FIRST-NAME", "user0")
-          .withEnv("KEYCLOAK_USERS_0_LAST-NAME", "user0")
-          .withEnv("KEYCLOAK_USERS_0_USERNAME", "user0")
-          .withEnv("KEYCLOAK_USERS_0_PASSWORD", "password")
-          .withEnv("KEYCLOAK_USERS_0_GROUPS_0", "groupA")
-          .withEnv("KEYCLOAK_USERS_0_GROUPS_1", "groupB")
-          .withEnv("KEYCLOAK_USERS_0_ROLES_0", "Identity")
-          .withEnv("KEYCLOAK_USERS_0_ROLES_1", "Operate")
-          .withEnv("KEYCLOAK_USERS_0_ROLES_2", "Tasklist")
-          .withEnv("KEYCLOAK_USERS_0_ROLES_3", "Zeebe")
-          .withEnv("KEYCLOAK_USERS_1_EMAIL", "user1@email.com")
-          .withEnv("KEYCLOAK_USERS_1_FIRST-NAME", "user1")
-          .withEnv("KEYCLOAK_USERS_1_LAST-NAME", "user1")
-          .withEnv("KEYCLOAK_USERS_1_USERNAME", "user1")
-          .withEnv("KEYCLOAK_USERS_1_PASSWORD", "password")
-          .withEnv("KEYCLOAK_USERS_1_GROUPS_0", "groupC")
-          .withEnv("KEYCLOAK_USERS_1_ROLES_0", "Zeebe")
-          // assign authorizations to groups
-          .withEnv("IDENTITY_AUTHORIZATIONS_0_GROUP_NAME", "groupA")
-          .withEnv("IDENTITY_AUTHORIZATIONS_0_RESOURCE_KEY", "*")
-          .withEnv("IDENTITY_AUTHORIZATIONS_0_RESOURCE_TYPE", "process-definition")
-          .withEnv("IDENTITY_AUTHORIZATIONS_0_PERMISSIONS_0", "READ")
-          .withEnv("IDENTITY_AUTHORIZATIONS_0_PERMISSIONS_1", "DELETE")
-          .withEnv("IDENTITY_AUTHORIZATIONS_1_GROUP_NAME", "groupB")
-          .withEnv("IDENTITY_AUTHORIZATIONS_1_RESOURCE_KEY", "*")
-          .withEnv("IDENTITY_AUTHORIZATIONS_1_RESOURCE_TYPE", "decision-definition")
-          .withEnv("IDENTITY_AUTHORIZATIONS_1_PERMISSIONS_0", "READ")
-          .withEnv("IDENTITY_AUTHORIZATIONS_1_PERMISSIONS_1", "DELETE")
-          // assign authorizations to users
-          .withEnv("IDENTITY_AUTHORIZATIONS_2_USERNAME", "user0")
-          .withEnv("IDENTITY_AUTHORIZATIONS_2_RESOURCE_KEY", "*")
-          .withEnv("IDENTITY_AUTHORIZATIONS_2_RESOURCE_TYPE", "process-definition")
-          .withEnv("IDENTITY_AUTHORIZATIONS_2_PERMISSIONS_0", "READ")
-          .withEnv("IDENTITY_AUTHORIZATIONS_2_PERMISSIONS_1", "UPDATE_PROCESS_INSTANCE")
-          .withEnv("IDENTITY_AUTHORIZATIONS_3_USERNAME", "user1")
-          .withEnv("IDENTITY_AUTHORIZATIONS_3_RESOURCE_KEY", "*")
-          .withEnv("IDENTITY_AUTHORIZATIONS_3_RESOURCE_TYPE", "decision-definition")
-          .withEnv("IDENTITY_AUTHORIZATIONS_3_PERMISSIONS_0", "READ")
-          .withEnv("IDENTITY_AUTHORIZATIONS_3_PERMISSIONS_1", "DELETE")
-          // tenant
-          .withEnv("IDENTITY_TENANTS_0_NAME", "tenant 1")
-          .withEnv("IDENTITY_TENANTS_0_TENANT-ID", "tenant1")
-          .withEnv("IDENTITY_TENANTS_0_MEMBERS_0_TYPE", "GROUP")
-          .withEnv("IDENTITY_TENANTS_0_MEMBERS_0_GROUP-NAME", "groupA")
-          .withEnv("IDENTITY_TENANTS_0_MEMBERS_1_TYPE", "USER")
-          .withEnv("IDENTITY_TENANTS_0_MEMBERS_1_USERNAME", "user0")
-          .withEnv("IDENTITY_TENANTS_0_MEMBERS_2_TYPE", "APPLICATION")
-          .withEnv("IDENTITY_TENANTS_0_MEMBERS_2_APPLICATION-ID", IDENTITY_CLIENT)
-          .withEnv("IDENTITY_TENANTS_1_NAME", "tenant 2")
-          .withEnv("IDENTITY_TENANTS_1_TENANT-ID", "tenant2")
-          .withEnv("IDENTITY_TENANTS_1_MEMBERS_0_TYPE", "GROUP")
-          .withEnv("IDENTITY_TENANTS_1_MEMBERS_0_GROUP-NAME", "groupB")
-          .withEnv("IDENTITY_TENANTS_1_MEMBERS_1_TYPE", "USER")
-          .withEnv("IDENTITY_TENANTS_1_MEMBERS_1_USERNAME", "user1")
-          .withEnv("IDENTITY_TENANTS_1_MEMBERS_2_TYPE", "APPLICATION")
-          .withEnv("IDENTITY_TENANTS_1_MEMBERS_2_APPLICATION-ID", IDENTITY_CLIENT)
-          // public client to be ignored
-          .withEnv("KEYCLOAK_CLIENTS_1_NAME", "console")
-          .withEnv("KEYCLOAK_CLIENTS_1_ID", "console")
-          .withEnv("KEYCLOAK_CLIENTS_1_ROOT_URL", "http://console.camunda.com")
-          .withEnv("KEYCLOAK_CLIENTS_1_TYPE", "public")
-          .waitingFor(
-              new HttpWaitStrategy()
-                  .forPort(8082)
-                  .forPath("/actuator/health/readiness")
-                  .allowInsecure()
-                  .forStatusCode(200)
-                  .withReadTimeout(Duration.ofSeconds(10))
-                  .withStartupTimeout(Duration.ofMinutes(5)));
-
-  private static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
-  private TestStandaloneIdentityMigration migration;
-  private CamundaClient client;
-
-  @BeforeAll
-  static void init() {
-    BROKER
-        .withCamundaExporter("http://" + ELASTIC.getHttpHostAddress())
-        .withProperty(
-            "camunda.data.secondary-storage.elasticsearch.url",
-            "http://" + ELASTIC.getHttpHostAddress())
-        .start();
-
-    IDENTITY
-        .withEnv(
-            "IDENTITY_AUTH_PROVIDER_ISSUER_URL",
-            "http://localhost:%d/realms/camunda-platform".formatted(KEYCLOAK.getMappedPort(8080)))
-        .start();
-  }
-
-  @AfterAll
-  static void afterAll() {
-    BROKER.stop();
-    IDENTITY.stop();
-  }
-
-  @BeforeEach
-  public void setup() throws Exception {
-    // given
-    final IdentityMigrationProperties migrationProperties = new IdentityMigrationProperties();
-    migrationProperties.setMode(Mode.KEYCLOAK);
-    migrationProperties.getManagementIdentity().setBaseUrl(externalIdentityUrl(IDENTITY));
-    migrationProperties
-        .getManagementIdentity()
-        .setIssuerBackendUrl(externalKeycloakUrl(KEYCLOAK) + "/realms/camunda-platform/");
-    migrationProperties.getManagementIdentity().setIssuerType("KEYCLOAK");
-    migrationProperties.getManagementIdentity().setClientId(IDENTITY_CLIENT);
-    migrationProperties.getManagementIdentity().setClientSecret(IDENTITY_CLIENT_SECRET);
-    migrationProperties.getManagementIdentity().setAudience(CAMUNDA_IDENTITY_RESOURCE_SERVER);
-    migrationProperties
-        .getCluster()
-        .setInitialContactPoints(List.of("localhost:" + BROKER.mappedPort(CLUSTER)));
-    migration = new TestStandaloneIdentityMigration(migrationProperties);
-
-    client = BROKER.newClientBuilder().build();
-  }
-
-  @AfterEach
-  void tearDown() {
-    migration.close();
-  }
+public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrationIT {
 
   @Test
   public void canMigrateRoles() {
@@ -728,48 +541,4 @@ public class KeycloakIdentityMigrationIT {
         .extracting(TenantClient::clientId)
         .containsExactlyInAnyOrder(IDENTITY_CLIENT);
   }
-
-  private GroupsTenantResponse searchGroupsInTenant(final String restAddress, final String tenantId)
-      throws URISyntaxException, IOException, InterruptedException {
-    final var encodedCredentials =
-        Base64.getEncoder().encodeToString("%s:%s".formatted("demo", "demo").getBytes());
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(
-                new URI("%s%s".formatted(restAddress, "v2/tenants/" + tenantId + "/groups/search")))
-            .POST(HttpRequest.BodyPublishers.ofString(""))
-            .header("Authorization", "Basic %s".formatted(encodedCredentials))
-            .build();
-
-    final HttpResponse<String> response =
-        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-    return OBJECT_MAPPER.readValue(response.body(), GroupsTenantResponse.class);
-  }
-
-  private ClientsTenantResponse searchClientsInTenant(
-      final String restAddress, final String tenantId)
-      throws URISyntaxException, IOException, InterruptedException {
-    final var encodedCredentials =
-        Base64.getEncoder().encodeToString("%s:%s".formatted("demo", "demo").getBytes());
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(
-                new URI(
-                    "%s%s".formatted(restAddress, "v2/tenants/" + tenantId + "/clients/search")))
-            .POST(HttpRequest.BodyPublishers.ofString(""))
-            .header("Authorization", "Basic %s".formatted(encodedCredentials))
-            .build();
-
-    final HttpResponse<String> response =
-        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-    return OBJECT_MAPPER.readValue(response.body(), ClientsTenantResponse.class);
-  }
-
-  private record GroupsTenantResponse(List<TenantGroup> items) {}
-
-  private record TenantGroup(String groupId) {}
-
-  private record ClientsTenantResponse(List<TenantClient> items) {}
-
-  private record TenantClient(String clientId) {}
 }

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationWithRBAIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationWithRBAIT.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.api.search.response.Authorization;
+import io.camunda.client.api.search.response.Role;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class KeycloakIdentityMigrationWithRBAIT extends AbstractKeycloakIdentityMigrationIT {
+
+  @Override
+  @BeforeEach
+  public void setup() throws Exception {
+    super.setup();
+    // given
+    migration.withAppConfig(properties -> properties.setResourceAuthorizationsEnabled(true));
+  }
+
+  @Test
+  public void canMigrateRolesWithRBAEnabled() {
+    // when
+    migration.start();
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var roles = client.newRolesSearchRequest().send().join();
+              assertThat(roles.items())
+                  .extracting(Role::getRoleId)
+                  .contains("operate", "tasklist", "zeebe", "identity");
+
+              final var authorizations = client.newAuthorizationSearchRequest().send().join();
+              assertThat(authorizations.items())
+                  .extracting(Authorization::getOwnerId)
+                  .contains("operate", "tasklist", "zeebe", "identity");
+            });
+
+    // then
+    assertThat(migration.getExitCode()).isEqualTo(0);
+
+    final var roles = client.newRolesSearchRequest().send().join();
+    assertThat(roles.items())
+        .extracting(Role::getRoleId, Role::getName)
+        .contains(
+            tuple("operate", "Operate"),
+            tuple("tasklist", "Tasklist"),
+            tuple("zeebe", "Zeebe"),
+            tuple("identity", "Identity"));
+
+    final var authorizations = client.newAuthorizationSearchRequest().send().join();
+    assertThat(authorizations.items())
+        .extracting(
+            Authorization::getOwnerId,
+            Authorization::getResourceType,
+            a -> new HashSet<>(a.getPermissionTypes()))
+        .contains(
+            tuple("operate", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)),
+            tuple("zeebe", ResourceType.SYSTEM, Set.of(PermissionType.READ, PermissionType.UPDATE)),
+            tuple("tasklist", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)),
+            tuple(
+                "identity",
+                ResourceType.GROUP,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE,
+                    PermissionType.CREATE)),
+            tuple(
+                "identity",
+                ResourceType.TENANT,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE,
+                    PermissionType.CREATE)),
+            tuple(
+                "identity",
+                ResourceType.ROLE,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE,
+                    PermissionType.CREATE)),
+            tuple(
+                "identity",
+                ResourceType.AUTHORIZATION,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE,
+                    PermissionType.CREATE)),
+            tuple("identity", ResourceType.USER, Set.of(PermissionType.READ)),
+            tuple("identity", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)));
+  }
+}

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -7,34 +7,16 @@
  */
 package io.camunda.it.migration;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static io.camunda.it.migration.IdentityMigrationTestUtil.CAMUNDA_IDENTITY_RESOURCE_SERVER;
-import static io.camunda.it.migration.IdentityMigrationTestUtil.IDENTITY_CLIENT;
-import static io.camunda.it.migration.IdentityMigrationTestUtil.IDENTITY_CLIENT_SECRET;
-import static io.camunda.it.migration.IdentityMigrationTestUtil.externalIdentityUrl;
 import static io.camunda.migration.identity.config.saas.StaticEntities.DEVELOPER_ROLE_ID;
 import static io.camunda.migration.identity.config.saas.StaticEntities.OPERATIONS_ENGINEER_ROLE_ID;
 import static io.camunda.migration.identity.config.saas.StaticEntities.ROLE_IDS;
 import static io.camunda.migration.identity.config.saas.StaticEntities.ROLE_PERMISSIONS;
 import static io.camunda.migration.identity.config.saas.StaticEntities.TASK_USER_ROLE_ID;
 import static io.camunda.migration.identity.config.saas.StaticEntities.VISITOR_ROLE_ID;
-import static io.camunda.zeebe.qa.util.cluster.TestZeebePort.CLUSTER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
@@ -43,155 +25,21 @@ import io.camunda.client.api.search.response.Group;
 import io.camunda.client.api.search.response.RoleUser;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.migration.identity.client.ConsoleClient.Role;
-import io.camunda.migration.identity.config.IdentityMigrationProperties;
-import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import io.camunda.zeebe.qa.util.cluster.TestStandaloneIdentityMigration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.AutoClose;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @WireMockTest
 @ZeebeIntegration
 @Testcontainers(parallel = true)
-public class SaaSIdentityMigrationIT {
-
-  public static final String CONSOLE_CLIENT_ID = "client-id";
-  public static final String CONSOLE_CLIENT_SECRET = "client-secret";
-  public static final String CONSOLE_AUDIENCE = "test-audience";
-
-  @TestZeebe(autoStart = false)
-  static final TestStandaloneBroker BROKER =
-      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
-
-  private static final String AUTH_TOKEN_BODY =
-      """
-      {
-          "client_id":"%s",
-          "client_secret":"%s",
-          "audience":"%s",
-          "grant_type":"client_credentials"
-        }
-      """;
-  private static final String TOKEN = loadFixture("jwt-identity-client.txt");
-
-  @Container
-  private static final ElasticsearchContainer ELASTIC = IdentityMigrationTestUtil.getElastic();
-
-  @Container
-  private static final GenericContainer<?> POSTGRES = IdentityMigrationTestUtil.getPostgres();
-
-  private static final GenericContainer<?> IDENTITY =
-      IdentityMigrationTestUtil.getManagementIdentitySaaS(POSTGRES)
-          .waitingFor(
-              new HttpWaitStrategy()
-                  .forPort(8082)
-                  .forPath("/actuator/health/readiness")
-                  .allowInsecure()
-                  .forStatusCode(200)
-                  .withReadTimeout(Duration.ofSeconds(10))
-                  .withStartupTimeout(Duration.ofMinutes(5)));
-  private static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
-  private TestStandaloneIdentityMigration migration;
-  private CamundaClient client;
-
-  @BeforeAll
-  static void init(final WireMockRuntimeInfo wmRuntimeInfo) {
-    BROKER
-        .withCamundaExporter("http://" + ELASTIC.getHttpHostAddress())
-        .withProperty(
-            "camunda.data.secondary-storage.elasticsearch.url",
-            "http://" + ELASTIC.getHttpHostAddress())
-        .start();
-
-    org.testcontainers.Testcontainers.exposeHostPorts(wmRuntimeInfo.getHttpPort());
-    IDENTITY.withEnv(
-        "IDENTITY_AUTH_PROVIDER_BACKEND_URL",
-        "http://host.testcontainers.internal:%d/".formatted(wmRuntimeInfo.getHttpPort()));
-    IDENTITY.withEnv(
-        "IDENTITY_AUTH_PROVIDER_ISSUER_URL",
-        "http://host.testcontainers.internal:%d/".formatted(wmRuntimeInfo.getHttpPort()));
-    IDENTITY.start();
-  }
-
-  @BeforeEach
-  public void setup(final WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-    // given
-    stubConsoleClient();
-
-    final IdentityMigrationProperties migrationProperties = new IdentityMigrationProperties();
-    migrationProperties.getManagementIdentity().setBaseUrl(externalIdentityUrl(IDENTITY));
-    migrationProperties.getManagementIdentity().setIssuerBackendUrl(wmRuntimeInfo.getHttpBaseUrl());
-    migrationProperties.getManagementIdentity().setIssuerType("AUTH0");
-    migrationProperties.getManagementIdentity().setClientId(IDENTITY_CLIENT);
-    migrationProperties.getManagementIdentity().setClientSecret(IDENTITY_CLIENT_SECRET);
-    migrationProperties.getManagementIdentity().setAudience(CAMUNDA_IDENTITY_RESOURCE_SERVER);
-    // Console properties
-    migrationProperties.setOrganizationId("org123");
-    migrationProperties.getConsole().setBaseUrl(wmRuntimeInfo.getHttpBaseUrl());
-    migrationProperties
-        .getConsole()
-        .setIssuerBackendUrl(wmRuntimeInfo.getHttpBaseUrl() + "/oauth/token");
-    migrationProperties.getConsole().setClientId(CONSOLE_CLIENT_ID);
-    migrationProperties.getConsole().setClientSecret(CONSOLE_CLIENT_SECRET);
-    migrationProperties.getConsole().setAudience(CONSOLE_AUDIENCE);
-    migrationProperties.getConsole().setClusterId("cluster123");
-    migrationProperties.getConsole().setInternalClientId("client123");
-
-    migration =
-        new TestStandaloneIdentityMigration(migrationProperties)
-            .withAppConfig(
-                config -> {
-                  config
-                      .getCluster()
-                      .setInitialContactPoints(List.of("localhost:" + BROKER.mappedPort(CLUSTER)));
-                });
-
-    client = BROKER.newClientBuilder().build();
-  }
-
-  @AfterAll
-  static void cleanup() {
-    BROKER.stop();
-    IDENTITY.stop();
-  }
-
-  @AfterEach
-  public void afterEach() {
-    if (migration != null) {
-      migration.close();
-    }
-    if (client != null) {
-      client.close();
-    }
-  }
+public class SaaSIdentityMigrationIT extends AbstractSaaSIdentityMigrationIT {
 
   @Test
   void canMigrateGroups() throws IOException, URISyntaxException, InterruptedException {
@@ -505,81 +353,6 @@ public class SaaSIdentityMigrationIT {
   }
 
   @Test
-  public void canMigratePermissionsWithRBAEnabled() {
-    // given
-    migration.withAppConfig(properties -> properties.setResourceAuthorizationsEnabled(true));
-
-    // when
-    migration.start();
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(5))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              final var authorizations =
-                  client.newAuthorizationSearchRequest().send().join().items();
-              final var migratedAuthorizations =
-                  authorizations.stream()
-                      .map(Authorization::getOwnerId)
-                      .filter(ROLE_IDS::contains)
-                      .toList();
-              assertThat(migratedAuthorizations.size()).isEqualTo(6);
-            });
-
-    // then
-    assertThat(migration.getExitCode()).isEqualTo(0);
-
-    final SearchResponse<Authorization> newResponse =
-        client.newAuthorizationSearchRequest().send().join();
-    assertThat(newResponse.items())
-        .extracting(
-            Authorization::getOwnerId,
-            Authorization::getOwnerType,
-            Authorization::getResourceId,
-            Authorization::getResourceType,
-            a -> new HashSet<>(a.getPermissionTypes()))
-        .contains(
-            // Role permissions
-            tuple(
-                DEVELOPER_ROLE_ID,
-                OwnerType.ROLE,
-                "operate",
-                ResourceType.COMPONENT,
-                Set.of(PermissionType.ACCESS)),
-            tuple(
-                DEVELOPER_ROLE_ID,
-                OwnerType.ROLE,
-                "tasklist",
-                ResourceType.COMPONENT,
-                Set.of(PermissionType.ACCESS)),
-            tuple(
-                OPERATIONS_ENGINEER_ROLE_ID,
-                OwnerType.ROLE,
-                "operate",
-                ResourceType.COMPONENT,
-                Set.of(PermissionType.ACCESS)),
-            tuple(
-                TASK_USER_ROLE_ID,
-                OwnerType.ROLE,
-                "tasklist",
-                ResourceType.COMPONENT,
-                Set.of(PermissionType.ACCESS)),
-            tuple(
-                VISITOR_ROLE_ID,
-                OwnerType.ROLE,
-                "operate",
-                ResourceType.COMPONENT,
-                Set.of(PermissionType.ACCESS)),
-            tuple(
-                VISITOR_ROLE_ID,
-                OwnerType.ROLE,
-                "tasklist",
-                ResourceType.COMPONENT,
-                Set.of(PermissionType.ACCESS)));
-  }
-
-  @Test
   public void canMigrateAuthorizations()
       throws URISyntaxException, IOException, InterruptedException {
     // when
@@ -638,7 +411,7 @@ public class SaaSIdentityMigrationIT {
   }
 
   @Test
-  public void canMigrateClients() throws IOException, URISyntaxException, InterruptedException {
+  public void canMigrateClients() {
     // when
     migration.start();
 
@@ -731,234 +504,5 @@ public class SaaSIdentityMigrationIT {
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.READ_USER_TASK,
                     PermissionType.UPDATE_USER_TASK)));
-  }
-
-  private void createAuthorizations() throws IOException, InterruptedException, URISyntaxException {
-    final HttpRequest request1 =
-        HttpRequest.newBuilder()
-            .uri(new URI("%s%s".formatted(externalIdentityUrl(IDENTITY), "/api/authorizations")))
-            .PUT(
-                HttpRequest.BodyPublishers.ofString(
-                    """
-                    {
-                       "entityId": "user0",
-                       "entityType": "USER",
-                       "resourceKey": "my-test-resource",
-                       "resourceType": "process-definition",
-                       "permissions":[
-                          "READ",
-                          "DELETE",
-                          "UPDATE_PROCESS_INSTANCE",
-                          "DELETE_PROCESS_INSTANCE",
-                          "START_PROCESS_INSTANCE"
-                       ],
-                       "organizationId": "org123"
-                    }
-                    """))
-            .header("Content-Type", "application/json")
-            .header("Authorization", "Bearer %s".formatted(TOKEN))
-            .build();
-
-    final HttpRequest request2 =
-        HttpRequest.newBuilder()
-            .uri(new URI("%s%s".formatted(externalIdentityUrl(IDENTITY), "/api/authorizations")))
-            .PUT(
-                HttpRequest.BodyPublishers.ofString(
-                    """
-                    {
-                       "entityId": "user1",
-                       "entityType": "USER",
-                       "resourceKey": "another-test-resource",
-                       "resourceType": "decision-definition",
-                       "permissions":[
-                          "READ",
-                          "DELETE"
-                       ],
-                       "organizationId": "org123"
-                    }
-                    """))
-            .header("Content-Type", "application/json")
-            .header("Authorization", "Bearer %s".formatted(TOKEN))
-            .build();
-
-    httpClient.send(request1, HttpResponse.BodyHandlers.ofString());
-    httpClient.send(request2, HttpResponse.BodyHandlers.ofString());
-  }
-
-  private void createGroups() throws IOException, InterruptedException, URISyntaxException {
-    final var groupsNames = List.of("groupA", "groupB", "groupC");
-    for (final String groupName : groupsNames) {
-      createGroup(groupName);
-    }
-  }
-
-  private void createGroup(final String groupName)
-      throws IOException, InterruptedException, URISyntaxException {
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(new URI("%s%s".formatted(externalIdentityUrl(IDENTITY), "/api/groups")))
-            .POST(
-                HttpRequest.BodyPublishers.ofString(
-                    """
-                    {
-                      "name": "%s",
-                      "organizationId": "org123"
-                    }
-                    """
-                        .formatted(groupName)))
-            .header("Content-Type", "application/json")
-            .header("Authorization", "Bearer %s".formatted(TOKEN))
-            .build();
-
-    httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-  }
-
-  private void assignGroupsToUsers() throws IOException, URISyntaxException, InterruptedException {
-    final var groupIds =
-        getGroups().stream().map(io.camunda.migration.identity.dto.Group::id).toList();
-    assignGroupToUser(groupIds.getFirst(), "user0");
-    assignGroupToUser(groupIds.get(1), "user0");
-    assignGroupToUser(groupIds.getLast(), "user1");
-  }
-
-  private void assignGroupToUser(final String groupId, final String userId)
-      throws IOException, InterruptedException, URISyntaxException {
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(
-                new URI(
-                    "%s%s"
-                        .formatted(
-                            externalIdentityUrl(IDENTITY),
-                            "/api/groups/%s/users".formatted(groupId))))
-            .POST(
-                HttpRequest.BodyPublishers.ofString(
-                    """
-                    {
-                      "userId": "%s",
-                      "organizationId": "org123"
-                    }
-                    """
-                        .formatted(userId)))
-            .header("Content-Type", "application/json")
-            .header("Authorization", "Bearer %s".formatted(TOKEN))
-            .build();
-
-    httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-  }
-
-  private List<io.camunda.migration.identity.dto.Group> getGroups()
-      throws IOException, InterruptedException, URISyntaxException {
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(
-                new URI(
-                    "%s%s"
-                        .formatted(
-                            externalIdentityUrl(IDENTITY), "/api/groups?organizationId=org123")))
-            .GET()
-            .header("Authorization", "Bearer %s".formatted(TOKEN))
-            .build();
-
-    final HttpResponse<String> response =
-        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-    return OBJECT_MAPPER.readValue(response.body(), new TypeReference<>() {});
-  }
-
-  private static void stubConsoleClient() {
-    // IDENTITY
-    stubFor(
-        get("/.well-known/jwks.json")
-            .willReturn(
-                ok().withHeader("Content-Type", "application/json")
-                    .withBody(loadFixture("jwks.json"))));
-
-    // console auth token
-    stubFor(
-        post(urlEqualTo("/oauth/token"))
-            .withHeader("Content-Type", equalTo("application/json"))
-            .withRequestBody(
-                WireMock.equalToJson(
-                    AUTH_TOKEN_BODY.formatted(
-                        CONSOLE_CLIENT_ID, CONSOLE_CLIENT_SECRET, CONSOLE_AUDIENCE)))
-            .willReturn(
-                aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody("{\"access_token\": \"" + TOKEN + "\"}")));
-
-    // management identity auth token
-    stubFor(
-        post(urlEqualTo("/oauth/token"))
-            .withHeader("Content-Type", equalTo("application/json"))
-            .withRequestBody(
-                WireMock.equalToJson(
-                    AUTH_TOKEN_BODY.formatted(
-                        IDENTITY_CLIENT, IDENTITY_CLIENT_SECRET, CAMUNDA_IDENTITY_RESOURCE_SERVER)))
-            .willReturn(
-                aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody("{\"access_token\": \"" + TOKEN + "\"}")));
-
-    // CONSOLE
-    final String endpoint =
-        MessageFormat.format(
-            "/external/organizations/{0}/clusters/{1}/migrationData/{2}",
-            "org123", "cluster123", "client123");
-
-    final String responseJson =
-        """
-        {
-          "members": [
-            {
-              "userId": "user0",
-              "roles": ["owner", "developer"],
-              "email": "user0@email.com",
-              "name": "John Doe"
-            },
-            {
-              "userId": "user1",
-              "roles": ["owner", "developer"],
-              "email": "user1@email.com",
-              "name": "John Doe"
-            }
-          ],
-          "clients": [
-            {
-              "name": "console-client",
-              "clientId": "client123",
-              "permissions": ["Operate", "Zeebe"]
-            },
-            {
-              "name": "Tasklist",
-              "clientId": "tasklist-client",
-              "permissions": ["Tasklist"]
-             }
-          ]
-        }
-        """;
-
-    stubFor(
-        get(urlEqualTo(endpoint))
-            .withHeader("Authorization", equalTo("Bearer " + TOKEN))
-            .willReturn(
-                aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody(responseJson)));
-  }
-
-  protected static String loadFixture(final String filename) {
-    try (final InputStream inputStream =
-        SaaSIdentityMigrationIT.class
-            .getClassLoader()
-            .getResourceAsStream("identity-migration/" + filename)) {
-      return new BufferedReader(new InputStreamReader(inputStream))
-          .lines()
-          .collect(Collectors.joining("\n"));
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 }

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationWithRBAIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationWithRBAIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.migration;
+
+import static io.camunda.migration.identity.config.saas.StaticEntities.DEVELOPER_ROLE_ID;
+import static io.camunda.migration.identity.config.saas.StaticEntities.OPERATIONS_ENGINEER_ROLE_ID;
+import static io.camunda.migration.identity.config.saas.StaticEntities.ROLE_IDS;
+import static io.camunda.migration.identity.config.saas.StaticEntities.TASK_USER_ROLE_ID;
+import static io.camunda.migration.identity.config.saas.StaticEntities.VISITOR_ROLE_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.api.search.response.Authorization;
+import io.camunda.client.api.search.response.SearchResponse;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SaaSIdentityMigrationWithRBAIT extends AbstractSaaSIdentityMigrationIT {
+
+  @Override
+  @BeforeEach
+  public void setup(final WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    super.setup(wmRuntimeInfo);
+    // given
+    migration.withAppConfig(properties -> properties.setResourceAuthorizationsEnabled(true));
+  }
+
+  @Test
+  public void canMigratePermissionsWithRBAEnabled() {
+    // given
+
+    // when
+    migration.start();
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var authorizations =
+                  client.newAuthorizationSearchRequest().send().join().items();
+              final var migratedAuthorizations =
+                  authorizations.stream()
+                      .map(Authorization::getOwnerId)
+                      .filter(ROLE_IDS::contains)
+                      .toList();
+              assertThat(migratedAuthorizations.size()).isEqualTo(6);
+            });
+
+    // then
+    assertThat(migration.getExitCode()).isEqualTo(0);
+
+    final SearchResponse<Authorization> newResponse =
+        client.newAuthorizationSearchRequest().send().join();
+    assertThat(newResponse.items())
+        .extracting(
+            Authorization::getOwnerId,
+            Authorization::getOwnerType,
+            Authorization::getResourceId,
+            Authorization::getResourceType,
+            a -> new HashSet<>(a.getPermissionTypes()))
+        .contains(
+            // Role permissions
+            tuple(
+                DEVELOPER_ROLE_ID,
+                OwnerType.ROLE,
+                "operate",
+                ResourceType.COMPONENT,
+                Set.of(PermissionType.ACCESS)),
+            tuple(
+                DEVELOPER_ROLE_ID,
+                OwnerType.ROLE,
+                "tasklist",
+                ResourceType.COMPONENT,
+                Set.of(PermissionType.ACCESS)),
+            tuple(
+                OPERATIONS_ENGINEER_ROLE_ID,
+                OwnerType.ROLE,
+                "operate",
+                ResourceType.COMPONENT,
+                Set.of(PermissionType.ACCESS)),
+            tuple(
+                TASK_USER_ROLE_ID,
+                OwnerType.ROLE,
+                "tasklist",
+                ResourceType.COMPONENT,
+                Set.of(PermissionType.ACCESS)),
+            tuple(
+                VISITOR_ROLE_ID,
+                OwnerType.ROLE,
+                "operate",
+                ResourceType.COMPONENT,
+                Set.of(PermissionType.ACCESS)),
+            tuple(
+                VISITOR_ROLE_ID,
+                OwnerType.ROLE,
+                "tasklist",
+                ResourceType.COMPONENT,
+                Set.of(PermissionType.ACCESS)));
+  }
+}


### PR DESCRIPTION
## Description
They were flaky as we run the migration with different settings with the same cluster + secondary storage, resulting in flakiness on leftovers from previous migration test cases.
This isolates Resource Authorization tests to dedicated test classes, to make sure the migration always uses the same settings for a set of test cases sharing a cluster setup.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
