### PR TITLE
perf: reduce the max terms count to 10_000

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
@@ -21,6 +21,7 @@ public class ElasticsearchProperties {
   public static final String DATE_FORMAT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
 
   public static final String ELS_DATE_FORMAT_DEFAULT = "date_time";
+  public static final int DEFAULT_MAX_TERMS_COUNT = 10_000;
 
   private String clusterName = "elasticsearch";
 
@@ -33,6 +34,7 @@ public class ElasticsearchProperties {
   private String elsDateFormat = ELS_DATE_FORMAT_DEFAULT;
 
   private int batchSize = 200;
+  private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
 
   private Integer socketTimeout;
   private Integer connectTimeout;
@@ -112,6 +114,14 @@ public class ElasticsearchProperties {
 
   public void setBatchSize(final int batchSize) {
     this.batchSize = batchSize;
+  }
+
+  public int getMaxTermsCount() {
+    return maxTermsCount;
+  }
+
+  public void setMaxTermsCount(final int maxTermsCount) {
+    this.maxTermsCount = maxTermsCount;
   }
 
   public boolean isCreateSchema() {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
@@ -21,6 +21,7 @@ public class OpenSearchProperties {
   public static final String DATE_FORMAT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
 
   public static final String ELS_DATE_FORMAT_DEFAULT = "date_time";
+  public static final int DEFAULT_MAX_TERMS_COUNT = 10_000;
 
   private String clusterName = "opensearch-cluster";
 
@@ -33,6 +34,7 @@ public class OpenSearchProperties {
   private String elsDateFormat = ELS_DATE_FORMAT_DEFAULT;
 
   private int batchSize = 200;
+  private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
 
   private Integer socketTimeout;
   private Integer connectTimeout;
@@ -113,6 +115,14 @@ public class OpenSearchProperties {
 
   public void setBatchSize(final int batchSize) {
     this.batchSize = batchSize;
+  }
+
+  public int getMaxTermsCount() {
+    return maxTermsCount;
+  }
+
+  public void setMaxTermsCount(final int maxTermsCount) {
+    this.maxTermsCount = maxTermsCount;
   }
 
   public boolean isCreateSchema() {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/VariableStore.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/VariableStore.java
@@ -29,8 +29,6 @@ public interface VariableStore {
 
   public TaskVariableEntity getTaskVariable(final String variableId, Set<String> fieldNames);
 
-  void refreshMaxTermsCount();
-
   public List<String> getProcessInstanceIdsWithMatchingVars(
       List<String> varNames, List<String> varValues);
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -10,7 +10,6 @@ package io.camunda.tasklist.store.elasticsearch;
 import static io.camunda.tasklist.schema.indices.ProcessInstanceDependant.PROCESS_INSTANCE_ID;
 import static io.camunda.tasklist.util.CollectionUtil.asMap;
 import static io.camunda.tasklist.util.CollectionUtil.getOrDefaultFromMap;
-import static io.camunda.tasklist.util.ElasticsearchUtil.DEFAULT_MAX_TERMS_COUNT;
 import static io.camunda.tasklist.util.ElasticsearchUtil.QueryType.ALL;
 import static io.camunda.tasklist.util.ElasticsearchUtil.SCROLL_KEEP_ALIVE_MS;
 import static io.camunda.tasklist.util.ElasticsearchUtil.createSearchRequest;
@@ -292,7 +291,7 @@ public class TaskStoreElasticSearch implements TaskStore {
       // we need to chunk them
       return scrollInChunks(
           processInstanceIds,
-          DEFAULT_MAX_TERMS_COUNT,
+          tasklistProperties.getElasticsearch().getMaxTermsCount(),
           this::buildSearchCreatedTasksByProcessInstanceIdsRequest,
           TaskEntity.class,
           objectMapper,

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -11,7 +11,6 @@ import static io.camunda.tasklist.schema.indices.ProcessInstanceDependant.PROCES
 import static io.camunda.tasklist.schema.templates.TaskTemplate.STATE;
 import static io.camunda.tasklist.util.CollectionUtil.asMap;
 import static io.camunda.tasklist.util.CollectionUtil.getOrDefaultFromMap;
-import static io.camunda.tasklist.util.OpenSearchUtil.DEFAULT_MAX_TERMS_COUNT;
 import static io.camunda.tasklist.util.OpenSearchUtil.QueryType.ALL;
 import static io.camunda.tasklist.util.OpenSearchUtil.SCROLL_KEEP_ALIVE_MS;
 import static io.camunda.tasklist.util.OpenSearchUtil.createSearchRequest;
@@ -289,11 +288,10 @@ public class TaskStoreOpenSearch implements TaskStore {
   private List<TaskEntity> getActiveTasksByProcessInstanceIds(
       final List<String> processInstanceIds) {
     try {
-      // the number of process instance ids may be large and exceed #DEFAULT_MAX_TERMS_COUNT, so
-      // we need to chunk them
+      // the number of process instance ids may be large, so we need to chunk them
       return scrollInChunks(
           processInstanceIds,
-          DEFAULT_MAX_TERMS_COUNT,
+          tasklistProperties.getOpenSearch().getMaxTermsCount(),
           this::buildSearchCreatedTasksByProcessInstanceIdsRequest,
           TaskEntity.class,
           osClient);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
@@ -81,7 +81,6 @@ public abstract class ElasticsearchUtil {
       30000; // this scroll timeout value is used for reindex and delete queries
   public static final int QUERY_MAX_SIZE = 10000;
   public static final int UPDATE_RETRY_COUNT = 3;
-  public static final int DEFAULT_MAX_TERMS_COUNT = 65536;
   public static final Function<SearchHit, Long> SEARCH_HIT_ID_TO_LONG =
       (hit) -> Long.valueOf(hit.getId());
   public static final Function<SearchHit, String> SEARCH_HIT_ID_TO_STRING = SearchHit::getId;
@@ -378,8 +377,7 @@ public abstract class ElasticsearchUtil {
 
   /**
    * Helper method to scroll in chunks. This is useful when you have a large number of ids and want
-   * to avoid sending them all at once to OpenSearch to not hit the max allowed terms limit {@link
-   * #DEFAULT_MAX_TERMS_COUNT}
+   * to avoid sending them all at once to Elasticsearch
    */
   public static <T extends TasklistEntity> List<T> scrollInChunks(
       final List<String> list,

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/OpenSearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/OpenSearchUtil.java
@@ -56,7 +56,6 @@ public abstract class OpenSearchUtil {
       "30000ms"; // this scroll timeout value is used for reindex and delete q
   public static final int QUERY_MAX_SIZE = 10000;
   public static final int UPDATE_RETRY_COUNT = 3;
-  public static final int DEFAULT_MAX_TERMS_COUNT = 65536;
   public static final Function<Hit, Long> SEARCH_HIT_ID_TO_LONG = (hit) -> Long.valueOf(hit.id());
   public static final Function<Hit, String> SEARCH_HIT_ID_TO_STRING = Hit::id;
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchUtil.class);
@@ -430,8 +429,7 @@ public abstract class OpenSearchUtil {
 
   /**
    * Helper method to scroll in chunks. This is useful when you have a large number of ids and want
-   * to avoid sending them all at once to OpenSearch to not hit the max allowed terms limit {@link
-   * #DEFAULT_MAX_TERMS_COUNT}
+   * to avoid sending them all at once to OpenSearch
    */
   public static <T extends TasklistEntity> List<T> scrollInChunks(
       final List<String> ids,

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/perf/TaskStorePerfIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/perf/TaskStorePerfIT.java
@@ -149,7 +149,7 @@ class TaskStorePerfIT extends TasklistIntegrationTest {
         Arguments.of(2, 1000, 500),
         Arguments.of(2, 3000, 1000),
         Arguments.of(1, 10_000, 2000),
-        Arguments.of(1, 30_000, 10000));
+        Arguments.of(1, 30_000, 6000));
   }
 
   private void assertWithRetry(final int maxAttempts, final Runnable assertion)

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/DatabaseTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/DatabaseTestExtension.java
@@ -19,10 +19,6 @@ import org.junit.jupiter.api.extension.Extension;
 
 public interface DatabaseTestExtension extends Extension {
 
-  void setIndexMaxTermsCount(final String indexName, final int maxTermsCount) throws IOException;
-
-  int getIndexMaxTermsCount(final String indexName) throws IOException;
-
   void assertMaxOpenScrollContexts(final int maxOpenScrollContexts);
 
   void refreshIndexesInElasticsearch();

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.tasklist.util;
 
-import static io.camunda.tasklist.store.elasticsearch.VariableStoreElasticSearch.MAX_TERMS_COUNT_SETTING;
 import static io.camunda.tasklist.util.ElasticsearchUtil.LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED;
 import static io.camunda.tasklist.util.ThreadUtil.sleepFor;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,8 +39,6 @@ import java.util.stream.Collectors;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
-import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
-import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
@@ -53,7 +50,6 @@ import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.GetComposableIndexTemplateRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetIndexResponse;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.index.reindex.ReindexRequest;
@@ -141,32 +137,6 @@ public class ElasticsearchTestExtension
         .getElasticsearch()
         .setIndexPrefix(TasklistElasticsearchProperties.DEFAULT_INDEX_PREFIX);
     assertMaxOpenScrollContexts(10);
-  }
-
-  @Override
-  public void setIndexMaxTermsCount(final String indexName, final int maxTermsCount)
-      throws IOException {
-    esClient
-        .indices()
-        .putSettings(
-            new UpdateSettingsRequest()
-                .indices(indexName)
-                .settings(Settings.builder().put(MAX_TERMS_COUNT_SETTING, maxTermsCount).build()),
-            RequestOptions.DEFAULT);
-  }
-
-  @Override
-  public int getIndexMaxTermsCount(final String indexName) throws IOException {
-    return Integer.parseInt(
-        esClient
-            .indices()
-            .getSettings(
-                new GetSettingsRequest()
-                    .indices(indexName)
-                    .includeDefaults(true)
-                    .names(MAX_TERMS_COUNT_SETTING),
-                RequestOptions.DEFAULT)
-            .getSetting(indexName, MAX_TERMS_COUNT_SETTING));
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.tasklist.util;
 
-import static io.camunda.tasklist.store.opensearch.VariableStoreOpenSearch.MAX_TERMS_COUNT_SETTING;
 import static io.camunda.tasklist.util.ThreadUtil.sleepFor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
@@ -46,9 +45,6 @@ import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.opensearch.client.opensearch.core.reindex.Source;
 import org.opensearch.client.opensearch.indices.GetIndexResponse;
-import org.opensearch.client.opensearch.indices.GetIndicesSettingsRequest;
-import org.opensearch.client.opensearch.indices.IndexSettings;
-import org.opensearch.client.opensearch.indices.PutIndicesSettingsRequest;
 import org.opensearch.client.opensearch.nodes.Stats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -126,35 +122,6 @@ public class OpenSearchTestExtension
         .getOpenSearch()
         .setIndexPrefix(TasklistOpenSearchProperties.DEFAULT_INDEX_PREFIX);
     assertMaxOpenScrollContexts(10);
-  }
-
-  @Override
-  public void setIndexMaxTermsCount(final String indexName, final int maxTermsCount)
-      throws IOException {
-
-    osClient
-        .indices()
-        .putSettings(
-            PutIndicesSettingsRequest.of(
-                f ->
-                    f.index(indexName)
-                        .settings(IndexSettings.of(s -> s.maxTermsCount(maxTermsCount)))));
-  }
-
-  @Override
-  public int getIndexMaxTermsCount(final String indexName) throws IOException {
-    return osClient
-        .indices()
-        .getSettings(
-            new GetIndicesSettingsRequest.Builder()
-                .index(indexName)
-                .includeDefaults(true)
-                .name(MAX_TERMS_COUNT_SETTING)
-                .build())
-        .get(indexName)
-        .settings()
-        .index()
-        .maxTermsCount();
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/VariableSearchTermsQueryChunkIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/VariableSearchTermsQueryChunkIT.java
@@ -8,13 +8,10 @@
 package io.camunda.tasklist.webapp;
 
 import static io.camunda.tasklist.util.assertions.CustomAssertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.queries.TaskByVariables;
-import io.camunda.tasklist.schema.indices.VariableIndex;
-import io.camunda.tasklist.store.VariableStore;
 import io.camunda.tasklist.util.MockMvcHelper;
 import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchResponse;
@@ -26,6 +23,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -33,15 +32,17 @@ public class VariableSearchTermsQueryChunkIT extends TasklistZeebeIntegrationTes
 
   @Autowired private ObjectMapper objectMapper;
 
-  @Autowired private VariableIndex variableIndex;
-
   @Autowired private WebApplicationContext context;
-
-  @Autowired private VariableStore variableStore;
 
   private MockMvcHelper mockMvcHelper;
 
   private final String benchmarkProcess = "VariableSearch_Process";
+
+  @DynamicPropertySource
+  static void configureProperties(final DynamicPropertyRegistry registry) {
+    registry.add("camunda.tasklist.elasticsearch.max-terms-count", () -> 5);
+    registry.add("camunda.tasklist.opensearch.max-terms-count", () -> 5);
+  }
 
   @BeforeEach
   public void setUp() throws IOException, InterruptedException {
@@ -56,13 +57,6 @@ public class VariableSearchTermsQueryChunkIT extends TasklistZeebeIntegrationTes
         .getProcesses()
         .getFirst()
         .getProcessDefinitionKey();
-
-    databaseTestExtension.setIndexMaxTermsCount(variableIndex.getFullQualifiedName(), 5);
-
-    assertEquals(
-        5, databaseTestExtension.getIndexMaxTermsCount(variableIndex.getFullQualifiedName()));
-
-    variableStore.refreshMaxTermsCount();
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
We found out that sending more than 10K terms in scroll query request, heavily degrade the response time for **Opensearch**. Between 10K terms and 20K there is 10x response time degradation factor.
In this pull request, we make the maximum number of terms configurable, with the default 10_000.
This allowed to reduce the expected response time for search task by variables for 10 to 6 seconds for the case of [30_000 matching tasks](https://github.com/camunda/camunda/blob/944c73238ee32046864d896a19b710cd77f5f1d6/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/perf/TaskStorePerfIT.java#L152).

Also, we removed the reading of the setting from the index itself. I think this was done to consider an override to increase it beyond the default 65536, which will give bad performance anyway.
Also this was silently throwing NPEs in the separate thread that was responsible of updating it from DB.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/32600
