### PR TITLE
fix: reference 8.8 snapshot for camunda helm integration

### DIFF
--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -29,7 +29,7 @@ jobs:
             tag: 8.8-SNAPSHOT
         optimize:
           image:
-            tag: 8-SNAPSHOT
+            tag: 8.8-SNAPSHOT
         connectors:
           image:
             tag: 8.8-SNAPSHOT

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -30,6 +30,9 @@ jobs:
         optimize:
           image:
             tag: 8-SNAPSHOT
+        connectors:
+          image:
+            tag: 8.8-SNAPSHOT
       vault-secret-mapping: |
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR | TEST_DOCKER_USERNAME;
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW | TEST_DOCKER_PASSWORD;

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -24,15 +24,9 @@ jobs:
       test-enabled: true
       caller-git-ref: main
       extra-values: |
-        zeebe:
+        orchestration:
           image:
-            tag: SNAPSHOT
-        operate:
-          image:
-            tag: SNAPSHOT
-        tasklist:
-          image:
-            tag: SNAPSHOT
+            tag: 8.8-SNAPSHOT
         optimize:
           image:
             tag: 8-SNAPSHOT


### PR DESCRIPTION
## Description

We recently started having failures in 
https://github.com/camunda/camunda/actions/workflows/camunda-helm-integration.yml

in part due to a recent helm test-integration-template change here:
https://github.com/camunda/camunda-platform-helm/pull/4200

which changes the default for values-digest to be off, for the reason that consumers of test-integration-template should be able to replace the image tag or digest themselves if they want. If we don't want the orchestration image to not use 8.8.0-alpha8 by default ( which this workflow is ran nightly so we want a more up-to-date image ) then we need to set orchestration.image.tag

the other parts of this diff are to update values.yaml options that are no longer relevant for the 8.8 chart version. 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
