### PR TITLE
deps: Update swagger-parser to 2.1.22

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -140,7 +140,7 @@
     <version.jackson-annotations>2.19.2</version.jackson-annotations>
     <version.json-path>2.9.0</version.json-path>
     <version.swagger-annotations>2.2.34</version.swagger-annotations>
-    <version.swagger-parser>2.1.16</version.swagger-parser>
+    <version.swagger-parser>2.1.22</version.swagger-parser>
     <version.checker-qual>3.49.5</version.checker-qual>
     <version.java-jwt>4.5.0</version.java-jwt>
     <version.reactive-streams>1.0.4</version.reactive-streams>


### PR DESCRIPTION
## Description

When running Swagger UI locally (through Standalone Camunda), the Orchestration Cluster API works fine but Operate-v1 and Tasklist-v1 breaks wit ha 400 error. This only affects local dev setup (it works fine in SaaS, Helm, C8Run). 

The issue is that our `swagger-parser` is not compatible with `swagger-annotations 2.2.34`. Upgrading the parser dep solves the issue.

https://github.com/user-attachments/assets/f99d4dd9-1277-48e4-9f1f-8d50611335b1

## Related issues

closes #38114 #38320
