### PR TITLE
fix(osano): updated styling for cookiebanner in tasklist and operate

### DIFF
--- a/operate/client/index.prod.html
+++ b/operate/client/index.prod.html
@@ -11,52 +11,34 @@
 
     <style>
       .osano-cm-widget {
-        display: none;
-      }
-      .osano-cm-widget:focus,
-      .osano-cm-widget:hover {
-        opacity: 1;
-        transform: none;
-      }
-      .osano-cm-widget:active {
-        transform: translateY(1px);
-      }
-      div.osano-cm-info__info-views.osano-cm-info-views.osano-cm-info-views--position_0
-        > div
-        > ul
-        > li:last-of-type {
-        display: none;
-      }
-      .osano-cm-button--type_accept {
-        border-radius: 30px;
-        border: 1px solid #000000;
-      }
-      .osano-cm-button--type_deny {
-        border-radius: 30px;
-      }
-      .osano-cm-button--type_save {
-        color: #434343;
-        background-color: #f7f7f7;
-        border-radius: 30px;
-        border: 1px solid #434343;
-      }
-      .osano-cm-button--type_denyAll {
-        color: #434343;
-        background-color: #f7f7f7;
-        border-radius: 30px;
-        border: 1px solid #434343;
-      }
-      .osano-cm-button--type_deny:hover {
-        color: #434343;
-      }
-      .osano-cm-button--type_denyAll:hover {
-        color: #434343;
-        background-color: #e6e6e6;
-      }
-      .osano-cm-button--type_save:hover {
-        color: #434343;
-        background-color: #e6e6e6;
-      }
+				display: none;
+			}
+			.osano-cm-widget:focus,
+			.osano-cm-widget:hover {
+				opacity: 1;
+				transform: none;
+			}
+			.osano-cm-widget:active {
+				transform: translateY(1px);
+			}
+
+			.osano-cm-button--type_accept {
+				order: 3;
+			}
+
+			.osano-cm-button--type_save:hover {
+				color: #434343;
+				background-color: #e6e6e6;
+			}
+
+			.osano-cm-button {
+				border-radius: 30px;
+			}
+
+			.osano-cm-button:hover {
+				color: #434343;
+				background-color: #e6e6e6;
+			}
     </style>
   </head>
   <body>

--- a/tasklist/client/index.prod.html
+++ b/tasklist/client/index.prod.html
@@ -43,52 +43,34 @@
 
     <style>
       .osano-cm-widget {
-        display: none;
-      }
-      .osano-cm-widget:focus,
-      .osano-cm-widget:hover {
-        opacity: 1;
-        transform: none;
-      }
-      .osano-cm-widget:active {
-        transform: translateY(1px);
-      }
-      div.osano-cm-info__info-views.osano-cm-info-views.osano-cm-info-views--position_0
-        > div
-        > ul
-        > li:last-of-type {
-        display: none;
-      }
-      .osano-cm-button--type_accept {
-        border-radius: 30px;
-        border: 1px solid #000000;
-      }
-      .osano-cm-button--type_deny {
-        border-radius: 30px;
-      }
-      .osano-cm-button--type_save {
-        color: #434343;
-        background-color: #f7f7f7;
-        border-radius: 30px;
-        border: 1px solid #434343;
-      }
-      .osano-cm-button--type_denyAll {
-        color: #434343;
-        background-color: #f7f7f7;
-        border-radius: 30px;
-        border: 1px solid #434343;
-      }
-      .osano-cm-button--type_deny:hover {
-        color: #434343;
-      }
-      .osano-cm-button--type_denyAll:hover {
-        color: #434343;
-        background-color: #e6e6e6;
-      }
-      .osano-cm-button--type_save:hover {
-        color: #434343;
-        background-color: #e6e6e6;
-      }
+				display: none;
+			}
+			.osano-cm-widget:focus,
+			.osano-cm-widget:hover {
+				opacity: 1;
+				transform: none;
+			}
+			.osano-cm-widget:active {
+				transform: translateY(1px);
+			}
+
+			.osano-cm-button--type_accept {
+				order: 3;
+			}
+
+			.osano-cm-button--type_save:hover {
+				color: #434343;
+				background-color: #e6e6e6;
+			}
+
+			.osano-cm-button {
+				border-radius: 30px;
+			}
+
+			.osano-cm-button:hover {
+				color: #434343;
+				background-color: #e6e6e6;
+			}
     </style>
     <link rel="stylesheet" href="./custom.css" />
   </head>


### PR DESCRIPTION
## Description

brought up in https://camunda.slack.com/archives/C034F8NA1G8/p1758793221758139?thread_ts=1758735007.499619&cid=C034F8NA1G8 looks like the CSS for osano is lagging behind a bit, preventing the Analytics option to show up.

i just did the same in https://github.com/camunda/camunda-cloud-management-apps/pull/5294 for console and accounts/signup, so i thought it might be helpful if i just replicate what i did there and you can take it from here :)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
