### PR TITLE
[Backport stable/8.8] ci: adjust API codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 # If you'd like to be added as an owner, don't hesitate to reach out to one of the existing ones.
 
 # C8 REST OpenAPI specification
-/zeebe/gateway-protocol/src/main/proto/rest-api.yaml @camunda/docs-api-reviewers
+/zeebe/gateway-protocol/src/main/proto/rest-api.yaml @camunda/c8-api-team
 
 # Testing guide
 /docs/testing.md       @npepinpe @ChrisKujawa


### PR DESCRIPTION
# Description
Backport of #38420 to `stable/8.8`.

relates to 