### PR TITLE
test: remove flakiness from job stream authorization test

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
@@ -168,7 +168,7 @@ public class JobStreamAuthorizationIT {
     // given
     // a job set for collecting jobs in the client
     final var jobCollector = new HashSet<ActivatedJob>();
-    // and a job stream created by the user1 client, with their authorizations
+    // and a job stream created by the user2 client, with their authorizations
     final var stream =
         user2Client
             .newStreamJobsCommand()


### PR DESCRIPTION
Remove flakiness in a test by waiting for jobs to be completed before assertions can be made.

This commit also cleans up the test class by moving some values into variables and re-using the default ADMIN user.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #37455
