### PR TITLE
fix: prevent 404 when showing flownode instance popover details

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchJobReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchJobReader.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
 package io.camunda.operate.webapp.elasticsearch.reader;
 
 import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchJobReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchJobReader.java
@@ -1,0 +1,60 @@
+package io.camunda.operate.webapp.elasticsearch.reader;
+
+import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+import io.camunda.operate.conditions.ElasticsearchCondition;
+import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.tenant.TenantAwareElasticsearchClient;
+import io.camunda.operate.util.ElasticsearchUtil;
+import io.camunda.operate.webapp.reader.JobReader;
+import io.camunda.webapps.schema.descriptors.template.JobTemplate;
+import io.camunda.webapps.schema.entities.JobEntity;
+import java.io.IOException;
+import java.util.Optional;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticsearchCondition.class)
+public class ElasticsearchJobReader extends AbstractReader implements JobReader {
+
+  private final JobTemplate jobTemplate;
+  private final TenantAwareElasticsearchClient tenantAwareClient;
+
+  public ElasticsearchJobReader(
+      final JobTemplate jobTemplate, final TenantAwareElasticsearchClient tenantAwareClient) {
+    this.jobTemplate = jobTemplate;
+    this.tenantAwareClient = tenantAwareClient;
+  }
+
+  @Override
+  public Optional<JobEntity> getJobByFlowNodeInstanceId(final String flowNodeInstanceId) {
+    final QueryBuilder query =
+        constantScoreQuery(termQuery(JobTemplate.FLOW_NODE_INSTANCE_ID, flowNodeInstanceId));
+    final SearchRequest request =
+        ElasticsearchUtil.createSearchRequest(jobTemplate)
+            .source(new SearchSourceBuilder().query(query).sort(JobTemplate.JOB_KEY));
+    try {
+      final SearchResponse response = tenantAwareClient.search(request);
+      final var hits = response.getHits();
+      final var totalHits =
+          (hits != null && hits.getTotalHits() != null) ? hits.getTotalHits().value : 0L;
+      if (totalHits >= 1) {
+        // take the first job found
+        final JobEntity job =
+            ElasticsearchUtil.fromSearchHit(
+                hits.getHits()[0].getSourceAsString(), objectMapper, JobEntity.class);
+        return Optional.of(job);
+      } else {
+        return Optional.empty();
+      }
+    } catch (final IOException e) {
+      throw new OperateRuntimeException("Error reading job from Elasticsearch", e);
+    }
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpenSearchJobReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpenSearchJobReader.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.opensearch.reader;
+
+import static io.camunda.operate.store.opensearch.dsl.QueryDSL.term;
+import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
+
+import io.camunda.operate.conditions.OpensearchCondition;
+import io.camunda.operate.webapp.reader.JobReader;
+import io.camunda.webapps.schema.descriptors.template.JobTemplate;
+import io.camunda.webapps.schema.entities.JobEntity;
+import java.util.Optional;
+import org.opensearch.client.opensearch.core.search.SearchResult;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Conditional(OpensearchCondition.class)
+@Component
+public class OpenSearchJobReader extends OpensearchAbstractReader implements JobReader {
+
+  private final JobTemplate jobTemplate;
+
+  public OpenSearchJobReader(final JobTemplate jobTemplate) {
+    this.jobTemplate = jobTemplate;
+  }
+
+  @Override
+  public Optional<JobEntity> getJobByFlowNodeInstanceId(final String flowNodeInstanceId) {
+    final var query = term(JobTemplate.FLOW_NODE_INSTANCE_ID, flowNodeInstanceId);
+    final var searchRequestBuilder =
+        searchRequestBuilder(jobTemplate.getAlias()).query(query).size(1);
+    final SearchResult<JobEntity> searchResult =
+        richOpenSearchClient.doc().fixedSearch(searchRequestBuilder.build(), JobEntity.class);
+    if (searchResult.hits().total() != null
+        && searchResult.hits().total().value() > 0
+        && !searchResult.hits().hits().isEmpty()) {
+      return Optional.ofNullable(searchResult.hits().hits().getFirst().source());
+    }
+    return Optional.empty();
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/EventReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/EventReader.java
@@ -8,7 +8,8 @@
 package io.camunda.operate.webapp.reader;
 
 import io.camunda.webapps.schema.entities.event.EventEntity;
+import java.util.Optional;
 
 public interface EventReader {
-  EventEntity getEventEntityByFlowNodeInstanceId(final String flowNodeInstanceId);
+  Optional<EventEntity> getEventEntityByFlowNodeInstanceId(final String flowNodeInstanceId);
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/JobReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/JobReader.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
 package io.camunda.operate.webapp.reader;
 
 import io.camunda.webapps.schema.entities.JobEntity;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/JobReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/JobReader.java
@@ -1,0 +1,9 @@
+package io.camunda.operate.webapp.reader;
+
+import io.camunda.webapps.schema.entities.JobEntity;
+import java.util.Optional;
+
+public interface JobReader {
+  /** Returns the JobEntity for the given flowNodeInstanceId, or Optional.empty() if not found. */
+  Optional<JobEntity> getJobByFlowNodeInstanceId(String flowNodeInstanceId);
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/BusinessRuleTaskInstanceMetadataDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/BusinessRuleTaskInstanceMetadataDto.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.rest.dto.metadata;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.event.EventEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import java.time.OffsetDateTime;
@@ -28,9 +29,11 @@ public class BusinessRuleTaskInstanceMetadataDto extends JobFlowNodeInstanceMeta
       final OffsetDateTime startDate,
       final OffsetDateTime endDate,
       final EventEntity event,
+      final JobEntity job,
+      final String eventId,
       final String calledDecisionInstanceId,
       final String calledDecisionDefinitionName) {
-    super(flowNodeId, flowNodeInstanceId, flowNodeType, startDate, endDate, event);
+    super(flowNodeId, flowNodeInstanceId, flowNodeType, startDate, endDate, eventId, event, job);
     if (calledDecisionInstanceId != null) {
       setCalledDecisionInstanceId(calledDecisionInstanceId);
     }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/CallActivityInstanceMetadataDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/CallActivityInstanceMetadataDto.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.rest.dto.metadata;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.event.EventEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import java.time.OffsetDateTime;
@@ -28,9 +29,11 @@ public class CallActivityInstanceMetadataDto extends JobFlowNodeInstanceMetadata
       final OffsetDateTime startDate,
       final OffsetDateTime endDate,
       final EventEntity event,
+      final JobEntity job,
+      final String eventId,
       final String calledProcessInstanceId,
       final String calledProcessDefinitionName) {
-    super(flowNodeId, flowNodeInstanceId, flowNodeType, startDate, endDate, event);
+    super(flowNodeId, flowNodeInstanceId, flowNodeType, startDate, endDate, eventId, event, job);
     setCalledProcessInstanceId(calledProcessInstanceId);
     setCalledProcessDefinitionName(calledProcessDefinitionName);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/FlowNodeInstanceMetadata.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/FlowNodeInstanceMetadata.java
@@ -10,16 +10,9 @@ package io.camunda.operate.webapp.rest.dto.metadata;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import java.time.OffsetDateTime;
 
-@JsonTypeInfo(
-    use = JsonTypeInfo.Id.NAME,
-    include = As.PROPERTY,
-    property = "flowNodeType",
-    defaultImpl = FlowNodeInstanceMetadataDto.class)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = UserTaskInstanceMetadataDto.class, name = "USER_TASK"),
   @JsonSubTypes.Type(value = ServiceTaskInstanceMetadataDto.class, name = "SERVICE_TASK"),

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/FlowNodeInstanceMetadataDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/FlowNodeInstanceMetadataDto.java
@@ -33,17 +33,20 @@ public class FlowNodeInstanceMetadataDto implements FlowNodeInstanceMetadata {
       final FlowNodeType flowNodeType,
       final OffsetDateTime startDate,
       final OffsetDateTime endDate,
+      final String eventId,
       final EventEntity event) {
     this.flowNodeId = flowNodeId;
     this.flowNodeInstanceId = flowNodeInstanceId;
     this.flowNodeType = flowNodeType;
     this.startDate = startDate;
     this.endDate = endDate;
-    eventId = event.getId();
-    final var eventMetadata = event.getMetadata();
-    if (eventMetadata != null) {
-      messageName = eventMetadata.getMessageName();
-      correlationKey = eventMetadata.getCorrelationKey();
+    this.eventId = eventId;
+    if (event != null) {
+      final var eventMetadata = event.getMetadata();
+      if (eventMetadata != null) {
+        messageName = eventMetadata.getMessageName();
+        correlationKey = eventMetadata.getCorrelationKey();
+      }
     }
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/JobFlowNodeInstanceMetadataDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/JobFlowNodeInstanceMetadataDto.java
@@ -9,8 +9,8 @@ package io.camunda.operate.webapp.rest.dto.metadata;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.event.EventEntity;
-import io.camunda.webapps.schema.entities.event.EventMetadataEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -35,15 +35,16 @@ public class JobFlowNodeInstanceMetadataDto extends FlowNodeInstanceMetadataDto
       final FlowNodeType flowNodeType,
       final OffsetDateTime startDate,
       final OffsetDateTime endDate,
-      final EventEntity event) {
-    super(flowNodeId, flowNodeInstanceId, flowNodeType, startDate, endDate, event);
-    final EventMetadataEntity eventMetadataEntity = event.getMetadata();
-    if (eventMetadataEntity != null) {
-      setJobCustomHeaders(eventMetadataEntity.getJobCustomHeaders())
-          .setJobDeadline(eventMetadataEntity.getJobDeadline())
-          .setJobRetries(eventMetadataEntity.getJobRetries())
-          .setJobType(eventMetadataEntity.getJobType())
-          .setJobWorker(eventMetadataEntity.getJobWorker());
+      final String eventId,
+      final EventEntity event,
+      final JobEntity job) {
+    super(flowNodeId, flowNodeInstanceId, flowNodeType, startDate, endDate, eventId, event);
+    if (job != null) {
+      setJobCustomHeaders(job.getCustomHeaders())
+          .setJobDeadline(job.getDeadline())
+          .setJobRetries(job.getRetries())
+          .setJobType(job.getType())
+          .setJobWorker(job.getWorker());
     }
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/ServiceTaskInstanceMetadataDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/ServiceTaskInstanceMetadataDto.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.rest.dto.metadata;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.event.EventEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import java.time.OffsetDateTime;
@@ -23,8 +24,10 @@ public class ServiceTaskInstanceMetadataDto extends JobFlowNodeInstanceMetadataD
       final FlowNodeType flowNodeType,
       final OffsetDateTime startDate,
       final OffsetDateTime endDate,
-      final EventEntity event) {
-    super(flowNodeId, flowNodeInstanceId, flowNodeType, startDate, endDate, event);
+      final String eventId,
+      final EventEntity event,
+      final JobEntity job) {
+    super(flowNodeId, flowNodeInstanceId, flowNodeType, startDate, endDate, eventId, event, job);
   }
 
   public ServiceTaskInstanceMetadataDto() {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/UserTaskInstanceMetadataDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/metadata/UserTaskInstanceMetadataDto.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.rest.dto.metadata;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.event.EventEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import java.time.OffsetDateTime;
@@ -38,8 +39,10 @@ public class UserTaskInstanceMetadataDto extends ServiceTaskInstanceMetadataDto
       final FlowNodeType flowNodeType,
       final OffsetDateTime startDate,
       final OffsetDateTime endDate,
-      final EventEntity event) {
-    super(flowNodeId, flowNodeInstanceId, flowNodeType, startDate, endDate, event);
+      final String eventId,
+      final EventEntity event,
+      final JobEntity job) {
+    super(flowNodeId, flowNodeInstanceId, flowNodeType, startDate, endDate, eventId, event, job);
   }
 
   public String getExternalReference() {

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilderTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilderTest.java
@@ -11,9 +11,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.camunda.operate.util.Tuple;
-import io.camunda.operate.webapp.elasticsearch.reader.ElasticsearchJobReader;
 import io.camunda.operate.webapp.reader.DecisionInstanceReader;
 import io.camunda.operate.webapp.reader.EventReader;
+import io.camunda.operate.webapp.reader.JobReader;
 import io.camunda.operate.webapp.reader.ListViewReader;
 import io.camunda.operate.webapp.reader.UserTaskReader;
 import io.camunda.operate.webapp.rest.dto.metadata.BusinessRuleTaskInstanceMetadataDto;
@@ -48,7 +48,7 @@ class FlowNodeInstanceMetadataBuilderTest {
   @Mock private DecisionInstanceReader decisionInstanceReader;
   @Mock private EventReader eventReader;
   @Mock private UserTaskReader userTaskReader;
-  @Mock private ElasticsearchJobReader elasticsearchJobReader;
+  @Mock private JobReader elasticsearchJobReader;
   private OffsetDateTime startDate;
   private OffsetDateTime endDate;
 

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilderTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilderTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.camunda.operate.util.Tuple;
+import io.camunda.operate.webapp.elasticsearch.reader.ElasticsearchJobReader;
 import io.camunda.operate.webapp.reader.DecisionInstanceReader;
 import io.camunda.operate.webapp.reader.EventReader;
 import io.camunda.operate.webapp.reader.ListViewReader;
@@ -22,6 +23,7 @@ import io.camunda.operate.webapp.rest.dto.metadata.FlowNodeInstanceMetadataDto;
 import io.camunda.operate.webapp.rest.dto.metadata.JobFlowNodeInstanceMetadataDto;
 import io.camunda.operate.webapp.rest.dto.metadata.ServiceTaskInstanceMetadataDto;
 import io.camunda.operate.webapp.rest.dto.metadata.UserTaskInstanceMetadataDto;
+import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.event.EventEntity;
 import io.camunda.webapps.schema.entities.event.EventMetadataEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
@@ -46,6 +48,7 @@ class FlowNodeInstanceMetadataBuilderTest {
   @Mock private DecisionInstanceReader decisionInstanceReader;
   @Mock private EventReader eventReader;
   @Mock private UserTaskReader userTaskReader;
+  @Mock private ElasticsearchJobReader elasticsearchJobReader;
   private OffsetDateTime startDate;
   private OffsetDateTime endDate;
 
@@ -53,7 +56,11 @@ class FlowNodeInstanceMetadataBuilderTest {
   void setUp() {
     builder =
         new FlowNodeInstanceMetadataBuilder(
-            listViewReader, decisionInstanceReader, eventReader, userTaskReader);
+            listViewReader,
+            decisionInstanceReader,
+            eventReader,
+            userTaskReader,
+            elasticsearchJobReader);
     assertThat(builder).isNotNull();
     startDate = OffsetDateTime.now();
     endDate = startDate.plusHours(5);
@@ -72,16 +79,16 @@ class FlowNodeInstanceMetadataBuilderTest {
     fillStandardValues(flowNodeInstance);
     when(eventReader.getEventEntityByFlowNodeInstanceId(flowNodeInstance.getId()))
         .thenReturn(
-            new EventEntity()
-                .setId("eventId")
-                .setMetadata(
-                    new EventMetadataEntity()
-                        .setMessageName("Last order")
-                        .setCorrelationKey("23-05")));
+            Optional.of(
+                new EventEntity()
+                    .setMetadata(
+                        new EventMetadataEntity()
+                            .setMessageName("Last order")
+                            .setCorrelationKey("23-05"))));
     final var metadata = builder.buildFrom(flowNodeInstance);
     assertThat(metadata).isInstanceOf(FlowNodeInstanceMetadataDto.class);
     assertStandardValues(metadata);
-    assertThat(metadata.getEventId()).isEqualTo("eventId");
+    assertThat(metadata.getEventId()).isEqualTo("2_1");
     assertThat(metadata.getFlowNodeType()).isEqualTo(FlowNodeType.INCLUSIVE_GATEWAY);
   }
 
@@ -104,12 +111,12 @@ class FlowNodeInstanceMetadataBuilderTest {
                 .setFormKey(String.valueOf(5L)));
     when(eventReader.getEventEntityByFlowNodeInstanceId(flowNodeInstance.getId()))
         .thenReturn(
-            new EventEntity()
-                .setId("eventId")
-                .setMetadata(
-                    new EventMetadataEntity()
-                        .setMessageName("Last order")
-                        .setCorrelationKey("23-05")));
+            Optional.of(
+                new EventEntity()
+                    .setMetadata(
+                        new EventMetadataEntity()
+                            .setMessageName("Last order")
+                            .setCorrelationKey("23-05"))));
     when(userTaskReader.getUserTaskByFlowNodeInstanceKey(flowNodeInstance.getKey()))
         .thenReturn(userTask);
     when(userTaskReader.getUserTaskVariables(userTask.get().getKey()))
@@ -130,7 +137,7 @@ class FlowNodeInstanceMetadataBuilderTest {
     assertThat(metadata.getFollowUpDate()).isEqualTo(followUpDate);
     assertThat(metadata.getTenantId()).isEqualTo("<default>");
     assertThat(metadata.getFormKey()).isEqualTo(5L);
-    assertThat(metadata.getEventId()).isEqualTo("eventId");
+    assertThat(metadata.getEventId()).isEqualTo("2_1");
     assertThat(metadata.getChangedAttributes()).isNull();
     assertThat(metadata.getExternalReference()).isNull();
     assertThat(metadata.getUserTaskKey()).isEqualTo(42L);
@@ -143,12 +150,12 @@ class FlowNodeInstanceMetadataBuilderTest {
     final var userTask = Optional.of(new TaskEntity().setKey(42L));
     when(eventReader.getEventEntityByFlowNodeInstanceId(flowNodeInstance.getId()))
         .thenReturn(
-            new EventEntity()
-                .setId("eventId")
-                .setMetadata(
-                    new EventMetadataEntity()
-                        .setMessageName("Last order")
-                        .setCorrelationKey("23-05")));
+            Optional.of(
+                new EventEntity()
+                    .setMetadata(
+                        new EventMetadataEntity()
+                            .setMessageName("Last order")
+                            .setCorrelationKey("23-05"))));
     when(userTaskReader.getUserTaskByFlowNodeInstanceKey(flowNodeInstance.getKey()))
         .thenReturn(userTask);
     final var metadata = (UserTaskInstanceMetadataDto) builder.buildFrom(flowNodeInstance);
@@ -164,34 +171,11 @@ class FlowNodeInstanceMetadataBuilderTest {
 
     final var jobDeadline = OffsetDateTime.now();
     setJobValues(jobDeadline, flowNodeInstance);
+    setEventValues(flowNodeInstance);
 
     final var metadata = (ServiceTaskInstanceMetadataDto) builder.buildFrom(flowNodeInstance);
     assertStandardValues(metadata);
     assertJobMetadata(metadata, jobDeadline);
-  }
-
-  private void setJobValues(
-      final OffsetDateTime jobDeadline, final FlowNodeInstanceEntity flowNodeInstance) {
-    final EventMetadataEntity eventMetadata =
-        new EventMetadataEntity()
-            .setJobCustomHeaders(Map.of("header", "value"))
-            .setJobDeadline(jobDeadline)
-            .setJobRetries(5)
-            .setJobType("manual")
-            .setJobWorker("Moe")
-            .setMessageName("Last order")
-            .setCorrelationKey("23-05");
-    when(eventReader.getEventEntityByFlowNodeInstanceId(flowNodeInstance.getId()))
-        .thenReturn(new EventEntity().setId("eventId").setMetadata(eventMetadata));
-  }
-
-  private static void assertJobMetadata(
-      final JobFlowNodeInstanceMetadataDto metadata, final OffsetDateTime jobDeadline) {
-    assertThat(metadata.getJobCustomHeaders()).isEqualTo(Map.of("header", "value"));
-    assertThat(metadata.getJobDeadline()).isEqualTo(jobDeadline);
-    assertThat(metadata.getJobRetries()).isEqualTo(5);
-    assertThat(metadata.getJobType()).isEqualTo("manual");
-    assertThat(metadata.getJobWorker()).isEqualTo("Moe");
   }
 
   @Test
@@ -200,6 +184,7 @@ class FlowNodeInstanceMetadataBuilderTest {
     fillStandardValues(flowNodeInstance);
     final var jobDeadline = OffsetDateTime.now();
     setJobValues(jobDeadline, flowNodeInstance);
+    setEventValues(flowNodeInstance);
     when(listViewReader.getCalledProcessInstanceIdAndNameByFlowNodeInstanceId(
             flowNodeInstance.getId()))
         .thenReturn(Tuple.of("calledProcessInstanceId", "calledProcessDefinitionName"));
@@ -210,7 +195,7 @@ class FlowNodeInstanceMetadataBuilderTest {
     assertThat(metadata.getCalledProcessInstanceId()).isEqualTo("calledProcessInstanceId");
     assertThat(metadata.getCalledProcessDefinitionName()).isEqualTo("calledProcessDefinitionName");
     assertJobMetadata(metadata, jobDeadline);
-    assertThat(metadata.getEventId()).isEqualTo("eventId");
+    assertThat(metadata.getEventId()).isEqualTo("2_1");
     assertThat(metadata.getFlowNodeType()).isEqualTo(FlowNodeType.CALL_ACTIVITY);
   }
 
@@ -221,6 +206,7 @@ class FlowNodeInstanceMetadataBuilderTest {
     fillStandardValues(flowNodeInstance);
     final var jobDeadline = OffsetDateTime.now();
     setJobValues(jobDeadline, flowNodeInstance);
+    setEventValues(flowNodeInstance);
 
     when(decisionInstanceReader.getCalledDecisionInstanceAndDefinitionByFlowNodeInstanceId(
             flowNodeInstance.getId()))
@@ -236,14 +222,47 @@ class FlowNodeInstanceMetadataBuilderTest {
     assertThat(metadata.getJobRetries()).isEqualTo(5);
     assertThat(metadata.getJobType()).isEqualTo("manual");
     assertThat(metadata.getJobWorker()).isEqualTo("Moe");
-    assertThat(metadata.getEventId()).isEqualTo("eventId");
+    assertThat(metadata.getEventId()).isEqualTo("2_1");
     assertThat(metadata.getMessageName()).isEqualTo("Last order");
     assertThat(metadata.getCorrelationKey()).isEqualTo("23-05");
     assertThat(metadata.getFlowNodeType()).isEqualTo(FlowNodeType.BUSINESS_RULE_TASK);
   }
 
+  private static void assertJobMetadata(
+      final JobFlowNodeInstanceMetadataDto metadata, final OffsetDateTime jobDeadline) {
+    assertThat(metadata.getJobCustomHeaders()).isEqualTo(Map.of("header", "value"));
+    assertThat(metadata.getJobDeadline()).isEqualTo(jobDeadline);
+    assertThat(metadata.getJobRetries()).isEqualTo(5);
+    assertThat(metadata.getJobType()).isEqualTo("manual");
+    assertThat(metadata.getJobWorker()).isEqualTo("Moe");
+  }
+
+  private void setEventValues(final FlowNodeInstanceEntity flowNodeInstance) {
+    final var eventMetadata =
+        new EventMetadataEntity().setCorrelationKey("23-05").setMessageName("Last order");
+    final var event = new EventEntity().setMetadata(eventMetadata);
+    when(eventReader.getEventEntityByFlowNodeInstanceId(flowNodeInstance.getId()))
+        .thenReturn(Optional.of(event));
+  }
+
+  private void setJobValues(
+      final OffsetDateTime jobDeadline, final FlowNodeInstanceEntity flowNodeInstance) {
+    final JobEntity job =
+        new JobEntity()
+            .setCustomHeaders(Map.of("header", "value"))
+            .setDeadline(jobDeadline)
+            .setRetries(5)
+            .setType("manual")
+            .setWorker("Moe");
+
+    when(elasticsearchJobReader.getJobByFlowNodeInstanceId(flowNodeInstance.getId()))
+        .thenReturn(Optional.of(job));
+  }
+
   private void fillStandardValues(final FlowNodeInstanceEntity flowNodeInstance) {
     flowNodeInstance
+        .setKey(1L)
+        .setProcessInstanceKey(2L)
         .setFlowNodeId("flowNodeId")
         .setId("id")
         .setStartDate(startDate)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR implements a fix for [#38131](https://github.com/camunda/camunda/issues/38131), which caused a 404 error when attempting to retrieve flow node instance popover metadata in certain scenarios (e.g., when the event index no longer holds data for certain elements like user tasks).

Key Fix Details:
	•	We are no longer retrieving job-related data from the Operate event index.
	•	Instead, job metadata (e.g. type, retries, worker, etc.) is now fetched from the Operate job index, via a newly introduced JobReader.
	•	The event index is now only queried when the flow node element is of type message, to retrieve the messageName and correlationKey.

This change prevents failures that previously occurred due to missing data in the event index for elements like user tasks.

Note:
I intentionally avoided making structural or architectural changes to the existing code. While the current implementation could benefit from a more maintainable pattern (e.g., a builder strategy based on element types), such a redesign was deemed unnecessary at this point — especially given that this logic is expected to be removed or refactored as part of the 8.9 release. This PR instead takes the minimal, non-invasive route to resolve the bug while preserving the current structure.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38131
