### PR TITLE
Fix candidate group resolution

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskRestrictionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskRestrictionsIT.java
@@ -60,8 +60,11 @@ public class UserTaskRestrictionsIT {
   private static final String USER2 = "user2";
   private static final String USER3 = "user3";
   private static final String USER4 = "user4";
+  private static final String USER5 = "user5";
   private static final String GROUP1 = "group1";
   private static final String GROUP2 = "group2";
+  private static final String GROUP3_ID = "group3";
+  private static final String GROUP3_NAME = "Group 3";
 
   private static final String PROCESS_ID_1 = "processWithCandidateUsers";
   private static final BpmnModelInstance PROCESS_1 =
@@ -86,11 +89,15 @@ public class UserTaskRestrictionsIT {
           .userTask("group1Task")
           .zeebeUserTask()
           .zeebeCandidateGroups(GROUP1)
-          .parallelGateway("endParallel")
+          .endEvent()
           .moveToNode("startParallel")
           .userTask("group2Task")
           .zeebeUserTask()
           .zeebeCandidateGroups(GROUP2)
+          .moveToNode("startParallel")
+          .userTask("group3Task")
+          .zeebeUserTask()
+          .zeebeCandidateGroups(GROUP3_NAME)
           .done();
 
   @UserDefinition
@@ -123,6 +130,9 @@ public class UserTaskRestrictionsIT {
   @UserDefinition
   private static final TestUser USER4_USER = new TestUser(USER4, "password", List.of());
 
+  @UserDefinition
+  private static final TestUser USER5_USER = new TestUser(USER5, "password", List.of());
+
   @GroupDefinition
   private static final TestGroup GROUP1_GROUP =
       new TestGroup(
@@ -139,6 +149,14 @@ public class UserTaskRestrictionsIT {
           List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))),
           List.of(new Membership(USER4, EntityType.USER)));
 
+  @GroupDefinition
+  private static final TestGroup GROUP3_GROUP =
+      new TestGroup(
+          GROUP3_ID,
+          GROUP3_NAME,
+          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))),
+          List.of(new Membership(USER5, EntityType.USER)));
+
   private static long processInstanceKeyCandidateUsers;
   private static long processInstanceKeyCandidateGroups;
 
@@ -152,7 +170,7 @@ public class UserTaskRestrictionsIT {
     processInstanceKeyCandidateGroups = startEvent2.getProcessInstanceKey();
 
     awaitUserTaskBeingAvailable(adminClient, processInstanceKeyCandidateUsers, 2);
-    awaitUserTaskBeingAvailable(adminClient, processInstanceKeyCandidateGroups, 2);
+    awaitUserTaskBeingAvailable(adminClient, processInstanceKeyCandidateGroups, 3);
   }
 
   @Test
@@ -201,18 +219,25 @@ public class UserTaskRestrictionsIT {
         final var tasklistUser4RestClient =
             STANDALONE_CAMUNDA
                 .newTasklistClient()
-                .withAuthentication(USER4_USER.username(), USER4_USER.password()); ) {
+                .withAuthentication(USER4_USER.username(), USER4_USER.password());
+        final var tasklistUser5RestClient =
+            STANDALONE_CAMUNDA
+                .newTasklistClient()
+                .withAuthentication(USER5_USER.username(), USER5_USER.password()); ) {
 
       // when
       // searching for tasks available to user1 and user2 (no process instance key provided)
       final HttpResponse<String> user3Response = tasklistUser3RestClient.searchTasks(null);
       final HttpResponse<String> user4Response = tasklistUser4RestClient.searchTasks(null);
+      final HttpResponse<String> user5Response = tasklistUser5RestClient.searchTasks(null);
 
       // then
       assertThat(user3Response).isNotNull();
       assertThat(user4Response).isNotNull();
+      assertThat(user5Response).isNotNull();
       assertThat(user3Response.statusCode()).isEqualTo(200);
       assertThat(user4Response.statusCode()).isEqualTo(200);
+      assertThat(user5Response.statusCode()).isEqualTo(200);
 
       final TaskSearchResponse[] tasksUser3 =
           TestRestTasklistClient.OBJECT_MAPPER.readValue(
@@ -224,6 +249,11 @@ public class UserTaskRestrictionsIT {
               user4Response.body(), TaskSearchResponse[].class);
       assertThat(tasksUser4).hasSize(1);
       assertThat(tasksUser4[0].getCandidateGroups()).containsExactly(GROUP2);
+      final var tasksUser5 =
+          TestRestTasklistClient.OBJECT_MAPPER.readValue(
+              user5Response.body(), TaskSearchResponse[].class);
+      assertThat(tasksUser5).hasSize(1);
+      assertThat(tasksUser5[0].getCandidateGroups()).containsExactly(GROUP3_NAME);
     }
   }
 

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -66,6 +66,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-service</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-domain</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- ELASTICSEARCH -->
     <dependency>
       <groupId>org.elasticsearch.client</groupId>

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -78,9 +78,15 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-schema-manager</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-connect</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-domain</artifactId>
     </dependency>
 
     <!-- ZEEBE -->

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
@@ -10,7 +10,10 @@ package io.camunda.tasklist.webapp.api.rest.v1.controllers;
 import static io.camunda.tasklist.webapp.mapper.TaskMapper.TASK_DESCRIPTION;
 import static java.util.Objects.requireNonNullElse;
 
