### PR TITLE
Add developer guides for the engine

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,3 +79,10 @@ using BPMN (Business Process Model and Notation) for process definition and exec
 - Always create composite actions in `.github/actions` subdirectories named in kebab case
 - Always create a `README.md` for composite actions describing purpose, inputs, outputs and example usage
 
+## Finding Documentation
+
+- Always check whether documentation exists for the module you are working on
+- If documentation exists in the module, read it before making changes to the code
+- Check README.md and other markdown files in the directory to find documentation
+- If you work on the workflow engine, check the engine [README](/zeebe/engine/README.md)
+- Further documentation and development guidelines can be found in the `docs/` directory

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,3 +86,4 @@ using BPMN (Business Process Model and Notation) for process definition and exec
 - Check README.md and other markdown files in the directory to find documentation
 - If you work on the workflow engine, check the engine [README](/zeebe/engine/README.md)
 - Further documentation and development guidelines can be found in the `docs/` directory
+

--- a/zeebe/README.md
+++ b/zeebe/README.md
@@ -5,22 +5,54 @@ Zeebe is the process automation engine powering Camunda 8. While written in Java
 ## Modules
 
 This is a small overview of the contents of the different modules:
-- `util` contains custom implementations of building blocks like an actor scheduler, buffer allocations, and metrics. Its parts are used in most of the other modules
-- `protocol` contains the SBE definition of the main message protocol
-- `bpmn-model` is a Java API for BPMN process definitions used for parsing etc.
-- `msgpack-*` is a custom msgpack implementation with extensions to evaluate json-path expressions on msgpack objects
-- `dispatcher` is a custom implementation of message passing between threads
-- `service-container` is a custom implementation to manage dependencies between different services
-- `logstreams` is an implementation of an append-only log backed by the filesystem
-- `transport` is our abstraction over network transports
-- `gateway` is the implementation of the gRPC gateway, using our SBE-based protocol to communicate with brokers
-- `gateway-protocol` contains the gRPC definitions for the Zeebe client-to-gateway protocol
-- `zb-db` is our RocksDB wrapper for state management
-- `engine`  is the implementation of the event stream processor
-- `broker` contains the Zeebe broker which is the server side of Zeebe
-- `client-java` contains the Java Zeebe client
+- `auth` authentication and authorization components shared by broker and gateway
 - `atomix` contains transport, membership, and consensus algorithms
-- `load-tests` contains utilities the team uses to run load tests
-- `exporters/elasticsearch-exporter` contains the official Elasticsearch exporter for Zeebe
+- `backup` abstracts how primary storage backups are handled in Zeebe
+- `backup-store` implementations for different backup stores
+  - `backup-stores/azure` Microsoft Azure Blob Storage backup store implementation
+  - `backup-stores/common` shared abstractions for backup store implementations
+  - `backup-stores/filesystem` filesystem-based backup store
+  - `backup-stores/gcs` Google Cloud Storage backup store implementation
+  - `backup-stores/s3` Amazon S3 backup store implementation
+  - `backup-stores/testkit` testing utilities/fakes for backup stores
+- `bpmn-model` is a Java API for BPMN process definitions used for parsing etc.
+- `broker` contains the Zeebe broker which is the server side of Zeebe
+- `broker-client` client for internal communication between cluster components
+- `client-java` contains the Java Zeebe client
+- `dmn` implementation of the DMN standard in the engine
+- `dynamic-config` dynamic configuration management for brokers
+- `engine` is the implementation of the event stream processor
+- `exporter-api` exporter SPI for implementing exporters
+  - `exporters/camunda-exporter` Camunda Platform exporter implementation
+  - `exporters/elasticsearch-exporter` contains the official Elasticsearch exporter for Zeebe
+  - `exporters/opensearch-exporter` OpenSearch exporter implementation
+  - `exporters/rdbms-exporter` RDBMS exporter implementation
+- `exporter-common` common utilities for exporter implementations
+- `exporter-test` thread-safe exporter test controller
+- `expression-language` engine core expression evaluation
+- `feel` engine integration with FEEL expression language
+- `feel-tagged-parameters` tagged parameter support FEEL extension
+- `gateway` is the implementation of the gRPC gateway, using our SBE-based protocol to communicate with brokers
+- `gateway-grpc` gateway gRPC server implementation
+- `gateway-protocol` contains the gRPC definitions for the Zeebe client-to-gateway protocol
+- `gateway-protocol-impl` gRPC protocol service definition
+- `gateway-rest` gateway REST API implementation
 - `journal` contains the append-only log used by the consensus algorithm
+- `logstreams` is an implementation of an append-only log backed by the filesystem
+- `msgpack-core` core Message Pack encoding/decoding implementation
+- `msgpack-value` Message Pack property value representation
+- `protocol` contains the SBE definition of the main message protocol
+- `protocol-asserts` protocol generated _assertj_ assertion utilities
+- `protocol-impl` protocol record definitions
+- `protocol-jackson` Jackson (JSON) mapping support for Zeebe protocol objects
+- `protocol-test-util` test utilities for working with protocol record and SBE
+- `restore` implementation of restoring primary storage state from backups
+- `scheduler` actor scheduler implementation
+- `service-container` is a custom implementation to manage dependencies between different services
 - `snapshots` abstracts how state snapshots (i.e. `zb-db`) are handled
+- `stream-platform` composable stream processing platform primitives used by the engine
+- `test-util` shared testing utilities
+- `transport` is our abstraction over network transports
+- `util` contains custom implementations of building blocks like an actor scheduler, buffer allocations, and metrics. Its parts are used in most of the other modules
+- `zb-db` is our RocksDB wrapper for state management
+- `qa` engine integration test suite

--- a/zeebe/README.md
+++ b/zeebe/README.md
@@ -5,54 +5,54 @@ Zeebe is the process automation engine powering Camunda 8. While written in Java
 ## Modules
 
 This is a small overview of the contents of the different modules:
