### PR TITLE
fix: apply default client config to all commands

### DIFF
--- a/clients/java-deprecated/pom.xml
+++ b/clients/java-deprecated/pom.xml
@@ -235,6 +235,24 @@
     </dependency>
 
     <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -481,7 +481,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
 
   @Override
   public CorrelateMessageCommandStep1 newCorrelateMessageCommand() {
-    return new CorrelateMessageCommandImpl(httpClient, jsonMapper);
+    return new CorrelateMessageCommandImpl(config, httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/command/CorrelateMessageCommandImpl.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/command/CorrelateMessageCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.CorrelateMessageCommandStep1;
@@ -48,11 +49,15 @@ public class CorrelateMessageCommandImpl extends CommandWithVariables<CorrelateM
   private final MessageCorrelationRequest request = new MessageCorrelationRequest();
   private final RequestConfig.Builder httpRequestConfig;
 
-  public CorrelateMessageCommandImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+  public CorrelateMessageCommandImpl(
+      final ZeebeClientConfiguration config,
+      final HttpClient httpClient,
+      final JsonMapper jsonMapper) {
     super(jsonMapper);
     this.httpClient = httpClient;
     this.jsonMapper = jsonMapper;
     httpRequestConfig = httpClient.newRequestConfig();
+    tenantId(config.getDefaultTenantId());
   }
 
   @Override

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -92,6 +92,7 @@ public final class CreateProcessInstanceCommandImpl
    *     CreateProcessInstanceCommandImpl#CreateProcessInstanceCommandImpl(GatewayStub, JsonMapper,
    *     ZeebeClientConfiguration, Predicate, HttpClient, boolean)}
    */
+  @Deprecated
   public CreateProcessInstanceCommandImpl(
       final GatewayStub asyncStub,
       final JsonMapper jsonMapper,

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/command/EvaluateDecisionCommandImpl.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/command/EvaluateDecisionCommandImpl.java
@@ -92,6 +92,7 @@ public class EvaluateDecisionCommandImpl extends CommandWithVariables<EvaluateDe
    *     EvaluateDecisionCommandImpl#EvaluateDecisionCommandImpl(GatewayStub, JsonMapper ,
    *     ZeebeClientConfiguration, Predicate, HttpClient)}
    */
