### PR TITLE
ci: reenable optimize e2e tests

### DIFF
--- a/.github/workflows/optimize-e2e-test-cloud.yml
+++ b/.github/workflows/optimize-e2e-test-cloud.yml
@@ -31,7 +31,6 @@ on:
 
 jobs:
   e2e-cloud-test:
-    if: false # This deactivates the pipeline
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -59,14 +58,6 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - name: Setup Chrome
-        shell: bash
-        run: |
-          # remove existing chrome
-          sudo apt-get remove -y google-chrome-stable
-          # install chrome 126
-          wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_126.0.6478.182-1_amd64.deb
-          sudo apt-get update && sudo apt-get install -y ./google-chrome-stable_126.0.6478.182-1_amd64.deb
       - name: "Read Java / Version Info"
         id: "pom-info"
         uses: YunaBraska/java-info-action@main

--- a/.github/workflows/optimize-e2e-tests-sm.yml
+++ b/.github/workflows/optimize-e2e-tests-sm.yml
@@ -44,7 +44,6 @@ jobs:
     name: E2E Self-Managed
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: false # this test is disabled
 
     steps:
       - name: Checkout code

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -105,21 +105,28 @@ services:
       - opensearch
   keycloak:
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3@sha256:da3df0976a9f9a664bdbde6cb5308b78f03ac94d0abf33b2df355bbb06cbc5b9
+    image: camunda/keycloak:quay-26
     profiles: ['self-managed', 'self-managed:opensearch', 'self-managed:elasticsearch']
+    command: [start]
     ports:
       - '18080:8080'
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8080/auth']
+      test: bash -c "echo -e 'GET /auth HTTP/1.0\r\n\r\n' >/dev/tcp/127.0.0.1/8080 || exit 1"
       interval: 30s
       timeout: 15s
       retries: 5
       start_period: 30s
     environment:
-      KEYCLOAK_ADMIN_USER: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
-      KEYCLOAK_DATABASE_VENDOR: dev-file
-      KEYCLOAK_HTTP_RELATIVE_PATH: /auth
+      KC_DB: dev-file
+      KC_CACHE: ispn
+      KC_HTTP_ENABLED: 'true'
+      KC_HTTP_RELATIVE_PATH: /auth
+      KC_HEALTH_ENABLED: 'true'
+      KC_HOSTNAME_STRICT: 'false'
   identity:
     depends_on:
       - keycloak

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       - opensearch
   keycloak:
     container_name: keycloak
-    image: camunda/keycloak:quay-26
+    image: camunda/keycloak:quay-26@sha256:62f78cccbb40d3a342629e4814f7fc53010906ced045879f7ebf1516f000e471
     profiles: ['self-managed', 'self-managed:opensearch', 'self-managed:elasticsearch']
     command: [start]
     ports:

--- a/optimize/client/e2e/sm-tests/Common.elements.js
+++ b/optimize/client/e2e/sm-tests/Common.elements.js
@@ -84,4 +84,4 @@ export const kpiTemplateSelection = Selector('input#KpiSelectionComboBox');
 export const emptyStateAdd = Selector('.EmptyState .cds--btn--primary');
 export const processItem = listItemLink('process', true);
 export const templateOption = (text) => Selector('.Modal .templateContainer button').withText(text);
-export const collectionsPage = Selector('a[href="#/collections"]');
+export const collectionsPage = Selector('header > nav a[href="#/collections"]');

