### PR TITLE
[Backport stable/8.7] ci: adjust API codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # C8 REST OpenAPI changes are owned by the API reviewers team
-/zeebe/gateway-protocol/src/main/proto/rest-api.yaml @camunda/docs-api-reviewers
+/zeebe/gateway-protocol/src/main/proto/rest-api.yaml @camunda/c8-api-team
 
 # C8Run by Distro team
 .github/actions/setup-c8run/* @camunda/distribution


### PR DESCRIPTION
# Description
Backport of #38420 to `stable/8.7`.

relates to 