### PR TITLE
fix: Operate returns unauthorized process instance data

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
@@ -181,16 +181,59 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     final List<IncidentsByProcessGroupStatisticsDto> response = requestIncidentsByProcess();
 
     assertThat(response).hasSize(3);
+    final var responseMap =
+        response.stream()
+            .collect(
+                Collectors.toMap(IncidentsByProcessGroupStatisticsDto::getBpmnProcessId, i -> i));
+    assertThat(responseMap)
+        .containsKey(DEMO_BPMN_PROCESS_ID)
+        .containsKey(ORDER_BPMN_PROCESS_ID)
+        .containsKey(LOAN_BPMN_PROCESS_ID);
+    assertThat(responseMap.get(DEMO_BPMN_PROCESS_ID).getInstancesWithActiveIncidentsCount())
+        .isEqualTo(4);
+    assertThat(responseMap.get(DEMO_BPMN_PROCESS_ID).getActiveInstancesCount()).isEqualTo(9);
+    assertThat(responseMap.get(ORDER_BPMN_PROCESS_ID).getInstancesWithActiveIncidentsCount())
+        .isOne();
+    assertThat(responseMap.get(ORDER_BPMN_PROCESS_ID).getActiveInstancesCount()).isEqualTo(8);
+    assertThat(responseMap.get(LOAN_BPMN_PROCESS_ID).getInstancesWithActiveIncidentsCount())
+        .isZero();
+    assertThat(responseMap.get(LOAN_BPMN_PROCESS_ID).getActiveInstancesCount()).isEqualTo(5);
+  }
+
+  @Test
+  public void
+      testIncidentsByProcessWithProcessDefinitionPermissionWhenNoProcessInstancePermissions()
+          throws Exception {
+
+    // given
+    createData();
+
+    // when
+    when(permissionsService.permissionsEnabled()).thenReturn(true);
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE))
+        .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of()));
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
+        .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
+
+    // then
+    final List<IncidentsByProcessGroupStatisticsDto> response = requestIncidentsByProcess();
+
+    assertThat(response).hasSize(3);
     assertThat(
             response.stream()
                 .map(IncidentsByProcessGroupStatisticsDto::getBpmnProcessId)
                 .collect(Collectors.toList()))
         .containsExactlyInAnyOrder(
             DEMO_BPMN_PROCESS_ID, ORDER_BPMN_PROCESS_ID, LOAN_BPMN_PROCESS_ID);
+    response.forEach(
+        r -> {
+          assertThat(r.getActiveInstancesCount()).isZero();
+          assertThat(r.getInstancesWithActiveIncidentsCount()).isZero();
+        });
   }
 
   @Test
-  public void testIncidentsByProcessWithPermissionWhenNotAllowed() throws Exception {
+  public void testIncidentsByProcessWithPermissionWhenPartiallyAllowed() throws Exception {
 
     // given
     createData();
@@ -211,6 +254,23 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
                 .map(IncidentsByProcessGroupStatisticsDto::getBpmnProcessId)
                 .collect(Collectors.toList()))
         .containsExactlyInAnyOrder(DEMO_BPMN_PROCESS_ID, ORDER_BPMN_PROCESS_ID);
+  }
+
+  @Test
+  public void testIncidentsByProcessWithPermissionWhenNotAllowed() throws Exception {
+
+    // given
+    createData();
+
+    // when
+    when(permissionsService.permissionsEnabled()).thenReturn(true);
+    when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
+        .thenReturn(PermissionsService.ResourcesAllowed.withIds(Set.of()));
+
+    // then
+    final List<IncidentsByProcessGroupStatisticsDto> response = requestIncidentsByProcess();
+
+    assertThat(response).isEmpty();
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchStatisticsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchStatisticsIT.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.opensearch;
+public class OpensearchStatisticsIT {
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchStatisticsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchStatisticsIT.java
@@ -6,5 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 package io.camunda.operate.opensearch;
-public class OpensearchStatisticsIT {
-}
+
+import io.camunda.operate.elasticsearch.IncidentStatisticsIT;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(
+    properties = {
+      "camunda.data.secondary-storage.type=opensearch",
+      "camunda.database.type=opensearch",
+      "camunda.tasklist.database=opensearch",
+      "camunda.operate.database=opensearch",
+    })
+public class OpensearchStatisticsIT extends IncidentStatisticsIT {}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchIncidentStatisticsReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchIncidentStatisticsReader.java
@@ -75,8 +75,10 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
 
   @Override
   public Set<IncidentsByProcessGroupStatisticsDto> getProcessAndIncidentsStatistics() {
+    final var pisWithReadPermissionQuery = createQueryForProcessInstancesWithReadPermission();
     final Map<Long, IncidentByProcessStatisticsDto> incidentsByProcessMap =
-        updateActiveInstances(getIncidentsByProcess());
+        updateActiveInstances(
+            getIncidentsByProcess(pisWithReadPermissionQuery), pisWithReadPermissionQuery);
     return collectStatisticsForProcessGroups(incidentsByProcessMap);
   }
 
@@ -94,9 +96,7 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
             ProcessIndex.VERSION);
 
     final Query query =
-        and(
-            ACTIVE_INCIDENT_QUERY,
-            createQueryForProcessesByPermission(PermissionType.READ_PROCESS_INSTANCE));
+        and(ACTIVE_INCIDENT_QUERY, createQueryForProcessInstancesWithReadPermission());
 
     final var uniqueProcessInstances =
         cardinalityAggregation(IncidentTemplate.PROCESS_INSTANCE_KEY);
@@ -150,8 +150,10 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
         .array();
   }
 
-  private Map<Long, IncidentByProcessStatisticsDto> getIncidentsByProcess() {
-    return searchAggBuckets(withTenantCheck(INCIDENTS_QUERY)).stream()
+  private Map<Long, IncidentByProcessStatisticsDto> getIncidentsByProcess(
+      final Query permittedProcessInstancesQuery) {
+    return searchAggBuckets(withTenantCheck(and(INCIDENTS_QUERY, permittedProcessInstancesQuery)))
+        .stream()
         .collect(
             Collectors.toMap(
                 bucket -> Long.valueOf(bucket.key()),
@@ -159,13 +161,15 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
   }
 
   private Map<Long, IncidentByProcessStatisticsDto> updateActiveInstances(
-      final Map<Long, IncidentByProcessStatisticsDto> statistics) {
+      final Map<Long, IncidentByProcessStatisticsDto> statistics,
+      final Query permittedProcessInstancesQuery) {
     final Map<Long, IncidentByProcessStatisticsDto> results = new HashMap<>(statistics);
     final Query query =
         withTenantCheck(
             and(
                 term(ListViewTemplate.STATE, ProcessInstanceState.ACTIVE.toString()),
-                term(JOIN_RELATION, PROCESS_INSTANCE_JOIN_RELATION)));
+                term(JOIN_RELATION, PROCESS_INSTANCE_JOIN_RELATION),
+                permittedProcessInstancesQuery));
 
     searchAggBuckets(query)
         .forEach(
@@ -239,9 +243,9 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
     return result;
   }
 
-  private Query createQueryForProcessesByPermission(final PermissionType permission) {
+  private Query createQueryForProcessInstancesWithReadPermission() {
     final PermissionsService.ResourcesAllowed allowed =
-        permissionsService.getProcessesWithPermission(permission);
+        permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_INSTANCE);
     return allowed.isAll()
         ? matchAll()
         : stringTerms(ListViewTemplate.BPMN_PROCESS_ID, allowed.getIds());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- added process instance permission check for the queries that collect process instance metadata
- added test cases

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/38198
