### PR TITLE
[Backport release-8.8.0] ci: increase timeout for changelog generation

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -256,7 +256,8 @@ jobs:
     needs: release
     name: Github Release
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Minor releases take more time since a lot of issues are included in the changelog
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Description
Backport of #38722 to `release-8.8.0`.

relates to 