### PR TITLE
feat: extend demo data with root cause decision

### DIFF
--- a/operate/data-generator/src/main/java/io/camunda/operate/data/develop/DevelopDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/develop/DevelopDataGenerator.java
@@ -116,10 +116,10 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
     sendMessages("messageTask1", "{\"messageVar\": \"someValue\"\n}", 1, String.valueOf(orderId));
     completeTask(instanceKey, "task1", null);
 
-    long rootCauseDecisionInstance1 = startRootCauseDecisionProcess();
+    final long rootCauseDecisionInstance1 = startRootCauseDecisionProcess();
     doNotTouchProcessInstanceKeys.add(rootCauseDecisionInstance1);
 
-    long rootCauseDecisionInstance2 = startRootCauseDecisionProcess();
+    final long rootCauseDecisionInstance2 = startRootCauseDecisionProcess();
     doNotTouchProcessInstanceKeys.add(rootCauseDecisionInstance2);
   }
 
@@ -695,10 +695,9 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
   }
 
   private long startRootCauseDecisionProcess() {
-      return ZeebeTestUtil.startProcessInstance(
-          true, client, getTenant(TENANT_A), "Process_rootCauseDecision", null);
-    }
-
+    return ZeebeTestUtil.startProcessInstance(
+        true, client, getTenant(TENANT_A), "Process_rootCauseDecision", null);
+  }
 
   private void createBigProcess(final int loopCardinality, final int numberOfClients) {
     final ObjectMapper objectMapper = new ObjectMapper();

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/develop/DevelopDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/develop/DevelopDataGenerator.java
@@ -116,11 +116,9 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
     sendMessages("messageTask1", "{\"messageVar\": \"someValue\"\n}", 1, String.valueOf(orderId));
     completeTask(instanceKey, "task1", null);
 
-    final long rootCauseDecisionInstance1 = startRootCauseDecisionProcess();
-    doNotTouchProcessInstanceKeys.add(rootCauseDecisionInstance1);
-
-    final long rootCauseDecisionInstance2 = startRootCauseDecisionProcess();
-    doNotTouchProcessInstanceKeys.add(rootCauseDecisionInstance2);
+    final long rootCauseDecisionInstance = ZeebeTestUtil.startProcessInstance(
+        true, client, getTenant(TENANT_A), "Process_rootCauseDecision", null);
+    doNotTouchProcessInstanceKeys.add(rootCauseDecisionInstance);
   }
 
   @Override
@@ -386,9 +384,9 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
                 true, client, getTenant(TENANT_A), "executionListeners", null));
 
         // Root cause decision process
-        processInstanceKeys.add(startRootCauseDecisionProcess());
-        processInstanceKeys.add(startRootCauseDecisionProcess());
-        processInstanceKeys.add(startRootCauseDecisionProcess());
+        processInstanceKeys.add(
+            ZeebeTestUtil.startProcessInstance(
+                true, client, getTenant(TENANT_A), "Process_rootCauseDecision", null));
 
         // reverted in Zeebe https://github.com/camunda/camunda/issues/13640
         //        processInstanceKeys.add(ZeebeTestUtil.startProcessInstance(true, client,
@@ -694,10 +692,6 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
         .open();
   }
 
-  private long startRootCauseDecisionProcess() {
-    return ZeebeTestUtil.startProcessInstance(
-        true, client, getTenant(TENANT_A), "Process_rootCauseDecision", null);
-  }
 
   private void createBigProcess(final int loopCardinality, final int numberOfClients) {
     final ObjectMapper objectMapper = new ObjectMapper();

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/develop/DevelopDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/develop/DevelopDataGenerator.java
@@ -115,6 +115,12 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
     doNotTouchProcessInstanceKeys.add(instanceKey);
     sendMessages("messageTask1", "{\"messageVar\": \"someValue\"\n}", 1, String.valueOf(orderId));
     completeTask(instanceKey, "task1", null);
+
+    long rootCauseDecisionInstance1 = startRootCauseDecisionProcess();
+    doNotTouchProcessInstanceKeys.add(rootCauseDecisionInstance1);
+
+    long rootCauseDecisionInstance2 = startRootCauseDecisionProcess();
+    doNotTouchProcessInstanceKeys.add(rootCauseDecisionInstance2);
   }
 
   @Override
@@ -286,6 +292,12 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
     ZeebeTestUtil.deployProcess(
         true, client, getTenant(TENANT_A), "develop/executionListeners.bpmn");
 
