### PR TITLE
[Backport stable/8.8] fix: align operate/tasklist usage metrics search with new api

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/dao/Query.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/dao/Query.java
@@ -28,7 +28,7 @@ public class Query {
     return instance;
   }
 
-  public static Query range(String field, Object gte, Object lte) {
+  public static Query range(String field, Object gte, Object lt) {
     final Query instance = new Query();
 
     RangeQueryBuilder rangeQueryBuilder = QueryBuilders.rangeQuery(field);
@@ -36,8 +36,8 @@ public class Query {
       rangeQueryBuilder = rangeQueryBuilder.gte(gte);
     }
 
-    if (lte != null) {
-      rangeQueryBuilder = rangeQueryBuilder.lte(lte);
+    if (lt != null) {
+      rangeQueryBuilder = rangeQueryBuilder.lt(lt);
     }
 
     instance.queryBuilder = rangeQueryBuilder;

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchMetricsStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchMetricsStore.java
@@ -9,7 +9,7 @@ package io.camunda.operate.store.opensearch;
 
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.sumAggregation;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.and;
-import static io.camunda.operate.store.opensearch.dsl.QueryDSL.gteLte;
+import static io.camunda.operate.store.opensearch.dsl.QueryDSL.gteLt;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.term;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
 import static io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate.END_TIME;
@@ -76,7 +76,7 @@ public class OpensearchMetricsStore implements MetricsStore {
   @Override
   public Long retrieveProcessInstanceCount(
       final OffsetDateTime startTime, final OffsetDateTime endTime, final String tenantId) {
-    var query = and(gteLte(END_TIME, startTime, endTime), term(EVENT_TYPE, RPI.name()));
+    var query = and(gteLt(END_TIME, startTime, endTime), term(EVENT_TYPE, RPI.name()));
     if (tenantId != null) {
       query = and(query, term(TENANT_ID, tenantId));
     }
@@ -92,7 +92,7 @@ public class OpensearchMetricsStore implements MetricsStore {
   @Override
   public Long retrieveDecisionInstanceCount(
       final OffsetDateTime startTime, final OffsetDateTime endTime, final String tenantId) {
-    var query = and(term(EVENT_TYPE, EDI.name()), gteLte(END_TIME, startTime, endTime));
+    var query = and(term(EVENT_TYPE, EDI.name()), gteLt(END_TIME, startTime, endTime));
     if (tenantId != null) {
       query = and(query, term(TENANT_ID, tenantId));
     }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/dsl/QueryDSL.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/dsl/QueryDSL.java
@@ -96,6 +96,10 @@ public interface QueryDSL {
     return RangeQuery.of(q -> q.field(field).gt(json(gt)).lte(json(lte)))._toQuery();
   }
 
+  static <A> Query gteLt(final String field, final A gte, final A lt) {
+    return RangeQuery.of(q -> q.field(field).gte(json(gte)).lt(json(lt)))._toQuery();
+  }
+
   static Query hasChildQuery(final String type, final Query query) {
     return HasChildQuery.of(q -> q.query(query).type(type).scoreMode(ChildScoreMode.None))
         ._toQuery();

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
@@ -83,7 +83,7 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
       final OffsetDateTime startTime, final OffsetDateTime endTime, final String tenantId) {
 
     final BoolQueryBuilder boolQuery =
-        boolQuery().must(QueryBuilders.rangeQuery(END_TIME).gte(startTime).lte(endTime));
+        boolQuery().must(QueryBuilders.rangeQuery(END_TIME).gte(startTime).lt(endTime));
 
     if (tenantId != null) {
       boolQuery.must(QueryBuilders.termQuery(TENANT_ID, tenantId));

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
@@ -88,7 +88,7 @@ public class TaskMetricsStoreOpenSearch implements TaskMetricsStore {
                   }
 
                   if (endTime != null) {
-                    r.lte(JsonData.of(endTime));
+                    r.lt(JsonData.of(endTime));
                   }
                   return r;
                 });

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearchTest.java
@@ -161,7 +161,7 @@ public class TaskMetricsStoreElasticSearchTest {
   private SearchRequest buildSearchRequest(
       final OffsetDateTime now, final OffsetDateTime oneHourBefore) {
     final BoolQueryBuilder rangeQuery =
-        boolQuery().must(QueryBuilders.rangeQuery(END_TIME).gte(oneHourBefore).lte(now));
+        boolQuery().must(QueryBuilders.rangeQuery(END_TIME).gte(oneHourBefore).lt(now));
     final TermsAggregationBuilder aggregation =
         AggregationBuilders.terms(ASSIGNEE).field(ASSIGNEE_HASH).size(AGGREGATION_TERMS_SIZE);
 


### PR DESCRIPTION
# Description
Backport of #38533 to `stable/8.8`.

relates to #38054