### PR TITLE
ci: add monorepo-ci-medic and runbook link to camunda helm integration

### DIFF
--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -85,7 +85,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>."
+                    "text": "<!subteam^S07D6C6B18T|monorepo-ci-medic> please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>.\n For how to investigate, see <https://github.com/camunda/camunda/wiki/CI-Runbooks#camunda-helm-chart-integration-test-failure|Runbook - Camunda Helm Chart Integration Test>."
                   }
                 }
               ]


### PR DESCRIPTION
## Description

This pull request makes a small but important update to the Slack notification message in the Camunda Helm integration workflow. The message now directly mentions the relevant Slack group and provides a link to the runbook for investigating test failures.

* The Slack notification message in `.github/workflows/camunda-helm-integration.yml` now mentions the `monorepo-ci-medic` group and includes a link to the runbook for Camunda Helm Chart Integration Test failures.
<img width="693" height="124" alt="image" src="https://github.com/user-attachments/assets/545d3efc-a899-4e70-80a8-cda7fca8afd9" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
