### PR TITLE
Creates a uber JAR for the debug CLI

### DIFF
--- a/debug-cli/pom.xml
+++ b/debug-cli/pom.xml
@@ -69,7 +69,7 @@
             </goals>
             <phase>package</phase>
             <configuration>
-              <finalName>cdb-${project.version}</finalName>
+              <finalName>cdbg-${project.version}</finalName>
               <minimizeJar>true</minimizeJar>
               <filters>
                 <filter>

--- a/debug-cli/pom.xml
+++ b/debug-cli/pom.xml
@@ -1,12 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <relativePath>../parent/pom.xml</relativePath>
     <version>8.9.0-SNAPSHOT</version>
+    <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>debug-cli</artifactId>

--- a/debug-cli/pom.xml
+++ b/debug-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <relativePath>../../parent/pom.xml</relativePath>
+    <relativePath>../parent/pom.xml</relativePath>
     <version>8.9.0-SNAPSHOT</version>
   </parent>
 

--- a/debug-cli/pom.xml
+++ b/debug-cli/pom.xml
@@ -8,10 +8,10 @@
     <relativePath>../../parent/pom.xml</relativePath>
     <version>8.9.0-SNAPSHOT</version>
   </parent>
-  <artifactId>debug-cli</artifactId>
-  <name>Archetype - debug-cli</name>
-  <url>http://maven.apache.org</url>
 
+  <artifactId>debug-cli</artifactId>
+  <name>Camunda 8 Debug CLI</name>
+  <url>http://maven.apache.org</url>
 
   <dependencies>
     <dependency>
@@ -19,9 +19,28 @@
       <artifactId>picocli</artifactId>
       <version>4.7.5</version>
     </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-cluster-config</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.github.resilience4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -29,10 +48,49 @@
       <artifactId>protobuf-java-util</artifactId>
       <version>${version.protobuf}</version>
     </dependency>
+
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>${version.protobuf}</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build-fatjar</id>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <finalName>cdb-${project.version}</finalName>
+              <minimizeJar>true</minimizeJar>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>**/*.xsd</exclude>
+                    <exclude>**/*.gif</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Main-Class>io.camunda.debug.cli.Main</Main-Class>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -78,10 +78,6 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-broker</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>debug-cli</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>io.camunda</groupId>
@@ -788,10 +784,6 @@
             <program>
               <id>broker</id>
               <mainClass>io.camunda.application.StandaloneBroker</mainClass>
-            </program>
-            <program>
-             <id>debug</id>
-              <mainClass>io.camunda.debug.cli.Main</mainClass>
             </program>
             <program>
               <id>gateway</id>


### PR DESCRIPTION
## Description

Adds `maven-shade-plugin` config and dependency exclusions to create a single executable JAR for the CLI, e.g. `java -jar cdb-8.9.0-SNAPSHOT.jar topology -f topology.meta`, and removes the CLI from the dist module.
