### PR TITLE
ci: add on release checks for core apps e2e test

### DIFF
--- a/.github/workflows/identity-e2e-tests.yml
+++ b/.github/workflows/identity-e2e-tests.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - "main"
       - "stable/**"
+      - "release**"
     paths:
       - ".ci/**"
       - ".github/actions/**"

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "stable/**"
+      - "release**"
     paths:
       - ".ci/**"
       - ".github/actions/**"

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - "main"
       - "stable/**"
+      - "release**"
   pull_request:
 
 permissions:


### PR DESCRIPTION
## Description
revereted the changes i did before when we [introduced this workflow](https://github.com/camunda/camunda/pull/37326)
So in summary i added back on release for identity,tasklist and operate tests
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
