### PR TITLE
[Backport stable/8.8] fix: show validation error on empty variable modification value

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
@@ -6,7 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {validateValueComplete, validateValueValid} from './validators';
+import {
+  validateValueComplete,
+  validateValueNotEmpty,
+  validateValueValid,
+} from './validators';
 import {Field, useField, useForm, useFormState} from 'react-final-form';
 import {useEffect, useState} from 'react';
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
@@ -126,25 +130,6 @@ const ExistingVariableValue: React.FC<Props> = observer(
     const isVariableValueUndefined = variable?.value === undefined;
     const pauseValidation = isPreview && isVariableValueUndefined;
 
-    /* This is a temporary solution until we can properly use the form state submission validation for the modification mode
-     * This should be done together with #38482
-     */
-    const validateValueNotEmptyWithModifications = (variableValue = '') => {
-      const scopeId = getScopeId();
-      const hasModificationForThisVariable =
-        modificationsStore.getLastVariableModification(
-          scopeId,
-          variableName,
-          'EDIT_VARIABLE',
-        );
-
-      if (hasModificationForThisVariable && variableValue === '') {
-        return ERRORS.INVALID_VALUE;
-      }
-
-      return;
-    };
-
     return (
       <Layer>
         <Field
@@ -156,7 +141,7 @@ const ExistingVariableValue: React.FC<Props> = observer(
               : mergeValidators(
                   validateValueComplete,
                   validateValueValid,
-                  validateValueNotEmptyWithModifications,
+                  validateValueNotEmpty,
                 )
           }
           parse={(value) => value}

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
@@ -27,7 +27,6 @@ import {getScopeId} from 'modules/utils/variables';
 import type {Variable} from '@camunda/camunda-api-zod-schemas/8.8';
 import {useVariable} from 'modules/queries/variables/useVariable';
 import {notificationsStore} from 'modules/stores/notifications';
-import {ERRORS} from './constants';
 
 type Props = {
   id?: string;

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/validators.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/validators.ts
@@ -226,6 +226,14 @@ const validateModifiedValueValid: FieldValidator<string | undefined> = (
   return ERRORS.INVALID_VALUE;
 };
 
+const validateValueNotEmpty = (variableValue = '') => {
+  if (variableValue === '') {
+    return ERRORS.INVALID_VALUE;
+  }
+
+  return;
+};
+
 export {
   validateNameCharacters,
   validateNameComplete,
@@ -238,4 +246,5 @@ export {
   validateModifiedValueValid,
   validateModifiedNameNotDuplicate,
   validateModifiedNameNotDuplicateDeprecated,
+  validateValueNotEmpty,
 };


### PR DESCRIPTION
# Description
Backport of #38485 to `stable/8.8`.

relates to #36375