### PR TITLE
fix: map correctly operation in pendingOperations.completedChange

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -410,8 +410,7 @@ final class ClusterApiUtils {
     return completedOperations.stream().map(ClusterApiUtils::mapCompletedOperation).toList();
   }
 
-  private static TopologyChangeCompletedInner mapCompletedOperation(
-      final CompletedOperation operation) {
+  static TopologyChangeCompletedInner mapCompletedOperation(final CompletedOperation operation) {
     final var mappedOperation =
         switch (operation.operation()) {
           case final MemberJoinOperation join ->
@@ -473,6 +472,31 @@ final class ClusterApiUtils {
                   .brokerId(Integer.parseInt(deleteExporterOperation.memberId().id()))
                   .partitionId(deleteExporterOperation.partitionId())
                   .exporterId(deleteExporterOperation.exporterId());
+          case final StartPartitionScaleUp startScaleUp ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.START_PARTITION_SCALE_UP)
+                  .brokerId(Integer.parseInt(startScaleUp.memberId().id()));
+          case final PartitionBootstrapOperation bootstrapOperation ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_BOOTSTRAP)
+                  .brokerId(Integer.parseInt(bootstrapOperation.memberId().id()))
+                  .partitionId(bootstrapOperation.partitionId())
+                  .priority(bootstrapOperation.priority());
+          case final DeleteHistoryOperation deleteHistoryOperation ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.DELETE_HISTORY);
+          case final AwaitRedistributionCompletion redistributionCompletion ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.AWAIT_REDISTRIBUTION)
+                  .brokerId(Integer.parseInt(redistributionCompletion.memberId().id()));
+          case final AwaitRelocationCompletion relocationCompletion ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.AWAIT_RELOCATION)
+                  .brokerId(Integer.parseInt(relocationCompletion.memberId().id()));
+          case final UpdateRoutingState updateRoutingState ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.UPDATE_ROUTING_STATE)
+                  .brokerId(Integer.parseInt(updateRoutingState.memberId().id()));
           default ->
               new TopologyChangeCompletedInner()
                   .operation(TopologyChangeCompletedInner.OperationEnum.UNKNOWN);

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.shared.management;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.DeleteHistoryOperation;
@@ -38,6 +39,8 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.management.cluster.ExporterStatus;
 import io.camunda.zeebe.management.cluster.ExporterStatus.StatusEnum;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
+import io.camunda.zeebe.management.cluster.TopologyChangeCompletedInner;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -73,6 +76,19 @@ final class ClusterApiUtilsTest {
     assertThat(encoded).isNotNull();
     assertThat(encoded.getOperation()).isNotEqualTo(OperationEnum.UNKNOWN);
     assertThat(OperationEnum.values())
+        .as("Operation " + operation + "is not mapped correctly")
+        .contains(encoded.getOperation());
+  }
+
+  @ParameterizedTest
+  @MethodSource("generateAllClusterConfigurationChangeOperationsAsArguments")
+  void shouldMapClusterCompletedOperation(final ClusterConfigurationChangeOperation operation) {
+    final var encoded =
+        ClusterApiUtils.mapCompletedOperation(
+            new CompletedOperation(operation, Instant.ofEpochSecond(17172371723L)));
+    assertThat(encoded).isNotNull();
+    assertThat(encoded.getOperation()).isNotEqualTo(OperationEnum.UNKNOWN);
+    assertThat(TopologyChangeCompletedInner.OperationEnum.values())
         .as("Operation " + operation + "is not mapped correctly")
         .contains(encoded.getOperation());
   }


### PR DESCRIPTION
## Description
The completedChange was mapped through another method, which was not updated.
Notably, OpenAPI generator generates two different enums for the same underlying OpenAPI enum `Operation`.

## Related issues

closes #37492