--- a/optimize/client/e2e/sm-tests/Dashboard.js
+++ b/optimize/client/e2e/sm-tests/Dashboard.js
@@ -492,7 +492,7 @@ test('add a report from the dashboard', async (t) => {
 
   await t.expect(Common.selectedOption('Order process').exists).ok();
 
-  await t.click(Common.modalConfirmButton).hover(Common.addButton).click('.DashboardRenderer');
+  await t.click(Common.modalConfirmButton).click(e.dashboardContainer);
 
   await u.save(t);
 

--- a/optimize/docker-compose.ccsm-with-optimize.yml
+++ b/optimize/docker-compose.ccsm-with-optimize.yml
@@ -66,18 +66,23 @@ services:
       - identity-network
   keycloak:
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3@sha256:da3df0976a9f9a664bdbde6cb5308b78f03ac94d0abf33b2df355bbb06cbc5b9
+    image: camunda/keycloak:quay-26
+    command: [ start ]
     ports:
       - "18080:8080"
     environment:
-      KEYCLOAK_ADMIN_USER: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
-      KEYCLOAK_DATABASE_VENDOR: dev-file
-      KEYCLOAK_HTTP_RELATIVE_PATH: /auth
-      KEYCLOAK_ENABLE_HEALTH_ENDPOINTS: true
-      JAVA_OPTS: -XX:UseSVE=0
+      KC_DB: dev-file
+      KC_CACHE: ispn
+      KC_HTTP_ENABLED: "true"
+      KC_HTTP_RELATIVE_PATH: /auth
+      KC_HEALTH_ENABLED: "true"
+      KC_HOSTNAME_STRICT: "false"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8080/health/ready"]
+      test: bash -c "echo -e 'GET /auth HTTP/1.0\r\n\r\n' >/dev/tcp/127.0.0.1/8080 || exit 1"
       interval: 30s
       timeout: 5s
       retries: 3

--- a/optimize/docker-compose.ccsm-with-optimize.yml
+++ b/optimize/docker-compose.ccsm-with-optimize.yml
@@ -66,7 +66,7 @@ services:
       - identity-network
   keycloak:
     container_name: keycloak
-    image: camunda/keycloak:quay-26
+    image: camunda/keycloak:quay-26@sha256:62f78cccbb40d3a342629e4814f7fc53010906ced045879f7ebf1516f000e471
     command: [ start ]
     ports:
       - "18080:8080"

--- a/optimize/docker-compose.ccsm-without-optimize.yml
+++ b/optimize/docker-compose.ccsm-without-optimize.yml
@@ -48,7 +48,7 @@
 services:
   keycloak:
     container_name: keycloak
-    image: camunda/keycloak:quay-26
+    image: camunda/keycloak:quay-26@sha256:62f78cccbb40d3a342629e4814f7fc53010906ced045879f7ebf1516f000e471
     command: [ start ]
     ports:
       - "18080:8080"

--- a/optimize/docker-compose.ccsm-without-optimize.yml
+++ b/optimize/docker-compose.ccsm-without-optimize.yml
@@ -48,18 +48,23 @@
 services:
   keycloak:
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3@sha256:da3df0976a9f9a664bdbde6cb5308b78f03ac94d0abf33b2df355bbb06cbc5b9
+    image: camunda/keycloak:quay-26
+    command: [ start ]
     ports:
       - "18080:8080"
     environment:
-      KEYCLOAK_ADMIN_USER: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
-      KEYCLOAK_DATABASE_VENDOR: dev-file
-      KEYCLOAK_HTTP_RELATIVE_PATH: /auth
-      KEYCLOAK_ENABLE_HEALTH_ENDPOINTS: true
-      JAVA_OPTS: -XX:UseSVE=0
+      KC_DB: dev-file
+      KC_CACHE: ispn
+      KC_HTTP_ENABLED: "true"
+      KC_HTTP_RELATIVE_PATH: /auth
+      KC_HEALTH_ENABLED: "true"
+      KC_HOSTNAME_STRICT: "false"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8080/health/ready"]
+      test: bash -c "echo -e 'GET /auth HTTP/1.0\r\n\r\n' >/dev/tcp/127.0.0.1/8080 || exit 1"
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
The Optimize e2e tests job was disabled recently in this [PR](https://github.com/camunda/camunda/pull/37481). The reason of the failure is mainly due to the [recent keycloak renovate update](https://camunda.slack.com/archives/C08F5RD5X8B/p1757442720737219) that broke all the docker compose files in the repo, including the one used for the e2e tests.

In this PR, i did the following: 
- Fix the docker compose files by using the official camunda keycloak instead of the bitnami(seems to not work anymore). 
- Re-enable the e2e tests
- Fix two flaky tests due to incorrect selectors.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37480