-- `auth` authentication and authorization components shared by broker and gateway
-- `atomix` contains transport, membership, and consensus algorithms
-- `backup` abstracts how primary storage backups are handled in Zeebe
-- `backup-store` implementations for different backup stores
-  - `backup-stores/azure` Microsoft Azure Blob Storage backup store implementation
-  - `backup-stores/common` shared abstractions for backup store implementations
-  - `backup-stores/filesystem` filesystem-based backup store
-  - `backup-stores/gcs` Google Cloud Storage backup store implementation
-  - `backup-stores/s3` Amazon S3 backup store implementation
-  - `backup-stores/testkit` testing utilities/fakes for backup stores
-- `bpmn-model` is a Java API for BPMN process definitions used for parsing etc.
-- `broker` contains the Zeebe broker which is the server side of Zeebe
-- `broker-client` client for internal communication between cluster components
-- `client-java` contains the Java Zeebe client
-- `dmn` implementation of the DMN standard in the engine
-- `dynamic-config` dynamic configuration management for brokers
-- `engine` is the implementation of the event stream processor
-- `exporter-api` exporter SPI for implementing exporters
-  - `exporters/camunda-exporter` Camunda Platform exporter implementation
-  - `exporters/elasticsearch-exporter` contains the official Elasticsearch exporter for Zeebe
-  - `exporters/opensearch-exporter` OpenSearch exporter implementation
-  - `exporters/rdbms-exporter` RDBMS exporter implementation
-- `exporter-common` common utilities for exporter implementations
-- `exporter-test` thread-safe exporter test controller
-- `expression-language` engine core expression evaluation
-- `feel` engine integration with FEEL expression language
-- `feel-tagged-parameters` tagged parameter support FEEL extension
-- `gateway` is the implementation of the gRPC gateway, using our SBE-based protocol to communicate with brokers
-- `gateway-grpc` gateway gRPC server implementation
-- `gateway-protocol` contains the gRPC definitions for the Zeebe client-to-gateway protocol
-- `gateway-protocol-impl` gRPC protocol service definition
-- `gateway-rest` gateway REST API implementation
-- `journal` contains the append-only log used by the consensus algorithm
-- `logstreams` is an implementation of an append-only log backed by the filesystem
-- `msgpack-core` core Message Pack encoding/decoding implementation
-- `msgpack-value` Message Pack property value representation
-- `protocol` contains the SBE definition of the main message protocol
-- `protocol-asserts` protocol generated _assertj_ assertion utilities
-- `protocol-impl` protocol record definitions
-- `protocol-jackson` Jackson (JSON) mapping support for Zeebe protocol objects
-- `protocol-test-util` test utilities for working with protocol record and SBE
-- `restore` implementation of restoring primary storage state from backups
-- `scheduler` actor scheduler implementation
-- `service-container` is a custom implementation to manage dependencies between different services
-- `snapshots` abstracts how state snapshots (i.e. `zb-db`) are handled
-- `stream-platform` composable stream processing platform primitives used by the engine
-- `test-util` shared testing utilities
-- `transport` is our abstraction over network transports
-- `util` contains custom implementations of building blocks like an actor scheduler, buffer allocations, and metrics. Its parts are used in most of the other modules
-- `zb-db` is our RocksDB wrapper for state management
-- `qa` engine integration test suite
+* `auth` authentication and authorization components shared by broker and gateway
+* `atomix` contains transport, membership, and consensus algorithms
+* `backup` abstracts how primary storage backups are handled in Zeebe
+* `backup-store` implementations for different backup stores
+  * `backup-stores/azure` Microsoft Azure Blob Storage backup store implementation
+  * `backup-stores/common` shared abstractions for backup store implementations
+  * `backup-stores/filesystem` filesystem-based backup store
+  * `backup-stores/gcs` Google Cloud Storage backup store implementation
+  * `backup-stores/s3` Amazon S3 backup store implementation
+  * `backup-stores/testkit` testing utilities/fakes for backup stores
+* `bpmn-model` is a Java API for BPMN process definitions used for parsing etc.
+* `broker` contains the Zeebe broker which is the server side of Zeebe
+* `broker-client` client for internal communication between cluster components
+* `client-java` contains the Java Zeebe client
+* `dmn` implementation of the DMN standard in the engine
+* `dynamic-config` dynamic configuration management for brokers
+* `engine` is the implementation of the event stream processor
+* `exporter-api` exporter SPI for implementing exporters
+  * `exporters/camunda-exporter` Camunda Platform exporter implementation
+  * `exporters/elasticsearch-exporter` contains the official Elasticsearch exporter for Zeebe
+  * `exporters/opensearch-exporter` OpenSearch exporter implementation
+  * `exporters/rdbms-exporter` RDBMS exporter implementation
+* `exporter-common` common utilities for exporter implementations
+* `exporter-test` thread-safe exporter test controller
+* `expression-language` engine core expression evaluation
+* `feel` engine integration with FEEL expression language
+* `feel-tagged-parameters` tagged parameter support FEEL extension
+* `gateway` is the implementation of the gRPC gateway, using our SBE-based protocol to communicate with brokers
+* `gateway-grpc` gateway gRPC server implementation
+* `gateway-protocol` contains the gRPC definitions for the Zeebe client-to-gateway protocol
+* `gateway-protocol-impl` gRPC protocol service definition
+* `gateway-rest` gateway REST API implementation
+* `journal` contains the append-only log used by the consensus algorithm
+* `logstreams` is an implementation of an append-only log backed by the filesystem
+* `msgpack-core` core Message Pack encoding/decoding implementation
+* `msgpack-value` Message Pack property value representation
+* `protocol` contains the SBE definition of the main message protocol
+* `protocol-asserts` protocol generated _assertj_ assertion utilities
+* `protocol-impl` protocol record definitions
+* `protocol-jackson` Jackson (JSON) mapping support for Zeebe protocol objects
+* `protocol-test-util` test utilities for working with protocol record and SBE
+* `restore` implementation of restoring primary storage state from backups
+* `scheduler` actor scheduler implementation
+* `service-container` is a custom implementation to manage dependencies between different services
+* `snapshots` abstracts how state snapshots (i.e. `zb-db`) are handled
+* `stream-platform` composable stream processing platform primitives used by the engine
+* `test-util` shared testing utilities
+* `transport` is our abstraction over network transports
+* `util` contains custom implementations of building blocks like an actor scheduler, buffer allocations, and metrics. Its parts are used in most of the other modules
+* `zb-db` is our RocksDB wrapper for state management
+* `qa` engine integration test suite

--- a/zeebe/README.md
+++ b/zeebe/README.md
@@ -8,13 +8,13 @@ This is a small overview of the contents of the different modules:
 * `auth` authentication and authorization components shared by broker and gateway
 * `atomix` contains transport, membership, and consensus algorithms
 * `backup` abstracts how primary storage backups are handled in Zeebe
-* `backup-store` implementations for different backup stores
-  * `backup-stores/azure` Microsoft Azure Blob Storage backup store implementation
-  * `backup-stores/common` shared abstractions for backup store implementations
-  * `backup-stores/filesystem` filesystem-based backup store
-  * `backup-stores/gcs` Google Cloud Storage backup store implementation
-  * `backup-stores/s3` Amazon S3 backup store implementation
-  * `backup-stores/testkit` testing utilities/fakes for backup stores
+* `backup-stores` implementations for different backup stores
+* `backup-stores/azure` Microsoft Azure Blob Storage backup store implementation
+* `backup-stores/common` shared abstractions for backup store implementations
+* `backup-stores/filesystem` filesystem-based backup store
+* `backup-stores/gcs` Google Cloud Storage backup store implementation
+* `backup-stores/s3` Amazon S3 backup store implementation
+* `backup-stores/testkit` testing utilities/fakes for backup stores
 * `bpmn-model` is a Java API for BPMN process definitions used for parsing etc.
 * `broker` contains the Zeebe broker which is the server side of Zeebe
 * `broker-client` client for internal communication between cluster components
