### PR TITLE
test: remove dispatch trigger to fix tile drag test

### DIFF
--- a/optimize/client/e2e/sm-tests/Dashboard.js
+++ b/optimize/client/e2e/sm-tests/Dashboard.js
@@ -676,17 +676,16 @@ test('drag a report in a Dashboard', async (t) => {
   await u.createNewDashboard(t);
   await u.addReportToDashboard(t, 'Blank report');
 
-  await t.dispatchEvent(e.gridItem, 'mousedown');
-  const leftOffset = await e.gridItem.getBoundingClientRectProperty('left');
+  const initialLeftOffset = await e.gridItem.getBoundingClientRectProperty('left');
   const DRAG_AMOUNT = 500;
-  await t.expect(leftOffset).lt(DRAG_AMOUNT);
+
+  // drop right
   await t.drag(e.gridItem, DRAG_AMOUNT, 0);
   const newLeftOffset = await e.gridItem.getBoundingClientRectProperty('left');
+  await t.expect(newLeftOffset).gt(initialLeftOffset);
 
-  await t.expect(newLeftOffset).gt(DRAG_AMOUNT);
-
+  // test after saving
   await u.save(t);
-
   const offsetAfterSave = await e.gridItem.getBoundingClientRectProperty('left');
-  await t.expect(offsetAfterSave).gt(DRAG_AMOUNT);
+  await t.expect(offsetAfterSave).gt(initialLeftOffset);
 });


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
There is a broken e2e test due to a recent dependency update (#38163)
The CI did not catch it before because the Optimize e2e tests were disabled. 
Enabling the e2e tests in #38366 exposed the failure.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
