### PR TITLE
fix: FNI and Variable aliases are used for V1 task search

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -146,7 +146,7 @@ public class VariableStoreElasticSearch implements VariableStore {
           applyFetchSourceForVariableIndex(searchSourceBuilder, fieldNames);
 
           final SearchRequest searchRequest =
-              new SearchRequest(variableIndex.getAlias()).source(searchSourceBuilder);
+              new SearchRequest(variableIndex.getFullQualifiedName()).source(searchSourceBuilder);
           try {
             variableEntities.addAll(
                 scroll(searchRequest, VariableEntity.class, objectMapper, esClient));

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -141,7 +141,7 @@ public class VariableStoreOpenSearch implements VariableStore {
                   .filter(OpenSearchUtil.joinWithAnd(flowNodeInstanceKeyQ, varNamesQ))
                   .build());
           final SearchRequest.Builder searchRequest = new SearchRequest.Builder();
-          searchRequest.index(variableIndex.getAlias()).query(query.build());
+          searchRequest.index(variableIndex.getFullQualifiedName()).query(query.build());
           applyFetchSourceForVariableIndex(searchRequest, fieldNames);
 
           try {
@@ -303,7 +303,7 @@ public class VariableStoreOpenSearch implements VariableStore {
 
     final SearchRequest.Builder searchRequestBuilder = new SearchRequest.Builder();
     searchRequestBuilder
-        .index(flowNodeInstanceIndex.getAlias())
+        .index(flowNodeInstanceIndex.getFullQualifiedName())
         .query(combinedQuery.build())
         .sort(
             sort ->

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearchTest.java
@@ -67,10 +67,10 @@ class VariableStoreElasticSearchTest {
 
     when(mockedResponse.getScrollId()).thenReturn("scrolling_id0");
 
-    final SearchHits mockedHints = mock();
-    when(mockedResponse.getHits()).thenReturn(mockedHints);
+    final SearchHits mockedHits = mock();
+    when(mockedResponse.getHits()).thenReturn(mockedHits);
 
-    when(mockedHints.getHits()).thenReturn(new SearchHit[] {});
+    when(mockedHits.getHits()).thenReturn(new SearchHit[] {});
 
     // When
     final List<FlowNodeInstanceEntity> result = instance.getFlowNodeInstances(List.of("1234567"));
@@ -79,10 +79,68 @@ class VariableStoreElasticSearchTest {
     verify(esClient, never()).scroll(any(SearchScrollRequest.class), any(RequestOptions.class));
 
     final SearchRequest capturedSearchRequest = searchRequestCaptor.getValue();
-    final String expectedAlias =
-        String.format("test-operate-flownode-instance-%s_", flowNodeInstanceIndex.getVersion());
-    assertThat(capturedSearchRequest.indices()).containsExactly(expectedAlias);
+    assertThat(capturedSearchRequest.indices())
+        .containsExactly(flowNodeInstanceIndex.getFullQualifiedName());
     assertThat(capturedSearchRequest.source().size()).isEqualTo(200);
     assertThat(result).isEmpty();
+  }
+
+  @Test
+  void getVariablesByFlowNodeInstanceIdsShouldUseVariableIndex() throws Exception {
+    // Given
+    final SearchResponse mockedResponse = mock();
+    when(esClient.search(searchRequestCaptor.capture(), eq(RequestOptions.DEFAULT)))
+        .thenReturn(mockedResponse);
+
+    when(mockedResponse.getScrollId()).thenReturn("scrolling_id1");
+
+    final SearchHits mockedHits = mock();
+    when(mockedResponse.getHits()).thenReturn(mockedHits);
+
+    when(mockedHits.getHits()).thenReturn(new SearchHit[] {});
+
+    // When
+    final var result =
+        instance.getVariablesByFlowNodeInstanceIds(List.of("flowNodeId1"), null, null);
+
+    // Then
+    final SearchRequest capturedSearchRequest = searchRequestCaptor.getValue();
+    assertThat(capturedSearchRequest.indices())
+        .containsExactly(variableIndex.getFullQualifiedName());
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void getVariablesByFlowNodeInstanceIdsWithVariableNamesShouldUseCorrectQuery() throws Exception {
+    // Given
+    final SearchResponse mockedResponse = mock();
+    when(esClient.search(searchRequestCaptor.capture(), eq(RequestOptions.DEFAULT)))
+        .thenReturn(mockedResponse);
+
+    when(mockedResponse.getScrollId()).thenReturn("scrolling_id2");
+
+    final SearchHits mockedHits = mock();
+    when(mockedResponse.getHits()).thenReturn(mockedHits);
+
+    when(mockedHits.getHits()).thenReturn(new SearchHit[] {});
+
+    // When
+    final List<String> varNames = List.of("varName1", "varName2");
+    final var result =
+        instance.getVariablesByFlowNodeInstanceIds(List.of("flowNodeId1"), varNames, null);
+
+    // Then
+    verify(esClient, never()).scroll(any(SearchScrollRequest.class), any(RequestOptions.class));
+
+    final SearchRequest capturedSearchRequest = searchRequestCaptor.getValue();
+    assertThat(capturedSearchRequest.indices())
+        .containsExactly(variableIndex.getFullQualifiedName());
+
+    // Verify query
+    final String queryAsString = capturedSearchRequest.source().toString();
+    assertThat(queryAsString)
+        .isEqualTo(
+            """
+           {"query":{"constant_score":{"filter":{"bool":{"must":[{"terms":{"scopeKey":["flowNodeId1"],"boost":1.0}},{"terms":{"name":["varName1","varName2"],"boost":1.0}}],"adjust_pure_negative":true,"boost":1.0}},"boost":1.0}}}""");
   }
 }

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearchTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.store.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.tasklist.CommonUtils;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
+import io.camunda.webapps.schema.descriptors.template.SnapshotTaskVariableTemplate;
+import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
+import io.camunda.webapps.schema.entities.VariableEntity;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+
+@ExtendWith(MockitoExtension.class)
+class VariableStoreOpenSearchTest {
+
+  @Captor private ArgumentCaptor<SearchRequest> searchRequestCaptor;
+  @Mock private OpenSearchClient osClient;
+  @Spy private VariableTemplate variableIndex = new VariableTemplate("test", true);
+
+  @Spy
+  private FlowNodeInstanceTemplate flowNodeInstanceIndex =
+      new FlowNodeInstanceTemplate("test", true);
+
+  @Spy
+  private SnapshotTaskVariableTemplate taskVariableTemplate =
+      new SnapshotTaskVariableTemplate("test", true);
+
+  @Spy private TasklistProperties tasklistProperties = new TasklistProperties();
+  @Spy private ObjectMapper objectMapper = CommonUtils.OBJECT_MAPPER;
+  @InjectMocks private VariableStoreOpenSearch instance;
+
+  @Test
+  void getVariablesByFlowNodeInstanceIdsShouldUseVariableIndex() throws Exception {
+    // Given
+    final SearchResponse<VariableEntity> mockedResponse = mock();
+    when(osClient.search(searchRequestCaptor.capture(), any(Class.class)))
+        .thenReturn(mockedResponse);
+
+    when(mockedResponse.scrollId()).thenReturn("scrolling_id1");
+    when(mockedResponse.hits()).thenReturn(mock());
+    when(mockedResponse.hits().hits()).thenReturn(List.of());
+
+    // When
+    final var result =
+        instance.getVariablesByFlowNodeInstanceIds(List.of("flowNodeId1"), null, null);
+
+    // Then
+    final SearchRequest capturedSearchRequest = searchRequestCaptor.getValue();
+    assertThat(capturedSearchRequest.index()).containsExactly(variableIndex.getFullQualifiedName());
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void getVariablesByFlowNodeInstanceIdsWithVariableNamesShouldUseCorrectQuery() throws Exception {
+    // Given
+    final SearchResponse mockedResponse = mock();
+    when(osClient.search(searchRequestCaptor.capture(), any())).thenReturn(mockedResponse);
+
+    when(mockedResponse.scrollId()).thenReturn("scrolling_id2");
+    when(mockedResponse.hits()).thenReturn(mock());
+    when(mockedResponse.hits().hits()).thenReturn(List.of());
+
+    // When
+    final List<String> varNames = List.of("varName1", "varName2");
+    final var result =
+        instance.getVariablesByFlowNodeInstanceIds(List.of("flowNodeId1"), varNames, Set.of());
+
+    // Then
+    final SearchRequest capturedSearchRequest = searchRequestCaptor.getValue();
+    assertThat(capturedSearchRequest.index()).containsExactly(variableIndex.getFullQualifiedName());
+    // Verify query
+    final var filters = capturedSearchRequest.query().constantScore().filter().bool().must();
+    assertThat(filters).hasSize(2);
+    assertThat(filters.getFirst().terms().field()).isEqualTo(FlowNodeInstanceTemplate.SCOPE_KEY);
+    assertThat(filters.getFirst().terms().terms().value().stream().map(FieldValue::_get))
+        .isEqualTo(List.of("flowNodeId1"));
+    assertThat(filters.getLast().terms().field()).isEqualTo(VariableTemplate.NAME);
+    assertThat(filters.getLast().terms().terms().value().stream().map(FieldValue::_get))
+        .isEqualTo(varNames);
+    assertThat(result).isEmpty();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
V1 Tasks search requires only runtime data, no need to use the alias of variables and FNI indices
This can have a performance overhead, since the search does a full scroll in these indices 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38696 
