### PR TITLE
[Backport stable/8.5] ci: adjust API codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # C8 REST OpenAPI changes are owned by the API reviewers team
-/zeebe/gateway-protocol/src/main/proto/rest-api.yaml @camunda/docs-api-reviewers
+/zeebe/gateway-protocol/src/main/proto/rest-api.yaml @camunda/c8-api-team


### PR DESCRIPTION
# Description
Backport of #38420 to `stable/8.5`.

relates to 