### PR TITLE
fix: conditional jackson converter setup

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rest/MappingJackson2HttpMessageConverterConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/MappingJackson2HttpMessageConverterConfiguration.java
@@ -8,10 +8,11 @@
 package io.camunda.application.commons.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
@@ -27,18 +28,20 @@ public class MappingJackson2HttpMessageConverterConfiguration {
 
   @Bean
   @Order(1)
+  @ConditionalOnRestGatewayEnabled
   public MappingJackson2HttpMessageConverter gatewayRestMappingJackson2HttpMessageConverter(
-      @Lazy @Qualifier("gatewayRestObjectMapper") final ObjectMapper objectMapper) {
+      @Qualifier("gatewayRestObjectMapper") final ObjectMapper objectMapper) {
     final PackageSpecificJackson2HttpMessageConverter messageConverter =
-        new PackageSpecificJackson2HttpMessageConverter("io.camunda.zeebe");
+        new PackageSpecificJackson2HttpMessageConverter("io.camunda.zeebe.gateway.protocol.rest");
     messageConverter.setObjectMapper(objectMapper);
     return messageConverter;
   }
 
   @Bean
   @Order(2)
+  @Profile("operate")
   public MappingJackson2HttpMessageConverter operateV1MappingJackson2HttpMessageConverter(
-      @Lazy @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     final PackageSpecificJackson2HttpMessageConverter messageConverter =
         new PackageSpecificJackson2HttpMessageConverter("io.camunda.operate");
     messageConverter.setObjectMapper(objectMapper);
@@ -47,8 +50,9 @@ public class MappingJackson2HttpMessageConverterConfiguration {
 
   @Bean
   @Order(3)
+  @Profile("tasklist")
   public MappingJackson2HttpMessageConverter tasklistV1MappingJackson2HttpMessageConverter(
-      @Lazy @Qualifier("tasklistObjectMapper") final ObjectMapper objectMapper) {
+      @Qualifier("tasklistObjectMapper") final ObjectMapper objectMapper) {
     final PackageSpecificJackson2HttpMessageConverter messageConverter =
         new PackageSpecificJackson2HttpMessageConverter("io.camunda.tasklist");
     messageConverter.setObjectMapper(objectMapper);

--- a/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
@@ -114,6 +114,54 @@ public class CamundaDockerIT {
     }
   }
 
+  // Regression for https://github.com/camunda/camunda/issues/38487
+  @Test
+  public void testStartStandaloneBrokerWithoutRestAPI() throws Exception {
+    // given
+    // create and start Elasticsearch container
+    final ElasticsearchContainer elasticsearchContainer =
+        createContainer(this::createElasticsearchContainer);
+    elasticsearchContainer.start();
+
+    // create camunda container with only StandaloneBroker app
+    final var standaloneBrokerContainer =
+        new GenericContainer<>(CAMUNDA_TEST_DOCKER_IMAGE)
+            .withCreateContainerCmdModifier(
+                (final CreateContainerCmd cmd) ->
+                    cmd.withEntrypoint("/usr/local/camunda/bin/broker"))
+            .withExposedPorts(SERVER_PORT, MANAGEMENT_PORT, GATEWAY_GRPC_PORT)
+            .withNetwork(Network.SHARED)
+            .withNetworkAliases(CAMUNDA_NETWORK_ALIAS)
+            .waitingFor(
+                new HttpWaitStrategy()
+                    .forPort(MANAGEMENT_PORT)
+                    .forPath("/actuator/health")
+                    .withReadTimeout(Duration.ofSeconds(120)))
+            .withStartupTimeout(Duration.ofSeconds(300))
+            // Unified Configuration
+            .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", DATABASE_TYPE)
+            .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL", elasticsearchUrl())
+            // disable the REST API
+            .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "false");
+
+    // when - then the container should start without errors
+    startContainer(createContainer(() -> standaloneBrokerContainer));
+
+    try (final CloseableHttpResponse healthCheckResponse =
+        HttpClients.createDefault()
+            .execute(
+                new HttpGet(
+                    String.format(
+                        "http://%s:%d%s",
+                        standaloneBrokerContainer.getHost(),
+                        standaloneBrokerContainer.getMappedPort(MANAGEMENT_PORT),
+                        "/actuator/cluster")))) {
+
+      // then - the status codershould be 200 OK (instead of a 500 error as reported in #38487)
+      assertThat(healthCheckResponse.getCode()).isEqualTo(200);
+    }
+  }
+
   @Test
   public void testStartStandaloneCamundaWithUnifiedConfiguration() throws URISyntaxException {
     final ElasticsearchContainer elasticsearchContainer =


### PR DESCRIPTION
## Description

Ensure specific converters are only setup when required, in contrast to using lazy, which lead to failure when they were accidentally picked up still in configuration setups where the objectMapper was not provided though.

One example is described in the [last comment on the issue](https://github.com/camunda/camunda/issues/38487#issuecomment-3318700148) (standalone broker with rest api disabled).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38487 
