### PR TITLE
[Backport release-8.8.0] [Backport stable/8.8] fix: determine element incident status from incident field

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/QueryHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/QueryHelper.java
@@ -435,4 +435,9 @@ public class QueryHelper {
         joinWithAnd(activitiesQuery, activityIdQuery, activityHasIncident),
         None);
   }
+
+  /** Setter for PermissionsService for testing purposes. */
+  void setPermissionsService(final PermissionsService permissionsService) {
+    this.permissionsService = permissionsService;
+  }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/QueryHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/QueryHelper.java
@@ -428,11 +428,11 @@ public class QueryHelper {
   private QueryBuilder createActivityIdIncidentQuery(final String activityId) {
     final QueryBuilder activitiesQuery = termQuery(ACTIVITY_STATE, FlowNodeState.ACTIVE.name());
     final QueryBuilder activityIdQuery = termQuery(ACTIVITY_ID, activityId);
-    final ExistsQueryBuilder incidentExists = existsQuery(ERROR_MSG);
+    final QueryBuilder activityHasIncident = termQuery(INCIDENT, true);
 
     return hasChildQuery(
         ACTIVITIES_JOIN_RELATION,
-        joinWithAnd(activitiesQuery, activityIdQuery, incidentExists),
+        joinWithAnd(activitiesQuery, activityIdQuery, activityHasIncident),
         None);
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/OpenSearchQueryHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/OpenSearchQueryHelper.java
@@ -182,7 +182,7 @@ public class OpenSearchQueryHelper {
         and(
             term(ACTIVITY_STATE, FlowNodeState.ACTIVE.name()),
             term(ACTIVITY_ID, activityId),
-            exists(ERROR_MSG));
+            term(INCIDENT, true));
 
     return QueryDSL.hasChildQuery(ACTIVITIES_JOIN_RELATION, query);
   }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/QueryHelperTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/QueryHelperTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
 package io.camunda.operate.webapp.elasticsearch;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/QueryHelperTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/QueryHelperTest.java
@@ -1,0 +1,40 @@
+package io.camunda.operate.webapp.elasticsearch;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.camunda.operate.webapp.rest.dto.listview.ListViewQueryDto;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.operate.webapp.security.permission.PermissionsService.ResourcesAllowed;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.junit.jupiter.api.Test;
+
+public class QueryHelperTest {
+
+  @Test
+  public void shouldUseIncidentFieldWhenActivityIdAndIncidentsAreSet() {
+    final QueryHelper queryHelper = new QueryHelper();
+    final String activityId = "testActivityId";
+
+    final PermissionsService permissionsService = mock(PermissionsService.class);
+    final ListViewQueryDto queryDto =
+        new ListViewQueryDto().setActivityId(activityId).setIncidents(true).setRunning(true);
+
+    queryHelper.setPermissionsService(permissionsService);
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(ResourcesAllowed.wildcard());
+
+    final QueryBuilder qb = queryHelper.createQueryFragment(queryDto);
+    assertNotNull(qb, "QueryBuilder should not be null");
+    final String queryString = qb.toString();
+    assertTrue(queryString.contains("activityState"), "Should contain activityState field");
+    assertTrue(queryString.contains("ACTIVE"), "Should contain activityState=ACTIVE");
+    assertTrue(queryString.contains("activityId"), "Should contain activityId field");
+    assertTrue(queryString.contains(activityId), "Should contain the provided activityId");
+    assertTrue(queryString.contains("incident"), "Should contain incident field");
+    assertTrue(queryString.contains("true"), "Should contain incident=true");
+    // Ensure error message field is not used
+    assertFalse(queryString.contains("errorMessage"), "Should not contain errorMessage field");
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/QueryHelperTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/QueryHelperTest.java
@@ -1,7 +1,8 @@
 package io.camunda.operate.webapp.elasticsearch;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.camunda.operate.webapp.rest.dto.listview.ListViewQueryDto;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
@@ -26,15 +27,17 @@ public class QueryHelperTest {
         .thenReturn(ResourcesAllowed.wildcard());
 
     final QueryBuilder qb = queryHelper.createQueryFragment(queryDto);
-    assertNotNull(qb, "QueryBuilder should not be null");
+    assertThat(qb).as("QueryBuilder should not be null").isNotNull();
     final String queryString = qb.toString();
-    assertTrue(queryString.contains("activityState"), "Should contain activityState field");
-    assertTrue(queryString.contains("ACTIVE"), "Should contain activityState=ACTIVE");
-    assertTrue(queryString.contains("activityId"), "Should contain activityId field");
-    assertTrue(queryString.contains(activityId), "Should contain the provided activityId");
-    assertTrue(queryString.contains("incident"), "Should contain incident field");
-    assertTrue(queryString.contains("true"), "Should contain incident=true");
+    assertThat(queryString).as("Should contain activityState field").contains("activityState");
+    assertThat(queryString).as("Should contain activityState=ACTIVE").contains("ACTIVE");
+    assertThat(queryString).as("Should contain activityId field").contains("activityId");
+    assertThat(queryString).as("Should contain the provided activityId").contains(activityId);
+    assertThat(queryString).as("Should contain incident field").contains("incident");
+    assertThat(queryString).as("Should contain incident=true").contains("true");
     // Ensure error message field is not used
-    assertFalse(queryString.contains("errorMessage"), "Should not contain errorMessage field");
+    assertThat(queryString)
+        .as("Should not contain errorMessage field")
+        .doesNotContain("errorMessage");
   }
 }


### PR DESCRIPTION
# Description
Backport of #38442 to `release-8.8.0`.

relates to #37805 #35169