### PR TITLE
test: adapt c8run api test to API 

### DIFF
--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -2,7 +2,7 @@
 
 printf "\nTest: Operate process instance api\n"
 
-curl -f -L -X POST 'http://localhost:8080/v2/process-instances/search' \
+curl --fail-with-body -L -X POST 'http://localhost:8080/v2/process-instances/search' \
         -H 'Content-Type: application/json' \
         -H 'Accept: application/json' \
         --data-raw '{
@@ -20,7 +20,7 @@ if [[ "$returnCode" != 0 ]]; then
 fi
 
 printf "\nTest: Tasklist user task\n"
-curl -f -L -X POST 'http://localhost:8080/v2/user-tasks/search' \
+curl --fail-with-body -L -X POST 'http://localhost:8080/v2/user-tasks/search' \
         -H 'Content-Type: application/json' \
         -H 'Accept: application/json' \
         --data-raw '{}'

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -7,8 +7,7 @@ curl --fail-with-body -L -X POST 'http://localhost:8080/v2/process-instances/sea
         -H 'Accept: application/json' \
         --data-raw '{
   "filter": {
-    "running": true,
-    "active": true
+    "state": "ACTIVE"
   }
 }'
 


### PR DESCRIPTION
## Description

Follow-up from a backport, where I noticed the api tests send invalid requests and thus run into 400s.
See https://github.com/camunda/camunda/pull/38609#issuecomment-3323643307

I also added a flag for curl to print the body on failure, helps root-causing issues easier going forward.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
