### PR TITLE
[Backport release-8.8.0] [Backport stable/8.8] Only username and password should be mandatory on user creation

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateUserCommandImpl.java
@@ -52,8 +52,6 @@ public final class CreateUserCommandImpl implements CreateUserCommandStep1 {
   @Override
   public CamundaFuture<CreateUserResponse> send() {
     ArgumentUtil.ensureNotNull("username", request.getUsername());
-    ArgumentUtil.ensureNotNull("email", request.getEmail());
-    ArgumentUtil.ensureNotNull("name", request.getName());
     ArgumentUtil.ensureNotNull("password", request.getPassword());
     final HttpCamundaFuture<CreateUserResponse> result = new HttpCamundaFuture<>();
     final CreateUserResponseImpl response = new CreateUserResponseImpl();

--- a/clients/java/src/test/java/io/camunda/client/user/CreateUserTest.java
+++ b/clients/java/src/test/java/io/camunda/client/user/CreateUserTest.java
@@ -74,38 +74,6 @@ public class CreateUserTest extends ClientRestTest {
   }
 
   @Test
-  void shouldRaiseExceptionOnNullEmail() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                client
-                    .newCreateUserCommand()
-                    .username(USERNAME)
-                    .name(NAME)
-                    .password(PASSWORD)
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("email must not be null");
-  }
-
-  @Test
-  void shouldRaiseExceptionOnNullName() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                client
-                    .newCreateUserCommand()
-                    .username(USERNAME)
-                    .email(EMAIL)
-                    .password(PASSWORD)
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("name must not be null");
-  }
-
-  @Test
   void shouldRaiseExceptionOnNullPassword() {
     // when / then
     assertThatThrownBy(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
@@ -69,6 +69,9 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
   }
 
   public UserRecord setName(final String name) {
+    if (name == null) {
+      return this;
+    }
     nameProp.setValue(name);
     return this;
   }
@@ -84,6 +87,9 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
   }
 
   public UserRecord setEmail(final String email) {
+    if (email == null) {
+      return this;
+    }
     emailProp.setValue(email);
     return this;
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateUserTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateUserTest.java
@@ -59,6 +59,22 @@ class CreateUserTest {
   }
 
   @Test
+  void shouldCreateUserWithMandatoryFields() {
+    // when
+    final var response =
+        client.newCreateUserCommand().username("aUsername").password("aPassword").send().join();
+
+    // then
+    ZeebeAssertHelper.assertUserCreated(
+        "aUsername",
+        (user) -> {
+          assertThat(user.getEmail()).isEmpty();
+          assertThat(user.getName()).isEmpty();
+          assertThat(user.getPassword()).isNotNull();
+        });
+  }
+
+  @Test
   void shouldRejectIfUsernameAlreadyExists() {
     // given
     client


### PR DESCRIPTION
# Description
Backport of #38514 to `release-8.8.0`.

relates to #38338 #38324