### PR TITLE
[Backport stable/8.8] deps: Update swagger-parser to 2.1.22

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -141,7 +141,7 @@
     <version.jackson-annotations>2.19.2</version.jackson-annotations>
     <version.json-path>2.9.0</version.json-path>
     <version.swagger-annotations>2.2.34</version.swagger-annotations>
-    <version.swagger-parser>2.1.16</version.swagger-parser>
+    <version.swagger-parser>2.1.22</version.swagger-parser>
     <version.checker-qual>3.49.5</version.checker-qual>
     <version.java-jwt>4.5.0</version.java-jwt>
     <version.reactive-streams>1.0.4</version.reactive-streams>


### PR DESCRIPTION
# Description
Backport of #38396 to `stable/8.8`.

relates to #38114