### PR TITLE
Close virtualThreadPool in SchemaManager

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/management/IndicesCheck.java
+++ b/operate/schema/src/main/java/io/camunda/operate/management/IndicesCheck.java
@@ -73,5 +73,6 @@ public class IndicesCheck implements CloseableSilently {
   @Override
   public void close() {
     searchEngineClient.close();
+    schemaManager.close();
   }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -18,6 +18,7 @@ import io.camunda.search.schema.metrics.SchemaManagerMetrics;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
+import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.retry.RetryDecorator;
 import java.util.Collection;
 import java.util.Collections;
@@ -36,7 +37,7 @@ import org.agrona.LangUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SchemaManager {
+public class SchemaManager implements CloseableSilently {
   public static final int INDEX_CREATION_TIMEOUT_SECONDS = 60;
   public static final String PI_ARCHIVING_BLOCKED_META_KEY = "processInstanceArchivingBlocked";
   private static final Logger LOG = LoggerFactory.getLogger(SchemaManager.class);
@@ -473,5 +474,10 @@ public class SchemaManager {
 
   public boolean isAllIndicesExist() {
     return getMissingIndices(allIndexDescriptors).isEmpty();
+  }
+
+  @Override
+  public void close() {
+    virtualThreadExecutor.close();
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/IndexSchemaValidatorElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/IndexSchemaValidatorElasticSearch.java
@@ -58,5 +58,6 @@ public class IndexSchemaValidatorElasticSearch implements IndexSchemaValidator, 
   @Override
   public void close() {
     searchEngineClient.close();
+    schemaManager.close();
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/DevUtilExternalController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/DevUtilExternalController.java
@@ -78,14 +78,15 @@ public class DevUtilExternalController {
           new ElasticsearchEngineClient(elasticsearchClient, connector.objectMapper());
       elasticsearchClient.indices().delete(r -> r.index(indicesToDelete));
       processCache.clearCache();
-      final var schemaManager =
+      try (final var schemaManager =
           new SchemaManager(
               searchEngineClient,
               indexDescriptors.indices(),
               indexDescriptors.templates(),
               configuration,
-              connector.objectMapper());
-      schemaManager.startup();
+              connector.objectMapper())) {
+        schemaManager.startup();
+      }
     }
     return ResponseEntity.ok().build();
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -122,10 +122,11 @@ public class CamundaExporter implements Exporter {
     this.controller = controller;
     setupExporterResources();
     searchEngineClient = clientAdapter.getSearchEngineClient();
-    final var schemaManager = createSchemaManager();
+    try (final var schemaManager = createSchemaManager()) {
 
-    if (!schemaManager.isSchemaReadyForUse()) {
-      throw new IllegalStateException("Schema is not ready for use");
+      if (!schemaManager.isSchemaReadyForUse()) {
+        throw new IllegalStateException("Schema is not ready for use");
+      }
     }
 
     writer = createBatchWriter();
@@ -230,13 +231,15 @@ public class CamundaExporter implements Exporter {
     try {
       setupExporterResources();
       searchEngineClient = clientAdapter.getSearchEngineClient();
-      final var schemaManager = createSchemaManager();
+      final List<String> emptiedIndices;
+      try (final var schemaManager = createSchemaManager()) {
 
-      // Indices
-      final var emptiedIndices = schemaManager.truncateIndices();
+        // Indices
+        emptiedIndices = schemaManager.truncateIndices();
 
-      // Delete archived indices
-      schemaManager.deleteArchivedIndices();
+        // Delete archived indices
+        schemaManager.deleteArchivedIndices();
+      }
 
       // At this point, several indices still have data, e.g.
       // deployment, tasklist-task, process, operate-event, operate-list-view,


### PR DESCRIPTION
 ## Description

* SchemaManager uses VirtualThreadPool, which spawns up to 32 (?) threads, but never closes them
 * This commit fixes this by implementing CloseSilently and using try-with-resource

## Related issues

reported here https://camunda.slack.com/archives/C0807665N8G/p1758349374723259?thread_ts=1758111376.933779&cid=C0807665N8G

closes https://github.com/camunda/camunda/issues/38830