### PR TITLE
fix: disable CSRF when in no-auth mode

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/SelfManagedOpenApiConfigurer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/SelfManagedOpenApiConfigurer.java
@@ -7,14 +7,19 @@
  */
 package io.camunda.zeebe.gateway.rest.config;
 
+import io.camunda.authentication.ConditionalOnUnprotectedApi;
 import io.camunda.security.ConditionalOnSelfManagedConfigured;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 
 @Configuration
 @ConditionalOnSelfManagedConfigured
@@ -43,5 +48,27 @@ public class SelfManagedOpenApiConfigurer extends OpenApiConfigurer {
         - **Basic Authentication**: Use the Authorize button to provide username/password credentials
         - **OAuth 2.0 Authentication**: Log into `/operate/login` to get proper credentials
         - **Bearer Token**: Use the Authorize button in Swagger UI to provide a Bearer token""";
+  }
+
+  @Bean
+  @ConditionalOnUnprotectedApi
+  public SwaggerCsrfPropertyOverride swaggerCsrfPropertyOverride(
+      final ConfigurableEnvironment environment) {
+    LOGGER.debug(
+        "SelfManagedOpenApiConfigurer: Disabling CSRF for Swagger UI in unprotected API mode");
+
+    final var propertySource =
+        new MapPropertySource(
+            "swaggerCsrfOverride", Map.of("springdoc.swagger-ui.csrf.enabled", "false"));
+
+    environment.getPropertySources().addFirst(propertySource);
+
+    LOGGER.debug("SelfManagedOpenApiConfigurer: Successfully disabled CSRF for Swagger UI");
+
+    return new SwaggerCsrfPropertyOverride();
+  }
+
+  public static class SwaggerCsrfPropertyOverride {
+    // Marker class to indicate the property override has been applied
   }
 }


### PR DESCRIPTION
## Description

This PR is adding a config override on `springdoc.swagger-ui.csrf.enabled` and set it to false when in SM and API is unprotected.

As shown in the screen record, no auth properly loads Swagger and doesn't send any CSRF header to the requests

## Related issues

closes #38505
