### PR TITLE
[Backport stable/8.8] fix: use LAX concurrency policy to mitigate stackoverflow in client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
@@ -61,6 +61,7 @@ import org.apache.hc.core5.http.config.CharCodingConfig;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.net.URIBuilder;
+import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
@@ -134,7 +135,10 @@ public class HttpClientFactory {
             .setHostnameVerifier(hostnameVerifier)
             .build();
     final PoolingAsyncClientConnectionManager connectionManager =
-        PoolingAsyncClientConnectionManagerBuilder.create().setTlsStrategy(tlsStrategy).build();
+        PoolingAsyncClientConnectionManagerBuilder.create()
+            .setTlsStrategy(tlsStrategy)
+            .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.LAX)
+            .build();
 
     final HttpAsyncClientBuilder builder =
         HttpAsyncClients.custom()


### PR DESCRIPTION
# Description
Backport of #38402 to `stable/8.8`.

relates to #34597