+    ZeebeTestUtil.deployDecision(
+        client, getTenant(TENANT_A), "develop/dmn-with-decisions-chain.dmn");
+
+    ZeebeTestUtil.deployProcess(
+        true, client, getTenant(TENANT_A), "develop/process-with-root-cause-decision.bpmn");
+
     // reverted in Zeebe https://github.com/camunda/camunda/issues/13640
     // ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A),
     // "develop/inclusiveGateway.bpmn");
@@ -372,6 +384,12 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
         processInstanceKeys.add(
             ZeebeTestUtil.startProcessInstance(
                 true, client, getTenant(TENANT_A), "executionListeners", null));
+
+        // Root cause decision process
+        processInstanceKeys.add(startRootCauseDecisionProcess());
+        processInstanceKeys.add(startRootCauseDecisionProcess());
+        processInstanceKeys.add(startRootCauseDecisionProcess());
+
         // reverted in Zeebe https://github.com/camunda/camunda/issues/13640
         //        processInstanceKeys.add(ZeebeTestUtil.startProcessInstance(true, client,
         // getTenant(TENANT_A), "inclusiveGatewayProcess",
@@ -675,6 +693,12 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
         .timeout(Duration.ofSeconds(JOB_WORKER_TIMEOUT))
         .open();
   }
+
+  private long startRootCauseDecisionProcess() {
+      return ZeebeTestUtil.startProcessInstance(
+          true, client, getTenant(TENANT_A), "Process_rootCauseDecision", null);
+    }
+
 
   private void createBigProcess(final int loopCardinality, final int numberOfClients) {
     final ObjectMapper objectMapper = new ObjectMapper();

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/develop/DevelopDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/develop/DevelopDataGenerator.java
@@ -116,8 +116,9 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
     sendMessages("messageTask1", "{\"messageVar\": \"someValue\"\n}", 1, String.valueOf(orderId));
     completeTask(instanceKey, "task1", null);
 
-    final long rootCauseDecisionInstance = ZeebeTestUtil.startProcessInstance(
-        true, client, getTenant(TENANT_A), "Process_rootCauseDecision", null);
+    final long rootCauseDecisionInstance =
+        ZeebeTestUtil.startProcessInstance(
+            true, client, getTenant(TENANT_A), "Process_rootCauseDecision", null);
     doNotTouchProcessInstanceKeys.add(rootCauseDecisionInstance);
   }
 
@@ -691,7 +692,6 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
         .timeout(Duration.ofSeconds(JOB_WORKER_TIMEOUT))
         .open();
   }
