### PR TITLE
fix: match on base package of target type not context class

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rest/PackageSpecificJackson2HttpMessageConverter.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/PackageSpecificJackson2HttpMessageConverter.java
@@ -8,7 +8,6 @@
 package io.camunda.application.commons.rest;
 
 import java.lang.reflect.Type;
-import java.util.Optional;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
@@ -22,10 +21,7 @@ public class PackageSpecificJackson2HttpMessageConverter
 
   @Override
   public boolean canRead(final Type type, final Class<?> contextClass, final MediaType mediaType) {
-    if (Optional.ofNullable(contextClass)
-        .map(Class::getPackage)
-        .map(p -> p.getName().startsWith(basePackage))
-        .orElse(false)) {
+    if (type.getTypeName().startsWith(basePackage)) {
       return super.canRead(type, contextClass, mediaType);
     }
     return false;


### PR DESCRIPTION
## Description

The currently configured package name is the one of the stub classes of the REST API, while the check was performed on the context class which is the controller class. This lead to the wrong mapper being used for the REST API.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

