### PR TITLE
Reuse clients in BackgroundManager Repositories

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -51,6 +51,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.jetbrains.annotations.NotNull;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.slf4j.Logger;
 
@@ -97,8 +99,24 @@ public final class BackgroundTaskManagerFactory {
     // initialize all repositories based on connection type to reuse clients
     final var connectionType = ConnectionTypes.from(config.getConnect().getType());
     switch (connectionType) {
-      case ELASTICSEARCH -> initElasticsearchBasedRepositories();
-      case OPENSEARCH -> initOpensearchBasedRepositories();
+      case ELASTICSEARCH -> {
+        final var connector = new ElasticsearchConnector(config.getConnect());
+        final ElasticsearchAsyncClient asyncClient = connector.createAsyncClient();
+
+        archiverRepository = createArchiverRepository(asyncClient);
+        incidentRepository = createIncidentUpdateRepository(asyncClient);
+        batchOperationUpdateRepository = createBatchOperationRepository(asyncClient);
+      }
+      case OPENSEARCH -> {
+        final var connector = new OpensearchConnector(config.getConnect());
+        final var asyncClient = connector.createAsyncClient();
+        final var genericClient =
+            new OpenSearchGenericClient(asyncClient._transport(), asyncClient._transportOptions());
+
+        archiverRepository = createArchiverRepository(asyncClient, genericClient);
+        incidentRepository = createIncidentUpdateRepository(asyncClient);
+        batchOperationUpdateRepository = createBatchOperationRepository(asyncClient);
+      }
     }
 
     final List<RunnableTask> tasks = buildTasks();
@@ -114,57 +132,22 @@ public final class BackgroundTaskManagerFactory {
         Duration.ofSeconds(5));
   }
 
