### PR TITLE
feat: delete deprecated indices, index and component templates

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/migration/PrefixMigrationHelper.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/PrefixMigrationHelper.java
@@ -257,9 +257,13 @@ public final class PrefixMigrationHelper {
         .forEach(deleteOperations::add);
 
     return () ->
-        CompletableFuture.supplyAsync(
-            () ->
-                prefixMigrationClient.deleteIndex(deleteOperations.toArray(String[]::new)).join());
+        deleteOperations.isEmpty()
+            ? CompletableFuture.completedFuture(null)
+            : CompletableFuture.supplyAsync(
+                () ->
+                    prefixMigrationClient
+                        .deleteIndex(deleteOperations.toArray(String[]::new))
+                        .join());
   }
 
   private static Supplier<CompletableFuture[]> deleteIndexTemplates(

--- a/schema-manager/src/main/java/io/camunda/search/schema/PrefixMigrationClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/PrefixMigrationClient.java
@@ -20,4 +20,10 @@ public interface PrefixMigrationClient {
       final String sourceAlias,
       final String destination,
       final String destinationAlias);
+
+  CompletableFuture<Void> deleteIndex(String... indexName);
+
+  CompletableFuture<Void> deleteComponentTemplate(String componentTemplateName);
+
+  CompletableFuture<Void> deleteIndexTemplate(String indexTemplateName);
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchPrefixMigrationClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchPrefixMigrationClient.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,7 @@ public class ElasticsearchPrefixMigrationClient implements PrefixMigrationClient
   public CompletableFuture<Void> deleteIndex(final String... index) {
     return asyncClient
         .indices()
-        .delete(d -> d.index(Arrays.asList(index)))
+        .delete(d -> d.index(Arrays.asList(index)).ignoreUnavailable(true))
         .thenRun(() -> LOG.info("Deleted indices [{}]", Arrays.stream(index).toList()));
   }
 
@@ -87,6 +88,18 @@ public class ElasticsearchPrefixMigrationClient implements PrefixMigrationClient
     return asyncClient
         .cluster()
         .deleteComponentTemplate(d -> d.name(componentTemplateName))
+        .exceptionally(
+            ex -> {
+              if (ex instanceof final ElasticsearchException esx && esx.status() == 404) {
+                LOG.warn(
+                    "Component template [{}] does not exist, nothing to delete",
+                    componentTemplateName);
+                return null;
+              } else {
+                throw new CompletionException(
+                    "Failed to delete component template [" + componentTemplateName + "]", ex);
+              }
+            })
         .thenRun(() -> LOG.info("Deleted component template [{}]", componentTemplateName));
   }
 
@@ -95,6 +108,17 @@ public class ElasticsearchPrefixMigrationClient implements PrefixMigrationClient
     return asyncClient
         .indices()
         .deleteIndexTemplate(d -> d.name(indexTemplateName))
+        .exceptionally(
+            ex -> {
+              if (ex instanceof final ElasticsearchException esx && esx.status() == 404) {
+                LOG.warn(
+                    "Index template [{}] does not exist, nothing to delete", indexTemplateName);
+                return null;
+              } else {
+                throw new CompletionException(
+                    "Failed to delete index template [" + indexTemplateName + "]", ex);
+              }
+            })
         .thenRun(() -> LOG.info("Deleted index template [{}]", indexTemplateName));
   }
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchPrefixMigrationClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchPrefixMigrationClient.java
@@ -10,6 +10,7 @@ package io.camunda.search.schema.opensearch;
 import io.camunda.search.schema.PrefixMigrationClient;
 import io.camunda.search.schema.utils.CloneResult;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
@@ -71,6 +72,44 @@ public class OpensearchPrefixMigrationClient implements PrefixMigrationClient {
         .exceptionally(ex -> handleMigrationFailure(ex, source, destination));
   }
 
+  @Override
+  public CompletableFuture<Void> deleteIndex(final String... index) {
+    try {
+      return asyncClient
+          .indices()
+          .delete(d -> d.index(Arrays.asList(index)))
+          .thenRun(() -> LOG.info("Deleted index [{}]", index));
+    } catch (final IOException e) {
+      throw new IllegalStateException("Failed to delete index [" + index + "]", e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<Void> deleteComponentTemplate(final String componentTemplateName) {
+    try {
+      return asyncClient
+          .cluster()
+          .deleteComponentTemplate(d -> d.name(componentTemplateName))
+          .thenRun(() -> LOG.info("Deleted component template [{}]", componentTemplateName));
+    } catch (final IOException e) {
+      throw new IllegalStateException(
+          "Failed to delete component template [" + componentTemplateName + "]", e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<Void> deleteIndexTemplate(final String indexTemplateName) {
+    try {
+      return asyncClient
+          .indices()
+          .deleteIndexTemplate(d -> d.name(indexTemplateName))
+          .thenRun(() -> LOG.info("Deleted index template [{}]", indexTemplateName));
+    } catch (final IOException e) {
+      throw new IllegalStateException(
+          "Failed to delete index template [" + indexTemplateName + "]", e);
+    }
+  }
+
   private CompletableFuture<Void> cloneIndex(final String source, final String destination) {
     try {
       return asyncClient
@@ -126,17 +165,6 @@ public class OpensearchPrefixMigrationClient implements PrefixMigrationClient {
     } catch (final IOException e) {
       throw new IllegalStateException(
           "Failed to update setting block: " + block + " index [" + index + "]", e);
-    }
-  }
-
-  private CompletableFuture<Void> deleteIndex(final String index) {
-    try {
-      return asyncClient
-          .indices()
-          .delete(d -> d.index(index))
-          .thenRun(() -> LOG.info("Deleted index [{}]", index));
-    } catch (final IOException e) {
-      throw new IllegalStateException("Failed to delete index [" + index + "]", e);
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Add missing `DraftTaskVariable` and `TasklistMetric` index to migrate
- Delete deprecated Operate & Tasklist indices
- Delete all index-templates
- Delete all component-templates

Index & Component templates will be applied by the Schema Manager when the 8.8 rollout occurs

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/38489
