### PR TITLE
feat: rdbms cleanup

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -155,7 +155,9 @@ public class RdbmsWriter {
             batchOperationWriter,
             messageSubscriptionWriter,
             correlatedMessageSubscriptionWriter,
-            metrics);
+            metrics,
+            usageMetricWriter,
+            usageMetricTUWriter);
   }
 
   public AuthorizationWriter getAuthorizationWriter() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -88,12 +88,14 @@ public record RdbmsWriterConfig(
       Duration minHistoryCleanupInterval,
       Duration maxHistoryCleanupInterval,
       int historyCleanupBatchSize,
+      Duration usageMetricsCleanup,
       Duration usageMetricsTTL) {
 
     public static final Duration DEFAULT_HISTORY_TTL = Duration.ofDays(30);
     public static final Duration DEFAULT_BATCH_OPERATION_HISTORY_TTL = Duration.ofDays(5);
     public static final Duration DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(1);
     public static final Duration DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(60);
+    public static final Duration DEFAULT_USAGE_METRICS_CLEANUP = Duration.ofDays(1);
     public static final Duration DEFAULT_USAGE_METRICS_TTL = Duration.ofDays(730);
     public static final int DEFAULT_HISTORY_CLEANUP_BATCH_SIZE = 1000;
 
@@ -115,6 +117,7 @@ public record RdbmsWriterConfig(
       private Duration minHistoryCleanupInterval = DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL;
       private Duration maxHistoryCleanupInterval = DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
       private int historyCleanupBatchSize = DEFAULT_HISTORY_CLEANUP_BATCH_SIZE;
+      private Duration usageMetricsCleanup = DEFAULT_USAGE_METRICS_CLEANUP;
       private Duration usageMetricsTTL = DEFAULT_USAGE_METRICS_TTL;
 
       public HistoryConfig.Builder defaultHistoryTTL(final Duration defaultHistoryTTL) {
@@ -166,6 +169,11 @@ public record RdbmsWriterConfig(
         return this;
       }
 
+      public HistoryConfig.Builder usageMetricsCleanup(final Duration usageMetricsCleanup) {
+        this.usageMetricsCleanup = usageMetricsCleanup;
+        return this;
+      }
+
       public HistoryConfig.Builder usageMetricsTTL(final Duration usageMetricsTTL) {
         this.usageMetricsTTL = usageMetricsTTL;
         return this;
@@ -182,6 +190,7 @@ public record RdbmsWriterConfig(
             minHistoryCleanupInterval,
             maxHistoryCleanupInterval,
             historyCleanupBatchSize,
+            usageMetricsCleanup,
             usageMetricsTTL);
       }
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -87,12 +87,14 @@ public record RdbmsWriterConfig(
       Duration batchOperationResolveIncidentHistoryTTL,
       Duration minHistoryCleanupInterval,
       Duration maxHistoryCleanupInterval,
-      int historyCleanupBatchSize) {
+      int historyCleanupBatchSize,
+      Duration usageMetricsTTL) {
 
     public static final Duration DEFAULT_HISTORY_TTL = Duration.ofDays(30);
     public static final Duration DEFAULT_BATCH_OPERATION_HISTORY_TTL = Duration.ofDays(5);
     public static final Duration DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(1);
     public static final Duration DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(60);
+    public static final Duration DEFAULT_USAGE_METRICS_TTL = Duration.ofDays(730);
     public static final int DEFAULT_HISTORY_CLEANUP_BATCH_SIZE = 1000;
 
     public static RdbmsWriterConfig.Builder builder() {
@@ -113,6 +115,7 @@ public record RdbmsWriterConfig(
       private Duration minHistoryCleanupInterval = DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL;
       private Duration maxHistoryCleanupInterval = DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
       private int historyCleanupBatchSize = DEFAULT_HISTORY_CLEANUP_BATCH_SIZE;
+      private Duration usageMetricsTTL = DEFAULT_USAGE_METRICS_TTL;
 
       public HistoryConfig.Builder defaultHistoryTTL(final Duration defaultHistoryTTL) {
         this.defaultHistoryTTL = defaultHistoryTTL;
@@ -163,6 +166,11 @@ public record RdbmsWriterConfig(
         return this;
       }
 
+      public HistoryConfig.Builder usageMetricsTTL(final Duration usageMetricsTTL) {
+        this.usageMetricsTTL = usageMetricsTTL;
+        return this;
+      }
+
       @Override
       public HistoryConfig build() {
         return new HistoryConfig(
@@ -173,7 +181,8 @@ public record RdbmsWriterConfig(
             batchOperationResolveIncidentHistoryTTL,
             minHistoryCleanupInterval,
             maxHistoryCleanupInterval,
-            historyCleanupBatchSize);
+            historyCleanupBatchSize,
+            usageMetricsTTL);
       }
     }
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterMetrics.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterMetrics.java
@@ -67,6 +67,13 @@ public class RdbmsWriterMetrics {
         .minimumExpectedValue(Duration.ofMillis(10));
   }
 
+  public ResourceSample measureUsageMetricsHistoryCleanupDuration() {
+    return Timer.resource(meterRegistry, meterName("historyCleanup.usageMetrics.duration.seconds"))
+        .description("Usage metrics history cleanup duration in seconds")
+        .publishPercentileHistogram()
+        .minimumExpectedValue(Duration.ofMillis(10));
+  }
+
   public void recordHistoryCleanupBulkSize(final int bulkSize, final String entityName) {
     DistributionSummary.builder(meterName("historyCleanup.bulk.size"))
         .description("Exporter bulk size")

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -30,6 +30,7 @@ public class HistoryCleanupService {
   private final Duration minCleanupInterval;
   private final Duration maxCleanupInterval;
   private final int cleanupBatchSize;
+  private final Duration usageMetricsCleanup;
   private final Duration usageMetricsTTL;
 
   private final RdbmsWriterMetrics metrics;
@@ -81,6 +82,7 @@ public class HistoryCleanupService {
         config.history().batchOperationResolveIncidentHistoryTTL();
     minCleanupInterval = config.history().minHistoryCleanupInterval();
     maxCleanupInterval = config.history().maxHistoryCleanupInterval();
+    usageMetricsCleanup = config.history().usageMetricsCleanup();
     usageMetricsTTL = config.history().usageMetricsTTL();
     cleanupBatchSize = config.history().historyCleanupBatchSize();
     this.processInstanceWriter = processInstanceWriter;
@@ -149,66 +151,52 @@ public class HistoryCleanupService {
   public Duration cleanupHistory(final int partitionId, final OffsetDateTime cleanupDate) {
     LOG.trace("Cleanup history for partition {} with TTL before {}", partitionId, cleanupDate);
 
-    final var sample = metrics.measureHistoryCleanupDuration();
-    final long start = System.currentTimeMillis();
+    try (final var sample = metrics.measureHistoryCleanupDuration()) {
+      final long start = System.currentTimeMillis();
 
-    final var numDeletedRecords = new HashMap<String, Integer>();
-    numDeletedRecords.put(
-        "processInstance",
-        processInstanceWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
-    numDeletedRecords.put(
-        "flowNodeInstance",
-        flowNodeInstanceWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
-    numDeletedRecords.put(
-        "incident", incidentWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
-    numDeletedRecords.put(
-        "userTask", userTaskWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
-    numDeletedRecords.put(
-        "variable",
-        variableInstanceWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
-    numDeletedRecords.put(
-        "decisionInstance",
-        decisionInstanceWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
-    numDeletedRecords.put(
-        "job", jobWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
-    numDeletedRecords.put(
-        "sequenceFlow",
-        sequenceFlowWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
-    numDeletedRecords.put(
-        "batchOperationItem",
-        batchOperationWriter.cleanupItemHistory(cleanupDate, cleanupBatchSize));
-    numDeletedRecords.put(
-        "batchOperation", batchOperationWriter.cleanupHistory(cleanupDate, cleanupBatchSize));
-    numDeletedRecords.put(
-        "messageSubscription",
-        messageSubscriptionWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
-    numDeletedRecords.put(
-        "correlatedMessageSubscription",
-        correlatedMessageSubscriptionWriter.cleanupHistory(
-            partitionId, cleanupDate, cleanupBatchSize));
-    final long end = System.currentTimeMillis();
-    sample.close();
+      final var numDeletedRecords = new HashMap<String, Integer>();
+      numDeletedRecords.put(
+          "processInstance",
+          processInstanceWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "flowNodeInstance",
+          flowNodeInstanceWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "incident", incidentWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "userTask", userTaskWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "variable",
+          variableInstanceWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "decisionInstance",
+          decisionInstanceWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "job", jobWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "sequenceFlow",
+          sequenceFlowWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "batchOperationItem",
+          batchOperationWriter.cleanupItemHistory(cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "batchOperation", batchOperationWriter.cleanupHistory(cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "messageSubscription",
+          messageSubscriptionWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "correlatedMessageSubscription",
+          correlatedMessageSubscriptionWriter.cleanupHistory(
+              partitionId, cleanupDate, cleanupBatchSize));
+      final long end = System.currentTimeMillis();
+      logCleanUpInfo("", partitionId, numDeletedRecords, cleanupDate, end, start);
+      final var nextDuration =
+          calculateNewDuration(lastCleanupInterval.get(partitionId), numDeletedRecords);
+      LOG.trace("Schedule next cleanup for partition {} with TTL in {}", partitionId, nextDuration);
 
-    final int sum = numDeletedRecords.values().stream().mapToInt(Integer::intValue).sum();
-
-    LOG.debug("Deleted history records: {}", numDeletedRecords);
-    for (final var entry : numDeletedRecords.entrySet()) {
-      LOG.debug("    Deleted {}s: {}", entry.getKey(), entry.getValue());
+      saveLastCleanupInterval(partitionId, nextDuration);
+      return nextDuration;
     }
-
-    LOG.debug(
-        "Cleanup history for partition {} with TTL before {} took {} ms. Deleted {} records",
-        partitionId,
-        cleanupDate,
-        end - start,
-        sum);
-
-    final var nextDuration =
-        calculateNewDuration(lastCleanupInterval.get(partitionId), numDeletedRecords);
-    LOG.trace("Schedule next cleanup for partition {} with TTL in {}", partitionId, nextDuration);
-
-    saveLastCleanupInterval(partitionId, nextDuration);
-    return nextDuration;
   }
 
   public Duration cleanupUsageMetricsHistory(final int partitionId, final OffsetDateTime now) {
@@ -219,35 +207,46 @@ public class HistoryCleanupService {
         partitionId,
         cleanupDate);
 
-    final var sample = metrics.measureHistoryCleanupDuration();
-    final long start = System.currentTimeMillis();
+    try (final var sample = metrics.measureUsageMetricsHistoryCleanupDuration()) {
+      final long start = System.currentTimeMillis();
 
-    final var numDeletedRecords = new HashMap<String, Integer>();
-    numDeletedRecords.put(
-        "usageMetrics",
-        usageMetricWriter.cleanupMetrics(partitionId, cleanupDate, cleanupBatchSize));
-    numDeletedRecords.put(
-        "usageMetricsTU",
-        usageMetricTUWriter.cleanupMetrics(partitionId, cleanupDate, cleanupBatchSize));
+      final var numDeletedRecords = new HashMap<String, Integer>();
+      numDeletedRecords.put(
+          "usageMetrics",
+          usageMetricWriter.cleanupMetrics(partitionId, cleanupDate, cleanupBatchSize));
+      numDeletedRecords.put(
+          "usageMetricsTU",
+          usageMetricTUWriter.cleanupMetrics(partitionId, cleanupDate, cleanupBatchSize));
 
-    final long end = System.currentTimeMillis();
-    sample.close();
+      final long end = System.currentTimeMillis();
 
+      logCleanUpInfo("Usage Metrics", partitionId, numDeletedRecords, cleanupDate, end, start);
+    }
+
+    return usageMetricsCleanup;
+  }
+
+  private static void logCleanUpInfo(
+      final String cleanupType,
+      final int partitionId,
+      final HashMap<String, Integer> numDeletedRecords,
+      final OffsetDateTime cleanupDate,
+      final long end,
+      final long start) {
     final int sum = numDeletedRecords.values().stream().mapToInt(Integer::intValue).sum();
 
-    LOG.debug("Deleted history records: {}", numDeletedRecords);
+    LOG.debug("Deleted {}history records: {}", cleanupType, numDeletedRecords);
     for (final var entry : numDeletedRecords.entrySet()) {
       LOG.debug("    Deleted {}s: {}", entry.getKey(), entry.getValue());
     }
 
     LOG.debug(
-        "Cleanup history for partition {} with TTL before {} took {} ms. Deleted {} records",
+        "{}Cleanup history for partition {} with TTL before {} took {} ms. Deleted {} records",
+        cleanupType,
         partitionId,
         cleanupDate,
         end - start,
         sum);
-
-    return defaultHistoryTTL;
   }
 
   private void saveLastCleanupInterval(final int partitionId, final Duration nextDuration) {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
@@ -81,7 +81,7 @@ class HistoryCleanupServiceTest {
 
     final var historyConfig = mock(RdbmsWriterConfig.HistoryConfig.class);
     when(config.history()).thenReturn(historyConfig);
-    when(historyConfig.defaultHistoryTTL()).thenReturn(Duration.ofDays(30));
+    when(historyConfig.defaultHistoryTTL()).thenReturn(Duration.ofDays(90));
     when(historyConfig.batchOperationCancelProcessInstanceHistoryTTL())
         .thenReturn(Duration.ofDays(2));
     when(historyConfig.batchOperationMigrateProcessInstanceHistoryTTL())
@@ -92,6 +92,7 @@ class HistoryCleanupServiceTest {
     when(historyConfig.minHistoryCleanupInterval()).thenReturn(Duration.ofHours(1));
     when(historyConfig.maxHistoryCleanupInterval()).thenReturn(Duration.ofDays(1));
     when(historyConfig.historyCleanupBatchSize()).thenReturn(100);
+    when(historyConfig.usageMetricsCleanup()).thenReturn(Duration.ofDays(1));
     when(historyConfig.usageMetricsTTL()).thenReturn(Duration.ofDays(730));
 
     historyCleanupService =
@@ -161,7 +162,7 @@ class HistoryCleanupServiceTest {
         historyCleanupService.cleanupUsageMetricsHistory(PARTITION_ID, CLEANUP_DATE);
 
     // then
-    assertThat(nextCleanupInterval).isEqualTo(Duration.ofDays(30));
+    assertThat(nextCleanupInterval).isEqualTo(Duration.ofDays(1));
     verify(usageMetricWriter)
         .cleanupMetrics(PARTITION_ID, CLEANUP_DATE.minus(Duration.ofDays(730)), 100);
     verify(usageMetricTUWriter)
@@ -262,6 +263,6 @@ class HistoryCleanupServiceTest {
         .isEqualTo(Duration.ofDays(5));
 
     assertThat(historyCleanupService.resolveBatchOperationTTL(BatchOperationType.ADD_VARIABLE))
-        .isEqualTo(Duration.ofDays(30)); // default history TTL
+        .isEqualTo(Duration.ofDays(90)); // default history TTL
   }
 }

--- a/dist/src/main/resources/application-rdbmsH2.yaml
+++ b/dist/src/main/resources/application-rdbmsH2.yaml
@@ -76,6 +76,7 @@ zeebe:
         args:
           flushInterval: PT0.5S
           queueSize: 1000
+          usageMetricsCleanup: PT1D
           usageMetricsTTL: PT730D
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter

--- a/dist/src/main/resources/application-rdbmsH2.yaml
+++ b/dist/src/main/resources/application-rdbmsH2.yaml
@@ -76,6 +76,7 @@ zeebe:
         args:
           flushInterval: PT0.5S
           queueSize: 1000
+          usageMetricsTTL: PT730D
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter
       #  args:

--- a/dist/src/main/resources/application-rdbmsMariaDB.yaml
+++ b/dist/src/main/resources/application-rdbmsMariaDB.yaml
@@ -87,6 +87,7 @@ zeebe:
             minHistoryCleanupInterval: PT1S
             maxHistoryCleanupInterval: PT1H
             historyCleanupBatchSize: 1000
+            usageMetricsCleanup: PT1D
             usageMetricsTTL: PT730D
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter

--- a/dist/src/main/resources/application-rdbmsMariaDB.yaml
+++ b/dist/src/main/resources/application-rdbmsMariaDB.yaml
@@ -87,6 +87,7 @@ zeebe:
             minHistoryCleanupInterval: PT1S
             maxHistoryCleanupInterval: PT1H
             historyCleanupBatchSize: 1000
+            usageMetricsTTL: PT730D
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter
       #  args:

--- a/dist/src/main/resources/application-rdbmsOracle.yaml
+++ b/dist/src/main/resources/application-rdbmsOracle.yaml
@@ -87,6 +87,7 @@ zeebe:
             minHistoryCleanupInterval: PT1S
             maxHistoryCleanupInterval: PT1H
             historyCleanupBatchSize: 1000
+            usageMetricsCleanup: PT1D
             usageMetricsTTL: PT730D
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter

--- a/dist/src/main/resources/application-rdbmsOracle.yaml
+++ b/dist/src/main/resources/application-rdbmsOracle.yaml
@@ -87,6 +87,7 @@ zeebe:
             minHistoryCleanupInterval: PT1S
             maxHistoryCleanupInterval: PT1H
             historyCleanupBatchSize: 1000
+            usageMetricsTTL: PT730D
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter
       #  args:

--- a/dist/src/main/resources/application-rdbmsPostgres.yaml
+++ b/dist/src/main/resources/application-rdbmsPostgres.yaml
@@ -87,6 +87,7 @@ zeebe:
             minHistoryCleanupInterval: PT1S
             maxHistoryCleanupInterval: PT1H
             historyCleanupBatchSize: 1000
+            usageMetricsCleanup: PT1D
             usageMetricsTTL: PT730D
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter

--- a/dist/src/main/resources/application-rdbmsPostgres.yaml
+++ b/dist/src/main/resources/application-rdbmsPostgres.yaml
@@ -87,6 +87,7 @@ zeebe:
             minHistoryCleanupInterval: PT1S
             maxHistoryCleanupInterval: PT1H
             historyCleanupBatchSize: 1000
+            usageMetricsTTL: PT730D
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter
       #  args:

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -145,6 +145,7 @@ public class ExporterConfiguration {
             .minHistoryCleanupInterval(history.getMinHistoryCleanupInterval())
             .maxHistoryCleanupInterval(history.getMaxHistoryCleanupInterval())
             .historyCleanupBatchSize(history.getHistoryCleanupBatchSize())
+            .usageMetricsCleanup(history.getUsageMetricsCleanup())
             .usageMetricsTTL(history.getUsageMetricsTTL())
             .build();
 
@@ -195,6 +196,8 @@ public class ExporterConfiguration {
     private Duration maxHistoryCleanupInterval =
         RdbmsWriterConfig.HistoryConfig.DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
     private int historyCleanupBatchSize = DEFAULT_CLEANUP_BATCH_SIZE;
+    private Duration usageMetricsCleanup =
+        RdbmsWriterConfig.HistoryConfig.DEFAULT_USAGE_METRICS_CLEANUP;
     private Duration usageMetricsTTL = RdbmsWriterConfig.HistoryConfig.DEFAULT_USAGE_METRICS_TTL;
 
     public Duration getDefaultHistoryTTL() {
@@ -276,6 +279,14 @@ public class ExporterConfiguration {
       this.historyCleanupBatchSize = historyCleanupBatchSize;
     }
 
+    public Duration getUsageMetricsCleanup() {
+      return usageMetricsCleanup;
+    }
+
+    public void setUsageMetricsCleanup(final Duration usageMetricsCleanup) {
+      this.usageMetricsCleanup = usageMetricsCleanup;
+    }
+
     public Duration getUsageMetricsTTL() {
       return usageMetricsTTL;
     }
@@ -308,6 +319,7 @@ public class ExporterConfiguration {
           errors);
       checkPositiveDuration(minHistoryCleanupInterval, "minHistoryCleanupInterval", errors);
       checkPositiveDuration(maxHistoryCleanupInterval, "maxHistoryCleanupInterval", errors);
+      checkPositiveDuration(usageMetricsCleanup, "usageMetricsCleanup", errors);
       checkPositiveDuration(usageMetricsTTL, "usageMetricsTTL", errors);
 
       if (maxHistoryCleanupInterval.compareTo(minHistoryCleanupInterval) <= 0) {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -145,6 +145,7 @@ public class ExporterConfiguration {
             .minHistoryCleanupInterval(history.getMinHistoryCleanupInterval())
             .maxHistoryCleanupInterval(history.getMaxHistoryCleanupInterval())
             .historyCleanupBatchSize(history.getHistoryCleanupBatchSize())
+            .usageMetricsTTL(history.getUsageMetricsTTL())
             .build();
 
     return new RdbmsWriterConfig.Builder()
@@ -194,6 +195,7 @@ public class ExporterConfiguration {
     private Duration maxHistoryCleanupInterval =
         RdbmsWriterConfig.HistoryConfig.DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
     private int historyCleanupBatchSize = DEFAULT_CLEANUP_BATCH_SIZE;
+    private Duration usageMetricsTTL = RdbmsWriterConfig.HistoryConfig.DEFAULT_USAGE_METRICS_TTL;
 
     public Duration getDefaultHistoryTTL() {
       return defaultHistoryTTL;
@@ -274,6 +276,14 @@ public class ExporterConfiguration {
       this.historyCleanupBatchSize = historyCleanupBatchSize;
     }
 
+    public Duration getUsageMetricsTTL() {
+      return usageMetricsTTL;
+    }
+
+    public void setUsageMetricsTTL(final Duration usageMetricsTTL) {
+      this.usageMetricsTTL = usageMetricsTTL;
+    }
+
     public List<String> validate() {
       final List<String> errors = new ArrayList<>();
 
@@ -298,6 +308,7 @@ public class ExporterConfiguration {
           errors);
       checkPositiveDuration(minHistoryCleanupInterval, "minHistoryCleanupInterval", errors);
       checkPositiveDuration(maxHistoryCleanupInterval, "maxHistoryCleanupInterval", errors);
+      checkPositiveDuration(usageMetricsTTL, "usageMetricsTTL", errors);
 
       if (maxHistoryCleanupInterval.compareTo(minHistoryCleanupInterval) <= 0) {
         errors.add(

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
@@ -34,6 +34,7 @@ class ExporterConfigurationTest {
     historyConfiguration.setDefaultBatchOperationHistoryTTL(Duration.ofMillis(-1000));
     historyConfiguration.setMinHistoryCleanupInterval(Duration.ofMillis(-1000));
     historyConfiguration.setMaxHistoryCleanupInterval(Duration.ofMillis(-2000));
+    historyConfiguration.setUsageMetricsCleanup(Duration.ofMillis(-2000));
     historyConfiguration.setUsageMetricsTTL(Duration.ofMillis(-2000));
     historyConfiguration.setHistoryCleanupBatchSize(-1000);
     historyConfiguration.setBatchOperationCancelProcessInstanceHistoryTTL(Duration.ofMillis(-1000));
@@ -62,6 +63,7 @@ class ExporterConfigurationTest {
         .hasMessageContaining("batchOperationResolveIncidentHistoryTTL must be")
         .hasMessageContaining("minHistoryCleanupInterval must be")
         .hasMessageContaining("maxHistoryCleanupInterval must be a positive duration")
+        .hasMessageContaining("usageMetricsCleanup must be a positive duration")
         .hasMessageContaining("usageMetricsTTL must be a positive duration")
         .hasMessageContaining(
             "maxHistoryCleanupInterval must be greater than minHistoryCleanupInterval")
@@ -204,7 +206,20 @@ class ExporterConfigurationTest {
   }
 
   @Test
-  public void shouldFailWithNegativeUsageMetricsMinimumAge() {
+  public void shouldFailWithNegativeUsageMetricsCleanup() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
+    final ExporterConfiguration configuration = new ExporterConfiguration();
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setUsageMetricsCleanup(Duration.ofMillis(-1000));
+
+    assertThatThrownBy(configuration::validate)
+        .hasMessageContaining("usageMetricsCleanup must be a positive duration");
+  }
+
+  @Test
+  public void shouldFailWithNegativeUsageMetricsTTL() {
     final ExporterConfiguration.HistoryConfiguration historyConfiguration =
         new ExporterConfiguration.HistoryConfiguration();
     final ExporterConfiguration configuration = new ExporterConfiguration();
@@ -230,7 +245,20 @@ class ExporterConfigurationTest {
   }
 
   @Test
-  public void shouldFailWithZeroUsageMetricsMinimumAge() {
+  public void shouldFailWithZeroUsageMetricsCleanup() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
+    final ExporterConfiguration configuration = new ExporterConfiguration();
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setUsageMetricsCleanup(Duration.ZERO);
+
+    assertThatThrownBy(configuration::validate)
+        .hasMessageContaining("usageMetricsCleanup must be a positive duration");
+  }
+
+  @Test
+  public void shouldFailWithZeroUsageMetricsTTL() {
     final ExporterConfiguration.HistoryConfiguration historyConfiguration =
         new ExporterConfiguration.HistoryConfiguration();
     final ExporterConfiguration configuration = new ExporterConfiguration();

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
@@ -34,6 +34,7 @@ class ExporterConfigurationTest {
     historyConfiguration.setDefaultBatchOperationHistoryTTL(Duration.ofMillis(-1000));
     historyConfiguration.setMinHistoryCleanupInterval(Duration.ofMillis(-1000));
     historyConfiguration.setMaxHistoryCleanupInterval(Duration.ofMillis(-2000));
+    historyConfiguration.setUsageMetricsTTL(Duration.ofMillis(-2000));
     historyConfiguration.setHistoryCleanupBatchSize(-1000);
     historyConfiguration.setBatchOperationCancelProcessInstanceHistoryTTL(Duration.ofMillis(-1000));
     historyConfiguration.setBatchOperationMigrateProcessInstanceHistoryTTL(
@@ -61,6 +62,7 @@ class ExporterConfigurationTest {
         .hasMessageContaining("batchOperationResolveIncidentHistoryTTL must be")
         .hasMessageContaining("minHistoryCleanupInterval must be")
         .hasMessageContaining("maxHistoryCleanupInterval must be a positive duration")
+        .hasMessageContaining("usageMetricsTTL must be a positive duration")
         .hasMessageContaining(
             "maxHistoryCleanupInterval must be greater than minHistoryCleanupInterval")
         .hasMessageContaining("historyCleanupBatchSize must be")
@@ -202,6 +204,19 @@ class ExporterConfigurationTest {
   }
 
   @Test
+  public void shouldFailWithNegativeUsageMetricsMinimumAge() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
+    final ExporterConfiguration configuration = new ExporterConfiguration();
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setUsageMetricsTTL(Duration.ofMillis(-1000));
+
+    assertThatThrownBy(configuration::validate)
+        .hasMessageContaining("usageMetricsTTL must be a positive duration");
+  }
+
+  @Test
   public void shouldFailWithZeroMaxHistoryCleanupInterval() {
     final ExporterConfiguration.HistoryConfiguration historyConfiguration =
         new ExporterConfiguration.HistoryConfiguration();
@@ -212,6 +227,19 @@ class ExporterConfigurationTest {
 
     assertThatThrownBy(configuration::validate)
         .hasMessageContaining("maxHistoryCleanupInterval must be a positive duration");
+  }
+
+  @Test
+  public void shouldFailWithZeroUsageMetricsMinimumAge() {
+    final ExporterConfiguration.HistoryConfiguration historyConfiguration =
+        new ExporterConfiguration.HistoryConfiguration();
+    final ExporterConfiguration configuration = new ExporterConfiguration();
+    configuration.setHistory(historyConfiguration);
+
+    historyConfiguration.setUsageMetricsTTL(Duration.ZERO);
+
+    assertThatThrownBy(configuration::validate)
+        .hasMessageContaining("usageMetricsTTL must be a positive duration");
   }
 
   @Test


### PR DESCRIPTION
## Description

Clean up metrics in rdbms that have `endTime` less than 730 days ago (configurable)
- On application startup
- With scheduled default TTL (30 days : Is this ok or it should be earlier❓)

## Related issues

closes #36482
