### PR TITLE
Automatically label namespace with the github handle of the author

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -273,6 +273,9 @@ jobs:
           ${{ inputs.stable-vms && '-f load-tests/setup/default/values-stable.yaml' || '' }}
           ${{ inputs.realistic && '-f https://raw.githubusercontent.com/zeebe-io/benchmark-helm/main/charts/zeebe-benchmark/values-realistic-benchmark.yaml' || '' }}
           ${{ inputs.benchmark-load }}
+      - name: Label namespace
+        run: >
+            kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite
       - name: Summarize deployment
         if: success()
         run: |


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

It sometimes is hard to know which person created a benchmark. This extra step in the workflow will label the namespace with the person who triggered the workflow. This could be a first step to sending reminders about stale benchmarks, saving us money in the long run.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
