### PR TITLE
Disable Operate/Tasklist Zeebe ES/OS Clients and Importer modules by default

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -54,6 +54,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -174,6 +175,7 @@ public class ElasticsearchConnector {
   }
 
   @Bean("zeebeEsClient")
+  @ConditionalOnProperty(value = "camunda.operate.importer-enabled", havingValue = "true")
   public RestHighLevelClient zeebeEsClient() {
     // some weird error when ELS sets available processors number for Netty - see
     // https://discuss.elastic.co/t/elasticsearch-5-4-1-availableprocessors-is-already-set/88036/3

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -62,6 +62,7 @@ import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBui
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -145,6 +146,7 @@ public class OpensearchConnector {
   }
 
   @Bean("zeebeOpensearchClient")
+  @ConditionalOnProperty(value = "camunda.operate.importer-enabled", havingValue = "true")
   public OpenSearchClient zeebeOpensearchClient() {
     System.setProperty("es.set.netty.runtime.available.processors", "false");
     zeebeOsClientRepository.load(operateProperties.getZeebeOpensearch().getInterceptorPlugins());

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -13,11 +13,11 @@ import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.operate.data.usertest.UserTestDataGenerator;
-import io.camunda.operate.store.ZeebeStore;
-import io.camunda.operate.zeebe.ZeebeESConstants;
+import io.camunda.operate.store.ProcessStore;
 import io.camunda.security.configuration.SecurityConfiguration;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -42,7 +42,7 @@ public abstract class AbstractDataGenerator implements DataGenerator {
   protected ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(3);
   @Autowired private SecurityConfiguration securityConfiguration;
   private boolean shutdown = false;
-  @Autowired private ZeebeStore zeebeStore;
+  @Autowired private ProcessStore processStore;
 
   @PostConstruct
   private void startDataGenerator() {
@@ -106,9 +106,13 @@ public abstract class AbstractDataGenerator implements DataGenerator {
 
   public boolean shouldCreateData(final boolean manuallyCalled) {
     if (!manuallyCalled) { // when called manually, always create the data
-      final String zeebeIndexPrefix = zeebeStore.getZeebeIndexPrefix();
-      final boolean exists =
-          zeebeStore.zeebeIndicesExists(zeebeIndexPrefix + "*" + ZeebeESConstants.DEPLOYMENT + "*");
+      final boolean exists;
+      try {
+        exists = processStore.count() > 0;
+      } catch (final IOException e) {
+        LOGGER.warn("Error occurred when counting processes.", e);
+        return false;
+      }
       if (exists) {
         // data already exists
         LOGGER.debug("Data already exists in Zeebe.");

--- a/operate/importer/src/main/java/io/camunda/operate/ImportModuleConfiguration.java
+++ b/operate/importer/src/main/java/io/camunda/operate/ImportModuleConfiguration.java
@@ -19,10 +19,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
 @ComponentScan(
     basePackages = "io.camunda.operate.zeebeimport",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@ConditionalOnProperty(
-    name = "camunda.operate.importer-enabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnProperty(name = "camunda.operate.importer-enabled", havingValue = "true")
 public class ImportModuleConfiguration {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ImportModuleConfiguration.class);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ElasticsearchConnectorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ElasticsearchConnectorIT.java
@@ -49,7 +49,7 @@ import org.testcontainers.utility.DockerImageName;
       UnifiedConfigurationHelper.class,
       UnifiedConfiguration.class
     },
-    properties = "camunda.data.secondary-storage.type=elasticsearch")
+    properties = OperateProperties.PREFIX + ".importer-enabled=true")
 public class ElasticsearchConnectorIT {
 
   @Container

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
@@ -45,6 +45,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 public class FinishedImportingIT extends OperateZeebeAbstractIT {
   private static final ElasticsearchExporter EXPORTER = new ElasticsearchExporter();
@@ -58,6 +60,11 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
   @Autowired private MeterRegistry registry;
   private final ProtocolFactory factory = new ProtocolFactory();
   private int emptyBatches = 0;
+
+  @DynamicPropertySource
+  static void setProperties(final DynamicPropertyRegistry registry) {
+    registry.add("camunda.operate.importer-enabled", () -> true);
+  }
 
   @Before
   public void beforeEach() {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/FullAppIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/FullAppIT.java
@@ -11,9 +11,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.operate.ImportModuleConfiguration;
 import io.camunda.operate.WebappModuleConfiguration;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.controllers.OperateIndexController;
 import org.junit.Test;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(
+    properties = {
+      OperateProperties.PREFIX + ".importer-enabled = true",
+    })
 public class FullAppIT extends ModuleAbstractIT {
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/ModuleAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/ModuleAbstractIT.java
@@ -22,7 +22,6 @@ import org.springframework.test.context.junit4.SpringRunner;
     },
     properties = {
       OperateProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
-      OperateProperties.PREFIX + ".archiver.rolloverEnabled = false",
       OperateProperties.PREFIX + ".zeebe.compatibility.enabled = true",
       "spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER",
       "spring.profiles.active=test,consolidated-auth"

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/OnlyImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/OnlyImportIT.java
@@ -19,6 +19,7 @@ import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(
     properties = {
+      OperateProperties.PREFIX + ".importer-enabled = true",
       OperateProperties.PREFIX + ".webappEnabled = false",
     })
 public class OnlyImportIT extends ModuleAbstractIT {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/OnlyWebappIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/OnlyWebappIT.java
@@ -11,13 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.operate.ImportModuleConfiguration;
 import io.camunda.operate.WebappModuleConfiguration;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.controllers.OperateIndexController;
 import org.junit.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.test.context.TestPropertySource;
 
-@TestPropertySource(properties = {OperateProperties.PREFIX + ".importerEnabled = false"})
 public class OnlyWebappIT extends ModuleAbstractIT {
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
@@ -37,6 +37,8 @@ import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchRequest.Builder;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
 /**
@@ -68,6 +70,11 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
   @Autowired private RichOpenSearchClient osClient;
   private final ProtocolFactory factory = new ProtocolFactory();
   private int emptyBatches;
+
+  @DynamicPropertySource
+  static void setProperties(final DynamicPropertyRegistry registry) {
+    registry.add("camunda.operate.importer-enabled", () -> true);
+  }
 
   @Before
   public void beforeEach() {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchOperateZeebeRuleProvider.java
@@ -53,8 +53,8 @@ public class ElasticsearchOperateZeebeRuleProvider implements OperateZeebeRulePr
   @Autowired public OperateProperties operateProperties;
 
   @Autowired
-  @Qualifier("zeebeEsClient")
-  protected RestHighLevelClient zeebeEsClient;
+  @Qualifier("esClient")
+  protected RestHighLevelClient esClient;
 
   protected ZeebeContainer zeebeContainer;
   @Autowired private SecurityConfiguration securityConfiguration;
@@ -80,7 +80,7 @@ public class ElasticsearchOperateZeebeRuleProvider implements OperateZeebeRulePr
     try {
       final GetComponentTemplatesRequest getRequest = new GetComponentTemplatesRequest(prefix);
       final GetComponentTemplatesResponse response =
-          zeebeEsClient.cluster().getComponentTemplate(getRequest, RequestOptions.DEFAULT);
+          esClient.cluster().getComponentTemplate(getRequest, RequestOptions.DEFAULT);
       final ComponentTemplate componentTemplate = response.getComponentTemplates().get(prefix);
       final Settings settings = componentTemplate.template().settings();
 
@@ -92,7 +92,7 @@ public class ElasticsearchOperateZeebeRuleProvider implements OperateZeebeRulePr
       final ComponentTemplate newComponentTemplate = new ComponentTemplate(newTemplate, null, null);
       request.componentTemplate(newComponentTemplate);
       assertThat(
-              zeebeEsClient
+              esClient
                   .cluster()
                   .putComponentTemplate(request, RequestOptions.DEFAULT)
                   .isAcknowledged())
@@ -108,7 +108,7 @@ public class ElasticsearchOperateZeebeRuleProvider implements OperateZeebeRulePr
       final String date =
           DateTimeFormatter.ofPattern(YYYY_MM_DD).withZone(ZoneId.systemDefault()).format(instant);
       final RefreshRequest refreshRequest = new RefreshRequest(prefix + "*" + date);
-      zeebeEsClient.indices().refresh(refreshRequest, RequestOptions.DEFAULT);
+      esClient.indices().refresh(refreshRequest, RequestOptions.DEFAULT);
     } catch (final IOException ex) {
       throw new RuntimeException(ex);
     }
@@ -122,7 +122,7 @@ public class ElasticsearchOperateZeebeRuleProvider implements OperateZeebeRulePr
       client = null;
     }
     if (!failed) {
-      TestUtil.removeAllIndices(zeebeEsClient, prefix);
+      TestUtil.removeAllIndices(esClient, prefix);
     }
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchTestRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchTestRuleProvider.java
@@ -86,10 +86,6 @@ public class ElasticsearchTestRuleProvider implements SearchTestRuleProvider {
 
   @Autowired protected RestHighLevelClient esClient;
 
-  @Autowired
-  @Qualifier("zeebeEsClient")
-  protected RestHighLevelClient zeebeEsClient;
-
   @Autowired protected OperateProperties operateProperties;
   @Autowired protected RecordsReaderHolder recordsReaderHolder;
   protected boolean failed = false;
@@ -169,7 +165,7 @@ public class ElasticsearchTestRuleProvider implements SearchTestRuleProvider {
     try {
       final RefreshRequest refreshRequest =
           new RefreshRequest(operateProperties.getZeebeElasticsearch().getPrefix() + "*");
-      zeebeEsClient.indices().refresh(refreshRequest, RequestOptions.DEFAULT);
+      esClient.indices().refresh(refreshRequest, RequestOptions.DEFAULT);
     } catch (final Exception t) {
       LOGGER.error("Could not refresh Zeebe Elasticsearch indices", t);
     }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
@@ -19,7 +19,7 @@ import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.qa.util.ContainerVersionsUtil;
 import io.camunda.operate.qa.util.TestContainerUtil;
-import io.camunda.operate.store.opensearch.client.sync.ZeebeRichOpenSearchClient;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.zeebe.containers.ZeebeContainer;
@@ -47,7 +47,7 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
       LoggerFactory.getLogger(OpensearchOperateZeebeRuleProvider.class);
   @Autowired public OperateProperties operateProperties;
   @Autowired public SearchEngineConfiguration searchEngineConfiguration;
-  @Autowired protected ZeebeRichOpenSearchClient zeebeRichOpenSearchClient;
+  @Autowired protected RichOpenSearchClient richOpenSearchClient;
   protected ZeebeContainer zeebeContainer;
   @Autowired private SecurityConfiguration securityConfiguration;
   @Autowired private TestContainerUtil testContainerUtil;
@@ -71,7 +71,7 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
   @Override
   public void updateRefreshInterval(final String value) {
     final ComponentTemplateSummary template =
-        zeebeRichOpenSearchClient.template().getComponentTemplate().get(prefix).template();
+        richOpenSearchClient.template().getComponentTemplate().get(prefix).template();
     final IndexSettings indexSettings = template.settings().get("index");
     final IndexSettings newSettings =
         IndexSettings.of(b -> b.index(indexSettings).refreshInterval(ri -> ri.time(value)));
@@ -79,7 +79,7 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
         IndexState.of(t -> t.settings(newSettings).mappings(template.mappings()));
     final var requestBuilder = componentTemplateRequestBuilder(prefix).template(newTemplate);
     assertThat(
-            zeebeRichOpenSearchClient
+            richOpenSearchClient
                 .template()
                 .createComponentTemplateWithRetries(requestBuilder.build()))
         .isTrue();
@@ -89,7 +89,7 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
   public void refreshIndices(final Instant instant) {
     final String date =
         DateTimeFormatter.ofPattern(YYYY_MM_DD).withZone(ZoneId.systemDefault()).format(instant);
-    zeebeRichOpenSearchClient.index().refresh(prefix + "*" + date);
+    richOpenSearchClient.index().refresh(prefix + "*" + date);
   }
 
   @Override
@@ -101,7 +101,7 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
     }
     if (!failed) {
       TestUtil.removeAllIndices(
-          zeebeRichOpenSearchClient.index(), zeebeRichOpenSearchClient.template(), prefix);
+          richOpenSearchClient.index(), richOpenSearchClient.template(), prefix);
     }
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchTestRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchTestRuleProvider.java
@@ -53,7 +53,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.junit.runner.Description;
-import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.ExpandWildcard;
 import org.opensearch.client.opensearch.indices.GetIndexResponse;
 import org.slf4j.Logger;
@@ -70,10 +69,6 @@ public class OpensearchTestRuleProvider implements SearchTestRuleProvider {
   protected static final Logger LOGGER = LoggerFactory.getLogger(OpensearchTestRuleProvider.class);
 
   @Autowired protected RichOpenSearchClient richOpenSearchClient;
-
-  @Autowired
-  @Qualifier("zeebeOpensearchClient")
-  protected OpenSearchClient zeebeOsClient;
 
   @Autowired protected OperateProperties operateProperties;
   @Autowired protected RecordsReaderHolder recordsReaderHolder;
@@ -152,9 +147,9 @@ public class OpensearchTestRuleProvider implements SearchTestRuleProvider {
   @Override
   public void refreshZeebeIndices() {
     try {
-      zeebeOsClient
-          .indices()
-          .refresh(r -> r.index(operateProperties.getZeebeOpensearch().getPrefix() + "*"));
+      richOpenSearchClient
+          .index()
+          .refresh(operateProperties.getZeebeOpensearch().getPrefix() + "*");
     } catch (final Exception t) {
       LOGGER.error("Could not refresh Zeebe Opensearch indices", t);
     }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/ElasticsearchZeebeManager.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/ElasticsearchZeebeManager.java
@@ -25,20 +25,20 @@ import org.springframework.stereotype.Component;
 public class ElasticsearchZeebeManager extends ZeebeContainerManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchZeebeManager.class);
 
-  private final RestHighLevelClient zeebeEsClient;
+  private final RestHighLevelClient esClient;
 
   public ElasticsearchZeebeManager(
       final OperateProperties operateProperties,
       final SecurityConfiguration securityConfiguration,
       final TestContainerUtil testContainerUtil,
-      @Qualifier("zeebeEsClient") final RestHighLevelClient zeebeEsClient,
+      @Qualifier("esClient") final RestHighLevelClient esClient,
       final IndexPrefixHolder indexPrefixHolder) {
     super(
         operateProperties,
         securityConfiguration,
         testContainerUtil,
         indexPrefixHolder.createNewIndexPrefix());
-    this.zeebeEsClient = zeebeEsClient;
+    this.esClient = esClient;
   }
 
   @Override
@@ -49,6 +49,6 @@ public class ElasticsearchZeebeManager extends ZeebeContainerManager {
 
   @Override
   protected void removeIndices() {
-    TestUtil.removeAllIndices(zeebeEsClient, prefix);
+    TestUtil.removeAllIndices(esClient, prefix);
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OpensearchZeebeContainerManager.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OpensearchZeebeContainerManager.java
@@ -10,7 +10,7 @@ package io.camunda.operate.util.j5templates;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.qa.util.TestContainerUtil;
-import io.camunda.operate.store.opensearch.client.sync.ZeebeRichOpenSearchClient;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.util.IndexPrefixHolder;
 import io.camunda.operate.util.TestUtil;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -25,20 +25,20 @@ public class OpensearchZeebeContainerManager extends ZeebeContainerManager {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(OpensearchZeebeContainerManager.class);
 
-  private final ZeebeRichOpenSearchClient zeebeRichOpenSearchClient;
+  private final RichOpenSearchClient richOpenSearchClient;
 
   public OpensearchZeebeContainerManager(
       final OperateProperties operateProperties,
       final SecurityConfiguration securityConfiguration,
       final TestContainerUtil testContainerUtil,
-      final ZeebeRichOpenSearchClient zeebeRichOpenSearchClient,
+      final RichOpenSearchClient richOpenSearchClient,
       final IndexPrefixHolder indexPrefixHolder) {
     super(
         operateProperties,
         securityConfiguration,
         testContainerUtil,
         indexPrefixHolder.createNewIndexPrefix());
-    this.zeebeRichOpenSearchClient = zeebeRichOpenSearchClient;
+    this.richOpenSearchClient = richOpenSearchClient;
   }
 
   @Override
@@ -50,6 +50,6 @@ public class OpensearchZeebeContainerManager extends ZeebeContainerManager {
   @Override
   protected void removeIndices() {
     TestUtil.removeAllIndices(
-        zeebeRichOpenSearchClient.index(), zeebeRichOpenSearchClient.template(), prefix);
+        richOpenSearchClient.index(), richOpenSearchClient.template(), prefix);
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OperateSearchAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OperateSearchAbstractIT.java
@@ -49,7 +49,6 @@ import org.springframework.test.web.servlet.MvcResult;
     },
     properties = {
       OperateProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
-      OperateProperties.PREFIX + ".archiver.rolloverEnabled = false",
       OperateProperties.PREFIX + ".zeebe.compatibility.enabled = true",
       "spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER",
       OperateProperties.PREFIX + ".multiTenancy.enabled = false",

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestElasticSearchRepository.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestElasticSearchRepository.java
@@ -67,22 +67,8 @@ public class TestElasticSearchRepository implements TestSearchRepository {
   @Autowired private RestHighLevelClient esClient;
 
   @Autowired
-  @Qualifier("zeebeEsClient")
-  private RestHighLevelClient zeebeEsClient;
-
-  @Autowired
   @Qualifier("operateObjectMapper")
   private ObjectMapper objectMapper;
-
-  @Override
-  public boolean isConnected() {
-    return esClient != null;
-  }
-
-  @Override
-  public boolean isZeebeConnected() {
-    return zeebeEsClient != null;
-  }
 
   @Override
   public boolean createIndex(final String indexName, final Map<String, ?> mapping)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestOpenSearchRepository.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestOpenSearchRepository.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
-import io.camunda.operate.store.opensearch.client.sync.ZeebeRichOpenSearchClient;
 import io.camunda.operate.store.opensearch.dsl.RequestDSL;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.VariableEntity;
@@ -57,19 +56,7 @@ import org.springframework.stereotype.Component;
 public class TestOpenSearchRepository implements TestSearchRepository {
   @Autowired private RichOpenSearchClient richOpenSearchClient;
 
-  @Autowired private ZeebeRichOpenSearchClient zeebeRichOpenSearchClient;
-
   @Autowired private ObjectMapper objectMapper;
-
-  @Override
-  public boolean isConnected() {
-    return richOpenSearchClient != null;
-  }
-
-  @Override
-  public boolean isZeebeConnected() {
-    return zeebeRichOpenSearchClient != null;
-  }
 
   @Override
   public boolean createIndex(final String indexName, final Map<String, ?> mapping)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestSearchRepository.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestSearchRepository.java
@@ -17,9 +17,6 @@ import java.util.Optional;
 import java.util.Set;
 
 public interface TestSearchRepository {
-  boolean isConnected();
-
-  boolean isZeebeConnected();
 
   boolean createIndex(String indexName, Map<String, ?> mapping) throws Exception;
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestZeebeElasticsearchRepository.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestZeebeElasticsearchRepository.java
@@ -34,13 +34,14 @@ import org.springframework.stereotype.Component;
 @Conditional(ElasticsearchCondition.class)
 public class TestZeebeElasticsearchRepository implements TestZeebeRepository {
   @Autowired
-  @Qualifier("zeebeEsClient")
-  protected RestHighLevelClient zeebeEsClient;
+  @Qualifier("esClient")
+  protected RestHighLevelClient esClient;
 
   @Autowired private ObjectMapper objectMapper;
 
   @Override
-  public <R> List<R> scrollTerm(String index, String field, long value, Class<R> clazz) {
+  public <R> List<R> scrollTerm(
+      final String index, final String field, final long value, final Class<R> clazz) {
     final List<R> result = new ArrayList<>();
 
     final SearchRequest request =
@@ -56,9 +57,9 @@ public class TestZeebeElasticsearchRepository implements TestZeebeRepository {
     final Consumer<SearchHits> hitsConsumer = hits -> result.addAll(hitsToListR.apply(hits));
 
     try {
-      scroll(request, hitsConsumer, zeebeEsClient);
+      scroll(request, hitsConsumer, esClient);
       return result;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new OperateRuntimeException(e);
     }
   }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestZeebeOpensearchRepository.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestZeebeOpensearchRepository.java
@@ -11,7 +11,7 @@ import static io.camunda.operate.store.opensearch.dsl.QueryDSL.term;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
 
 import io.camunda.operate.conditions.OpensearchCondition;
-import io.camunda.operate.store.opensearch.client.sync.ZeebeRichOpenSearchClient;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Conditional;
@@ -20,12 +20,13 @@ import org.springframework.stereotype.Component;
 @Component
 @Conditional(OpensearchCondition.class)
 public class TestZeebeOpensearchRepository implements TestZeebeRepository {
-  @Autowired protected ZeebeRichOpenSearchClient zeebeRichOpenSearchClient;
+  @Autowired protected RichOpenSearchClient richOpenSearchClient;
 
   @Override
-  public <R> List<R> scrollTerm(String index, String field, long value, Class<R> clazz) {
+  public <R> List<R> scrollTerm(
+      final String index, final String field, final long value, final Class<R> clazz) {
     final var requestBuilder = searchRequestBuilder(index).query(term(field, value));
 
-    return zeebeRichOpenSearchClient.doc().scrollValues(requestBuilder, clazz);
+    return richOpenSearchClient.doc().scrollValues(requestBuilder, clazz);
   }
 }

--- a/operate/schema/pom.xml
+++ b/operate/schema/pom.xml
@@ -53,6 +53,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>

--- a/operate/schema/src/main/java/io/camunda/operate/store/ProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/ProcessStore.java
@@ -59,6 +59,8 @@ public interface ProcessStore {
 
   long deleteProcessInstancesAndDependants(Set<Long> processInstanceKeys);
 
+  long count() throws IOException;
+
   class ProcessKey {
     private String bpmnProcessId;
     private String tenantId;

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
@@ -67,6 +67,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.IdsQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -678,6 +679,13 @@ public class ElasticsearchProcessStore implements ProcessStore {
     }
 
     return count;
+  }
+
+  @Override
+  public long count() throws IOException {
+    return esClient
+        .count(new CountRequest(processIndex.getAlias()), RequestOptions.DEFAULT)
+        .getCount();
   }
 
   private QueryBuilder buildQuery(final String tenantId, final Set<String> allowedBPMNProcessIds) {

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchZeebeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchZeebeStore.java
@@ -21,11 +21,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 @Conditional(ElasticsearchCondition.class)
 @Component
+@ConditionalOnProperty(value = "camunda.operate.importer-enabled", havingValue = "true")
 public class ElasticsearchZeebeStore implements ZeebeStore {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ZeebeStore.class);

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
@@ -46,6 +46,7 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.aggregations.FiltersBucket;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.slf4j.Logger;
@@ -470,6 +471,13 @@ public class OpensearchProcessStore implements ProcessStore {
                 listViewTemplate.getAlias(),
                 longTerms(ListViewTemplate.PROCESS_INSTANCE_KEY, processInstanceKeys));
     return count;
+  }
+
+  @Override
+  public long count() {
+    return richOpenSearchClient
+        .doc()
+        .docCount(new SearchRequest.Builder().index(processIndex.getAlias()));
   }
 
   private Query withTenantIdQuery(@Nullable final String tenantId, @Nullable final Query query) {

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchZeebeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchZeebeStore.java
@@ -16,11 +16,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
 @Component
+@ConditionalOnProperty(value = "camunda.operate.importer-enabled", havingValue = "true")
 public class OpensearchZeebeStore implements ZeebeStore {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchZeebeStore.class);

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/ZeebeRichOpenSearchClient.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/ZeebeRichOpenSearchClient.java
@@ -13,11 +13,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
 @Component
+@ConditionalOnProperty(name = "camunda.operate.importer-enabled", havingValue = "true")
 public class ZeebeRichOpenSearchClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(ZeebeRichOpenSearchClient.class);
   BeanFactory beanFactory;

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -181,10 +181,6 @@
       <artifactId>lucene-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>co.elastic.clients</groupId>
-      <artifactId>elasticsearch-java</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
     </dependency>

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
@@ -7,14 +7,8 @@
  */
 package io.camunda.operate.webapp;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import io.camunda.operate.conditions.DatabaseInfo;
-import io.camunda.operate.connect.ElasticsearchConnector;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.zeebe.operation.OperationExecutor;
 import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,17 +23,6 @@ public class StartupBean {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StartupBean.class);
 
-  @Autowired(required = false)
-  private RestHighLevelClient esClient;
-
-  @Autowired(required = false)
-  private RestHighLevelClient zeebeEsClient;
-
-  @Autowired(required = false)
-  private ElasticsearchClient elasticsearchClient;
-
-  @Autowired private OperateProperties operateProperties;
-
   @Autowired private OperationExecutor operationExecutor;
 
   @PostConstruct
@@ -47,14 +30,5 @@ public class StartupBean {
     LOGGER.info("INIT: Start operation executor...");
     operationExecutor.startExecuting();
     LOGGER.info("INIT: DONE");
-  }
-
-  @PreDestroy
-  public void shutdown() {
-    if (DatabaseInfo.isElasticsearch()) {
-      LOGGER.info("Shutdown elasticsearch clients.");
-      ElasticsearchConnector.closeEsClient(esClient);
-      ElasticsearchConnector.closeEsClient(zeebeEsClient);
-    }
   }
 }

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/CamundaMigrator.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/CamundaMigrator.java
@@ -148,6 +148,8 @@ public class CamundaMigrator extends ApiCallable implements AutoCloseable {
                   cfg.getExperimental().setVersionCheckRestrictionEnabled(false);
                   cfg.getGateway().setEnable(true);
                 })
+            .withProperty("camunda.operate.importer-enabled", "true")
+            .withProperty("camunda.tasklist.importer-enabled", "true")
             .withWorkingDirectory(zeebeDataPath.resolve("usr/local/zeebe"));
 
     if (profiles != null && profiles.length > 0) {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
@@ -72,6 +72,7 @@ import org.elasticsearch.client.RestHighLevelClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -161,6 +162,7 @@ public class ElasticsearchConnector {
   }
 
   @Bean(destroyMethod = "close")
+  @ConditionalOnProperty(value = "camunda.tasklist.importer-enabled", havingValue = "true")
   public RestHighLevelClient tasklistZeebeEsClient() {
     // some weird error when ELS sets available processors number for Netty - see
     // https://discuss.elastic.co/t/elasticsearch-5-4-1-availableprocessors-is-already-set/88036/3

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -66,6 +66,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -130,6 +131,7 @@ public class OpenSearchConnector {
   }
 
   @Bean
+  @ConditionalOnProperty(value = "camunda.tasklist.importer-enabled", havingValue = "true")
   public OpenSearchClient tasklistZeebeOsClient() {
     System.setProperty("es.set.netty.runtime.available.processors", "false");
     zeebeOsClientRepository.load(tasklistProperties.getZeebeOpenSearch().getInterceptorPlugins());

--- a/tasklist/data-generator/pom.xml
+++ b/tasklist/data-generator/pom.xml
@@ -21,7 +21,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>tasklist-els-schema</artifactId>
+      <artifactId>webapps-schema</artifactId>
     </dependency>
 
     <!-- SPRING -->
@@ -55,11 +55,6 @@
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-client</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch</artifactId>
     </dependency>
 
     <!-- OPENSEARCH -->

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/es/DevDataGeneratorElasticSearch.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/es/DevDataGeneratorElasticSearch.java
@@ -7,16 +7,14 @@
  */
 package io.camunda.tasklist.data.es;
 
-import static io.camunda.tasklist.util.ElasticsearchUtil.LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED;
-
 import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.data.DevDataGeneratorAbstract;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
-import io.camunda.tasklist.zeebe.ZeebeESConstants;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import java.io.IOException;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.indices.GetIndexRequest;
+import org.elasticsearch.client.core.CountRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,28 +36,25 @@ public class DevDataGeneratorElasticSearch extends DevDataGeneratorAbstract
   private static final Logger LOGGER = LoggerFactory.getLogger(DevDataGeneratorElasticSearch.class);
 
   @Autowired
-  @Qualifier("tasklistZeebeEsClient")
-  private RestHighLevelClient zeebeEsClient;
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient tasklistEsClient;
 
   @Override
   public boolean shouldCreateData() {
     try {
-      final GetIndexRequest request =
-          new GetIndexRequest(
-              tasklistProperties.getZeebeElasticsearch().getPrefix()
-                  + "*"
-                  + ZeebeESConstants.DEPLOYMENT
-                  + "*");
-      request.indicesOptions(LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED);
-      final boolean exists = zeebeEsClient.indices().exists(request, RequestOptions.DEFAULT);
+      final var request =
+          new CountRequest(
+              new ProcessIndex(tasklistProperties.getElasticsearch().getIndexPrefix(), true)
+                  .getFullQualifiedName());
+      final boolean exists = tasklistEsClient.count(request, RequestOptions.DEFAULT).getCount() > 0;
       if (exists) {
         // data already exists
-        LOGGER.debug("Data already exists in Zeebe.");
+        LOGGER.debug("Data already exists.");
         return false;
       }
     } catch (final IOException io) {
       LOGGER.debug(
-          "Error occurred while checking existence of data in Zeebe: {}. Demo data won't be created.",
+          "Error occurred while checking existence of data in ES: {}. Demo data won't be created.",
           io.getMessage());
       return false;
     }

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/os/DevDataGeneratorOpenSearch.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/os/DevDataGeneratorOpenSearch.java
@@ -10,9 +10,8 @@ package io.camunda.tasklist.data.os;
 import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.data.DevDataGeneratorAbstract;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
-import io.camunda.tasklist.zeebe.ZeebeESConstants;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import java.io.IOException;
-import java.util.List;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,27 +33,23 @@ public class DevDataGeneratorOpenSearch extends DevDataGeneratorAbstract impleme
   private static final Logger LOGGER = LoggerFactory.getLogger(DevDataGeneratorOpenSearch.class);
 
   @Autowired
-  @Qualifier("tasklistZeebeOsClient")
-  private OpenSearchClient zeebeOsClient;
+  @Qualifier("tasklistOsClient")
+  private OpenSearchClient tasklistOsClient;
 
   @Override
   public boolean shouldCreateData() {
     try {
 
       final boolean exists =
-          zeebeOsClient
-              .indices()
-              .exists(
-                  e ->
-                      e.index(
-                              List.of(
-                                  tasklistProperties.getZeebeOpenSearch().getPrefix()
-                                      + "*"
-                                      + ZeebeESConstants.DEPLOYMENT
-                                      + "*"))
-                          .allowNoIndices(false)
-                          .ignoreUnavailable(true))
-              .value();
+          tasklistOsClient
+                  .count(
+                      b ->
+                          b.index(
+                              new ProcessIndex(
+                                      tasklistProperties.getOpenSearch().getIndexPrefix(), false)
+                                  .getFullQualifiedName()))
+                  .count()
+              > 0;
 
       if (exists) {
         // data already exists
@@ -63,7 +58,7 @@ public class DevDataGeneratorOpenSearch extends DevDataGeneratorAbstract impleme
       }
     } catch (final IOException io) {
       LOGGER.debug(
-          "Error occurred while checking existence of data in Zeebe: {}. Demo data won't be created.",
+          "Error occurred while checking existence of data in OS: {}. Demo data won't be created.",
           io.getMessage());
       return false;
     }

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/ImportModuleConfiguration.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/ImportModuleConfiguration.java
@@ -25,10 +25,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
           pattern = "io\\.camunda\\.tasklist\\.zeebeimport\\.security\\..*")
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@ConditionalOnProperty(
-    name = "camunda.tasklist.importer-enabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnProperty(name = "camunda.tasklist.importer-enabled", havingValue = "true")
 public class ImportModuleConfiguration {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ImportModuleConfiguration.class);

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportPositionHolderOpenSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportPositionHolderOpenSearch.java
@@ -49,7 +49,7 @@ public class ImportPositionHolderOpenSearch extends ImportPositionHolderAbstract
 
   // this is the in-memory only storage
 
-  @Qualifier("tasklistZeebeOsClient")
+  @Qualifier("tasklistOsClient")
   @Autowired
   private OpenSearchClient osClient;
 

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/security/ImporterSecurityModuleConfiguration.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/security/ImporterSecurityModuleConfiguration.java
@@ -16,8 +16,5 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
 @ComponentScan(
     basePackages = "io.camunda.tasklist.zeebeimport.security",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@ConditionalOnProperty(
-    name = "camunda.tasklist.importer-enabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnProperty(name = "camunda.tasklist.importer-enabled", havingValue = "true")
 public class ImporterSecurityModuleConfiguration {}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorIT.java
@@ -50,7 +50,9 @@ import org.testcontainers.utility.DockerImageName;
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     },
-    properties = TasklistProperties.PREFIX + ".database=elasticsearch")
+    properties = {
+      TasklistProperties.PREFIX + ".importer-enabled=true",
+    })
 public class ElasticsearchConnectorIT {
 
   @Container

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
@@ -51,6 +51,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTest {
 
@@ -69,6 +71,11 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
   @BeforeAll
   public static void beforeClass() {
     assumeTrue(TestUtil.isElasticSearch());
+  }
+
+  @DynamicPropertySource
+  static void setProperties(final DynamicPropertyRegistry registry) {
+    registry.add("camunda.tasklist.importer-enabled", () -> true);
   }
 
   @BeforeEach

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorIT.java
@@ -36,7 +36,7 @@ import org.springframework.test.util.ReflectionTestUtils;
     classes = {TestApplication.class, UnifiedConfigurationHelper.class, UnifiedConfiguration.class},
     properties = {
       TasklistProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
-      TasklistProperties.PREFIX + ".archiver.rolloverEnabled = false",
+      TasklistProperties.PREFIX + ".importer-enabled = true",
       TasklistProperties.PREFIX + ".zeebe.gatewayAddress = localhost:55500",
       TasklistProperties.PREFIX + ".zeebe.compatibility.enabled = true"
     },

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/FullAppIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/FullAppIT.java
@@ -11,9 +11,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.tasklist.ImportModuleConfiguration;
 import io.camunda.tasklist.WebappModuleConfiguration;
+import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.controllers.TasklistIndexController;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
 
+@TestPropertySource(properties = {TasklistProperties.PREFIX + ".importer-enabled = true"})
 public class FullAppIT extends ModuleIntegrationTest {
 
   @Test

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModuleIntegrationTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModuleIntegrationTest.java
@@ -28,9 +28,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       SearchEngineConnectPropertiesOverride.class
     },
     properties = {
-      TasklistProperties.PREFIX + ".elasticsearch.createSchema = false",
       TasklistProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
-      TasklistProperties.PREFIX + ".archiver.rolloverEnabled = false",
       TasklistProperties.PREFIX + ".zeebe.compatibility.enabled = true"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/OnlyImportIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/OnlyImportIT.java
@@ -20,8 +20,8 @@ import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(
     properties = {
-      TasklistProperties.PREFIX + ".webappEnabled = false",
-      TasklistProperties.PREFIX + ".archiverEnabled = false"
+      TasklistProperties.PREFIX + ".importer-enabled = true",
+      TasklistProperties.PREFIX + ".webapp-enabled = false",
     })
 public class OnlyImportIT extends ModuleIntegrationTest {
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/OnlyWebappIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/OnlyWebappIT.java
@@ -12,17 +12,10 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 
 import io.camunda.tasklist.ImportModuleConfiguration;
 import io.camunda.tasklist.WebappModuleConfiguration;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.controllers.TasklistIndexController;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.test.context.TestPropertySource;
 
-@TestPropertySource(
-    properties = {
-      TasklistProperties.PREFIX + ".importerEnabled = false",
-      TasklistProperties.PREFIX + ".archiverEnabled = false",
-    })
 public class OnlyWebappIT extends ModuleIntegrationTest {
 
   @Test

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
@@ -44,7 +44,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
     },
     properties = {
       TasklistProperties.PREFIX + ".elasticsearch.createSchema = false",
-      TasklistProperties.PREFIX + ".zeebe.compatibility.enabled = true"
+      TasklistProperties.PREFIX + ".zeebe.compatibility.enabled = true",
+      TasklistProperties.PREFIX + ".importer-enabled=true",
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ContextConfiguration(initializers = {OpenSearchConnectorBasicAuthIT.OpenSearchStarter.class})

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
@@ -48,7 +48,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       UnifiedConfiguration.class,
       UnifiedConfigurationHelper.class
     },
-    properties = "camunda.data.secondary-storage.type=opensearch")
+    properties = {
+      "camunda.data.secondary-storage.type=opensearch",
+      "camunda.tasklist.importer-enabled=true",
+    })
 public class OpensearchConnectorIT {
 
   private static final OpensearchContainer<?> OPENSEARCH_CONTAINER =

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
@@ -51,6 +51,8 @@ import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.indices.RefreshRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest {
   private static final OpensearchExporter EXPORTER = new OpensearchExporter();
@@ -73,6 +75,11 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
   @BeforeAll
   public static void beforeClass() {
     assumeTrue(TestUtil.isOpenSearch());
+  }
+
+  @DynamicPropertySource
+  static void setProperties(final DynamicPropertyRegistry registry) {
+    registry.add("camunda.tasklist.importer-enabled", () -> true);
   }
 
   @BeforeEach

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
@@ -69,10 +69,6 @@ public class ElasticsearchTestExtension
   @Qualifier("tasklistEsClient")
   private RestHighLevelClient esClient;
 
-  @Autowired
-  @Qualifier("tasklistZeebeEsClient")
-  private RestHighLevelClient zeebeEsClient;
-
   @Autowired private TasklistProperties tasklistProperties;
   @Autowired private SearchEngineConfiguration searchEngineConfiguration;
   private boolean failed = false;
@@ -159,7 +155,7 @@ public class ElasticsearchTestExtension
     try {
       final RefreshRequest refreshRequest =
           new RefreshRequest(tasklistProperties.getZeebeElasticsearch().getPrefix() + "*");
-      zeebeEsClient.indices().refresh(refreshRequest, RequestOptions.DEFAULT);
+      esClient.indices().refresh(refreshRequest, RequestOptions.DEFAULT);
     } catch (final Exception t) {
       LOGGER.error("Could not refresh Zeebe Elasticsearch indices", t);
     }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
@@ -18,7 +18,6 @@ import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.qa.util.TasklistIndexPrefixHolder;
 import io.camunda.tasklist.qa.util.TestSchemaManager;
 import io.camunda.tasklist.qa.util.TestUtil;
-import io.camunda.tasklist.zeebeimport.RecordsReaderHolder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -58,13 +57,8 @@ public class OpenSearchTestExtension
   @Qualifier("tasklistOsClient")
   private OpenSearchClient osClient;
 
-  @Autowired
-  @Qualifier("tasklistZeebeOsClient")
-  private OpenSearchClient zeebeOsClient;
-
   @Autowired private TasklistProperties tasklistProperties;
   @Autowired private SearchEngineConfiguration searchEngineConfiguration;
-  @Autowired private RecordsReaderHolder recordsReaderHolder;
   private boolean failed = false;
   @Autowired private TestSchemaManager schemaManager;
 
@@ -151,7 +145,7 @@ public class OpenSearchTestExtension
   @Override
   public void refreshZeebeIndices() {
     try {
-      zeebeOsClient
+      osClient
           .indices()
           .refresh(
               r -> r.index(List.of(tasklistProperties.getZeebeOpenSearch().getPrefix() + "*")));

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistIntegrationTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistIntegrationTest.java
@@ -27,7 +27,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
     classes = {TestApplication.class},
     properties = {
       TasklistProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
-      TasklistProperties.PREFIX + ".archiver.rolloverEnabled = false",
       TasklistProperties.PREFIX + "importer.jobType = testJobType",
       "camunda.webapps.enabled = true",
       "camunda.webapps.default-app = tasklist",

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
@@ -16,15 +16,12 @@ import io.zeebe.containers.ZeebeContainer;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
-import org.opensearch.client.opensearch.OpenSearchClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,8 +36,6 @@ public abstract class TasklistZeebeExtension
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(15);
   private static final Logger LOGGER = LoggerFactory.getLogger(TasklistZeebeExtension.class);
 
-  private static ContainerPoolManager<ZeebeContainer> zeebeContainerContainerPoolManager;
-
   @Autowired protected TasklistProperties tasklistProperties;
   @Autowired protected SecurityConfiguration securityConfiguration;
   @Autowired protected TasklistIndexPrefixHolder indexPrefixHolder;
@@ -53,8 +48,6 @@ public abstract class TasklistZeebeExtension
   private Environment environment;
 
   private String prefix;
-
-  public abstract void refreshIndices(Instant instant);
 
   @Override
   public void beforeEach(final ExtensionContext extensionContext) {
@@ -169,10 +162,6 @@ public abstract class TasklistZeebeExtension
   public void setTasklistProperties(final TasklistProperties tasklistProperties) {
     this.tasklistProperties = tasklistProperties;
   }
-
-  public abstract void setZeebeOsClient(final OpenSearchClient zeebeOsClient);
-
-  public abstract void setZeebeEsClient(final RestHighLevelClient zeebeOsClient);
 
   protected abstract int getDatabasePort();
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
@@ -10,12 +10,7 @@ package io.camunda.tasklist.util;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
 import io.camunda.tasklist.qa.util.TestUtil;
-import java.io.IOException;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,25 +25,14 @@ import org.springframework.stereotype.Component;
 public class TasklistZeebeExtensionOpenSearch extends TasklistZeebeExtension {
 
   @Autowired
-  @Qualifier("tasklistZeebeOsClient")
-  private OpenSearchClient zeebeOsClient;
-
-  @Override
-  public void refreshIndices(final Instant instant) {
-    try {
-      final String date =
-          DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneId.systemDefault()).format(instant);
-      zeebeOsClient.indices().refresh(r -> r.index(getPrefix() + "*" + date));
-    } catch (final IOException ex) {
-      throw new RuntimeException(ex);
-    }
-  }
+  @Qualifier("tasklistOsClient")
+  private OpenSearchClient osClient;
 
   @Override
   public void afterEach(final ExtensionContext extensionContext) {
     super.afterEach(extensionContext);
     if (!failed) {
-      TestUtil.removeAllIndices(zeebeOsClient, getPrefix());
+      TestUtil.removeAllIndices(osClient, getPrefix());
     }
   }
 
@@ -89,14 +73,6 @@ public class TasklistZeebeExtensionOpenSearch extends TasklistZeebeExtension {
         // ---
         Map.entry("CAMUNDA_DATABASE_INDEXPREFIX", indexPrefix));
   }
-
-  @Override
-  public void setZeebeOsClient(final OpenSearchClient zeebeOsClient) {
-    this.zeebeOsClient = zeebeOsClient;
-  }
-
-  @Override
-  public void setZeebeEsClient(final RestHighLevelClient zeebeEsClient) {}
 
   @Override
   protected int getDatabasePort() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
SM Greenfield deployments do not need to bother configuring the elasticsearch zeebe client, neither having the importer run by default
The importers will be enabled in SaaS and for SM brownfield deployments using a dedicated helm value
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38342 
