### PR TITLE
ci: update release-e2e-tests workflow

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -36,58 +36,48 @@ jobs:
         id: image-tag
         run: |
           set -euo pipefail
+          EVENT="${{ github.event_name }}"
+            REF_NAME="${{ github.ref_name }}"
+          PR_BASE="${{ github.event.pull_request.base.ref || '' }}"
 
-          # 1. Try direct base_ref (PR context)
-          BASE_CANDIDATE="${{ github.base_ref }}"
-          REF_NAME="${{ github.ref_name }}"
-          REPO="${{ github.repository }}"
-          OWNER="${{ github.repository_owner }}"
+          echo "Event: $EVENT"
+          echo "Ref name: $REF_NAME"
+          echo "PR base: $PR_BASE"
 
-          echo "Initial base_ref: '${BASE_CANDIDATE}' (empty means non‑PR push)"
-          echo "Ref name: '${REF_NAME}'"
-
-          # 2. If push event (no base_ref), attempt to discover an open PR whose head matches this ref
-          if [[ -z "$BASE_CANDIDATE" ]]; then
-            echo "No base_ref (push event). Attempting PR lookup for head=${OWNER}:${REF_NAME}"
-            API_RESPONSE=$(curl -s -H "Authorization: Bearer ${{ github.token }}" \
-              "https://api.github.com/repos/${REPO}/pulls?head=${OWNER}:${REF_NAME}&state=open&per_page=1")
-            DISCOVERED_BASE=$(printf '%s' "$API_RESPONSE" | grep -Eo '"base":\{[^}]*\}' | grep -Eo '"ref":"[^"]+"' | head -1 | cut -d':' -f2 | tr -d '"')
-            if [[ -n "$DISCOVERED_BASE" ]]; then
-              BASE_CANDIDATE="$DISCOVERED_BASE"
-              echo "Discovered base via open PR: '$BASE_CANDIDATE'"
-            else
-              echo "No open PR found for this branch."
-            fi
+          if [[ "$EVENT" == "pull_request" ]]; then
+            CANDIDATE_BRANCH="$PR_BASE"
+          else
+            CANDIDATE_BRANCH="$REF_NAME"
           fi
 
-          # 3. Final fallback: use the ref name itself
-            if [[ -z "$BASE_CANDIDATE" ]]; then
-            BASE_CANDIDATE="$REF_NAME"
-            echo "Falling back to branch itself as base: '$BASE_CANDIDATE'"
-          fi
+          RAW_CANDIDATE="$CANDIDATE_BRANCH"
+          CANDIDATE_BRANCH="$(echo -n "$CANDIDATE_BRANCH" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
 
-          # Sanitize
-          BASE_CANDIDATE="$(echo -n "$BASE_CANDIDATE" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-          echo "Using candidate branch for version extraction: $BASE_CANDIDATE"
+          echo "Raw candidate: >$RAW_CANDIDATE<"
+          echo "Sanitized candidate: >$CANDIDATE_BRANCH<"
 
-          # Accept: release-M.m, release-M.m.p, optionally with suffix: -rc1, -hotfix, -workflow, etc.
-          if [[ "$BASE_CANDIDATE" =~ ^release-([0-9]+)\.([0-9]+)(?:\.([0-9]+))?(?:[-.].*)?$ ]]; then
+            if [[ "$CANDIDATE_BRANCH" =~ ^release-([0-9]+)\.([0-9]+)\.([0-9]+)(-[A-Za-z0-9]+)?$ ]]; then
             MAJOR="${BASH_REMATCH[1]}"
             MINOR="${BASH_REMATCH[2]}"
             PATCH="${BASH_REMATCH[3]}"
-            [[ -z "$PATCH" ]] && PATCH=0
-            if { [[ "$MAJOR" -eq 8 && "$MINOR" -ge 8 ]] || [[ "$MAJOR" -gt 8 ]] ; }; then
-              IMAGE_TAG="$MAJOR.$MINOR.$PATCH"
-              echo "Extracted version: MAJOR=$MAJOR MINOR=$MINOR PATCH=$PATCH -> IMAGE_TAG=$IMAGE_TAG"
-              echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+            SUFFIX="${BASH_REMATCH[4]}"
+            VERSION="$MAJOR.$MINOR.$PATCH${SUFFIX}"
+            if { [[ "$MAJOR" -eq 8 && "$MINOR" -ge 8 ]] || [[ "$MAJOR" -gt 8 ]]; }; then
+              IMAGE_TAG="$VERSION"
+              echo "Extracted release version: $IMAGE_TAG"
             else
-              echo "Version $MAJOR.$MINOR.$PATCH < 8.8 -> skipping."
-              echo "image-tag=SKIPPED" >> "$GITHUB_OUTPUT"
+              echo "Error: Version $VERSION is < 8.8 (unsupported)."
+              exit 1
             fi
           else
