### PR TITLE
Only username and password should be mandatory on user creation

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateUserCommandImpl.java
@@ -52,8 +52,6 @@ public final class CreateUserCommandImpl implements CreateUserCommandStep1 {
   @Override
   public CamundaFuture<CreateUserResponse> send() {
     ArgumentUtil.ensureNotNull("username", request.getUsername());
-    ArgumentUtil.ensureNotNull("email", request.getEmail());
-    ArgumentUtil.ensureNotNull("name", request.getName());
     ArgumentUtil.ensureNotNull("password", request.getPassword());
     final HttpCamundaFuture<CreateUserResponse> result = new HttpCamundaFuture<>();
     final CreateUserResponseImpl response = new CreateUserResponseImpl();

--- a/clients/java/src/test/java/io/camunda/client/user/CreateUserTest.java
+++ b/clients/java/src/test/java/io/camunda/client/user/CreateUserTest.java
@@ -74,38 +74,6 @@ public class CreateUserTest extends ClientRestTest {
   }
 
   @Test
-  void shouldRaiseExceptionOnNullEmail() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                client
-                    .newCreateUserCommand()
-                    .username(USERNAME)
-                    .name(NAME)
-                    .password(PASSWORD)
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("email must not be null");
-  }
-
-  @Test
-  void shouldRaiseExceptionOnNullName() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                client
-                    .newCreateUserCommand()
-                    .username(USERNAME)
-                    .email(EMAIL)
-                    .password(PASSWORD)
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("name must not be null");
-  }
-
-  @Test
   void shouldRaiseExceptionOnNullPassword() {
     // when / then
     assertThatThrownBy(

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7793,6 +7793,9 @@ components:
         email:
           description: The email of the user.
           type: "string"
+      required:
+        - username
+        - password
     UserCreateResult:
       type: object
       properties:

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
@@ -69,6 +69,9 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
   }
 
   public UserRecord setName(final String name) {
+    if (name == null) {
+      return this;
+    }
     nameProp.setValue(name);
     return this;
   }
@@ -84,6 +87,9 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
   }
 
   public UserRecord setEmail(final String email) {
+    if (email == null) {
+      return this;
+    }
     emailProp.setValue(email);
     return this;
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateUserTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateUserTest.java
@@ -59,6 +59,22 @@ class CreateUserTest {
   }
 
   @Test
+  void shouldCreateUserWithMandatoryFields() {
+    // when
+    final var response =
+        client.newCreateUserCommand().username("aUsername").password("aPassword").send().join();
+
+    // then
+    ZeebeAssertHelper.assertUserCreated(
+        "aUsername",
+        (user) -> {
+          assertThat(user.getEmail()).isEmpty();
+          assertThat(user.getName()).isEmpty();
+          assertThat(user.getPassword()).isNotNull();
+        });
+  }
+
+  @Test
   void shouldRejectIfUsernameAlreadyExists() {
     // given
     client


### PR DESCRIPTION
## Description
On user creation only `username` and `password` should be mandatory.

Currently, in the [docs](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/create-user/) all fields apart from name are mandatory.

On the client side we have validation for all fields on user creation:
```
ArgumentUtil.ensureNotNull("username", request.getUsername());
ArgumentUtil.ensureNotNull("email", request.getEmail());
ArgumentUtil.ensureNotNull("name", request.getName());
ArgumentUtil.ensureNotNull("password", request.getPassword());
```

We also do not handle null values for `name` and `email` in `UserRecord`

I've tested the below scenario (as per ticket test case):
Creating a user:
<img width="953" height="265" alt="Screenshot 2025-09-18 at 11 25 16" src="https://github.com/user-attachments/assets/85c28c32-a5cf-4c49-af5d-3faa562a3e7f" />

Calling get current user response:
<img width="511" height="365" alt="Screenshot 2025-09-18 at 11 26 46" src="https://github.com/user-attachments/assets/86a66cb9-f969-4f99-a4fc-a377ad0bfa9f" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38324
