### PR TITLE
Add partition scaling to weekly E2E tests

### DIFF
--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -97,3 +97,15 @@ jobs:
       fault: '"scale-brokers"'
       maxInstanceDuration: 40m
     secrets: inherit
+
+  e2e-scaling-partitions-brokers:
+    name: Scaling brokers
+    uses: ./.github/workflows/zeebe-e2e-testbench.yaml
+    with:
+      branch: main
+      generation: Zeebe SNAPSHOT
+      maxTestDuration: PT2H
+      clusterPlan: Production - M
+      fault: '"scale-partitions"'
+      maxInstanceDuration: 40m
+    secrets: inherit

--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -5,10 +5,10 @@
 name: Zeebe Weekly E2E tests
 
 on:
-  workflow_dispatch: { }
+  workflow_dispatch: {}
   schedule:
     # Run at 7:00 on every monday
-    - cron: '0 7 * * 1'
+    - cron: "0 7 * * 1"
 
 jobs:
   # This job will figure out the last supported versions based on the latest tags.
@@ -52,13 +52,13 @@ jobs:
       fail-fast: false
       matrix:
         branch:
-          - 'main'
+          - main
           - ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
           - ${{ format('stable/{0}', needs.get-versions.outputs.second-last-version) }}
           - ${{ format('stable/{0}', needs.get-versions.outputs.third-last-version) }}
         include:
-          - branch: 'main'
-            generation_template: 'Zeebe SNAPSHOT'
+          - branch: main
+            generation_template: "Zeebe SNAPSHOT"
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
             generation_template: ${{ format('Camunda {0}+gen1', needs.get-versions.outputs.latest-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.second-last-version) }}

--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -92,7 +92,7 @@ jobs:
     with:
       branch: main
       generation: Zeebe SNAPSHOT
-      maxTestDuration: PT4H
+      maxTestDuration: PT2H
       clusterPlan: Production - M
       fault: '"scale-brokers"'
       maxInstanceDuration: 40m


### PR DESCRIPTION
## Description
- Enable the fault 'scale-partitions' to run in the weekly E2E tests:
  -  The max duration is set to 2H since there is no need to run the fault more than once: after the first time nothing will be done.
- Reduce MaxDuration for scale-brokers to 2H since the fault does not need to run more than once
- Minor refactoring/formatting from the suggestion of the LSP 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #34813
