### PR TITLE
Close CamundaExporter resources properly

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -108,16 +108,17 @@ public class CamundaExporter implements Exporter {
   public void configure(final Context context) {
     this.context = context;
     configuration = context.getConfiguration().instantiate(ExporterConfiguration.class);
-    ConfigValidator.validate(configuration);
-    context.setFilter(new CamundaExporterRecordFilter());
     partitionId = context.getPartitionId();
 
+    LOG.info("Configuring exporter with {}", configuration);
+    ConfigValidator.validate(configuration);
+    context.setFilter(new CamundaExporterRecordFilter());
     verifySetupOfResources();
-    LOG.debug("Exporter configured with {}", configuration);
   }
 
   @Override
   public void open(final Controller controller) {
+    LOG.info("Opening Exporter on partition {}", partitionId);
     this.controller = controller;
     setupExporterResources();
     searchEngineClient = clientAdapter.getSearchEngineClient();
@@ -167,7 +168,7 @@ public class CamundaExporter implements Exporter {
       CloseHelper.close(error -> LOG.warn("Failed to close background tasks", error), taskManager);
       taskManager = null;
     }
-    LOG.info("Exporter closed");
+    LOG.info("Exporter resources closed");
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -161,7 +161,6 @@ public class CamundaExporter implements Exporter {
       metrics = null;
     }
 
-    metadata = null;
     provider.reset();
 
     if (taskManager != null) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -254,17 +254,18 @@ public class CamundaExporter implements Exporter {
 
   private void verifySetupOfResources() {
     // given the context and configuration
-
-    // we need setup all resources
-    // to ensure that we can create the clients,
-    // connect and make use of the configuration given
-    setupExporterResources();
-
-    // afterward we need to clean up all the resources
-    // as we only wanted to verify the setup and the exporter
-    // might simply just run in passive mode - so there is no
-    // need to keep the clients opens
-    close();
+    try {
+      // we need setup all resources
+      // to ensure that we can create the clients,
+      // connect and make use of the configuration given
+      setupExporterResources();
+    } finally {
+      // afterward we need to clean up all the resources
+      // as we only wanted to verify the setup and the exporter
+      // might simply just run in passive mode - so there is no
+      // need to keep the clients opens
+      close();
+    }
   }
 
   private void setupExporterResources() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -334,6 +334,28 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   }
 
   @Override
+  public void reset() {
+    // clean up all references
+    indexDescriptors = null;
+    if (exportHandlers != null) {
+      exportHandlers.clear();
+      exportHandlers = null;
+    }
+    if (batchOperationCache != null) {
+      batchOperationCache.clear();
+      batchOperationCache = null;
+    }
+    if (formCache != null) {
+      formCache.clear();
+      formCache = null;
+    }
+    if (processCache != null) {
+      processCache.clear();
+      processCache = null;
+    }
+  }
+
+  @Override
   public Collection<IndexDescriptor> getIndexDescriptors() {
     return indexDescriptors.indices();
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -32,6 +32,9 @@ public interface ExporterResourceProvider {
       final ExporterMetadata exporterMetadata,
       final ObjectMapper objectMapper);
 
+  /** Resets the provider to its initial state. To avoid unnecessary resources consumptions. */
+  void reset();
+
   /**
    * This should return descriptors describing the desired state of all indices provided.
    *

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -264,12 +264,12 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(recordExportDuration);
 
     // Remove custom gauges by their names if needed
-    Gauge gauge = meterRegistry.find(meterName("since.last.flush.seconds")).gauge();
-    if (gauge != null) {
-      meterRegistry.remove(gauge);
-    }
+    removeGaugeIfExists(meterName("since.last.flush.seconds"));
+    removeGaugeIfExists(meterName("process.instances.awaiting.archival"));
+  }
 
-    gauge = meterRegistry.find(meterName("process.instances.awaiting.archival")).gauge();
+  private void removeGaugeIfExists(final String meterName) {
+    final var gauge = meterRegistry.find(meterName).gauge();
     if (gauge != null) {
       meterRegistry.remove(gauge);
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ElasticsearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ElasticsearchRepository.java
@@ -153,6 +153,6 @@ public class ElasticsearchRepository implements AutoCloseable {
 
   @Override
   public void close() throws Exception {
-    client._transport().close();
+    client.close();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/TestExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/TestExporterResourceProvider.java
@@ -28,13 +28,10 @@ import java.util.function.BiConsumer;
 
 public class TestExporterResourceProvider implements ExporterResourceProvider {
 
-  private IndexDescriptors indexDescriptors;
-  private final String indexPrefix;
-  private final boolean isElasticsearch;
+  private final IndexDescriptors indexDescriptors;
 
   public TestExporterResourceProvider(final String indexPrefix, final boolean isElasticsearch) {
-    this.indexPrefix = indexPrefix;
-    this.isElasticsearch = isElasticsearch;
+    indexDescriptors = new IndexDescriptors(indexPrefix, isElasticsearch);
   }
 
   @Override
@@ -43,14 +40,10 @@ public class TestExporterResourceProvider implements ExporterResourceProvider {
       final ExporterEntityCacheProvider entityCacheProvider,
       final MeterRegistry meterRegistry,
       final ExporterMetadata exporterMetadata,
-      final ObjectMapper objectMapper) {
-    indexDescriptors = new IndexDescriptors(indexPrefix, isElasticsearch);
-  }
+      final ObjectMapper objectMapper) {}
 
   @Override
-  public void reset() {
-    indexDescriptors = null;
-  }
+  public void reset() {}
 
   @Override
   public Collection<IndexDescriptor> getIndexDescriptors() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/TestExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/TestExporterResourceProvider.java
@@ -28,10 +28,13 @@ import java.util.function.BiConsumer;
 
 public class TestExporterResourceProvider implements ExporterResourceProvider {
 
-  private final IndexDescriptors indexDescriptors;
+  private IndexDescriptors indexDescriptors;
+  private final String indexPrefix;
+  private final boolean isElasticsearch;
 
   public TestExporterResourceProvider(final String indexPrefix, final boolean isElasticsearch) {
-    indexDescriptors = new IndexDescriptors(indexPrefix, isElasticsearch);
+    this.indexPrefix = indexPrefix;
+    this.isElasticsearch = isElasticsearch;
   }
 
   @Override
@@ -40,7 +43,14 @@ public class TestExporterResourceProvider implements ExporterResourceProvider {
       final ExporterEntityCacheProvider entityCacheProvider,
       final MeterRegistry meterRegistry,
       final ExporterMetadata exporterMetadata,
-      final ObjectMapper objectMapper) {}
+      final ObjectMapper objectMapper) {
+    indexDescriptors = new IndexDescriptors(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public void reset() {
+    indexDescriptors = null;
+  }
 
   @Override
   public Collection<IndexDescriptor> getIndexDescriptors() {


### PR DESCRIPTION
## Description

We have recently detected that the CamundaExporter is not properly closing all resources, especially as it is opening clients during the configure, which also happens on bootstrap or followers. 
https://camunda.slack.com/archives/C0807665N8G/p1758117776010439?thread_ts=1758111376.933779&cid=C0807665N8G

This PR is an attempt to close all resources from the CamundaExporter properly

Pre-work:

* Prepare the resource provider to correctly close/reset resources
* Add method to close/de-register metrics from the meter registry
* Use the correct public close method of the ELS client

Actual work:

 * The CamundaExporter#configure is called in different cases to ensure that we can properly
   configure and create the related Exporter
 * This means we need to make sure that we use the provided configuration in the #configure
   to connect to the ELS cluster to validate whether the connection details are correct
 * Previously, we simply created the clients, but did not close them afterwards.
 * This means even when we simply configure the Exporter on followers, where we just
   want to verify and set up the Exporter object, we have Clients, Metrics, and
   all sorts of resources flying around. Without actually using them.
 * This PR extracts the setup code into a separate method to be used
   In the configure and open.
 * UNDER THE ASSUMPTION that we want to keep the existing behavior of validating the connectivity, the following was done
   * When we configure the exporter, we still set up the resources to validate
     the provided details, but also close them afterwards (to clean up)
 * Furthermore, on the close, we close more resources that we missed previously

Additionally:

* Some tests or resources have been adjusted; see related commits.
* I see more potential to improve, for example, remove the need for the ResourceProvider on the ArchiverRepository, and do some related refactorings.
  * Right now, it looks to me we are often interested in the IndexDescriptors, but have to create a much bigger object with dependencies, the Provider, where we dont use any of the other properties.

## Related issues

Coming up in load tests done for the stable/8.8 branch https://camunda.slack.com/archives/C0807665N8G/p1758111376933779

Related https://github.com/camunda/camunda/issues/29146