### PR TITLE
fix: change session creation to never in security filter for api path in oidc

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -460,8 +460,7 @@ public class WebSecurityConfig {
         final HttpSecurity httpSecurity,
         final AuthFailureHandler authFailureHandler,
         final SecurityConfiguration securityConfiguration,
-        final CookieCsrfTokenRepository csrfTokenRepository,
-        final CamundaAuthenticationProvider authenticationProvider)
+        final CookieCsrfTokenRepository csrfTokenRepository)
         throws Exception {
       LOG.info("The API is protected by HTTP Basic authentication.");
       final var filterChainBuilder =
@@ -716,8 +715,7 @@ public class WebSecurityConfig {
         final SecurityConfiguration securityConfiguration,
         final CookieCsrfTokenRepository csrfTokenRepository,
         final OAuth2AuthorizedClientRepository authorizedClientRepository,
-        final OAuth2AuthorizedClientManager authorizedClientManager,
-        final CamundaAuthenticationProvider authenticationProvider)
+        final OAuth2AuthorizedClientManager authorizedClientManager)
         throws Exception {
       final var filterChainBuilder =
           httpSecurity
@@ -737,6 +735,8 @@ public class WebSecurityConfig {
                           securityConfiguration.getSaas().isConfigured()))
               .exceptionHandling(
                   (exceptionHandling) -> exceptionHandling.accessDeniedHandler(authFailureHandler))
+              .sessionManagement(
+                  configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.NEVER))
               .cors(AbstractHttpConfigurer::disable)
               .formLogin(AbstractHttpConfigurer::disable)
               .anonymous(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## Description

We are storing sessions when API calls are being made to endpoint on the API when using OIDC authentication methods. Expected behaviour is that API calls (/api/, /v2/, /v1) are not stored as sessions in the camunda-web-session index.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37983