-            echo "Branch '$BASE_CANDIDATE' not a release pattern -> skipping."
+            echo "ERROR: Pattern did not match: '$CANDIDATE_BRANCH'"
+            echo "Expected: release-X.Y.Z (>= 8.8) optionally with suffix (e.g. release-8.8.0, release-8.9.1, release-9.0.0, release-9.0.0-rc1)"
             echo "image-tag=SKIPPED" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
+
+          echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "Final image tag: $IMAGE_TAG"
 
       - name: Check release image availability
         id: check-image
@@ -201,12 +191,6 @@ jobs:
         if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
         run: npx playwright install --with-deps chromium
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
-
-      - name: Python setup
-        if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
 
       - name: Run E2E Tests
         if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -17,120 +17,159 @@ permissions: {}
 
 jobs:
   release-e2e-tests:
+    name: Release E2E Tests (Tasklist ${{ matrix.tasklist_mode }} mode)
+    strategy:
+      fail-fast: false
+      matrix:
+        tasklist_mode: [v1, v2]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions: {}
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
       - name: Determine Image Tag
         id: image-tag
-        shell: bash
         run: |
-          # Extract version from 8.8+ release branch patterns:
-          # - release-8.8.0, release-8.9.1, release-9.0.0
-          # - origin/release-8.8.2
-          # - custom-release-8.8.0-rc3, custom-release-9.0.0-beta1
-          BRANCH_NAME="${{ github.ref_name }}"
-          echo "Analyzing branch name: $BRANCH_NAME"
+          set -euo pipefail
 
