### PR TITLE
[Backport main] perf: reduce the max terms count to 10_000

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
@@ -21,6 +21,7 @@ public class ElasticsearchProperties {
   public static final String DATE_FORMAT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
 
   public static final String ELS_DATE_FORMAT_DEFAULT = "date_time";
+  public static final int DEFAULT_MAX_TERMS_COUNT = 10_000;
 
   private String clusterName = "elasticsearch";
 
@@ -33,6 +34,7 @@ public class ElasticsearchProperties {
   private String elsDateFormat = ELS_DATE_FORMAT_DEFAULT;
 
   private int batchSize = 200;
+  private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
 
   private Integer socketTimeout;
   private Integer connectTimeout;
@@ -110,6 +112,14 @@ public class ElasticsearchProperties {
 
   public void setBatchSize(final int batchSize) {
     this.batchSize = batchSize;
+  }
+
+  public int getMaxTermsCount() {
+    return maxTermsCount;
+  }
+
+  public void setMaxTermsCount(final int maxTermsCount) {
+    this.maxTermsCount = maxTermsCount;
   }
 
   public boolean isCreateSchema() {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
@@ -21,6 +21,7 @@ public class OpenSearchProperties {
   public static final String DATE_FORMAT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
 
   public static final String ELS_DATE_FORMAT_DEFAULT = "date_time";
+  public static final int DEFAULT_MAX_TERMS_COUNT = 10_000;
 
   private String clusterName = "opensearch-cluster";
 
@@ -33,6 +34,7 @@ public class OpenSearchProperties {
   private String elsDateFormat = ELS_DATE_FORMAT_DEFAULT;
 
   private int batchSize = 200;
+  private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
 
   private Integer socketTimeout;
   private Integer connectTimeout;
@@ -111,6 +113,14 @@ public class OpenSearchProperties {
 
   public void setBatchSize(final int batchSize) {
     this.batchSize = batchSize;
+  }
+
+  public int getMaxTermsCount() {
+    return maxTermsCount;
+  }
+
+  public void setMaxTermsCount(final int maxTermsCount) {
+    this.maxTermsCount = maxTermsCount;
   }
 
   public boolean isCreateSchema() {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/VariableStore.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/VariableStore.java
@@ -40,8 +40,6 @@ public interface VariableStore {
   public SnapshotTaskVariableEntity getTaskVariable(
       final String variableId, Set<String> fieldNames);
 
-  void refreshMaxTermsCount();
-
   public List<String> getProcessInstanceIdsWithMatchingVars(
       List<String> varNames, List<String> varValues);
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -9,6 +9,10 @@ package io.camunda.tasklist.store.elasticsearch;
 
 import static io.camunda.tasklist.util.CollectionUtil.asMap;
 import static io.camunda.tasklist.util.CollectionUtil.getOrDefaultFromMap;
+<<<<<<< HEAD
+=======
+import static io.camunda.tasklist.util.ElasticsearchUtil.QueryType.ALL;
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
 import static io.camunda.tasklist.util.ElasticsearchUtil.SCROLL_KEEP_ALIVE_MS;
 import static io.camunda.tasklist.util.ElasticsearchUtil.fromSearchHit;
 import static io.camunda.tasklist.util.ElasticsearchUtil.joinWithAnd;
@@ -304,6 +308,38 @@ public class TaskStoreElasticSearch implements TaskStore {
         asMap(TaskTemplate.FORM_ID, formBpmnId, TaskTemplate.FORM_VERSION, formVersion));
   }
 
+<<<<<<< HEAD
+=======
+  private List<TaskEntity> getActiveTasksByProcessInstanceIds(
+      final List<String> processInstanceIds) {
+    try {
+      // the number of process instance ids may be large and exceed #DEFAULT_MAX_TERMS_COUNT, so
+      // we need to chunk them
+      return scrollInChunks(
+          processInstanceIds,
+          tasklistProperties.getElasticsearch().getMaxTermsCount(),
+          this::buildSearchCreatedTasksByProcessInstanceIdsRequest,
+          TaskEntity.class,
+          objectMapper,
+          esClient);
+    } catch (final IOException e) {
+      throw new TasklistRuntimeException(e.getMessage(), e);
+    }
+  }
+
+  private SearchRequest buildSearchCreatedTasksByProcessInstanceIdsRequest(
+      final List<String> processInstanceIds) {
+    return createSearchRequest(taskTemplate)
+        .source(
+            searchSource()
+                .query(
+                    boolQuery()
+                        .must(termsQuery(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceIds))
+                        .must(termQuery(TaskTemplate.STATE, TaskState.CREATED)))
+                .size(tasklistProperties.getElasticsearch().getBatchSize()));
+  }
+
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
   private SearchHit[] getTasksRawResponse(final List<String> ids) throws IOException {
 
     final QueryBuilder query = termsQuery(TaskTemplate.KEY, ids);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -9,6 +9,10 @@ package io.camunda.tasklist.store.opensearch;
 
 import static io.camunda.tasklist.util.CollectionUtil.asMap;
 import static io.camunda.tasklist.util.CollectionUtil.getOrDefaultFromMap;
+<<<<<<< HEAD
+=======
+import static io.camunda.tasklist.util.OpenSearchUtil.QueryType.ALL;
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
 import static io.camunda.tasklist.util.OpenSearchUtil.SCROLL_KEEP_ALIVE_MS;
 import static io.camunda.tasklist.util.OpenSearchUtil.joinQueryBuilderWithAnd;
 import static java.util.stream.Collectors.toList;
@@ -284,6 +288,51 @@ public class TaskStoreOpenSearch implements TaskStore {
         asMap(TaskTemplate.FORM_ID, formBpmnId, TaskTemplate.FORM_VERSION, formVersion));
   }
 
+<<<<<<< HEAD
+=======
+  private List<TaskEntity> getActiveTasksByProcessInstanceIds(
+      final List<String> processInstanceIds) {
+    try {
+      // the number of process instance ids may be large, so we need to chunk them
+      return scrollInChunks(
+          processInstanceIds,
+          tasklistProperties.getOpenSearch().getMaxTermsCount(),
+          this::buildSearchCreatedTasksByProcessInstanceIdsRequest,
+          TaskEntity.class,
+          osClient);
+    } catch (final IOException e) {
+      throw new TasklistRuntimeException(e.getMessage(), e);
+    }
+  }
+
+  private Builder buildSearchCreatedTasksByProcessInstanceIdsRequest(
+      final List<String> processInstanceIds) {
+    return createSearchRequest(taskTemplate)
+        .query(
+            q ->
+                q.bool(
+                    b ->
+                        b.must(
+                                m ->
+                                    m.terms(
+                                        t ->
+                                            t.field(PROCESS_INSTANCE_ID)
+                                                .terms(
+                                                    terms ->
+                                                        terms.value(
+                                                            processInstanceIds.stream()
+                                                                .map(FieldValue::of)
+                                                                .toList()))))
+                            .must(
+                                m ->
+                                    m.term(
+                                        t ->
+                                            t.field(STATE)
+                                                .value(FieldValue.of(TaskState.CREATED.name()))))))
+        .size(tasklistProperties.getOpenSearch().getBatchSize());
+  }
+
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
   /**
    * In case of searchAfterOrEqual and searchBeforeOrEqual add additional task either at the
    * beginning of the list, or at the end, to conform with "orEqual" part.

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -8,7 +8,10 @@
 package io.camunda.tasklist.store.opensearch;
 
 import static io.camunda.tasklist.util.CollectionUtil.isNotEmpty;
+<<<<<<< HEAD
 import static io.camunda.tasklist.util.OpenSearchUtil.SCROLL_KEEP_ALIVE_MS;
+=======
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
 import static io.camunda.tasklist.util.OpenSearchUtil.createSearchRequest;
 import static io.camunda.webapps.schema.descriptors.template.VariableTemplate.ID;
 import static io.camunda.webapps.schema.descriptors.template.VariableTemplate.NAME;
@@ -26,6 +29,7 @@ import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.store.VariableStore;
 import io.camunda.tasklist.tenant.TenantAwareOpenSearchClient;
 import io.camunda.tasklist.util.OpenSearchUtil;
+<<<<<<< HEAD
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.SnapshotTaskVariableTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
@@ -35,6 +39,8 @@ import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import io.camunda.webapps.schema.entities.usertask.SnapshotTaskVariableEntity;
 import jakarta.annotation.PostConstruct;
+=======
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,8 +52,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.ListUtils;
@@ -63,8 +67,6 @@ import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
 import org.opensearch.client.opensearch.core.*;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
-import org.opensearch.client.opensearch.indices.GetIndicesSettingsRequest;
-import org.opensearch.client.opensearch.indices.GetIndicesSettingsResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,8 +77,11 @@ import org.springframework.stereotype.Component;
 @Component
 @Conditional(OpenSearchCondition.class)
 public class VariableStoreOpenSearch implements VariableStore {
+<<<<<<< HEAD
   public static final int DEFAULT_MAX_TERMS_COUNT = 65536;
   public static final String MAX_TERMS_COUNT_SETTING = "index.max_terms_count";
+=======
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
   private static final Logger LOGGER = LoggerFactory.getLogger(VariableStoreOpenSearch.class);
 
   @Autowired
@@ -92,19 +97,13 @@ public class VariableStoreOpenSearch implements VariableStore {
   @Autowired private SnapshotTaskVariableTemplate taskVariableTemplate;
 
   @Autowired private TasklistProperties tasklistProperties;
-  private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
-
-  @PostConstruct
-  void scheduleUpdateTermsCount() {
-    Executors.newSingleThreadScheduledExecutor()
-        .scheduleAtFixedRate(this::refreshMaxTermsCount, 30, 1800, TimeUnit.SECONDS);
-  }
 
   @Override
   public List<VariableEntity> getVariablesByFlowNodeInstanceIds(
       final List<String> flowNodeInstanceIds,
       final List<String> varNames,
       final Set<String> fieldNames) {
+<<<<<<< HEAD
 
     final List<List<String>> flowNodeInstanceIdsChunks =
         ListUtils.partition(flowNodeInstanceIds, maxTermsCount);
@@ -149,6 +148,20 @@ public class VariableStoreOpenSearch implements VariableStore {
           }
         });
     return variableEntities;
+=======
+    try {
+      return OpenSearchUtil.scrollInChunks(
+          flowNodeInstanceIds,
+          tasklistProperties.getOpenSearch().getMaxTermsCount(),
+          chunk -> buildSearchVariablesByScopeFNIsAndVarNamesRequest(chunk, varNames, fieldNames),
+          VariableEntity.class,
+          osClient);
+    } catch (final IOException e) {
+      final String message =
+          String.format("Exception occurred, while obtaining all variables: %s", e.getMessage());
+      throw new TasklistRuntimeException(message, e);
+    }
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
   }
 
   @Override
@@ -252,6 +265,7 @@ public class VariableStoreOpenSearch implements VariableStore {
   @Override
   public List<FlowNodeInstanceEntity> getFlowNodeInstances(final List<String> processInstanceIds) {
 
+<<<<<<< HEAD
     final var processInstanceKeyQuery =
         TermsQuery.of(
                 t ->
@@ -306,6 +320,14 @@ public class VariableStoreOpenSearch implements VariableStore {
 
     try {
       return OpenSearchUtil.scroll(searchRequestBuilder, FlowNodeInstanceEntity.class, osClient);
+=======
+      return scrollInChunks(
+          processInstanceIds,
+          tasklistProperties.getOpenSearch().getMaxTermsCount(),
+          this::buildSearchFNIByProcessInstanceIdsRequest,
+          FlowNodeInstanceEntity.class,
+          osClient);
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
     } catch (final IOException e) {
       final String message =
           String.format("Exception occurred, while obtaining all flow nodes: %s", e.getMessage());
@@ -363,26 +385,6 @@ public class VariableStoreOpenSearch implements VariableStore {
       final String message =
           String.format("Exception occurred, while obtaining task variable: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
-    }
-  }
-
-  @Override
-  public void refreshMaxTermsCount() {
-    final GetIndicesSettingsResponse response;
-    try {
-      response =
-          osClient
-              .indices()
-              .getSettings(
-                  new GetIndicesSettingsRequest.Builder()
-                      .index(variableIndex.getFullQualifiedName())
-                      .includeDefaults(true)
-                      .name(MAX_TERMS_COUNT_SETTING)
-                      .build());
-      maxTermsCount =
-          response.get(variableIndex.getFullQualifiedName()).settings().index().maxTermsCount();
-    } catch (final IOException e) {
-      LOGGER.warn("Failed to update max_terms_count setting", e);
     }
   }
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
@@ -374,7 +374,30 @@ public abstract class ElasticsearchUtil {
     return entity;
   }
 
+<<<<<<< HEAD
   public static <T> List<T> scroll(
+=======
+  /**
+   * Helper method to scroll in chunks. This is useful when you have a large number of ids and want
+   * to avoid sending them all at once to Elasticsearch
+   */
+  public static <T extends TasklistEntity> List<T> scrollInChunks(
+      final List<String> list,
+      final int chunkSize,
+      final Function<List<String>, SearchRequest> chunkToSearchRequest,
+      final Class<T> clazz,
+      final ObjectMapper objectMapper,
+      final RestHighLevelClient esClient)
+      throws IOException {
+    final var result = new ArrayList<T>();
+    for (final var chunk : ListUtils.partition(list, chunkSize)) {
+      result.addAll(scroll(chunkToSearchRequest.apply(chunk), clazz, objectMapper, esClient));
+    }
+    return result;
+  }
+
+  public static <T extends TasklistEntity> List<T> scroll(
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
       final SearchRequest searchRequest,
       final Class<T> clazz,
       final ObjectMapper objectMapper,

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/OpenSearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/OpenSearchUtil.java
@@ -428,7 +428,29 @@ public abstract class OpenSearchUtil {
     return builder;
   }
 
+<<<<<<< HEAD
   public static <T> List<T> scroll(
+=======
+  /**
+   * Helper method to scroll in chunks. This is useful when you have a large number of ids and want
+   * to avoid sending them all at once to OpenSearch
+   */
+  public static <T extends TasklistEntity> List<T> scrollInChunks(
+      final List<String> ids,
+      final int chunkSize,
+      final Function<List<String>, SearchRequest.Builder> chunkToSearchRequestBuilder,
+      final Class<T> clazz,
+      final OpenSearchClient osClient)
+      throws IOException {
+    final var result = new ArrayList<T>();
+    for (final var chunk : ListUtils.partition(ids, chunkSize)) {
+      result.addAll(scroll(chunkToSearchRequestBuilder.apply(chunk), clazz, osClient));
+    }
+    return result;
+  }
+
+  public static <T extends TasklistEntity> List<T> scroll(
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
       final SearchRequest.Builder searchRequest,
       final Class<T> clazz,
       final OpenSearchClient osClient)

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/perf/TaskStorePerfIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/perf/TaskStorePerfIT.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.perf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.tasklist.entities.FlowNodeInstanceEntity;
+import io.camunda.tasklist.entities.FlowNodeState;
+import io.camunda.tasklist.entities.FlowNodeType;
+import io.camunda.tasklist.entities.TaskEntity;
+import io.camunda.tasklist.entities.TaskState;
+import io.camunda.tasklist.entities.VariableEntity;
+import io.camunda.tasklist.queries.TaskByVariables;
+import io.camunda.tasklist.queries.TaskQuery;
+import io.camunda.tasklist.schema.indices.FlowNodeInstanceIndex;
+import io.camunda.tasklist.schema.indices.VariableIndex;
+import io.camunda.tasklist.schema.templates.TaskTemplate;
+import io.camunda.tasklist.store.TaskStore;
+import io.camunda.tasklist.util.DatabaseTestExtension;
+import io.camunda.tasklist.util.TasklistIntegrationTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class TaskStorePerfIT extends TasklistIntegrationTest {
+  private static final Logger LOG = LoggerFactory.getLogger(TaskStorePerfIT.class);
+
+  @RegisterExtension @Autowired public DatabaseTestExtension databaseTestExtension;
+
+  @Autowired private TaskStore taskStore;
+
+  @Autowired private FlowNodeInstanceIndex flowNodeInstanceIndex;
+
+  @Autowired private VariableIndex variableIndex;
+
+  @Autowired private TaskTemplate taskTemplate;
+
+  @BeforeEach
+  public void setUp() {
+    super.before();
+    databaseTestExtension.refreshTasklistIndices();
+  }
+
+  /**
+   * This test depends on many factors like Elasticsearch configuration, hardware, current load,
+   * etc. It is mainly meant to assert that the response time is within a certain order of
+   * magnitude. In case of failure, please check if the expected response time should be increased.
+   */
+  @ParameterizedTest
+  @MethodSource("performanceTestParams")
+  void shouldQueryTasksByVariablesNotExceedResponseTime(
+      final int numberOfVariablesPerTask,
+      final int numberOfMatchingTasks,
+      final int maxResponseTimeMs)
+      throws Exception {
+    final int total = 100_000;
+    /**
+     * The test creates 100_000 process instances, flownode instances, tasks and
+     * (numberOfVariablesPerTask* 100_000) variables.
+     */
+    final List<TaskEntity> tasks = new ArrayList<>(total);
+    final List<FlowNodeInstanceEntity> flowNodeInstances = new ArrayList<>(total);
+    final List<VariableEntity> variables = new ArrayList<>(total * numberOfVariablesPerTask);
+    final long piOffset = total * 0;
+    final long fniOffset = total * 1;
+    final long taskOffset = total * 2;
+    final long variableOffset = total * 3;
+    for (int i = 0; i < total; i++) {
+      flowNodeInstances.add(
+          new FlowNodeInstanceEntity()
+              .setId(String.valueOf(fniOffset + i))
+              .setKey(fniOffset + i)
+              .setProcessInstanceId(String.valueOf(piOffset + i))
+              .setParentFlowNodeId(String.valueOf(piOffset + i))
+              .setType(FlowNodeType.USER_TASK)
+              .setState(FlowNodeState.ACTIVE));
+      for (int j = 0; j < numberOfVariablesPerTask; j++) {
+        variables.add(
+            new VariableEntity()
+                .setId(String.valueOf(variableOffset + numberOfVariablesPerTask * i + j))
+                .setKey(variableOffset + numberOfVariablesPerTask * i + j)
+                .setProcessInstanceId(String.valueOf(piOffset + i))
+                .setScopeFlowNodeId(String.valueOf(fniOffset + i))
+                .setName("var" + j)
+                .setValue(
+                    i < numberOfMatchingTasks ? String.format("\"value%d\"", j) : "\"other\""));
+      }
+      tasks.add(
+          new TaskEntity()
+              .setId(String.valueOf(taskOffset + i))
+              .setKey(taskOffset + i)
+              .setProcessInstanceId(String.valueOf(piOffset + i))
+              .setFlowNodeInstanceId(String.valueOf(fniOffset + i))
+              .setState(TaskState.CREATED));
+    }
+    databaseTestExtension.bulkIndex(flowNodeInstanceIndex, flowNodeInstances);
+    databaseTestExtension.bulkIndex(variableIndex, variables);
+    databaseTestExtension.bulkIndex(taskTemplate, tasks);
+
+    LOG.info("Data loaded, starting performance test");
+    assertWithRetry(
+        3,
+        () -> {
+          final int pageSize = 10_000;
+          final long start = System.currentTimeMillis();
+          assertThat(
+                  taskStore.getTasks(
+                      new TaskQuery()
+                          .setState(TaskState.CREATED)
+                          .setPageSize(
+                              pageSize) // use max allowed page size to make sure we get all tasks
+                          .setTaskVariables(
+                              IntStream.range(0, numberOfVariablesPerTask)
+                                  .mapToObj(
+                                      i ->
+                                          new TaskByVariables()
+                                              .setName("var" + i)
+                                              .setValue(String.format("\"value%d\"", i)))
+                                  .toArray(TaskByVariables[]::new))))
+              .hasSize(Math.min(numberOfMatchingTasks, pageSize));
+          LOG.info(
+              "Performance test, for {} matches, finished in {} ms. Max response time is set to {} ms.",
+              numberOfMatchingTasks,
+              System.currentTimeMillis() - start,
+              maxResponseTimeMs);
+          assertThat(System.currentTimeMillis() - start).isLessThan(maxResponseTimeMs);
+        });
+  }
+
+  /** (int numberOfVariablesPerTask, int numberOfMatchingTasks, int maxResponseTimeMs) */
+  private static Stream<Arguments> performanceTestParams() {
+    return Stream.of(
+        Arguments.of(1, 1000, 500),
+        Arguments.of(1, 3000, 1000),
+        Arguments.of(2, 1000, 500),
+        Arguments.of(2, 3000, 1000),
+        Arguments.of(1, 10_000, 2000),
+        Arguments.of(1, 30_000, 6000));
+  }
+
+  private void assertWithRetry(final int maxAttempts, final Runnable assertion)
+      throws InterruptedException {
+    int attempt = 0;
+    while (attempt < maxAttempts) {
+      try {
+        assertion.run();
+        return;
+      } catch (final AssertionError e) {
+        attempt++;
+        if (attempt == maxAttempts) {
+          throw e;
+        }
+        Thread.sleep(500);
+      }
+    }
+  }
+}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/DatabaseTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/DatabaseTestExtension.java
@@ -13,10 +13,6 @@ import org.junit.jupiter.api.extension.Extension;
 
 public interface DatabaseTestExtension extends Extension {
 
-  void setIndexMaxTermsCount(final String indexName, final int maxTermsCount) throws IOException;
-
-  int getIndexMaxTermsCount(final String indexName) throws IOException;
-
   void assertMaxOpenScrollContexts(final int maxOpenScrollContexts);
 
   void refreshIndexesInElasticsearch();

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
@@ -7,7 +7,11 @@
  */
 package io.camunda.tasklist.util;
 
+<<<<<<< HEAD
 import static io.camunda.tasklist.store.elasticsearch.VariableStoreElasticSearch.MAX_TERMS_COUNT_SETTING;
+=======
+import static io.camunda.tasklist.util.ElasticsearchUtil.LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED;
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
 import static io.camunda.tasklist.util.ThreadUtil.sleepFor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
@@ -25,13 +29,30 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+<<<<<<< HEAD
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+=======
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestHighLevelClient;
+<<<<<<< HEAD
 import org.elasticsearch.common.settings.Settings;
+=======
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.client.indices.GetComposableIndexTemplateRequest;
+import org.elasticsearch.client.indices.GetIndexRequest;
+import org.elasticsearch.client.indices.GetIndexResponse;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.index.reindex.ReindexRequest;
+import org.elasticsearch.xcontent.XContentType;
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -109,32 +130,6 @@ public class ElasticsearchTestExtension
         .connect()
         .setIndexPrefix(TasklistElasticsearchProperties.DEFAULT_INDEX_PREFIX);
     assertMaxOpenScrollContexts(10);
-  }
-
-  @Override
-  public void setIndexMaxTermsCount(final String indexName, final int maxTermsCount)
-      throws IOException {
-    esClient
-        .indices()
-        .putSettings(
-            new UpdateSettingsRequest()
-                .indices(indexName)
-                .settings(Settings.builder().put(MAX_TERMS_COUNT_SETTING, maxTermsCount).build()),
-            RequestOptions.DEFAULT);
-  }
-
-  @Override
-  public int getIndexMaxTermsCount(final String indexName) throws IOException {
-    return Integer.parseInt(
-        esClient
-            .indices()
-            .getSettings(
-                new GetSettingsRequest()
-                    .indices(indexName)
-                    .includeDefaults(true)
-                    .names(MAX_TERMS_COUNT_SETTING),
-                RequestOptions.DEFAULT)
-            .getSetting(indexName, MAX_TERMS_COUNT_SETTING));
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.tasklist.util;
 
-import static io.camunda.tasklist.store.opensearch.VariableStoreOpenSearch.MAX_TERMS_COUNT_SETTING;
 import static io.camunda.tasklist.util.ThreadUtil.sleepFor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
@@ -29,10 +28,22 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.opensearch.client.opensearch.OpenSearchClient;
+<<<<<<< HEAD
 import org.opensearch.client.opensearch.indices.FlushRequest;
 import org.opensearch.client.opensearch.indices.GetIndicesSettingsRequest;
 import org.opensearch.client.opensearch.indices.IndexSettings;
 import org.opensearch.client.opensearch.indices.PutIndicesSettingsRequest;
+=======
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch._types.mapping.TypeMapping;
+import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.bulk.IndexOperation;
+import org.opensearch.client.opensearch.core.reindex.Source;
+import org.opensearch.client.opensearch.indices.GetIndexResponse;
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
 import org.opensearch.client.opensearch.nodes.Stats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,35 +109,6 @@ public class OpenSearchTestExtension
         .connect()
         .setIndexPrefix(TasklistOpenSearchProperties.DEFAULT_INDEX_PREFIX);
     assertMaxOpenScrollContexts(10);
-  }
-
-  @Override
-  public void setIndexMaxTermsCount(final String indexName, final int maxTermsCount)
-      throws IOException {
-
-    osClient
-        .indices()
-        .putSettings(
-            PutIndicesSettingsRequest.of(
-                f ->
-                    f.index(indexName)
-                        .settings(IndexSettings.of(s -> s.maxTermsCount(maxTermsCount)))));
-  }
-
-  @Override
-  public int getIndexMaxTermsCount(final String indexName) throws IOException {
-    return osClient
-        .indices()
-        .getSettings(
-            new GetIndicesSettingsRequest.Builder()
-                .index(indexName)
-                .includeDefaults(true)
-                .name(MAX_TERMS_COUNT_SETTING)
-                .build())
-        .get(indexName)
-        .settings()
-        .index()
-        .maxTermsCount();
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/VariableSearchTermsQueryChunkIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/VariableSearchTermsQueryChunkIT.java
@@ -12,7 +12,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.queries.TaskByVariables;
+<<<<<<< HEAD
 import io.camunda.tasklist.store.VariableStore;
+=======
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
 import io.camunda.tasklist.util.MockMvcHelper;
 import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchResponse;
@@ -27,6 +30,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -34,15 +39,22 @@ public class VariableSearchTermsQueryChunkIT extends TasklistZeebeIntegrationTes
 
   @Autowired private ObjectMapper objectMapper;
 
+<<<<<<< HEAD
   @Autowired private VariableTemplate variableTemplate;
 
+=======
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
   @Autowired private WebApplicationContext context;
-
-  @Autowired private VariableStore variableStore;
 
   private MockMvcHelper mockMvcHelper;
 
   private final String benchmarkProcess = "VariableSearch_Process";
+
+  @DynamicPropertySource
+  static void configureProperties(final DynamicPropertyRegistry registry) {
+    registry.add("camunda.tasklist.elasticsearch.max-terms-count", () -> 5);
+    registry.add("camunda.tasklist.opensearch.max-terms-count", () -> 5);
+  }
 
   @BeforeEach
   public void setUp() throws IOException, InterruptedException {
@@ -57,6 +69,7 @@ public class VariableSearchTermsQueryChunkIT extends TasklistZeebeIntegrationTes
         .getProcesses()
         .getFirst()
         .getProcessDefinitionKey();
+<<<<<<< HEAD
 
     databaseTestExtension.setIndexMaxTermsCount(variableTemplate.getFullQualifiedName(), 5);
 
@@ -65,6 +78,8 @@ public class VariableSearchTermsQueryChunkIT extends TasklistZeebeIntegrationTes
         .isEqualTo(5);
 
     variableStore.refreshMaxTermsCount();
+=======
+>>>>>>> 944c7323 (perf: reduce the max terms count to 10_000)
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #38695 to `main`.

relates to camunda/camunda#32600