### PR TITLE
fix: use LAX concurrency policy to mitigate stackoverflow in client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
@@ -61,6 +61,7 @@ import org.apache.hc.core5.http.config.CharCodingConfig;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.net.URIBuilder;
+import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
@@ -134,7 +135,10 @@ public class HttpClientFactory {
             .setHostnameVerifier(hostnameVerifier)
             .build();
     final PoolingAsyncClientConnectionManager connectionManager =
-        PoolingAsyncClientConnectionManagerBuilder.create().setTlsStrategy(tlsStrategy).build();
+        PoolingAsyncClientConnectionManagerBuilder.create()
+            .setTlsStrategy(tlsStrategy)
+            .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.LAX)
+            .build();
 
     final HttpAsyncClientBuilder builder =
         HttpAsyncClients.custom()


### PR DESCRIPTION
## Description

Using the `STRICT` policy caused sometimes a stackoverflow error in our benchmark clusters bringing the cluster to stop working. While the root cause wasn't reproducible via unit tests, the `LAX` configuration showed more stable benchmarks.

We might follow up investigating further, but this change will already bring more stability to the REST usage in 8.8.

See see original issue for more [details](https://github.com/camunda/camunda/issues/34597#issuecomment-3301797932) about the root cause / investigation / etc.

## Related issues

closes #34597 
