### PR TITLE
test: increase timeout since task could not be found

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
@@ -65,11 +65,11 @@ class TaskPanelPage {
         this.availableTasks
           .getByText(name, {exact: true})
           .nth(0)
-          .waitFor({state: 'visible', timeout: 5000}),
+          .waitFor({state: 'visible', timeout: 10000}),
         this.availableTasks
           .getByText(processId, {exact: true})
           .nth(0)
-          .waitFor({state: 'visible', timeout: 5000}),
+          .waitFor({state: 'visible', timeout: 10000}),
       ]);
       const nameLocator = this.availableTasks
         .getByText(name, {exact: true})


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Task could not be found, so increased the timeout to 10seconds.

Run: https://github.com/camunda/camunda/actions/runs/17855846934

Run: 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
