### PR TITLE
[Backport release-8.8.0] [Backport stable/8.8] fix: change session creation to never in security filter for api path in oidc

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -467,8 +467,7 @@ public class WebSecurityConfig {
         final HttpSecurity httpSecurity,
         final AuthFailureHandler authFailureHandler,
         final SecurityConfiguration securityConfiguration,
-        final CookieCsrfTokenRepository csrfTokenRepository,
-        final CamundaAuthenticationProvider authenticationProvider)
+        final CookieCsrfTokenRepository csrfTokenRepository)
         throws Exception {
       LOG.info("The API is protected by HTTP Basic authentication.");
       final var filterChainBuilder =
@@ -758,8 +757,7 @@ public class WebSecurityConfig {
         final SecurityConfiguration securityConfiguration,
         final CookieCsrfTokenRepository csrfTokenRepository,
         final OAuth2AuthorizedClientRepository authorizedClientRepository,
-        final OAuth2AuthorizedClientManager authorizedClientManager,
-        final CamundaAuthenticationProvider authenticationProvider)
+        final OAuth2AuthorizedClientManager authorizedClientManager)
         throws Exception {
       final var filterChainBuilder =
           httpSecurity
@@ -779,6 +777,8 @@ public class WebSecurityConfig {
                           securityConfiguration.getSaas().isConfigured()))
               .exceptionHandling(
                   (exceptionHandling) -> exceptionHandling.accessDeniedHandler(authFailureHandler))
+              .sessionManagement(
+                  configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.NEVER))
               .cors(AbstractHttpConfigurer::disable)
               .formLogin(AbstractHttpConfigurer::disable)
               .anonymous(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
# Description
Backport of #38483 to `release-8.8.0`.

relates to #38347 #37983