### PR TITLE
Remove enableIdentitySetup flag

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -38,7 +38,6 @@ public final class FeatureFlagsCfg {
   private boolean enableStraightThroughProcessingLoopDetector =
       DEFAULT_SETTINGS.enableStraightThroughProcessingLoopDetector();
   private boolean enablePartitionScaling = DEFAULT_SETTINGS.enablePartitionScaling();
-  private boolean enableIdentitySetup = DEFAULT_SETTINGS.enableIdentitySetup();
   private boolean enableMessageBodyOnExpired = DEFAULT_SETTINGS.enableMessageBodyOnExpired();
 
   public boolean isEnableYieldingDueDateChecker() {
@@ -90,14 +89,6 @@ public final class FeatureFlagsCfg {
     this.enablePartitionScaling = enablePartitionScaling;
   }
 
-  public boolean isEnableIdentitySetup() {
-    return enableIdentitySetup;
-  }
-
-  public void setEnableIdentitySetup(final boolean enableIdentitySetup) {
-    this.enableIdentitySetup = enableIdentitySetup;
-  }
-
   public boolean isEnableMessageBodyOnExpired() {
     return enableMessageBodyOnExpired;
   }
@@ -114,7 +105,6 @@ public final class FeatureFlagsCfg {
         enableTimerDueDateCheckerAsync,
         enableStraightThroughProcessingLoopDetector,
         enablePartitionScaling,
-        enableIdentitySetup,
         enableMessageBodyOnExpired
         /*, enableFoo*/ );
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -51,6 +51,7 @@ public final class EngineConfiguration {
   public static final Duration DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL = Duration.ofSeconds(10);
   public static final Duration DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION =
       Duration.ofMinutes(5);
+  public static final boolean DEFAULT_ENABLE_IDENTITY_SETUP = true;
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
@@ -87,6 +88,8 @@ public final class EngineConfiguration {
   private Duration commandRedistributionInterval = DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL;
   private Duration commandRedistributionMaxBackoff =
       DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION;
+
+  private boolean enableIdentitySetup = DEFAULT_ENABLE_IDENTITY_SETUP;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -322,6 +325,15 @@ public final class EngineConfiguration {
   public EngineConfiguration setCommandRedistributionMaxBackoff(
       final Duration commandRedistributionMaxBackoff) {
     this.commandRedistributionMaxBackoff = commandRedistributionMaxBackoff;
+    return this;
+  }
+
+  public boolean isEnableIdentitySetup() {
+    return enableIdentitySetup;
+  }
+
+  public EngineConfiguration setEnableIdentitySetup(final boolean enableIdentitySetup) {
+    this.enableIdentitySetup = enableIdentitySetup;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -323,7 +323,7 @@ public final class EngineProcessors {
         commandDistributionBehavior);
 
     IdentitySetupProcessors.addIdentitySetupProcessors(
-        keyGenerator, typedRecordProcessors, writers, securityConfig, featureFlags);
+        keyGenerator, typedRecordProcessors, writers, securityConfig, config);
 
     addResourceFetchProcessors(typedRecordProcessors, writers, processingState, authCheckBehavior);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer;
@@ -22,12 +23,12 @@ public final class IdentitySetupProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final SecurityConfiguration securityConfig,
-      final FeatureFlags featureFlags) {
+      final EngineConfiguration config) {
     typedRecordProcessors
         .onCommand(
             ValueType.IDENTITY_SETUP,
             IdentitySetupIntent.INITIALIZE,
             new IdentitySetupInitializeProcessor(writers, keyGenerator))
-        .withListener(new IdentitySetupInitializer(securityConfig, featureFlags));
+        .withListener(new IdentitySetupInitializer(securityConfig, config.isEnableIdentitySetup()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
-import io.camunda.zeebe.util.FeatureFlags;
 
 public final class IdentitySetupProcessors {
   public static void addIdentitySetupProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD
 
 import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
@@ -43,13 +44,13 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   public static final String DEFAULT_TENANT_NAME = "Default";
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
   private final SecurityConfiguration securityConfig;
-  private final FeatureFlags featureFlags;
+  private final boolean enableIdentitySetup;
   private final PasswordEncoder passwordEncoder;
 
   public IdentitySetupInitializer(
-      final SecurityConfiguration securityConfig, final FeatureFlags featureFlags) {
+      final SecurityConfiguration securityConfig, final boolean enableIdentitySetup) {
     this.securityConfig = securityConfig;
-    this.featureFlags = featureFlags;
+    this.enableIdentitySetup = enableIdentitySetup;
     passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
   }
 
@@ -57,7 +58,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     // We can disable identity setup by disabling the feature flag. This is useful to prevent
     // interference in our engine tests, as this setup will write "unexpected" commands/events
-    if (!featureFlags.enableIdentitySetup()) {
+    if (!enableIdentitySetup) {
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD
 
 import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
@@ -32,7 +31,6 @@ import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
-import io.camunda.zeebe.util.FeatureFlags;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -128,7 +128,12 @@ public final class EngineRule extends ExternalResource {
   private ArrayList<TestInterPartitionCommandSender> interPartitionCommandSenders;
   private Consumer<SecurityConfiguration> securityConfigModifier =
       cfg -> cfg.getAuthorizations().setEnabled(false);
-  private Consumer<EngineConfiguration> engineConfigModifier = cfg -> {};
+  private Consumer<EngineConfiguration> engineConfigModifier =
+      cfg -> {
+        // identity setup is disabled by default so we can have deterministic writes
+        // if you need it enabled, use #withIdentitySetup
+        cfg.setEnableIdentitySetup(false);
+      };
   private SearchClientsProxy searchClientsProxy;
   private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
   private Optional<RoutingState> initialRoutingState = Optional.empty();
@@ -199,7 +204,7 @@ public final class EngineRule extends ExternalResource {
 
   public EngineRule withIdentitySetup() {
     awaitIdentitySetup = true;
-    withFeatureFlags(ff -> ff.setEnableIdentitySetup(true));
+    withEngineConfig(c -> c.setEnableIdentitySetup(true));
     return this;
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
@@ -71,7 +71,7 @@ public class FailOverReplicationTest {
   @Test
   public void shouldNotReceiveEntriesOnDisconnect() {
     // given
-    final var segmentCount = 2;
+    final var segmentCount = 4;
     final var oldLeaderId = clusteringRule.getLeaderForPartition(1).getNodeId();
     final var oldLeader = clusteringRule.getBroker(oldLeaderId);
     clusteringRule.disconnect(oldLeader);
@@ -294,6 +294,5 @@ public class FailOverReplicationTest {
     data.setLogSegmentSize(maxSize);
     data.setLogIndexDensity(1);
     brokerCfg.getNetwork().setMaxMessageSize(maxSize);
-    brokerCfg.getExperimental().getFeatures().setEnableIdentitySetup(false);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
@@ -32,7 +32,6 @@ public class InstallRequestHandlingTest {
             config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(32));
             config.getData().setLogSegmentSize(DataSize.ofKilobytes(32));
             config.getData().setSnapshotPeriod(SNAPSHOT_PERIOD);
-            config.getExperimental().getFeatures().setEnableIdentitySetup(false);
           });
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
@@ -31,7 +31,6 @@ public class ReaderCloseTest {
           config -> {
             config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(32));
             config.getData().setLogSegmentSize(DataSize.ofKilobytes(32));
-            config.getExperimental().getFeatures().setEnableIdentitySetup(false);
             // no exporters so that segments are immediately compacted after a snapshot.
             config.setExporters(Map.of());
           });

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SingleBrokerDataDeletionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SingleBrokerDataDeletionTest.java
@@ -276,7 +276,6 @@ public class SingleBrokerDataDeletionTest {
     data.setLogSegmentSize(LOG_SEGMENT_SIZE);
     data.setLogIndexDensity(5);
     brokerCfg.getNetwork().setMaxMessageSize(MAX_MESSAGE_SIZE);
-    brokerCfg.getExperimental().getFeatures().setEnableIdentitySetup(false);
 
     final ExporterCfg exporterCfg = new ExporterCfg();
     exporterCfg.setClassName(ControllableExporter.class.getName());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/IdentitySetupOnStartupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/IdentitySetupOnStartupTest.java
@@ -38,10 +38,6 @@ final class IdentitySetupOnStartupTest {
                 .withReplicationFactor(3)
                 .withBrokerConfig(
                     cfg -> {
-                      cfg.brokerConfig()
-                          .getExperimental()
-                          .getFeatures()
-                          .setEnableIdentitySetup(true);
                       cfg.brokerConfig().getNetwork().setMaxMessageSize(DataSize.ofKilobytes(32));
                       cfg.brokerConfig().getProcessing().setMaxCommandsInBatch(100);
                     })

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -55,7 +55,6 @@ public final class FeatureFlags {
   private boolean enableTimerDueDateCheckerAsync;
   private boolean enableStraightThroughProcessingLoopDetector;
   private boolean enablePartitionScaling;
-  private boolean enableIdentitySetup;
   private boolean enableMessageBodyOnExpired;
 
   public FeatureFlags(
@@ -65,7 +64,6 @@ public final class FeatureFlags {
       final boolean enableTimerDueDateCheckerAsync,
       final boolean enableStraightThroughProcessingLoopDetector,
       final boolean enablePartitionScaling,
-      final boolean enableIdentitySetup,
       final boolean enableMessageBodyOnExpired
       /*, boolean foo*/ ) {
     this.yieldingDueDateChecker = yieldingDueDateChecker;
@@ -74,7 +72,6 @@ public final class FeatureFlags {
     this.enableTimerDueDateCheckerAsync = enableTimerDueDateCheckerAsync;
     this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
     this.enablePartitionScaling = enablePartitionScaling;
-    this.enableIdentitySetup = enableIdentitySetup;
     this.enableMessageBodyOnExpired = enableMessageBodyOnExpired;
   }
 
@@ -86,7 +83,6 @@ public final class FeatureFlags {
         ENABLE_DUE_DATE_CHECKER_ASYNC,
         ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR,
         ENABLE_PARTITION_SCALING,
-        ENABLE_IDENTITY_SETUP,
         ENABLE_MESSAGE_BODY_ON_EXPIRED
         /*, FOO_DEFAULT*/ );
   }
@@ -104,7 +100,6 @@ public final class FeatureFlags {
         true, /* ENABLE_DUE_DATE_CHECKER_ASYNC */
         true, /* ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR */
         true, /* ENABLE_PARTITION_SCALING */
-        false, /* ENABLE_IDENTITY_SETUP */
         false /* ENABLE_MESSAGE_BODY_ON_EXPIRED */
         /*, FOO_DEFAULT*/ );
   }
@@ -131,10 +126,6 @@ public final class FeatureFlags {
 
   public boolean enablePartitionScaling() {
     return enablePartitionScaling;
-  }
-
-  public boolean enableIdentitySetup() {
-    return enableIdentitySetup;
   }
 
   public boolean enableMessageBodyOnExpired() {
@@ -164,10 +155,6 @@ public final class FeatureFlags {
 
   public void setEnablePartitionScaling(final boolean enablePartitionScaling) {
     this.enablePartitionScaling = enablePartitionScaling;
-  }
-
-  public void setEnableIdentitySetup(final boolean enableIdentitySetup) {
-    this.enableIdentitySetup = enableIdentitySetup;
   }
 
   public void setEnableMessageBodyOnExpired(final boolean enableMessageBodyOnExpired) {


### PR DESCRIPTION
## Description

This PR removes the `enableIdentitySetup` flag, and moves it to a pure engine configuration option which is still disabled by default in tests.

## Related issues

closes #38597 
