### PR TITLE
[Backport release-8.8.0] fix: Get decision instance by ID does not return evaluatedInputs and matchedRules

### DIFF
--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -458,6 +458,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -455,12 +455,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>configuration</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
@@ -15,8 +15,6 @@ import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AV
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
-import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
-import static org.skyscreamer.jsonassert.JSONCompareMode.LENIENT;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -126,7 +124,7 @@ class DecisionInstanceSearchTest {
 
   @Test
   public void shouldRetrieveDecisionInstanceByDecisionDefinitionKey(
-      final CamundaClient camundaClient) throws Exception {
+      final CamundaClient camundaClient) {
     // when
     final long decisionDefinitionKey =
         EVALUATED_DECISIONS
@@ -146,34 +144,27 @@ class DecisionInstanceSearchTest {
 
     // then
     assertThat(result.items().size()).isEqualTo(1);
-    final String expected =
-        """
-            {
-               "decisionInstanceKey": %d,
-               "decisionInstanceId": "%s",
-               "state": "EVALUATED",
-               "evaluationFailure": null,
-               "processDefinitionKey": -1,
-               "processInstanceKey": -1,
-               "elementInstanceKey": -1,
-               "decisionDefinitionId": "decision_1",
-               "decisionDefinitionName": "Loan Eligibility",
-               "decisionDefinitionVersion": 1,
-               "decisionDefinitionType": "DECISION_TABLE",
-               "tenantId": "<default>",
-               "evaluatedInputs": null,
-               "matchedRules": null,
-               "result": "\\"Eligible\\"",
-               "decisionDefinitionKey": %d
-             }"""
-            .formatted(decisionInstanceKey, decisionInstanceId, decisionDefinitionKey);
-    assertEquals(
-        expected,
-        result.singleItem().toJson(),
-        LENIENT); // lenient since we cannot assert the evaluationDate
-    assertThat(result.singleItem().getEvaluationDate()).isNotNull();
-    assertThat(result.singleItem().getEvaluatedInputs()).isNull();
-    assertThat(result.singleItem().getMatchedRules()).isNull();
+    final var decisionInstance = result.singleItem();
+
+    assertThat(decisionInstance.getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
+    assertThat(decisionInstance.getDecisionInstanceId()).isEqualTo(decisionInstanceId);
+    assertThat(decisionInstance.getState()).isEqualTo(DecisionInstanceState.EVALUATED);
+    assertThat(decisionInstance.getEvaluationFailure()).isNull();
+    assertThat(decisionInstance.getProcessDefinitionKey()).isEqualTo(-1L);
+    assertThat(decisionInstance.getProcessInstanceKey()).isEqualTo(-1L);
+    assertThat(decisionInstance.getElementInstanceKey()).isEqualTo(-1L);
+    assertThat(decisionInstance.getDecisionDefinitionId()).isEqualTo("decision_1");
+    assertThat(decisionInstance.getDecisionDefinitionName()).isEqualTo("Loan Eligibility");
+    assertThat(decisionInstance.getDecisionDefinitionVersion()).isEqualTo(1);
+    assertThat(decisionInstance.getDecisionDefinitionType())
+        .isEqualTo(DecisionDefinitionType.DECISION_TABLE);
+    assertThat(decisionInstance.getTenantId()).isEqualTo("<default>");
+    assertThat(decisionInstance.getDecisionDefinitionKey()).isEqualTo(decisionDefinitionKey);
+    assertThat(decisionInstance.getResult()).isEqualTo("\"Eligible\"");
+    assertThat(decisionInstance.getEvaluationDate()).isNotNull();
+    // evaluated inputs and matched rules are not included in search results, only in get by id
+    assertThat(decisionInstance.getEvaluatedInputs()).isNull();
+    assertThat(decisionInstance.getMatchedRules()).isNull();
   }
 
   @Test
@@ -415,7 +406,7 @@ class DecisionInstanceSearchTest {
   }
 
   @Test
-  void shouldGetDecisionInstance() throws Exception {
+  void shouldGetDecisionInstance() {
     // when
     final long decisionInstanceKey =
         EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_2).getDecisionInstanceKey();
@@ -430,53 +421,42 @@ class DecisionInstanceSearchTest {
         camundaClient.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
 
     // then
-    final String expected =
-        """
-            {
-                 "decisionInstanceKey": %d,
-                 "decisionInstanceId": "%s",
-                 "state": "EVALUATED",
-                 "evaluationFailure": null,
-                 "processDefinitionKey": -1,
-                 "processInstanceKey": -1,
-                 "elementInstanceKey": -1,
-                 "decisionDefinitionId": "invoiceClassification",
-                 "decisionDefinitionName": "Invoice Classification",
-                 "decisionDefinitionVersion": 1,
-                 "decisionDefinitionType": "DECISION_TABLE",
-                 "tenantId": "<default>",
-                 "evaluatedInputs": [
-                     {
-                         "inputId": "clause1",
-                         "inputName": "Invoice Amount",
-                         "inputValue": "100"
-                     },
-                     {
-                         "inputId": "InputClause_15qmk0v",
-                         "inputName": "Invoice Category",
-                         "inputValue": "\\"Misc\\""
-                     }
-                 ],
-                 "matchedRules": [
-                     {
-                         "ruleId": "DecisionRule_1of5a87",
-                         "ruleIndex": 1,
-                         "evaluatedOutputs": [
-                             {
-                                 "outputId": "clause3",
-                                 "outputName": "Classification",
-                                 "outputValue": "\\"day-to-day expense\\""
-                             }
-                         ]
-                     }
-                 ],
-                 "result": "\\"day-to-day expense\\"",
-                 "decisionDefinitionKey": %d
-             }"""
-            .formatted(decisionInstanceKey, decisionInstanceId, decisionDefinitionKey);
-    assertEquals(
-        expected, result.toJson(), LENIENT); // lenient since we cannot assert the evaluationDate
+    assertThat(result.getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
+    assertThat(result.getDecisionInstanceId()).isEqualTo(decisionInstanceId);
+    assertThat(result.getState()).isEqualTo(DecisionInstanceState.EVALUATED);
+    assertThat(result.getEvaluationFailure()).isNull();
+    assertThat(result.getProcessDefinitionKey()).isEqualTo(-1L);
+    assertThat(result.getProcessInstanceKey()).isEqualTo(-1L);
+    assertThat(result.getElementInstanceKey()).isEqualTo(-1L);
+    assertThat(result.getDecisionDefinitionId()).isEqualTo("invoiceClassification");
+    assertThat(result.getDecisionDefinitionName()).isEqualTo("Invoice Classification");
+    assertThat(result.getDecisionDefinitionVersion()).isEqualTo(1);
+    assertThat(result.getDecisionDefinitionType()).isEqualTo(DecisionDefinitionType.DECISION_TABLE);
+    assertThat(result.getTenantId()).isEqualTo("<default>");
+    assertThat(result.getDecisionDefinitionKey()).isEqualTo(decisionDefinitionKey);
+    assertThat(result.getResult()).isEqualTo("\"day-to-day expense\"");
     assertThat(result.getEvaluationDate()).isNotNull();
+
+    // Assert evaluated inputs
+    assertThat(result.getEvaluatedInputs()).hasSize(2);
+    assertThat(result.getEvaluatedInputs().get(0).getInputId()).isEqualTo("clause1");
+    assertThat(result.getEvaluatedInputs().get(0).getInputName()).isEqualTo("Invoice Amount");
+    assertThat(result.getEvaluatedInputs().get(0).getInputValue()).isEqualTo("100");
+    assertThat(result.getEvaluatedInputs().get(1).getInputId()).isEqualTo("InputClause_15qmk0v");
+    assertThat(result.getEvaluatedInputs().get(1).getInputName()).isEqualTo("Invoice Category");
+    assertThat(result.getEvaluatedInputs().get(1).getInputValue()).isEqualTo("\"Misc\"");
+
+    // Assert matched rules
+    assertThat(result.getMatchedRules()).hasSize(1);
+    assertThat(result.getMatchedRules().get(0).getRuleId()).isEqualTo("DecisionRule_1of5a87");
+    assertThat(result.getMatchedRules().get(0).getRuleIndex()).isEqualTo(1);
+    assertThat(result.getMatchedRules().get(0).getEvaluatedOutputs()).hasSize(1);
+    assertThat(result.getMatchedRules().get(0).getEvaluatedOutputs().get(0).getOutputId())
+        .isEqualTo("clause3");
+    assertThat(result.getMatchedRules().get(0).getEvaluatedOutputs().get(0).getOutputName())
+        .isEqualTo("Classification");
+    assertThat(result.getMatchedRules().get(0).getEvaluatedOutputs().get(0).getOutputValue())
+        .isEqualTo("\"day-to-day expense\"");
   }
 
   @Test

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DecisionInstanceDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DecisionInstanceDocumentReader.java
@@ -27,7 +27,12 @@ public class DecisionInstanceDocumentReader extends DocumentBasedReader
       final String id, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()
         .getByQuery(
-            DecisionInstanceQuery.of(b -> b.filter(f -> f.decisionInstanceIds(id)).singleResult()),
+            DecisionInstanceQuery.of(
+                b ->
+                    b.filter(f -> f.decisionInstanceIds(id))
+                        .resultConfig(
+                            c -> c.includeEvaluatedInputs(true).includeEvaluatedOutputs(true))
+                        .singleResult()),
             io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity.class);
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionInstanceExportHandler.java
@@ -102,6 +102,7 @@ public class DecisionInstanceExportHandler
         .evaluationFailure(
             state == DecisionInstanceState.FAILED ? value.getEvaluationFailureMessage() : null)
         .partitionId(record.getPartitionId())
+        .tenantId(value.getTenantId())
         .build();
   }
 

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -315,13 +315,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.vaadin.external.google</groupId>
-      <artifactId>android-json</artifactId>
-      <version>0.0.20131108.vaadin1</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
       <scope>test</scope>

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -171,7 +170,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
           expected,
           new String(Objects.requireNonNull(actualBytes), StandardCharsets.UTF_8),
           JSONCompareMode.NON_EXTENSIBLE);
-    } catch (final JSONException e) {
+    } catch (final Exception e) {
       throw new AssertionError(e);
     }
   }


### PR DESCRIPTION
# Description
Backport of #38648 to `release-8.8.0`.

relates to #38634