### PR TITLE
fix: active digest for hc integration tests

### DIFF
--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -23,6 +23,7 @@ jobs:
       camunda-helm-dir: camunda-platform-8.8
       test-enabled: true
       caller-git-ref: main
+      values-digest: true
       extra-values: |
         zeebe:
           image:


### PR DESCRIPTION
## Description

Re-enable the use of digest values for the monorepo HC integration tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
