### PR TITLE
Fix: Add network configuration for localhost

### DIFF
--- a/c8run/configuration/application.yaml
+++ b/c8run/configuration/application.yaml
@@ -23,3 +23,6 @@ zeebe:
         args:
           createSchema: true
         className: io.camunda.exporter.CamundaExporter
+    network:
+      host: localhost
+      advertisedHost: localhost


### PR DESCRIPTION
This pull request adds network configuration settings to the Zeebe section in the `c8run/configuration/application.yaml` file. The main change is the explicit definition of the host and advertisedHost properties.

Network configuration:

* Added `network.host` and `network.advertisedHost` settings with value `localhost` to the Zeebe network configuration in `c8run/configuration/application.yaml`.The C8Run doesn't start with the default configuration on some MacOS setups

## Description

Ensure the C8Run starts on macOS

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
