### PR TITLE
feat: add validation for message start event

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ProcessValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ProcessValidator.java
@@ -48,6 +48,9 @@ public class ProcessValidator implements ModelElementValidator<Process> {
     ModelUtil.verifyNoDuplicateSignalStartEvents(
         element, error -> validationResultCollector.addError(0, error));
 
+    ModelUtil.verifyNoDuplicateMessageStartEvents(
+        element, error -> validationResultCollector.addError(0, error));
+
     ModelUtil.verifyLinkIntermediateEvents(
         element, error -> validationResultCollector.addError(0, error));
   }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
@@ -254,7 +254,14 @@ public class ZeebeMessageValidationTest extends AbstractZeebeValidationTest {
             .endEvent("test")
             .done(),
         singletonList(expect(MessageEventDefinition.class, "Must reference a message"))
-      }
+      },
+      {
+        getProcessWithMultipleStartEventsWithSameMessageName(),
+        singletonList(
+            expect(
+                "process",
+                "Multiple message event definitions with the same name 'messageName' are not allowed."))
+      },
     };
   }
 
@@ -282,6 +289,14 @@ public class ZeebeMessageValidationTest extends AbstractZeebeValidationTest {
     final String messageName = "messageName";
     process.startEvent("start1").message(m -> m.id("start-message").name(messageName)).endEvent();
     process.startEvent("start2").message(messageName).endEvent();
+    return process.done();
+  }
+
+  private static BpmnModelInstance getProcessWithMultipleStartEventsWithSameMessageName() {
+    final ProcessBuilder process = Bpmn.createExecutableProcess("process");
+    final String messageName = "messageName";
+    process.startEvent("start1").message(m -> m.id("start1-message").name(messageName)).endEvent();
+    process.startEvent("start2").message(m -> m.id("start2-message").name(messageName)).endEvent();
     return process.done();
   }
 


### PR DESCRIPTION
## Description
Add new validation to ensure that duplicate message names are not allowed in message definitions that reference different messages.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38234
