### PR TITLE
[Backport stable/8.8] fix: use new orchestration value

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -256,6 +256,10 @@ jobs:
           --reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set camunda-platform.orchestration.image.registry=gcr.io
+          --set camunda-platform.orchestration.image.repository=zeebe-io/zeebe
+          --set camunda-platform.orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          # Keep this for compatibility with older versions of the benchmark chart
           --set camunda-platform.core.image.registry=gcr.io
           --set camunda-platform.core.image.repository=zeebe-io/zeebe
           --set camunda-platform.core.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}


### PR DESCRIPTION
# Description
Backport of #38398 to `stable/8.8`.

relates to 