### PR TITLE
fix: Creating Duplicate Beans for Tasklist & Operate

### DIFF
--- a/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/v8_7/processors/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/v8_7/processors/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -38,7 +38,6 @@ import org.apache.commons.lang3.concurrent.LazyInitializer;
 import org.apache.commons.lang3.function.FailableSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -54,8 +53,7 @@ public class FlowNodeInstanceZeebeRecordProcessor {
 
   public FlowNodeInstanceZeebeRecordProcessor(
       final FlowNodeStore flowNodeStore,
-      final @Qualifier("operateFlowNodeInstanceTemplate") FlowNodeInstanceTemplate
-              flowNodeInstanceTemplate,
+      final FlowNodeInstanceTemplate flowNodeInstanceTemplate,
       final OperateProperties operateProperties,
       final PartitionHolder partitionHolder,
       final Metrics metrics) {

--- a/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/v8_7/processors/processors/ProcessZeebeRecordProcessor.java
+++ b/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/v8_7/processors/processors/ProcessZeebeRecordProcessor.java
@@ -27,7 +27,6 @@ import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -47,9 +46,7 @@ public class ProcessZeebeRecordProcessor {
 
   @Autowired private ListViewStore listViewStore;
 
-  @Autowired
-  @Qualifier("operateProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   @Autowired private XMLUtil xmlUtil;
 

--- a/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/v8_7/processors/processors/VariableZeebeRecordProcessor.java
+++ b/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/v8_7/processors/processors/VariableZeebeRecordProcessor.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -39,9 +38,7 @@ public class VariableZeebeRecordProcessor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(VariableZeebeRecordProcessor.class);
 
-  @Autowired
-  @Qualifier("operateVariableTemplate")
-  private VariableTemplate variableTemplate;
+  @Autowired private VariableTemplate variableTemplate;
 
   @Autowired private OperateProperties operateProperties;
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchBatchRequestIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchBatchRequestIT.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(properties = DatabaseCondition.DATABASE_PROPERTY + "=opensearch")
@@ -40,9 +39,7 @@ public class OpensearchBatchRequestIT extends OpensearchOperateAbstractIT {
   private static SchemaWithExporter schemaExporterHelper;
   @Autowired RichOpenSearchClient richOpenSearchClient;
 
-  @Autowired
-  @Qualifier("operateProcessIndex")
-  ProcessIndex processIndex;
+  @Autowired ProcessIndex processIndex;
 
   @BeforeClass
   public static void beforeClass() {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/operation/ProcessInstanceMigrationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/operation/ProcessInstanceMigrationIT.java
@@ -22,13 +22,10 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 class ProcessInstanceMigrationIT extends OperateZeebeSearchAbstractIT {
 
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
   @Autowired private MigrateProcessInstanceHandler migrateProcessInstanceHandler;
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchChecks.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchChecks.java
@@ -60,7 +60,6 @@ import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -86,15 +85,11 @@ public class ElasticsearchChecks {
 
   @Autowired private ListenerReader listenerReader;
 
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
   @Autowired private EventTemplate eventTemplate;
 
-  @Autowired
-  @Qualifier("operateVariableTemplate")
-  private VariableTemplate variableTemplate;
+  @Autowired private VariableTemplate variableTemplate;
 
   @Autowired private IncidentTemplate incidentTemplate;
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchTestRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchTestRuleProvider.java
@@ -67,7 +67,6 @@ import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -93,13 +92,9 @@ public class ElasticsearchTestRuleProvider implements SearchTestRuleProvider {
   @Autowired private SearchEngineConfiguration searchEngineConfiguration;
   @Autowired private ListViewTemplate listViewTemplate;
 
-  @Autowired
-  @Qualifier("operateVariableTemplate")
-  private VariableTemplate variableTemplate;
+  @Autowired private VariableTemplate variableTemplate;
 
-  @Autowired
-  @Qualifier("operateProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   @Autowired private OperationTemplate operationTemplate;
   @Autowired private BatchOperationTemplate batchOperationTemplate;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/IndexTemplateDescriptorsConfigurator.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/IndexTemplateDescriptorsConfigurator.java
@@ -113,7 +113,7 @@ public class IndexTemplateDescriptorsConfigurator {
     };
   }
 
-  @Bean("operateProcessIndex")
+  @Bean
   public ProcessIndex getProcessIndex(
       final OperateProperties operateProperties,
       final DatabaseInfo databaseInfo,
@@ -158,7 +158,7 @@ public class IndexTemplateDescriptorsConfigurator {
     };
   }
 
-  @Bean("operateFlowNodeInstanceTemplate")
+  @Bean
   public FlowNodeInstanceTemplate getFlowNodeInstanceTemplate(
       final OperateProperties operateProperties,
       final DatabaseInfo databaseInfo,
@@ -274,7 +274,7 @@ public class IndexTemplateDescriptorsConfigurator {
     };
   }
 
-  @Bean("operateVariableTemplate")
+  @Bean
   public VariableTemplate getVariableTemplate(
       final OperateProperties operateProperties,
       final DatabaseInfo databaseInfo,
@@ -319,7 +319,7 @@ public class IndexTemplateDescriptorsConfigurator {
     };
   }
 
-  @Bean("operateSnapshotTaskVariableTemplate")
+  @Bean
   public SnapshotTaskVariableTemplate getSnapshotTaskVariableTemplate(
       final DatabaseInfo databaseInfo, final IndexPrefixHolder indexPrefixHolder) {
     return new SnapshotTaskVariableTemplate("", databaseInfo.isElasticsearchDb()) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchChecks.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchChecks.java
@@ -54,7 +54,6 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -73,19 +72,14 @@ public class OpensearchChecks {
   @Autowired private RichOpenSearchClient richOpenSearchClient;
   @Autowired private ProcessReader processReader;
   @Autowired private ProcessInstanceReader processInstanceReader;
-  @Autowired private FlowNodeInstanceReader flowNodeInstanceReader;
 
   @Autowired private ListenerReader listenerReader;
 
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
   @Autowired private EventTemplate eventTemplate;
 
-  @Autowired
-  @Qualifier("operateVariableTemplate")
-  private VariableTemplate variableTemplate;
+  @Autowired private VariableTemplate variableTemplate;
 
   @Autowired private IncidentTemplate incidentTemplate;
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchTestRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchTestRuleProvider.java
@@ -58,7 +58,6 @@ import org.opensearch.client.opensearch.indices.GetIndexResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -77,13 +76,9 @@ public class OpensearchTestRuleProvider implements SearchTestRuleProvider {
   @Autowired private SearchEngineConfiguration searchEngineConfiguration;
   @Autowired private ListViewTemplate listViewTemplate;
 
-  @Autowired
-  @Qualifier("operateVariableTemplate")
-  private VariableTemplate variableTemplate;
+  @Autowired private VariableTemplate variableTemplate;
 
-  @Autowired
-  @Qualifier("operateProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   @Autowired private OperationTemplate operationTemplate;
   @Autowired private BatchOperationTemplate batchOperationTemplate;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateTester.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateTester.java
@@ -44,7 +44,6 @@ import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
 import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto;
 import io.camunda.operate.webapp.zeebe.operation.OperationExecutor;
 import io.camunda.operate.zeebeimport.ZeebeImporter;
-import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.event.EventType;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
@@ -204,10 +203,6 @@ public class OperateTester {
   @Autowired
   @Qualifier("userTasksAreCreated")
   private Predicate<Object[]> userTasksAreCreated;
-
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
   @Autowired private OperationReader operationReader;
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DaoRfc3339SerializationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DaoRfc3339SerializationIT.java
@@ -44,7 +44,6 @@ import io.camunda.webapps.schema.entities.listview.ProcessInstanceState;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -89,9 +88,7 @@ public class DaoRfc3339SerializationIT extends OperateSearchAbstractIT {
 
   @Autowired private DecisionInstanceTemplate decisionInstanceIndex;
 
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceIndex;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceIndex;
 
   @Autowired private IncidentTemplate incidentIndex;
   @Autowired private ListViewTemplate processInstanceIndex;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/FlowNodeInstanceDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/FlowNodeInstanceDaoIT.java
@@ -27,7 +27,6 @@ import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class FlowNodeInstanceDaoIT extends OperateSearchAbstractIT {
@@ -37,9 +36,7 @@ public class FlowNodeInstanceDaoIT extends OperateSearchAbstractIT {
   private final String endDate = "2024-02-15T22:41:10.834+0000";
   @Autowired private FlowNodeInstanceDao dao;
 
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceIndex;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceIndex;
 
   @MockitoBean private ProcessCache processCache;
   @Autowired private OperateDateTimeFormatter dateTimeFormatter;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/FlowNodeStatisticsDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/FlowNodeStatisticsDaoIT.java
@@ -20,7 +20,6 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 public class FlowNodeStatisticsDaoIT extends OperateSearchAbstractIT {
 
@@ -28,9 +27,7 @@ public class FlowNodeStatisticsDaoIT extends OperateSearchAbstractIT {
   private static final Long PROCESS_DEFINITION_KEY = 2251799813685249L;
   @Autowired private FlowNodeStatisticsDao dao;
 
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceIndex;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceIndex;
 
   @Override
   public void runAdditionalBeforeAllSetup() throws Exception {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/ProcessDefinitionDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/ProcessDefinitionDaoIT.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import javax.xml.parsers.ParserConfigurationException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
@@ -36,9 +35,7 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
 
   @Autowired private ProcessDefinitionDao dao;
 
-  @Autowired
-  @Qualifier("operateProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   private ProcessEntity pe1;
   private ProcessEntity pe2;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/VariableDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/VariableDaoIT.java
@@ -20,14 +20,11 @@ import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.VariableEntity;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 public class VariableDaoIT extends OperateSearchAbstractIT {
   @Autowired private VariableDao dao;
 
-  @Autowired
-  @Qualifier("operateVariableTemplate")
-  private VariableTemplate variableIndex;
+  @Autowired private VariableTemplate variableIndex;
 
   @Override
   protected void runAdditionalBeforeAllSetup() throws Exception {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/MultiProcessZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/MultiProcessZeebeImportIT.java
@@ -16,13 +16,10 @@ import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 public class MultiProcessZeebeImportIT extends OperateZeebeSearchAbstractIT {
 
-  @Autowired
-  @Qualifier("operateProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   @Test
   public void shouldReadFromMultiProcessDiagram() throws IOException {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ProcessInstanceZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ProcessInstanceZeebeImportIT.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.web.servlet.MvcResult;
 
 public class ProcessInstanceZeebeImportIT extends OperateZeebeAbstractIT {
@@ -61,9 +60,7 @@ public class ProcessInstanceZeebeImportIT extends OperateZeebeAbstractIT {
 
   @Autowired private TestSearchRepository testSearchRepository;
 
-  @Autowired
-  @Qualifier("operateVariableTemplate")
-  private VariableTemplate variableTemplate;
+  @Autowired private VariableTemplate variableTemplate;
 
   @Test
   public void testProcessInstanceCreated() {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/IndexTemplateDescriptorsConfigurator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/IndexTemplateDescriptorsConfigurator.java
@@ -77,7 +77,7 @@ public class IndexTemplateDescriptorsConfigurator {
         databaseInfo.isElasticsearchDb());
   }
 
-  @Bean("operateProcessIndex")
+  @Bean
   public ProcessIndex getProcessIndex(
       final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
     return new ProcessIndex(
@@ -101,7 +101,7 @@ public class IndexTemplateDescriptorsConfigurator {
         databaseInfo.isElasticsearchDb());
   }
 
-  @Bean("operateFlowNodeInstanceTemplate")
+  @Bean
   public FlowNodeInstanceTemplate getFlowNodeInstanceTemplate(
       final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
     return new FlowNodeInstanceTemplate(
@@ -151,9 +151,7 @@ public class IndexTemplateDescriptorsConfigurator {
 
   @Bean
   public TaskTemplate getTaskTemplate(
-      final OperateProperties operateProperties,
-      final DatabaseInfo databaseInfo,
-      final ProcessIndex operateProcessIndex) {
+      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
     return new TaskTemplate(
         operateProperties.getIndexPrefix(databaseInfo.getCurrent()),
         databaseInfo.isElasticsearchDb());
@@ -167,7 +165,7 @@ public class IndexTemplateDescriptorsConfigurator {
         databaseInfo.isElasticsearchDb());
   }
 
-  @Bean("operateVariableTemplate")
+  @Bean
   public VariableTemplate getVariableTemplate(
       final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
     return new VariableTemplate(
@@ -191,7 +189,7 @@ public class IndexTemplateDescriptorsConfigurator {
         databaseInfo.isElasticsearchDb());
   }
 
-  @Bean("operateSnapshotTaskVariableTemplate")
+  @Bean
   public SnapshotTaskVariableTemplate getSnapshotTaskVariableTemplate(
       final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
     return new SnapshotTaskVariableTemplate(

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchFlowNodeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchFlowNodeStore.java
@@ -36,7 +36,6 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -46,9 +45,7 @@ public class ElasticsearchFlowNodeStore implements FlowNodeStore {
 
   @Autowired private ListViewTemplate listViewTemplate;
 
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
   @Autowired private RestHighLevelClient esClient;
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
@@ -123,7 +123,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
   private final OperateProperties operateProperties;
 
   public ElasticsearchProcessStore(
-      final @Qualifier("operateProcessIndex") ProcessIndex processIndex,
+      final ProcessIndex processIndex,
       final ListViewTemplate listViewTemplate,
       final List<ProcessInstanceDependant> processInstanceDependantTemplates,
       @Qualifier("operateObjectMapper") final ObjectMapper objectMapper,

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchFlowNodeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchFlowNodeStore.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -37,9 +36,7 @@ public class OpensearchFlowNodeStore implements FlowNodeStore {
 
   @Autowired private ListViewTemplate listViewTemplate;
 
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
   @Autowired private RichOpenSearchClient richOpenSearchClient;
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
@@ -52,7 +52,6 @@ import org.opensearch.client.opensearch.core.search.Hit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -64,9 +63,7 @@ public class OpensearchProcessStore implements ProcessStore {
 
   @Autowired private RichOpenSearchClient richOpenSearchClient;
 
-  @Autowired
-  @Qualifier("operateProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   @Autowired private ListViewTemplate listViewTemplate;
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchFlowNodeInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchFlowNodeInstanceDao.java
@@ -31,7 +31,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -40,9 +39,7 @@ import org.springframework.stereotype.Component;
 public class ElasticsearchFlowNodeInstanceDao extends ElasticsearchDao<FlowNodeInstance>
     implements FlowNodeInstanceDao {
 
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceIndex;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceIndex;
 
   @Autowired private ProcessCache processCache;
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchFlowNodeStatisticsDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchFlowNodeStatisticsDao.java
@@ -42,7 +42,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -50,9 +49,8 @@ import org.springframework.stereotype.Component;
 @Component("ElasticsearchFlowNodeStatisticsDaoV1")
 public class ElasticsearchFlowNodeStatisticsDao extends ElasticsearchDao<FlowNodeStatistics>
     implements FlowNodeStatisticsDao {
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
+
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
   @Override
   protected void buildFiltering(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDao.java
@@ -31,7 +31,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -40,9 +39,7 @@ import org.springframework.stereotype.Component;
 public class ElasticsearchProcessDefinitionDao extends ElasticsearchDao<ProcessDefinition>
     implements ProcessDefinitionDao {
 
-  @Autowired
-  @Qualifier("operateProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   @Override
   public Results<ProcessDefinition> search(final Query<ProcessDefinition> query)

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchVariableDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchVariableDao.java
@@ -30,7 +30,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -38,9 +37,7 @@ import org.springframework.stereotype.Component;
 @Component("ElasticsearchVariableDaoV1")
 public class ElasticsearchVariableDao extends ElasticsearchDao<Variable> implements VariableDao {
 
-  @Autowired
-  @Qualifier("operateVariableTemplate")
-  private VariableTemplate variableIndex;
+  @Autowired private VariableTemplate variableIndex;
 
   @Override
   protected void buildFiltering(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeInstanceDao.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.client.opensearch.core.SearchRequest;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -41,8 +40,7 @@ public class OpensearchFlowNodeInstanceDao
       final OpensearchQueryDSLWrapper queryDSLWrapper,
       final OpensearchRequestDSLWrapper requestDSLWrapper,
       final RichOpenSearchClient richOpenSearchClient,
-      final @Qualifier("operateFlowNodeInstanceTemplate") FlowNodeInstanceTemplate
-              flowNodeInstanceIndex,
+      final FlowNodeInstanceTemplate flowNodeInstanceIndex,
       final ProcessCache processCache,
       final OperateDateTimeFormatter dateTimeFormatter) {
     super(queryDSLWrapper, requestDSLWrapper, richOpenSearchClient);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeStatisticsDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeStatisticsDao.java
@@ -26,7 +26,6 @@ import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -45,8 +44,7 @@ public class OpensearchFlowNodeStatisticsDao implements FlowNodeStatisticsDao {
       final OpensearchRequestDSLWrapper requestDSLWrapper,
       final OpensearchAggregationDSLWrapper aggregationDSLWrapper,
       final RichOpenSearchClient richOpenSearchClient,
-      final @Qualifier("operateFlowNodeInstanceTemplate") FlowNodeInstanceTemplate
-              flowNodeInstanceTemplate) {
+      final FlowNodeInstanceTemplate flowNodeInstanceTemplate) {
     this.flowNodeInstanceTemplate = flowNodeInstanceTemplate;
     this.richOpenSearchClient = richOpenSearchClient;
     this.queryDSLWrapper = queryDSLWrapper;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.opensearch.client.opensearch.core.SearchRequest;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -39,7 +38,7 @@ public class OpensearchProcessDefinitionDao
       final OpensearchQueryDSLWrapper queryDSLWrapper,
       final OpensearchRequestDSLWrapper requestDSLWrapper,
       final RichOpenSearchClient richOpenSearchClient,
-      final @Qualifier("operateProcessIndex") ProcessIndex processIndex) {
+      final ProcessIndex processIndex) {
     super(queryDSLWrapper, requestDSLWrapper, richOpenSearchClient);
     this.processIndex = processIndex;
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchVariableDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchVariableDao.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.opensearch.client.opensearch.core.SearchRequest;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -34,7 +33,7 @@ public class OpensearchVariableDao extends OpensearchKeyFilteringDao<Variable, V
       final OpensearchQueryDSLWrapper queryDSLWrapper,
       final OpensearchRequestDSLWrapper requestDSLWrapper,
       final RichOpenSearchClient richOpenSearchClient,
-      final @Qualifier("operateVariableTemplate") VariableTemplate variableIndex) {
+      final VariableTemplate variableIndex) {
     super(queryDSLWrapper, requestDSLWrapper, richOpenSearchClient);
     this.variableIndex = variableIndex;
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchUserTaskReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchUserTaskReader.java
@@ -30,7 +30,6 @@ import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -47,8 +46,7 @@ public class ElasticsearchUserTaskReader extends AbstractReader implements UserT
 
   public ElasticsearchUserTaskReader(
       final TaskTemplate taskTemplate,
-      @Qualifier("operateSnapshotTaskVariableTemplate")
-          final SnapshotTaskVariableTemplate snapshotTaskVariableTemplate) {
+      final SnapshotTaskVariableTemplate snapshotTaskVariableTemplate) {
     this.taskTemplate = taskTemplate;
     this.snapshotTaskVariableTemplate = snapshotTaskVariableTemplate;
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/FlowNodeInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/FlowNodeInstanceReader.java
@@ -89,7 +89,6 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -100,9 +99,7 @@ public class FlowNodeInstanceReader extends AbstractReader
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FlowNodeInstanceReader.class);
 
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
   @Autowired private DecisionInstanceTemplate decisionInstanceTemplate;
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/VariableReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/VariableReader.java
@@ -43,7 +43,6 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -54,9 +53,7 @@ public class VariableReader extends AbstractReader
 
   private static final Logger LOGGER = LoggerFactory.getLogger(VariableReader.class);
 
-  @Autowired
-  @Qualifier("operateVariableTemplate")
-  private VariableTemplate variableTemplate;
+  @Autowired private VariableTemplate variableTemplate;
 
   @Autowired private OperationReader operationReader;
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchFlowNodeInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchFlowNodeInstanceReader.java
@@ -83,7 +83,6 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -92,9 +91,7 @@ import org.springframework.stereotype.Component;
 public class OpensearchFlowNodeInstanceReader extends OpensearchAbstractReader
     implements FlowNodeInstanceReader {
 
-  @Autowired
-  @Qualifier("operateFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
   @Autowired private IncidentTemplate incidentTemplate;
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchUserTaskReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchUserTaskReader.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -39,8 +38,7 @@ public class OpensearchUserTaskReader extends OpensearchAbstractReader implement
 
   public OpensearchUserTaskReader(
       final TaskTemplate taskTemplate,
-      @Qualifier("operateSnapshotTaskVariableTemplate")
-          final SnapshotTaskVariableTemplate snapshotTaskVariableTemplate) {
+      final SnapshotTaskVariableTemplate snapshotTaskVariableTemplate) {
     this.taskTemplate = taskTemplate;
     this.snapshotTaskVariableTemplate = snapshotTaskVariableTemplate;
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchVariableReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchVariableReader.java
@@ -42,9 +42,7 @@ public class OpensearchVariableReader implements VariableReader {
 
   @Autowired private OperateProperties operateProperties;
 
-  @Autowired
-  @Qualifier("operateVariableTemplate")
-  private VariableTemplate variableTemplate;
+  @Autowired private VariableTemplate variableTemplate;
 
   @Autowired private OperationReader operationReader;
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1ApiPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1ApiPermissionsIT.java
@@ -28,7 +28,6 @@ import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import io.camunda.application.Profile;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.Decision;
 import io.camunda.qa.util.auth.GroupDefinition;
@@ -64,7 +63,6 @@ public class OperateV1ApiPermissionsIT {
       new TestCamundaApplication()
           .withAuthorizationsEnabled()
           .withBasicAuth()
-          .withAdditionalProfile(Profile.OPERATE)
           .withProperty("camunda.tasklist.webappEnabled", "false");
 
   // endpoint urls
@@ -539,11 +537,9 @@ public class OperateV1ApiPermissionsIT {
 
   private static Stream<Arguments> deleteRequestParameters() {
     return Stream.of(
-        /* depends on fix for https://github.com/camunda/camunda/issues/36067
         Arguments.of(AUTHORIZED_USERNAME, HttpStatus.OK.value()),
         Arguments.of(ROLE_AUTHORIZED_USERNAME, HttpStatus.OK.value()),
         Arguments.of(GROUP_AUTHORIZED_USERNAME, HttpStatus.OK.value()),
-        */
         Arguments.of(UNAUTHORIZED_USERNAME, HttpStatus.FORBIDDEN.value()));
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/IndexTemplateDescriptorsConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/IndexTemplateDescriptorsConfigurator.java
@@ -84,7 +84,7 @@ public class IndexTemplateDescriptorsConfigurator {
         operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
   }
 
-  @Bean("operateProcessIndex")
+  @Bean
   public ProcessIndex getProcessIndex(
       final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
     return new ProcessIndex(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
@@ -103,7 +103,7 @@ public class IndexTemplateDescriptorsConfigurator {
     return new EventTemplate(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
   }
 
-  @Bean("operateFlowNodeInstanceTemplate")
+  @Bean
   public FlowNodeInstanceTemplate getFlowNodeInstanceTemplate(
       final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
     return new FlowNodeInstanceTemplate(
@@ -151,7 +151,7 @@ public class IndexTemplateDescriptorsConfigurator {
     return new JobTemplate(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
   }
 
-  @Bean("operateVariableTemplate")
+  @Bean
   public VariableTemplate getVariableTemplate(
       final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
     return new VariableTemplate(
@@ -195,16 +195,8 @@ public class IndexTemplateDescriptorsConfigurator {
         operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
   }
 
-  @Bean("operateSnapshotTaskVariableTemplate")
-  public SnapshotTaskVariableTemplate getOperateSnapshotTaskVariableTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
-    // Just take the provided DatabaseInfo, no need to distinguish between Tasklist or Operate
-    return new SnapshotTaskVariableTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
-  }
-
-  @Bean("tasklistSnapshotTaskVariableTemplate")
-  public SnapshotTaskVariableTemplate getTasklistSnapshotTaskVariableTemplate(
+  @Bean
+  public SnapshotTaskVariableTemplate getSnapshotTaskVariableTemplate(
       final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
     // Just take the provided DatabaseInfo, no need to distinguish between Tasklist or Operate
     return new SnapshotTaskVariableTemplate(
@@ -218,30 +210,10 @@ public class IndexTemplateDescriptorsConfigurator {
     return new TaskTemplate(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
   }
 
-  @Bean("tasklistVariableTemplate")
-  public VariableTemplate getTasklistVariableTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
-    return new VariableTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
-  }
-
-  @Bean("tasklistFlowNodeInstanceTemplate")
-  public FlowNodeInstanceTemplate getTasklistFlowNodeInstanceTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
-    return new FlowNodeInstanceTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
-  }
-
   @Bean
   public TasklistImportPositionIndex getTasklistImportPositionIndex(
       final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
     return new TasklistImportPositionIndex(
         operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
-  }
-
-  @Bean("tasklistProcessIndex")
-  public ProcessIndex getTasklistProcessIndex(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
-    return new ProcessIndex(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
   }
 }

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistProperties.java
@@ -369,12 +369,15 @@ public class TasklistProperties {
     this.documentation = documentation;
   }
 
+  public boolean isElasticsearchDB() {
+    return ELASTIC_SEARCH.equals(database);
+  }
+
   public String getIndexPrefix() {
-    if (database.equals(ELASTIC_SEARCH)) {
-      return elasticsearch.getIndexPrefix();
-    } else if (database.equals(OPEN_SEARCH)) {
-      return openSearch.getIndexPrefix();
-    }
-    return null;
+    return switch (database) {
+      case ELASTIC_SEARCH -> getElasticsearch().getIndexPrefix();
+      case OPEN_SEARCH -> getOpenSearch().getIndexPrefix();
+      default -> null;
+    };
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/TasklistIndexTemplateDescriptorsConfigurator.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/TasklistIndexTemplateDescriptorsConfigurator.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.tasklist.schema;
 
-import static io.camunda.tasklist.property.TasklistProperties.ELASTIC_SEARCH;
-
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
@@ -34,69 +32,65 @@ public class TasklistIndexTemplateDescriptorsConfigurator {
   @Bean
   public DraftTaskVariableTemplate draftTaskVariableTemplate() {
     return new DraftTaskVariableTemplate(
-        getIndexPrefix(tasklistProperties), isElasticsearch(tasklistProperties));
+        tasklistProperties.getIndexPrefix(), tasklistProperties.isElasticsearchDB());
   }
 
   @Bean
   public FormIndex formIndex() {
-    return new FormIndex(getIndexPrefix(tasklistProperties), isElasticsearch(tasklistProperties));
+    return new FormIndex(
+        tasklistProperties.getIndexPrefix(), tasklistProperties.isElasticsearchDB());
   }
 
   @Bean
   public TasklistMetricIndex tasklistMetricIndex() {
     return new TasklistMetricIndex(
-        getIndexPrefix(tasklistProperties), isElasticsearch(tasklistProperties));
+        tasklistProperties.getIndexPrefix(), tasklistProperties.isElasticsearchDB());
   }
 
   @Bean
   public UsageMetricTUTemplate usageMetricTUTemplate() {
     return new UsageMetricTUTemplate(
-        getIndexPrefix(tasklistProperties), isElasticsearch(tasklistProperties));
-  }
-
-  @Bean("tasklistSnapshotTaskVariableTemplate")
-  public SnapshotTaskVariableTemplate snapshotTaskVariableTemplate() {
-    return new SnapshotTaskVariableTemplate(
-        getIndexPrefix(tasklistProperties), isElasticsearch(tasklistProperties));
+        tasklistProperties.getIndexPrefix(), tasklistProperties.isElasticsearchDB());
   }
 
   @Bean
-  public TaskTemplate taskTemplate() {
+  @Profile("!operate")
+  public SnapshotTaskVariableTemplate getSnapshotTaskVariableTemplate() {
+    return new SnapshotTaskVariableTemplate(
+        tasklistProperties.getIndexPrefix(), tasklistProperties.isElasticsearchDB());
+  }
+
+  @Bean
+  @Profile("!operate")
+  public TaskTemplate getTaskTemplate() {
     return new TaskTemplate(
-        getIndexPrefix(tasklistProperties), isElasticsearch(tasklistProperties));
+        tasklistProperties.getIndexPrefix(), tasklistProperties.isElasticsearchDB());
   }
 
-  @Bean("tasklistVariableTemplate")
-  public VariableTemplate tasklistVariableTemplate() {
+  @Bean
+  @Profile("!operate")
+  public VariableTemplate getVariableTemplate() {
     return new VariableTemplate(
-        getIndexPrefix(tasklistProperties), isElasticsearch(tasklistProperties));
+        tasklistProperties.getIndexPrefix(), tasklistProperties.isElasticsearchDB());
   }
 
-  @Bean("tasklistFlowNodeInstanceTemplate")
-  public FlowNodeInstanceTemplate flowNodeInstanceTemplate() {
+  @Bean
+  @Profile("!operate")
+  public FlowNodeInstanceTemplate getFlowNodeInstanceTemplate() {
     return new FlowNodeInstanceTemplate(
-        getIndexPrefix(tasklistProperties), isElasticsearch(tasklistProperties));
+        tasklistProperties.getIndexPrefix(), tasklistProperties.isElasticsearchDB());
   }
 
   @Bean
   public TasklistImportPositionIndex tasklistImportPositionIndex() {
     return new TasklistImportPositionIndex(
-        getIndexPrefix(tasklistProperties), isElasticsearch(tasklistProperties));
+        tasklistProperties.getIndexPrefix(), tasklistProperties.isElasticsearchDB());
   }
 
-  @Bean("tasklistProcessIndex")
-  public ProcessIndex processIndex() {
+  @Bean
+  @Profile("!operate")
+  public ProcessIndex getProcessIndex() {
     return new ProcessIndex(
-        getIndexPrefix(tasklistProperties), isElasticsearch(tasklistProperties));
-  }
-
-  private boolean isElasticsearch(final TasklistProperties tasklistProperties) {
-    return ELASTIC_SEARCH.equals(tasklistProperties.getDatabase());
-  }
-
-  private String getIndexPrefix(final TasklistProperties tasklistProperties) {
-    return isElasticsearch(tasklistProperties)
-        ? tasklistProperties.getElasticsearch().getIndexPrefix()
-        : tasklistProperties.getOpenSearch().getIndexPrefix();
+        tasklistProperties.getIndexPrefix(), tasklistProperties.isElasticsearchDB());
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
@@ -54,9 +54,7 @@ public class FormStoreElasticSearch implements FormStore {
 
   @Autowired private TaskTemplate taskTemplate;
 
-  @Autowired
-  @Qualifier("tasklistProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
@@ -13,7 +13,6 @@ import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
 import io.camunda.tasklist.exceptions.NotFoundException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.IdentityProperties;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.store.ProcessStore;
 import io.camunda.tasklist.tenant.TenantAwareElasticsearchClient;
 import io.camunda.tasklist.util.ElasticsearchUtil;
@@ -63,18 +62,14 @@ public class ProcessStoreElasticSearch implements ProcessStore {
   private static final String MAX_VERSION_DOCUMENTS_AGG_NAME = "max_version_docs";
   private static final String STARTED_BY_FORM_FILTERED_DOCS = "started_by_form_docs";
 
-  @Autowired
-  @Qualifier("tasklistProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
+  @Autowired private SecurityConfiguration securityConfiguration;
+
+  @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 
   @Autowired
   @Qualifier("tasklistObjectMapper")
   private ObjectMapper objectMapper;
-
-  @Autowired private TasklistProperties tasklistProperties;
-  @Autowired private SecurityConfiguration securityConfiguration;
-
-  @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 
   @Override
   public ProcessEntity getProcessByProcessDefinitionKey(final String processDefinitionKey) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -102,9 +102,7 @@ public class TaskStoreElasticSearch implements TaskStore {
 
   @Autowired private VariableStore variableStoreElasticSearch;
 
-  @Autowired
-  @Qualifier("tasklistSnapshotTaskVariableTemplate")
-  private SnapshotTaskVariableTemplate taskVariableTemplate;
+  @Autowired private SnapshotTaskVariableTemplate taskVariableTemplate;
 
   @Autowired
   @Qualifier("tasklistObjectMapper")

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -98,17 +98,11 @@ public class VariableStoreElasticSearch implements VariableStore {
 
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 
-  @Autowired
-  @Qualifier("tasklistVariableTemplate")
-  private VariableTemplate variableIndex;
+  @Autowired private VariableTemplate variableIndex;
 
-  @Autowired
-  @Qualifier("tasklistFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceIndex;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceIndex;
 
-  @Autowired
-  @Qualifier("tasklistSnapshotTaskVariableTemplate")
-  private SnapshotTaskVariableTemplate taskVariableTemplate;
+  @Autowired private SnapshotTaskVariableTemplate taskVariableTemplate;
 
   @Autowired private TasklistProperties tasklistProperties;
   private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
@@ -50,9 +50,7 @@ public class FormStoreOpenSearch implements FormStore {
 
   @Autowired private TaskTemplate taskTemplate;
 
-  @Autowired
-  @Qualifier("tasklistProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   @Autowired private TenantAwareOpenSearchClient tenantAwareClient;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
@@ -64,9 +64,7 @@ public class ProcessStoreOpenSearch implements ProcessStore {
   private static final String MAX_VERSION_DOCUMENTS_AGG_NAME = "max_version_docs";
   private static final String STARTED_BY_FORM_FILTERED_DOCS = "started_by_form_docs";
 
-  @Autowired
-  @Qualifier("tasklistProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   @Autowired private TenantAwareOpenSearchClient tenantAwareClient;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -98,9 +98,7 @@ public class TaskStoreOpenSearch implements TaskStore {
 
   @Autowired private VariableStore variableStoreElasticSearch;
 
-  @Autowired
-  @Qualifier("tasklistSnapshotTaskVariableTemplate")
-  private SnapshotTaskVariableTemplate taskVariableTemplate;
+  @Autowired private SnapshotTaskVariableTemplate taskVariableTemplate;
 
   @Autowired private TaskVariableSearchUtil taskVariableSearchUtil;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -85,17 +85,11 @@ public class VariableStoreOpenSearch implements VariableStore {
 
   @Autowired private TenantAwareOpenSearchClient tenantAwareClient;
 
-  @Autowired
-  @Qualifier("tasklistVariableTemplate")
-  private VariableTemplate variableIndex;
+  @Autowired private VariableTemplate variableIndex;
 
-  @Autowired
-  @Qualifier("tasklistFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceIndex;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceIndex;
 
-  @Autowired
-  @Qualifier("tasklistSnapshotTaskVariableTemplate")
-  private SnapshotTaskVariableTemplate taskVariableTemplate;
+  @Autowired private SnapshotTaskVariableTemplate taskVariableTemplate;
 
   @Autowired private TasklistProperties tasklistProperties;
   private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/ProcessInstanceZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/ProcessInstanceZeebeRecordProcessorElasticSearch.java
@@ -58,9 +58,7 @@ public class ProcessInstanceZeebeRecordProcessorElasticSearch {
   @Qualifier("tasklistObjectMapper")
   private ObjectMapper objectMapper;
 
-  @Autowired
-  @Qualifier("tasklistFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceIndex;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceIndex;
 
   public void processProcessInstanceRecord(final Record record, final BulkRequest bulkRequest)
       throws PersistenceException {

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/ProcessZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/ProcessZeebeRecordProcessorElasticSearch.java
@@ -52,9 +52,7 @@ public class ProcessZeebeRecordProcessorElasticSearch {
   @Qualifier("tasklistObjectMapper")
   private ObjectMapper objectMapper;
 
-  @Autowired
-  @Qualifier("tasklistProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   @Autowired private FormIndex formIndex;
 

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
@@ -50,9 +50,7 @@ public class UserTaskZeebeRecordProcessorElasticSearch {
 
   @Autowired private UserTaskRecordToVariableEntityMapper userTaskRecordToVariableEntityMapper;
 
-  @Autowired
-  @Qualifier("tasklistSnapshotTaskVariableTemplate")
-  private SnapshotTaskVariableTemplate variableIndex;
+  @Autowired private SnapshotTaskVariableTemplate variableIndex;
 
   @Autowired private UserTaskRecordToTaskEntityMapper userTaskRecordToTaskEntityMapper;
 

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/VariableZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/VariableZeebeRecordProcessorElasticSearch.java
@@ -40,9 +40,7 @@ public class VariableZeebeRecordProcessorElasticSearch {
   @Qualifier("tasklistObjectMapper")
   private ObjectMapper objectMapper;
 
-  @Autowired
-  @Qualifier("tasklistVariableTemplate")
-  private VariableTemplate variableIndex;
+  @Autowired private VariableTemplate variableIndex;
 
   @Autowired private TasklistProperties tasklistProperties;
 

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/ProcessInstanceZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/ProcessInstanceZeebeRecordProcessorOpenSearch.java
@@ -30,7 +30,6 @@ import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -55,9 +54,7 @@ public class ProcessInstanceZeebeRecordProcessorOpenSearch {
     FLOW_NODE_STATES.add(ELEMENT_ACTIVATING.name());
   }
 
-  @Autowired
-  @Qualifier("tasklistFlowNodeInstanceTemplate")
-  private FlowNodeInstanceTemplate flowNodeInstanceIndex;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceIndex;
 
   public void processProcessInstanceRecord(
       final Record record, final List<BulkOperation> operations) throws PersistenceException {

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
@@ -51,9 +51,7 @@ public class ProcessZeebeRecordProcessorOpenSearch {
   @Qualifier("tasklistObjectMapper")
   private ObjectMapper objectMapper;
 
-  @Autowired
-  @Qualifier("tasklistProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   @Autowired private FormIndex formIndex;
 

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
@@ -47,9 +47,7 @@ public class UserTaskZeebeRecordProcessorOpenSearch {
 
   @Autowired private TaskTemplate taskTemplate;
 
-  @Autowired
-  @Qualifier("tasklistSnapshotTaskVariableTemplate")
-  private SnapshotTaskVariableTemplate variableIndex;
+  @Autowired private SnapshotTaskVariableTemplate variableIndex;
 
   @Autowired private UserTaskRecordToTaskEntityMapper userTaskRecordToTaskEntityMapper;
 

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/VariableZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/VariableZeebeRecordProcessorOpenSearch.java
@@ -23,7 +23,6 @@ import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -34,9 +33,7 @@ public class VariableZeebeRecordProcessorOpenSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(VariableZeebeRecordProcessorOpenSearch.class);
 
-  @Autowired
-  @Qualifier("tasklistVariableTemplate")
-  private VariableTemplate variableIndex;
+  @Autowired private VariableTemplate variableIndex;
 
   @Autowired private TasklistProperties tasklistProperties;
 

--- a/tasklist/importer-common/src/main/java/io/camunda/tasklist/zeebeimport/common/ProcessDefinitionDeletionProcessor.java
+++ b/tasklist/importer-common/src/main/java/io/camunda/tasklist/zeebeimport/common/ProcessDefinitionDeletionProcessor.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /*
@@ -41,9 +40,7 @@ public class ProcessDefinitionDeletionProcessor {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ProcessDefinitionDeletionProcessor.class);
 
-  @Autowired
-  @Qualifier("tasklistProcessIndex")
-  private ProcessIndex processIndex;
+  @Autowired private ProcessIndex processIndex;
 
   @Autowired private FormIndex formIndex;
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchChecks.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchChecks.java
@@ -16,17 +16,13 @@ import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.store.ProcessStore;
 import io.camunda.tasklist.webapp.rest.exception.NotFoundApiException;
-import io.camunda.webapps.schema.descriptors.template.SnapshotTaskVariableTemplate;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskState;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -41,15 +37,9 @@ import org.springframework.context.annotation.Configuration;
 @Conditional(ElasticSearchCondition.class)
 public class ElasticsearchChecks {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchChecks.class);
-
   @Autowired private ElasticsearchHelper elasticsearchHelper;
 
   @Autowired private ProcessStore processStore;
-
-  @Autowired
-  @Qualifier("tasklistSnapshotTaskVariableTemplate")
-  private SnapshotTaskVariableTemplate taskVariableTemplate;
 
   /** Checks whether the process of given args[0] processId (Long) is deployed. */
   @Bean(name = PROCESS_IS_DEPLOYED_CHECK)

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchHelper.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchHelper.java
@@ -53,13 +53,9 @@ public class ElasticsearchHelper implements NoSqlHelper {
 
   @Autowired private TaskTemplate taskTemplate;
 
-  @Autowired
-  @Qualifier("tasklistSnapshotTaskVariableTemplate")
-  private SnapshotTaskVariableTemplate taskVariableTemplate;
+  @Autowired private SnapshotTaskVariableTemplate taskVariableTemplate;
 
-  @Autowired
-  @Qualifier("tasklistVariableTemplate")
-  private VariableTemplate variableIndex;
+  @Autowired private VariableTemplate variableIndex;
 
   @Autowired
   @Qualifier("tasklistEsClient")

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchChecks.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchChecks.java
@@ -16,17 +16,13 @@ import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.store.ProcessStore;
 import io.camunda.tasklist.webapp.rest.exception.NotFoundApiException;
-import io.camunda.webapps.schema.descriptors.template.SnapshotTaskVariableTemplate;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskState;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -41,15 +37,9 @@ import org.springframework.context.annotation.Configuration;
 @Conditional(OpenSearchCondition.class)
 public class OpenSearchChecks {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchChecks.class);
-
   @Autowired private OpenSearchHelper openSearchHelper;
 
   @Autowired private ProcessStore processStore;
-
-  @Autowired
-  @Qualifier("tasklistSnapshotTaskVariableTemplate")
-  private SnapshotTaskVariableTemplate taskVariableTemplate;
 
   /** Checks whether the process of given args[0] processId (Long) is deployed. */
   @Bean(name = PROCESS_IS_DEPLOYED_CHECK)

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TasklistIndexTemplateDescriptorsConfigurator.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TasklistIndexTemplateDescriptorsConfigurator.java
@@ -79,7 +79,7 @@ public class TasklistIndexTemplateDescriptorsConfigurator {
     };
   }
 
-  @Bean("tasklistSnapshotTaskVariableTemplate")
+  @Bean
   public SnapshotTaskVariableTemplate snapshotTaskVariableTemplate(
       final TasklistProperties tasklistProperties,
       final TasklistIndexPrefixHolder indexPrefixHolder) {
@@ -105,8 +105,8 @@ public class TasklistIndexTemplateDescriptorsConfigurator {
     };
   }
 
-  @Bean("tasklistVariableTemplate")
-  public VariableTemplate tasklistVariableTemplate(
+  @Bean
+  public VariableTemplate variableTemplate(
       final TasklistProperties tasklistProperties,
       final TasklistIndexPrefixHolder indexPrefixHolder) {
     return new VariableTemplate(
@@ -118,7 +118,7 @@ public class TasklistIndexTemplateDescriptorsConfigurator {
     };
   }
 
-  @Bean("tasklistFlowNodeInstanceTemplate")
+  @Bean
   public FlowNodeInstanceTemplate flowNodeInstanceTemplate(
       final TasklistProperties tasklistProperties,
       final TasklistIndexPrefixHolder indexPrefixHolder) {
@@ -144,7 +144,7 @@ public class TasklistIndexTemplateDescriptorsConfigurator {
     };
   }
 
-  @Bean("tasklistProcessIndex")
+  @Bean
   public ProcessIndex processIndex(
       final TasklistProperties tasklistProperties,
       final TasklistIndexPrefixHolder indexPrefixHolder) {


### PR DESCRIPTION
## Description

Previously, the Tasklist and Operate apps each had their own Elasticsearch/OpenSearch indexes, requiring separate beans of the same record type since they wrote to different indexes. Starting with v8.8, both apps now share the same indexes for reading and writing. Despite this, we were still creating two beans of the same type, with distinct names based on the app usage. As a result, running in standalone mode would unnecessarily create about four extra index template beans.

This change eliminates the need to create and wire duplicate beans by name. Instead, a single bean per type is created. However, in standalone mode, both Tasklist and Operate could end up creating identical beans without differentiation. To prevent this, Tasklist beans are annotated with an exclusion, ensuring they are only created when the "operate" profile is not active.

An additional benefit is that, in standalone mode, a "delete process instance by ID" request is no longer sent to all beans, including duplicates. This reduces the number of redundant delete calls made to the same indices due to duplicate beans—previously, about four unnecessary delete calls occurred.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/36067