-  private void initOpensearchBasedRepositories() {
-    final var listViewTemplate =
-        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
-    final var flowNodeTemplate =
-        resourceProvider.getIndexTemplateDescriptor(FlowNodeInstanceTemplate.class);
-    final var incidentTemplate =
-        resourceProvider.getIndexTemplateDescriptor(IncidentTemplate.class);
-    final var postImporterTemplate =
-        resourceProvider.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
+  private OpensearchBatchOperationUpdateRepository createBatchOperationRepository(
+      final OpenSearchAsyncClient asyncClient) {
     final var operationTemplate =
         resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
     final var batchOperationTemplate =
         resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
-
-    final var connector = new OpensearchConnector(config.getConnect());
-    final var asyncClient = connector.createAsyncClient();
-    final var genericClient =
-        new OpenSearchGenericClient(asyncClient._transport(), asyncClient._transportOptions());
-    archiverRepository =
-        new OpenSearchArchiverRepository(
-            partitionId,
-            config.getHistory(),
-            resourceProvider,
-            asyncClient,
-            genericClient,
-            executor,
-            metrics,
-            logger);
-    incidentRepository =
-        new OpenSearchIncidentUpdateRepository(
-            partitionId,
-            postImporterTemplate.getAlias(),
-            incidentTemplate.getAlias(),
-            listViewTemplate.getAlias(),
-            listViewTemplate.getFullQualifiedName(),
-            flowNodeTemplate.getAlias(),
-            operationTemplate.getAlias(),
-            asyncClient,
-            executor,
-            logger);
-
-    batchOperationUpdateRepository =
-        new OpensearchBatchOperationUpdateRepository(
-            asyncClient,
-            executor,
-            batchOperationTemplate.getFullQualifiedName(),
-            operationTemplate.getFullQualifiedName(),
-            logger);
+    return new OpensearchBatchOperationUpdateRepository(
+        asyncClient,
+        executor,
+        batchOperationTemplate.getFullQualifiedName(),
+        operationTemplate.getFullQualifiedName(),
+        logger);
   }
 
-  private void initElasticsearchBasedRepositories() {
+  private OpenSearchIncidentUpdateRepository createIncidentUpdateRepository(
+      final OpenSearchAsyncClient asyncClient) {
     final var listViewTemplate =
         resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
     final var flowNodeTemplate =
@@ -177,38 +160,75 @@ public final class BackgroundTaskManagerFactory {
         resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
     final var batchOperationTemplate =
         resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
+    return new OpenSearchIncidentUpdateRepository(
+        partitionId,
+        postImporterTemplate.getAlias(),
+        incidentTemplate.getAlias(),
+        listViewTemplate.getAlias(),
+        listViewTemplate.getFullQualifiedName(),
+        flowNodeTemplate.getAlias(),
+        operationTemplate.getAlias(),
+        asyncClient,
+        executor,
+        logger);
+  }
 
-    final var connector = new ElasticsearchConnector(config.getConnect());
-    final ElasticsearchAsyncClient asyncClient = connector.createAsyncClient();
-    archiverRepository =
-        new ElasticsearchArchiverRepository(
-            partitionId,
-            config.getHistory(),
-            resourceProvider,
-            asyncClient,
-            executor,
-            metrics,
-            logger);
-    incidentRepository =
-        new ElasticsearchIncidentUpdateRepository(
-            partitionId,
-            postImporterTemplate.getAlias(),
-            incidentTemplate.getAlias(),
-            listViewTemplate.getAlias(),
-            listViewTemplate.getFullQualifiedName(),
-            flowNodeTemplate.getAlias(),
-            operationTemplate.getAlias(),
-            asyncClient,
-            executor,
-            logger);
+  private @NotNull OpenSearchArchiverRepository createArchiverRepository(
+      final OpenSearchAsyncClient asyncClient, final OpenSearchGenericClient genericClient) {
+    return new OpenSearchArchiverRepository(
+        partitionId,
+        config.getHistory(),
+        resourceProvider,
+        asyncClient,
+        genericClient,
+        executor,
+        metrics,
+        logger);
+  }
 
-    batchOperationUpdateRepository =
-        new ElasticsearchBatchOperationUpdateRepository(
-            asyncClient,
-            executor,
-            batchOperationTemplate.getFullQualifiedName(),
-            operationTemplate.getFullQualifiedName(),
-            logger);
+  private ElasticsearchBatchOperationUpdateRepository createBatchOperationRepository(
+      final ElasticsearchAsyncClient asyncClient) {
+    final var operationTemplate =
+        resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
+    final var batchOperationTemplate =
+        resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
+    return new ElasticsearchBatchOperationUpdateRepository(
+        asyncClient,
+        executor,
+        operationTemplate.getFullQualifiedName(),
+        batchOperationTemplate.getFullQualifiedName(),
+        logger);
+  }
+
+  private @NotNull ElasticsearchIncidentUpdateRepository createIncidentUpdateRepository(
+      final ElasticsearchAsyncClient asyncClient) {
+    final var listViewTemplate =
+        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+    final var flowNodeTemplate =
+        resourceProvider.getIndexTemplateDescriptor(FlowNodeInstanceTemplate.class);
+    final var incidentTemplate =
+        resourceProvider.getIndexTemplateDescriptor(IncidentTemplate.class);
+    final var postImporterTemplate =
+        resourceProvider.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
+    final var operationTemplate =
+        resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
+    return new ElasticsearchIncidentUpdateRepository(
+        partitionId,
+        postImporterTemplate.getAlias(),
+        incidentTemplate.getAlias(),
+        listViewTemplate.getAlias(),
+        listViewTemplate.getFullQualifiedName(),
+        flowNodeTemplate.getAlias(),
+        operationTemplate.getAlias(),
+        asyncClient,
+        executor,
+        logger);
+  }
+
+  private @NotNull ElasticsearchArchiverRepository createArchiverRepository(
+      final ElasticsearchAsyncClient asyncClient) {
+    return new ElasticsearchArchiverRepository(
+        partitionId, config.getHistory(), resourceProvider, asyncClient, executor, metrics, logger);
   }
 
   private List<RunnableTask> buildTasks() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -51,7 +51,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import org.jetbrains.annotations.NotNull;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.slf4j.Logger;
@@ -170,7 +169,7 @@ public final class BackgroundTaskManagerFactory {
         logger);
   }
 
-  private @NotNull OpenSearchArchiverRepository createArchiverRepository(
+  private OpenSearchArchiverRepository createArchiverRepository(
       final OpenSearchAsyncClient asyncClient, final OpenSearchGenericClient genericClient) {
     return new OpenSearchArchiverRepository(
         partitionId,
@@ -197,7 +196,7 @@ public final class BackgroundTaskManagerFactory {
         logger);
   }
 
-  private @NotNull ElasticsearchIncidentUpdateRepository createIncidentUpdateRepository(
+  private ElasticsearchIncidentUpdateRepository createIncidentUpdateRepository(
       final ElasticsearchAsyncClient asyncClient) {
     final var listViewTemplate =
         resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
@@ -222,7 +221,7 @@ public final class BackgroundTaskManagerFactory {
         logger);
   }
 
-  private @NotNull ElasticsearchArchiverRepository createArchiverRepository(
+  private ElasticsearchArchiverRepository createArchiverRepository(
       final ElasticsearchAsyncClient asyncClient) {
     return new ElasticsearchArchiverRepository(
         partitionId, config.getHistory(), resourceProvider, asyncClient, executor, metrics, logger);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -152,8 +152,6 @@ public final class BackgroundTaskManagerFactory {
         resourceProvider.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
     final var operationTemplate =
         resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
-    final var batchOperationTemplate =
-        resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
     return new OpenSearchIncidentUpdateRepository(
         partitionId,
         postImporterTemplate.getAlias(),
@@ -189,8 +187,8 @@ public final class BackgroundTaskManagerFactory {
     return new ElasticsearchBatchOperationUpdateRepository(
         asyncClient,
         executor,
-        operationTemplate.getFullQualifiedName(),
         batchOperationTemplate.getFullQualifiedName(),
+        operationTemplate.getFullQualifiedName(),
         logger);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -36,7 +36,6 @@ import io.camunda.exporter.tasks.incident.OpenSearchIncidentUpdateRepository;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
-import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
@@ -237,12 +236,6 @@ public final class BackgroundTaskManagerFactory {
   }
 
   private ArchiverRepository buildArchiverRepository() {
-    final var listViewTemplate =
-        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
-    final var batchOperationTemplate =
-        resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
-    final var tasklistImportPositionIndex =
-        resourceProvider.getIndexDescriptor(TasklistImportPositionIndex.class);
     return switch (ConnectionTypes.from(config.getConnect().getType())) {
       case ELASTICSEARCH -> {
         final var connector = new ElasticsearchConnector(config.getConnect());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -13,7 +13,6 @@ import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.ExporterResourceProvider;
-import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.notifier.HttpClientWrapper;
@@ -96,8 +95,7 @@ public final class BackgroundTaskManagerFactory {
     executor = buildExecutor();
 
     // initialize all repositories based on connection type to reuse clients
-    final var connectionType = ConnectionTypes.from(config.getConnect().getType());
-    if (connectionType == ConnectionTypes.OPENSEARCH) {
+    if (config.getConnect().getTypeEnum().isOpenSearch()) {
       final var connector = new OpensearchConnector(config.getConnect());
       final var asyncClient = connector.createAsyncClient();
       final var genericClient =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -94,89 +94,11 @@ public final class BackgroundTaskManagerFactory {
   public BackgroundTaskManager build() {
     executor = buildExecutor();
 
-    final var listViewTemplate =
-        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
-    final var flowNodeTemplate =
-        resourceProvider.getIndexTemplateDescriptor(FlowNodeInstanceTemplate.class);
-    final var incidentTemplate =
-        resourceProvider.getIndexTemplateDescriptor(IncidentTemplate.class);
-    final var postImporterTemplate =
-        resourceProvider.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
-    final var operationTemplate =
-        resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
-    final var batchOperationTemplate =
-        resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
-
-    switch (ConnectionTypes.from(config.getConnect().getType())) {
-      case ELASTICSEARCH -> {
-        final var connector = new ElasticsearchConnector(config.getConnect());
-        final ElasticsearchAsyncClient asyncClient = connector.createAsyncClient();
-        archiverRepository =
-            new ElasticsearchArchiverRepository(
-                partitionId,
-                config.getHistory(),
-                resourceProvider,
-                asyncClient,
-                executor,
-                metrics,
-                logger);
-        incidentRepository =
-            new ElasticsearchIncidentUpdateRepository(
-                partitionId,
-                postImporterTemplate.getAlias(),
-                incidentTemplate.getAlias(),
-                listViewTemplate.getAlias(),
-                listViewTemplate.getFullQualifiedName(),
-                flowNodeTemplate.getAlias(),
-                operationTemplate.getAlias(),
-                asyncClient,
-                executor,
-                logger);
-
-        batchOperationUpdateRepository =
-            new ElasticsearchBatchOperationUpdateRepository(
-                asyncClient,
-                executor,
-                batchOperationTemplate.getFullQualifiedName(),
-                operationTemplate.getFullQualifiedName(),
-                logger);
-      }
-      case OPENSEARCH -> {
-        final var connector = new OpensearchConnector(config.getConnect());
-        final var asyncClient = connector.createAsyncClient();
-        final var genericClient =
-            new OpenSearchGenericClient(asyncClient._transport(), asyncClient._transportOptions());
-        archiverRepository =
-            new OpenSearchArchiverRepository(
-                partitionId,
-                config.getHistory(),
-                resourceProvider,
-                asyncClient,
-                genericClient,
-                executor,
-                metrics,
-                logger);
-        incidentRepository =
-            new OpenSearchIncidentUpdateRepository(
-                partitionId,
-                postImporterTemplate.getAlias(),
-                incidentTemplate.getAlias(),
-                listViewTemplate.getAlias(),
-                listViewTemplate.getFullQualifiedName(),
-                flowNodeTemplate.getAlias(),
-                operationTemplate.getAlias(),
-                asyncClient,
-                executor,
-                logger);
-
-        batchOperationUpdateRepository =
-            new OpensearchBatchOperationUpdateRepository(
-                asyncClient,
-                executor,
-                batchOperationTemplate.getFullQualifiedName(),
-                operationTemplate.getFullQualifiedName(),
-                logger);
-      }
+    // initialize all repositories based on connection type to reuse clients
+    final var connectionType = ConnectionTypes.from(config.getConnect().getType());
+    switch (connectionType) {
+      case ELASTICSEARCH -> initElasticsearchBasedRepositories();
+      case OPENSEARCH -> initOpensearchBasedRepositories();
     }
 
     final List<RunnableTask> tasks = buildTasks();
@@ -190,6 +112,103 @@ public final class BackgroundTaskManagerFactory {
         executor,
         tasks,
         Duration.ofSeconds(5));
+  }
+
+  private void initOpensearchBasedRepositories() {
+    final var listViewTemplate =
+        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+    final var flowNodeTemplate =
+        resourceProvider.getIndexTemplateDescriptor(FlowNodeInstanceTemplate.class);
+    final var incidentTemplate =
+        resourceProvider.getIndexTemplateDescriptor(IncidentTemplate.class);
+    final var postImporterTemplate =
+        resourceProvider.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
+    final var operationTemplate =
+        resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
+    final var batchOperationTemplate =
+        resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
+
+    final var connector = new OpensearchConnector(config.getConnect());
+    final var asyncClient = connector.createAsyncClient();
+    final var genericClient =
+        new OpenSearchGenericClient(asyncClient._transport(), asyncClient._transportOptions());
+    archiverRepository =
+        new OpenSearchArchiverRepository(
+            partitionId,
+            config.getHistory(),
+            resourceProvider,
+            asyncClient,
+            genericClient,
+            executor,
+            metrics,
+            logger);
+    incidentRepository =
+        new OpenSearchIncidentUpdateRepository(
+            partitionId,
+            postImporterTemplate.getAlias(),
+            incidentTemplate.getAlias(),
+            listViewTemplate.getAlias(),
+            listViewTemplate.getFullQualifiedName(),
+            flowNodeTemplate.getAlias(),
+            operationTemplate.getAlias(),
+            asyncClient,
+            executor,
+            logger);
+
+    batchOperationUpdateRepository =
+        new OpensearchBatchOperationUpdateRepository(
+            asyncClient,
+            executor,
+            batchOperationTemplate.getFullQualifiedName(),
+            operationTemplate.getFullQualifiedName(),
+            logger);
+  }
+
+  private void initElasticsearchBasedRepositories() {
+    final var listViewTemplate =
+        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+    final var flowNodeTemplate =
+        resourceProvider.getIndexTemplateDescriptor(FlowNodeInstanceTemplate.class);
+    final var incidentTemplate =
+        resourceProvider.getIndexTemplateDescriptor(IncidentTemplate.class);
+    final var postImporterTemplate =
+        resourceProvider.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
+    final var operationTemplate =
+        resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
+    final var batchOperationTemplate =
+        resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
+
+    final var connector = new ElasticsearchConnector(config.getConnect());
+    final ElasticsearchAsyncClient asyncClient = connector.createAsyncClient();
+    archiverRepository =
+        new ElasticsearchArchiverRepository(
+            partitionId,
+            config.getHistory(),
+            resourceProvider,
+            asyncClient,
+            executor,
+            metrics,
+            logger);
+    incidentRepository =
+        new ElasticsearchIncidentUpdateRepository(
+            partitionId,
+            postImporterTemplate.getAlias(),
+            incidentTemplate.getAlias(),
+            listViewTemplate.getAlias(),
+            listViewTemplate.getFullQualifiedName(),
+            flowNodeTemplate.getAlias(),
+            operationTemplate.getAlias(),
+            asyncClient,
+            executor,
+            logger);
+
+    batchOperationUpdateRepository =
+        new ElasticsearchBatchOperationUpdateRepository(
+            asyncClient,
+            executor,
+            batchOperationTemplate.getFullQualifiedName(),
+            operationTemplate.getFullQualifiedName(),
+            logger);
   }
 
   private List<RunnableTask> buildTasks() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -98,25 +98,22 @@ public final class BackgroundTaskManagerFactory {
 
     // initialize all repositories based on connection type to reuse clients
     final var connectionType = ConnectionTypes.from(config.getConnect().getType());
-    switch (connectionType) {
-      case ELASTICSEARCH -> {
-        final var connector = new ElasticsearchConnector(config.getConnect());
-        final ElasticsearchAsyncClient asyncClient = connector.createAsyncClient();
+    if (connectionType == ConnectionTypes.OPENSEARCH) {
+      final var connector = new OpensearchConnector(config.getConnect());
+      final var asyncClient = connector.createAsyncClient();
+      final var genericClient =
+          new OpenSearchGenericClient(asyncClient._transport(), asyncClient._transportOptions());
 
-        archiverRepository = createArchiverRepository(asyncClient);
-        incidentRepository = createIncidentUpdateRepository(asyncClient);
-        batchOperationUpdateRepository = createBatchOperationRepository(asyncClient);
-      }
-      case OPENSEARCH -> {
-        final var connector = new OpensearchConnector(config.getConnect());
-        final var asyncClient = connector.createAsyncClient();
-        final var genericClient =
-            new OpenSearchGenericClient(asyncClient._transport(), asyncClient._transportOptions());
+      archiverRepository = createArchiverRepository(asyncClient, genericClient);
+      incidentRepository = createIncidentUpdateRepository(asyncClient);
+      batchOperationUpdateRepository = createBatchOperationRepository(asyncClient);
+    } else {
+      final var connector = new ElasticsearchConnector(config.getConnect());
+      final ElasticsearchAsyncClient asyncClient = connector.createAsyncClient();
 
-        archiverRepository = createArchiverRepository(asyncClient, genericClient);
-        incidentRepository = createIncidentUpdateRepository(asyncClient);
-        batchOperationUpdateRepository = createBatchOperationRepository(asyncClient);
-      }
+      archiverRepository = createArchiverRepository(asyncClient);
+      incidentRepository = createIncidentUpdateRepository(asyncClient);
+      batchOperationUpdateRepository = createBatchOperationRepository(asyncClient);
     }
 
     final List<RunnableTask> tasks = buildTasks();


### PR DESCRIPTION
## Description

* Refactored the BackgroundManagerFactory, to be specific, the code where the repositories are created in a way such that we are able to reuse the clients
* Refactoring is done in several steps, and are visible in the respective commits
* At the end we have fine-granular methods that take a client and create repository, without side-effects

## Related issues

https://camunda.slack.com/archives/C0807665N8G/p1758349374723259?thread_ts=1758111376.933779&cid=C0807665N8G

closes https://github.com/camunda/camunda/issues/38831
