### PR TITLE
ci: update release workflow to be trigerred against tasklist v1 and v2 modes

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -17,16 +17,23 @@ permissions: {}
 
 jobs:
   release-e2e-tests:
+    name: Release E2E Tests (Tasklist ${{ matrix.tasklist_mode }} mode)
+    strategy:
+      fail-fast: false
+      matrix:
+        tasklist_mode: [v1, v2]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions: {}
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
       - name: Determine Image Tag
         id: image-tag
-        shell: bash
         run: |
           # Extract version from 8.8+ release branch patterns:
           # - release-8.8.0, release-8.9.1, release-9.0.0
@@ -64,7 +71,6 @@ jobs:
 
       - name: Update Docker Compose with Release Image
         if: steps.image-tag.outcome == 'success'
-        shell: bash
         run: |
           IMAGE_TAG="${{ steps.image-tag.outputs.image-tag }}"
           echo "Updating Docker Compose configuration for version: $IMAGE_TAG"
@@ -81,25 +87,27 @@ jobs:
 
       - name: Start Camunda
         if: steps.image-tag.outcome == 'success'
-        shell: bash
         run: |
           echo "Starting Camunda with image tag: ${{ steps.image-tag.outputs.image-tag }}"
-          export DATABASE=elasticsearch
-          DATABASE=elasticsearch docker compose up -d camunda
+          echo "Tasklist mode: ${{ matrix.tasklist_mode }}"
+
+          if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
+            echo "Starting with Tasklist V2 mode enabled"
+            CAMUNDA_TASKLIST_V2_MODE_ENABLED=true DATABASE=elasticsearch docker compose up -d camunda
+          else
+            echo "Starting with default Tasklist V1 mode"
+            DATABASE=elasticsearch docker compose up -d camunda
+          fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
-        env:
-          DATABASE: elasticsearch
 
       - name: List running Docker containers
         if: steps.image-tag.outcome == 'success'
-        shell: bash
         run: docker ps -a
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: Wait for services to be ready
         if: steps.image-tag.outcome == 'success'
         id: wait-for-services
-        shell: bash
         run: |
           echo "Checking if services are up..."
           ready=false
@@ -139,7 +147,6 @@ jobs:
 
       - name: Clean install dependencies
         if: steps.image-tag.outcome == 'success'
-        shell: bash
         run: |
           rm -rf node_modules package-lock.json
           npm install
@@ -161,13 +168,17 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.image-tag.outcome == 'success'
-        shell: bash
         run: npx playwright install --with-deps chromium
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 
+      - name: Python setup
+        if: steps.image-tag.outcome == 'success'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
       - name: Run E2E Tests
         if: steps.image-tag.outcome == 'success'
-        shell: bash
         env:
           LOCAL_TEST: "false"
           CAMUNDA_AUTH_STRATEGY: "BASIC"
@@ -176,14 +187,25 @@ jobs:
           CORE_APPLICATION_URL: "http://localhost:8080"
           ZEEBE_REST_ADDRESS: "http://localhost:8080"
           RELEASE_VERSION: ${{ steps.image-tag.outputs.image-tag }}
+          CAMUNDA_TASKLIST_V2_MODE_ENABLED: ${{ matrix.tasklist_mode == 'v2' && 'true' || 'false' }}
         run: |
           echo "Running E2E tests against Camunda release version: $RELEASE_VERSION"
-          npm run test -- --project=chromium
+          echo "Tasklist mode: ${{ matrix.tasklist_mode }}"
+
+          if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
+            echo "Running focused tests in V2 mode: Tasklist + HTO flows (excluding @v1-only tests)"
+            TEST_ARGS=(--project=chromium tests/tasklist/ tests/common-flows/hto-user-flows.spec.ts --grep-invert '@v1-only')
+          else
+            echo "Running all tests in V1 mode"
+            TEST_ARGS=(--project=chromium)
+          fi
+
+          echo "Running tests with args: ${TEST_ARGS[*]}"
+          npm run test -- "${TEST_ARGS[@]}"
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 
       - name: Publish test results to TestRail
         if: always() && steps.image-tag.outcome == 'success'
-        shell: bash
         env:
           TESTRAIL_HOST: "https://camunda.testrail.com/"
           TESTRAIL_USERNAME: ${{ steps.secrets.outputs.TESTRAIL_QA_EMAIL }}
@@ -196,7 +218,7 @@ jobs:
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
             parse_junit --suite-id 17050 \
-            --title "${{ steps.image-tag.outputs.image-tag }}-Release OC test" \
+            --title "${{ steps.image-tag.outputs.image-tag }}-Release OC test (Tasklist ${{ matrix.tasklist_mode }} mode)" \
             --close-run \
             -f "$JUNIT_RESULTS_FILE"
 
@@ -204,13 +226,12 @@ jobs:
         if: always() && steps.image-tag.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.image-tag.outputs.image-tag }}-Release OC test
+          name: ${{ steps.image-tag.outputs.image-tag }}-Release OC test (Tasklist ${{ matrix.tasklist_mode }} mode)
           path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 10
 
       - name: Print Docker logs before failing
         if: failure()
-        shell: bash
         run: |
           echo "=== Camunda logs ==="
           docker compose logs camunda || true


### PR DESCRIPTION
Update release E2E workflow to support Tasklist v1 and v2 modes

- Add matrix strategy with `tasklist_mode: [v1, v2]` to test both modes
- Update job name to include Tasklist mode for better identification
- Add conditional test filtering for v2 mode (Tasklist + HTO flows, excluding @v1-only tests)
- Update TestRail titles and artifact names to include mode information
- Maintains existing release validation logic for 8.8+ versions

Aligns with other E2E workflows (nightly, on-demand) that already support both modes.

❗ Failing tests are because the tests are trigerred against alpha8 as extracted from the branch name
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
