### PR TITLE
fix: Incorrect Not Found Message in Get User API

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchTest.java
@@ -14,11 +14,14 @@ import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
 import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
 import static io.camunda.it.util.TestHelper.waitForScopedActiveProcessInstances;
+import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_ID_NOT_FOUND;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.MigrationPlan;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.BatchOperationItemState;
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
@@ -146,6 +149,17 @@ public class BatchOperationSearchTest {
     // then
     assertItems(items1, ACTIVE_PROCESS_INSTANCES_1);
     assertItems(items2, ACTIVE_PROCESS_INSTANCES_2);
+  }
+
+  @Test
+  void shouldReturnNotFoundOnGetWhenIdDoesNotExist() {
+    // when / then
+    assertThatThrownBy(
+            () -> camundaClient.newBatchOperationGetRequest("someBatchOperation").send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining(
+            ERROR_ENTITY_BY_ID_NOT_FOUND.formatted("Batch Operation", "id", "someBatchOperation"));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
@@ -12,7 +12,9 @@ import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
 import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceIsEnded;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_ID_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
@@ -393,6 +395,18 @@ class DecisionInstanceSearchTest {
     // then
     assertThat(result.getDecisionInstanceId()).isEqualTo(decisionInstanceId);
     assertThat(result.getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
+  }
+
+  @Test
+  void shouldReturnNotFoundOnGetWhenIdDoesNotExist() {
+    // when / then
+    assertThatThrownBy(
+            () -> camundaClient.newDecisionInstanceGetRequest("someDecisionInstance").send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining(
+            ERROR_ENTITY_BY_ID_NOT_FOUND.formatted(
+                "Decision Instance", "id", "someDecisionInstance"));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByTenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByTenantIntegrationTest.java
@@ -8,14 +8,17 @@
 package io.camunda.it.client;
 
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_ID_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.TenantGroup;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
+import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -111,5 +114,15 @@ public class GroupsByTenantIntegrationTest {
     final var clientsSearchResponse =
         camundaClient.newGroupsByTenantSearchRequest("someTenantId").send().join();
     assertThat(clientsSearchResponse.items()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnNotFoundOnGetWhenGroupDoesNotExist() {
+    // when / then
+    Assertions.assertThatThrownBy(
+            () -> camundaClient.newGroupGetRequest("someGroupId").send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining(ERROR_ENTITY_BY_ID_NOT_FOUND.formatted("Group", "id", "someGroupId"));
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/TenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/TenantIntegrationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.client;
 
+import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_ID_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -56,7 +57,9 @@ public class TenantIntegrationTest {
     // when / then
     assertThatThrownBy(() -> camundaClient.newTenantGetRequest("someTenantId").send().join())
         .isInstanceOf(ProblemException.class)
-        .hasMessageContaining("Failed with code 404: 'Not Found'");
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining(
+            ERROR_ENTITY_BY_ID_NOT_FOUND.formatted("Tenant", "id", "someTenantId"));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIntegrationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.client;
 
+import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_ID_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -66,10 +67,11 @@ public class UsersSearchIntegrationTest {
   @Test
   void shouldReturnNotFoundWhenGettingUserThatDoesNotExist() {
     // when / then
-    assertThatThrownBy(() -> camundaClient.newUserGetRequest("testUsername").send().join())
+    assertThatThrownBy(() -> camundaClient.newUserGetRequest("someUserName").send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
-        .hasMessageContaining("User with id 'testUsername' not found");
+        .hasMessageContaining(
+            ERROR_ENTITY_BY_ID_NOT_FOUND.formatted("User", "username", "someUserName"));
   }
 
   @Test

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -320,9 +320,9 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   @Override
-  public UserEntity getUser(final String id) {
-    return doGetWithReader(readers.userReader(), id)
-        .orElseThrow(() -> entityByIdNotFoundException("User", id));
+  public UserEntity getUser(final String username) {
+    return doGetWithReader(readers.userReader(), username)
+        .orElseThrow(() -> entityByUsernameNotFoundException(username));
   }
 
   @Override
@@ -448,7 +448,16 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   protected CamundaSearchException entityByIdNotFoundException(
       final String entityType, final String id) {
+    return entityByIdNotFoundException(entityType, "id", id);
+  }
+
+  protected CamundaSearchException entityByUsernameNotFoundException(final String id) {
+    return entityByIdNotFoundException("User", "username", id);
+  }
+
+  private CamundaSearchException entityByIdNotFoundException(
+      final String entityType, final String idType, final String id) {
     return new CamundaSearchException(
-        ERROR_ENTITY_BY_ID_NOT_FOUND.formatted(entityType, id), Reason.NOT_FOUND);
+        ERROR_ENTITY_BY_ID_NOT_FOUND.formatted(entityType, idType, id), Reason.NOT_FOUND);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
@@ -10,8 +10,7 @@ package io.camunda.search.exception;
 public class ErrorMessages {
 
   public static final String ERROR_ENTITY_BY_KEY_NOT_FOUND = "%s with key '%d' not found";
-  public static final String ERROR_ENTITY_BY_ID_NOT_FOUND = "%s with id '%s' not found";
-
+  public static final String ERROR_ENTITY_BY_ID_NOT_FOUND = "%s with %s '%s' not found";
   public static final String ERROR_FAILED_DELETE_REQUEST = "Failed to execute delete request";
   public static final String ERROR_FAILED_FIND_ALL_QUERY = "Failed to execute findAll query";
   public static final String ERROR_FAILED_GET_ALIAS_REQUEST = "Failed to execute getAlias request";


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- added custom message for username search errors to refer to the username as "username" instead of "id"
- improved error message test coverage

Even though we internally treat the username as an id, this is not clear from the naming.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/37741