@@ -23,10 +23,10 @@ This is a small overview of the contents of the different modules:
 * `dynamic-config` dynamic configuration management for brokers
 * `engine` is the implementation of the event stream processor
 * `exporter-api` exporter SPI for implementing exporters
-  * `exporters/camunda-exporter` Camunda Platform exporter implementation
-  * `exporters/elasticsearch-exporter` contains the official Elasticsearch exporter for Zeebe
-  * `exporters/opensearch-exporter` OpenSearch exporter implementation
-  * `exporters/rdbms-exporter` RDBMS exporter implementation
+* `exporters/camunda-exporter` Camunda Platform exporter implementation
+* `exporters/elasticsearch-exporter` contains the official Elasticsearch exporter for Zeebe
+* `exporters/opensearch-exporter` OpenSearch exporter implementation
+* `exporters/rdbms-exporter` RDBMS exporter implementation
 * `exporter-common` common utilities for exporter implementations
 * `exporter-test` thread-safe exporter test controller
 * `expression-language` engine core expression evaluation

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -1,6 +1,11 @@
 # The Zeebe Workflow Engine
 
-## Introduction
+The workflow engine is the core component of Zeebe. It is responsible for executing process
+instances, managing state, and ensuring the correct execution of BPMN processes, as well as the
+evaluation of decision instances.
+
+This README will provide an overview of the engine's architecture, key components, and guidelines
+for contributing to its development.
 
 ## High-level engine architecture
 

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -85,7 +85,8 @@ access the read-only `DbUserState` methods, but the `UserCreatedApplier` class u
 
 ### `metrics` package
 
-// TODO: add metrics package description
+The `metrics` package contains the classes used by the engine to collect processing-related metrics.
+When adding a new feature, consider if it would be useful to add new metrics to monitor its behavior.
 
 ## How do I implement a new feature?
 

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -72,15 +72,21 @@ the journey of a command record begins, once it enters the engine domain.
 
 - TODO: example feature
 
-### Do's and Don'ts
+### Testing guidelines
 
-#### The stream processor is single threaded
+### Follow-up tasks
+
+- Zeebe QA, Camunda QA, clients...
+
+## Do's and Don'ts
+
+### The stream processor is single threaded
 
 - Only one command is processed at a time.
 - **Don't** block the thread unnecessarily.
 - **Do** take small steps by breaking up the processing into smaller chunks by appending follow-up commands.
 
-#### State changes should be reflected on the log stream
+### State changes should be reflected on the log stream
 
 - This allows events to be replayed on restart to rebuild the state.
 - **Don't** change state from a processor.
@@ -91,17 +97,17 @@ the journey of a command record begins, once it enters the engine domain.
 - Keep documentation up to date
 - **Do** update config templates when adding new configuration options.
 
-#### We prefer composition over inheritance
+### We prefer composition over inheritance
 
 - **Do** create behavior classes to reuse code.
 - **Don't** use subclasses for code reuse.
 
-#### Processors do not have access to the secondary storage
+### Processors do not have access to the secondary storage
 
 - **Do** access the immutable state from a processor.
 - **Do** access the secondary storage from a scheduled task.
 
-#### Event appliers are not allowed to be changed after having been released
+### Event appliers are not allowed to be changed after having been released
 
 - Events must be applied in the same way on replay as when they were initially appended.
 - **Don't** change the event applier implementation.
@@ -115,48 +121,42 @@ the journey of a command record begins, once it enters the engine domain.
 - **Do** use the state data to decide whether the request is possible.
 - **Do** use the state data as the basis for modifications.
 
-#### Construction of records is expensive
+### Construction of records is expensive
 
 - **Do** reuse and modify them for performance.
 - **Do** use `wrap` to quickly pass data from one object to another.
 - **Do** use `copyFrom` if you need a deep copy for more safety.
 
-#### Record values are data objects that are often reused across different records of the same value type
+### Record values are data objects that are often reused across different records of the same value type
 
 - **Do** use a different value type when only a subset of properties are relevant to a specific intent. But if you need to, please document the properties in the record that are only provided on specific intents.
 
-#### State classes provide references that may be modified without your knowledge
+### State classes provide references that may be modified without your knowledge
 
 - **Do** use the `Supplier` parameter to create safe copies directly if needed. Comes at the cost of performance.
 
-#### The state and rejection writers do not take care of writing a response to the request
+### The state and rejection writers do not take care of writing a response to the request
 
 - The command may belong to a request that's awaiting a response.
 - **Do** use the response writer to send a response.
 
-#### Side-effects are not guaranteed to be executed
+### Side-effects are not guaranteed to be executed
 
 - Side-effects are executed before the next command is picked up, but if execution fails or if failover occurs the side-effect may not be executed.
 - **Don't** do things that must happen in a side-effect.
 - **Do** use side-effects for things like updating caches or sending responses.
 
-#### Changes to transformers may result in differences during replay
+### Changes to transformers may result in differences during replay
 
 - Transformers are not versioned like event appliers.
 - **Do** be careful about changing existing transformers.
 
-#### Scheduled tasks can flood the logstream
+### Scheduled tasks can flood the logstream
 
 - The stream processor may not be fast enough to process all the commands appended by a scheduled task.
 - **Do** yield the thread after some time
 - **Do** yield the thread after some number of actions taken, e.g. commands appended.
 
-#### The `RecordingExporter` keeps the stream open unless short-circuited
+### The `RecordingExporter` keeps the stream open unless short-circuited
 
 - **Do** short-circuit the `RecordingExporter`  using `.limit`, `.getFirst` , `.exists`.
-
-### Testing guidelines
-
-### Follow-up tasks
-
-- Zeebe QA, Camunda QA, clients...

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -60,7 +60,28 @@ the journey of a command record begins, once it enters the engine domain.
 
 ### `state` package
 
-// TODO: add state package description
+The `state` package contains the state model of the engine. This is the next stop after a command
+record is processed by a processor class. Processor classes use the `stateWriter` to output event
+records. These event records are then applied to the various Zeebe `State` classes using `Applier`
+classes, both contained withing this package.
+
+You can find all the applier classes listed in the `EventAppliers` class. `EventApplier` classes
+extract the data from the event record and pass it to a `State` class. One example is the
+`UserCreatedApplier` class, which passes the user information from a `User` event record to the
+`UserState` class. It is important to not that if the behavior of an `EventApplier` class is changed,
+a follow-up version of that `EventApplier` class must be created to ensure that the engine can
+correctly apply the event record in the future.
+
+The various `State` classes are instantiated in the `ProcessingDbState` class, which is used by
+the `EngineProcessor` and `BpmnProcessor` classes to access the state of the engine, as well as the
+`EventApplier` classes to apply event records to the state.
+
+However, the `Processor` classes may only access the read-only interfaces of the `State` classes,
+while the `EventApplier` classes should use the `MutableState` interfaces of a State implementation.
+This is to ensure that the state is only modified by event records, and not by processor classes. As
+an example, consider that in the `UserCreateProcessor` class, the `UserState` interface is used to
+access the read-only `DbUserState` methods, but the `UserCreatedApplier` class uses the
+`MutableUserState` interface to access the `DbUserState` methods that modify the state.
 
 ### `metrics` package
 

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -4,7 +4,22 @@
 
 ## High-level engine architecture
 
