### PR TITLE
refactor: remove session creation on api calls

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -108,6 +108,7 @@ import org.springframework.security.web.header.writers.CrossOriginEmbedderPolicy
 import org.springframework.security.web.header.writers.CrossOriginOpenerPolicyHeaderWriter.CrossOriginOpenerPolicy;
 import org.springframework.security.web.header.writers.CrossOriginResourcePolicyHeaderWriter.CrossOriginResourcePolicy;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
+import org.springframework.security.web.savedrequest.NullRequestCache;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Configuration
@@ -502,7 +503,8 @@ public class WebSecurityConfig {
               // only
               .sessionManagement(
                   (sessionManagement) ->
-                      sessionManagement.sessionCreationPolicy(SessionCreationPolicy.NEVER));
+                      sessionManagement.sessionCreationPolicy(SessionCreationPolicy.NEVER))
+              .requestCache((cache) -> cache.requestCache(new NullRequestCache()));
 
       applyCsrfConfiguration(httpSecurity, securityConfiguration, csrfTokenRepository);
 
@@ -776,6 +778,12 @@ public class WebSecurityConfig {
                           headers,
                           securityConfiguration.getHttpHeaders(),
                           securityConfiguration.getSaas().isConfigured()))
+              // do not create a session on api authentication, that's to be done on webapp login
+              // only
+              .sessionManagement(
+                  (sessionManagement) ->
+                      sessionManagement.sessionCreationPolicy(SessionCreationPolicy.NEVER))
+              .requestCache((cache) -> cache.requestCache(new NullRequestCache()))
               .exceptionHandling(
                   (exceptionHandling) -> exceptionHandling.accessDeniedHandler(authFailureHandler))
               .sessionManagement(

--- a/authentication/src/main/java/io/camunda/authentication/session/WebSessionDeletionTask.java
+++ b/authentication/src/main/java/io/camunda/authentication/session/WebSessionDeletionTask.java
@@ -12,7 +12,8 @@ import org.slf4j.LoggerFactory;
 
 public class WebSessionDeletionTask implements Runnable {
 
-  public static final int DELETE_EXPIRED_SESSIONS_DELAY = 1_000 * 60 * 30;
+  public static final int DELETE_EXPIRED_SESSIONS_INITIAL_DELAY = 1_000 * 60 * 5;
+  public static final int DELETE_EXPIRED_SESSIONS_RUN_DELAY = 1_000 * 60 * 10;
   private static final Logger LOGGER = LoggerFactory.getLogger(WebSessionDeletionTask.class);
   private final WebSessionRepository webSessionRepository;
 

--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -79,8 +79,8 @@ public class WebSessionRepositoryConfiguration {
         new SelfSchedulingTask(
             executor,
             new WebSessionDeletionTask(webSessionRepository),
-            WebSessionDeletionTask.DELETE_EXPIRED_SESSIONS_DELAY),
-        WebSessionDeletionTask.DELETE_EXPIRED_SESSIONS_DELAY,
+            WebSessionDeletionTask.DELETE_EXPIRED_SESSIONS_RUN_DELAY),
+        WebSessionDeletionTask.DELETE_EXPIRED_SESSIONS_INITIAL_DELAY,
         TimeUnit.MILLISECONDS);
     return executor;
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR:
* Prevents sessions being stored for API calls
* Prevents Spring security requests being stored for API calls
* Reduces the initial delay of the web session deletion job to be 5 minutes
* Reduces the on going delay of the web session deletion job to be 10 minutes

References:
* I sought out Spring docs for the storage of sessions as I was still seeing requests being stored in the index with the session policy set, I found this: "I am using SessionCreationPolicy.NEVER but [the application is still creating sessions](https://docs.spring.io/spring-security/reference/servlet/authentication/session-management.html#never-policy-session-still-created).". Looking into the links shows that there is a second configuration param https://docs.spring.io/spring-security/reference/servlet/architecture.html#requestcache-prevent-saved-request

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37983, closes #37984, closes #37986
