### PR TITLE
[Backport stable/8.6] deps: Update springdoc to 2.7.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -138,7 +138,7 @@
     <version.checker-qual>3.47.0</version.checker-qual>
     <version.java-jwt>4.4.0</version.java-jwt>
     <version.reactive-streams>1.0.4</version.reactive-streams>
-    <version.postgresql>42.7.7</version.postgresql>
+    <version.postgresql>42.7.8</version.postgresql>
     <version.h2>2.3.232</version.h2>
     <version.aws-signing>2.3.1</version.aws-signing>
     <version.tc-keycloak>3.3.1</version.tc-keycloak>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -133,19 +133,10 @@
     <version.validation-api>3.1.1</version.validation-api>
     <version.jackson-databind-nullable>0.2.7</version.jackson-databind-nullable>
     <version.findbugs.jsr305>3.0.2</version.findbugs.jsr305>
-<<<<<<< HEAD
     <version.jackson-annotations>2.17.3</version.jackson-annotations>
     <version.swagger-annotations>2.2.37</version.swagger-annotations>
     <version.checker-qual>3.47.0</version.checker-qual>
     <version.java-jwt>4.4.0</version.java-jwt>
-=======
-    <version.jackson-annotations>2.19.2</version.jackson-annotations>
-    <version.json-path>2.9.0</version.json-path>
-    <version.swagger-annotations>2.2.34</version.swagger-annotations>
-    <version.swagger-parser>2.1.22</version.swagger-parser>
-    <version.checker-qual>3.49.5</version.checker-qual>
-    <version.java-jwt>4.5.0</version.java-jwt>
->>>>>>> 37a2fab5 (deps: Update swagger-parser to 2.1.22)
     <version.reactive-streams>1.0.4</version.reactive-streams>
     <version.postgresql>42.7.8</version.postgresql>
     <version.h2>2.3.232</version.h2>
@@ -160,7 +151,7 @@
     <version.thymeleaf>3.1.3.RELEASE</version.thymeleaf>
     <version.unboundid-ldapsdk>7.0.3</version.unboundid-ldapsdk>
     <version.parsson>1.1.7</version.parsson>
-    <version.springdoc>2.6.0</version.springdoc>
+    <version.springdoc>2.7.0</version.springdoc>
     <version.jakarta.json>2.0.1</version.jakarta.json>
 
     <version.node>v20.12.2</version.node>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -133,10 +133,19 @@
     <version.validation-api>3.1.1</version.validation-api>
     <version.jackson-databind-nullable>0.2.7</version.jackson-databind-nullable>
     <version.findbugs.jsr305>3.0.2</version.findbugs.jsr305>
+<<<<<<< HEAD
     <version.jackson-annotations>2.17.3</version.jackson-annotations>
     <version.swagger-annotations>2.2.37</version.swagger-annotations>
     <version.checker-qual>3.47.0</version.checker-qual>
     <version.java-jwt>4.4.0</version.java-jwt>
+=======
+    <version.jackson-annotations>2.19.2</version.jackson-annotations>
+    <version.json-path>2.9.0</version.json-path>
+    <version.swagger-annotations>2.2.34</version.swagger-annotations>
+    <version.swagger-parser>2.1.22</version.swagger-parser>
+    <version.checker-qual>3.49.5</version.checker-qual>
+    <version.java-jwt>4.5.0</version.java-jwt>
+>>>>>>> 37a2fab5 (deps: Update swagger-parser to 2.1.22)
     <version.reactive-streams>1.0.4</version.reactive-streams>
     <version.postgresql>42.7.8</version.postgresql>
     <version.h2>2.3.232</version.h2>


### PR DESCRIPTION
# Description
Backport of #38396 to `stable/8.6`.

relates to #38114