### PR TITLE
test: Re-enable `SchemaUpdateIT` test and usage-metric policy assertions

### DIFF
--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
@@ -44,10 +43,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @ExtendWith(SchemaManagerITInvocationProvider.class)
-@Disabled(
-    "Disabled due to usage-metric index/template upgrade mismatch: previous version creates concrete indices, "
-        + "but current version expects template-based indices. Re-enable once template conversion "
-        + "is backported to stable/8.8 and upgrade path is supported.")
 class SchemaUpdateIT {
 
   private static final Logger LOG = LoggerFactory.getLogger(SchemaUpdateIT.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -208,15 +208,18 @@ final class ElasticsearchArchiverRepositoryIT {
         resourceProvider
             .getIndexTemplateDescriptor(BatchOperationTemplate.class)
             .getFullQualifiedName();
+    final var usageMetricIndex =
+        resourceProvider
+            .getIndexTemplateDescriptor(UsageMetricTemplate.class)
+            .getFullQualifiedName();
+    final var usageMetricTUIndex =
+        resourceProvider
+            .getIndexTemplateDescriptor(UsageMetricTUTemplate.class)
+            .getFullQualifiedName();
 
-    // FIXME: once the metrics index rollover is correctly implemented, put back these indices in
-    // the test https://github.com/camunda/camunda/issues/34709
-    /*
     final var usageMetricsIndices =
-        List.of(
-            formattedPrefix + "camunda-usage-metric-8.3.0_2024-01-02",
-            formattedPrefix + "camunda-usage-metric-tu-8.3.0_2024-01-02");
-     */
+        List.of(usageMetricIndex + "2024-01-02", usageMetricTUIndex + "2024-01-02");
+
     final var historicalIndices =
         List.of(processInstanceIndex + "2024-01-02", batchOperationIndex + "2024-01");
     final var untouchedIndices =
@@ -231,6 +234,7 @@ final class ElasticsearchArchiverRepositoryIT {
     final var repository = createRepository();
     final var indices = new ArrayList<String>();
     indices.addAll(historicalIndices);
+    indices.addAll(usageMetricsIndices);
     indices.addAll(untouchedIndices);
 
     retention.setEnabled(true);
@@ -248,17 +252,12 @@ final class ElasticsearchArchiverRepositoryIT {
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
 
-    // verify that the usage metrics policy was applied to all usage metric indices
-    // FIXME: once the metrics index rollover is correctly implemented, put back these asserts
-    // https://github.com/camunda/camunda/issues/34709
-    /*
     for (final var index : usageMetricsIndices) {
       assertThat(getLifeCycle(index))
           .isNotNull()
           .extracting(IndexSettingsLifecycle::name)
           .isEqualTo("custom-usage-metrics-policy");
     }
-    */
 
     // verify that the default policy was applied to all other indices
     for (final var index : historicalIndices) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -597,7 +597,7 @@ final class OpenSearchArchiverRepositoryIT {
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     final var batch = result.join();
-    assertThat(batch.ids()).containsExactly("1", "2");
+    assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
 
@@ -629,7 +629,7 @@ final class OpenSearchArchiverRepositoryIT {
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     final var batch = result.join();
-    assertThat(batch.ids()).containsExactly("10", "11");
+    assertThat(batch.ids()).containsExactlyInAnyOrder("10", "11");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -222,14 +222,18 @@ final class OpenSearchArchiverRepositoryIT {
         resourceProvider
             .getIndexTemplateDescriptor(BatchOperationTemplate.class)
             .getFullQualifiedName();
-    // FIXME: uncomment once the metrics index rollover is correctly implemented,
-    // https://github.com/camunda/camunda/issues/34709
-    /*
+
+    final var usageMetricIndex =
+        resourceProvider
+            .getIndexTemplateDescriptor(UsageMetricTemplate.class)
+            .getFullQualifiedName();
+    final var usageMetricTUIndex =
+        resourceProvider
+            .getIndexTemplateDescriptor(UsageMetricTUTemplate.class)
+            .getFullQualifiedName();
+
     final var usageMetricsIndices =
-        List.of(
-            formattedPrefix + "camunda-usage-metric-8.3.0_2024-01-02",
-            formattedPrefix + "camunda-usage-metric-tu-8.3.0_2024-01-02");
-     */
+        List.of(usageMetricIndex + "2024-01-02", usageMetricTUIndex + "2024-01-02");
     final var historicalIndices =
         List.of(processInstanceIndex + "2024-01-02", batchOperationIndex + "2024-01");
     final var untouchedIndices =
@@ -244,6 +248,7 @@ final class OpenSearchArchiverRepositoryIT {
     connectConfiguration.setIndexPrefix(prefix);
     final var repository = createRepository();
     final var indices = new ArrayList<>(historicalIndices);
+    indices.addAll(usageMetricsIndices);
     indices.addAll(untouchedIndices);
 
     retention.setEnabled(true);
@@ -261,16 +266,12 @@ final class OpenSearchArchiverRepositoryIT {
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     // verify that the usage metrics policy was applied to all usage metric indices
-    // FIXME: uncomment once the metrics index rollover is correctly implemented,
-    // https://github.com/camunda/camunda/issues/34709
-    /*
     for (final var index : usageMetricsIndices) {
       assertThat(fetchPolicyForIndexWithAwait(index))
           .as("Expected 'custom-usage-metrics-policy' policy to be applied for %s", index)
           .isNotNull()
           .isEqualTo("custom-usage-metrics-policy");
     }
-     */
     // verify that the default policy was applied to all other indices
     for (final var index : historicalIndices) {
       assertThat(fetchPolicyForIndexWithAwait(index))


### PR DESCRIPTION
## Description

This PR restores tests/assertions for usage-metric indices and hardens our AWS OpenSearch integration tests. 

It’s test-only (no production code changes).

Changes:
- Re-enable `SchemaUpdateIT#shouldRunConcurrentUpdates`: Previously disabled due to usage-metric indices not being template-managed on 8.8. Now that the template conversion is backported to `stable/8.8`, the upgrade scenario is valid again.
- Re-enable policy assertions for usage-metric indices: Adds back the ILM/policy check that was missed in #38467.
- Selective cleanup for AWS OS archiver IT: Replace wildcard `DELETE /*` with targeted deletion of only test-created indices to avoid `security_exception` on AWS OS 2.17/2.19 CI jobs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #34709
