### PR TITLE
refactor: add more info to API header

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/OpenApiResourceConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/OpenApiResourceConfig.java
@@ -11,7 +11,9 @@ import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.gateway.rest.util.OpenApiYamlLoader;
 import io.camunda.zeebe.gateway.rest.util.OpenApiYamlLoader.OpenApiLoadingException;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springdoc.core.models.GroupedOpenApi;
@@ -48,8 +50,17 @@ public class OpenApiResourceConfig {
     // Load base OpenAPI specification from YAML
     loadBaseOpenApiSpec(openApi);
 
-    // Set API description and configure security based on deployment type
-    openApi.info(new Info().description(openApiConfigurer.getApiDescription()));
+    // Set API info and configure security based on deployment type
+    openApi.info(
+        new Info()
+            .title("Orchestration Cluster API")
+            .version("v2")
+            .contact(new Contact().url("https://www.camunda.com"))
+            .license(
+                new License()
+                    .name("License")
+                    .url("https://docs.camunda.io/docs/reference/licenses/"))
+            .description(openApiConfigurer.getApiDescription()));
     openApiConfigurer.configureSecurity(openApi);
   }
 


### PR DESCRIPTION
## Description

I'm adding title, contact and license to the API info for the v2 API for consistency with the v1 APIs. This doesn't affect the current behavior, just a nicer UI display 🙂 

https://github.com/user-attachments/assets/d98afd76-f101-4795-950b-006e622eaab6