-https://github.com/zeebe-io/enhancements/blob/master/ZEP004-wf-stream-processing.md
+The Zeebe Workflow Engine is a state machine for entities like jobs and processes.
+
+The engine is implemented as a state machine that maintains the state of entities (jobs, processes, etc.) in a key-value store (RocksDB).
+State transitions are driven by a stream of records that are appended to an append-only log.
+
+The engine is implemented as a collection of stream processors. It is designed to be able to recover its state by replaying the record stream.
+For this reason, records in the stream are split into commands, events, and rejections.
+
+- **Commands** are requests to the engine to perform some action, e.g. create a new process instance or complete a job.
+- **Events** are the result of processing commands, e.g. a process instance was created or a job was completed.
+- **Rejections** are indications that a command could not be processed.
+
+During **command** processing, the engine may append events and follow-up commands to the stream.
+State changes are applied when processing **events** from the stream.
+
+To learn more about replay, see [ZEP004](https://github.com/zeebe-io/enhancements/blob/master/ZEP004-wf-stream-processing.md).
 
 ## How do I implement a new feature?
 

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -111,11 +111,17 @@ To illustrate how to implement a new feature in the engine, let's consider the f
    You might need to break down your state class into multiple objects depending on the complexity.
    Add your new state to [`ProcessingState`](src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java).
 
-3. **Add a new Intent**.
+3. **Add a new Intent**. You normally need to introduce a new intent when you introduce a new value type.
+   In this case, we need a new intent [`UserIntent`](../protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserIntent.java).
 
-4. **Add a new Processor**.
+4. **Add a new Processor**. You need to add a new processor to handle the new command.
+   In this case, we need a new processor [`UserCreateProcessor`](src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java) to handle the `CREATE` command.
+   Register your new processor in [`EngineProcessors`](src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java).
 
 5. **Add a new EventApplier**.
+    You need to add a new event applier to apply the new event to the state.
+    In this case, we need a new event applier [`UserCreatedApplier`](src/main/java/io/camunda/zeebe/engine/state/appliers/UserCreatedApplier.java) to apply the `CREATED` event.
+    Register your new event applier in [`EventAppliers`](src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java).
 
 ### Testing guidelines
 

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -165,50 +165,59 @@ processed by the test engine until the failure. This is provided by the [`Compac
 and is very useful for debugging test failures. You can also get this output by adding an
 `assert false` statement at the end of your test.
 
-The `CompactRecordLogger` output always provides a detailed legend of the abbreviations used, as
-well as the deployed BPMN processes and decomposed keys for easier debugging. Here is an example of
-a failure output from a test that:
+Here is an example of a failure output from a test that:
 1. Deploys a simple process with a service task
 2. Creates a process instance of that process
 3. And updates a job that was created for the service task.
 
-```
-INFO  io.camunda.zeebe.test - Test failed, following records were exported:
-INFO  io.camunda.zeebe.test - Compact log representation:
---------
+The `CompactRecordLogger` output always provides a detailed legend of the abbreviations used:
+<details>
+
 	['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position] K[key] - [summary of value]
 	P9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
 	Keys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
 	Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
 	Headers defined in 'Protocol' are abbreviated (e.g. 'io.camunda.zeebe:userTaskKey:2251799813685253' -> 'uTK:K005').
---------
-C USG_MTRC  EXPORT     #01-> -1  -1 NONE:ACTIVE start[-1] end[-1] reset[-1] (no metricValues)
-E USG_MTRC  EXPORTED   #02->#01 K01 NONE:ACTIVE start[-1] end[-1] reset[T08:33:10.737] (no metricValues)
-C DPLY      CREATE     #03-> -1  -1
-E PROC      CREATED    #04->#03 K03 process.bpmn -> "process" (version:1)
-E DPLY      CREATED    #05->#03 K02 process.bpmn
-C CREA      CREATE     #06-> -1  -1 new <process "process"> (default start)  (no vars)
-C PI        ACTIVATE   #07->#06 K04 PROCESS "process" in <process "process"[K04]>
-E CREA      CREATED    #08->#06 K05 new <process "process"> (default start)  (no vars)
-E PI        ACTIVATING #09->#06 K04 PROCESS "process" in <process "process"[K04]> EI:[K04] PD:[K03]
-E PI        ACTIVATED  #10->#06 K04 PROCESS "process" in <process "process"[K04]>
-C PI        ACTIVATE   #11->#06  -1 START_EVENT "start" in <process "process"[K04]>
-E PI        ACTIVATING #12->#06 K06 START_EVENT "start" in <process "process"[K04]> EI:[K04->K06] PD:[K03]
-E PI        ACTIVATED  #13->#06 K06 START_EVENT "start" in <process "process"[K04]>
-C PI        COMPLETE   #14->#06 K06 START_EVENT "start" in <process "process"[K04]>
-E PI        COMPLETING #15->#06 K06 START_EVENT "start" in <process "process"[K04]>
-E PI        COMPLETED  #16->#06 K06 START_EVENT "start" in <process "process"[K04]>
-E PI        SQ_FLW_TKN #17->#06 K07 SEQUENCE_FLOW "sequenc..e88de26" in <process "process"[K04]>
-C PI        ACTIVATE   #18->#06 K08 SERVICE_TASK "task" in <process "process"[K04]>
-E PI        ACTIVATING #19->#06 K08 SERVICE_TASK "task" in <process "process"[K04]> EI:[K04->K08] PD:[K03]
-E JOB       CREATED    #20->#06 K09 "id-7..d76e" @"task"[K08] 3 retries, (no vars)
-E PI        ACTIVATED  #21->#06 K08 SERVICE_TASK "task" in <process "process"[K04]>
-C JOB_BATCH ACTIVATE   #22-> -1  -1 "id-7921b6c2-24cf-402d-84a2-9e8defc6d76e" max: 10
-E JOB_BATCH ACTIVATED  #23->#22 K10 "id-7921b6c2-24cf-402d-84a2-9e8defc6d76e" 1/10
-                K09 "id-7..d76e" @"task"[K08] 3 retries, (no vars)
-C JOB       UPDATE     #24-> -1 K09  5 retries, (no vars)
-E JOB       UPDATED    #25->#24 K09 "id-7..d76e" @"task"[K08] 5 retries, (no vars)
+</details>
 
+It will provide an abbreviated log of all the records that were processed until the failure:
+<details>
+
+```
+  C USG_MTRC  EXPORT     #01-> -1  -1 NONE:ACTIVE start[-1] end[-1] reset[-1] (no metricValues)
+  E USG_MTRC  EXPORTED   #02->#01 K01 NONE:ACTIVE start[-1] end[-1] reset[T08:33:10.737] (no metricValues)
+  C DPLY      CREATE     #03-> -1  -1
+  E PROC      CREATED    #04->#03 K03 process.bpmn -> "process" (version:1)
+  E DPLY      CREATED    #05->#03 K02 process.bpmn
+  C CREA      CREATE     #06-> -1  -1 new <process "process"> (default start)  (no vars)
+  C PI        ACTIVATE   #07->#06 K04 PROCESS "process" in <process "process"[K04]>
+  E CREA      CREATED    #08->#06 K05 new <process "process"> (default start)  (no vars)
+  E PI        ACTIVATING #09->#06 K04 PROCESS "process" in <process "process"[K04]> EI:[K04] PD:[K03]
+  E PI        ACTIVATED  #10->#06 K04 PROCESS "process" in <process "process"[K04]>
+  C PI        ACTIVATE   #11->#06  -1 START_EVENT "start" in <process "process"[K04]>
+  E PI        ACTIVATING #12->#06 K06 START_EVENT "start" in <process "process"[K04]> EI:[K04->K06] PD:[K03]
+  E PI        ACTIVATED  #13->#06 K06 START_EVENT "start" in <process "process"[K04]>
+  C PI        COMPLETE   #14->#06 K06 START_EVENT "start" in <process "process"[K04]>
+  E PI        COMPLETING #15->#06 K06 START_EVENT "start" in <process "process"[K04]>
+  E PI        COMPLETED  #16->#06 K06 START_EVENT "start" in <process "process"[K04]>
+  E PI        SQ_FLW_TKN #17->#06 K07 SEQUENCE_FLOW "sequenc..e88de26" in <process "process"[K04]>
+  C PI        ACTIVATE   #18->#06 K08 SERVICE_TASK "task" in <process "process"[K04]>
+  E PI        ACTIVATING #19->#06 K08 SERVICE_TASK "task" in <process "process"[K04]> EI:[K04->K08] PD:[K03]
+  E JOB       CREATED    #20->#06 K09 "id-7..d76e" @"task"[K08] 3 retries, (no vars)
+  E PI        ACTIVATED  #21->#06 K08 SERVICE_TASK "task" in <process "process"[K04]>
+  C JOB_BATCH ACTIVATE   #22-> -1  -1 "id-7921b6c2-24cf-402d-84a2-9e8defc6d76e" max: 10
+  E JOB_BATCH ACTIVATED  #23->#22 K10 "id-7921b6c2-24cf-402d-84a2-9e8defc6d76e" 1/10
+                  K09 "id-7..d76e" @"task"[K08] 3 retries, (no vars)
+  C JOB       UPDATE     #24-> -1 K09  5 retries, (no vars)
+  E JOB       UPDATED    #25->#24 K09 "id-7..d76e" @"task"[K08] 5 retries, (no vars)
+```
+
+</details>
+
+And it will also provide the full XML of the deployed process for reference:
+<details>
+
+```
 -------------- Deployed Processes ----------------------
 process.bpmn -> "process" (version:1)[K03] ------
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
@@ -252,8 +261,14 @@ process.bpmn -> "process" (version:1)[K03] ------
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </definitions>
+```
 
+</details>
 
+And finally, it will provide a breakdown of the keys used in the test for easier debugging:
+<details>
+
+```
 --------------- Decomposed keys (for debugging) -----------------
  -1 <-> -1
 K01 <-> 2251799813685249
@@ -267,6 +282,8 @@ K08 <-> 2251799813685256
 K09 <-> 2251799813685257
 K10 <-> 2251799813685258
 ```
+
+</details>
 
 ### Follow-up tasks
 

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -1,0 +1,1 @@
+# The Zeebe Workflow Engine

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -34,6 +34,12 @@ The engine operates in two modes: processing and replay.
   Events are applied deterministically and in the order that they were added to the logstream.
   To learn more about replay, see [ZEP004](https://github.com/zeebe-io/enhancements/blob/master/ZEP004-wf-stream-processing.md).
 
+There are three sources of commands.
+
+- Clients can request changes by sending commands, e.g. create a new process instance.
+- Command processors can request next steps by appending commands, e.g. flow to the next element in the process after completing a task.
+- Scheduled tasks that run periodically inside the engine can append commands, e.g. to remove a message from the buffer after its TTL has expired.
+
 ## Basic module structure
 
 At the root of the `zeebe/engine` module, you will find the `Engine` class where you can map the

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -21,18 +21,32 @@ The engine is implemented as a collection of command processors and event applie
 - **Events** are the result of processing commands describing that the state has changed, e.g. a process instance was created or a timer was triggered.
 - **Command rejections** are indications that a command could not be processed, e.g. because the requested change was not allowed.
 
-It is designed to recover its state by replaying the events of the logstream.
-To avoid unnecessary work, it can replay from a snapshot of the state.
-
 The engine operates in two modes: processing and replay.
 
-- In **processing** mode, the engine processes **commands**.
-  Commands are processed in the order that they were added to the logstream.
-  During command processing, the engine can append new records to the logstream and respond to requests.
-  Command processors can reject commands by appending command rejections, append and apply events to change the state, and append follow-up commands to request next steps to do.
-- In **replay** mode, the engine applies **events** to reconstruct its state.
-  Events are applied deterministically and in the order that they were added to the logstream.
-  To learn more about replay, see [ZEP004](https://github.com/zeebe-io/enhancements/blob/master/ZEP004-wf-stream-processing.md).
+### Replay mode
+
+In **replay** mode, the engine applies **events** to reconstruct its state.
+The engine always starts in replay mode first.
+Events are applied deterministically and in the order that they were added to the logstream.
+
+To avoid unnecessary work, replay can start from a snapshot of the state.
+Replay then starts with the first event that has not yet been applied to that snapshot.
+
+To learn more about replay, see [ZEP004](https://github.com/zeebe-io/enhancements/blob/master/ZEP004-wf-stream-processing.md).
+
+### Processing mode
+
+In **processing** mode, the engine processes **commands**.
+Commands are processed in the order that they were added to the logstream.
+
+During command processing, the engine can append new records to the logstream, respond to requests, and execute side-effects.
+
+Command processors can:
+- reject commands by appending command rejections,
+- append and apply events to change the state,
+- append follow-up commands to request next steps to do,
+- respond to requests with a rejection or an event,
+- append side-effects to be executed when processing successfully completes.
 
 There are three sources of commands.
 

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -54,6 +54,22 @@ There are three sources of commands.
 - Command processors can request next steps by appending commands, e.g. flow to the next element in the process after completing a task.
 - Scheduled tasks that run periodically inside the engine can append commands, e.g. to remove a message from the buffer after its TTL has expired.
 
+### Relation to other components
+
+The workflow engine is build on top of the `protocol` and `stream-platform` modules.
+
+The `procotol` module defines the available records.
+This includes their schema as well as the available value types which specify the data schema of records of that particular type.
+For example, records of the value type `JOB` contain data specific to jobs.
+
+The `stream-platform` module offers the replicated logstream.
+It instructs the engine to process commands and replay events.
+The stream platform can keep multiple engines, one for each partition (a shard of the data).
+The stream platform provides access to the state that the engine can modify.
+This access is split into two parts.
+- a processing state which is modifable, which is used during processing and replay.
+- a scheduled task state which is immutable, which is used by the scheduled tasks.
+
 ## Basic module structure
 
 At the root of the `zeebe/engine` module, you will find the `Engine` class where you can map the

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -1,11 +1,11 @@
 # The Zeebe Workflow Engine
 
-The workflow engine is the core component of Zeebe. It is responsible for executing process
-instances, managing state, and ensuring the correct execution of BPMN processes, as well as the
-evaluation of decision instances.
+The workflow engine is a core component of Zeebe.
 
-This README will provide an overview of the engine's architecture, key components, and guidelines
-for contributing to its development.
+It is responsible for the correct execution of BPMN processes and the evaluation of DMN decisions.
+It also manages all system entities like users, roles, and authorizations for Identity, as well as the user tasks and forms for Tasklist.
+
+This README provides an overview of the engine's architecture, module structure, and guidelines for contributing to its development.
 
 ## High-level engine architecture
 

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -26,17 +26,51 @@ State changes are applied when processing **events** from the stream.
 
 To learn more about replay, see [ZEP004](https://github.com/zeebe-io/enhancements/blob/master/ZEP004-wf-stream-processing.md).
 
+## Basic module structure
+
+At the root of the `zeebe/engine` module, you will find the `Engine` class where you can map the
+high-level engine architecture concepts you were introduced to in the section above.
+
+There is also the `EngineConfiguration` class which is used to configure the engine. It allows you
+to adjust the behavior of the engine through various parameters such as cache sizes, timeouts, and
+other settings.
+
+The following are the main packages that make up the engine's core functionality.
+
+### `processing` package
+
+The `processing` package is where the core processing logic of the engine resides. This is where
+the journey of a command record begins, once it enters the engine domain.
+
+- Browse the `EngineProcessor` and `BpmnProcessor` classes to understand how the engine processes
+  different types of records.
+- Processor classes output results through various classes in the `streamprocessor/writers` package.
+  A processor may use a `stateWriter` to modify the state, a `responseWriter` to send a response back
+  to the client, or a `rejectionWriter` to reject a command. It can also add new command records to
+  itself using a `commandWriter`.
+- Shared logic used by multiple `Processor` classes is contained withing `Behavior` classes. As an
+  example, have a look at the `BpmnJobActivationBehavior` class to see how job activation is handled.
+- In the `EngineProcessor` and `BpmnProcessor` classes, you may notice `Checker` classes. These are
+  usually "listener"-type classes that react to the changes of the Engine modes (i.e. `processing`,
+  `replay`), and perform actions accordingly. For example, the `JobTimeoutChecker` checks for jobs
+  that have timed out when the engine is in `processing` mode, and writes a `JobTimedOut` command
+  using a `commandWriter`.
+
+### `state` package
+
+// TODO: add state package description
+
+### `metrics` package
+
+// TODO: add metrics package description
+
 ## How do I implement a new feature?
-
-### Basic module structure
-
-- Processors
-- Appliers
-- State classes
 
 [Developer handpook](../../docs/zeebe/developer_handbook.md)
 
 - TODO: example feature
+
+### Engine Do's and Don'ts
 
 ### Testing guidelines
 

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -119,9 +119,16 @@ To illustrate how to implement a new feature in the engine, let's consider the f
 
 ### Testing guidelines
 
+The `zeebe-worklow-engine` module contains various types of tests to ensure the quality of the
+engine code is maintained. Have a look at the following classes.
+
+- JUnit4 `EngineRule` class
+- JUnit5 `ProcessingStateExtension` class
+
 ### Follow-up tasks
 
-- Zeebe QA, Camunda QA, clients...
+- Zeebe QA, clients...
+- Consider adding acceptance tests in the [Camunda QA module](../../qa/README.md) module.
 
 ## Do's and Don'ts
 

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -1,1 +1,25 @@
 # The Zeebe Workflow Engine
+
+## Introduction
+
+## High-level engine architecture
+
+https://github.com/zeebe-io/enhancements/blob/master/ZEP004-wf-stream-processing.md
+
+## How do I implement a new feature?
+
+### Basic module structure
+
+- Processors
+- Appliers
+- State classes
+
+[Developer handpook](../../docs/zeebe/developer_handbook.md)
+
+- TODO: example feature
+
+### Testing guidelines
+
+### Follow-up tasks
+
+- Zeebe QA, Camunda QA, clients...

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -21,9 +21,11 @@ For this reason, records in the stream are split into commands, events, and reje
 - **Events** are the result of processing commands, e.g. a process instance was created or a job was completed.
 - **Rejections** are indications that a command could not be processed.
 
-During **command** processing, the engine may append events and follow-up commands to the stream.
-State changes are applied when processing **events** from the stream.
+The engine operates in two modes: processing and replay.
 
+- In **processing** mode, the engine processes **commands** and **events**. During command processing, the engine
+  may append events, rejections, and follow-up commands to the stream.
+- In **replay** mode, the engine processes only **events** from the stream to reconstruct its state.
 To learn more about replay, see [ZEP004](https://github.com/zeebe-io/enhancements/blob/master/ZEP004-wf-stream-processing.md).
 
 ## Basic module structure

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -92,7 +92,30 @@ When adding a new feature, consider if it would be useful to add new metrics to 
 
 [Developer handpook](../../docs/zeebe/developer_handbook.md)
 
-- TODO: example feature
+### Example feature
+
+To illustrate how to implement a new feature in the engine, let's consider the following example.
+
+**Feature Description**: Camunda has introduced a user management system that allows managing users and their roles within the orchestration cluster. The engine needs to support a new command to create a user.
+
+**Steps to Implement the Feature**:
+
+1. **Decide whether you need a new record and value type**.
+   Records are defined in the [Zeebe protocol](../protocol) and implemented in the ['zeebe-protocol-impl'](../protocol-impl) module.
+   In this case, we do need a new record [`UserRecord`](../protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserRecordValue.java).
+   Follow [this guide](../../docs/zeebe/developer_handbook.md#how-to-create-a-new-record) on creating a new record.
+
+2. **Introduce new state if needed**. Consider whether you need to add a new state type or if you can add new data to an existing state type.
+   In this case, we need a new state type [`UserState`](src/main/java/io/camunda/zeebe/engine/state/immutable/UserState.java) to persist users.
+   Start by defining immutable & mutable versions of the interface, then implement them in a single class, e.g. [`DbUserState`](src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java).
+   You might need to break down your state class into multiple objects depending on the complexity.
+   Add your new state to [`ProcessingState`](src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java).
+
+3. **Add a new Intent**.
+
+4. **Add a new Processor**.
+
+5. **Add a new EventApplier**.
 
 ### Testing guidelines
 
@@ -136,7 +159,7 @@ When adding a new feature, consider if it would be useful to add new metrics to 
 - **Do** register a new version of an event applier.
 - **Don't** change code in methods called by event appliers, like state class implementations.
 - It's fine to change it while unreleased. No need to register a new version in this case.
-- Not all data in a command value can be trusted. It may be out of date by the time it's processed. 
+- Not all data in a command value can be trusted. It may be out of date by the time it's processed.
 - **Don't** trust data in a command's `RecordValue` as up to date.
 - **Do** gain an understanding which command data is the requested change, e.g. Assign to `assignee`.
 - **Do** read the latest entity data from the state.

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -72,7 +72,88 @@ the journey of a command record begins, once it enters the engine domain.
 
 - TODO: example feature
 
-### Engine Do's and Don'ts
+### Do's and Don'ts
+
+#### The stream processor is single threaded
+
+- Only one command is processed at a time.
+- **Don't** block the thread unnecessarily.
+- **Do** take small steps by breaking up the processing into smaller chunks by appending follow-up commands.
+
+#### State changes should be reflected on the log stream
+
+- This allows events to be replayed on restart to rebuild the state.
+- **Don't** change state from a processor.
+- **Don't** use a mutable state class from a processor.
+- **Do** only produce state changes from an event applier.
+- **Do** avoid changing state of an unrelated entity in another entity's event applier. In some cases this is fine, but not in all. For example, `Incident:CREATED` also disables a job.
+- **Do** consider whether the state change should be visible on the logstream. For example, extract `Job:DISABLED` from `Incident:CREATED`  to highlight the change on the logstream.
+- Keep documentation up to date
+- **Do** update config templates when adding new configuration options.
+
+#### We prefer composition over inheritance
+
+- **Do** create behavior classes to reuse code.
+- **Don't** use subclasses for code reuse.
+
+#### Processors do not have access to the secondary storage
+
+- **Do** access the immutable state from a processor.
+- **Do** access the secondary storage from a scheduled task.
+
+#### Event appliers are not allowed to be changed after having been released
+
+- Events must be applied in the same way on replay as when they were initially appended.
+- **Don't** change the event applier implementation.
+- **Do** register a new version of an event applier.
+- **Don't** change code in methods called by event appliers, like state class implementations.
+- It's fine to change it while unreleased. No need to register a new version in this case.
+- Not all data in a command value can be trusted. It may be out of date by the time it's processed. 
+- **Don't** trust data in a command's `RecordValue` as up to date.
+- **Do** gain an understanding which command data is the requested change, e.g. Assign to `assignee`.
+- **Do** read the latest entity data from the state.
+- **Do** use the state data to decide whether the request is possible.
+- **Do** use the state data as the basis for modifications.
+
+#### Construction of records is expensive
+
+- **Do** reuse and modify them for performance.
+- **Do** use `wrap` to quickly pass data from one object to another.
+- **Do** use `copyFrom` if you need a deep copy for more safety.
+
+#### Record values are data objects that are often reused across different records of the same value type
+
+- **Do** use a different value type when only a subset of properties are relevant to a specific intent. But if you need to, please document the properties in the record that are only provided on specific intents.
+
+#### State classes provide references that may be modified without your knowledge
+
+- **Do** use the `Supplier` parameter to create safe copies directly if needed. Comes at the cost of performance.
+
+#### The state and rejection writers do not take care of writing a response to the request
+
+- The command may belong to a request that's awaiting a response.
+- **Do** use the response writer to send a response.
+
+#### Side-effects are not guaranteed to be executed
+
+- Side-effects are executed before the next command is picked up, but if execution fails or if failover occurs the side-effect may not be executed.
+- **Don't** do things that must happen in a side-effect.
+- **Do** use side-effects for things like updating caches or sending responses.
+
+#### Changes to transformers may result in differences during replay
+
+- Transformers are not versioned like event appliers.
+- **Do** be careful about changing existing transformers.
+
+#### Scheduled tasks can flood the logstream
+
+- The stream processor may not be fast enough to process all the commands appended by a scheduled task.
+- **Do** yield the thread after some time
+- **Do** yield the thread after some number of actions taken, e.g. commands appended.
+
+#### The `RecordingExporter` keeps the stream open unless short-circuited
+
+- **Do** short-circuit the `RecordingExporter`  using `.limit`, `.getFirst` , `.exists`.
 
 ### Testing guidelines
 

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -161,9 +161,9 @@ To illustrate how to implement a new feature in the engine, let's consider the f
    Register your new processor in [`EngineProcessors`](src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java).
 
 5. **Add a new EventApplier**.
-    You need to add a new event applier to apply the new event to the state.
-    In this case, we need a new event applier [`UserCreatedApplier`](src/main/java/io/camunda/zeebe/engine/state/appliers/UserCreatedApplier.java) to apply the `CREATED` event.
-    Register your new event applier in [`EventAppliers`](src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java).
+   You need to add a new event applier to apply the new event to the state.
+   In this case, we need a new event applier [`UserCreatedApplier`](src/main/java/io/camunda/zeebe/engine/state/appliers/UserCreatedApplier.java) to apply the `CREATED` event.
+   Register your new event applier in [`EventAppliers`](src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java).
 
 ### Testing guidelines
 
@@ -207,50 +207,54 @@ Here is an example of a failure output from a test that:
 3. And updates a job that was created for the service task.
 
 The `CompactRecordLogger` output always provides a detailed legend of the abbreviations used:
+
 <details>
 
-	['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position] K[key] - [summary of value]
-	P9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
-	Keys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
-	Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
-	Headers defined in 'Protocol' are abbreviated (e.g. 'io.camunda.zeebe:userTaskKey:2251799813685253' -> 'uTK:K005').
+        ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position] K[key] - [summary of value]
+        P9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
+        Keys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
+        Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
+        Headers defined in 'Protocol' are abbreviated (e.g. 'io.camunda.zeebe:userTaskKey:2251799813685253' -> 'uTK:K005').
+
 </details>
 
 It will provide an abbreviated log of all the records that were processed until the failure:
+
 <details>
 
 ```
-  C USG_MTRC  EXPORT     #01-> -1  -1 NONE:ACTIVE start[-1] end[-1] reset[-1] (no metricValues)
-  E USG_MTRC  EXPORTED   #02->#01 K01 NONE:ACTIVE start[-1] end[-1] reset[T08:33:10.737] (no metricValues)
-  C DPLY      CREATE     #03-> -1  -1
-  E PROC      CREATED    #04->#03 K03 process.bpmn -> "process" (version:1)
-  E DPLY      CREATED    #05->#03 K02 process.bpmn
-  C CREA      CREATE     #06-> -1  -1 new <process "process"> (default start)  (no vars)
-  C PI        ACTIVATE   #07->#06 K04 PROCESS "process" in <process "process"[K04]>
-  E CREA      CREATED    #08->#06 K05 new <process "process"> (default start)  (no vars)
-  E PI        ACTIVATING #09->#06 K04 PROCESS "process" in <process "process"[K04]> EI:[K04] PD:[K03]
-  E PI        ACTIVATED  #10->#06 K04 PROCESS "process" in <process "process"[K04]>
-  C PI        ACTIVATE   #11->#06  -1 START_EVENT "start" in <process "process"[K04]>
-  E PI        ACTIVATING #12->#06 K06 START_EVENT "start" in <process "process"[K04]> EI:[K04->K06] PD:[K03]
-  E PI        ACTIVATED  #13->#06 K06 START_EVENT "start" in <process "process"[K04]>
-  C PI        COMPLETE   #14->#06 K06 START_EVENT "start" in <process "process"[K04]>
-  E PI        COMPLETING #15->#06 K06 START_EVENT "start" in <process "process"[K04]>
-  E PI        COMPLETED  #16->#06 K06 START_EVENT "start" in <process "process"[K04]>
-  E PI        SQ_FLW_TKN #17->#06 K07 SEQUENCE_FLOW "sequenc..e88de26" in <process "process"[K04]>
-  C PI        ACTIVATE   #18->#06 K08 SERVICE_TASK "task" in <process "process"[K04]>
-  E PI        ACTIVATING #19->#06 K08 SERVICE_TASK "task" in <process "process"[K04]> EI:[K04->K08] PD:[K03]
-  E JOB       CREATED    #20->#06 K09 "id-7..d76e" @"task"[K08] 3 retries, (no vars)
-  E PI        ACTIVATED  #21->#06 K08 SERVICE_TASK "task" in <process "process"[K04]>
-  C JOB_BATCH ACTIVATE   #22-> -1  -1 "id-7921b6c2-24cf-402d-84a2-9e8defc6d76e" max: 10
-  E JOB_BATCH ACTIVATED  #23->#22 K10 "id-7921b6c2-24cf-402d-84a2-9e8defc6d76e" 1/10
-                  K09 "id-7..d76e" @"task"[K08] 3 retries, (no vars)
-  C JOB       UPDATE     #24-> -1 K09  5 retries, (no vars)
-  E JOB       UPDATED    #25->#24 K09 "id-7..d76e" @"task"[K08] 5 retries, (no vars)
+C USG_MTRC  EXPORT     #01-> -1  -1 NONE:ACTIVE start[-1] end[-1] reset[-1] (no metricValues)
+E USG_MTRC  EXPORTED   #02->#01 K01 NONE:ACTIVE start[-1] end[-1] reset[T08:33:10.737] (no metricValues)
+C DPLY      CREATE     #03-> -1  -1
+E PROC      CREATED    #04->#03 K03 process.bpmn -> "process" (version:1)
+E DPLY      CREATED    #05->#03 K02 process.bpmn
+C CREA      CREATE     #06-> -1  -1 new <process "process"> (default start)  (no vars)
+C PI        ACTIVATE   #07->#06 K04 PROCESS "process" in <process "process"[K04]>
+E CREA      CREATED    #08->#06 K05 new <process "process"> (default start)  (no vars)
+E PI        ACTIVATING #09->#06 K04 PROCESS "process" in <process "process"[K04]> EI:[K04] PD:[K03]
+E PI        ACTIVATED  #10->#06 K04 PROCESS "process" in <process "process"[K04]>
+C PI        ACTIVATE   #11->#06  -1 START_EVENT "start" in <process "process"[K04]>
+E PI        ACTIVATING #12->#06 K06 START_EVENT "start" in <process "process"[K04]> EI:[K04->K06] PD:[K03]
+E PI        ACTIVATED  #13->#06 K06 START_EVENT "start" in <process "process"[K04]>
+C PI        COMPLETE   #14->#06 K06 START_EVENT "start" in <process "process"[K04]>
+E PI        COMPLETING #15->#06 K06 START_EVENT "start" in <process "process"[K04]>
+E PI        COMPLETED  #16->#06 K06 START_EVENT "start" in <process "process"[K04]>
+E PI        SQ_FLW_TKN #17->#06 K07 SEQUENCE_FLOW "sequenc..e88de26" in <process "process"[K04]>
+C PI        ACTIVATE   #18->#06 K08 SERVICE_TASK "task" in <process "process"[K04]>
+E PI        ACTIVATING #19->#06 K08 SERVICE_TASK "task" in <process "process"[K04]> EI:[K04->K08] PD:[K03]
+E JOB       CREATED    #20->#06 K09 "id-7..d76e" @"task"[K08] 3 retries, (no vars)
+E PI        ACTIVATED  #21->#06 K08 SERVICE_TASK "task" in <process "process"[K04]>
+C JOB_BATCH ACTIVATE   #22-> -1  -1 "id-7921b6c2-24cf-402d-84a2-9e8defc6d76e" max: 10
+E JOB_BATCH ACTIVATED  #23->#22 K10 "id-7921b6c2-24cf-402d-84a2-9e8defc6d76e" 1/10
+                K09 "id-7..d76e" @"task"[K08] 3 retries, (no vars)
+C JOB       UPDATE     #24-> -1 K09  5 retries, (no vars)
+E JOB       UPDATED    #25->#24 K09 "id-7..d76e" @"task"[K08] 5 retries, (no vars)
 ```
 
 </details>
 
 And it will also provide the full XML of the deployed process for reference:
+
 <details>
 
 ```
@@ -302,6 +306,7 @@ process.bpmn -> "process" (version:1)[K03] ------
 </details>
 
 And finally, it will provide a breakdown of the keys used in the test for easier debugging:
+
 <details>
 
 ```
@@ -408,3 +413,4 @@ K10 <-> 2251799813685258
 ### The `RecordingExporter` keeps the stream open unless short-circuited
 
 - **Do** short-circuit the `RecordingExporter`  using `.limit`, `.getFirst` , `.exists`.
+


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This adds some developer guides to the workflow engine to help onboarding and facilitate contributions.

- Add a README file in the `zeebe/engine` module.
- Updates the `zeebe` module README.
- Adds copilot instructions to take these docs into account.

## Related issues

ℹ️ Part of the Core Engine workshop (24-25 September 2025)