### PR TITLE
[Backport stable/8.5] [Backport stable/8.7] fix: do not set the commitIndex to be greater than biggest logIndex

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -527,8 +527,14 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    * @param commitIndex The commit index.
    * @return the previous commit index
    */
-  public long setCommitIndex(final long commitIndex) {
+  public long setCommitIndex(long commitIndex) {
     checkArgument(commitIndex >= 0, "commitIndex must be positive");
+
+    // Do not set the commitIndex to be greater than the events we persisted.
+    // In case of a heartbeat, the leader sends its commitIndex which may be greater than what's
+    // persisted in case we failed to persist a previous AppendEntries
+    commitIndex = Math.min(commitIndex, raftLog.getLastIndex());
+
     final long previousCommitIndex = this.commitIndex;
     if (commitIndex > previousCommitIndex) {
       this.commitIndex = commitIndex;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -537,15 +537,18 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
     final long previousCommitIndex = this.commitIndex;
     if (commitIndex > previousCommitIndex) {
-      this.commitIndex = commitIndex;
-      raftLog.setCommitIndex(Math.min(commitIndex, raftLog.getLastIndex()));
       if (isLeader()) {
         // leader counts itself in quorum, so in order to commit the leader must persist
         raftLog.flush();
       }
-      final long configurationIndex = cluster.getConfiguration().index();
-      if (configurationIndex > previousCommitIndex && configurationIndex <= commitIndex) {
-        cluster.commitCurrentConfiguration();
+      raftLog.setCommitIndex(commitIndex);
+      this.commitIndex = commitIndex;
+      final var clusterConfig = cluster.getConfiguration();
+      if (clusterConfig != null) {
+        final long configurationIndex = clusterConfig.index();
+        if (configurationIndex > previousCommitIndex && configurationIndex <= commitIndex) {
+          cluster.commitCurrentConfiguration();
+        }
       }
       replicationMetrics.setCommitIndex(commitIndex);
       notifyCommitListeners(commitIndex);
@@ -892,8 +895,13 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   public void setFirstCommitIndex(final long firstCommitIndex) {
     if (this.firstCommitIndex == 0) {
       this.firstCommitIndex = firstCommitIndex;
+<<<<<<< HEAD
       log.info(
           "Setting firstCommitIndex to {}. RaftServer is ready only after it has committed events upto this index",
+=======
+      LOGGER.info(
+          "Setting firstCommitIndex to {}. RaftServer is ready only after it has committed events up to this index",
+>>>>>>> 152021ed (refactor: merge checks on commitIndex/raftLog.getLastIndex())
           firstCommitIndex);
     }
   }
@@ -1266,7 +1274,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     COMPLETED
   }
 
-  /** Commit listener is active only until the server is ready * */
+  /** Commit listener is active only until the server is ready */
   final class AwaitingReadyCommitListener implements RaftCommitListener {
     private final Logger throttledLogger = new ThrottledLogger(log, Duration.ofSeconds(30));
 


### PR DESCRIPTION
# Description
Backport of #38118 to `stable/8.5`.

relates to #30354 #27852