### PR TITLE
fix: show validation error on empty variable modification value

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
@@ -6,7 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {validateValueComplete, validateValueValid} from './validators';
+import {
+  validateValueComplete,
+  validateValueNotEmpty,
+  validateValueValid,
+} from './validators';
 import {Field, useField, useForm, useFormState} from 'react-final-form';
 import {useEffect, useState} from 'react';
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
@@ -126,25 +130,6 @@ const ExistingVariableValue: React.FC<Props> = observer(
     const isVariableValueUndefined = variable?.value === undefined;
     const pauseValidation = isPreview && isVariableValueUndefined;
 
-    /* This is a temporary solution until we can properly use the form state submission validation for the modification mode
-     * This should be done together with #38482
-     */
-    const validateValueNotEmptyWithModifications = (variableValue = '') => {
-      const scopeId = getScopeId();
-      const hasModificationForThisVariable =
-        modificationsStore.getLastVariableModification(
-          scopeId,
-          variableName,
-          'EDIT_VARIABLE',
-        );
-
-      if (hasModificationForThisVariable && variableValue === '') {
-        return ERRORS.INVALID_VALUE;
-      }
-
-      return;
-    };
-
     return (
       <Layer>
         <Field
@@ -156,7 +141,7 @@ const ExistingVariableValue: React.FC<Props> = observer(
               : mergeValidators(
                   validateValueComplete,
                   validateValueValid,
-                  validateValueNotEmptyWithModifications,
+                  validateValueNotEmpty,
                 )
           }
           parse={(value) => value}

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
@@ -27,7 +27,6 @@ import {getScopeId} from 'modules/utils/variables';
 import type {Variable} from '@camunda/camunda-api-zod-schemas/8.8';
 import {useVariable} from 'modules/queries/variables/useVariable';
 import {notificationsStore} from 'modules/stores/notifications';
-import {ERRORS} from './constants';
 
 type Props = {
   id?: string;

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/validators.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/validators.ts
@@ -226,6 +226,14 @@ const validateModifiedValueValid: FieldValidator<string | undefined> = (
   return ERRORS.INVALID_VALUE;
 };
 
+const validateValueNotEmpty = (variableValue = '') => {
+  if (variableValue === '') {
+    return ERRORS.INVALID_VALUE;
+  }
+
+  return;
+};
+
 export {
   validateNameCharacters,
   validateNameComplete,
@@ -238,4 +246,5 @@ export {
   validateModifiedValueValid,
   validateModifiedNameNotDuplicate,
   validateModifiedNameNotDuplicateDeprecated,
+  validateValueNotEmpty,
 };


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I consider this as a temporary fix since I believe should have been handled at the submission validation at the form level but for some reason the modification "submit" button is not part of the form so I have no access to the form state

Ideally the modal should not open with an invalid form either, but this is the current behavior we have when adding a new variable. So I preferred to be consistent

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #36375
