### PR TITLE
ci: increase timeout for changelog generation

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -276,7 +276,8 @@ jobs:
     needs: release
     name: Github Release
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Minor releases take more time since a lot of issues are included in the changelog
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

During the 8.8.0 minor release (RC build) we discovered that [zcl](https://github.com/camunda/zeebe-changelog) can take more than 10 minutes to label 1000+ GitHub issues. This will also affect subsequent RC and the final build.

Example failure:

* https://github.com/camunda/camunda/actions/runs/17983861059/job/51165011649

Workaround for now is increasing the timeout from 10min to 30min to allow for the `zcl` to complete. 30min are probably not needed, but within 10min only 66% of the issues get labeled so 20min might be close.

Long-term it would be nice if `zcl` could parallelize the network operations to GitHub more to reduce idle waiting time and allow more efficient processing of 1000+ issues:

* https://github.com/camunda/zeebe-changelog/issues/22

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)) - no for now, I'm unsure whether retrying of https://github.com/camunda/camunda/actions/runs/17983861059 will pick up this change from `main` - if not, we might have to rebuild the artifacts

## Related issues

None