-
 
   private void createBigProcess(final int loopCardinality, final int numberOfClients) {
     final ObjectMapper objectMapper = new ObjectMapper();

--- a/operate/data-generator/src/main/resources/develop/dmn-with-decisions-chain.dmn
+++ b/operate/data-generator/src/main/resources/develop/dmn-with-decisions-chain.dmn
@@ -27,26 +27,26 @@
     </decisionTable>
   </decision>
   <decision id="decision-a" name="DecisionA">
-    <informationRequirement id="InformationRequirement_A_requires_B">
-      <requiredDecision href="#decision-b" />
-    </informationRequirement>
-    <decisionTable id="DecisionTable_A">
-      <input id="Input_A" label="From DecisionB">
-        <inputExpression id="InputExpression_A" typeRef="string">
-          <text>DecisionB</text>
-        </inputExpression>
-      </input>
-      <output id="Output_A" name="Result" typeRef="string"/>
-      <rule id="Rule_A_1">
-        <inputEntry id="InputEntry_A_1">
-          <text>"passed"</text>
-        </inputEntry>
-        <outputEntry id="OutputEntry_A_1">
-          <text>if random() &lt; 0.3 then assert(0,1) else "final"</text>
-        </outputEntry>
-      </rule>
-    </decisionTable>
-  </decision>
+      <informationRequirement id="InformationRequirement_A_requires_B">
+        <requiredDecision href="#decision-b"/>
+      </informationRequirement>
+      <decisionTable id="DecisionTable_A">
+        <input id="Input_A" label="From DecisionB">
+          <inputExpression id="InputExpression_A" typeRef="string">
+            <text>DecisionB</text>
+          </inputExpression>
+        </input>
+        <output id="Output_A" name="Result" typeRef="string"/>
+        <rule id="Rule_A_1">
+          <inputEntry id="InputEntry_A_1">
+            <text>"passed"</text>
+          </inputEntry>
+          <outputEntry id="OutputEntry_A_1">
+            <text>"final"</text>
+          </outputEntry>
+        </rule>
+      </decisionTable>
+    </decision>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
       <dmndi:DMNShape dmnElementRef="decision-b">

--- a/operate/data-generator/src/main/resources/develop/dmn-with-decisions-chain.dmn
+++ b/operate/data-generator/src/main/resources/develop/dmn-with-decisions-chain.dmn
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_root_cause_drd" name="Root Cause Decision DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <decision id="decision-c" name="DecisionC">
+    <literalExpression id="LiteralExpression_C">
+      <text>assert(0,1)</text>
+    </literalExpression>
+  </decision>
+  <decision id="decision-b" name="DecisionB">
+    <informationRequirement id="InformationRequirement_B_requires_C">
+      <requiredDecision href="#decision-c" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_B">
+      <input id="Input_B" label="From DecisionC">
+        <inputExpression id="InputExpression_B" typeRef="string">
+          <text>DecisionC</text>
+        </inputExpression>
+      </input>
+      <output id="Output_B" name="Result" typeRef="string" />
+      <rule id="Rule_B_1">
+        <inputEntry id="InputEntry_B_1">
+          <text>"ok"</text>
+        </inputEntry>
+        <outputEntry id="OutputEntry_B_1">
+          <text>"passed"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="decision-a" name="DecisionA">
+    <informationRequirement id="InformationRequirement_A_requires_B">
+      <requiredDecision href="#decision-b" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_A">
+      <input id="Input_A" label="From DecisionB">
+        <inputExpression id="InputExpression_A" typeRef="string">
+          <text>DecisionB</text>
+        </inputExpression>
+      </input>
+      <output id="Output_A" name="Result" typeRef="string"/>
+      <rule id="Rule_A_1">
+        <inputEntry id="InputEntry_A_1">
+          <text>"passed"</text>
+        </inputEntry>
+        <outputEntry id="OutputEntry_A_1">
+          <text>if random() &lt; 0.3 then assert(0,1) else "final"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="decision-b">
+        <dc:Bounds height="80" width="180" x="340" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape dmnElementRef="decision-c">
+        <dc:Bounds height="80" width="180" x="120" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge dmnElementRef="InformationRequirement_A_requires_B">
+        <di:waypoint x="520" y="140" />
+        <di:waypoint x="540" y="140" />
+        <di:waypoint x="560" y="140" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge dmnElementRef="InformationRequirement_B_requires_C">
+        <di:waypoint x="300" y="140" />
+        <di:waypoint x="340" y="140" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNShape id="DMNShape_1d0zc3a" dmnElementRef="decision-a">
+        <dc:Bounds height="80" width="180" x="560" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/operate/data-generator/src/main/resources/develop/process-with-root-cause-decision.bpmn
+++ b/operate/data-generator/src/main/resources/develop/process-with-root-cause-decision.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.34.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_rootCauseDecision" name="Process with root cause decision" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start" />
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="BusinessRuleTask_1" />
+    <bpmn:businessRuleTask id="BusinessRuleTask_1" name="Evaluate Main Decision">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="decision-a" resultVariable="result" />
+      </bpmn:extensionElements>
+    </bpmn:businessRuleTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="BusinessRuleTask_1" targetRef="UserTask_1" />
+    <bpmn:userTask id="UserTask_1" name="Manual Review">
+      <bpmn:extensionElements>
+        <zeebe:assignmentDefinition candidateGroups="demo" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="UserTask_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1" name="End" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_rootCauseDecision">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_BusinessRuleTask_1" bpmnElement="BusinessRuleTask_1">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_UserTask_1" bpmnElement="UserTask_1">
+        <dc:Bounds x="380" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="EndEvent_1">
+        <dc:Bounds x="520" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_Flow_1" bpmnElement="Flow_1">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_Flow_2" bpmnElement="Flow_2">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="380" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_Flow_3" bpmnElement="Flow_3">
+        <di:waypoint x="480" y="118" />
+        <di:waypoint x="520" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

- Added DMN decision chain and BPMN process Process_rootCauseDecision as a demo data for root cause decision
- `DevelopDataGenerator` extended to include new instances 

<img width="473" height="597" alt="image" src="https://github.com/user-attachments/assets/e5da747f-744c-4ed2-b56e-b730690b1aed" />


## Related issues

related to #38517 
