### PR TITLE
feat: unified config: add option not to enable the camunda exporter

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
@@ -22,6 +22,15 @@ public class SecondaryStorage {
           "camunda.tasklist.database",
           "zeebe.broker.exporters.camundaexporter.args.connect.type");
 
+  /**
+   * When enabled, the default exporter camundaexporter is automatically configured using the
+   * secondary-storage properties. Manual configuration of camundaexporter is not necessary. If
+   * disabled, camundaexporter will not be configured automatically, but can still be enabled
+   * through manual configuration if required. Manual configuration of camundaexporter is generally
+   * not recommended, and can result in unexpected behavior if not configured correctly.
+   */
+  private boolean autoconfigureCamundaExporter = true;
+
   /** Determines the type of the secondary storage database. */
   private SecondaryStorage.SecondaryStorageType type = SecondaryStorageType.elasticsearch;
 
@@ -30,6 +39,14 @@ public class SecondaryStorage {
 
   /** Stores the Elasticsearch configuration, when type is set to 'elasticsearch'. */
   @NestedConfigurationProperty private Opensearch opensearch = new Opensearch();
+
+  public boolean getAutoconfigureCamundaExporter() {
+    return autoconfigureCamundaExporter;
+  }
+
+  public void setAutoconfigureCamundaExporter(final boolean autoconfigureCamundaExporter) {
+    this.autoconfigureCamundaExporter = autoconfigureCamundaExporter;
+  }
 
   public SecondaryStorageType getType() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -74,7 +74,7 @@ public class BrokerBasedPropertiesOverride {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BrokerBasedPropertiesOverride.class);
   private static final String CAMUNDA_EXPORTER_CLASS_NAME = "io.camunda.exporter.CamundaExporter";
-  private static final String CAMUNDA_EXPORTER_NAME = "camundaExporter";
+  private static final String CAMUNDA_EXPORTER_NAME = "camundaexporter";
 
   private final UnifiedConfiguration unifiedConfiguration;
   private final LegacyBrokerBasedProperties legacyBrokerBasedProperties;
@@ -512,6 +512,11 @@ public class BrokerBasedPropertiesOverride {
   private void populateCamundaExporter(final BrokerBasedProperties override) {
     final SecondaryStorage secondaryStorage =
         unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
+
+    if (!secondaryStorage.getAutoconfigureCamundaExporter()) {
+      LOGGER.debug("Skipping autoconfiguration of the (default) exporter 'camundaexporter'");
+      return;
+    }
 
     final SecondaryStorageDatabase database;
     if (SecondaryStorageType.elasticsearch == secondaryStorage.getType()) {

--- a/configuration/src/main/java/io/camunda/configuration/beans/BrokerBasedProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/BrokerBasedProperties.java
@@ -9,7 +9,6 @@ package io.camunda.configuration.beans;
 
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
-import java.util.List;
 
 // NOTE: This class has been moved away from dist. The reason for this is that as, for now,
 //  we're storing the unified configuration objects and beans in the configuration module,
@@ -25,14 +24,6 @@ import java.util.List;
 public class BrokerBasedProperties extends BrokerCfg {
 
   public ExporterCfg getCamundaExporter() {
-    final List<ExporterCfg> exporters =
-        this.getExporters().values().stream()
-            .filter(e -> e.getClassName().equals("io.camunda.exporter.CamundaExporter"))
-            .toList();
-    if (exporters.isEmpty()) {
-      return null;
-    }
-
-    return exporters.get(0);
+    return this.getExporters().get("camundaexporter");
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -289,7 +289,7 @@ public class SecondaryStorageElasticsearchTest {
       properties = {
         "camunda.data.secondary-storage.type=elasticsearch",
         "camunda.data.secondary-storage.elasticsearch.url=http://matching-url:4321",
-        "zeebe.broker.exporters.camunda.class-name=io.camunda.exporter.CamundaExporter"
+        "zeebe.broker.exporters.camundaexporter.class-name=io.camunda.exporter.CamundaExporter"
       })
   class ExporterTestWithoutArgs {
     final OperateProperties operateProperties;
@@ -316,6 +316,54 @@ public class SecondaryStorageElasticsearchTest {
       assertThat(camundaExporter).isNotNull();
       final Map<String, Object> args = camundaExporter.getArgs();
       assertThat(args).isNull();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.autoconfigure-camunda-exporter=false",
+        "camunda.data.secondary-storage.elasticsearch.url=http://unwanted-url:4321",
+      })
+  class ExporterAutoconfigurationDisabled {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    ExporterAutoconfigurationDisabled(
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void testExporterAutoconfigurationDisabled() {
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNull();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.autoconfigure-camunda-exporter=true",
+        "camunda.data.secondary-storage.elasticsearch.url=http://wanted-url:4321",
+      })
+  class ExporterAutoconfigurationEnabled {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    ExporterAutoconfigurationEnabled(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void testExporterAutoconfigurationEnabled() {
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNotNull();
+
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToExporterConfiguration(args);
+      assertThat(exporterConfiguration.getConnect().getUrl()).isEqualTo("http://wanted-url:4321");
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Issue:
https://github.com/camunda/camunda/issues/38593

Additional context:
https://camunda.slack.com/archives/C08E56YUUMS/p1758552888424629

This PR will add an option to prevent the default camundaexporter exporter from being initialized and therefore enabled. 

The need for this comes primarily from the fact that we need a more granular configuration to enable the exporter in the case of a multi-region cluster.

NOTE: As the camundaexporter will need to be configured manually, while the ID can be chosen arbitrarily, the class name will be the one of the CamundaExporter. For this reason, we are changing the logic that retrieves the current camundaexporter in a way that the ID is used instead of the class name.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/38593
