### PR TITLE
[Backport stable/8.8] fix: refresh token exchange should build client assertion when client auth method is private_key_jwt

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/AssertionJwkProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/AssertionJwkProvider.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.util.Base64;
+import com.nimbusds.jose.util.Base64URL;
+import io.camunda.security.configuration.AssertionConfiguration;
+import io.camunda.security.configuration.AssertionConfiguration.KidCase;
+import io.camunda.security.configuration.AssertionConfiguration.KidDigestAlgorithm;
+import io.camunda.security.configuration.AssertionConfiguration.KidEncoding;
+import io.camunda.security.configuration.AssertionConfiguration.KidSource;
+import java.security.KeyStore;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.interfaces.RSAPublicKey;
+import java.util.HexFormat;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AssertionJwkProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AssertionJwkProvider.class);
+  private final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository;
+
+  public AssertionJwkProvider(
+      final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository) {
+    this.oidcAuthenticationConfigurationRepository = oidcAuthenticationConfigurationRepository;
+  }
+
+  public JWK createJwk(final String clientRegistrationId) {
+    final var assertionConfig =
+        oidcAuthenticationConfigurationRepository
+            .getOidcAuthenticationConfigurationById(clientRegistrationId)
+            .getAssertion();
+    final var keystoreConfig = assertionConfig.getKeystore();
+    final var alias = keystoreConfig.getKeyAlias();
+    final var password = keystoreConfig.getKeyPassword().toCharArray();
+    try {
+      final KeyStore keyStore = keystoreConfig.loadKeystore();
+      final var pk = (PrivateKey) keyStore.getKey(alias, password);
+      final var cert = keyStore.getCertificate(alias);
+      final var pub = (RSAPublicKey) cert.getPublicKey();
+      return new RSAKey.Builder(pub)
+          .privateKey(pk)
+          .x509CertChain(List.of(Base64.encode(cert.getEncoded())))
+          .keyID(generateKid(cert, assertionConfig)) // default for Keycloak
+          .x509CertSHA256Thumbprint(thumbprintCertificateSha256(cert)) // default for Entra
+          .build();
+    } catch (final Exception e) {
+      throw new IllegalStateException("Unable to load keystore", e);
+    }
+  }
+
+  private Base64URL thumbprintCertificateSha256(final Certificate cert)
+      throws NoSuchAlgorithmException, CertificateEncodingException {
+    final MessageDigest sha1 = MessageDigest.getInstance("SHA-256");
+    final byte[] digest = sha1.digest(cert.getEncoded());
+    return Base64URL.encode(digest);
+  }
+
+  /**
+   * Generates the <code>key ID</code> expected by some IdPs to match a registered certificate for
+   * the client.
+   *
+   * <p>The <code>kid</code> generation can be modified using the {@link AssertionConfiguration} to
+   * control if the certificate or it's public key is used, which hashing algorithm will be used,
+   * what will be the encoding of the <code>kid</code> string, and if the <code>kid</code> string
+   * will be in lowercase or uppercase (relevant for hex encoding).
+   *
+   * @implNote the default <code>kid</code> generated if no configuration is set will be a SHA-256
+   *     digest of the public key with base46url encoding
+   * @see KidSource
+   * @see KidDigestAlgorithm
+   * @see KidEncoding
+   * @see KidCase
+   * @param cert Certificate used as the source for the digest
+   * @param config Settings defining the form of the <code>kid</code> being generated
+   * @return the <code>kid</code> based on the config, or default if config is not set
+   */
+  private String generateKid(final Certificate cert, final AssertionConfiguration config) {
+    final var digestAlg = getKidDigestAlgorithmInstance(config.getKidDigestAlgorithm());
+    final var sourceBytes = getKidSourceBytes(cert, config.getKidSource());
+    final var digest = digestAlg.digest(sourceBytes);
+    final var kid =
+        switch (config.getKidEncoding()) {
+          case BASE64URL -> Base64URL.encode(digest).toString();
+          case HEX -> getHexFormatWithCase(config.getKidCase()).formatHex(digest);
+        };
+    LOG.debug("generated kid '{}' from keystore '{}'", kid, config.getKeystore().getPath());
+    return kid;
+  }
+
+  private MessageDigest getKidDigestAlgorithmInstance(final KidDigestAlgorithm alg) {
+    try {
+      return switch (alg) {
+        case SHA256 -> MessageDigest.getInstance("SHA-256");
+        case SHA1 -> MessageDigest.getInstance("SHA-1");
+      };
+    } catch (final NoSuchAlgorithmException e) {
+      throw new IllegalStateException("failed to instantiate digest algorithm", e);
+    }
+  }
+
+  private byte[] getKidSourceBytes(final Certificate cert, final KidSource source) {
+    try {
+      return switch (source) {
+        case PUBLIC_KEY -> cert.getPublicKey().getEncoded();
+        case CERTIFICATE -> cert.getEncoded();
+      };
+    } catch (final CertificateEncodingException e) {
+      throw new IllegalStateException("failed to fetch encoded kid source", e);
+    }
+  }
+
+  private HexFormat getHexFormatWithCase(final KidCase kidCase) {
+    return switch (kidCase) {
+      case UPPER -> HexFormat.of().withUpperCase();
+      case LOWER -> HexFormat.of().withLowerCase();
+      case null -> HexFormat.of();
+    };
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcAuthenticationConfigurationRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcAuthenticationConfigurationRepository.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 public class OidcAuthenticationConfigurationRepository {
 
-  private static final String REGISTRATION_ID = "oidc";
+  public static final String REGISTRATION_ID = "oidc";
   private final Map<String, OidcAuthenticationConfiguration> providers;
 
   public OidcAuthenticationConfigurationRepository(

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcTokenEndpointCustomizer.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcTokenEndpointCustomizer.java
@@ -8,23 +8,6 @@
 package io.camunda.authentication.config;
 
 import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.RSAKey;
-import com.nimbusds.jose.util.Base64;
-import com.nimbusds.jose.util.Base64URL;
-import io.camunda.security.configuration.AssertionConfiguration;
-import io.camunda.security.configuration.AssertionConfiguration.KidCase;
-import io.camunda.security.configuration.AssertionConfiguration.KidDigestAlgorithm;
-import io.camunda.security.configuration.AssertionConfiguration.KidEncoding;
-import io.camunda.security.configuration.AssertionConfiguration.KidSource;
-import java.security.KeyStore;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateEncodingException;
-import java.security.interfaces.RSAPublicKey;
-import java.util.HexFormat;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
@@ -46,11 +29,14 @@ public class OidcTokenEndpointCustomizer
 
   private static final Logger LOG = LoggerFactory.getLogger(OidcTokenEndpointCustomizer.class);
   private final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository;
+  private final AssertionJwkProvider assertionJwkProvider;
   private final Map<String, JWK> resolvedJwks;
 
   public OidcTokenEndpointCustomizer(
-      final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository) {
+      final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository,
+      final AssertionJwkProvider assertionJwkProvider) {
     this.oidcAuthenticationConfigurationRepository = oidcAuthenticationConfigurationRepository;
+    this.assertionJwkProvider = assertionJwkProvider;
     resolvedJwks = new ConcurrentHashMap<>();
   }
 
@@ -100,99 +86,6 @@ public class OidcTokenEndpointCustomizer
   }
 
   private JWK resolveJwk(final String clientRegistrationId) {
-    return resolvedJwks.computeIfAbsent(clientRegistrationId, this::createJwk);
-  }
-
-  private JWK createJwk(final String clientRegistrationId) {
-    final var assertionConfig =
-        oidcAuthenticationConfigurationRepository
-            .getOidcAuthenticationConfigurationById(clientRegistrationId)
-            .getAssertion();
-    final var keystoreConfig = assertionConfig.getKeystore();
-    final var alias = keystoreConfig.getKeyAlias();
-    final var password = keystoreConfig.getKeyPassword().toCharArray();
-    try {
-      final KeyStore keyStore = keystoreConfig.loadKeystore();
-      final var pk = (PrivateKey) keyStore.getKey(alias, password);
-      final var cert = keyStore.getCertificate(alias);
-      final var pub = (RSAPublicKey) cert.getPublicKey();
-      return new RSAKey.Builder(pub)
-          .privateKey(pk)
-          .x509CertChain(List.of(Base64.encode(cert.getEncoded())))
-          .keyID(generateKid(cert, assertionConfig)) // default for Keycloak
-          .x509CertSHA256Thumbprint(thumbprintCertificateSha256(cert)) // default for Entra
-          .build();
-    } catch (final Exception e) {
-      throw new IllegalStateException("Unable to load keystore", e);
-    }
-  }
-
-  private Base64URL thumbprintCertificateSha256(final Certificate cert)
-      throws NoSuchAlgorithmException, CertificateEncodingException {
-    final MessageDigest sha1 = MessageDigest.getInstance("SHA-256");
-    final byte[] digest = sha1.digest(cert.getEncoded());
-    return Base64URL.encode(digest);
-  }
-
-  /**
-   * Generates the <code>key ID</code> expected by some IdPs to match a registered certificate for
-   * the client.
-   *
-   * <p>The <code>kid</code> generation can be modified using the {@link AssertionConfiguration} to
-   * control if the certificate or it's public key is used, which hashing algorithm will be used,
-   * what will be the encoding of the <code>kid</code> string, and if the <code>kid</code> string
-   * will be in lowercase or uppercase (relevant for hex encoding).
-   *
-   * @implNote the default <code>kid</code> generated if no configuration is set will be a SHA-256
-   *     digest of the public key with base46url encoding
-   * @see KidSource
-   * @see KidDigestAlgorithm
-   * @see KidEncoding
-   * @see KidCase
-   * @param cert Certificate used as the source for the digest
-   * @param config Settings defining the form of the <code>kid</code> being generated
-   * @return the <code>kid</code> based on the config, or default if config is not set
-   */
-  private String generateKid(final Certificate cert, final AssertionConfiguration config) {
-    final var digestAlg = getKidDigestAlgorithmInstance(config.getKidDigestAlgorithm());
-    final var sourceBytes = getKidSourceBytes(cert, config.getKidSource());
-    final var digest = digestAlg.digest(sourceBytes);
-    final var kid =
-        switch (config.getKidEncoding()) {
-          case BASE64URL -> Base64URL.encode(digest).toString();
-          case HEX -> getHexFormatWithCase(config.getKidCase()).formatHex(digest);
-        };
-    LOG.debug("generated kid '{}' from keystore '{}'", kid, config.getKeystore().getPath());
-    return kid;
-  }
-
-  private MessageDigest getKidDigestAlgorithmInstance(final KidDigestAlgorithm alg) {
-    try {
-      return switch (alg) {
-        case SHA256 -> MessageDigest.getInstance("SHA-256");
-        case SHA1 -> MessageDigest.getInstance("SHA-1");
-      };
-    } catch (final NoSuchAlgorithmException e) {
-      throw new IllegalStateException("failed to instantiate digest algorithm", e);
-    }
-  }
-
-  private byte[] getKidSourceBytes(final Certificate cert, final KidSource source) {
-    try {
-      return switch (source) {
-        case PUBLIC_KEY -> cert.getPublicKey().getEncoded();
-        case CERTIFICATE -> cert.getEncoded();
-      };
-    } catch (final CertificateEncodingException e) {
-      throw new IllegalStateException("failed to fetch encoded kid source", e);
-    }
-  }
-
-  private HexFormat getHexFormatWithCase(final KidCase kidCase) {
-    return switch (kidCase) {
-      case UPPER -> HexFormat.of().withUpperCase();
-      case LOWER -> HexFormat.of().withLowerCase();
-      case null -> HexFormat.of();
-    };
+    return resolvedJwks.computeIfAbsent(clientRegistrationId, assertionJwkProvider::createJwk);
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -700,9 +700,17 @@ public class WebSecurityConfig {
     }
 
     @Bean
-    public OidcTokenEndpointCustomizer oidcTokenEndpointCustomizer(
+    public AssertionJwkProvider assertionJwkProvider(
         final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository) {
-      return new OidcTokenEndpointCustomizer(oidcAuthenticationConfigurationRepository);
+      return new AssertionJwkProvider(oidcAuthenticationConfigurationRepository);
+    }
+
+    @Bean
+    public OidcTokenEndpointCustomizer oidcTokenEndpointCustomizer(
+        final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository,
+        final AssertionJwkProvider assertionJwkProvider) {
+      return new OidcTokenEndpointCustomizer(
+          oidcAuthenticationConfigurationRepository, assertionJwkProvider);
     }
 
     @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -80,10 +80,16 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.endpoint.NimbusJwtClientAuthenticationParametersConverter;
+import org.springframework.security.oauth2.client.endpoint.OAuth2RefreshTokenGrantRequest;
+import org.springframework.security.oauth2.client.endpoint.RestClientRefreshTokenTokenResponseClient;
 import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
@@ -711,6 +717,33 @@ public class WebSecurityConfig {
         final AssertionJwkProvider assertionJwkProvider) {
       return new OidcTokenEndpointCustomizer(
           oidcAuthenticationConfigurationRepository, assertionJwkProvider);
+    }
+
+    @Bean
+    public OAuth2AuthorizedClientManager authorizedClientManager(
+        final ClientRegistrationRepository registrations,
+        final OAuth2AuthorizedClientRepository authorizedClientRepository,
+        final AssertionJwkProvider assertionJwkProvider) {
+
+      final var manager =
+          new DefaultOAuth2AuthorizedClientManager(registrations, authorizedClientRepository);
+
+      // we build a refresh token flow client manually to add support for private_key_jwt
+      final var refreshClient = new RestClientRefreshTokenTokenResponseClient();
+      final var assertionConverter =
+          new NimbusJwtClientAuthenticationParametersConverter<OAuth2RefreshTokenGrantRequest>(
+              registration -> assertionJwkProvider.createJwk(registration.getRegistrationId()));
+      refreshClient.addParametersConverter(assertionConverter);
+
+      final OAuth2AuthorizedClientProvider provider =
+          OAuth2AuthorizedClientProviderBuilder.builder()
+              .authorizationCode()
+              .refreshToken(c -> c.accessTokenResponseClient(refreshClient))
+              .clientCredentials()
+              .build();
+
+      manager.setAuthorizedClientProvider(provider);
+      return manager;
     }
 
     @Bean

--- a/authentication/src/test/java/io/camunda/authentication/OidcClientSecretBasicKeycloakTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/OidcClientSecretBasicKeycloakTest.java
@@ -26,7 +26,6 @@ import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.camunda.authentication.config.WebSecurityConfig;
 import io.camunda.authentication.config.controllers.OidcFlowTestContext;
 import io.camunda.authentication.config.controllers.TestApiController;
-import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -84,8 +83,6 @@ import org.springframework.web.util.UriComponentsBuilder;
       "camunda.security.authentication.oidc.client-secret="
           + OidcClientSecretBasicKeycloakTest.CLIENT_SECRET,
       "camunda.security.authentication.oidc.redirect-uri=http://localhost/sso-callback",
-      "camunda.security.authentication.oidc.clientAuthenticationMethod="
-          + OidcAuthenticationConfiguration.CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC,
       "camunda.security.authentication.oidc.resource=https://api.example.com/app1/, https://api.example.com/app2/",
       "logging.level.io.camunda.authentication.config=DEBUG"
       // essential for debugging the flow

--- a/authentication/src/test/java/io/camunda/authentication/OidcPrivateKeyJwtCustomizeAssertionTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/OidcPrivateKeyJwtCustomizeAssertionTest.java
@@ -11,6 +11,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.notContaining;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -204,15 +205,16 @@ class OidcPrivateKeyJwtCustomizeAssertionTest {
         1,
         postRequestedFor(urlEqualTo(ENDPOINT_TOKEN))
             .withHeader("Content-Type", containing("application/x-www-form-urlencoded"))
-            .withRequestBody(matching(".*grant_type=authorization_code.*"))
-            .withRequestBody(matching(".*code=test_authorization_code.*"))
-            .withRequestBody(matching(".*client_id=" + CLIENT_ID + ".*"))
-            .withRequestBody(matching(".*resource=https%3A%2F%2Fapi.example.com%2Fapp1%2F.*"))
+            .withRequestBody(containing("grant_type=authorization_code"))
+            .withRequestBody(containing("code=test_authorization_code"))
+            .withRequestBody(containing("client_id=" + CLIENT_ID))
+            .withRequestBody(containing("resource=https%3A%2F%2Fapi.example.com%2Fapp1%2F"))
             .withRequestBody(
-                matching(
-                    ".*client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer.*"))
+                containing(
+                    "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer"))
             // client_assertion=<A JWT>
-            .withRequestBody(matching(".*client_assertion=" + REGEX_JWT + ".*")));
+            .withRequestBody(matching(".*client_assertion=" + REGEX_JWT + ".*"))
+            .withRequestBody(notContaining("client_secret")));
   }
 
   private void verifyClientAssertion() throws ParseException {

--- a/authentication/src/test/java/io/camunda/authentication/OidcPrivateKeyJwtKeycloakTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/OidcPrivateKeyJwtKeycloakTest.java
@@ -18,6 +18,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.camunda.authentication.config.OidcAuthenticationConfigurationRepository.REGISTRATION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
@@ -27,13 +28,17 @@ import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.SignedJWT;
 import io.camunda.authentication.config.WebSecurityConfig;
 import io.camunda.authentication.config.controllers.OidcFlowTestContext;
+import io.camunda.authentication.config.controllers.TestApiController;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -44,6 +49,17 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -101,9 +117,9 @@ import org.springframework.web.util.UriComponentsBuilder;
       "camunda.security.authentication.oidc.assertion.keystore.keyAlias=camunda-standalone",
       "camunda.security.authentication.oidc.assertion.keystore.keyPassword=password",
       "camunda.security.authentication.oidc.resource=https://api.example.com/app1/, https://api.example.com/app2/",
-      "logging.level.io.camunda.authentication.config=DEBUG"
+      "logging.level.io.camunda.authentication.config=DEBUG",
       // essential for debugging the flow
-      //      "logging.level.org.springframework.security=TRACE",
+      "logging.level.org.springframework.security=TRACE",
     })
 @ActiveProfiles("consolidated-auth")
 class OidcPrivateKeyJwtKeycloakTest {
@@ -127,7 +143,10 @@ class OidcPrivateKeyJwtKeycloakTest {
       Base64URL.from("gCC_MwKDLUCxMYUlm95bDX8ol6nNHhCohhudSkJAJhQ");
   static final String REGEX_JWT = "[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]*";
   final String expectedTokenEndpointUrl = "http://localhost:" + wireMock.getPort() + ENDPOINT_TOKEN;
+
   @Autowired MockMvcTester mockMvcTester;
+  @Autowired OAuth2AuthorizedClientService authorizedClientService;
+  @Autowired ClientRegistrationRepository clientRegistrationRepository;
 
   @DynamicPropertySource
   static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
@@ -174,6 +193,56 @@ class OidcPrivateKeyJwtKeycloakTest {
     // in the form of a client id and client assertion
     verifyRequestStructure();
     verifyClientAssertion();
+  }
+
+  @Test
+  public void shouldSendClientAssertionToTokenEndpointDuringRefreshToken() {
+    stubIdpEndpoints();
+
+    final var principalName = "a_user";
+    final var client = createExpiredAuthorizedClientWithRefreshToken(principalName);
+
+    final var oauth2User =
+        new DefaultOAuth2User(
+            Set.of(() -> "USER"),
+            java.util.Map.of("sub", principalName, "name", "Test User"),
+            "sub");
+
+    final var authenticationToken =
+        new OAuth2AuthenticationToken(oauth2User, Set.of(() -> "USER"), REGISTRATION_ID);
+    authenticationToken.setAuthenticated(true);
+    authorizedClientService.saveAuthorizedClient(client, authenticationToken);
+
+    final var session = new MockHttpSession();
+    final SecurityContext context = SecurityContextHolder.createEmptyContext();
+    context.setAuthentication(authenticationToken);
+    session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+    session.setAttribute(
+        "org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizedClientRepository.AUTHORIZED_CLIENTS",
+        Map.of(REGISTRATION_ID, client));
+
+    final var result =
+        mockMvcTester
+            .get()
+            .uri(TestApiController.DUMMY_WEBAPP_ENDPOINT)
+            .accept(MediaType.TEXT_HTML)
+            .with(SecurityMockMvcRequestPostProcessors.authentication(authenticationToken))
+            .session(session)
+            .exchange();
+
+    // If not implemented, the exception will be
+    // java.lang.IllegalArgumentException: This class supports `client_secret_basic`,
+    // `client_secret_post`, and `none` by default. Client [oidc] is using [private_key_jwt]
+    // instead. Please use a supported client authentication method, or use
+    // `setRequestEntityConverter` to supply an instance that supports [private_key_jwt].
+    assertThat(result.getUnresolvedException()).isNull();
+
+    verify(
+        1,
+        postRequestedFor(urlEqualTo(ENDPOINT_TOKEN))
+            .withHeader("Content-Type", containing("application/x-www-form-urlencoded"))
+            .withRequestBody(containing("grant_type=refresh_token")));
+    // TODO check for assertion
   }
 
   private static void stubIdpEndpoints() {
@@ -277,6 +346,28 @@ class OidcPrivateKeyJwtKeycloakTest {
         .map(field -> field.split("=")[1])
         .findFirst()
         .orElseThrow();
+  }
+
+  private OAuth2AuthorizedClient createExpiredAuthorizedClientWithRefreshToken(
+      final String principalName) {
+    final var now = Instant.now();
+    final var expiredAccessToken =
+        new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            "access_token",
+            now.minus(2, ChronoUnit.HOURS),
+            now.minus(1, ChronoUnit.HOURS),
+            Set.of("read", "write"));
+
+    final var refreshToken =
+        new OAuth2RefreshToken(
+            "refresh_token", now.minus(2, ChronoUnit.HOURS), now.plus(30, ChronoUnit.DAYS));
+
+    final var clientRegistration =
+        clientRegistrationRepository.findByRegistrationId(REGISTRATION_ID);
+
+    return new OAuth2AuthorizedClient(
+        clientRegistration, principalName, expiredAccessToken, refreshToken);
   }
 
   private static String wellKnownResponse() {

--- a/authentication/src/test/java/io/camunda/authentication/config/AssertionJwkProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/AssertionJwkProviderTest.java
@@ -26,17 +26,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 @SuppressWarnings("DataFlowIssue")
-class OidcTokenEndpointCustomizerTest {
+class AssertionJwkProviderTest {
 
   @Test
   void testGenerateDefaultKid() throws Exception {
     final var mockRepository = Mockito.mock(OidcAuthenticationConfigurationRepository.class);
-    final var customizer = new OidcTokenEndpointCustomizer(mockRepository);
+    final var assertionJwkProvider = new AssertionJwkProvider(mockRepository);
     final var keystorePath =
-        OidcTokenEndpointCustomizerTest.class
-            .getClassLoader()
-            .getResource("keystore.p12")
-            .getPath();
+        AssertionJwkProviderTest.class.getClassLoader().getResource("keystore.p12").getPath();
     final var keystoreConfig =
         KeystoreConfiguration.builder()
             .path(keystorePath)
@@ -49,11 +46,11 @@ class OidcTokenEndpointCustomizerTest {
     final var cert = keystoreConfig.loadKeystore().getCertificate(keystoreConfig.getKeyAlias());
 
     final Method generateKid =
-        OidcTokenEndpointCustomizer.class.getDeclaredMethod(
+        AssertionJwkProvider.class.getDeclaredMethod(
             "generateKid", Certificate.class, AssertionConfiguration.class);
     generateKid.setAccessible(true);
 
-    final var kid = (String) generateKid.invoke(customizer, cert, config);
+    final var kid = (String) generateKid.invoke(assertionJwkProvider, cert, config);
     Assertions.assertThat(kid).isEqualTo("opaYc1PqzH6XYGbL3KF4BK1rkNRS4IuMAfh3qPZILHo");
   }
 
@@ -67,12 +64,9 @@ class OidcTokenEndpointCustomizerTest {
       final String expectedKid)
       throws Exception {
     final var mockRepository = Mockito.mock(OidcAuthenticationConfigurationRepository.class);
-    final var customizer = new OidcTokenEndpointCustomizer(mockRepository);
+    final var assertionJwkProvider = new AssertionJwkProvider(mockRepository);
     final var keystorePath =
-        OidcTokenEndpointCustomizerTest.class
-            .getClassLoader()
-            .getResource("keystore.p12")
-            .getPath();
+        AssertionJwkProviderTest.class.getClassLoader().getResource("keystore.p12").getPath();
     final var keystoreConfig =
         KeystoreConfiguration.builder()
             .path(keystorePath)
@@ -91,11 +85,11 @@ class OidcTokenEndpointCustomizerTest {
     final var cert = keystoreConfig.loadKeystore().getCertificate(keystoreConfig.getKeyAlias());
 
     final Method generateKid =
-        OidcTokenEndpointCustomizer.class.getDeclaredMethod(
+        AssertionJwkProvider.class.getDeclaredMethod(
             "generateKid", Certificate.class, AssertionConfiguration.class);
     generateKid.setAccessible(true);
 
-    final var kid = (String) generateKid.invoke(customizer, cert, config);
+    final var kid = (String) generateKid.invoke(assertionJwkProvider, cert, config);
     Assertions.assertThat(kid).isEqualTo(expectedKid);
   }
 


### PR DESCRIPTION
# Description
Backport of #38651 to `stable/8.8`.

relates to #37680