### PR TITLE
[Backport stable/8.8] fix: prefer client claim over username claim in GRPC code paths

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -106,16 +106,17 @@ public sealed interface AuthenticationHandler {
                 .withCause(e));
       }
 
-      if (principals.username() != null) {
-        return Either.right(
-            context
-                .withValue(USERNAME, principals.username())
-                .withValue(USER_CLAIMS, token.getClaims()));
-      }
       if (principals.clientId() != null) {
         return Either.right(
             context
                 .withValue(CLIENT_ID, principals.clientId())
+                .withValue(USER_CLAIMS, token.getClaims()));
+      }
+
+      if (principals.username() != null) {
+        return Either.right(
+            context
+                .withValue(USERNAME, principals.username())
                 .withValue(USER_CLAIMS, token.getClaims()));
       }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -426,7 +426,7 @@ public class AuthenticationInterceptorTest {
   }
 
   @Test
-  public void addsUsernameInPreferenceToClientIdInOidcToContext() {
+  public void addsClientIdInPreferenceToUsernameInOidcToContext() {
     // given
     final Metadata metadata = createAuthHeader();
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
@@ -452,8 +452,8 @@ public class AuthenticationInterceptorTest {
             metadata,
             (call, headers) -> {
               // then
-              assertUsername().isEqualTo("test-user");
-              assertClientId().isNull();
+              assertUsername().isNull();
+              assertClientId().isEqualTo("app-id");
 
               call.close(Status.OK, headers);
               return null;


### PR DESCRIPTION
# Description
Backport of #38448 to `stable/8.8`.

relates to 