### PR TITLE
On user update ensure only mandatory fields are verified

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateUserCommandImpl.java
@@ -72,8 +72,6 @@ public class UpdateUserCommandImpl implements UpdateUserCommandStep1 {
 
   @Override
   public CamundaFuture<UpdateUserResponse> send() {
-    ArgumentUtil.ensureNotNullNorEmpty("name", request.getName());
-    ArgumentUtil.ensureNotNullNorEmpty("email", request.getEmail());
     final HttpCamundaFuture<UpdateUserResponse> result = new HttpCamundaFuture<>();
     final UpdateUserResponseImpl response = new UpdateUserResponseImpl();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -102,13 +102,8 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
   }
 
   private UserRecord overlayUser(final UserRecord persistedUser, final UserRecord updatedUser) {
-    if (!updatedUser.getName().isEmpty()) {
-      persistedUser.setName(updatedUser.getName());
-    }
-
-    if (!updatedUser.getEmail().isEmpty()) {
-      persistedUser.setEmail(updatedUser.getEmail());
-    }
+    persistedUser.setName(updatedUser.getName());
+    persistedUser.setEmail(updatedUser.getEmail());
 
     if (!updatedUser.getPassword().isEmpty()) {
       persistedUser.setPassword(updatedUser.getPassword());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserFieldsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserFieldsTest.java
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class UpdateUserPatchTest {
+public class UpdateUserFieldsTest {
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
@@ -32,7 +32,7 @@ public class UpdateUserPatchTest {
   private final UserRecord updatedUser;
   private final UserRecord expectedUser;
 
-  public UpdateUserPatchTest(
+  public UpdateUserFieldsTest(
       final UserRecord baseUser, final UserRecord updatedUser, final UserRecord expectedUser) {
     this.baseUser = baseUser;
     this.updatedUser = updatedUser;
@@ -82,7 +82,7 @@ public class UpdateUserPatchTest {
             new UserRecord()
                 .setUsername("user-1")
                 .setName("Bar Foo")
-                .setEmail("foo@bar")
+                .setEmail("")
                 .setPassword("password")
           },
           // Update the email field
@@ -95,7 +95,7 @@ public class UpdateUserPatchTest {
             new UserRecord().setEmail("bar@foo"),
             new UserRecord()
                 .setUsername("user-2")
-                .setName("Foo Bar")
+                .setName("")
                 .setEmail("bar@foo")
                 .setPassword("password")
           },
@@ -109,8 +109,8 @@ public class UpdateUserPatchTest {
             new UserRecord().setPassword("updated-password"),
             new UserRecord()
                 .setUsername("user-3")
-                .setName("Foo Bar")
-                .setEmail("foo@bar")
+                .setName("")
+                .setEmail("")
                 .setPassword("updated-password")
           },
           // Update the name and email field


### PR DESCRIPTION
## Description
For user update we are not supposed to have any mandatory fields.
If `name` or `email` or both are not provided, we are supposed to update them in the processor to an empty string.
Validation for `password` stays in place, we do not override the password.

The solution was also tested manually.

Creating user:
 
<img width="951" height="233" alt="Screenshot 2025-09-19 at 09 44 50" src="https://github.com/user-attachments/assets/28e3b91e-05be-402a-9a8c-9b5677913f59" />

Updating the user without `name` and `email`:
<img width="919" height="236" alt="Screenshot 2025-09-19 at 09 45 05" src="https://github.com/user-attachments/assets/ff77d9bc-3ae2-4f35-be4e-565b44053a55" />

Updating the user with `name` and `email`:
<img width="899" height="216" alt="Screenshot 2025-09-19 at 09 45 39" src="https://github.com/user-attachments/assets/00119bf2-f683-4460-aa5b-25b058520f78" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38340
