### PR TITLE
feat: integrate decision instance query hook in decision- and variables-panel UI

### DIFF
--- a/operate/client/src/App/DecisionInstance/DecisionPanel/index.test.tsx
+++ b/operate/client/src/App/DecisionInstance/DecisionPanel/index.test.tsx
@@ -11,13 +11,11 @@ import {
   invoiceClassification,
   assignApproverGroup,
   literalExpression,
-} from 'modules/mocks/mockDecisionInstance';
+} from 'modules/mocks/mockDecisionInstanceV2';
 import {mockDmnXml} from 'modules/mocks/mockDmnXml';
-import {decisionInstanceDetailsStore} from 'modules/stores/decisionInstanceDetails';
 import {DecisionPanel} from '.';
 import {mockFetchDecisionDefinitionXML} from 'modules/mocks/api/v2/decisionDefinitions/fetchDecisionDefinitionXML';
-import {mockFetchDecisionInstance} from 'modules/mocks/api/decisionInstances/fetchDecisionInstance';
-import {useEffect} from 'react';
+import {mockFetchDecisionInstance} from 'modules/mocks/api/v2/decisionInstances/fetchDecisionInstance';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {QueryClientProvider} from '@tanstack/react-query';
 
@@ -36,11 +34,6 @@ vi.mock('modules/components/DecisionViewer', () => ({
 }));
 
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
-  useEffect(() => {
-    return () => {
-      decisionInstanceDetailsStore.reset();
-    };
-  }, []);
   return (
     <QueryClientProvider client={getMockQueryClient()}>
       {children}
@@ -56,9 +49,9 @@ describe('<DecisionPanel />', () => {
   it('should render decision table', async () => {
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('337423841237089');
-
-    render(<DecisionPanel />, {wrapper: Wrapper});
+    render(<DecisionPanel decisionEvaluationInstanceKey="337423841237089" />, {
+      wrapper: Wrapper,
+    });
 
     expect(
       await screen.findByText('DecisionTable view mock'),
@@ -69,9 +62,9 @@ describe('<DecisionPanel />', () => {
   it('should render literal expression', async () => {
     mockFetchDecisionInstance().withSuccess(literalExpression);
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('337423841237089');
-
-    render(<DecisionPanel />, {wrapper: Wrapper});
+    render(<DecisionPanel decisionEvaluationInstanceKey="337423841237089" />, {
+      wrapper: Wrapper,
+    });
 
     expect(
       await screen.findByText('LiteralExpression view mock'),
@@ -81,9 +74,9 @@ describe('<DecisionPanel />', () => {
   it('should render incident banner', async () => {
     mockFetchDecisionInstance().withSuccess(assignApproverGroup);
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('337423841237089');
-
-    render(<DecisionPanel />, {wrapper: Wrapper});
+    render(<DecisionPanel decisionEvaluationInstanceKey="337423841237089" />, {
+      wrapper: Wrapper,
+    });
 
     expect(await screen.findByText('An error occurred')).toBeInTheDocument();
   });
@@ -92,9 +85,9 @@ describe('<DecisionPanel />', () => {
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
     mockFetchDecisionDefinitionXML().withServerError(403);
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('337423841237089');
-
-    render(<DecisionPanel />, {wrapper: Wrapper});
+    render(<DecisionPanel decisionEvaluationInstanceKey="337423841237089" />, {
+      wrapper: Wrapper,
+    });
 
     expect(
       await screen.findByText('Missing permissions to view the Definition'),

--- a/operate/client/src/App/DecisionInstance/DecisionPanel/index.tsx
+++ b/operate/client/src/App/DecisionInstance/DecisionPanel/index.tsx
@@ -15,9 +15,9 @@ import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
 import {useDecisionInstance} from 'modules/queries/decisionInstances/useDecisionInstance';
 import {useMemo} from 'react';
 
-interface DecisionPanelProps {
+type DecisionPanelProps = {
   decisionEvaluationInstanceKey: string;
-}
+};
 
 const DecisionPanel: React.FC<DecisionPanelProps> = (props) => {
   const {data: decisionInstance} = useDecisionInstance(

--- a/operate/client/src/App/DecisionInstance/DecisionPanel/index.tsx
+++ b/operate/client/src/App/DecisionInstance/DecisionPanel/index.tsx
@@ -30,7 +30,7 @@ const DecisionPanel: React.FC<DecisionPanelProps> = (props) => {
 
     return Array.from(
       new Set(decisionInstance.matchedRules.map((rule) => rule.ruleIndex)),
-    ).filter((ruleIndex) => ruleIndex !== undefined);
+    );
   }, [decisionInstance?.matchedRules]);
 
   const {

--- a/operate/client/src/App/DecisionInstance/DecisionPanel/index.tsx
+++ b/operate/client/src/App/DecisionInstance/DecisionPanel/index.tsx
@@ -6,24 +6,32 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {observer} from 'mobx-react';
 import {DiagramShell} from 'modules/components/DiagramShell';
 import {IncidentBanner, Section} from './styled';
 import {DecisionViewer} from 'modules/components/DecisionViewer';
-import {decisionInstanceDetailsStore} from 'modules/stores/decisionInstanceDetails';
 import {useDecisionDefinitionXmlOptions} from 'modules/queries/decisionDefinitions/useDecisionDefinitionXml';
 import {useQuery} from '@tanstack/react-query';
 import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
+import {useDecisionInstance} from 'modules/queries/decisionInstances/useDecisionInstance';
+import {useMemo} from 'react';
 
-const DecisionPanel: React.FC = observer(() => {
-  const {decisionInstance} = decisionInstanceDetailsStore.state;
-  const highlightableRules = Array.from(
-    new Set(
-      decisionInstanceDetailsStore.state.decisionInstance?.evaluatedOutputs.map(
-        (output) => output.ruleIndex,
-      ),
-    ),
-  ).filter((item) => item !== undefined);
+interface DecisionPanelProps {
+  decisionEvaluationInstanceKey: string;
+}
+
+const DecisionPanel: React.FC<DecisionPanelProps> = (props) => {
+  const {data: decisionInstance} = useDecisionInstance(
+    props.decisionEvaluationInstanceKey,
+  );
+  const highlightableRules = useMemo(() => {
+    if (!decisionInstance?.matchedRules) {
+      return [];
+    }
+
+    return Array.from(
+      new Set(decisionInstance.matchedRules.map((rule) => rule.ruleIndex)),
+    ).filter((ruleIndex) => ruleIndex !== undefined);
+  }, [decisionInstance?.matchedRules]);
 
   const {
     data: decisionDefinitionXml,
@@ -32,8 +40,8 @@ const DecisionPanel: React.FC = observer(() => {
     error,
   } = useQuery(
     useDecisionDefinitionXmlOptions({
-      decisionDefinitionKey: decisionInstance?.decisionDefinitionId ?? '',
-      enabled: decisionInstance !== null,
+      decisionDefinitionKey: decisionInstance?.decisionDefinitionKey ?? '',
+      enabled: !!decisionInstance,
     }),
   );
 
@@ -58,18 +66,18 @@ const DecisionPanel: React.FC = observer(() => {
     >
       {decisionInstance?.state === 'FAILED' && (
         <IncidentBanner data-testid="incident-banner">
-          {decisionInstance.errorMessage}
+          {decisionInstance.evaluationFailure}
         </IncidentBanner>
       )}
       <DiagramShell status={getStatus()}>
         <DecisionViewer
           xml={decisionDefinitionXml ?? null}
-          decisionViewId={decisionInstance?.decisionId ?? null}
+          decisionViewId={decisionInstance?.decisionDefinitionId ?? null}
           highlightableRules={highlightableRules}
         />
       </DiagramShell>
     </Section>
   );
-});
+};
 
 export {DecisionPanel};

--- a/operate/client/src/App/DecisionInstance/Header/index.tsx
+++ b/operate/client/src/App/DecisionInstance/Header/index.tsx
@@ -50,9 +50,9 @@ const getHeaderColumns = (isMultiTenancyEnabled: boolean = false) => {
   ];
 };
 
-interface HeaderProps {
+type HeaderProps = {
   decisionEvaluationInstanceKey: string;
-}
+};
 
 const Header: React.FC<HeaderProps> = ({decisionEvaluationInstanceKey}) => {
   const isMultiTenancyEnabled = window.clientConfig?.multiTenancyEnabled;

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/InputsAndOutputs/index.test.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/InputsAndOutputs/index.test.tsx
@@ -16,27 +16,23 @@ import {
   assignApproverGroup,
   assignApproverGroupWithoutVariables,
   invoiceClassification,
-} from 'modules/mocks/mockDecisionInstance';
-import {decisionInstanceDetailsStore} from 'modules/stores/decisionInstanceDetails';
+} from 'modules/mocks/mockDecisionInstanceV2';
 import {InputsAndOutputs} from './index';
-import {mockFetchDecisionInstance} from 'modules/mocks/api/decisionInstances/fetchDecisionInstance';
-import {useEffect} from 'react';
+import {mockFetchDecisionInstance} from 'modules/mocks/api/v2/decisionInstances/fetchDecisionInstance';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
-const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
-  useEffect(() => {
-    return decisionInstanceDetailsStore.reset;
-  }, []);
-
-  return <>{children}</>;
-};
+const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
 
 describe('<InputsAndOutputs />', () => {
   it('should have section panels', async () => {
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('1');
-
-    render(<InputsAndOutputs />, {
+    render(<InputsAndOutputs decisionEvaluationInstanceKey="1" />, {
       wrapper: Wrapper,
     });
 
@@ -51,9 +47,9 @@ describe('<InputsAndOutputs />', () => {
   it('should show a loading skeleton', async () => {
     mockFetchDecisionInstance().withServerError();
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('1');
-
-    render(<InputsAndOutputs />, {wrapper: Wrapper});
+    render(<InputsAndOutputs decisionEvaluationInstanceKey="1" />, {
+      wrapper: Wrapper,
+    });
 
     expect(screen.getByTestId('inputs-skeleton')).toBeInTheDocument();
     expect(screen.getByTestId('outputs-skeleton')).toBeInTheDocument();
@@ -69,9 +65,9 @@ describe('<InputsAndOutputs />', () => {
   it('should show empty message for failed decision instances with variables', async () => {
     mockFetchDecisionInstance().withSuccess(assignApproverGroup);
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('1');
-
-    render(<InputsAndOutputs />, {wrapper: Wrapper});
+    render(<InputsAndOutputs decisionEvaluationInstanceKey="1" />, {
+      wrapper: Wrapper,
+    });
 
     expect(
       await screen.findByText(
@@ -89,9 +85,9 @@ describe('<InputsAndOutputs />', () => {
       assignApproverGroupWithoutVariables,
     );
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('1');
-
-    render(<InputsAndOutputs />, {wrapper: Wrapper});
+    render(<InputsAndOutputs decisionEvaluationInstanceKey="1" />, {
+      wrapper: Wrapper,
+    });
 
     expect(
       await screen.findByText(
@@ -107,9 +103,9 @@ describe('<InputsAndOutputs />', () => {
   it('should load inputs and outputs', async () => {
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('1');
-
-    render(<InputsAndOutputs />, {wrapper: Wrapper});
+    render(<InputsAndOutputs decisionEvaluationInstanceKey="1" />, {
+      wrapper: Wrapper,
+    });
 
     await waitForElementToBeRemoved(() =>
       screen.queryByTestId('inputs-skeleton'),
@@ -154,9 +150,9 @@ describe('<InputsAndOutputs />', () => {
   it('should show an error', async () => {
     mockFetchDecisionInstance().withServerError();
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('1');
-
-    render(<InputsAndOutputs />, {wrapper: Wrapper});
+    render(<InputsAndOutputs decisionEvaluationInstanceKey="1" />, {
+      wrapper: Wrapper,
+    });
 
     expect(
       await screen.findAllByText(/data could not be fetched/i),

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/InputsAndOutputs/index.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/InputsAndOutputs/index.tsx
@@ -6,9 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useEffect, useRef, useState} from 'react';
-import {observer} from 'mobx-react';
-import {decisionInstanceDetailsStore} from 'modules/stores/decisionInstanceDetails';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import {
   ResizablePanel,
   SplitDirection,
@@ -22,6 +20,10 @@ import {
   ErrorMessage,
 } from './styled';
 import {Skeleton} from './Skeleton';
+import type {DecisionInstance} from '@camunda/camunda-api-zod-schemas/8.8';
+import {useDecisionInstance} from 'modules/queries/decisionInstances/useDecisionInstance';
+
+type RowProps = React.ComponentProps<typeof StructuredList>['rows'][number];
 
 const inputMappingsColumns = [
   {
@@ -49,10 +51,16 @@ const outputMappingsColumns = [
   },
 ];
 
-const InputsAndOutputs: React.FC = observer(() => {
-  const {
-    state: {status, decisionInstance},
-  } = decisionInstanceDetailsStore;
+interface InputAndOutputProps {
+  decisionEvaluationInstanceKey: DecisionInstance['decisionEvaluationInstanceKey'];
+}
+
+const InputsAndOutputs: React.FC<InputAndOutputProps> = ({
+  decisionEvaluationInstanceKey,
+}) => {
+  const {data: decisionInstance, status} = useDecisionInstance(
+    decisionEvaluationInstanceKey,
+  );
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [clientWidth, setClientWidth] = useState(0);
@@ -63,6 +71,37 @@ const InputsAndOutputs: React.FC = observer(() => {
 
   const panelMinWidth = clientWidth / 3;
 
+  const evaluatedInputsRows = useMemo<RowProps[]>(() => {
+    if (!decisionInstance?.evaluatedInputs?.length) {
+      return [];
+    }
+
+    return decisionInstance.evaluatedInputs.map((input) => ({
+      key: input.inputId,
+      columns: [
+        {cellContent: input.inputName},
+        {cellContent: input.inputValue},
+      ],
+    }));
+  }, [decisionInstance?.evaluatedInputs]);
+
+  const evaluatedOutputRows = useMemo<RowProps[]>(() => {
+    if (!decisionInstance?.matchedRules?.length) {
+      return [];
+    }
+
+    return decisionInstance.matchedRules.flatMap((rule) => {
+      return rule.evaluatedOutputs.map<RowProps>((output) => ({
+        key: `${output.outputId}--${rule.ruleId}`,
+        columns: [
+          {cellContent: rule.ruleIndex},
+          {cellContent: output.outputName},
+          {cellContent: output.outputValue},
+        ],
+      }));
+    });
+  }, [decisionInstance?.matchedRules]);
+
   return (
     <Container ref={containerRef}>
       <ResizablePanel
@@ -72,84 +111,53 @@ const InputsAndOutputs: React.FC = observer(() => {
       >
         <Panel aria-label="input variables">
           {status !== 'error' && <Title>Inputs</Title>}
-          {status === 'initial' && (
+          {status === 'pending' && (
             <Skeleton
               dataTestId="inputs-skeleton"
               columnWidths={inputMappingsColumns.map(({width}) => width)}
             />
           )}
-          {status === 'fetched' &&
-            decisionInstance?.state === 'FAILED' &&
-            decisionInstance?.evaluatedInputs.length === 0 && (
+          {status === 'success' &&
+            decisionInstance.state === 'FAILED' &&
+            evaluatedInputsRows.length === 0 && (
               <EmptyMessage message="No input available because the evaluation failed" />
             )}
-          {status === 'fetched' &&
-            decisionInstance?.evaluatedInputs !== undefined &&
-            decisionInstance.evaluatedInputs.length > 0 && (
-              <StructuredList
-                label="Inputs"
-                headerSize="sm"
-                isFlush={false}
-                headerColumns={inputMappingsColumns}
-                rows={decisionInstance?.evaluatedInputs.map(
-                  ({id, name, value}) => {
-                    return {
-                      key: id,
-                      columns: [
-                        {
-                          cellContent: name,
-                        },
-                        {cellContent: value},
-                      ],
-                    };
-                  },
-                )}
-              />
-            )}
+          {status === 'success' && evaluatedInputsRows.length > 0 && (
+            <StructuredList
+              label="Inputs"
+              headerSize="sm"
+              isFlush={false}
+              headerColumns={inputMappingsColumns}
+              rows={evaluatedInputsRows}
+            />
+          )}
           {status === 'error' && <ErrorMessage />}
         </Panel>
         <Panel aria-label="output variables">
           {status !== 'error' && <Title>Outputs</Title>}
-          {status === 'initial' && (
+          {status === 'pending' && (
             <Skeleton
               dataTestId="outputs-skeleton"
               columnWidths={outputMappingsColumns.map(({width}) => width)}
             />
           )}
-          {status === 'fetched' && decisionInstance?.state !== 'FAILED' && (
+          {status === 'success' && decisionInstance.state !== 'FAILED' && (
             <StructuredList
               label="Outputs"
               headerSize="sm"
               isFlush={false}
               headerColumns={outputMappingsColumns}
-              rows={
-                decisionInstance?.evaluatedOutputs.map(
-                  ({id, ruleId, ruleIndex, name, value}) => {
-                    return {
-                      key: `${id}--${ruleId}`,
-                      columns: [
-                        {
-                          cellContent: ruleIndex,
-                        },
-                        {
-                          cellContent: name,
-                        },
-                        {cellContent: value},
-                      ],
-                    };
-                  },
-                ) ?? []
-              }
+              rows={evaluatedOutputRows}
             />
           )}
           {status === 'error' && <ErrorMessage />}
-          {decisionInstance?.state === 'FAILED' && (
+          {status === 'success' && decisionInstance.state === 'FAILED' && (
             <EmptyMessage message="No output available because the evaluation failed" />
           )}
         </Panel>
       </ResizablePanel>
     </Container>
   );
-});
+};
 
 export {InputsAndOutputs};

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/Result/index.test.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/Result/index.test.tsx
@@ -14,22 +14,23 @@ import {
 import {
   assignApproverGroup,
   invoiceClassification,
-} from 'modules/mocks/mockDecisionInstance';
-import {decisionInstanceDetailsStore} from 'modules/stores/decisionInstanceDetails';
+} from 'modules/mocks/mockDecisionInstanceV2';
 import {Result} from './index';
-import {mockFetchDecisionInstance} from 'modules/mocks/api/decisionInstances/fetchDecisionInstance';
+import {mockFetchDecisionInstance} from 'modules/mocks/api/v2/decisionInstances/fetchDecisionInstance';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+
+const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
 
 describe('<Result />', () => {
-  beforeEach(() => {
-    decisionInstanceDetailsStore.reset();
-  });
-
   it('should show an error message', async () => {
     mockFetchDecisionInstance().withServerError();
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('1');
-
-    render(<Result />);
+    render(<Result decisionEvaluationInstanceKey="1" />, {wrapper: Wrapper});
 
     expect(
       await screen.findByText(/data could not be fetched/i),
@@ -39,9 +40,7 @@ describe('<Result />', () => {
   it('should show a loading spinner', async () => {
     mockFetchDecisionInstance().withServerError();
 
-    render(<Result />);
-
-    decisionInstanceDetailsStore.fetchDecisionInstance('1');
+    render(<Result decisionEvaluationInstanceKey="1" />, {wrapper: Wrapper});
 
     expect(screen.getByTestId('result-loading-spinner')).toBeInTheDocument();
 
@@ -53,9 +52,7 @@ describe('<Result />', () => {
   it('should show the result on the json editor', async () => {
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('1');
-
-    render(<Result />);
+    render(<Result decisionEvaluationInstanceKey="1" />, {wrapper: Wrapper});
 
     expect(
       await screen.findByTestId('results-json-viewer'),
@@ -65,9 +62,7 @@ describe('<Result />', () => {
   it('should show empty message for failed decision instances', async () => {
     mockFetchDecisionInstance().withSuccess(assignApproverGroup);
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('1');
-
-    render(<Result />);
+    render(<Result decisionEvaluationInstanceKey="1" />, {wrapper: Wrapper});
 
     expect(
       await screen.findByText(

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/Result/index.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/Result/index.tsx
@@ -19,9 +19,9 @@ const JSONViewer = lazy(async () => {
   return {default: JSONViewer};
 });
 
-interface ResultProps {
+type ResultProps = {
   decisionEvaluationInstanceKey: DecisionInstance['decisionEvaluationInstanceKey'];
-}
+};
 
 const Result: React.FC<ResultProps> = ({decisionEvaluationInstanceKey}) => {
   const {data: decisionInstance, status} = useDecisionInstance(

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/Result/index.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/Result/index.tsx
@@ -6,28 +6,32 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {observer} from 'mobx-react';
-import {decisionInstanceDetailsStore} from 'modules/stores/decisionInstanceDetails';
 import {Container} from './styled';
 import {EmptyMessage} from 'modules/components/EmptyMessage';
 import {ErrorMessage} from 'modules/components/ErrorMessage';
 import {Loading} from '@carbon/react';
 import {lazy, Suspense} from 'react';
+import type {DecisionInstance} from '@camunda/camunda-api-zod-schemas/8.8';
+import {useDecisionInstance} from 'modules/queries/decisionInstances/useDecisionInstance';
 
 const JSONViewer = lazy(async () => {
   const {JSONViewer} = await import('./JSONViewer');
   return {default: JSONViewer};
 });
 
-const Result: React.FC = observer(() => {
-  const {
-    state: {status, decisionInstance},
-  } = decisionInstanceDetailsStore;
+interface ResultProps {
+  decisionEvaluationInstanceKey: DecisionInstance['decisionEvaluationInstanceKey'];
+}
+
+const Result: React.FC<ResultProps> = ({decisionEvaluationInstanceKey}) => {
+  const {data: decisionInstance, status} = useDecisionInstance(
+    decisionEvaluationInstanceKey,
+  );
 
   return (
     <Container>
-      {status === 'initial' && <Loading data-testid="result-loading-spinner" />}
-      {status === 'fetched' &&
+      {status === 'pending' && <Loading data-testid="result-loading-spinner" />}
+      {status === 'success' &&
         decisionInstance !== null &&
         decisionInstance.state !== 'FAILED' && (
           <Suspense>
@@ -37,12 +41,12 @@ const Result: React.FC = observer(() => {
             />
           </Suspense>
         )}
-      {status === 'fetched' && decisionInstance?.state === 'FAILED' && (
+      {status === 'success' && decisionInstance?.state === 'FAILED' && (
         <EmptyMessage message="No result available because the evaluation failed" />
       )}
       {status === 'error' && <ErrorMessage />}
     </Container>
   );
-});
+};
 
 export {Result};

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/index.test.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/index.test.tsx
@@ -12,23 +12,31 @@ import {
   waitForElementToBeRemoved,
 } from 'modules/testing-library';
 import {VariablesPanel} from './index';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchDecisionInstance} from 'modules/mocks/api/v2/decisionInstances/fetchDecisionInstance';
 import {
   invoiceClassification,
   literalExpression,
-} from 'modules/mocks/mockDecisionInstance';
-import {decisionInstanceDetailsStore} from 'modules/stores/decisionInstanceDetails';
-import {mockFetchDecisionInstance} from 'modules/mocks/api/decisionInstances/fetchDecisionInstance';
-import {useEffect} from 'react';
+} from 'modules/mocks/mockDecisionInstanceV2';
+
+const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
 
 describe('<VariablesPanel />', () => {
-  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
-    useEffect(() => decisionInstanceDetailsStore.reset);
-
-    return <>{children}</>;
-  };
-
   it('should have 2 tabs', () => {
-    render(<VariablesPanel />, {wrapper: Wrapper});
+    mockFetchDecisionInstance().withSuccess(invoiceClassification);
+
+    render(
+      <VariablesPanel
+        decisionEvaluationInstanceKey="1"
+        decisionDefinitionType="UNKNOWN"
+      />,
+      {wrapper: Wrapper},
+    );
 
     expect(
       screen.getByRole('tab', {
@@ -43,7 +51,15 @@ describe('<VariablesPanel />', () => {
   });
 
   it('should render the default tab content', () => {
-    render(<VariablesPanel />, {wrapper: Wrapper});
+    mockFetchDecisionInstance().withSuccess(invoiceClassification);
+
+    render(
+      <VariablesPanel
+        decisionEvaluationInstanceKey="1"
+        decisionDefinitionType="DECISION_TABLE"
+      />,
+      {wrapper: Wrapper},
+    );
 
     expect(
       screen.getByRole('heading', {
@@ -60,9 +76,13 @@ describe('<VariablesPanel />', () => {
   it('should switch tab content', async () => {
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('1');
-
-    const {user} = render(<VariablesPanel />, {wrapper: Wrapper});
+    const {user} = render(
+      <VariablesPanel
+        decisionEvaluationInstanceKey="1"
+        decisionDefinitionType="DECISION_TABLE"
+      />,
+      {wrapper: Wrapper},
+    );
 
     await waitForElementToBeRemoved(() =>
       screen.queryByTestId('inputs-skeleton'),
@@ -99,9 +119,13 @@ describe('<VariablesPanel />', () => {
   it('should hide input/output tab for literal expressions', async () => {
     mockFetchDecisionInstance().withSuccess(literalExpression);
 
-    decisionInstanceDetailsStore.fetchDecisionInstance('1');
-
-    render(<VariablesPanel />, {wrapper: Wrapper});
+    render(
+      <VariablesPanel
+        decisionEvaluationInstanceKey="1"
+        decisionDefinitionType="LITERAL_EXPRESSION"
+      />,
+      {wrapper: Wrapper},
+    );
 
     expect(
       await screen.findByTestId('results-json-viewer'),

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/index.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/index.tsx
@@ -6,41 +6,58 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {observer} from 'mobx-react';
-import {decisionInstanceDetailsStore} from 'modules/stores/decisionInstanceDetails';
+import {useMemo} from 'react';
 import {TabView} from 'modules/components/TabView';
 import {InputsAndOutputs} from './InputsAndOutputs';
 import {Result} from './Result';
+import type {DecisionInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 
-const VariablesPanel: React.FC = observer(() => {
-  const isLiteralExpression =
-    decisionInstanceDetailsStore.state.decisionInstance?.decisionType ===
-    'LITERAL_EXPRESSION';
+interface VariablesPanelProps {
+  decisionEvaluationInstanceKey: DecisionInstance['decisionEvaluationInstanceKey'];
+  decisionDefinitionType: DecisionInstance['decisionDefinitionType'];
+}
+
+const VariablesPanel: React.FC<VariablesPanelProps> = ({
+  decisionEvaluationInstanceKey,
+  decisionDefinitionType,
+}) => {
+  const tabs = useMemo(() => {
+    let tabs: React.ComponentProps<typeof TabView>['tabs'] = [
+      {
+        id: 'result',
+        label: 'Result',
+        content: (
+          <Result
+            decisionEvaluationInstanceKey={decisionEvaluationInstanceKey}
+          />
+        ),
+        removePadding: true,
+      },
+    ];
+
+    if (decisionDefinitionType !== 'LITERAL_EXPRESSION') {
+      tabs.unshift({
+        id: 'inputs-and-outputs',
+        label: 'Inputs and Outputs',
+        content: (
+          <InputsAndOutputs
+            decisionEvaluationInstanceKey={decisionEvaluationInstanceKey}
+          />
+        ),
+        removePadding: true,
+      });
+    }
+
+    return tabs;
+  }, [decisionDefinitionType, decisionEvaluationInstanceKey]);
 
   return (
     <TabView
       dataTestId="decision-instance-variables-panel"
-      tabs={[
-        ...(isLiteralExpression
-          ? []
-          : [
-              {
-                id: 'inputs-and-outputs',
-                label: 'Inputs and Outputs',
-                content: <InputsAndOutputs />,
-                removePadding: true,
-              },
-            ]),
-        {
-          id: 'result',
-          label: 'Result',
-          content: <Result />,
-          removePadding: true,
-        },
-      ]}
+      tabs={tabs}
       eventName="variables-panel-used"
     />
   );
-});
+};
 
 export {VariablesPanel};

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/index.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/index.tsx
@@ -12,10 +12,10 @@ import {InputsAndOutputs} from './InputsAndOutputs';
 import {Result} from './Result';
 import type {DecisionInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 
-interface VariablesPanelProps {
+type VariablesPanelProps = {
   decisionEvaluationInstanceKey: DecisionInstance['decisionEvaluationInstanceKey'];
   decisionDefinitionType: DecisionInstance['decisionDefinitionType'];
-}
+};
 
 const VariablesPanel: React.FC<VariablesPanelProps> = ({
   decisionEvaluationInstanceKey,

--- a/operate/client/src/App/DecisionInstance/index.test.tsx
+++ b/operate/client/src/App/DecisionInstance/index.test.tsx
@@ -261,6 +261,7 @@ describe('<DecisionInstance />', () => {
     mockFetchDrdData().withSuccess(mockDrdData);
     mockFetchDecisionDefinitionXML().withSuccess(mockDmnXml);
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
+    mockFetchDecisionInstanceV2().withSuccess(invoiceClassificationV2);
 
     render(<DecisionInstance />, {wrapper: Wrapper});
 

--- a/operate/client/src/App/DecisionInstance/index.tsx
+++ b/operate/client/src/App/DecisionInstance/index.tsx
@@ -78,7 +78,9 @@ const DecisionInstance: React.FC = observer(() => {
       <DecisionInstanceContainer>
         <InstanceDetail
           header={<Header decisionEvaluationInstanceKey={decisionInstanceId} />}
-          topPanel={<DecisionPanel />}
+          topPanel={
+            <DecisionPanel decisionEvaluationInstanceKey={decisionInstanceId} />
+          }
           bottomPanel={<VariablesPanel />}
           type="decision"
           rightPanel={

--- a/operate/client/src/App/DecisionInstance/index.tsx
+++ b/operate/client/src/App/DecisionInstance/index.tsx
@@ -81,7 +81,12 @@ const DecisionInstance: React.FC = observer(() => {
           topPanel={
             <DecisionPanel decisionEvaluationInstanceKey={decisionInstanceId} />
           }
-          bottomPanel={<VariablesPanel />}
+          bottomPanel={
+            <VariablesPanel
+              decisionEvaluationInstanceKey={decisionInstanceId}
+              decisionDefinitionType={data?.decisionDefinitionType ?? 'UNKNOWN'}
+            />
+          }
           type="decision"
           rightPanel={
             drdStore.state.panelState === 'minimized' ? (


### PR DESCRIPTION
## Description

Migrates the `DecisionPanel` and `VariablePanel` components display decision instance data from the v2 API through the `useDecisionInstance` hook.

With these changes, all components in `src/App/DecisionInstance` (apart from `Drd` and `DrdPanel`) are migrated to use the query hook instead of the MobX store. As far as I can tell, we cannot remove code related to the v1 endpoint yet as the `decisionInstanceDetailsStore` is used by the `drdDataStore`, which will be migrated in #28392.

## Checklist

- [ ] Notice that this PR is stacked on #38542
- [X] ~**DO NOT MERGE!** See #38634. Merging this already would potentially result in missing information for users.~

## Related issues

closes #27347
