### PR TITLE
refactor: use OffsetDateTime for date-time response fields in Camunda client

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/parameter/CompatActivatedJobParameterResolver.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/parameter/CompatActivatedJobParameterResolver.java
@@ -18,8 +18,10 @@ package io.camunda.client.jobhandling.parameter;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.response.UserTaskProperties;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class CompatActivatedJobParameterResolver implements ParameterResolver {
 
@@ -150,12 +152,16 @@ public class CompatActivatedJobParameterResolver implements ParameterResolver {
 
         @Override
         public String getDueDate() {
-          return job.getUserTask().getDueDate();
+          return Optional.ofNullable(job.getUserTask().getDueDate())
+              .map(OffsetDateTime::toString)
+              .orElse(null);
         }
 
         @Override
         public String getFollowUpDate() {
-          return job.getUserTask().getFollowUpDate();
+          return Optional.ofNullable(job.getUserTask().getFollowUpDate())
+              .map(OffsetDateTime::toString)
+              .orElse(null);
         }
 
         @Override

--- a/clients/java/src/main/java/io/camunda/client/api/response/UserTaskProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UserTaskProperties.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.response;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 /** Represents the properties of a user task associated with a job. */
@@ -48,12 +49,12 @@ public interface UserTaskProperties {
   /**
    * @return the due date of the user task in ISO 8601 format.
    */
-  String getDueDate();
+  OffsetDateTime getDueDate();
 
   /**
    * @return the follow-up date of the user task in ISO 8601 format.
    */
-  String getFollowUpDate();
+  OffsetDateTime getFollowUpDate();
 
   /**
    * @return the key of the form associated with the user task.

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperation.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperation.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.search.response;
 
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface BatchOperation {
@@ -30,9 +31,9 @@ public interface BatchOperation {
 
   BatchOperationType getType();
 
-  String getStartDate();
+  OffsetDateTime getStartDate();
 
-  String getEndDate();
+  OffsetDateTime getEndDate();
 
   Integer getOperationsTotalCount();
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperationItems.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperationItems.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.search.response;
 
 import io.camunda.client.api.search.enums.BatchOperationItemState;
 import io.camunda.client.api.search.enums.BatchOperationType;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface BatchOperationItems {
@@ -32,7 +33,7 @@ public interface BatchOperationItems {
 
     Long getProcessInstanceKey();
 
-    String getProcessedDate();
+    OffsetDateTime getProcessedDate();
 
     String getErrorMessage();
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/CorrelatedMessageSubscription.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/CorrelatedMessageSubscription.java
@@ -15,11 +15,13 @@
  */
 package io.camunda.client.api.search.response;
 
+import java.time.OffsetDateTime;
+
 public interface CorrelatedMessageSubscription {
 
   String getCorrelationKey();
 
-  String getCorrelationTime();
+  OffsetDateTime getCorrelationTime();
 
   String getElementId();
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionInstance.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionInstance.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.search.response;
 
 import io.camunda.client.api.response.EvaluatedDecisionInput;
 import io.camunda.client.api.response.MatchedDecisionRule;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface DecisionInstance {
@@ -39,7 +40,7 @@ public interface DecisionInstance {
   /**
    * @return the evaluation date of the decision instance
    */
-  String getEvaluationDate();
+  OffsetDateTime getEvaluationDate();
 
   /**
    * @return the evaluation failure of the decision instance

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ElementInstance.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ElementInstance.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.search.response;
 
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.enums.ElementInstanceType;
+import java.time.OffsetDateTime;
 
 public interface ElementInstance {
 
@@ -39,10 +40,10 @@ public interface ElementInstance {
   String getElementName();
 
   /** start date of element instance */
-  String getStartDate();
+  OffsetDateTime getStartDate();
 
   /** end date of element instance */
-  String getEndDate();
+  OffsetDateTime getEndDate();
 
   /** whether element instance has an incident */
   Boolean getIncident();

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Incident.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Incident.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.search.response;
 
 import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.IncidentState;
+import java.time.OffsetDateTime;
 
 public interface Incident {
 
@@ -36,7 +37,7 @@ public interface Incident {
 
   Long getElementInstanceKey();
 
-  String getCreationTime();
+  OffsetDateTime getCreationTime();
 
   IncidentState getState();
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Job.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Job.java
@@ -18,6 +18,7 @@ package io.camunda.client.api.search.response;
 import io.camunda.client.api.search.enums.JobKind;
 import io.camunda.client.api.search.enums.JobState;
 import io.camunda.client.api.search.enums.ListenerEventType;
+import java.time.OffsetDateTime;
 import java.util.Map;
 
 public interface Job {
@@ -48,9 +49,9 @@ public interface Job {
 
   Map<String, String> getCustomerHeaders();
 
-  String getDeadline();
+  OffsetDateTime getDeadline();
 
-  String getEndTime();
+  OffsetDateTime getEndTime();
 
   String getProcessDefinitionId();
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/MessageSubscription.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/MessageSubscription.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.search.response;
 
 import io.camunda.client.api.search.enums.MessageSubscriptionState;
+import java.time.OffsetDateTime;
 
 public interface MessageSubscription {
 
@@ -33,7 +34,7 @@ public interface MessageSubscription {
 
   MessageSubscriptionState getMessageSubscriptionState();
 
-  String getLastUpdatedDate();
+  OffsetDateTime getLastUpdatedDate();
 
   String getMessageName();
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Operation.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Operation.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.client.api.search.response;
 
+import java.time.OffsetDateTime;
+
 public interface Operation {
 
   String getId();
@@ -27,5 +29,5 @@ public interface Operation {
 
   String getErrorMessage();
 
-  String getCompletedDate();
+  OffsetDateTime getCompletedDate();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstance.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstance.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.search.response;
 
 import io.camunda.client.api.search.enums.ProcessInstanceState;
+import java.time.OffsetDateTime;
 import java.util.Set;
 
 public interface ProcessInstance {
@@ -36,9 +37,9 @@ public interface ProcessInstance {
 
   Long getParentElementInstanceKey();
 
-  String getStartDate();
+  OffsetDateTime getStartDate();
 
-  String getEndDate();
+  OffsetDateTime getEndDate();
 
   ProcessInstanceState getState();
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/UserTask.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/UserTask.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.search.response;
 
 import io.camunda.client.api.search.enums.UserTaskState;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -57,16 +58,16 @@ public interface UserTask {
   Long getFormKey();
 
   /** Creation date of the task */
-  String getCreationDate();
+  OffsetDateTime getCreationDate();
 
   /** Completion date of the task */
-  String getCompletionDate();
+  OffsetDateTime getCompletionDate();
 
   /** Follow-up date of the task */
-  String getFollowUpDate();
+  OffsetDateTime getFollowUpDate();
 
   /** Due date of the task */
-  String getDueDate();
+  OffsetDateTime getDueDate();
 
   /** Tenant identifiers */
   String getTenantId();

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DocumentMetadataImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DocumentMetadataImpl.java
@@ -35,16 +35,7 @@ public class DocumentMetadataImpl implements DocumentMetadata {
 
   @Override
   public OffsetDateTime getExpiresAt() {
-    final String expiresAt = response.getExpiresAt();
-    if (expiresAt == null) {
-      return null;
-    }
-    try {
-      return OffsetDateTime.parse(expiresAt);
-    } catch (final Exception e) {
-      throw new IllegalArgumentException(
-          "Failed to parse expiresAt date: " + response.getExpiresAt(), e);
-    }
+    return ParseUtil.parseOffsetDateTimeOrNull(response.getExpiresAt());
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UserTaskPropertiesImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UserTaskPropertiesImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.response;
 import io.camunda.client.api.response.UserTaskProperties;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -29,8 +30,8 @@ public final class UserTaskPropertiesImpl implements UserTaskProperties {
   private final List<String> candidateGroups;
   private final List<String> candidateUsers;
   private final List<String> changedAttributes;
-  private final String dueDate;
-  private final String followUpDate;
+  private final OffsetDateTime dueDate;
+  private final OffsetDateTime followUpDate;
   private final Long formKey;
   private final Integer priority;
   private final Long userTaskKey;
@@ -41,8 +42,12 @@ public final class UserTaskPropertiesImpl implements UserTaskProperties {
     candidateGroups = props.getCandidateGroupsList();
     candidateUsers = props.getCandidateUsersList();
     changedAttributes = props.getChangedAttributesList();
-    dueDate = orNull(props::hasDueDate, props::getDueDate);
-    followUpDate = orNull(props::hasFollowUpDate, props::getFollowUpDate);
+    dueDate =
+        orNull(props::hasDueDate, () -> ParseUtil.parseOffsetDateTimeOrNull(props.getDueDate()));
+    followUpDate =
+        orNull(
+            props::hasFollowUpDate,
+            () -> ParseUtil.parseOffsetDateTimeOrNull(props.getFollowUpDate()));
     formKey = orNull(props::hasFormKey, props::getFormKey);
     priority = orNull(props::hasPriority, props::getPriority);
     userTaskKey = orNull(props::hasUserTaskKey, props::getUserTaskKey);
@@ -54,8 +59,8 @@ public final class UserTaskPropertiesImpl implements UserTaskProperties {
     candidateGroups = props.getCandidateGroups();
     candidateUsers = props.getCandidateUsers();
     changedAttributes = props.getChangedAttributes();
-    dueDate = props.getDueDate();
-    followUpDate = props.getFollowUpDate();
+    dueDate = ParseUtil.parseOffsetDateTimeOrNull(props.getDueDate());
+    followUpDate = ParseUtil.parseOffsetDateTimeOrNull(props.getFollowUpDate());
     formKey = ParseUtil.parseLongOrNull(props.getFormKey());
     priority = props.getPriority();
     userTaskKey = ParseUtil.parseLongOrNull(props.getUserTaskKey());
@@ -87,12 +92,12 @@ public final class UserTaskPropertiesImpl implements UserTaskProperties {
   }
 
   @Override
-  public String getDueDate() {
+  public OffsetDateTime getDueDate() {
     return dueDate;
   }
 
   @Override
-  public String getFollowUpDate() {
+  public OffsetDateTime getFollowUpDate() {
     return followUpDate;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
@@ -20,8 +20,10 @@ import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.response.BatchOperation;
 import io.camunda.client.api.search.response.BatchOperationError;
 import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.client.protocol.rest.BatchOperationResponse;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,8 +33,8 @@ public class BatchOperationImpl implements BatchOperation {
   private final String batchOperationKey;
   private final BatchOperationType type;
   private final BatchOperationState status;
-  private final String startDate;
-  private final String endDate;
+  private final OffsetDateTime startDate;
+  private final OffsetDateTime endDate;
   private final Integer operationsTotalCount;
   private final Integer operationsFailedCount;
   private final Integer operationsCompletedCount;
@@ -54,8 +56,8 @@ public class BatchOperationImpl implements BatchOperation {
     batchOperationKey = item.getBatchOperationKey();
     type = EnumUtil.convert(item.getBatchOperationType(), BatchOperationType.class);
     status = item.getState() != null ? BatchOperationState.valueOf(item.getState().name()) : null;
-    startDate = item.getStartDate();
-    endDate = item.getEndDate();
+    startDate = ParseUtil.parseOffsetDateTimeOrNull(item.getStartDate());
+    endDate = ParseUtil.parseOffsetDateTimeOrNull(item.getEndDate());
     operationsTotalCount = item.getOperationsTotalCount();
     operationsFailedCount = item.getOperationsFailedCount();
     operationsCompletedCount = item.getOperationsCompletedCount();
@@ -82,12 +84,12 @@ public class BatchOperationImpl implements BatchOperation {
   }
 
   @Override
-  public String getStartDate() {
+  public OffsetDateTime getStartDate() {
     return startDate;
   }
 
   @Override
-  public String getEndDate() {
+  public OffsetDateTime getEndDate() {
     return endDate;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationItemsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationItemsImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.BatchOperationItemResponse;
 import io.camunda.client.protocol.rest.BatchOperationItemSearchQueryResult;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,7 +49,7 @@ public class BatchOperationItemsImpl implements BatchOperationItems {
     private final Long itemKey;
     private final Long processInstanceKey;
     private final BatchOperationItemState status;
-    private final String processedDate;
+    private final OffsetDateTime processedDate;
     private final String errorMessage;
 
     public BatchOperationItemImpl(final BatchOperationItemResponse item) {
@@ -57,7 +58,7 @@ public class BatchOperationItemsImpl implements BatchOperationItems {
       itemKey = ParseUtil.parseLongOrNull(item.getItemKey());
       processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
       status = EnumUtil.convert(item.getState(), BatchOperationItemState.class);
-      processedDate = item.getProcessedDate();
+      processedDate = ParseUtil.parseOffsetDateTimeOrNull(item.getProcessedDate());
       errorMessage = item.getErrorMessage();
     }
 
@@ -82,7 +83,7 @@ public class BatchOperationItemsImpl implements BatchOperationItems {
     }
 
     @Override
-    public String getProcessedDate() {
+    public OffsetDateTime getProcessedDate() {
       return processedDate;
     }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/CorrelatedMessageSubscriptionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/CorrelatedMessageSubscriptionImpl.java
@@ -18,12 +18,13 @@ package io.camunda.client.impl.search.response;
 import io.camunda.client.api.search.response.CorrelatedMessageSubscription;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.CorrelatedMessageSubscriptionResult;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 
 public class CorrelatedMessageSubscriptionImpl implements CorrelatedMessageSubscription {
 
   private final String correlationKey;
-  private final String correlationTime;
+  private final OffsetDateTime correlationTime;
   private final String elementId;
   private final Long elementInstanceKey;
   private final Long messageKey;
@@ -37,7 +38,7 @@ public class CorrelatedMessageSubscriptionImpl implements CorrelatedMessageSubsc
 
   public CorrelatedMessageSubscriptionImpl(final CorrelatedMessageSubscriptionResult item) {
     correlationKey = item.getCorrelationKey();
-    correlationTime = item.getCorrelationTime();
+    correlationTime = ParseUtil.parseOffsetDateTimeOrNull(item.getCorrelationTime());
     elementId = item.getElementId();
     elementInstanceKey = ParseUtil.parseLongOrNull(item.getElementInstanceKey());
     messageKey = ParseUtil.parseLongOrNull(item.getMessageKey());
@@ -56,7 +57,7 @@ public class CorrelatedMessageSubscriptionImpl implements CorrelatedMessageSubsc
   }
 
   @Override
-  public String getCorrelationTime() {
+  public OffsetDateTime getCorrelationTime() {
     return correlationTime;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionInstanceImpl.java
@@ -25,10 +25,12 @@ import io.camunda.client.api.search.response.DecisionInstanceState;
 import io.camunda.client.impl.response.EvaluatedDecisionInputImpl;
 import io.camunda.client.impl.response.MatchedDecisionRuleImpl;
 import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.DecisionDefinitionTypeEnum;
 import io.camunda.client.protocol.rest.DecisionInstanceGetQueryResult;
 import io.camunda.client.protocol.rest.DecisionInstanceResult;
 import io.camunda.client.protocol.rest.DecisionInstanceStateEnum;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -39,7 +41,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
   private final long decisionInstanceKey;
   private final String decisionInstanceId;
   private final DecisionInstanceState state;
-  private final String evaluationDate;
+  private final OffsetDateTime evaluationDate;
   private final String evaluationFailure;
   private final Long processDefinitionKey;
   private final Long processInstanceKey;
@@ -60,7 +62,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
         Long.parseLong(item.getDecisionEvaluationKey()),
         item.getDecisionEvaluationInstanceKey(),
         toDecisionInstanceState(item.getState()),
-        item.getEvaluationDate(),
+        ParseUtil.parseOffsetDateTimeOrNull(item.getEvaluationDate()),
         item.getEvaluationFailure(),
         Long.parseLong(item.getProcessDefinitionKey()),
         Long.parseLong(item.getProcessInstanceKey()),
@@ -83,7 +85,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
         Long.parseLong(item.getDecisionEvaluationKey()),
         item.getDecisionEvaluationInstanceKey(),
         toDecisionInstanceState(item.getState()),
-        item.getEvaluationDate(),
+        ParseUtil.parseOffsetDateTimeOrNull(item.getEvaluationDate()),
         item.getEvaluationFailure(),
         Long.parseLong(item.getProcessDefinitionKey()),
         Long.parseLong(item.getProcessInstanceKey()),
@@ -108,7 +110,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
       final long decisionInstanceKey,
       final String decisionInstanceId,
       final DecisionInstanceState state,
-      final String evaluationDate,
+      final OffsetDateTime evaluationDate,
       final String evaluationFailure,
       final Long processDefinitionKey,
       final Long processInstanceKey,
@@ -202,7 +204,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
   }
 
   @Override
-  public String getEvaluationDate() {
+  public OffsetDateTime getEvaluationDate() {
     return evaluationDate;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.ElementInstanceResult;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 
 public final class ElementInstanceImpl implements ElementInstance {
@@ -31,8 +32,8 @@ public final class ElementInstanceImpl implements ElementInstance {
   private final Long processInstanceKey;
   private final String elementId;
   private final String elementName;
-  private final String startDate;
-  private final String endDate;
+  private final OffsetDateTime startDate;
+  private final OffsetDateTime endDate;
   private final Boolean incident;
   private final Long incidentKey;
   private final ElementInstanceState state;
@@ -46,8 +47,8 @@ public final class ElementInstanceImpl implements ElementInstance {
     processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
     elementId = item.getElementId();
     elementName = item.getElementName();
-    startDate = item.getStartDate();
-    endDate = item.getEndDate();
+    startDate = ParseUtil.parseOffsetDateTimeOrNull(item.getStartDate());
+    endDate = ParseUtil.parseOffsetDateTimeOrNull(item.getEndDate());
     incident = item.getHasIncident();
     incidentKey = ParseUtil.parseLongOrNull(item.getIncidentKey());
     state = EnumUtil.convert(item.getState(), ElementInstanceState.class);
@@ -86,12 +87,12 @@ public final class ElementInstanceImpl implements ElementInstance {
   }
 
   @Override
-  public String getStartDate() {
+  public OffsetDateTime getStartDate() {
     return startDate;
   }
 
   @Override
-  public String getEndDate() {
+  public OffsetDateTime getEndDate() {
     return endDate;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/IncidentImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/IncidentImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.IncidentResult;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 
 public class IncidentImpl implements Incident {
@@ -33,7 +34,7 @@ public class IncidentImpl implements Incident {
   private final String errorMessage;
   private final String elementId;
   private final Long elementInstanceKey;
-  private final String creationTime;
+  private final OffsetDateTime creationTime;
   private final IncidentState state;
   private final Long jobKey;
   private final String tenantId;
@@ -47,7 +48,7 @@ public class IncidentImpl implements Incident {
     errorMessage = item.getErrorMessage();
     elementId = item.getElementId();
     elementInstanceKey = ParseUtil.parseLongOrNull(item.getElementInstanceKey());
-    creationTime = item.getCreationTime();
+    creationTime = ParseUtil.parseOffsetDateTimeOrNull(item.getCreationTime());
     state = EnumUtil.convert(item.getState(), IncidentState.class);
     jobKey = ParseUtil.parseLongOrNull(item.getJobKey());
     tenantId = item.getTenantId();
@@ -94,7 +95,7 @@ public class IncidentImpl implements Incident {
   }
 
   @Override
-  public String getCreationTime() {
+  public OffsetDateTime getCreationTime() {
     return creationTime;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/JobImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/JobImpl.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.search.response.Job;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.JobSearchResult;
+import java.time.OffsetDateTime;
 import java.util.Map;
 
 public class JobImpl implements Job {
@@ -39,8 +40,8 @@ public class JobImpl implements Job {
   private final String errorCode;
   private final String errorMessage;
   private final Map<String, String> customerHeaders;
-  private final String deadline;
-  private final String endTime;
+  private final OffsetDateTime deadline;
+  private final OffsetDateTime endTime;
   private final String processDefinitionId;
   private final Long processDefinitionKey;
   private final Long processInstanceKey;
@@ -62,8 +63,8 @@ public class JobImpl implements Job {
     errorCode = item.getErrorCode();
     errorMessage = item.getErrorMessage();
     customerHeaders = item.getCustomHeaders();
-    deadline = item.getDeadline();
-    endTime = item.getEndTime();
+    deadline = ParseUtil.parseOffsetDateTimeOrNull(item.getDeadline());
+    endTime = ParseUtil.parseOffsetDateTimeOrNull(item.getEndTime());
     processDefinitionId = item.getProcessDefinitionId();
     processDefinitionKey = ParseUtil.parseLongOrNull(item.getProcessDefinitionKey());
     processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
@@ -138,12 +139,12 @@ public class JobImpl implements Job {
   }
 
   @Override
-  public String getDeadline() {
+  public OffsetDateTime getDeadline() {
     return deadline;
   }
 
   @Override
-  public String getEndTime() {
+  public OffsetDateTime getEndTime() {
     return endTime;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageSubscriptionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageSubscriptionImpl.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.MessageSubscriptionResult;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 
 public class MessageSubscriptionImpl implements MessageSubscription {
@@ -31,7 +32,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
   private final String elementId;
   private final Long elementInstanceKey;
   private final MessageSubscriptionState messageSubscriptionState;
-  private final String lastUpdatedDate;
+  private final OffsetDateTime lastUpdatedDate;
   private final String messageName;
   private final String correlationKey;
   private final String tenantId;
@@ -45,7 +46,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
     elementInstanceKey = ParseUtil.parseLongOrNull(item.getElementInstanceKey());
     messageSubscriptionState =
         EnumUtil.convert(item.getMessageSubscriptionState(), MessageSubscriptionState.class);
-    lastUpdatedDate = item.getLastUpdatedDate();
+    lastUpdatedDate = ParseUtil.parseOffsetDateTimeOrNull(item.getLastUpdatedDate());
     messageName = item.getMessageName();
     correlationKey = item.getCorrelationKey();
     tenantId = item.getTenantId();
@@ -87,7 +88,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
   }
 
   @Override
-  public String getLastUpdatedDate() {
+  public OffsetDateTime getLastUpdatedDate() {
     return lastUpdatedDate;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceImpl.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.ProcessInstanceResult;
+import java.time.OffsetDateTime;
 import java.util.Set;
 
 public class ProcessInstanceImpl implements ProcessInstance {
@@ -32,8 +33,8 @@ public class ProcessInstanceImpl implements ProcessInstance {
   private final Long processDefinitionKey;
   private final Long parentProcessInstanceKey;
   private final Long parentElementInstanceKey;
-  private final String startDate;
-  private final String endDate;
+  private final OffsetDateTime startDate;
+  private final OffsetDateTime endDate;
   private final ProcessInstanceState state;
   private final Boolean hasIncident;
   private final String tenantId;
@@ -48,8 +49,8 @@ public class ProcessInstanceImpl implements ProcessInstance {
     processDefinitionKey = ParseUtil.parseLongOrNull(item.getProcessDefinitionKey());
     parentProcessInstanceKey = ParseUtil.parseLongOrNull(item.getParentProcessInstanceKey());
     parentElementInstanceKey = ParseUtil.parseLongOrNull(item.getParentElementInstanceKey());
-    startDate = item.getStartDate();
-    endDate = item.getEndDate();
+    startDate = ParseUtil.parseOffsetDateTimeOrNull(item.getStartDate());
+    endDate = ParseUtil.parseOffsetDateTimeOrNull(item.getEndDate());
     state = EnumUtil.convert(item.getState(), ProcessInstanceState.class);
     hasIncident = item.getHasIncident();
     tenantId = item.getTenantId();
@@ -97,12 +98,12 @@ public class ProcessInstanceImpl implements ProcessInstance {
   }
 
   @Override
-  public String getStartDate() {
+  public OffsetDateTime getStartDate() {
     return startDate;
   }
 
   @Override
-  public String getEndDate() {
+  public OffsetDateTime getEndDate() {
     return endDate;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/UserTaskImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/UserTaskImpl.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.UserTaskResult;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -37,10 +38,10 @@ public class UserTaskImpl implements UserTask {
   private final Long processDefinitionKey;
   private final Long processInstanceKey;
   private final Long formKey;
-  private final String creationDate;
-  private final String completionDate;
-  private final String followUpDate;
-  private final String dueDate;
+  private final OffsetDateTime creationDate;
+  private final OffsetDateTime completionDate;
+  private final OffsetDateTime followUpDate;
+  private final OffsetDateTime dueDate;
   private final String tenantId;
   private final String externalFormReference;
   private final Integer processDefinitionVersion;
@@ -60,10 +61,10 @@ public class UserTaskImpl implements UserTask {
     processDefinitionKey = ParseUtil.parseLongOrNull(item.getProcessDefinitionKey());
     processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
     formKey = ParseUtil.parseLongOrNull(item.getFormKey());
-    creationDate = item.getCreationDate();
-    completionDate = item.getCompletionDate();
-    followUpDate = item.getFollowUpDate();
-    dueDate = item.getDueDate();
+    creationDate = ParseUtil.parseOffsetDateTimeOrNull(item.getCreationDate());
+    completionDate = ParseUtil.parseOffsetDateTimeOrNull(item.getCompletionDate());
+    followUpDate = ParseUtil.parseOffsetDateTimeOrNull(item.getFollowUpDate());
+    dueDate = ParseUtil.parseOffsetDateTimeOrNull(item.getDueDate());
     tenantId = item.getTenantId();
     externalFormReference = item.getExternalFormReference();
     processDefinitionVersion = item.getProcessDefinitionVersion();
@@ -132,22 +133,22 @@ public class UserTaskImpl implements UserTask {
   }
 
   @Override
-  public String getCreationDate() {
+  public OffsetDateTime getCreationDate() {
     return creationDate;
   }
 
   @Override
-  public String getCompletionDate() {
+  public OffsetDateTime getCompletionDate() {
     return completionDate;
   }
 
   @Override
-  public String getFollowUpDate() {
+  public OffsetDateTime getFollowUpDate() {
     return followUpDate;
   }
 
   @Override
-  public String getDueDate() {
+  public OffsetDateTime getDueDate() {
     return dueDate;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/util/ParseUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/ParseUtil.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.client.impl.util;
 
+import java.time.OffsetDateTime;
+
 public class ParseUtil {
 
   public static Long parseLongOrNull(final String input) {
@@ -27,5 +29,16 @@ public class ParseUtil {
 
   public static String keyToString(final Long input) {
     return input == null ? null : String.valueOf(input);
+  }
+
+  public static OffsetDateTime parseOffsetDateTimeOrNull(final String dateTime) {
+    if (dateTime == null) {
+      return null;
+    }
+    try {
+      return OffsetDateTime.parse(dateTime);
+    } catch (final Exception e) {
+      throw new IllegalArgumentException("Failed to parse date: " + dateTime, e);
+    }
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.protocol.rest.*;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
+import java.time.OffsetDateTime;
 import java.util.*;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,11 @@ public class QueryBatchOperationTest extends ClientRestTest {
     // given
     final String batchOperationKey = "123";
     gatewayService.onBatchOperationRequest(
-        batchOperationKey, Instancio.create(BatchOperationResponse.class));
+        batchOperationKey,
+        Instancio.create(BatchOperationResponse.class)
+            .endDate(OffsetDateTime.now().toString())
+            .startDate(OffsetDateTime.now().toString())
+            .endDate(OffsetDateTime.now().toString()));
 
     // when
     client.newBatchOperationGetRequest(batchOperationKey).send().join();

--- a/clients/java/src/test/java/io/camunda/client/decision/GetDecisionInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/GetDecisionInstanceTest.java
@@ -21,6 +21,7 @@ import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.protocol.rest.DecisionInstanceResult;
 import io.camunda.client.util.ClientRestTest;
+import java.time.OffsetDateTime;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +38,8 @@ public final class GetDecisionInstanceTest extends ClientRestTest {
             .decisionDefinitionKey("2")
             .elementInstanceKey("3")
             .processDefinitionKey("4")
-            .processInstanceKey("5"));
+            .processInstanceKey("5")
+            .evaluationDate(OffsetDateTime.now().toString()));
 
     // when
     client.newDecisionInstanceGetRequest(decisionInstanceId).send().join();

--- a/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
@@ -353,7 +353,9 @@ public class ElementInstanceTest extends ClientRestTest {
             .elementInstanceKey("1")
             .processInstanceKey("2")
             .incidentKey("3")
-            .processDefinitionKey("4"));
+            .processDefinitionKey("4")
+            .startDate(OffsetDateTime.now().toString())
+            .endDate(OffsetDateTime.now().toString()));
 
     // when
     client.newElementInstanceGetRequest(elementInstanceKey).send().join();

--- a/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
+++ b/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
@@ -29,6 +29,7 @@ import io.camunda.client.protocol.rest.IncidentFilter.ErrorTypeEnum;
 import io.camunda.client.protocol.rest.IncidentFilter.StateEnum;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 import org.instancio.Instancio;
@@ -49,7 +50,8 @@ public class SearchIncidentTest extends ClientRestTest {
             .elementInstanceKey("2")
             .processInstanceKey("3")
             .processDefinitionKey("4")
-            .jobKey("5"));
+            .jobKey("5")
+            .creationTime(OffsetDateTime.now().toString()));
 
     // when
     client.newIncidentGetRequest(incidentKey).send().join();

--- a/clients/java/src/test/java/io/camunda/client/usertask/GetUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/GetUserTaskTest.java
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.protocol.rest.UserTaskResult;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
+import java.time.OffsetDateTime;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +38,11 @@ public class GetUserTaskTest extends ClientRestTest {
             .elementInstanceKey("2")
             .processDefinitionKey("3")
             .processInstanceKey("4")
-            .userTaskKey("5"));
+            .userTaskKey("5")
+            .creationDate(OffsetDateTime.now().toString())
+            .completionDate(OffsetDateTime.now().toString())
+            .dueDate(OffsetDateTime.now().toString())
+            .followUpDate(OffsetDateTime.now().toString()));
 
     // when
     client.newUserTaskGetRequest(userTaskKey).send().join();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CorrelatedMessageSubscriptionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CorrelatedMessageSubscriptionSearchTest.java
@@ -18,7 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.CorrelatedMessageSubscription;
 import io.camunda.qa.util.multidb.MultiDbTest;
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeAll;
@@ -93,9 +92,7 @@ public class CorrelatedMessageSubscriptionSearchTest {
             .filter(
                 f ->
                     f.correlationKey(expectedCorrelatedMessageSubscription.getCorrelationKey())
-                        .correlationTime(
-                            OffsetDateTime.parse(
-                                expectedCorrelatedMessageSubscription.getCorrelationTime()))
+                        .correlationTime(expectedCorrelatedMessageSubscription.getCorrelationTime())
                         .elementId(expectedCorrelatedMessageSubscription.getElementId())
                         .elementInstanceKey(
                             expectedCorrelatedMessageSubscription.getElementInstanceKey())
@@ -129,9 +126,7 @@ public class CorrelatedMessageSubscriptionSearchTest {
             .filter(
                 f ->
                     f.correlationKey(expectedCorrelatedMessageSubscription.getCorrelationKey())
-                        .correlationTime(
-                            OffsetDateTime.parse(
-                                expectedCorrelatedMessageSubscription.getCorrelationTime()))
+                        .correlationTime(expectedCorrelatedMessageSubscription.getCorrelationTime())
                         .elementId(expectedCorrelatedMessageSubscription.getElementId())
                         .messageKey(expectedCorrelatedMessageSubscription.getMessageKey())
                         .messageName(expectedCorrelatedMessageSubscription.getMessageName())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
@@ -284,7 +284,7 @@ class DecisionInstanceSearchTest {
     final var result =
         camundaClient
             .newDecisionInstanceSearchRequest()
-            .filter(f -> f.evaluationDate(OffsetDateTime.parse(di.getEvaluationDate())))
+            .filter(f -> f.evaluationDate(di.getEvaluationDate()))
             .send()
             .join();
 
@@ -306,7 +306,7 @@ class DecisionInstanceSearchTest {
             .send()
             .join();
     final var di = allResult.items().getFirst();
-    final var requestDate = OffsetDateTime.parse(di.getEvaluationDate());
+    final var requestDate = di.getEvaluationDate();
 
     // when
     final var result =
@@ -319,8 +319,8 @@ class DecisionInstanceSearchTest {
     // then
     assertThat(result.items()).hasSize(4);
     assertThat(result.items())
-        .extracting("evaluationDate", String.class)
-        .allMatch(date -> requestDate.isBefore(OffsetDateTime.parse(date)));
+        .extracting("evaluationDate", OffsetDateTime.class)
+        .allMatch(requestDate::isBefore);
     assertThat(result.items())
         .extracting("decisionInstanceKey", Long.class)
         .noneMatch(key -> di.getDecisionInstanceKey() == key);
@@ -338,7 +338,7 @@ class DecisionInstanceSearchTest {
             .send()
             .join();
     final var di = allResult.items().getFirst();
-    final var requestDate = OffsetDateTime.parse(di.getEvaluationDate());
+    final var requestDate = di.getEvaluationDate();
 
     // when
     final var result =
@@ -351,8 +351,8 @@ class DecisionInstanceSearchTest {
     // then
     assertThat(result.items()).hasSize(5);
     assertThat(result.items())
-        .extracting("evaluationDate", String.class)
-        .allMatch(date -> !OffsetDateTime.parse(date).isBefore(requestDate));
+        .extracting("evaluationDate", OffsetDateTime.class)
+        .allMatch(date -> !date.isBefore(requestDate));
     assertThat(result.items())
         .extracting("decisionInstanceKey", Long.class)
         .anyMatch(key -> di.getDecisionInstanceKey() == key);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchTest.java
@@ -122,7 +122,7 @@ public class ElementInstanceSearchTest {
             .join()
             .items()
             .getFirst();
-    final var startDate = OffsetDateTime.parse(ei.getStartDate());
+    final var startDate = ei.getStartDate();
     // when
     final var result =
         camundaClient
@@ -164,7 +164,7 @@ public class ElementInstanceSearchTest {
             .join()
             .items()
             .getFirst();
-    final var endDate = OffsetDateTime.parse(ei.getEndDate());
+    final var endDate = ei.getEndDate();
     // when
     final var result =
         camundaClient

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
@@ -23,7 +23,6 @@ import io.camunda.client.api.search.enums.UserTaskState;
 import io.camunda.client.api.search.response.Job;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.time.Duration;
-import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -465,7 +464,7 @@ public class JobSearchTest {
     final var result =
         camundaClient
             .newJobSearchRequest()
-            .filter(f -> f.deadline(o -> o.eq(OffsetDateTime.parse(deadline))))
+            .filter(f -> f.deadline(o -> o.eq(deadline)))
             .send()
             .join();
 
@@ -501,7 +500,7 @@ public class JobSearchTest {
     final var result =
         camundaClient
             .newJobSearchRequest()
-            .filter(f -> f.endTime(o -> o.eq(OffsetDateTime.parse(endTime))))
+            .filter(f -> f.endTime(o -> o.eq(endTime)))
             .send()
             .join();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchTest.java
@@ -18,7 +18,6 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.MessageSubscriptionState;
 import io.camunda.client.api.search.response.MessageSubscription;
 import io.camunda.qa.util.multidb.MultiDbTest;
-import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
@@ -97,8 +96,7 @@ public class MessageSubscriptionSearchTest {
                         .elementInstanceKey(expectedMessageSubscription.getElementInstanceKey())
                         .messageSubscriptionState(
                             expectedMessageSubscription.getMessageSubscriptionState())
-                        .lastUpdatedDate(
-                            OffsetDateTime.parse(expectedMessageSubscription.getLastUpdatedDate()))
+                        .lastUpdatedDate(expectedMessageSubscription.getLastUpdatedDate())
                         .messageName(expectedMessageSubscription.getMessageName())
                         .correlationKey(expectedMessageSubscription.getCorrelationKey())
                         .tenantId(expectedMessageSubscription.getTenantId()))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
@@ -31,7 +31,6 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.lang.reflect.Method;
-import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
@@ -357,7 +356,7 @@ public class ProcessDefinitionStatisticsTest {
         f -> f.processDefinitionKey(processDefinitionKey).state(ProcessInstanceState.COMPLETED),
         2);
     final var pi = getProcessInstance(piKey);
-    final var startDate = OffsetDateTime.parse(pi.getStartDate());
+    final var startDate = pi.getStartDate();
 
     // when
     final var actual =
@@ -391,7 +390,7 @@ public class ProcessDefinitionStatisticsTest {
         f -> f.processDefinitionKey(processDefinitionKey).state(ProcessInstanceState.COMPLETED),
         2);
     final var pi = getProcessInstance(piKey);
-    final var startDate = OffsetDateTime.parse(pi.getStartDate());
+    final var startDate = pi.getStartDate();
 
     // when
     final var actual =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchTest.java
@@ -30,7 +30,6 @@ import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.qa.util.multidb.MultiDbTest;
-import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -349,7 +348,7 @@ public class ProcessInstanceSearchTest {
             .join()
             .items()
             .getFirst();
-    final var startDate = OffsetDateTime.parse(pi.getStartDate());
+    final var startDate = pi.getStartDate();
 
     // when
     final var result =
@@ -411,7 +410,7 @@ public class ProcessInstanceSearchTest {
             .join()
             .items()
             .getFirst();
-    final var startDate = OffsetDateTime.parse(pi.getStartDate());
+    final var startDate = pi.getStartDate();
 
     // when
     final var result =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
@@ -549,9 +549,9 @@ class UserTaskSearchTest {
     // Assert that the creation date of item 0 is before item 1, and item 1 is before item 2
     final UserTask firstItem = result.items().get(0);
     final UserTask lastItem = result.items().get(7);
-    assertThat(firstItem.getCreationDate()).isLessThan(result.items().get(1).getCreationDate());
+    assertThat(firstItem.getCreationDate()).isBefore(result.items().get(1).getCreationDate());
     assertThat(result.items().get(1).getCreationDate())
-        .isLessThan(result.items().get(2).getCreationDate());
+        .isBefore(result.items().get(2).getCreationDate());
   }
 
   @Test
@@ -562,11 +562,11 @@ class UserTaskSearchTest {
     assertThat(result.items().size()).isEqualTo(8);
 
     assertThat(result.items().get(0).getCreationDate())
-        .isGreaterThanOrEqualTo(result.items().get(1).getCreationDate());
+        .isAfterOrEqualTo(result.items().get(1).getCreationDate());
     assertThat(result.items().get(1).getCreationDate())
-        .isGreaterThanOrEqualTo(result.items().get(2).getCreationDate());
+        .isAfterOrEqualTo(result.items().get(2).getCreationDate());
     assertThat(result.items().get(2).getCreationDate())
-        .isGreaterThanOrEqualTo(result.items().get(3).getCreationDate());
+        .isAfterOrEqualTo(result.items().get(3).getCreationDate());
   }
 
   @Test
@@ -800,7 +800,7 @@ class UserTaskSearchTest {
         camundaClient.newUserTaskSearchRequest().page(p -> p.limit(1)).send().join();
 
     final var userTaskCreationDateExample =
-        OffsetDateTime.parse(userTaskList.items().stream().findFirst().get().getCreationDate());
+        userTaskList.items().stream().findFirst().get().getCreationDate();
 
     final var result =
         camundaClient
@@ -815,7 +815,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var creationDate = OffsetDateTime.parse(item.getCreationDate());
+              final var creationDate = item.getCreationDate();
               assertThat(creationDate).isAfter(userTaskCreationDateExample.minusSeconds(1));
             });
   }
@@ -827,7 +827,7 @@ class UserTaskSearchTest {
         camundaClient.newUserTaskSearchRequest().page(p -> p.limit(1)).send().join();
 
     final var userTaskCreationDateExample =
-        OffsetDateTime.parse(userTaskList.items().stream().findFirst().get().getCreationDate());
+        userTaskList.items().stream().findFirst().get().getCreationDate();
 
     final var result =
         camundaClient
@@ -842,7 +842,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var creationDate = OffsetDateTime.parse(item.getCreationDate());
+              final var creationDate = item.getCreationDate();
               assertThat(creationDate).isBefore(userTaskCreationDateExample.plusSeconds(1));
             });
   }
@@ -854,7 +854,7 @@ class UserTaskSearchTest {
         camundaClient.newUserTaskSearchRequest().page(p -> p.limit(1)).send().join();
 
     final var userTaskCreationDateExample =
-        OffsetDateTime.parse(userTaskList.items().stream().findFirst().get().getCreationDate());
+        userTaskList.items().stream().findFirst().get().getCreationDate();
 
     final var result =
         camundaClient
@@ -870,7 +870,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var creationDate = OffsetDateTime.parse(item.getCreationDate());
+              final var creationDate = item.getCreationDate();
               assertThat(creationDate)
                   .isAfterOrEqualTo(userTaskCreationDateExample.minusSeconds(1));
             });
@@ -883,7 +883,7 @@ class UserTaskSearchTest {
         camundaClient.newUserTaskSearchRequest().page(p -> p.limit(1)).send().join();
 
     final var userTaskCreationDateExample =
-        OffsetDateTime.parse(userTaskList.items().stream().findFirst().get().getCreationDate());
+        userTaskList.items().stream().findFirst().get().getCreationDate();
 
     final var result =
         camundaClient
@@ -899,7 +899,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var creationDate = OffsetDateTime.parse(item.getCreationDate());
+              final var creationDate = item.getCreationDate();
               assertThat(creationDate)
                   .isBeforeOrEqualTo(userTaskCreationDateExample.plusSeconds(1));
             });
@@ -912,7 +912,7 @@ class UserTaskSearchTest {
         camundaClient.newUserTaskSearchRequest().page(p -> p.limit(1)).send().join();
 
     final var userTaskCreationDateExample =
-        OffsetDateTime.parse(userTaskList.items().stream().findFirst().get().getCreationDate());
+        userTaskList.items().stream().findFirst().get().getCreationDate();
 
     final var result =
         camundaClient
@@ -927,7 +927,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var creationDate = OffsetDateTime.parse(item.getCreationDate());
+              final var creationDate = item.getCreationDate();
               assertThat(creationDate).isEqualTo(userTaskCreationDateExample);
             });
   }
@@ -944,8 +944,7 @@ class UserTaskSearchTest {
             .join();
 
     final var userTaskCompletionDateExample =
-        OffsetDateTime.parse(
-            userTaskListComplete.items().stream().findFirst().get().getCompletionDate());
+        userTaskListComplete.items().stream().findFirst().get().getCompletionDate();
 
     final var result =
         camundaClient
@@ -962,7 +961,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var completionDate = OffsetDateTime.parse(item.getCompletionDate());
+              final var completionDate = item.getCompletionDate();
               assertThat(completionDate)
                   .isAfterOrEqualTo(userTaskCompletionDateExample.minusSeconds(1));
             });
@@ -980,8 +979,7 @@ class UserTaskSearchTest {
             .join();
 
     final var userTaskCompletionDateExample =
-        OffsetDateTime.parse(
-            userTaskListComplete.items().stream().findFirst().get().getCompletionDate());
+        userTaskListComplete.items().stream().findFirst().get().getCompletionDate();
 
     final var result =
         camundaClient
@@ -997,7 +995,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var completionDate = OffsetDateTime.parse(item.getCompletionDate());
+              final var completionDate = item.getCompletionDate();
               assertThat(completionDate)
                   .isBeforeOrEqualTo(userTaskCompletionDateExample.plusSeconds(1));
             });
@@ -1015,8 +1013,7 @@ class UserTaskSearchTest {
             .join();
 
     final var userTaskCompletionDateExample =
-        OffsetDateTime.parse(
-            userTaskListComplete.items().stream().findFirst().get().getCompletionDate());
+        userTaskListComplete.items().stream().findFirst().get().getCompletionDate();
 
     final var result =
         camundaClient
@@ -1036,7 +1033,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var completionDate = OffsetDateTime.parse(item.getCompletionDate());
+              final var completionDate = item.getCompletionDate();
               assertThat(completionDate)
                   .isBetween(
                       userTaskCompletionDateExample.minusDays(1),
@@ -1056,8 +1053,7 @@ class UserTaskSearchTest {
             .join();
 
     final var userTaskCompletionDateExample =
-        OffsetDateTime.parse(
-            userTaskListComplete.items().stream().findFirst().get().getCompletionDate());
+        userTaskListComplete.items().stream().findFirst().get().getCompletionDate();
 
     final var result =
         camundaClient
@@ -1077,7 +1073,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var completionDate = OffsetDateTime.parse(item.getCompletionDate());
+              final var completionDate = item.getCompletionDate();
               assertThat(completionDate).isAfter(userTaskCompletionDateExample.minusDays(1));
               assertThat(completionDate).isBefore(userTaskCompletionDateExample.plusDays(1));
             });
@@ -1131,8 +1127,7 @@ class UserTaskSearchTest {
             .join();
 
     final var userTaskCompletionDateExample =
-        OffsetDateTime.parse(
-            userTaskListComplete.items().stream().findFirst().get().getCompletionDate());
+        userTaskListComplete.items().stream().findFirst().get().getCompletionDate();
 
     final var result =
         camundaClient
@@ -1147,7 +1142,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var completionDate = OffsetDateTime.parse(item.getCompletionDate());
+              final var completionDate = item.getCompletionDate();
               assertThat(completionDate).isEqualTo(userTaskCompletionDateExample);
             });
   }
@@ -1164,8 +1159,7 @@ class UserTaskSearchTest {
             .join();
 
     final var userTaskCompletionDateExample =
-        OffsetDateTime.parse(
-            userTaskListComplete.items().stream().findFirst().get().getCompletionDate());
+        userTaskListComplete.items().stream().findFirst().get().getCompletionDate();
 
     final var result =
         camundaClient
@@ -1180,7 +1174,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var completionDate = OffsetDateTime.parse(item.getCompletionDate());
+              final var completionDate = item.getCompletionDate();
               assertThat(completionDate).isAfter(userTaskCompletionDateExample.minusSeconds(1));
             });
   }
@@ -1197,8 +1191,7 @@ class UserTaskSearchTest {
             .join();
 
     final var userTaskCompletionDateExample =
-        OffsetDateTime.parse(
-            userTaskListComplete.items().stream().findFirst().get().getCompletionDate());
+        userTaskListComplete.items().stream().findFirst().get().getCompletionDate();
 
     final var result =
         camundaClient
@@ -1213,7 +1206,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var completionDate = OffsetDateTime.parse(item.getCompletionDate());
+              final var completionDate = item.getCompletionDate();
               assertThat(completionDate).isBefore(userTaskCompletionDateExample.plusSeconds(1));
             });
   }
@@ -1250,7 +1243,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var dueDate = OffsetDateTime.parse(item.getDueDate());
+              final var dueDate = item.getDueDate();
               assertThat(dueDate).isAfter(now.minusDays(2));
               assertThat(dueDate).isBefore(now.plusDays(2));
             });
@@ -1261,7 +1254,7 @@ class UserTaskSearchTest {
     // when
     final var userTaskList =
         camundaClient.newUserTaskSearchRequest().page(p -> p.limit(1)).send().join();
-    final var dueDateExample = OffsetDateTime.parse(userTaskList.items().get(0).getDueDate());
+    final var dueDateExample = userTaskList.items().get(0).getDueDate();
 
     final var result =
         camundaClient
@@ -1276,7 +1269,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var dueDate = OffsetDateTime.parse(item.getDueDate());
+              final var dueDate = item.getDueDate();
               assertThat(dueDate).isEqualTo(dueDateExample);
             });
   }
@@ -1286,8 +1279,7 @@ class UserTaskSearchTest {
     // when
     final var userTaskList =
         camundaClient.newUserTaskSearchRequest().page(p -> p.limit(1)).send().join();
-    final var followUpDateExample =
-        OffsetDateTime.parse(userTaskList.items().get(0).getFollowUpDate());
+    final var followUpDateExample = userTaskList.items().get(0).getFollowUpDate();
 
     final var result =
         camundaClient
@@ -1302,7 +1294,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var followUpDate = OffsetDateTime.parse(item.getFollowUpDate());
+              final var followUpDate = item.getFollowUpDate();
               assertThat(followUpDate).isEqualTo(followUpDateExample);
             });
   }
@@ -1324,7 +1316,7 @@ class UserTaskSearchTest {
         .items()
         .forEach(
             item -> {
-              final var followUpDate = OffsetDateTime.parse(item.getFollowUpDate());
+              final var followUpDate = item.getFollowUpDate();
               assertThat(followUpDate).isAfterOrEqualTo(now.minusDays(5));
               assertThat(followUpDate).isBeforeOrEqualTo(now.plusDays(5));
             });

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/SearchAndCreateTaskMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/SearchAndCreateTaskMigrationIT.java
@@ -123,13 +123,13 @@ public class SearchAndCreateTaskMigrationIT extends UserTaskMigrationHelper {
               assertThat(item.getProcessInstanceKey()).isNotNull();
 
               assertThat(item.getCreationDate()).isNotNull();
-              final var creationInstant = Instant.parse(item.getCreationDate());
+              final var creationInstant = Instant.from(item.getCreationDate());
               assertThat(creationInstant).isAfter(STARTING_INSTANT);
 
               if (item.getUserTaskKey().equals(USER_TASK_KEYS.get("first"))) {
                 assertThat(item.getState()).isEqualTo(UserTaskState.COMPLETED);
                 assertThat(item.getCompletionDate()).isNotNull();
-                final var completionInstant = Instant.parse(item.getCompletionDate());
+                final var completionInstant = Instant.from(item.getCompletionDate());
                 assertThat(completionInstant).isAfter(creationInstant);
               } else {
                 assertThat(item.getState()).isEqualTo(UserTaskState.CREATED);

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/UserTaskAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/UserTaskAssertTest.java
@@ -571,7 +571,7 @@ public class UserTaskAssertTest {
 
   @Nested
   public class DueDate {
-    private static final String DUE_DATE = "2025-05-01T10:00:00.000Z";
+    private static final String DUE_DATE = "2025-05-01T10:00:00.100Z";
 
     @Test
     public void hasDueDate() {
@@ -606,7 +606,7 @@ public class UserTaskAssertTest {
                           .name("c")
                           .elementInstanceKey("1")
                           .state(UserTaskStateEnum.CREATED)
-                          .dueDate("2025-04-30T10:00:00.000Z")),
+                          .dueDate("2025-04-30T10:00:00.100Z")),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("a")
@@ -630,19 +630,19 @@ public class UserTaskAssertTest {
                           .name("a")
                           .elementInstanceKey("1")
                           .state(UserTaskStateEnum.CREATED)
-                          .dueDate("2025-04-30T10:00:00.000Z"))));
+                          .dueDate("2025-04-30T10:00:00.100Z"))));
 
       // then
       Assertions.assertThatThrownBy(
               () -> assertThatUserTask(UserTaskSelectors.byTaskName("a")).hasDueDate(DUE_DATE))
           .hasMessage(
-              "Expected [taskName: a] to have due date '2025-05-01T10:00:00.000Z', but was '2025-04-30T10:00:00.000Z'");
+              "Expected [taskName: a] to have due date '2025-05-01T10:00:00.100Z', but was '2025-04-30T10:00:00.100Z'");
     }
   }
 
   @Nested
   public class CompletionDate {
-    private static final String COMPLETION_DATE = "2025-05-01T10:00:00.000Z";
+    private static final String COMPLETION_DATE = "2025-05-01T10:00:00.100Z";
 
     @Test
     public void hasCompletionDate() {
@@ -677,7 +677,7 @@ public class UserTaskAssertTest {
                           .name("c")
                           .elementInstanceKey("1")
                           .state(UserTaskStateEnum.CREATED)
-                          .completionDate("2025-04-30T10:00:00.000Z")),
+                          .completionDate("2025-04-30T10:00:00.100Z")),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("a")
@@ -701,7 +701,7 @@ public class UserTaskAssertTest {
                           .name("a")
                           .elementInstanceKey("1")
                           .state(UserTaskStateEnum.CREATED)
-                          .completionDate("2025-04-30T10:00:00.000Z"))));
+                          .completionDate("2025-04-30T10:00:00.100Z"))));
 
       // then
       Assertions.assertThatThrownBy(
@@ -709,13 +709,13 @@ public class UserTaskAssertTest {
                   assertThatUserTask(UserTaskSelectors.byTaskName("a"))
                       .hasCompletionDate(COMPLETION_DATE))
           .hasMessage(
-              "Expected [taskName: a] to have completion date '2025-05-01T10:00:00.000Z', but was '2025-04-30T10:00:00.000Z'");
+              "Expected [taskName: a] to have completion date '2025-05-01T10:00:00.100Z', but was '2025-04-30T10:00:00.100Z'");
     }
   }
 
   @Nested
   public class FollowUpDate {
-    private static final String FOLLOW_UP_DATE = "2025-05-01T10:00:00.000Z";
+    private static final String FOLLOW_UP_DATE = "2025-05-01T10:00:00.100Z";
 
     @Test
     public void hasFollowUpDate() {
@@ -750,7 +750,7 @@ public class UserTaskAssertTest {
                           .name("c")
                           .elementInstanceKey("1")
                           .state(UserTaskStateEnum.CREATED)
-                          .followUpDate("2025-04-30T10:00:00.000Z")),
+                          .followUpDate("2025-04-30T10:00:00.100Z")),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("a")
@@ -774,7 +774,7 @@ public class UserTaskAssertTest {
                           .name("a")
                           .elementInstanceKey("1")
                           .state(UserTaskStateEnum.CREATED)
-                          .followUpDate("2025-04-30T10:00:00.000Z"))));
+                          .followUpDate("2025-04-30T10:00:00.100Z"))));
 
       // then
       Assertions.assertThatThrownBy(
@@ -782,13 +782,13 @@ public class UserTaskAssertTest {
                   assertThatUserTask(UserTaskSelectors.byTaskName("a"))
                       .hasFollowUpDate(FOLLOW_UP_DATE))
           .hasMessage(
-              "Expected [taskName: a] to have follow-up date '2025-05-01T10:00:00.000Z', but was '2025-04-30T10:00:00.000Z'");
+              "Expected [taskName: a] to have follow-up date '2025-05-01T10:00:00.100Z', but was '2025-04-30T10:00:00.100Z'");
     }
   }
 
   @Nested
   public class CreationDate {
-    private static final String CREATION_DATE = "2025-05-01T10:00:00.000Z";
+    private static final String CREATION_DATE = "2025-05-01T10:00:00.100Z";
 
     @Test
     public void hasCreationDate() {
@@ -823,7 +823,7 @@ public class UserTaskAssertTest {
                           .name("c")
                           .elementInstanceKey("1")
                           .state(UserTaskStateEnum.CREATED)
-                          .creationDate("2025-04-30T10:00:00.000Z")),
+                          .creationDate("2025-04-30T10:00:00.100Z")),
                   new UserTaskImpl(
                       new UserTaskResult()
                           .name("a")
@@ -847,7 +847,7 @@ public class UserTaskAssertTest {
                           .name("a")
                           .elementInstanceKey("1")
                           .state(UserTaskStateEnum.CREATED)
-                          .creationDate("2025-04-30T10:00:00.000Z"))));
+                          .creationDate("2025-04-30T10:00:00.100Z"))));
 
       // then
       Assertions.assertThatThrownBy(
@@ -855,7 +855,7 @@ public class UserTaskAssertTest {
                   assertThatUserTask(UserTaskSelectors.byTaskName("a"))
                       .hasCreationDate(CREATION_DATE))
           .hasMessage(
-              "Expected [taskName: a] to have creation date '2025-05-01T10:00:00.000Z', but was '2025-04-30T10:00:00.000Z'");
+              "Expected [taskName: a] to have creation date '2025-05-01T10:00:00.100Z', but was '2025-04-30T10:00:00.100Z'");
     }
   }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/ElementInstanceBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/ElementInstanceBuilder.java
@@ -18,11 +18,12 @@ package io.camunda.process.test.utils;
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.enums.ElementInstanceType;
 import io.camunda.client.api.search.response.ElementInstance;
+import java.time.OffsetDateTime;
 
 public class ElementInstanceBuilder implements ElementInstance {
 
-  private static final String START_DATE = "2024-01-01T10:00:00";
-  private static final String END_DATE = "2024-01-02T15:00:00";
+  private static final OffsetDateTime START_DATE = OffsetDateTime.parse("2024-01-01T10:00:00Z");
+  private static final OffsetDateTime END_DATE = OffsetDateTime.parse("2024-01-02T15:00:00Z");
 
   private Long elementInstanceKey;
   private Long processDefinitionKey;
@@ -30,8 +31,8 @@ public class ElementInstanceBuilder implements ElementInstance {
   private Long processInstanceKey;
   private String elementId;
   private String elementName;
-  private String startDate;
-  private String endDate;
+  private OffsetDateTime startDate;
+  private OffsetDateTime endDate;
   private Boolean incident;
   private Long incidentKey;
   private ElementInstanceState state;
@@ -69,12 +70,12 @@ public class ElementInstanceBuilder implements ElementInstance {
   }
 
   @Override
-  public String getStartDate() {
+  public OffsetDateTime getStartDate() {
     return startDate;
   }
 
   @Override
-  public String getEndDate() {
+  public OffsetDateTime getEndDate() {
     return endDate;
   }
 
@@ -128,12 +129,12 @@ public class ElementInstanceBuilder implements ElementInstance {
     return this;
   }
 
-  public ElementInstanceBuilder setEndDate(final String endDate) {
+  public ElementInstanceBuilder setEndDate(final OffsetDateTime endDate) {
     this.endDate = endDate;
     return this;
   }
 
-  public ElementInstanceBuilder setStartDate(final String startDate) {
+  public ElementInstanceBuilder setStartDate(final OffsetDateTime startDate) {
     this.startDate = startDate;
     return this;
   }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/IncidentBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/IncidentBuilder.java
@@ -18,6 +18,7 @@ package io.camunda.process.test.utils;
 import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.response.Incident;
+import java.time.OffsetDateTime;
 
 public class IncidentBuilder implements Incident {
 
@@ -29,7 +30,7 @@ public class IncidentBuilder implements Incident {
   private String errorMessage;
   private String elementId;
   private Long elementInstanceKey;
-  private String creationTime;
+  private OffsetDateTime creationTime;
   private IncidentState state;
   private Long jobKey;
   private String tenantId;
@@ -75,7 +76,7 @@ public class IncidentBuilder implements Incident {
   }
 
   @Override
-  public String getCreationTime() {
+  public OffsetDateTime getCreationTime() {
     return creationTime;
   }
 
@@ -109,7 +110,7 @@ public class IncidentBuilder implements Incident {
     return this;
   }
 
-  public IncidentBuilder setCreationTime(final String creationTime) {
+  public IncidentBuilder setCreationTime(final OffsetDateTime creationTime) {
     this.creationTime = creationTime;
     return this;
   }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/MessageSubscriptionBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/MessageSubscriptionBuilder.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.utils;
 
 import io.camunda.client.api.search.enums.MessageSubscriptionState;
 import io.camunda.client.api.search.response.MessageSubscription;
+import java.time.OffsetDateTime;
 
 public class MessageSubscriptionBuilder implements MessageSubscription {
 
@@ -26,7 +27,7 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
   private Long processInstanceKey;
   private String elementId;
   private Long elementInstanceKey;
-  private String lastUpdatedDate;
+  private OffsetDateTime lastUpdatedDate;
   private String messageName;
   private String correlationKey;
   private String tenantId;
@@ -68,7 +69,7 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
   }
 
   @Override
-  public String getLastUpdatedDate() {
+  public OffsetDateTime getLastUpdatedDate() {
     return lastUpdatedDate;
   }
 
@@ -102,7 +103,7 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
     return this;
   }
 
-  public MessageSubscriptionBuilder setLastUpdatedDate(final String lastUpdatedDate) {
+  public MessageSubscriptionBuilder setLastUpdatedDate(final OffsetDateTime lastUpdatedDate) {
     this.lastUpdatedDate = lastUpdatedDate;
     return this;
   }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/ProcessInstanceBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/ProcessInstanceBuilder.java
@@ -17,14 +17,14 @@ package io.camunda.process.test.utils;
 
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.search.response.ProcessInstance;
+import java.time.OffsetDateTime;
 import java.util.Set;
 
 public class ProcessInstanceBuilder implements ProcessInstance {
 
   private static final String PROCESS_DEFINITION_ID = "process";
-  private static final String START_DATE = "2024-01-01T09:00:00";
-  private static final String END_DATE = "2024-01-02T16:00:00";
-
+  private static final OffsetDateTime START_DATE = OffsetDateTime.parse("2024-01-01T09:00:00Z");
+  private static final OffsetDateTime END_DATE = OffsetDateTime.parse("2024-01-02T16:00:00Z");
   private Long processInstanceKey;
   private String processDefinitionId;
   private String processDefinitionName;
@@ -33,8 +33,8 @@ public class ProcessInstanceBuilder implements ProcessInstance {
   private Long processDefinitionKey;
   private Long parentProcessInstanceKey;
   private Long parentElementInstanceKey;
-  private String startDate;
-  private String endDate;
+  private OffsetDateTime startDate;
+  private OffsetDateTime endDate;
   private ProcessInstanceState state;
   private Boolean hasIncident;
   private String tenantId;
@@ -81,12 +81,12 @@ public class ProcessInstanceBuilder implements ProcessInstance {
   }
 
   @Override
-  public String getStartDate() {
+  public OffsetDateTime getStartDate() {
     return startDate;
   }
 
   @Override
-  public String getEndDate() {
+  public OffsetDateTime getEndDate() {
     return endDate;
   }
 
@@ -130,12 +130,12 @@ public class ProcessInstanceBuilder implements ProcessInstance {
     return this;
   }
 
-  public ProcessInstanceBuilder setEndDate(final String endDate) {
+  public ProcessInstanceBuilder setEndDate(final OffsetDateTime endDate) {
     this.endDate = endDate;
     return this;
   }
 
-  public ProcessInstanceBuilder setStartDate(final String startDate) {
+  public ProcessInstanceBuilder setStartDate(final OffsetDateTime startDate) {
     this.startDate = startDate;
     return this;
   }


### PR DESCRIPTION
## Description

Converts all date fields to OffsetDateTime in camunda-client-java response dtos.

Adapts the mapping done previously only in `DocumentMetadataImpl` to all client response dto implementations, mapping from the String type on protocol classes to the more practical OffsetDatetime type.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #33678
