### PR TITLE
[Backport main] test: implemented test cases for the cluster api endpoints

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-api-tests.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  assertRequiredFields,
+  buildUrl,
+  defaultHeaders,
+} from '../../../utils/http';
+import {
+  brokerResponseFields,
+  clusterTopologyResponseFields,
+  partionsResponseFields,
+} from '../../../utils/beans/requestBeans';
+
+test.describe('Cluster API Tests', () => {
+  test('Get Cluster Topology', async ({request}) => {
+    const res = await request.get(buildUrl('/topology'), {
+      headers: defaultHeaders(),
+    });
+    expect(res.status()).toBe(200);
+    const result = await res.json();
+    assertRequiredFields(result, clusterTopologyResponseFields);
+    expect(result.brokers).toHaveLength(1);
+    assertRequiredFields(result.brokers[0], brokerResponseFields);
+    expect(result.brokers[0].partitions).toHaveLength(1);
+    assertRequiredFields(
+      result.brokers[0].partitions[0],
+      partionsResponseFields,
+    );
+  });
+
+  test('Get Cluster Topology - Unauthorized', async ({request}) => {
+    const res = await request.get(buildUrl('/topology'));
+    expect(res.status()).toBe(401);
+    const result = await res.json();
+    expect(result.title).toBe('Unauthorized');
+    expect(result.detail).toBe(
+      'An Authentication object was not found in the SecurityContext',
+    );
+    expect(result.instance).toBe('/v2/topology');
+  });
+
+  test('Get Cluster Status', async ({request}) => {
+    const res = await request.get(buildUrl('/status'));
+    expect(res.status()).toBe(204);
+    const result = await res.body();
+    expect(result.length).toBe(0);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -23,6 +23,22 @@ import {
 import {APIRequestContext} from 'playwright-core';
 import {DecisionDeployment} from '@camunda8/sdk/dist/c8/lib/C8Dto';
 
+export const clusterTopologyResponseFields = [
+  'brokers',
+  'clusterSize',
+  'partitionsCount',
+  'replicationFactor',
+  'gatewayVersion',
+  'lastCompletedChangeId',
+];
+export const brokerResponseFields = [
+  'nodeId',
+  'host',
+  'port',
+  'partitions',
+  'version',
+];
+export const partionsResponseFields = ['partitionId', 'role', 'health'];
 export const groupRequiredFields: string[] = ['groupId', 'name', 'description'];
 export const tenantRequiredFields: string[] = [
   'tenantId',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -39,15 +39,11 @@ function has(obj: unknown, prop: string): boolean {
 export function assertRequiredFields(obj: unknown, required: string[]): void {
   expect(obj).toBeTruthy();
   for (const f of required) {
-<<<<<<< HEAD
     if (!has(obj, f)) {
       console.error('❌ Missing required field:', f);
       console.error('Full response object:', JSON.stringify(obj, null, 2));
     }
     expect(has(obj, f)).toBe(true);
-=======
-    expect(has(obj, f), {message: `Missing required field: ${f}`}).toBe(true);
->>>>>>> d3ce8df2 (test: implemented test cases for the cluster api endpoints)
     const v = (obj as Record<string, unknown>)[f];
     expect(v).toBeDefined();
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -39,11 +39,15 @@ function has(obj: unknown, prop: string): boolean {
 export function assertRequiredFields(obj: unknown, required: string[]): void {
   expect(obj).toBeTruthy();
   for (const f of required) {
+<<<<<<< HEAD
     if (!has(obj, f)) {
       console.error('❌ Missing required field:', f);
       console.error('Full response object:', JSON.stringify(obj, null, 2));
     }
     expect(has(obj, f)).toBe(true);
+=======
+    expect(has(obj, f), {message: `Missing required field: ${f}`}).toBe(true);
+>>>>>>> d3ce8df2 (test: implemented test cases for the cluster api endpoints)
     const v = (obj as Record<string, unknown>)[f];
     expect(v).toBeDefined();
   }


### PR DESCRIPTION
# Description
Backport of #38245 to `main`.

relates to 