### PR TITLE
test: that new fields must be annotation and have a default, for data layer entities

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2729,6 +2729,27 @@
           </configuration>
         </plugin>
 
+        <!-- Plugin to check for api changes -->
+        <plugin>
+          <groupId>com.github.siom79.japicmp</groupId>
+          <artifactId>japicmp-maven-plugin</artifactId>
+          <version>${plugin.version.japicmp}</version>
+          <configuration>
+            <parameter>
+              <accessModifier>private</accessModifier>
+              <postAnalysisScript>${project.basedir}/src/main/scripts/failOnNewFieldWithoutAnnotation.groovy</postAnalysisScript>
+            </parameter>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>cmp</goal>
+              </goals>
+              <phase>verify</phase>
+            </execution>
+          </executions>
+        </plugin>
+
         <plugin>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
@@ -2815,28 +2836,6 @@
             <version>${plugin.version.google-java-format}</version>
           </dependency>
         </dependencies>
-      </plugin>
-
-      <!-- Plugin to check for api changes -->
-      <plugin>
-        <groupId>com.github.siom79.japicmp</groupId>
-        <artifactId>japicmp-maven-plugin</artifactId>
-        <version>${plugin.version.japicmp}</version>
-        <configuration>
-          <parameter>
-            <accessModifier>private</accessModifier>
-            <postAnalysisScript>${project.basedir}/src/main/scripts/failOnNewFieldWithoutAnnotation.groovy</postAnalysisScript>
-          </parameter>
-          <skip>true</skip>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>cmp</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
       </plugin>
 
     </plugins>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -156,6 +156,7 @@
     <version.sqlformatter>2.0.5</version.sqlformatter>
     <version.caffeine>3.2.2</version.caffeine>
     <version.commons-collections>20040616</version.commons-collections>
+    <version.reflections>0.10.2</version.reflections>
 
     <version.commons-io>2.20.0</version.commons-io>
     <version.thymeleaf>3.1.3.RELEASE</version.thymeleaf>
@@ -1310,6 +1311,13 @@
         <groupId>org.instancio</groupId>
         <artifactId>instancio-core</artifactId>
         <version>${version.instancio}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.reflections</groupId>
+        <artifactId>reflections</artifactId>
+        <version>${version.reflections}</version>
         <scope>test</scope>
       </dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -227,6 +227,7 @@
     <plugin.version.versions>2.18.0</plugin.version.versions>
     <plugin.version.frontend-maven>1.15.1</plugin.version.frontend-maven>
     <plugin.version.maven-source>3.3.1</plugin.version.maven-source>
+    <plugin.version.japicmp>0.23.1</plugin.version.japicmp>
 
     <!-- when updating this version, also change it in .idea/externalDependencies.xml -->
     <plugin.version.google-java-format>1.25.2</plugin.version.google-java-format>
@@ -2814,6 +2815,28 @@
             <version>${plugin.version.google-java-format}</version>
           </dependency>
         </dependencies>
+      </plugin>
+
+      <!-- Plugin to check for api changes -->
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+        <version>${plugin.version.japicmp}</version>
+        <configuration>
+          <parameter>
+            <accessModifier>private</accessModifier>
+            <postAnalysisScript>${project.basedir}/src/main/scripts/failOnNewFieldWithoutAnnotation.groovy</postAnalysisScript>
+          </parameter>
+          <skip>true</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>cmp</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
       </plugin>
 
     </plugins>

