### PR TITLE
fix: skip snapshot when nothing processed and not forced

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -222,6 +222,12 @@ public final class AsyncSnapshotDirector extends Actor
               } else {
                 inProgressSnapshot.lowerBoundSnapshotPosition =
                     position == StreamProcessor.UNSET_POSITION ? 0L : position;
+                if (inProgressSnapshot.lowerBoundSnapshotPosition == 0 && !forceSnapshot) {
+                  LOG.debug(
+                      "We will skip taking this snapshot, because we haven't processed anything yet.");
+                  snapshotFuture.complete(null);
+                  return;
+                }
                 snapshot(inProgressSnapshot, forceSnapshot).onComplete(snapshotFuture);
               }
             });


### PR DESCRIPTION
## Description

When snapshot is scheduled too fast and nothing has been processed yet, we should skip it. Otherwise it will fail at a later stage when trying to read the index entry at position 0. The impact of this is low, as the result is just noisy error logs. Otherwise the system works fine and the next snapshot after processing at least one record will be successful. This was the previous behavior which got changed when we added forced snapshot for migration. We want to allow taking snapshot at position 0 only when the snapshot is forced.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38484 