+import io.camunda.search.query.GroupQuery;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.GroupServices;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.queries.TaskByCandidateUserOrGroup;
 import io.camunda.tasklist.util.LazySupplier;
@@ -82,6 +85,7 @@ public class TaskController extends ApiErrorController {
   @Autowired private TaskMapper taskMapper;
   @Autowired private CamundaAuthenticationProvider authenticationProvider;
   @Autowired private UserGroupService userGroupService;
+  @Autowired private GroupServices groupServices;
   @Autowired private TasklistProperties tasklistProperties;
   @Autowired private TasklistPermissionServices permissionServices;
 
@@ -128,11 +132,13 @@ public class TaskController extends ApiErrorController {
         // this is backwards compatible with previous versions, but in the future this will change
         && userName != null
         && !userName.isEmpty()) {
-      final List<String> listOfUserGroups = userGroupService.getUserGroups();
       final TaskByCandidateUserOrGroup taskByCandidateUserOrGroup =
           new TaskByCandidateUserOrGroup();
-      taskByCandidateUserOrGroup.setUserGroups(listOfUserGroups.toArray(String[]::new));
       taskByCandidateUserOrGroup.setUserName(userName);
+
+      final var setOfUserGroupNames = resolveGroupNames(userGroupService.getUserGroups());
+      taskByCandidateUserOrGroup.setUserGroups(setOfUserGroupNames.toArray(String[]::new));
+
       query.setTaskByCandidateUserOrGroup(taskByCandidateUserOrGroup);
     }
 
@@ -253,13 +259,13 @@ public class TaskController extends ApiErrorController {
       // this is backwards compatible with previous versions, but in the future this will change
       return true;
     }
-    final List<String> listOfUserGroups = userGroupService.getUserGroups();
+    final Set<String> setOfUserGroups = resolveGroupNames(userGroupService.getUserGroups());
     final var task = taskSupplier.get();
     final boolean allUsersTask =
         task.getCandidateUsers() == null && task.getCandidateGroups() == null;
     final boolean candidateGroupTasks =
         task.getCandidateGroups() != null
-            && !Collections.disjoint(Arrays.asList(task.getCandidateGroups()), listOfUserGroups);
+            && !Collections.disjoint(Arrays.asList(task.getCandidateGroups()), setOfUserGroups);
     final boolean candidateUserTasks =
         task.getCandidateUsers() != null
             && Arrays.asList(task.getCandidateUsers()).contains(userName);
@@ -521,6 +527,22 @@ public class TaskController extends ApiErrorController {
     variables.forEach(resp -> unsetBigVariableValuesIfNeeded(resp, variableNamesToReturnFullValue));
 
     return ResponseEntity.ok(variables);
+  }
+
+  private Set<String> resolveGroupNames(final List<String> userGroupIds) {
+    // candidate groups use group names instead of group ids
+    // so we need to resolve the group names from the group ids
+    if (userGroupIds.isEmpty()) {
+      return Collections.EMPTY_SET;
+    }
+    final Set<String> setOfUserGroupIds = userGroupIds.stream().collect(Collectors.toSet());
+    final var groups =
+        groupServices
+            .withAuthentication(CamundaAuthentication.anonymous())
+            .search(
+                GroupQuery.of(
+                    groupQuery -> groupQuery.filter(filter -> filter.groupIds(setOfUserGroupIds))));
+    return groups.items().stream().map(g -> g.name()).collect(Collectors.toSet());
   }
 
   private LazySupplier<TaskDTO> getTaskSupplier(final String taskId) {

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerTest.java
@@ -20,8 +20,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.GroupServices;
 import io.camunda.tasklist.exceptions.NotFoundException;
 import io.camunda.tasklist.property.IdentityProperties;
 import io.camunda.tasklist.property.TasklistProperties;
@@ -69,6 +72,7 @@ class TaskControllerTest {
   @Mock private TaskService taskService;
   @Mock private VariableService variableService;
   @Mock private TaskMapper taskMapper;
+  @Mock private GroupServices groupServices;
   @InjectMocks private TaskController instance;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -84,13 +88,13 @@ class TaskControllerTest {
     setAuthenticatedClient("foo");
   }
 
-  protected void setAuthenticatedUser(String name) {
+  protected void setAuthenticatedUser(final String name) {
 
     final var authentication = CamundaAuthentication.of(b -> b.user(name));
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
   }
 
-  protected void setAuthenticatedClient(String id) {
+  protected void setAuthenticatedClient(final String id) {
 
     final var authentication = CamundaAuthentication.of(b -> b.clientId(id));
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
@@ -1139,6 +1143,10 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
+        when(groupServices.withAuthentication(CamundaAuthentication.anonymous()))
+            .thenReturn(groupServices);
+        when(groupServices.search(any()))
+            .thenReturn(SearchQueryResult.of(new GroupEntity(1L, "Admins", "Admins", "default")));
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
         when(taskService.getTasks(searchQuery, Set.of(TASK_DESCRIPTION), false))
             .thenReturn(List.of(providedTask));
@@ -1256,6 +1264,10 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
+        when(groupServices.withAuthentication(CamundaAuthentication.anonymous()))
+            .thenReturn(groupServices);
+        when(groupServices.search(any()))
+            .thenReturn(SearchQueryResult.of(new GroupEntity(1L, "Admins", "Admins", "default")));
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
         when(taskMapper.toTaskSearchResponse(providedTask)).thenReturn(taskResponse);
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
@@ -1319,6 +1331,10 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
+        when(groupServices.withAuthentication(CamundaAuthentication.anonymous()))
+            .thenReturn(groupServices);
+        when(groupServices.search(any()))
+            .thenReturn(SearchQueryResult.of(new GroupEntity(1L, "Admins", "Admins", "default")));
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
         when(taskService.getTasks(searchQuery, Set.of(TASK_DESCRIPTION), false))
             .thenReturn(List.of(providedTask));
@@ -1358,6 +1374,10 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
+        when(groupServices.withAuthentication(CamundaAuthentication.anonymous()))
+            .thenReturn(groupServices);
+        when(groupServices.search(any()))
+            .thenReturn(SearchQueryResult.of(new GroupEntity(1L, "Admins", "Admins", "default")));
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
 
         // When
@@ -1405,6 +1425,10 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
+        when(groupServices.withAuthentication(CamundaAuthentication.anonymous()))
+            .thenReturn(groupServices);
+        when(groupServices.search(any()))
+            .thenReturn(SearchQueryResult.of(new GroupEntity(1L, "Admins", "Admins", "default")));
         when(taskService.getTask(taskId)).thenReturn(taskDto);
         when(taskService.completeTask(taskId, variables, true)).thenReturn(taskDto);
         when(taskMapper.toTaskResponse(taskDto)).thenReturn(expectedTaskResponse);
@@ -1452,6 +1476,10 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Demo"));
+        when(groupServices.withAuthentication(CamundaAuthentication.anonymous()))
+            .thenReturn(groupServices);
+        when(groupServices.search(any()))
+            .thenReturn(SearchQueryResult.of(new GroupEntity(1L, "Demo", "Demo", "default")));
         when(taskService.getTask(taskId)).thenReturn(taskDto);
         when(taskService.completeTask(taskId, variables, true)).thenReturn(taskDto);
         when(taskMapper.toTaskResponse(taskDto)).thenReturn(expectedTaskResponse);
@@ -1504,6 +1532,10 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
+        when(groupServices.withAuthentication(CamundaAuthentication.anonymous()))
+            .thenReturn(groupServices);
+        when(groupServices.search(any()))
+            .thenReturn(SearchQueryResult.of(new GroupEntity(1L, "Admins", "Admins", "default")));
         when(taskService.getTask(taskId)).thenReturn(providedTask);
         when(taskMapper.toTaskResponse(providedTask)).thenReturn(taskResponse);
 
@@ -1553,6 +1585,10 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
+        when(groupServices.withAuthentication(CamundaAuthentication.anonymous()))
+            .thenReturn(groupServices);
+        when(groupServices.search(any()))
+            .thenReturn(SearchQueryResult.of(new GroupEntity(1L, "Admins", "Admins", "default")));
         when(taskService.getTask(taskId)).thenReturn(providedTask);
         when(taskMapper.toTaskResponse(providedTask)).thenReturn(taskResponse);
 
@@ -1604,6 +1640,10 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Test"));
+        when(groupServices.withAuthentication(CamundaAuthentication.anonymous()))
+            .thenReturn(groupServices);
+        when(groupServices.search(any()))
+            .thenReturn(SearchQueryResult.of(new GroupEntity(1L, "Test", "Test", "default")));
         when(taskService.getTask(taskId)).thenReturn(providedTask);
         when(taskMapper.toTaskResponse(providedTask)).thenReturn(taskResponse);
 
@@ -1657,6 +1697,10 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         setAuthenticatedUser("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
+        when(groupServices.withAuthentication(CamundaAuthentication.anonymous()))
+            .thenReturn(groupServices);
+        when(groupServices.search(any()))
+            .thenReturn(SearchQueryResult.of(new GroupEntity(1L, "Admins", "Admins", "default")));
         when(tasklistPermissionServices.hasPermissionToUpdateUserTask(any())).thenReturn(true);
 
         // When


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
User task restrictions for candidate groups use the Group Name instead of the Group ID. When searching for tasks, Tasklist V1 now needs to resolve the group names from the provided authorized group IDs of the user.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38515
