### PR TITLE
pg/tenant-based-importer-completion

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeESConstants.java
+++ b/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeESConstants.java
@@ -24,4 +24,5 @@ public interface ZeebeESConstants {
   String PROCESS_MESSAGE_SUBSCRIPTION_INDEX_NAME = "process-message-subscription";
   String USER_TASK_INDEX_NAME = "user-task";
   String DEPLOYMENT = "deployment";
+  String TENANT = "tenant";
 }

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebe/ImportValueType.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebe/ImportValueType.java
@@ -18,7 +18,8 @@ public enum ImportValueType {
   VARIABLE(ZeebeESConstants.VARIABLE_INDEX_NAME),
   VARIABLE_DOCUMENT(ZeebeESConstants.VARIABLE_DOCUMENT_INDEX_NAME),
   PROCESS_MESSAGE_SUBSCRIPTION(ZeebeESConstants.PROCESS_MESSAGE_SUBSCRIPTION_INDEX_NAME),
-  USER_TASK(ZeebeESConstants.USER_TASK_INDEX_NAME);
+  USER_TASK(ZeebeESConstants.USER_TASK_INDEX_NAME),
+  TENANT(ZeebeESConstants.TENANT);
 
   public static final ImportValueType[] IMPORT_VALUE_TYPES =
       new ImportValueType[] {
@@ -32,7 +33,8 @@ public enum ImportValueType {
         VARIABLE,
         VARIABLE_DOCUMENT,
         PROCESS_MESSAGE_SUBSCRIPTION,
-        USER_TASK
+        USER_TASK,
+        TENANT,
       };
   private final String aliasTemplate;
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
@@ -124,6 +124,35 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  public void shouldMarkRecordReadersAsCompletedIfTenantRecordReceived() throws IOException {
+
+    // given
+    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
+    EXPORTER.export(record);
+    esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    tester.performOneRoundOfImport();
+
+    // when
+    final var record2 = generateRecord(ValueType.TENANT, "8.8.0", 1);
+    EXPORTER.export(record2);
+    esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+
+    // receives 8.7 record and marks partition as finished importing
+    tester.performOneRoundOfImport();
+
+    // then
+    // require multiple checks to avoid race condition. If records are written to zeebe indices and
+    // before a refresh, the record reader pulls the import batch is empty so it then says that the
+    // record reader is done when it is not.
+    for (int i = 0; i < emptyBatches; i++) {
+      tester.performOneRoundOfImport();
+    }
+
+    // the import position for
+    await().atMost(Duration.ofSeconds(30)).until(() -> isRecordReaderCompleted("1-tenant"));
+  }
+
+  @Test
   public void shouldMarkMultiplePositionIndexAsCompletedIf880RecordReceived() throws IOException {
 
     final var processInstanceRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);

--- a/qa/migration-tests/pom.xml
+++ b/qa/migration-tests/pom.xml
@@ -292,6 +292,16 @@
       <artifactId>camunda-exporter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/qa/migration-tests/pom.xml
+++ b/qa/migration-tests/pom.xml
@@ -292,11 +292,6 @@
       <artifactId>camunda-exporter</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch-core</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/MigrationsShouldCompleteWithoutAnyDataAndDisabledAuthIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/MigrationsShouldCompleteWithoutAnyDataAndDisabledAuthIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.migration;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import io.camunda.application.Profile;
+import io.camunda.it.migration.util.CamundaMigrator;
+import io.camunda.it.migration.util.MigrationITExtension;
+import io.camunda.migration.commons.storage.MigrationRepositoryIndex;
+import io.camunda.migration.commons.storage.TasklistMigrationRepositoryIndex;
+import io.camunda.zeebe.util.VersionUtil;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@Tag("multi-db-test")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class MigrationsShouldCompleteWithoutAnyDataAndDisabledAuthIT {
+
+  @RegisterExtension
+  private static final MigrationITExtension PROVIDER =
+      new MigrationITExtension()
+          .withAuthenticationDisabled()
+          .withPostUpdateAdditionalProfiles(
+              Profile.PROCESS_MIGRATION, Profile.USAGE_METRIC_MIGRATION, Profile.TASK_MIGRATION);
+
+  private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+  @Test
+  void allMigrationsHaveRun(final CamundaMigrator migrator)
+      throws IOException, InterruptedException {
+    final var tasklistMigrationIndex =
+        new TasklistMigrationRepositoryIndex(migrator.getIndexPrefix(), migrator.isElasticsearch());
+    final var operateMigrationIndex =
+        new MigrationRepositoryIndex(migrator.getIndexPrefix(), migrator.isElasticsearch());
+
+    // Migrations with suffix "1" is the Tasklist Task index Migrations
+    assertMigrationStepsExist(tasklistMigrationIndex.getFullQualifiedName(), "1");
+
+    // Migration with suffix "2" is the Usage Metrics Migration
+    assertMigrationStepsExist(tasklistMigrationIndex.getFullQualifiedName(), "2");
+
+    // Since there is no data available for the process migration it will not be present in the
+    // migration index as no action has been taken. That's the reason the suffix "1" is missing
+    // here.
+
+    // Migration with suffix "2" is the Usage Metrics Migration
+    assertMigrationStepsExist(operateMigrationIndex.getFullQualifiedName(), "2");
+  }
+
+  private void assertMigrationStepsExist(final String index, final String migrationIdSuffix)
+      throws IOException, InterruptedException {
+    final var url = PROVIDER.getDatabaseUrl();
+    final var migrationId = VersionUtil.getVersion() + "-" + migrationIdSuffix;
+    final var targetUrl = String.format("%s/%s/_doc/%s", url, index, migrationId);
+
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .GET()
+            .uri(URI.create(targetUrl))
+            .header("Content-Type", "application/json")
+            .build();
+
+    final HttpResponse<Void> response = HTTP_CLIENT.send(request, BodyHandlers.discarding());
+    assertThat(response.statusCode()).isEqualTo(200);
+  }
+}

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationDatabaseChecks.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationDatabaseChecks.java
@@ -99,21 +99,6 @@ public class MigrationDatabaseChecks extends ElasticOpenSearchSetupHelper {
     return totalDocs > 0;
   }
 
-  public boolean checkDemoUserIsPresent() throws IOException, InterruptedException {
-    final String targetUrl =
-        String.format("%s/%s-camunda-user-8.8.0_/_doc/demo", endpoint, indexPrefix);
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(URI.create(targetUrl))
-            .header("Content-Type", "application/json")
-            .GET()
-            .build();
-
-    LOGGER.info("Checking if demo user is present");
-    final var response = httpClient.send(request, BodyHandlers.ofString());
-    return response.statusCode() == 200;
-  }
-
   @Override
   public void close() {
     cleanup(indexPrefix);

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
@@ -168,10 +168,6 @@ public class MigrationITExtension
     migrator.update(envOverrides, exporterArgsOverride, postUpdateProfiles);
     awaitExporterReadiness();
     awaitDemoUserIsPresent();
-
-    /* Ingest an 8.8 Record in order to trigger importers empty batch counting */
-    ingestRecordToTriggerImporters(migrator.getCamundaClient());
-
     awaitImportersFinished();
 
     if (shouldWaitForMigrations()) {
@@ -282,14 +278,6 @@ public class MigrationITExtension
         .pollInterval(Duration.ofSeconds(2))
         .atMost(Duration.ofSeconds(60))
         .untilAsserted(() -> assertThat(migrator.isMigrationCompleted()).isTrue());
-  }
-
-  private void ingestRecordToTriggerImporters(final CamundaClient client) {
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("process/error-end-event.bpmn")
-        .send()
-        .join();
   }
 
   private boolean areImportersDisabled() {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/zeebe/ZeebeESConstants.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/zeebe/ZeebeESConstants.java
@@ -18,5 +18,6 @@ public interface ZeebeESConstants {
   String VARIABLE_INDEX_NAME = "variable";
   String FORM_INDEX_NAME = "form";
   String USER_TASK_INDEX_NAME = "user-task";
+  String TENANT = "tenant";
   String DEPLOYMENT = "deployment";
 }

--- a/tasklist/importer-common/src/main/java/io/camunda/tasklist/zeebe/ImportValueType.java
+++ b/tasklist/importer-common/src/main/java/io/camunda/tasklist/zeebe/ImportValueType.java
@@ -13,11 +13,12 @@ public enum ImportValueType {
   PROCESS(ZeebeESConstants.PROCESS_INDEX_NAME),
   VARIABLE(ZeebeESConstants.VARIABLE_INDEX_NAME),
   FORM(ZeebeESConstants.FORM_INDEX_NAME),
-  USER_TASK(ZeebeESConstants.USER_TASK_INDEX_NAME);
+  USER_TASK(ZeebeESConstants.USER_TASK_INDEX_NAME),
+  TENANT(ZeebeESConstants.TENANT);
 
   private final String aliasTemplate;
 
-  ImportValueType(String aliasTemplate) {
+  ImportValueType(final String aliasTemplate) {
     this.aliasTemplate = aliasTemplate;
   }
 
@@ -25,11 +26,11 @@ public enum ImportValueType {
     return aliasTemplate;
   }
 
-  public String getIndicesPattern(String prefix) {
+  public String getIndicesPattern(final String prefix) {
     return String.format("%s*%s*", prefix, aliasTemplate);
   }
 
-  public String getAliasName(String prefix) {
+  public String getAliasName(final String prefix) {
     return String.format("%s-%s", prefix, aliasTemplate);
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
@@ -136,6 +136,37 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
   }
 
   @Test
+  public void shouldMarkRecordReadersAsCompletedIfTenantRecordReceived() throws IOException {
+    // given
+    final var record = generateRecord(ValueType.JOB, "8.7.0", 1);
+    EXPORTER.export(record);
+    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+
+    zeebeImporter.performOneRoundOfImport();
+
+    // when
+    final var record2 = generateRecord(ValueType.TENANT, "8.8.0", 1);
+    EXPORTER.export(record2);
+    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+
+    // receives 8.7 record and marks partition as finished importing
+    zeebeImporter.performOneRoundOfImport();
+
+    // then
+    // require multiple checks to avoid race condition. If records are written to zeebe indices and
+    // before a refresh, the record reader pulls the import batch is empty so it then says that the
+    // record reader is done when it is not.
+    for (int i = 0; i < emptyBatches; i++) {
+      zeebeImporter.performOneRoundOfImport();
+    }
+
+    // the import position for
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .until(() -> isRecordReaderIsCompleted("1-tenant"));
+  }
+
+  @Test
   public void shouldMarkMultiplePositionIndexAsCompletedIf880RecordReceived() throws IOException {
     final var processInstanceRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     final var jobRecord = generateRecord(ValueType.JOB, "8.7.0", 1);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -108,6 +108,7 @@ public class ElasticsearchExporterConfiguration {
       case AD_HOC_SUB_PROCESS_INSTRUCTION -> index.adHocSubProcessInstruction;
       case ASYNC_REQUEST -> index.asyncRequest;
       case RUNTIME_INSTRUCTION -> index.runtimeInstruction;
+      case TENANT -> index.tenant;
       default -> false;
     };
   }
@@ -129,6 +130,7 @@ public class ElasticsearchExporterConfiguration {
       case PROCESS_INSTANCE -> index.processInstance;
       case USER_TASK -> index.userTask;
       case JOB -> index.job;
+      case TENANT -> index.tenant;
       default -> false;
     };
   }
@@ -212,6 +214,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean compensationSubscription = true;
     public boolean messageCorrelation = true;
     public boolean user = true;
+    public boolean tenant = true;
     public boolean authorization = true;
     public boolean runtimeInstruction = true;
 
@@ -341,6 +344,8 @@ public class ElasticsearchExporterConfiguration {
           + messageCorrelation
           + ", user="
           + user
+          + ", tenant="
+          + tenant
           + ", authorization="
           + authorization
           + ", asyncRequest="

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
@@ -187,6 +187,9 @@ public class ElasticsearchExporterSchemaManager {
       if (index.runtimeInstruction) {
         createValueIndexTemplate(ValueType.RUNTIME_INSTRUCTION, version);
       }
+      if (index.tenant) {
+        createValueIndexTemplate(ValueType.TENANT, version);
+      }
     }
 
     indexTemplatesCreated.add(version);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-tenant-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-tenant-template.json
@@ -1,0 +1,47 @@
+{
+  "index_patterns": [
+    "zeebe-record_tenant_*"
+  ],
+  "composed_of": [
+    "zeebe-record"
+  ],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-tenant": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "entityId": {
+              "type": "keyword"
+            },
+            "tenantKey": {
+              "type": "long"
+            },
+            "tenantId": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "description": {
+              "type": "text"
+            },
+            "entityType": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -253,7 +253,8 @@ final class ElasticsearchExporterIT {
         || valueType == ValueType.INCIDENT
         || valueType == ValueType.USER_TASK
         || valueType == ValueType.DEPLOYMENT
-        || valueType == ValueType.JOB) {
+        || valueType == ValueType.JOB
+        || valueType == ValueType.TENANT) {
       final var response = testClient.getExportedDocumentFor(record);
       assertThat(response)
           .extracting(

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -73,6 +73,7 @@ final class TestSupport {
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
       case RUNTIME_INSTRUCTION -> config.runtimeInstruction = value;
+      case TENANT -> config.tenant = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -115,7 +116,6 @@ final class TestSupport {
             ValueType.AUTHORIZATION,
             ValueType.USER,
             ValueType.ROLE,
-            ValueType.TENANT,
             ValueType.GROUP,
             ValueType.MAPPING_RULE,
             ValueType.IDENTITY_SETUP,

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -372,6 +372,9 @@ public class OpensearchExporter implements Exporter {
       if (index.runtimeInstruction) {
         createValueIndexTemplate(ValueType.RUNTIME_INSTRUCTION, version);
       }
+      if (index.tenant) {
+        createValueIndexTemplate(ValueType.TENANT, version);
+      }
     }
 
     indexTemplatesCreated.add(version);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -107,6 +107,7 @@ public class OpensearchExporterConfiguration {
       case AD_HOC_SUB_PROCESS_INSTRUCTION -> index.adHocSubProcessInstruction;
       case ASYNC_REQUEST -> index.asyncRequest;
       case RUNTIME_INSTRUCTION -> index.runtimeInstruction;
+      case TENANT -> index.tenant;
       default -> false;
     };
   }
@@ -128,6 +129,7 @@ public class OpensearchExporterConfiguration {
       case PROCESS_INSTANCE -> index.processInstance;
       case USER_TASK -> index.userTask;
       case JOB -> index.job;
+      case TENANT -> index.tenant;
       default -> false;
     };
   }
@@ -201,7 +203,7 @@ public class OpensearchExporterConfiguration {
     public boolean compensationSubscription = true;
     public boolean messageCorrelation = true;
     public boolean user = true;
-
+    public boolean tenant = true;
     public boolean authorization = true;
 
     public boolean runtimeInstruction = true;
@@ -330,6 +332,8 @@ public class OpensearchExporterConfiguration {
           + messageCorrelation
           + ", user="
           + user
+          + ", tenant="
+          + tenant
           + ", authorization="
           + authorization
           + ", asyncRequest="

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-tenant-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-tenant-template.json
@@ -1,0 +1,47 @@
+{
+  "index_patterns": [
+    "zeebe-record_tenant_*"
+  ],
+  "composed_of": [
+    "zeebe-record"
+  ],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-tenant": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "entityId": {
+              "type": "keyword"
+            },
+            "tenantKey": {
+              "type": "long"
+            },
+            "tenantId": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "description": {
+              "type": "text"
+            },
+            "entityType": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -329,7 +329,8 @@ final class OpensearchExporterIT {
         || valueType == ValueType.INCIDENT
         || valueType == ValueType.USER_TASK
         || valueType == ValueType.DEPLOYMENT
-        || valueType == ValueType.JOB) {
+        || valueType == ValueType.JOB
+        || valueType == ValueType.TENANT) {
       final var response = testClient.getExportedDocumentFor(record);
       assertThat(response)
           .extracting(

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -74,6 +74,7 @@ final class TestSupport {
       case ASYNC_REQUEST -> config.asyncRequest = value;
       case USAGE_METRIC -> config.usageMetrics = value;
       case RUNTIME_INSTRUCTION -> config.runtimeInstruction = value;
+      case TENANT -> config.tenant = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -116,7 +117,6 @@ final class TestSupport {
             ValueType.AUTHORIZATION,
             ValueType.USER,
             ValueType.ROLE,
-            ValueType.TENANT,
             ValueType.GROUP,
             ValueType.MAPPING_RULE,
             ValueType.IDENTITY_SETUP,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Remove requirement for cluster processing in order to complete the Importers by having them access the `Tenant` created records.

These records, will be created by default once the upgrade to 8.8 has happened.

- Have ES/OS Exporters export `ValueType.TENANT` records by default
- Have Tasklist RecordReaders scrape the `tenant` aliased Zeebe record indices
- Have Operate RecordReaders scrape the `tenant` aliased Zeebe record indices

For verification, the manual ingestion of records during the Migration test suite has been removed and solely relies on the auto exporting of the `tenant` records

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38476