--- a/webapps-schema/pom.xml
+++ b/webapps-schema/pom.xml
@@ -82,22 +82,6 @@
       <plugin>
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <version>0.23.1</version>
-        <configuration>
-          <parameter>
-            <accessModifier>private</accessModifier>
-            <postAnalysisScript>${project.basedir}/src/main/scripts/failOnNewFieldWithoutAnnotation.groovy</postAnalysisScript>
-          </parameter>
-          <skip>true</skip>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>cmp</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/webapps-schema/pom.xml
+++ b/webapps-schema/pom.xml
@@ -65,6 +65,17 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.10.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/webapps-schema/pom.xml
+++ b/webapps-schema/pom.xml
@@ -68,7 +68,6 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <version>0.10.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -77,5 +76,30 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+        <version>0.23.1</version>
+        <configuration>
+          <parameter>
+            <accessModifier>private</accessModifier>
+            <postAnalysisScript>${project.basedir}/src/main/scripts/failOnNewFieldWithoutAnnotation.groovy</postAnalysisScript>
+          </parameter>
+          <skip>true</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>cmp</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion.java
@@ -16,4 +16,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SinceVersion {
   String value();
+
+  boolean nullable() default false;
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion.java
@@ -12,6 +12,29 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * New fields in entities stored at {@link io.camunda.webapps.schema.entities} must have the
+ * annotation {@link io.camunda.webapps.schema.entities.SinceVersion} with the value being the
+ * semantic version the field was introduced.
+ *
+ * <p>In addition, all fields with this annotation must have a non-null default value. This is to
+ * maintain backwards compatability. However, if the nullable field is set to true then it is
+ * acceptable for the field to have a null default.
+ *
+ * <p>Example usage:
+ *
+ * <pre><code>
+ *   class Foo {
+ *     private String newField; // This will fail
+ *
+ *    {@literal @SinceVersion("8.8.0")}
+ *     private String newField = "bar" // This will pass
+ *
+ *    {@literal @SinceVersion(value = "8.8.0", nullable = true)}
+ *     private String newField; // This will pass
+ *   }
+ * </code></pre>
+ */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SinceVersion {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SinceVersion {
+  String value();
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantMemberEntity.java
@@ -8,11 +8,14 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class TenantMemberEntity extends AbstractExporterEntity<TenantMemberEntity> {
 
+  @SinceVersion(value = "8.8.0", nullable = true)
   private String tenantId;
+
   private String memberId;
   private EntityType memberType;
 

--- a/webapps-schema/src/main/scripts/failOnNewFieldWithoutAnnotation.groovy
+++ b/webapps-schema/src/main/scripts/failOnNewFieldWithoutAnnotation.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+import japicmp.model.JApiChangeStatus
+import japicmp.model.*
+
+def requiredAnnotation = "io.camunda.webapps.schema.entities.SinceVersion"
+
+jApiClasses.each { jApiClass ->
+    // Only consider classes that were modified
+    if (jApiClass.getFullyQualifiedName().startsWith("io.camunda.webapps.schema.entities") &&
+            jApiClass.getChangeStatus() == JApiChangeStatus.MODIFIED &&
+            jApiClass.getClassType().getOldTypeOptional().get() != JApiClassType.ClassType.ENUM ) {
+
+        jApiClass.getFields().each { field ->
+            // Check only fields that are newly added within the modified class
+            if (field.getChangeStatus() == JApiChangeStatus.NEW) {
+                if (!field.getAnnotations().any { it.getFullyQualifiedName() == requiredAnnotation }) {
+                    throw new Exception(
+                            "New field added without required annotation @SinceVersion: " +
+                                    "${jApiClass.getFullyQualifiedName()}.${field.getName()}"
+                    )
+                }
+            }
+        }
+    }
+}
+
+return jApiClasses
+

--- a/webapps-schema/src/test/java/io/camunda/webapps/schema/EntityTest.java
+++ b/webapps-schema/src/test/java/io/camunda/webapps/schema/EntityTest.java
@@ -57,7 +57,9 @@ public class EntityTest {
     final Field[] fields = entityClass.getDeclaredFields();
 
     for (final Field field : fields) {
-      if (field.isAnnotationPresent(SinceVersion.class)) {
+      if (field.isAnnotationPresent(SinceVersion.class)
+          && !field.getAnnotation(SinceVersion.class).nullable()) {
+
         Assertions.assertThat(hasValidDefault(field))
             .withFailMessage(
                 "Field '%s' in class '%s' introduced in version '%s' must have a default value",

--- a/webapps-schema/src/test/java/io/camunda/webapps/schema/EntityTest.java
+++ b/webapps-schema/src/test/java/io/camunda/webapps/schema/EntityTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestInstance;
+import org.reflections.Reflections;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class EntityTest {
+  private Reflections reflections;
+  private ObjectMapper objectMapper;
+
+  @BeforeAll
+  void setUp() {
+    reflections = new Reflections("io.camunda.webapps.schema.entities");
+    objectMapper = new ObjectMapper();
+  }
+
+  @TestFactory
+  Stream<DynamicTest> factoryForEntityTests() {
+    return entityClasses().stream()
+        .filter(clazz -> !clazz.isInterface() && !Modifier.isAbstract(clazz.getModifiers()))
+        .map(this::createValidationTest);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Set<Class<? extends ExporterEntity<?>>> entityClasses() {
+    return reflections.getSubTypesOf(ExporterEntity.class).stream()
+        .map(clazz -> (Class<? extends ExporterEntity<?>>) clazz)
+        .collect(Collectors.toSet());
+  }
+
+  private DynamicTest createValidationTest(final Class<? extends ExporterEntity<?>> entityClass) {
+    return DynamicTest.dynamicTest(
+        "shouldHaveDefaultsForNewFields : " + entityClass.getSimpleName(),
+        () -> validateNewFieldsHaveDefaults(entityClass));
+  }
+
+  private void validateNewFieldsHaveDefaults(final Class<? extends ExporterEntity<?>> entityClass) {
+    final Field[] fields = entityClass.getDeclaredFields();
+
+    for (final Field field : fields) {
+      if (field.isAnnotationPresent(SinceVersion.class)) {
+        Assertions.assertThat(hasValidDefault(field))
+            .withFailMessage(
+                "Field '%s' in class '%s' introduced in version '%s' must have a default value",
+                field.getName(),
+                entityClass.getSimpleName(),
+                field.getAnnotation(SinceVersion.class).value())
+            .isTrue();
+      }
+    }
+  }
+
+  private boolean hasValidDefault(final Field field) {
+    try {
+      final Object instance = createDefaultInstance(field.getDeclaringClass());
+      field.setAccessible(true);
+      final Object value = field.get(instance);
+      return value != null;
+    } catch (final Exception e) {
+      return false;
+    }
+  }
+
+  private Object createDefaultInstance(final Class<?> clazz) throws Exception {
+    try {
+      return clazz.getDeclaredConstructor().newInstance();
+    } catch (final Exception e) {
+      // If default constructor fails, try with ObjectMapper
+      return objectMapper.readValue("{}", clazz);
+    }
+  }
+}


### PR DESCRIPTION
## Description

When adding new fields there is a possibility that when processing old documents without that field we run into NPEs due to a lack of default. To mitigate this a test is added that checks for all fields with a `@SinceVersion` tag must have a default specified.

There is just 1 unknown, currently there is nothing forcing users to add a `@SinceVersion` annotation for new fields, there's two solutions.
1. Specify this in documentation (not that great).
2. in the test store the current fields of every entity class (this will be hundreds of lines), and that way if there is a new field without a `@SinceVersion` we can fail, with the drawback being each new field will require a test change.

I'm partial to approach 2 as it's quite simple but open to any other approaches.

<img width="1227" height="475" alt="image" src="https://github.com/user-attachments/assets/d0842f7e-d026-4298-a8c1-e4a9d82721aa" />
<img width="1925" height="364" alt="image" src="https://github.com/user-attachments/assets/65bde790-3c76-45c7-9157-d39516c93971" />


I'm partial to approach 2 but open to thoughts.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37761