-          if [[ "$BRANCH_NAME" =~ ^(origin/)?.*release-([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?)$ ]]; then
-            VERSION="${BASH_REMATCH[2]}"
-            
-            # Extract major and minor version numbers
-            MAJOR=$(echo "$VERSION" | cut -d. -f1)
-            MINOR=$(echo "$VERSION" | cut -d. -f2)
-            
-            # Check if version is 8.8 or greater (consolidated architecture)
-            if [[ "$MAJOR" -eq 8 && "$MINOR" -ge 8 ]] || [[ "$MAJOR" -gt 8 ]]; then
-              IMAGE_TAG="$VERSION"
-              echo "Extracted version $IMAGE_TAG from branch name (8.8+ supported)"
+          # 1. Try direct base_ref (PR context)
+          BASE_CANDIDATE="${{ github.base_ref }}"
+          REF_NAME="${{ github.ref_name }}"
+          REPO="${{ github.repository }}"
+          OWNER="${{ github.repository_owner }}"
+
+          echo "Initial base_ref: '${BASE_CANDIDATE}' (empty means non‑PR push)"
+          echo "Ref name: '${REF_NAME}'"
+
+          # 2. If push event (no base_ref), attempt to discover an open PR whose head matches this ref
+          if [[ -z "$BASE_CANDIDATE" ]]; then
+            echo "No base_ref (push event). Attempting PR lookup for head=${OWNER}:${REF_NAME}"
+            API_RESPONSE=$(curl -s -H "Authorization: Bearer ${{ github.token }}" \
+              "https://api.github.com/repos/${REPO}/pulls?head=${OWNER}:${REF_NAME}&state=open&per_page=1")
+            DISCOVERED_BASE=$(printf '%s' "$API_RESPONSE" | grep -Eo '"base":\{[^}]*\}' | grep -Eo '"ref":"[^"]+"' | head -1 | cut -d':' -f2 | tr -d '"')
+            if [[ -n "$DISCOVERED_BASE" ]]; then
+              BASE_CANDIDATE="$DISCOVERED_BASE"
+              echo "Discovered base via open PR: '$BASE_CANDIDATE'"
             else
-              echo "Error: Version $VERSION is not supported"
-              echo "This workflow only supports 8.8+ releases (consolidated architecture)"
-              echo "Found version: $VERSION (requires 8.8+)"
-              exit 1
+              echo "No open PR found for this branch."
             fi
-          else
-            echo "Error: Could not extract version from branch name: $BRANCH_NAME"
-            echo "Expected patterns: release-X.Y.Z where X.Y >= 8.8"
-            echo "Examples: release-8.8.0, release-8.9.1, release-9.0.0"
-            exit 1
           fi
 
-          echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
-          echo "Final image tag: $IMAGE_TAG"
+          # 3. Final fallback: use the ref name itself
+            if [[ -z "$BASE_CANDIDATE" ]]; then
+            BASE_CANDIDATE="$REF_NAME"
+            echo "Falling back to branch itself as base: '$BASE_CANDIDATE'"
+          fi
+
+          # Sanitize
+          BASE_CANDIDATE="$(echo -n "$BASE_CANDIDATE" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          echo "Using candidate branch for version extraction: $BASE_CANDIDATE"
+
+          # Accept: release-M.m, release-M.m.p, optionally with suffix: -rc1, -hotfix, -workflow, etc.
+          if [[ "$BASE_CANDIDATE" =~ ^release-([0-9]+)\.([0-9]+)(?:\.([0-9]+))?(?:[-.].*)?$ ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+            [[ -z "$PATCH" ]] && PATCH=0
+            if { [[ "$MAJOR" -eq 8 && "$MINOR" -ge 8 ]] || [[ "$MAJOR" -gt 8 ]] ; }; then
+              IMAGE_TAG="$MAJOR.$MINOR.$PATCH"
+              echo "Extracted version: MAJOR=$MAJOR MINOR=$MINOR PATCH=$PATCH -> IMAGE_TAG=$IMAGE_TAG"
+              echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+            else
+              echo "Version $MAJOR.$MINOR.$PATCH < 8.8 -> skipping."
+              echo "image-tag=SKIPPED" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "Branch '$BASE_CANDIDATE' not a release pattern -> skipping."
+            echo "image-tag=SKIPPED" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check release image availability
+        id: check-image
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.image-tag.outputs.image-tag }}"
+          if [[ -z "$TAG" || "$TAG" == "SKIPPED" ]]; then
+            echo "No valid image tag (value: '$TAG')."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Inspecting docker manifest for camunda/camunda:$TAG"
+          if docker manifest inspect "camunda/camunda:$TAG" >/dev/null 2>&1; then
+            echo "Image exists."
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Image camunda/camunda:$TAG not yet published. Skipping job steps."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip notice (image not yet published)
+        if: steps.check-image.outputs.available != 'true'
+        run: |
+          echo "Skipping Tasklist ${{ matrix.tasklist_mode }} mode: image camunda/camunda:${{ steps.image-tag.outputs.image-tag }} not available."
 
       - name: Update Docker Compose with Release Image
-        if: steps.image-tag.outcome == 'success'
-        shell: bash
+        if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
         run: |
           IMAGE_TAG="${{ steps.image-tag.outputs.image-tag }}"
-          echo "Updating Docker Compose configuration for version: $IMAGE_TAG"
-
-          # Update consolidated image for all versions
+          echo "Updating docker-compose for $IMAGE_TAG"
           sed -i -E "s|image: camunda/camunda:[^[:space:]]*|image: camunda/camunda:$IMAGE_TAG|g" \
             qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
-
-          echo "Updated docker-compose.yml to use image: camunda/camunda:$IMAGE_TAG"
-
-          # Verify the change
-          echo "Updated image configuration:"
           grep "image: camunda/camunda:" qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml || echo "No consolidated image found"
+        working-directory: .
 
       - name: Start Camunda
-        if: steps.image-tag.outcome == 'success'
-        shell: bash
+        if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
         run: |
           echo "Starting Camunda with image tag: ${{ steps.image-tag.outputs.image-tag }}"
-          export DATABASE=elasticsearch
-          DATABASE=elasticsearch docker compose up -d camunda
+          echo "Tasklist mode: ${{ matrix.tasklist_mode }}"
+          if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
+            echo "Tasklist V2 enabled"
+            CAMUNDA_TASKLIST_V2_MODE_ENABLED=true DATABASE=elasticsearch docker compose up -d camunda
+          else
+            echo "Tasklist V1 mode"
+            DATABASE=elasticsearch docker compose up -d camunda
+          fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
-        env:
-          DATABASE: elasticsearch
 
       - name: List running Docker containers
-        if: steps.image-tag.outcome == 'success'
-        shell: bash
+        if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
         run: docker ps -a
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: Wait for services to be ready
-        if: steps.image-tag.outcome == 'success'
+        if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
         id: wait-for-services
-        shell: bash
         run: |
-          echo "Checking if services are up..."
+          echo "Waiting for services..."
           ready=false
           for i in {1..90}; do
-            tasklist_status=$(curl -s -m 5 http://localhost:8080/tasklist || echo "Failed")
-            operate_status=$(curl -s -m 5 http://localhost:8080/operate || echo "Failed")
-            identity_status=$(curl -s -m 5 http://localhost:8080/identity || echo "Failed")
-
-            if [[ "$tasklist_status" != "Failed" && "$operate_status" != "Failed" && "$identity_status" != "Failed" ]]; then
-              echo "Services are ready!"
+            tasklist_status=$(curl -s -m 5 http://localhost:8080/tasklist || echo Failed)
+            operate_status=$(curl -s -m 5 http://localhost:8080/operate || echo Failed)
+            identity_status=$(curl -s -m 5 http://localhost:8080/identity || echo Failed)
+            if [[ "$tasklist_status" != Failed && "$operate_status" != Failed && "$identity_status" != Failed ]]; then
+              echo "All services ready."
               ready=true
               break
             fi
-
-            echo "Waiting for services... ($i/90)"
-            echo "Response from Tasklist: $tasklist_status"
-            echo "Response from Operate: $operate_status"
-            echo "Response from Identity: $identity_status"
+            echo "Attempt $i/90 still waiting..."
             sleep 10
           done
-
-          if [ "$ready" = true ]; then
+          if [[ "$ready" == true ]]; then
             echo "ready=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Services failed to start in time."
+            echo "Timeout waiting for services."
             exit 1
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: Setup Node.js
-        if: steps.image-tag.outcome == 'success'
+        if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -138,15 +177,14 @@ jobs:
           cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
 
       - name: Clean install dependencies
-        if: steps.image-tag.outcome == 'success'
-        shell: bash
+        if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
         run: |
           rm -rf node_modules package-lock.json
           npm install
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 
       - name: Import Secrets
-        if: steps.image-tag.outcome == 'success'
+        if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
         id: secrets
         uses: hashicorp/vault-action@2c5827061f1ad91ca97897d6257ebe638e033699
         with:
@@ -160,14 +198,18 @@ jobs:
             secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
 
       - name: Install Playwright Browsers
-        if: steps.image-tag.outcome == 'success'
-        shell: bash
+        if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
         run: npx playwright install --with-deps chromium
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 
+      - name: Python setup
+        if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
       - name: Run E2E Tests
-        if: steps.image-tag.outcome == 'success'
-        shell: bash
+        if: steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
         env:
           LOCAL_TEST: "false"
           CAMUNDA_AUTH_STRATEGY: "BASIC"
@@ -176,14 +218,20 @@ jobs:
           CORE_APPLICATION_URL: "http://localhost:8080"
           ZEEBE_REST_ADDRESS: "http://localhost:8080"
           RELEASE_VERSION: ${{ steps.image-tag.outputs.image-tag }}
+          CAMUNDA_TASKLIST_V2_MODE_ENABLED: ${{ matrix.tasklist_mode == 'v2' && 'true' || 'false' }}
         run: |
-          echo "Running E2E tests against Camunda release version: $RELEASE_VERSION"
-          npm run test -- --project=chromium
+          echo "Running E2E tests for $RELEASE_VERSION (Tasklist ${{ matrix.tasklist_mode }} mode)"
+          if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
+            TEST_ARGS=(--project=chromium tests/tasklist/ tests/common-flows/hto-user-flows.spec.ts --grep-invert '@v1-only')
+          else
+            TEST_ARGS=(--project=chromium)
+          fi
+          echo "Args: ${TEST_ARGS[*]}"
+          npm run test -- "${TEST_ARGS[@]}"
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 
       - name: Publish test results to TestRail
-        if: always() && steps.image-tag.outcome == 'success'
-        shell: bash
+        if: always() && steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
         env:
           TESTRAIL_HOST: "https://camunda.testrail.com/"
           TESTRAIL_USERNAME: ${{ steps.secrets.outputs.TESTRAIL_QA_EMAIL }}
@@ -196,21 +244,20 @@ jobs:
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
             parse_junit --suite-id 17050 \
-            --title "${{ steps.image-tag.outputs.image-tag }}-Release OC test" \
+            --title "${{ steps.image-tag.outputs.image-tag }}-Release OC test (Tasklist ${{ matrix.tasklist_mode }} mode)" \
             --close-run \
             -f "$JUNIT_RESULTS_FILE"
 
       - name: Upload test results
-        if: always() && steps.image-tag.outcome == 'success'
+        if: always() && steps.image-tag.outcome == 'success' && steps.check-image.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.image-tag.outputs.image-tag }}-Release OC test
+          name: ${{ steps.image-tag.outputs.image-tag }}-Release OC test (Tasklist ${{ matrix.tasklist_mode }} mode)
           path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 10
 
       - name: Print Docker logs before failing
-        if: failure()
-        shell: bash
+        if: failure() && steps.check-image.outputs.available == 'true'
         run: |
           echo "=== Camunda logs ==="
           docker compose logs camunda || true


### PR DESCRIPTION
## Description

This PR fixes the reported issue with the workflow on [slack](https://camunda.slack.com/archives/C06UWQNCU7M/p1758552747240399?thread_ts=1758513606.067619&cid=C06UWQNCU7M). Workflow now derives version from PR base, validates release image availability, and skips gracefully if not yet published,.
Also add the support if tasklist V2 api as on [stable/8.8](https://github.com/camunda/camunda/pull/38528)
**Key Changes**
- Version detection now uses PR base branch
- Adds Docker manifest probe; skips heavy steps if image not published (no failure)

## Checklist
🧪 Tested via this [job](https://github.com/camunda/camunda/actions/runs/17921070876/job/50955886958) on this [PR](https://github.com/camunda/camunda/pull/38560)
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
