### PR TITLE
test: add QA test when state is large

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
@@ -14,6 +14,7 @@ import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
@@ -105,15 +106,8 @@ final class Utils {
 
   static long deployProcessModel(
       final CamundaClient camundaClient,
-      final String jobType,
-      final String processId,
+      final BpmnModelInstance process,
       final boolean waitDeployment) {
-    final var process =
-        Bpmn.createExecutableProcess(processId)
-            .startEvent()
-            .serviceTask("task", t -> t.zeebeJobType(jobType))
-            .endEvent()
-            .done();
     final var deploymentKey =
         camundaClient
             .newDeployResourceCommand()
@@ -125,6 +119,20 @@ final class Utils {
       new ZeebeResourcesHelper(camundaClient).waitUntilDeploymentIsDone(deploymentKey);
     }
     return deploymentKey;
+  }
+
+  static long deployProcessModel(
+      final CamundaClient camundaClient,
+      final String jobType,
+      final String processId,
+      final boolean waitDeployment) {
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    return deployProcessModel(camundaClient, process, waitDeployment);
   }
 
   static List<Long> createInstanceWithAJobOnAllPartitions(


### PR DESCRIPTION


## Description
The state for bootstrap is around 83MB, with 100 different process definitions and 1000 users.
Process definition contains a 400KB string to inflate its size. The entire scaling operations takes around 5 seconds: the assertions verifies it takes less than 30 seconds to account for CI variability
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
