### PR TITLE
fix: update legacy operations appearance in operations panel

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.5
+
+### 🩹 Fixes
+
+- update batch operation schema types ([#38331](https://github.com/camunda/camunda/pull/38331))
+
+### ❤️ Contributors
+
+- Yuliia Saienko ([@juliasaienko](https://github.com/juliasaienko))
+
 ## v0.0.4
 
 ### 🩹 Fixes

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/batch-operation.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/batch-operation.ts
@@ -14,6 +14,9 @@ const batchOperationTypeSchema = z.enum([
 	'RESOLVE_INCIDENT',
 	'MIGRATE_PROCESS_INSTANCE',
 	'MODIFY_PROCESS_INSTANCE',
+	'DELETE_DECISION_DEFINITION',
+	'DELETE_PROCESS_DEFINITION',
+	'DELETE_PROCESS_INSTANCE',
 ]);
 type BatchOperationType = z.infer<typeof batchOperationTypeSchema>;
 

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.10.2",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.4",
+        "@camunda/camunda-api-zod-schemas": "0.0.5",
         "@camunda/camunda-composite-components": "0.19.1",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.57.0",
@@ -557,9 +557,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.4.tgz",
-      "integrity": "sha512-zw/K1e0R0L0orqK60fMaIUqp4yEHifasdeHl9JZ41tiK2IhiQ45v7IONrOrp1uSeMCYaS63OpWDJTlUg5Q3Erg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.5.tgz",
+      "integrity": "sha512-VZJ4CO51NFR97zhScNRXl3ur3roWcp1nXGpXF+o8Ea8lCYcWtcC8EGlVAmg/mNFFFoQFWbci+84PKJPiwai6Cg==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.10.2",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.4",
+    "@camunda/camunda-api-zod-schemas": "0.0.5",
     "@camunda/camunda-composite-components": "0.19.1",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.57.0",

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.test.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.test.tsx
@@ -125,4 +125,46 @@ describe('OperationEntryStatus', () => {
     expect(screen.getByText(/4 retries succeeded/i)).toBeInTheDocument();
     expect(screen.getByText(/2 rejected/i)).toBeInTheDocument();
   });
+
+  it('should render delete process instance operation status', () => {
+    render(
+      <OperationEntryStatus
+        type="DELETE_PROCESS_INSTANCE"
+        failedCount={1}
+        completedCount={3}
+        state="COMPLETED"
+      />,
+    );
+
+    expect(screen.getByText(/3 operations succeeded/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 failed/i)).toBeInTheDocument();
+  });
+
+  it('should render delete process definition operation status', () => {
+    render(
+      <OperationEntryStatus
+        type="DELETE_PROCESS_DEFINITION"
+        failedCount={0}
+        completedCount={2}
+        state="COMPLETED"
+      />,
+    );
+
+    expect(screen.getByText(/2 operations succeeded/i)).toBeInTheDocument();
+    expect(screen.queryByText(/\d+\s(failed)/i)).not.toBeInTheDocument();
+  });
+
+  it('should render delete decision definition operation status', () => {
+    render(
+      <OperationEntryStatus
+        type="DELETE_DECISION_DEFINITION"
+        failedCount={5}
+        completedCount={0}
+        state="COMPLETED"
+      />,
+    );
+
+    expect(screen.getByText(/5 operations failed/i)).toBeInTheDocument();
+    expect(screen.queryByText(/\d+\s(succeeded)/i)).not.toBeInTheDocument();
+  });
 });

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.tsx
@@ -16,15 +16,22 @@ import {Stack} from '@carbon/react';
 import {PartiallyCompleted} from './PartiallyCompleted';
 import {Failed} from './Failed';
 
+// Extended type to handle legacy operation types
+type ExtendedBatchOperationType =
+  | BatchOperationType
+  | 'DELETE_PROCESS_INSTANCE'
+  | 'DELETE_PROCESS_DEFINITION'
+  | 'DELETE_DECISION_DEFINITION';
+
 type Props = {
-  type: BatchOperationType;
+  type: ExtendedBatchOperationType;
   failedCount?: number;
   completedCount?: number;
   state: BatchOperationState;
 };
 
 const getSuccessMessage = (
-  type: BatchOperationType,
+  type: ExtendedBatchOperationType,
   completedCount: number,
 ): string => {
   if (type === 'RESOLVE_INCIDENT') {
@@ -35,7 +42,7 @@ const getSuccessMessage = (
 };
 
 const getFailureMessage = (
-  type: BatchOperationType,
+  type: ExtendedBatchOperationType,
   failedCount: number,
   completedCount: number,
 ): string => {

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/OperationEntryStatus/index.tsx
@@ -16,22 +16,15 @@ import {Stack} from '@carbon/react';
 import {PartiallyCompleted} from './PartiallyCompleted';
 import {Failed} from './Failed';
 
-// Extended type to handle legacy operation types
-type ExtendedBatchOperationType =
-  | BatchOperationType
-  | 'DELETE_PROCESS_INSTANCE'
-  | 'DELETE_PROCESS_DEFINITION'
-  | 'DELETE_DECISION_DEFINITION';
-
 type Props = {
-  type: ExtendedBatchOperationType;
+  type: BatchOperationType;
   failedCount?: number;
   completedCount?: number;
   state: BatchOperationState;
 };
 
 const getSuccessMessage = (
-  type: ExtendedBatchOperationType,
+  type: BatchOperationType,
   completedCount: number,
 ): string => {
   if (type === 'RESOLVE_INCIDENT') {
@@ -42,7 +35,7 @@ const getSuccessMessage = (
 };
 
 const getFailureMessage = (
-  type: ExtendedBatchOperationType,
+  type: BatchOperationType,
   failedCount: number,
   completedCount: number,
 ): string => {

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.setup.ts
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.setup.ts
@@ -11,16 +11,10 @@ import type {
   BatchOperationType,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 
-type ExtendedOperationType =
-  | BatchOperationType
-  | 'DELETE_PROCESS_INSTANCE'
-  | 'DELETE_PROCESS_DEFINITION'
-  | 'DELETE_DECISION_DEFINITION';
-
 const OPERATIONS: Record<
-  ExtendedOperationType,
+  BatchOperationType,
   Omit<BatchOperation, 'batchOperationType'> & {
-    batchOperationType: ExtendedOperationType;
+    batchOperationType: BatchOperationType;
   }
 > = {
   RESOLVE_INCIDENT: {

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.setup.ts
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.setup.ts
@@ -11,7 +11,18 @@ import type {
   BatchOperationType,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 
-const OPERATIONS: Record<BatchOperationType, BatchOperation> = {
+type ExtendedOperationType =
+  | BatchOperationType
+  | 'DELETE_PROCESS_INSTANCE'
+  | 'DELETE_PROCESS_DEFINITION'
+  | 'DELETE_DECISION_DEFINITION';
+
+const OPERATIONS: Record<
+  ExtendedOperationType,
+  Omit<BatchOperation, 'batchOperationType'> & {
+    batchOperationType: ExtendedOperationType;
+  }
+> = {
   RESOLVE_INCIDENT: {
     batchOperationKey: 'b42fd629-73b1-4709-befb-7ccd900fb18d',
     batchOperationType: 'RESOLVE_INCIDENT',
@@ -47,6 +58,36 @@ const OPERATIONS: Record<BatchOperationType, BatchOperation> = {
     batchOperationKey: '8ba1a9a7-8537-4af3-97dc-f7249743b20b',
     batchOperationType: 'MIGRATE_PROCESS_INSTANCE',
     startDate: '2023-10-22T09:02:30.178+0100',
+    endDate: '2023-11-22T09:03:29.564+0100',
+    operationsFailedCount: 0,
+    operationsTotalCount: 1,
+    operationsCompletedCount: 1,
+    state: 'COMPLETED',
+  },
+  DELETE_PROCESS_INSTANCE: {
+    batchOperationKey: 'delete-pi-12345-67890-abcdef',
+    batchOperationType: 'DELETE_PROCESS_INSTANCE',
+    startDate: '2023-11-22T09:02:30.178+0100',
+    endDate: '2023-11-22T09:03:29.564+0100',
+    operationsFailedCount: 0,
+    operationsTotalCount: 3,
+    operationsCompletedCount: 3,
+    state: 'COMPLETED',
+  },
+  DELETE_PROCESS_DEFINITION: {
+    batchOperationKey: 'delete-pd-98765-43210-fedcba',
+    batchOperationType: 'DELETE_PROCESS_DEFINITION',
+    startDate: '2023-11-22T09:02:30.178+0100',
+    endDate: '2023-11-22T09:03:29.564+0100',
+    operationsFailedCount: 1,
+    operationsTotalCount: 2,
+    operationsCompletedCount: 1,
+    state: 'COMPLETED',
+  },
+  DELETE_DECISION_DEFINITION: {
+    batchOperationKey: 'delete-dd-11111-22222-33333',
+    batchOperationType: 'DELETE_DECISION_DEFINITION',
+    startDate: '2023-11-22T09:02:30.178+0100',
     endDate: '2023-11-22T09:03:29.564+0100',
     operationsFailedCount: 0,
     operationsTotalCount: 1,

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.test.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.test.tsx
@@ -137,6 +137,64 @@ describe('OperationsEntry', () => {
     expect(screen.getByTestId('operation-migrate-icon')).toBeInTheDocument();
   });
 
+  it('should render delete process instance operation', () => {
+    render(
+      <OperationsEntry
+        {...mockProps}
+        operation={OPERATIONS.DELETE_PROCESS_INSTANCE}
+      />,
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.getByText(OPERATIONS_TIMESTAMP)).toBeInTheDocument();
+    expect(
+      screen.getByText('delete-pi-12345-67890-abcdef'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+    expect(screen.getByTestId('operation-delete-icon')).toBeInTheDocument();
+  });
+
+  it('should render delete process definition operation', () => {
+    render(
+      <OperationsEntry
+        {...mockProps}
+        operation={OPERATIONS.DELETE_PROCESS_DEFINITION}
+      />,
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.getByText(OPERATIONS_TIMESTAMP)).toBeInTheDocument();
+    expect(
+      screen.getByText('delete-pd-98765-43210-fedcba'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+    expect(screen.getByTestId('operation-delete-icon')).toBeInTheDocument();
+  });
+
+  it('should render delete decision definition operation', () => {
+    render(
+      <OperationsEntry
+        {...mockProps}
+        operation={OPERATIONS.DELETE_DECISION_DEFINITION}
+      />,
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.getByText(OPERATIONS_TIMESTAMP)).toBeInTheDocument();
+    expect(screen.getByText('delete-dd-11111-22222-33333')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+    expect(screen.getByTestId('operation-delete-icon')).toBeInTheDocument();
+  });
+
   it('should render id link for non-delete instance operations', () => {
     render(
       <OperationsEntry
@@ -156,6 +214,26 @@ describe('OperationsEntry', () => {
         name: OPERATIONS.CANCEL_PROCESS_INSTANCE.batchOperationKey,
       }),
     ).toBeInTheDocument();
+  });
+
+  it('should render operation id as text for delete operations (not as link)', () => {
+    render(
+      <OperationsEntry
+        {...mockProps}
+        operation={OPERATIONS.DELETE_PROCESS_INSTANCE}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    expect(screen.getByTestId('operation-id')).toHaveTextContent(
+      'delete-pi-12345-67890-abcdef',
+    );
+
+    expect(
+      screen.queryByRole('link', {
+        name: OPERATIONS.DELETE_PROCESS_INSTANCE.batchOperationKey,
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it('should filter by Operation and expand Filters Panel', async () => {

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
@@ -76,9 +76,11 @@ const OperationsEntry: React.FC<Props> = ({operation}) => {
         {batchOperationType === 'MIGRATE_PROCESS_INSTANCE' && (
           <MigrateAlt size={16} data-testid="operation-migrate-icon" />
         )}
-        {(batchOperationType === 'DELETE_PROCESS_INSTANCE' ||
-          batchOperationType === 'DELETE_PROCESS_DEFINITION' ||
-          batchOperationType === 'DELETE_DECISION_DEFINITION') && (
+        {[
+          'DELETE_PROCESS_INSTANCE',
+          'DELETE_PROCESS_DEFINITION',
+          'DELETE_DECISION_DEFINITION',
+        ].includes(batchOperationType) && (
           <TrashCan size={16} data-testid="operation-delete-icon" />
         )}
       </Header>

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
@@ -27,15 +27,7 @@ import type {
 
 type OperationLabelType = 'Retry' | 'Cancel' | 'Modify' | 'Migrate' | 'Delete';
 
-type ExtendedOperationLabelType =
-  | BatchOperationType
-  | 'DELETE_PROCESS_INSTANCE'
-  | 'DELETE_PROCESS_DEFINITION'
-  | 'DELETE_DECISION_DEFINITION';
-
-const TYPE_LABELS: Readonly<
-  Record<ExtendedOperationLabelType, OperationLabelType>
-> = {
+const TYPE_LABELS: Readonly<Record<BatchOperationType, OperationLabelType>> = {
   RESOLVE_INCIDENT: 'Retry',
   CANCEL_PROCESS_INSTANCE: 'Cancel',
   MODIFY_PROCESS_INSTANCE: 'Modify',
@@ -45,12 +37,8 @@ const TYPE_LABELS: Readonly<
   DELETE_DECISION_DEFINITION: 'Delete',
 };
 
-type ExtendedBatchOperation = Omit<BatchOperation, 'batchOperationType'> & {
-  batchOperationType: ExtendedOperationLabelType;
-};
-
 type Props = {
-  operation: ExtendedBatchOperation;
+  operation: BatchOperation;
 };
 
 const OperationsEntry: React.FC<Props> = ({operation}) => {
@@ -76,19 +64,21 @@ const OperationsEntry: React.FC<Props> = ({operation}) => {
     <Container data-testid="operations-entry">
       <Header>
         <Title>{label}</Title>
-        {label === 'Cancel' && (
+        {batchOperationType === 'CANCEL_PROCESS_INSTANCE' && (
           <Error size={16} data-testid="operation-cancel-icon" />
         )}
-        {label === 'Retry' && (
+        {batchOperationType === 'RESOLVE_INCIDENT' && (
           <RetryFailed size={16} data-testid="operation-retry-icon" />
         )}
-        {label === 'Modify' && (
+        {batchOperationType === 'MODIFY_PROCESS_INSTANCE' && (
           <Tools size={16} data-testid="operation-modify-icon" />
         )}
-        {label === 'Migrate' && (
+        {batchOperationType === 'MIGRATE_PROCESS_INSTANCE' && (
           <MigrateAlt size={16} data-testid="operation-migrate-icon" />
         )}
-        {label === 'Delete' && (
+        {(batchOperationType === 'DELETE_PROCESS_INSTANCE' ||
+          batchOperationType === 'DELETE_PROCESS_DEFINITION' ||
+          batchOperationType === 'DELETE_DECISION_DEFINITION') && (
           <TrashCan size={16} data-testid="operation-delete-icon" />
         )}
       </Header>

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.16.0",
         "@bpmn-io/form-js-viewer": "1.16.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.4",
+        "@camunda/camunda-api-zod-schemas": "0.0.5",
         "@camunda/camunda-composite-components": "0.20.2",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.87.1",
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.4.tgz",
-      "integrity": "sha512-zw/K1e0R0L0orqK60fMaIUqp4yEHifasdeHl9JZ41tiK2IhiQ45v7IONrOrp1uSeMCYaS63OpWDJTlUg5Q3Erg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.5.tgz",
+      "integrity": "sha512-VZJ4CO51NFR97zhScNRXl3ur3roWcp1nXGpXF+o8Ea8lCYcWtcC8EGlVAmg/mNFFFoQFWbci+84PKJPiwai6Cg==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.16.0",
     "@bpmn-io/form-js-viewer": "1.16.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.4",
+    "@camunda/camunda-api-zod-schemas": "0.0.5",
     "@camunda/camunda-composite-components": "0.20.2",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.87.1",


### PR DESCRIPTION
## Description

Update delete operations appearance in the operations panel by showing the corresponding:
- operation icon
- operation title
- textual(not a link) representation for the operation id

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37370 
