### PR TITLE
feat: migrate operate UI to use query and state hooks for DRD data

### DIFF
--- a/operate/client/e2e-playwright/a11y/decisionInstance.spec.ts
+++ b/operate/client/e2e-playwright/a11y/decisionInstance.spec.ts
@@ -10,13 +10,13 @@ import {test} from '../visual-fixtures';
 import {
   mockEvaluatedDecisionInstance,
   mockResponses,
-  mockEvaluatedDrdData,
+  mockEvaluatedDecisionInstancesSearch,
   mockEvaluatedXml,
   mockFailedDecisionInstance,
-  mockFailedDrdData,
+  mockFailedDecisionInstancesSearch,
   mockFailedXml,
   mockEvaluatedDecisionInstanceWithoutPanels,
-  mockEvaluatedDrdDataWithoutPanels,
+  mockEvaluatedDecisionInstancesSearchWithoutPanels,
   mockEvaluatedXmlWithoutPanels,
 } from '../mocks/decisionInstance.mocks';
 import {validateResults} from './validateResults';
@@ -45,7 +45,7 @@ test.describe('decision detail', () => {
       URL_API_PATTERN,
       mockResponses({
         decisionInstanceDetail: mockEvaluatedDecisionInstance,
-        drdData: mockEvaluatedDrdData,
+        decisionInstancesSearch: mockEvaluatedDecisionInstancesSearch,
         xml: mockEvaluatedXml,
       }),
     );
@@ -70,7 +70,7 @@ test.describe('decision detail', () => {
       URL_API_PATTERN,
       mockResponses({
         decisionInstanceDetail: mockFailedDecisionInstance,
-        drdData: mockFailedDrdData,
+        decisionInstancesSearch: mockFailedDecisionInstancesSearch,
         xml: mockFailedXml,
       }),
     );
@@ -95,7 +95,7 @@ test.describe('decision detail', () => {
       URL_API_PATTERN,
       mockResponses({
         decisionInstanceDetail: mockEvaluatedDecisionInstanceWithoutPanels,
-        drdData: mockEvaluatedDrdDataWithoutPanels,
+        decisionInstancesSearch: mockEvaluatedDecisionInstancesSearchWithoutPanels,
         xml: mockEvaluatedXmlWithoutPanels,
       }),
     );

--- a/operate/client/e2e-playwright/visual/decisionInstance.spec.ts
+++ b/operate/client/e2e-playwright/visual/decisionInstance.spec.ts
@@ -11,13 +11,13 @@ import {test} from '../visual-fixtures';
 import {
   mockEvaluatedDecisionInstance,
   mockEvaluatedDecisionInstanceWithoutPanels,
-  mockEvaluatedDrdData,
-  mockEvaluatedDrdDataWithoutPanels,
+  mockEvaluatedDecisionInstancesSearch,
+  mockEvaluatedDecisionInstancesSearchWithoutPanels,
   mockEvaluatedLargeXml,
   mockEvaluatedXml,
   mockEvaluatedXmlWithoutPanels,
   mockFailedDecisionInstance,
-  mockFailedDrdData,
+  mockFailedDecisionInstancesSearch,
   mockFailedXml,
   mockResponses,
 } from '../mocks/decisionInstance.mocks';
@@ -53,7 +53,7 @@ test.describe('decision instance page', () => {
       URL_API_PATTERN,
       mockResponses({
         decisionInstanceDetail: mockEvaluatedDecisionInstance,
-        drdData: mockEvaluatedDrdData,
+        decisionInstancesSearch: mockEvaluatedDecisionInstancesSearch,
         xml: mockEvaluatedXml,
       }),
     );
@@ -85,7 +85,7 @@ test.describe('decision instance page', () => {
       URL_API_PATTERN,
       mockResponses({
         decisionInstanceDetail: mockEvaluatedDecisionInstance,
-        drdData: mockEvaluatedDrdData,
+        decisionInstancesSearch: mockEvaluatedDecisionInstancesSearch,
         xml: mockEvaluatedXml,
       }),
     );
@@ -110,7 +110,7 @@ test.describe('decision instance page', () => {
       URL_API_PATTERN,
       mockResponses({
         decisionInstanceDetail: mockEvaluatedDecisionInstanceWithoutPanels,
-        drdData: mockEvaluatedDrdDataWithoutPanels,
+        decisionInstancesSearch: mockEvaluatedDecisionInstancesSearchWithoutPanels,
         xml: mockEvaluatedXmlWithoutPanels,
       }),
     );
@@ -130,7 +130,7 @@ test.describe('decision instance page', () => {
       URL_API_PATTERN,
       mockResponses({
         decisionInstanceDetail: mockEvaluatedDecisionInstance,
-        drdData: mockEvaluatedDrdData,
+        decisionInstancesSearch: mockEvaluatedDecisionInstancesSearch,
         xml: mockEvaluatedLargeXml,
       }),
     );
@@ -155,7 +155,7 @@ test.describe('decision instance page', () => {
       URL_API_PATTERN,
       mockResponses({
         decisionInstanceDetail: mockFailedDecisionInstance,
-        drdData: mockFailedDrdData,
+        decisionInstancesSearch: mockFailedDecisionInstancesSearch,
         xml: mockFailedXml,
       }),
     );
@@ -172,7 +172,7 @@ test.describe('decision instance page', () => {
       URL_API_PATTERN,
       mockResponses({
         decisionInstanceDetail: mockFailedDecisionInstance,
-        drdData: mockFailedDrdData,
+        decisionInstancesSearch: mockFailedDecisionInstancesSearch,
         xml: mockFailedXml,
       }),
     );

--- a/operate/client/src/App/DecisionInstance/Drd/index.test.tsx
+++ b/operate/client/src/App/DecisionInstance/Drd/index.test.tsx
@@ -6,31 +6,17 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useEffect} from 'react';
 import {render, screen} from 'modules/testing-library';
-import {invoiceClassification} from 'modules/mocks/mockDecisionInstance';
+import {invoiceClassification} from 'modules/mocks/mockDecisionInstanceV2';
 import {mockDmnXml} from 'modules/mocks/mockDmnXml';
-import {mockDrdData} from 'modules/mocks/mockDrdData';
-import {decisionInstanceDetailsStore} from 'modules/stores/decisionInstanceDetails';
-import {drdDataStore} from 'modules/stores/drdData';
 import {Drd} from '.';
 import {MemoryRouter} from 'react-router-dom';
 import {mockFetchDecisionDefinitionXML} from 'modules/mocks/api/v2/decisionDefinitions/fetchDecisionDefinitionXML';
-import {mockFetchDrdData} from 'modules/mocks/api/decisionInstances/fetchDrdData';
-import {mockFetchDecisionInstance} from 'modules/mocks/api/decisionInstances/fetchDecisionInstance';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
 
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
-  drdDataStore.init();
-  decisionInstanceDetailsStore.fetchDecisionInstance('337423841237089');
-
-  useEffect(() => {
-    return () => {
-      decisionInstanceDetailsStore.reset();
-      drdDataStore.reset();
-    };
-  }, []);
   return (
     <QueryClientProvider client={getMockQueryClient()}>
       <MemoryRouter>{children}</MemoryRouter>
@@ -41,14 +27,25 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 describe('<Drd />', () => {
   beforeEach(() => {
     mockFetchDecisionDefinitionXML().withSuccess(mockDmnXml);
-    mockFetchDrdData().withSuccess(mockDrdData);
-    mockFetchDecisionInstance().withSuccess(invoiceClassification);
+    mockSearchDecisionInstances().withSuccess({
+      items: [invoiceClassification],
+      page: {totalItems: 1},
+    });
   });
 
   it('should render DRD', async () => {
-    render(<Drd decisionDefinitionKey="22123481044261742" />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <Drd
+        decisionEvaluationInstanceKey={
+          invoiceClassification.decisionEvaluationInstanceKey
+        }
+        decisionEvaluationKey={invoiceClassification.decisionEvaluationKey}
+        decisionDefinitionKey={invoiceClassification.decisionDefinitionKey}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
 
     expect(await screen.findByText('Default View mock')).toBeInTheDocument();
     expect(

--- a/operate/client/src/App/DecisionInstance/Drd/index.test.tsx
+++ b/operate/client/src/App/DecisionInstance/Drd/index.test.tsx
@@ -41,6 +41,8 @@ describe('<Drd />', () => {
         }
         decisionEvaluationKey={invoiceClassification.decisionEvaluationKey}
         decisionDefinitionKey={invoiceClassification.decisionDefinitionKey}
+        drdPanelState="minimized"
+        onChangeDrdPanelState={() => void 0}
       />,
       {
         wrapper: Wrapper,

--- a/operate/client/src/App/DecisionInstance/Drd/index.tsx
+++ b/operate/client/src/App/DecisionInstance/Drd/index.tsx
@@ -11,7 +11,6 @@ import {observer} from 'mobx-react';
 import {useNavigate} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 import {DrdViewer} from 'modules/dmn-js/DrdViewer';
-import {drdStore} from 'modules/stores/drd';
 import {PanelHeader, Container, Stack} from './styled';
 import {tracking} from 'modules/tracking';
 import {decisionDefinitionStore} from 'modules/stores/decisionDefinition';
@@ -22,18 +21,17 @@ import {useQuery} from '@tanstack/react-query';
 import {useDecisionDefinitionXmlOptions} from 'modules/queries/decisionDefinitions/useDecisionDefinitionXml';
 import {useDrdData} from 'modules/queries/decisionInstances/useDrdData';
 import {useDrdStateOverlay} from 'modules/queries/decisionInstances/useDrdStateOverlay';
+import type {DrdPanelState} from 'modules/queries/decisionInstances/useDrdPanelState';
 
 interface DrdProps {
   decisionEvaluationInstanceKey: string;
   decisionDefinitionKey?: string;
   decisionEvaluationKey?: string;
+  drdPanelState: DrdPanelState;
+  onChangeDrdPanelState(state: DrdPanelState): void;
 }
 
 const Drd: React.FC<DrdProps> = observer((props) => {
-  const {
-    setPanelState,
-    state: {panelState},
-  } = drdStore;
   const drdViewer = useRef<DrdViewer | null>(null);
   const drdViewerRef = useRef<HTMLDivElement | null>(null);
   const navigate = useNavigate();
@@ -83,7 +81,7 @@ const Drd: React.FC<DrdProps> = observer((props) => {
     <Container data-testid="drd">
       <PanelHeader title={decisionDefinitionStore.name ?? ''}>
         <Stack orientation="horizontal">
-          {panelState === 'minimized' && (
+          {props.drdPanelState === 'minimized' && (
             <Button
               kind="ghost"
               hasIconOnly
@@ -93,7 +91,7 @@ const Drd: React.FC<DrdProps> = observer((props) => {
               aria-label="Maximize DRD Panel"
               size="lg"
               onClick={() => {
-                setPanelState('maximized');
+                props.onChangeDrdPanelState('maximized');
                 tracking.track({
                   eventName: 'drd-panel-interaction',
                   action: 'maximize',
@@ -101,7 +99,7 @@ const Drd: React.FC<DrdProps> = observer((props) => {
               }}
             />
           )}
-          {panelState === 'maximized' && (
+          {props.drdPanelState === 'maximized' && (
             <Button
               kind="ghost"
               hasIconOnly
@@ -111,7 +109,7 @@ const Drd: React.FC<DrdProps> = observer((props) => {
               aria-label="Minimize DRD Panel"
               size="lg"
               onClick={() => {
-                setPanelState('minimized');
+                props.onChangeDrdPanelState('minimized');
                 tracking.track({
                   eventName: 'drd-panel-interaction',
                   action: 'minimize',
@@ -128,7 +126,7 @@ const Drd: React.FC<DrdProps> = observer((props) => {
             aria-label="Close DRD Panel"
             size="lg"
             onClick={() => {
-              setPanelState('closed');
+              props.onChangeDrdPanelState('closed');
               tracking.track({
                 eventName: 'drd-panel-interaction',
                 action: 'close',

--- a/operate/client/src/App/DecisionInstance/Drd/index.tsx
+++ b/operate/client/src/App/DecisionInstance/Drd/index.tsx
@@ -7,13 +7,11 @@
  */
 
 import {useEffect, useRef} from 'react';
-import {autorun} from 'mobx';
 import {observer} from 'mobx-react';
 import {useNavigate} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 import {DrdViewer} from 'modules/dmn-js/DrdViewer';
 import {drdStore} from 'modules/stores/drd';
-import {drdDataStore} from 'modules/stores/drdData';
 import {PanelHeader, Container, Stack} from './styled';
 import {tracking} from 'modules/tracking';
 import {decisionDefinitionStore} from 'modules/stores/decisionDefinition';
@@ -22,136 +20,134 @@ import {Close, Maximize, Minimize} from '@carbon/react/icons';
 import {StateOverlay} from 'modules/components/StateOverlay';
 import {useQuery} from '@tanstack/react-query';
 import {useDecisionDefinitionXmlOptions} from 'modules/queries/decisionDefinitions/useDecisionDefinitionXml';
+import {useDrdData} from 'modules/queries/decisionInstances/useDrdData';
+import {useDrdStateOverlay} from 'modules/queries/decisionInstances/useDrdStateOverlay';
 
-const Drd: React.FC<{decisionDefinitionKey?: string}> = observer(
-  ({decisionDefinitionKey}) => {
-    const {
-      setPanelState,
-      state: {panelState},
-    } = drdStore;
-    const drdViewer = useRef<DrdViewer | null>(null);
-    const drdViewerRef = useRef<HTMLDivElement | null>(null);
-    const navigate = useNavigate();
+interface DrdProps {
+  decisionEvaluationInstanceKey: string;
+  decisionDefinitionKey?: string;
+  decisionEvaluationKey?: string;
+}
 
-    const handleDecisionSelection = (decisionId: string) => {
-      const decisionInstances = drdDataStore.state.drdData?.[decisionId];
+const Drd: React.FC<DrdProps> = observer((props) => {
+  const {
+    setPanelState,
+    state: {panelState},
+  } = drdStore;
+  const drdViewer = useRef<DrdViewer | null>(null);
+  const drdViewerRef = useRef<HTMLDivElement | null>(null);
+  const navigate = useNavigate();
 
-      if (decisionInstances === undefined) {
-        return;
-      }
+  const [overlayState, overlayActions] = useDrdStateOverlay();
+  const {data: drdData} = useDrdData(props.decisionEvaluationKey);
+  const {data: decisionDefinitionXml} = useQuery(
+    useDecisionDefinitionXmlOptions({
+      decisionDefinitionKey: props.decisionDefinitionKey ?? '',
+      enabled: props.decisionDefinitionKey !== undefined,
+    }),
+  );
 
-      const decisionInstanceId =
-        decisionInstances[decisionInstances.length - 1]?.decisionInstanceId;
-
-      if (decisionInstanceId !== undefined) {
-        navigate(Paths.decisionInstance(decisionInstanceId));
-      }
+  if (drdViewer.current === null) {
+    const handleDecisionSelection = (decisionEvaluationInstanceKey: string) => {
+      navigate(Paths.decisionInstance(decisionEvaluationInstanceKey));
     };
+    drdViewer.current = new DrdViewer(handleDecisionSelection);
+  }
 
-    if (drdViewer.current === null) {
-      drdViewer.current = new DrdViewer(handleDecisionSelection);
+  useEffect(() => {
+    if (
+      drdViewerRef.current !== null &&
+      drdData !== undefined &&
+      decisionDefinitionXml !== undefined
+    ) {
+      drdViewer.current!.render(
+        props.decisionEvaluationInstanceKey,
+        drdViewerRef.current,
+        drdData,
+        decisionDefinitionXml,
+        overlayActions,
+      );
     }
 
-    const {data: decisionDefinitionXml} = useQuery(
-      useDecisionDefinitionXmlOptions({
-        decisionDefinitionKey: decisionDefinitionKey ?? '',
-        enabled: decisionDefinitionKey !== undefined,
-      }),
-    );
+    return () => {
+      drdViewer.current?.reset();
+    };
+  }, [
+    props.decisionEvaluationInstanceKey,
+    decisionDefinitionXml,
+    drdData,
+    overlayActions,
+  ]);
 
-    useEffect(() => {
-      const disposer = autorun(() => {
-        if (
-          drdViewerRef.current !== null &&
-          decisionDefinitionXml !== undefined
-        ) {
-          drdViewer.current!.render(
-            drdViewerRef.current,
-            decisionDefinitionXml,
-            drdDataStore.selectableDecisions,
-            drdDataStore.currentDecision,
-            drdDataStore.decisionStates,
-          );
-        }
-      });
-      return () => {
-        disposer();
-        drdViewer.current?.reset();
-      };
-    }, [decisionDefinitionXml]);
-
-    return (
-      <Container data-testid="drd">
-        <PanelHeader title={decisionDefinitionStore.name ?? ''}>
-          <Stack orientation="horizontal">
-            {panelState === 'minimized' && (
-              <Button
-                kind="ghost"
-                hasIconOnly
-                renderIcon={Maximize}
-                tooltipPosition="left"
-                iconDescription="Maximize DRD Panel"
-                aria-label="Maximize DRD Panel"
-                size="lg"
-                onClick={() => {
-                  setPanelState('maximized');
-                  tracking.track({
-                    eventName: 'drd-panel-interaction',
-                    action: 'maximize',
-                  });
-                }}
-              />
-            )}
-            {panelState === 'maximized' && (
-              <Button
-                kind="ghost"
-                hasIconOnly
-                renderIcon={Minimize}
-                tooltipPosition="left"
-                iconDescription="Minimize DRD Panel"
-                aria-label="Minimize DRD Panel"
-                size="lg"
-                onClick={() => {
-                  setPanelState('minimized');
-                  tracking.track({
-                    eventName: 'drd-panel-interaction',
-                    action: 'minimize',
-                  });
-                }}
-              />
-            )}
+  return (
+    <Container data-testid="drd">
+      <PanelHeader title={decisionDefinitionStore.name ?? ''}>
+        <Stack orientation="horizontal">
+          {panelState === 'minimized' && (
             <Button
               kind="ghost"
               hasIconOnly
-              renderIcon={Close}
+              renderIcon={Maximize}
               tooltipPosition="left"
-              iconDescription="Close DRD Panel"
-              aria-label="Close DRD Panel"
+              iconDescription="Maximize DRD Panel"
+              aria-label="Maximize DRD Panel"
               size="lg"
               onClick={() => {
-                setPanelState('closed');
+                setPanelState('maximized');
                 tracking.track({
                   eventName: 'drd-panel-interaction',
-                  action: 'close',
+                  action: 'maximize',
                 });
               }}
             />
-          </Stack>
-        </PanelHeader>
-        <div data-testid="drd-viewer" ref={drdViewerRef} />
-
-        {drdDataStore.state.decisionStateOverlays.map(
-          ({decisionId, state, container}) => (
-            <StateOverlay
-              key={decisionId}
-              state={state}
-              container={container}
+          )}
+          {panelState === 'maximized' && (
+            <Button
+              kind="ghost"
+              hasIconOnly
+              renderIcon={Minimize}
+              tooltipPosition="left"
+              iconDescription="Minimize DRD Panel"
+              aria-label="Minimize DRD Panel"
+              size="lg"
+              onClick={() => {
+                setPanelState('minimized');
+                tracking.track({
+                  eventName: 'drd-panel-interaction',
+                  action: 'minimize',
+                });
+              }}
             />
-          ),
-        )}
-      </Container>
-    );
-  },
-);
+          )}
+          <Button
+            kind="ghost"
+            hasIconOnly
+            renderIcon={Close}
+            tooltipPosition="left"
+            iconDescription="Close DRD Panel"
+            aria-label="Close DRD Panel"
+            size="lg"
+            onClick={() => {
+              setPanelState('closed');
+              tracking.track({
+                eventName: 'drd-panel-interaction',
+                action: 'close',
+              });
+            }}
+          />
+        </Stack>
+      </PanelHeader>
+      <div data-testid="drd-viewer" ref={drdViewerRef} />
+
+      {overlayState.map((overlay) => (
+        <StateOverlay
+          key={overlay.decisionDefinitionId}
+          state={overlay.state}
+          container={overlay.container}
+        />
+      ))}
+    </Container>
+  );
+});
 
 export {Drd};

--- a/operate/client/src/App/DecisionInstance/Drd/index.tsx
+++ b/operate/client/src/App/DecisionInstance/Drd/index.tsx
@@ -23,13 +23,13 @@ import {useDrdData} from 'modules/queries/decisionInstances/useDrdData';
 import {useDrdStateOverlay} from 'modules/queries/decisionInstances/useDrdStateOverlay';
 import type {DrdPanelState} from 'modules/queries/decisionInstances/useDrdPanelState';
 
-interface DrdProps {
+type DrdProps = {
   decisionEvaluationInstanceKey: string;
   decisionDefinitionKey?: string;
   decisionEvaluationKey?: string;
   drdPanelState: DrdPanelState;
   onChangeDrdPanelState(state: DrdPanelState): void;
-}
+};
 
 const Drd: React.FC<DrdProps> = observer((props) => {
   const drdViewer = useRef<DrdViewer | null>(null);

--- a/operate/client/src/App/DecisionInstance/DrdPanel/index.tsx
+++ b/operate/client/src/App/DecisionInstance/DrdPanel/index.tsx
@@ -6,9 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {drdStore} from 'modules/stores/drd';
 import {useLayoutEffect, useRef} from 'react';
 import {Container, Handle, Panel} from './styled';
+import {
+  getDrdPanelWidth,
+  persistDrdPanelWidth,
+} from 'modules/queries/decisionInstances/useDrdPanelState';
 
 const minWidth = 540;
 const maxWidthRatio = 3 / 5;
@@ -36,10 +39,9 @@ const DrdPanel: React.FC<Props> = ({children}) => {
   };
 
   useLayoutEffect(() => {
-    const {panelWidth} = drdStore.state;
-
-    if (panelWidth !== null) {
-      setPanelWidth(panelWidth);
+    const initialWidth = getDrdPanelWidth();
+    if (initialWidth !== null) {
+      setPanelWidth(initialWidth);
     }
 
     const handleResize = (event: MouseEvent) => {
@@ -79,7 +81,7 @@ const DrdPanel: React.FC<Props> = ({children}) => {
       const width = containerRef.current?.clientWidth;
 
       if (width !== undefined) {
-        drdStore.setPanelWidth(width);
+        persistDrdPanelWidth(width);
       }
     };
 

--- a/operate/client/src/App/DecisionInstance/Header/index.tsx
+++ b/operate/client/src/App/DecisionInstance/Header/index.tsx
@@ -6,7 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {drdStore} from 'modules/stores/drd';
 import {Button} from '@carbon/react';
 import {tracking} from 'modules/tracking';
 import {InstanceHeader} from 'modules/components/InstanceHeader';
@@ -16,6 +15,7 @@ import {Locations, Paths} from 'modules/Routes';
 import {formatDate} from 'modules/utils/date';
 import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
 import {useDecisionInstance} from 'modules/queries/decisionInstances/useDecisionInstance';
+import type {DrdPanelState} from 'modules/queries/decisionInstances/useDrdPanelState';
 
 const getHeaderColumns = (isMultiTenancyEnabled: boolean = false) => {
   return [
@@ -52,9 +52,13 @@ const getHeaderColumns = (isMultiTenancyEnabled: boolean = false) => {
 
 type HeaderProps = {
   decisionEvaluationInstanceKey: string;
+  onChangeDrdPanelState(state: DrdPanelState): void;
 };
 
-const Header: React.FC<HeaderProps> = ({decisionEvaluationInstanceKey}) => {
+const Header: React.FC<HeaderProps> = ({
+  decisionEvaluationInstanceKey,
+  onChangeDrdPanelState,
+}) => {
   const isMultiTenancyEnabled = window.clientConfig?.multiTenancyEnabled;
   const headerColumns = getHeaderColumns(isMultiTenancyEnabled);
   const tenantsById = useAvailableTenants();
@@ -164,7 +168,7 @@ const Header: React.FC<HeaderProps> = ({decisionEvaluationInstanceKey}) => {
             title="Open Decision Requirements Diagram"
             aria-label="Open Decision Requirements Diagram"
             onClick={() => {
-              drdStore.setPanelState('minimized');
+              onChangeDrdPanelState('minimized');
               tracking.track({
                 eventName: 'drd-panel-interaction',
                 action: 'open',

--- a/operate/client/src/App/DecisionInstance/Header/tests/index.test.tsx
+++ b/operate/client/src/App/DecisionInstance/Header/tests/index.test.tsx
@@ -44,7 +44,10 @@ describe('<Header />', () => {
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
 
     render(
-      <Header decisionEvaluationInstanceKey={MOCK_DECISION_INSTANCE_ID} />,
+      <Header
+        decisionEvaluationInstanceKey={MOCK_DECISION_INSTANCE_ID}
+        onChangeDrdPanelState={() => void 0}
+      />,
       {wrapper: Wrapper},
     );
 
@@ -59,7 +62,10 @@ describe('<Header />', () => {
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
 
     render(
-      <Header decisionEvaluationInstanceKey={MOCK_DECISION_INSTANCE_ID} />,
+      <Header
+        decisionEvaluationInstanceKey={MOCK_DECISION_INSTANCE_ID}
+        onChangeDrdPanelState={() => void 0}
+      />,
       {wrapper: Wrapper},
     );
 

--- a/operate/client/src/App/DecisionInstance/Header/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/DecisionInstance/Header/tests/multiTenancy.test.tsx
@@ -50,7 +50,10 @@ describe('InstanceHeader', () => {
     );
 
     render(
-      <Header decisionEvaluationInstanceKey={MOCK_DECISION_INSTANCE_ID} />,
+      <Header
+        decisionEvaluationInstanceKey={MOCK_DECISION_INSTANCE_ID}
+        onChangeDrdPanelState={() => void 0}
+      />,
       {wrapper: Wrapper},
     );
 
@@ -88,7 +91,10 @@ describe('InstanceHeader', () => {
     );
 
     render(
-      <Header decisionEvaluationInstanceKey={MOCK_DECISION_INSTANCE_ID} />,
+      <Header
+        decisionEvaluationInstanceKey={MOCK_DECISION_INSTANCE_ID}
+        onChangeDrdPanelState={() => void 0}
+      />,
       {wrapper: Wrapper},
     );
 

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/InputsAndOutputs/index.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/InputsAndOutputs/index.tsx
@@ -51,9 +51,9 @@ const outputMappingsColumns = [
   },
 ];
 
-interface InputAndOutputProps {
+type InputAndOutputProps = {
   decisionEvaluationInstanceKey: DecisionInstance['decisionEvaluationInstanceKey'];
-}
+};
 
 const InputsAndOutputs: React.FC<InputAndOutputProps> = ({
   decisionEvaluationInstanceKey,

--- a/operate/client/src/App/DecisionInstance/index.test.tsx
+++ b/operate/client/src/App/DecisionInstance/index.test.tsx
@@ -14,16 +14,13 @@ import {
   within,
 } from 'modules/testing-library';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
-import {invoiceClassification} from 'modules/mocks/mockDecisionInstance';
-import {invoiceClassification as invoiceClassificationV2} from 'modules/mocks/mockDecisionInstanceV2';
-import {mockDrdData} from 'modules/mocks/mockDrdData';
+import {invoiceClassification} from 'modules/mocks/mockDecisionInstanceV2';
 import {DecisionInstance} from './';
 import {drdStore} from 'modules/stores/drd';
 import {mockDmnXml} from 'modules/mocks/mockDmnXml';
 import {mockFetchDecisionDefinitionXML} from 'modules/mocks/api/v2/decisionDefinitions/fetchDecisionDefinitionXML';
-import {mockFetchDrdData} from 'modules/mocks/api/decisionInstances/fetchDrdData';
-import {mockFetchDecisionInstance} from 'modules/mocks/api/decisionInstances/fetchDecisionInstance';
-import {mockFetchDecisionInstance as mockFetchDecisionInstanceV2} from 'modules/mocks/api/v2/decisionInstances/fetchDecisionInstance';
+import {mockFetchDecisionInstance} from 'modules/mocks/api/v2/decisionInstances/fetchDecisionInstance';
+import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
 import {Paths} from 'modules/Routes';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
@@ -56,10 +53,12 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 
 describe('<DecisionInstance />', () => {
   beforeEach(() => {
-    mockFetchDrdData().withSuccess(mockDrdData);
     mockFetchDecisionDefinitionXML().withSuccess(mockDmnXml);
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
-    mockFetchDecisionInstanceV2().withSuccess(invoiceClassificationV2);
+    mockSearchDecisionInstances().withSuccess({
+      items: [invoiceClassification],
+      page: {totalItems: 1},
+    });
     mockMe().withSuccess(createUser());
     mockMe().withSuccess(createUser());
   });
@@ -75,7 +74,7 @@ describe('<DecisionInstance />', () => {
     ).toBeInTheDocument();
 
     expect(document.title).toBe(
-      `Operate: Decision Instance ${DECISION_INSTANCE_ID} of ${invoiceClassification.decisionName}`,
+      `Operate: Decision Instance ${DECISION_INSTANCE_ID} of ${invoiceClassification.decisionDefinitionName}`,
     );
   });
 
@@ -195,8 +194,11 @@ describe('<DecisionInstance />', () => {
     unmount();
 
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
-    mockFetchDrdData().withSuccess(mockDrdData);
     mockFetchDecisionDefinitionXML().withSuccess(mockDmnXml);
+    mockSearchDecisionInstances().withSuccess({
+      items: [invoiceClassification],
+      page: {totalItems: 1},
+    });
 
     render(<DecisionInstance />, {wrapper: Wrapper});
 
@@ -258,10 +260,12 @@ describe('<DecisionInstance />', () => {
 
     unmount();
 
-    mockFetchDrdData().withSuccess(mockDrdData);
     mockFetchDecisionDefinitionXML().withSuccess(mockDmnXml);
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
-    mockFetchDecisionInstanceV2().withSuccess(invoiceClassificationV2);
+    mockSearchDecisionInstances().withSuccess({
+      items: [invoiceClassification],
+      page: {totalItems: 1},
+    });
 
     render(<DecisionInstance />, {wrapper: Wrapper});
 
@@ -282,7 +286,6 @@ describe('<DecisionInstance />', () => {
 
   it('should display forbidden content', async () => {
     mockFetchDecisionInstance().withServerError(403);
-    mockFetchDecisionInstanceV2().withServerError(403);
     render(<DecisionInstance />, {wrapper: Wrapper});
 
     expect(

--- a/operate/client/src/App/DecisionInstance/index.tsx
+++ b/operate/client/src/App/DecisionInstance/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import {useEffect} from 'react';
-import {observer} from 'mobx-react';
 import {useParams} from 'react-router-dom';
 import {VisuallyHiddenH1} from 'modules/components/VisuallyHiddenH1';
 import {PAGE_TITLE} from 'modules/constants';
@@ -18,13 +17,14 @@ import {Header} from './Header';
 import {VariablesPanel} from './VariablesPanel';
 import {Forbidden} from 'modules/components/Forbidden';
 import {DrdPanel} from './DrdPanel';
-import {drdStore} from 'modules/stores/drd';
 import {DecisionInstanceContainer} from './styled';
 import {Drd} from './Drd';
 import {useDecisionInstance} from 'modules/queries/decisionInstances/useDecisionInstance';
+import {useDrdPanelState} from 'modules/queries/decisionInstances/useDrdPanelState';
 
-const DecisionInstance: React.FC = observer(() => {
+const DecisionInstance: React.FC = () => {
   const {decisionInstanceId = ''} = useParams<{decisionInstanceId: string}>();
+  const [drdPanelState, setDrdPanelState] = useDrdPanelState();
   const {data, error, isFetchedAfterMount} =
     useDecisionInstance(decisionInstanceId);
 
@@ -53,12 +53,14 @@ const DecisionInstance: React.FC = observer(() => {
     return <Forbidden />;
   }
 
-  if (drdStore.state.panelState === 'maximized') {
+  if (drdPanelState === 'maximized') {
     return (
       <Drd
         decisionEvaluationInstanceKey={decisionInstanceId}
         decisionEvaluationKey={data?.decisionEvaluationKey}
         decisionDefinitionKey={data?.decisionDefinitionKey}
+        drdPanelState={drdPanelState}
+        onChangeDrdPanelState={setDrdPanelState}
       />
     );
   }
@@ -68,7 +70,12 @@ const DecisionInstance: React.FC = observer(() => {
       <VisuallyHiddenH1>Operate Decision Instance</VisuallyHiddenH1>
       <DecisionInstanceContainer>
         <InstanceDetail
-          header={<Header decisionEvaluationInstanceKey={decisionInstanceId} />}
+          header={
+            <Header
+              decisionEvaluationInstanceKey={decisionInstanceId}
+              onChangeDrdPanelState={setDrdPanelState}
+            />
+          }
           topPanel={
             <DecisionPanel decisionEvaluationInstanceKey={decisionInstanceId} />
           }
@@ -80,12 +87,14 @@ const DecisionInstance: React.FC = observer(() => {
           }
           type="decision"
           rightPanel={
-            drdStore.state.panelState === 'minimized' ? (
+            drdPanelState === 'minimized' ? (
               <DrdPanel>
                 <Drd
                   decisionEvaluationInstanceKey={decisionInstanceId}
                   decisionEvaluationKey={data?.decisionEvaluationKey}
                   decisionDefinitionKey={data?.decisionDefinitionKey}
+                  drdPanelState={drdPanelState}
+                  onChangeDrdPanelState={setDrdPanelState}
                 />
               </DrdPanel>
             ) : null
@@ -94,6 +103,6 @@ const DecisionInstance: React.FC = observer(() => {
       </DecisionInstanceContainer>
     </>
   );
-});
+};
 
 export {DecisionInstance};

--- a/operate/client/src/App/DecisionInstance/index.tsx
+++ b/operate/client/src/App/DecisionInstance/index.tsx
@@ -10,8 +10,6 @@ import {useEffect} from 'react';
 import {observer} from 'mobx-react';
 import {useParams} from 'react-router-dom';
 import {VisuallyHiddenH1} from 'modules/components/VisuallyHiddenH1';
-import {decisionInstanceDetailsStore} from 'modules/stores/decisionInstanceDetails';
-import {drdDataStore} from 'modules/stores/drdData';
 import {PAGE_TITLE} from 'modules/constants';
 import {tracking} from 'modules/tracking';
 import {InstanceDetail} from '../Layout/InstanceDetail';
@@ -29,19 +27,6 @@ const DecisionInstance: React.FC = observer(() => {
   const {decisionInstanceId = ''} = useParams<{decisionInstanceId: string}>();
   const {data, error, isFetchedAfterMount} =
     useDecisionInstance(decisionInstanceId);
-
-  useEffect(() => {
-    drdDataStore.init();
-
-    return () => {
-      decisionInstanceDetailsStore.reset();
-      drdDataStore.reset();
-    };
-  }, []);
-
-  useEffect(() => {
-    decisionInstanceDetailsStore.fetchDecisionInstance(decisionInstanceId);
-  }, [decisionInstanceId]);
 
   useEffect(() => {
     if (
@@ -69,7 +54,13 @@ const DecisionInstance: React.FC = observer(() => {
   }
 
   if (drdStore.state.panelState === 'maximized') {
-    return <Drd decisionDefinitionKey={data?.decisionDefinitionKey} />;
+    return (
+      <Drd
+        decisionEvaluationInstanceKey={decisionInstanceId}
+        decisionEvaluationKey={data?.decisionEvaluationKey}
+        decisionDefinitionKey={data?.decisionDefinitionKey}
+      />
+    );
   }
 
   return (
@@ -91,7 +82,11 @@ const DecisionInstance: React.FC = observer(() => {
           rightPanel={
             drdStore.state.panelState === 'minimized' ? (
               <DrdPanel>
-                <Drd decisionDefinitionKey={data?.decisionDefinitionKey} />
+                <Drd
+                  decisionEvaluationInstanceKey={decisionInstanceId}
+                  decisionEvaluationKey={data?.decisionEvaluationKey}
+                  decisionDefinitionKey={data?.decisionDefinitionKey}
+                />
               </DrdPanel>
             ) : null
           }

--- a/operate/client/src/modules/components/StateOverlay/index.tsx
+++ b/operate/client/src/modules/components/StateOverlay/index.tsx
@@ -17,13 +17,11 @@ import {
 } from '@carbon/react/icons';
 import {observer} from 'mobx-react';
 import {currentTheme} from 'modules/stores/currentTheme';
-import type {
-  FlowNodeState,
-  DecisionInstanceEntityState,
-} from 'modules/types/operate';
+import type {FlowNodeState} from 'modules/types/operate';
+import type {DecisionInstanceState} from '@camunda/camunda-api-zod-schemas/8.8';
 
 type Props = {
-  state: (FlowNodeState | 'completedEndEvents') | DecisionInstanceEntityState;
+  state: (FlowNodeState | 'completedEndEvents') | DecisionInstanceState;
   container: HTMLElement;
   count?: number;
   isFaded?: boolean;
@@ -41,6 +39,11 @@ const StateOverlay: React.FC<Props> = observer(
     title,
   }) => {
     const showStatistic = count !== undefined;
+
+    // FIXME: What icons and colors should be used for these new states?
+    if (state === 'UNKNOWN' || state === 'UNSPECIFIED') {
+      state = 'FAILED';
+    }
 
     return createPortal(
       <Container

--- a/operate/client/src/modules/queries/decisionInstances/useDrdData.test.tsx
+++ b/operate/client/src/modules/queries/decisionInstances/useDrdData.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import {QueryClientProvider} from '@tanstack/react-query';
-import {renderHook, waitFor} from '@testing-library/react';
+import {renderHook, waitFor} from 'modules/testing-library';
 import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
 import {
   assignApproverGroup,

--- a/operate/client/src/modules/queries/decisionInstances/useDrdData.test.tsx
+++ b/operate/client/src/modules/queries/decisionInstances/useDrdData.test.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {QueryClientProvider} from '@tanstack/react-query';
+import {renderHook, waitFor} from '@testing-library/react';
+import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
+import {
+  assignApproverGroup,
+  invoiceClassification,
+  literalExpression,
+} from 'modules/mocks/mockDecisionInstanceV2';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {useDrdData} from './useDrdData';
+
+const wrapper = ({children}: {children: React.ReactNode}) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useDrdData', () => {
+  it('should map decision instances search results to drd data', async () => {
+    mockSearchDecisionInstances().withSuccess({
+      items: [invoiceClassification, assignApproverGroup],
+      page: {totalItems: 2},
+    });
+
+    const {result} = renderHook(() => useDrdData('29283472932831'), {wrapper});
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual({
+      [assignApproverGroup.decisionDefinitionId]: {
+        decisionDefinitionId: assignApproverGroup.decisionDefinitionId,
+        decisionEvaluationInstanceKey:
+          assignApproverGroup.decisionEvaluationInstanceKey,
+        state: assignApproverGroup.state,
+      },
+      [invoiceClassification.decisionDefinitionId]: {
+        decisionDefinitionId: invoiceClassification.decisionDefinitionId,
+        decisionEvaluationInstanceKey:
+          invoiceClassification.decisionEvaluationInstanceKey,
+        state: invoiceClassification.state,
+      },
+    });
+  });
+
+  it('should use the last result item as the value for a decision instance id', async () => {
+    mockSearchDecisionInstances().withSuccess({
+      items: [
+        invoiceClassification,
+        {...invoiceClassification, state: 'FAILED'},
+      ],
+      page: {totalItems: 2},
+    });
+
+    const {result} = renderHook(() => useDrdData('29283472932831'), {wrapper});
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual({
+      [invoiceClassification.decisionDefinitionId]: {
+        decisionDefinitionId: invoiceClassification.decisionDefinitionId,
+        decisionEvaluationInstanceKey:
+          invoiceClassification.decisionEvaluationInstanceKey,
+        state: 'FAILED',
+      },
+    });
+  });
+
+  it('should load remaining results items if more are available', async () => {
+    mockSearchDecisionInstances().withSuccess({
+      items: [invoiceClassification],
+      page: {totalItems: 3},
+    });
+    mockSearchDecisionInstances().withSuccess({
+      items: [assignApproverGroup, literalExpression],
+      page: {totalItems: 3},
+    });
+
+    const {result} = renderHook(() => useDrdData('29283472932831'), {wrapper});
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual({
+      [assignApproverGroup.decisionDefinitionId]: {
+        decisionDefinitionId: assignApproverGroup.decisionDefinitionId,
+        decisionEvaluationInstanceKey:
+          assignApproverGroup.decisionEvaluationInstanceKey,
+        state: assignApproverGroup.state,
+      },
+      [invoiceClassification.decisionDefinitionId]: {
+        decisionDefinitionId: invoiceClassification.decisionDefinitionId,
+        decisionEvaluationInstanceKey:
+          invoiceClassification.decisionEvaluationInstanceKey,
+        state: invoiceClassification.state,
+      },
+      [literalExpression.decisionDefinitionId]: {
+        decisionDefinitionId: literalExpression.decisionDefinitionId,
+        decisionEvaluationInstanceKey:
+          literalExpression.decisionEvaluationInstanceKey,
+        state: literalExpression.state,
+      },
+    });
+  });
+});

--- a/operate/client/src/modules/queries/decisionInstances/useDrdData.ts
+++ b/operate/client/src/modules/queries/decisionInstances/useDrdData.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import {queryKeys} from '../queryKeys';
+import {searchDecisionInstances} from 'modules/api/v2/decisionInstances/searchDecisionInstances';
+import type {DecisionInstance} from '@camunda/camunda-api-zod-schemas/8.8';
+
+interface DrdData {
+  [decisionDefinitionId: DecisionInstance['decisionDefinitionId']]: {
+    decisionDefinitionId: DecisionInstance['decisionDefinitionId'];
+    decisionEvaluationInstanceKey: DecisionInstance['decisionEvaluationInstanceKey'];
+    state: DecisionInstance['state'];
+  };
+}
+
+const useDrdData = (decisionEvaluationKey?: string) => {
+  return useQuery({
+    enabled: !!decisionEvaluationKey,
+    queryKey: queryKeys.decisionInstances.drdData(decisionEvaluationKey ?? ''),
+    queryFn: async () => {
+      const {response, error} = await searchDecisionInstances({
+        filter: {decisionEvaluationKey},
+      });
+      if (error) {
+        throw error;
+      }
+
+      let drdData = {} as DrdData;
+      for (const item of response.items) {
+        // Displaying DRD data always works with the last decisionDefinitionId
+        // if multiple exists for the same `decisionEvaluationKey`.
+        drdData[item.decisionDefinitionId] = {
+          decisionDefinitionId: item.decisionDefinitionId,
+          decisionEvaluationInstanceKey: item.decisionEvaluationInstanceKey,
+          state: item.state,
+        };
+      }
+      return drdData;
+    },
+  });
+};
+
+export {useDrdData, type DrdData};

--- a/operate/client/src/modules/queries/decisionInstances/useDrdData.ts
+++ b/operate/client/src/modules/queries/decisionInstances/useDrdData.ts
@@ -11,13 +11,13 @@ import {queryKeys} from '../queryKeys';
 import {searchDecisionInstances} from 'modules/api/v2/decisionInstances/searchDecisionInstances';
 import type {DecisionInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 
-interface DrdData {
+type DrdData = {
   [decisionDefinitionId: DecisionInstance['decisionDefinitionId']]: {
     decisionDefinitionId: DecisionInstance['decisionDefinitionId'];
     decisionEvaluationInstanceKey: DecisionInstance['decisionEvaluationInstanceKey'];
     state: DecisionInstance['state'];
   };
-}
+};
 
 const useDrdData = (decisionEvaluationKey?: string) => {
   return useQuery({

--- a/operate/client/src/modules/queries/decisionInstances/useDrdPanelState.ts
+++ b/operate/client/src/modules/queries/decisionInstances/useDrdPanelState.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getStateLocally, storeStateLocally} from 'modules/utils/localStorage';
+import {useCallback, useState} from 'react';
+
+type DrdPanelState = 'closed' | 'maximized' | 'minimized';
+
+function getInitialState(): DrdPanelState {
+  const {drdPanelState} = getStateLocally('panelStates');
+  return drdPanelState ?? 'minimized';
+}
+
+function useDrdPanelState(): [
+  state: DrdPanelState,
+  update: (state: DrdPanelState) => void,
+] {
+  const [state, setState] = useState(getInitialState);
+  const update = useCallback((state: DrdPanelState) => {
+    storeStateLocally({drdPanelState: state}, 'panelStates');
+    setState(state);
+  }, []);
+
+  return [state, update];
+}
+
+function getDrdPanelWidth(): number | null {
+  const {drdPanelWidth} = getStateLocally('panelStates');
+  return drdPanelWidth ?? null;
+}
+
+function persistDrdPanelWidth(width: number): void {
+  storeStateLocally({drdPanelWidth: width}, 'panelStates');
+}
+
+export {
+  useDrdPanelState,
+  getDrdPanelWidth,
+  persistDrdPanelWidth,
+  type DrdPanelState,
+};

--- a/operate/client/src/modules/queries/decisionInstances/useDrdStateOverlay.ts
+++ b/operate/client/src/modules/queries/decisionInstances/useDrdStateOverlay.ts
@@ -9,17 +9,17 @@
 import type {DecisionInstanceState} from '@camunda/camunda-api-zod-schemas/8.8';
 import {useMemo, useState} from 'react';
 
-interface DecisionStateOverlay {
+type DecisionStateOverlay = {
   state: DecisionInstanceState;
   decisionDefinitionId: string;
   container: HTMLDivElement;
-}
+};
 
-interface DecisionStateOverlayActions {
+type DecisionStateOverlayActions = {
   replaceOverlays(overlays: DecisionStateOverlay[]): void;
   addOverlay(overlay: DecisionStateOverlay): void;
   clearOverlays(): void;
-}
+};
 
 function useDrdStateOverlay(): [
   state: DecisionStateOverlay[],

--- a/operate/client/src/modules/queries/decisionInstances/useDrdStateOverlay.ts
+++ b/operate/client/src/modules/queries/decisionInstances/useDrdStateOverlay.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {DecisionInstanceState} from '@camunda/camunda-api-zod-schemas/8.8';
+import {useMemo, useState} from 'react';
+
+interface DecisionStateOverlay {
+  state: DecisionInstanceState;
+  decisionDefinitionId: string;
+  container: HTMLDivElement;
+}
+
+interface DecisionStateOverlayActions {
+  replaceOverlays(overlays: DecisionStateOverlay[]): void;
+  addOverlay(overlay: DecisionStateOverlay): void;
+  clearOverlays(): void;
+}
+
+function useDrdStateOverlay(): [
+  state: DecisionStateOverlay[],
+  actions: DecisionStateOverlayActions,
+] {
+  const [state, setState] = useState<DecisionStateOverlay[]>([]);
+
+  const actions = useMemo<DecisionStateOverlayActions>(
+    () => ({
+      replaceOverlays: (overlays) => setState(overlays),
+      addOverlay: (overlay) => setState((prev) => [...prev, overlay]),
+      clearOverlays: () => setState([]),
+    }),
+    [],
+  );
+
+  return [state, actions];
+}
+
+export {
+  useDrdStateOverlay,
+  type DecisionStateOverlay,
+  type DecisionStateOverlayActions,
+};

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -26,6 +26,10 @@ const queryKeys = {
       'decisionInstance',
       decisionEvaluationInstanceKey,
     ],
+    drdData: (decisionEvaluationKey: string) => [
+      'decisionInstanceDrdData',
+      decisionEvaluationKey,
+    ],
   },
 };
 


### PR DESCRIPTION
## Description

Migrates the decision instance UI to use query state and local React state for DRD data and panel state instead of the `drdStore` and `drdDataStore`. The changes are separated between commits for easier review:

1. The first commit adds a new hook for loading and transforming search data into DRD data.
2. The second commit migrates the React components and refactors the `DrdViewer` class to work with the architecture constraints of React state.
3. The last commit replaces the `drdStore` with local React state and loaded localStorage data.

Note: While the components have been cleaned up to no longer call stores and load v1 API data, the stores, endpoints, and mocks have not been removed yet. This will be done in #38717.


## Checklist

- [ ] Notice that this PR is stacked on #38639

## Related issues

closes #28392