+  @Deprecated
   public EvaluateDecisionCommandImpl(
       final GatewayStub asyncStub,
       final JsonMapper jsonMapper,

--- a/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/DefaultTenantAwarenessTest.java
+++ b/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/DefaultTenantAwarenessTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.constructors;
+
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
+import io.camunda.zeebe.client.impl.command.CreateProcessInstanceWithResultCommandImpl;
+import java.util.Set;
+
+@AnalyzeClasses(
+    packages = "io.camunda.zeebe.client",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public class DefaultTenantAwarenessTest {
+
+  /**
+   * Tries to ensure that every command implementation that is tenant-aware respects the configured
+   * default tenant.
+   *
+   * @implNote Every class implementing {@link CommandWithTenantStep} must have a constructor that
+   *     retrieves the default tenant via {@link ZeebeClientConfiguration#getDefaultTenantId()}.
+   *     Doesn't check how the default tenant is used, we assume that no one retrieves it but then
+   *     uses it for anything other than the default tenant for this command.
+   */
+  @ArchTest
+  static final ArchRule COMMAND_WITH_TENANT_STEP_MUST_INITIALIZE_DEFAULT_TENANT =
+      constructors()
+          .that()
+          .areDeclaredInClassesThat()
+          .areAssignableTo(CommandWithTenantStep.class)
+          .and()
+          // Some constructors are only there for backwards compatibility and we can't change them
+          // use the default tenant.
+          .areNotAnnotatedWith(Deprecated.class)
+          .and()
+          // Special case: This command inherits the default tenant id from the
+          // CreateProcessInstanceCommandImpl that it wraps.
+          .areNotDeclaredIn(CreateProcessInstanceWithResultCommandImpl.class)
+          .should(useDefaultTenant());
+
+  private static ArchCondition<JavaConstructor> useDefaultTenant() {
+    return new ArchCondition<JavaConstructor>(
+        "have a constructor that retrieves the default tenant from `CamundaClientConfiguration`") {
+      @Override
+      public void check(final JavaConstructor constructor, final ConditionEvents events) {
+        final Class<?> commandClass = constructor.getOwner().reflect();
+        final Set<JavaMethodCall> allCallsFromConstructor = constructor.getMethodCallsFromSelf();
+
+        final boolean callsGetDefault =
+            allCallsFromConstructor.stream()
+                .anyMatch(DefaultTenantAwarenessTest::isGetDefaultTenantIdCall);
+        if (!callsGetDefault) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  constructor,
+                  String.format(
+                      "Command %s is tenant-aware but doesn't use the default tenant from %s",
+                      commandClass.getName(), ZeebeClientConfiguration.class.getName())));
+        } else {
+          events.add(
+              SimpleConditionEvent.satisfied(
+                  constructor,
+                  String.format(
+                      "Command %s retrieves the default tenant from %s",
+                      commandClass.getName(), ZeebeClientConfiguration.class.getName())));
+        }
+      }
+    };
+  }
+
+  private static boolean isGetDefaultTenantIdCall(final JavaMethodCall call) {
+    return call.getTargetOwner().isEquivalentTo(ZeebeClientConfiguration.class)
+        && (call.getName().equals("getDefaultTenantId")
+            || call.getName().equals("getDefaultJobWorkerTenantIds"));
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -652,7 +652,7 @@ public final class CamundaClientImpl implements CamundaClient {
 
   @Override
   public CorrelateMessageCommandStep1 newCorrelateMessageCommand() {
-    return new CorrelateMessageCommandImpl(httpClient, jsonMapper);
+    return new CorrelateMessageCommandImpl(config, httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CorrelateMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CorrelateMessageCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.impl.command;
 
+import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CorrelateMessageCommandStep1;
@@ -41,8 +42,12 @@ public class CorrelateMessageCommandImpl extends CommandWithVariables<CorrelateM
   private final MessageCorrelationRequest request = new MessageCorrelationRequest();
   private final RequestConfig.Builder httpRequestConfig;
 
-  public CorrelateMessageCommandImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+  public CorrelateMessageCommandImpl(
+      final CamundaClientConfiguration config,
+      final HttpClient httpClient,
+      final JsonMapper jsonMapper) {
     super(jsonMapper);
+    tenantId(config.getDefaultTenantId());
     this.httpClient = httpClient;
     this.jsonMapper = jsonMapper;
     httpRequestConfig = httpClient.newRequestConfig();

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -98,6 +98,7 @@ public final class CreateProcessInstanceCommandImpl
    *     CreateProcessInstanceCommandImpl#CreateProcessInstanceCommandImpl(GatewayStub, JsonMapper,
    *     CamundaClientConfiguration, Predicate, HttpClient, boolean)}
    */
+  @Deprecated
   public CreateProcessInstanceCommandImpl(
       final GatewayStub asyncStub,
       final JsonMapper jsonMapper,

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
@@ -151,7 +151,7 @@ public final class CreateProcessInstanceWithResultCommandImpl
 
   @Override
   public CreateProcessInstanceWithResultCommandStep1 tenantId(final String tenantId) {
-    // todo(#13536): replace dummy implementation
+    createProcessInstanceRequestBuilder.setTenantId(tenantId);
     httpRequestObject.setTenantId(tenantId);
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateDecisionCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateDecisionCommandImpl.java
@@ -85,6 +85,7 @@ public class EvaluateDecisionCommandImpl extends CommandWithVariables<EvaluateDe
    *     EvaluateDecisionCommandImpl#EvaluateDecisionCommandImpl(GatewayStub, JsonMapper,
    *     CamundaClientConfiguration, Predicate, HttpClient)}
    */
+  @Deprecated
   public EvaluateDecisionCommandImpl(
       final GatewayStub asyncStub,
       final JsonMapper jsonMapper,

--- a/clients/java/src/test/java/io/camunda/client/DefaultTenantAwarenessTest.java
+++ b/clients/java/src/test/java/io/camunda/client/DefaultTenantAwarenessTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.constructors;
+
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import io.camunda.client.api.command.CommandWithTenantStep;
+import io.camunda.client.impl.command.CreateProcessInstanceWithResultCommandImpl;
+import java.util.Set;
+
+@AnalyzeClasses(
+    packages = "io.camunda.client",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public class DefaultTenantAwarenessTest {
+
+  /**
+   * Tries to ensure that every command implementation that is tenant-aware respects the configured
+   * default tenant.
+   *
+   * @implNote Every class implementing {@link CommandWithTenantStep} must have a constructor that
+   *     retrieves the default tenant via {@link CamundaClientConfiguration#getDefaultTenantId()}.
+   *     Doesn't check how the default tenant is used, we assume that no one retrieves it but then
+   *     uses it for anything other than the default tenant for this command.
+   */
+  @ArchTest
+  static final ArchRule COMMAND_WITH_TENANT_STEP_MUST_INITIALIZE_DEFAULT_TENANT =
+      constructors()
+          .that()
+          .areDeclaredInClassesThat()
+          .areAssignableTo(CommandWithTenantStep.class)
+          .and()
+          // Some constructors are only there for backwards compatibility and we can't change them
+          // use the default tenant.
+          .areNotAnnotatedWith(Deprecated.class)
+          .and()
+          // Special case: This command inherits the default tenant id from the
+          // CreateProcessInstanceCommandImpl that it wraps.
+          .areNotDeclaredIn(CreateProcessInstanceWithResultCommandImpl.class)
+          .should(useDefaultTenant());
+
+  private static ArchCondition<JavaConstructor> useDefaultTenant() {
+    return new ArchCondition<JavaConstructor>(
+        "have a constructor that retrieves the default tenant from `CamundaClientConfiguration`") {
+      @Override
+      public void check(final JavaConstructor constructor, final ConditionEvents events) {
+        final Class<?> commandClass = constructor.getOwner().reflect();
+        final Set<JavaMethodCall> allCallsFromConstructor = constructor.getMethodCallsFromSelf();
+
+        final boolean callsGetDefault =
+            allCallsFromConstructor.stream()
+                .anyMatch(DefaultTenantAwarenessTest::isGetDefaultTenantIdCall);
+        if (!callsGetDefault) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  constructor,
+                  String.format(
+                      "Command %s is tenant-aware but doesn't use the default tenant from %s",
+                      commandClass.getName(), CamundaClientConfiguration.class.getName())));
+        } else {
+          events.add(
+              SimpleConditionEvent.satisfied(
+                  constructor,
+                  String.format(
+                      "Command %s retrieves the default tenant from %s",
+                      commandClass.getName(), CamundaClientConfiguration.class.getName())));
+        }
+      }
+    };
+  }
+
+  private static boolean isGetDefaultTenantIdCall(final JavaMethodCall call) {
+    return call.getTargetOwner().isEquivalentTo(CamundaClientConfiguration.class)
+        && (call.getName().equals("getDefaultTenantId")
+            || call.getName().equals("getDefaultJobWorkerTenantIds"));
+  }
+}


### PR DESCRIPTION
This fixes the behavior for several commands that previously didn't respect the configured default tenant, always requiring users to explicitly set the tenant instead.

This is now enforced on a best-effort manner with an arch unit test.

Also fixes one edge case for the command to create a process instance with result, best explained in the commit message eebb977a5665bc011943863cb2b5e89a5803bb2c.

closes #38157