### PR TITLE
feat: add query hook for GET decision instance v2 api

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.4
+
+### 🩹 Fixes
+
+- rename decisionInstanceSchema properties to match the api spec ([#38357](https://github.com/camunda/camunda/pull/38357))
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.3
 
 ### 🩹 Fixes

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/decision-instance.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/decision-instance.ts
@@ -44,8 +44,8 @@ type DecisionInstance = z.infer<typeof decisionInstanceSchema>;
 
 const queryDecisionInstancesRequestBodySchema = getQueryRequestBodySchema({
 	sortFields: [
-		'decisionInstanceKey',
-		'decisionInstanceId',
+		'decisionEvaluationKey',
+		'decisionEvaluationInstanceKey',
 		'state',
 		'evaluationDate',
 		'evaluationFailure',
@@ -65,7 +65,7 @@ const queryDecisionInstancesRequestBodySchema = getQueryRequestBodySchema({
 			evaluationDate: advancedDateTimeFilterSchema,
 			decisionDefinitionKey: basicStringFilterSchema,
 			...decisionInstanceSchema.pick({
-				decisionInstanceId: true,
+        decisionEvaluationInstanceKey: true,
 				state: true,
 				evaluationFailure: true,
 				decisionDefinitionId: true,
@@ -73,7 +73,7 @@ const queryDecisionInstancesRequestBodySchema = getQueryRequestBodySchema({
 				decisionDefinitionVersion: true,
 				decisionDefinitionType: true,
 				tenantId: true,
-				decisionInstanceKey: true,
+				decisionEvaluationKey: true,
 				processDefinitionKey: true,
 				processInstanceKey: true,
 				elementInstanceKey: true,

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/decision-instance.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/decision-instance.ts
@@ -24,7 +24,7 @@ const decisionInstanceStateSchema = z.enum(['EVALUATED', 'FAILED', 'UNSPECIFIED'
 type DecisionInstanceState = z.infer<typeof decisionInstanceStateSchema>;
 
 const decisionInstanceSchema = z.object({
-	decisionInstanceId: z.string(),
+	decisionEvaluationInstanceKey: z.string(),
 	state: decisionInstanceStateSchema,
 	evaluationDate: z.string(),
 	evaluationFailure: z.string(),
@@ -34,7 +34,7 @@ const decisionInstanceSchema = z.object({
 	decisionDefinitionType: decisionDefinitionTypeSchema,
 	result: z.string(),
 	tenantId: z.string(),
-	decisionInstanceKey: z.string(),
+	decisionEvaluationKey: z.string(),
 	processDefinitionKey: z.string(),
 	processInstanceKey: z.string(),
 	decisionDefinitionKey: z.string(),
@@ -98,9 +98,9 @@ const queryDecisionInstances: Endpoint = {
 	getUrl: () => `/${API_VERSION}/decision-instances/search`,
 };
 
-const getDecisionInstance: Endpoint<Pick<DecisionInstance, 'decisionInstanceId'>> = {
+const getDecisionInstance: Endpoint<Pick<DecisionInstance, 'decisionEvaluationInstanceKey'>> = {
 	method: 'GET',
-	getUrl: ({decisionInstanceId}) => `/${API_VERSION}/decision-instances/${decisionInstanceId}`,
+	getUrl: ({decisionEvaluationInstanceKey}) => `/${API_VERSION}/decision-instances/${decisionEvaluationInstanceKey}`,
 };
 
 export {

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.10.2",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "file:../../client-components/packages/camunda-api-zod-schemas",
+        "@camunda/camunda-api-zod-schemas": "0.0.4",
         "@camunda/camunda-composite-components": "0.19.1",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.57.0",
@@ -98,23 +98,6 @@
         "vitest": "3.2.4",
         "vitest-browser-react": "1.0.1",
         "zod": "4.0.5"
-      }
-    },
-    "../../client-components/packages/camunda-api-zod-schemas": {
-      "name": "@camunda/camunda-api-zod-schemas",
-      "version": "0.0.3",
-      "license": "LicenseRef-Camunda-1.0",
-      "devDependencies": {
-        "@types/node": "24.3.0",
-        "changelogen": "0.6.2",
-        "typescript": "5.9.2",
-        "vite": "7.1.5",
-        "vite-plugin-circular-dependency": "0.5.0",
-        "vite-plugin-dts": "4.5.4",
-        "zod": "^4.0.17"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -574,8 +557,13 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "resolved": "../../client-components/packages/camunda-api-zod-schemas",
-      "link": true
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.4.tgz",
+      "integrity": "sha512-zw/K1e0R0L0orqK60fMaIUqp4yEHifasdeHl9JZ41tiK2IhiQ45v7IONrOrp1uSeMCYaS63OpWDJTlUg5Q3Erg==",
+      "license": "LicenseRef-Camunda-1.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     },
     "node_modules/@camunda/camunda-composite-components": {
       "version": "0.19.1",
@@ -14263,7 +14251,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
       "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.10.2",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.3",
+        "@camunda/camunda-api-zod-schemas": "file:../../client-components/packages/camunda-api-zod-schemas",
         "@camunda/camunda-composite-components": "0.19.1",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.57.0",
@@ -98,6 +98,23 @@
         "vitest": "3.2.4",
         "vitest-browser-react": "1.0.1",
         "zod": "4.0.5"
+      }
+    },
+    "../../client-components/packages/camunda-api-zod-schemas": {
+      "name": "@camunda/camunda-api-zod-schemas",
+      "version": "0.0.3",
+      "license": "LicenseRef-Camunda-1.0",
+      "devDependencies": {
+        "@types/node": "24.3.0",
+        "changelogen": "0.6.2",
+        "typescript": "5.9.2",
+        "vite": "7.1.5",
+        "vite-plugin-circular-dependency": "0.5.0",
+        "vite-plugin-dts": "4.5.4",
+        "zod": "^4.0.17"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -557,13 +574,8 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.3.tgz",
-      "integrity": "sha512-oHafuP0EYmaoZsT0E794GHx8dMuXfvoV/510KGhAaBKscvEwyHd6DsrTtt8T7cBs43z0S/krkJLkuF792afs4A==",
-      "license": "LicenseRef-Camunda-1.0",
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      }
+      "resolved": "../../client-components/packages/camunda-api-zod-schemas",
+      "link": true
     },
     "node_modules/@camunda/camunda-composite-components": {
       "version": "0.19.1",
@@ -14251,6 +14263,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
       "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.10.2",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.3",
+    "@camunda/camunda-api-zod-schemas": "file:../../client-components/packages/camunda-api-zod-schemas",
     "@camunda/camunda-composite-components": "0.19.1",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.57.0",

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.10.2",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "file:../../client-components/packages/camunda-api-zod-schemas",
+    "@camunda/camunda-api-zod-schemas": "0.0.4",
     "@camunda/camunda-composite-components": "0.19.1",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.57.0",

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Incident/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Incident/index.tsx
@@ -89,12 +89,12 @@ const Incident: React.FC<Props> = ({
             <SummaryDataValue>
               <Link
                 to={Paths.decisionInstance(
-                  rootCauseDecisionInstance.decisionInstanceKey,
+                  rootCauseDecisionInstance.decisionEvaluationKey,
                 )}
-                title={`View root cause decision ${rootCauseDecisionInstance.decisionDefinitionName} - ${rootCauseDecisionInstance.decisionInstanceKey}`}
-                aria-label={`View root cause decision ${rootCauseDecisionInstance.decisionDefinitionName} - ${rootCauseDecisionInstance.decisionInstanceKey}`}
+                title={`View root cause decision ${rootCauseDecisionInstance.decisionDefinitionName} - ${rootCauseDecisionInstance.decisionEvaluationKey}`}
+                aria-label={`View root cause decision ${rootCauseDecisionInstance.decisionDefinitionName} - ${rootCauseDecisionInstance.decisionEvaluationKey}`}
               >
-                {`${rootCauseDecisionInstance.decisionDefinitionName} - ${rootCauseDecisionInstance.decisionInstanceKey}`}
+                {`${rootCauseDecisionInstance.decisionDefinitionName} - ${rootCauseDecisionInstance.decisionEvaluationKey}`}
               </Link>
             </SummaryDataValue>
           </Stack>

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/calledDecisions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/calledDecisions.test.tsx
@@ -294,8 +294,8 @@ describe('MetadataPopover', () => {
     const {rootCauseDecision} = calledFailedDecisionMetadata!.incident!;
 
     const mockRootCauseDecisionInstance = {
-      decisionInstanceId: rootCauseDecision!.instanceId,
-      decisionInstanceKey: rootCauseDecision!.instanceId,
+      decisionEvaluationInstanceKey: rootCauseDecision!.instanceId,
+      decisionEvaluationKey: rootCauseDecision!.instanceId,
       decisionDefinitionName: rootCauseDecision!.decisionName!,
       decisionDefinitionId: 'decision-2',
       decisionDefinitionKey: '456',

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
@@ -90,8 +90,8 @@ const mockElementInstance: ElementInstance = {
 };
 
 const mockDecisionInstance: DecisionInstance = {
-  decisionInstanceId: '2251799813685591',
-  decisionInstanceKey: '2251799813685591',
+  decisionEvaluationInstanceKey: '2251799813685591',
+  decisionEvaluationKey: '2251799813685591',
   decisionDefinitionName: 'Test Decision',
   decisionDefinitionId: 'decision-1',
   decisionDefinitionKey: '123',

--- a/operate/client/src/modules/api/v2/decisionInstances/fetchDecisionInstance.ts
+++ b/operate/client/src/modules/api/v2/decisionInstances/fetchDecisionInstance.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type GetDecisionInstanceResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import {requestWithThrow} from 'modules/request';
+
+const fetchDecisionInstance = async (decisionEvaluationInstanceKey: string) => {
+  return requestWithThrow<GetDecisionInstanceResponseBody>({
+    url: endpoints.getDecisionInstance.getUrl({decisionEvaluationInstanceKey}),
+    method: endpoints.getDecisionInstance.method,
+  });
+};
+
+export {fetchDecisionInstance};

--- a/operate/client/src/modules/queries/decisionInstances/useDecisionInstance.ts
+++ b/operate/client/src/modules/queries/decisionInstances/useDecisionInstance.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {fetchDecisionInstance} from 'modules/api/v2/decisionInstances/fetchDecisionInstance';
+import {queryKeys} from '../queryKeys';
+import {useQuery} from '@tanstack/react-query';
+
+const useDecisionInstance = (decisionEvaluationInstanceKey: string) => {
+  return useQuery({
+    queryKey: queryKeys.decisionInstances.get(decisionEvaluationInstanceKey),
+    queryFn: async () => {
+      const {response, error} = await fetchDecisionInstance(
+        decisionEvaluationInstanceKey,
+      );
+      if (response !== null) {
+        return response;
+      }
+      throw error;
+    },
+  });
+};
+
+export {useDecisionInstance};

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -21,6 +21,12 @@ const queryKeys = {
       value?: Variable['value'];
     }) => [...queryKeys.variables.search(), ...Object.values(params)],
   },
+  decisionInstances: {
+    get: (decisionEvaluationInstanceKey: string) => [
+      'decisionInstance',
+      decisionEvaluationInstanceKey,
+    ],
+  },
 };
 
 export {queryKeys};

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.16.0",
         "@bpmn-io/form-js-viewer": "1.16.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.3",
+        "@camunda/camunda-api-zod-schemas": "0.0.4",
         "@camunda/camunda-composite-components": "0.20.2",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.87.1",
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.3.tgz",
-      "integrity": "sha512-oHafuP0EYmaoZsT0E794GHx8dMuXfvoV/510KGhAaBKscvEwyHd6DsrTtt8T7cBs43z0S/krkJLkuF792afs4A==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.4.tgz",
+      "integrity": "sha512-zw/K1e0R0L0orqK60fMaIUqp4yEHifasdeHl9JZ41tiK2IhiQ45v7IONrOrp1uSeMCYaS63OpWDJTlUg5Q3Erg==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.16.0",
     "@bpmn-io/form-js-viewer": "1.16.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.3",
+    "@camunda/camunda-api-zod-schemas": "0.0.4",
     "@camunda/camunda-composite-components": "0.20.2",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.87.1",


### PR DESCRIPTION
## Description

Adds a new query hook for the `GET /v2/decision-instances/<key>` API. Furthermore, it adjusts the response schema properties for the payload to match the latest api definition.

## Checklist

- [ ] remove the local dependency reference to `@camunda/camunda-api-zod-schemas` again once `v0.0.4` is released.

## Related issues

relates #27347
