### PR TITLE
Close resources when schema is not ready

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -126,7 +126,7 @@ public class CamundaExporter implements Exporter {
 
       try (final var schemaManager = createSchemaManager()) {
         if (!schemaManager.isSchemaReadyForUse()) {
-          throw new IllegalStateException("Schema is not ready for use");
+          throw new ExporterException("Schema is not ready for use");
         }
       }
 
@@ -140,8 +140,7 @@ public class CamundaExporter implements Exporter {
     } catch (final Exception e) {
       searchEngineClient.close();
       close();
-      final String errorMessage = "Unexpected exception occurred opening exporter.";
-      throw new ExporterException(errorMessage, e);
+      throw e;
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -120,22 +120,29 @@ public class CamundaExporter implements Exporter {
   public void open(final Controller controller) {
     LOG.info("Opening Exporter on partition {}", partitionId);
     this.controller = controller;
-    setupExporterResources();
-    searchEngineClient = clientAdapter.getSearchEngineClient();
-    try (final var schemaManager = createSchemaManager()) {
+    try {
+      setupExporterResources();
+      searchEngineClient = clientAdapter.getSearchEngineClient();
 
-      if (!schemaManager.isSchemaReadyForUse()) {
-        throw new IllegalStateException("Schema is not ready for use");
+      try (final var schemaManager = createSchemaManager()) {
+        if (!schemaManager.isSchemaReadyForUse()) {
+          throw new IllegalStateException("Schema is not ready for use");
+        }
       }
+
+      writer = createBatchWriter();
+
+      checkImportersCompletedAndReschedule();
+      controller.readMetadata().ifPresent(metadata::deserialize);
+      taskManager.start();
+
+      LOG.info("Exporter opened");
+    } catch (final Exception e) {
+      searchEngineClient.close();
+      close();
+      final String errorMessage = "Unexpected exception occurred opening exporter.";
+      throw new ExporterException(errorMessage, e);
     }
-
-    writer = createBatchWriter();
-
-    checkImportersCompletedAndReschedule();
-    controller.readMetadata().ifPresent(metadata::deserialize);
-    taskManager.start();
-
-    LOG.info("Exporter opened");
   }
 
   @Override


### PR DESCRIPTION
## Description

 * We were opening resources every time on open, but failed when the Schema is not ready.
 * The problem here was that we tried to open from outside and didn't close the resources again.
 * This means we were overriding and creating several clients, threads, etc.

<!-- Describe the goal and purpose of this PR. -->

## Related issues

https://camunda.slack.com/archives/C0807665N8G/p1758349374723259?thread_ts=1758111376.933779&cid=C0807665N8G

closes https://github.com/camunda/camunda/issues/38833