### PR TITLE
fix: do not retry opening disable exporter

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -551,7 +551,15 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
               .runWithRetry(
                   () -> {
                     try {
-                      container.openExporter();
+                      // If the exporter was disable or removed concurrently, then don't retry
+                      // opening.
+                      if (containers.contains(container)) {
+                        container.openExporter();
+                      } else {
+                        LOG.debug(
+                            "Exporter '{}' was disabled or removed before it could be opened.",
+                            container.getId());
+                      }
                       return true;
                     } catch (final Exception e) {
                       LOG.warn("Failed to open exporter '{}'. Retrying...", container.getId());


### PR DESCRIPTION
## Description

This PR adds a test to reproduce this bug. To fix the issue, a check is added before retrying the open everytime. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38724
