### PR TITLE
fix:Handling exception in case of forked repository

### DIFF
--- a/.ci/scripts/outdated-pr-scripts/lib/check-pr-commits.sh
+++ b/.ci/scripts/outdated-pr-scripts/lib/check-pr-commits.sh
@@ -9,15 +9,16 @@ check_pr_commits() {
   
   echo "📊 Calculating commits behind for PR #$pr_number (excluding renovate commits)..." >&2
   
-  # Only process internal branches
-  if [[ "$repo_owner" != "${GITHUB_REPOSITORY_OWNER}" ]]; then
+  # Validate branch exists before attempting git log
+  if ! git rev-parse --verify "origin/$branch_name" >/dev/null 2>&1; then
+    echo "⚠️  Branch origin/$branch_name does not exist (likely from forked repository)" >&2
     echo "0"
     return
   fi
   
   # Get commits and filter renovate
   local commits_behind
-  commits_behind=$(git log origin/"$branch_name"..origin/"$base_branch" --pretty=format:"%an|%ae" --no-merges | grep -v -E 'renovate\[bot\]|mend\[bot\]' | wc -l)
+  commits_behind=$(git log origin/"$branch_name"..origin/"$base_branch" --pretty=format:"%an|%ae" --no-merges 2>/dev/null | grep -v -E 'renovate\[bot\]|mend\[bot\]' | wc -l)
   
   echo "🔧 Found $commits_behind non-renovate and non-mend commits behind $base_branch" >&2
   echo "$commits_behind"


### PR DESCRIPTION
## Description

Fixing a fatal error issue in case the PR is opened from a forked repository

Currently in case of forked repo, fatal error is thrown:
<img width="907" height="108" alt="image" src="https://github.com/user-attachments/assets/c225b444-40b6-498b-aac1-1b7da7c0a611" />

After the changes, the PRs from forked repository will be handled more properly:
<img width="457" height="55" alt="image" src="https://github.com/user-attachments/assets/c2d55046-1369-45b3-9fe4-8f57f72221cc" />

Related issue:
https://github.com/camunda/camunda/issues/24649

