### PR TITLE
feat: pass local user/groups flag to engine

### DIFF
--- a/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
@@ -11,6 +11,8 @@ import static io.camunda.security.entity.AuthenticationMethod.OIDC;
 import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_ANONYMOUS_USER;
 import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_CLIENT_ID;
 import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
+import static io.camunda.zeebe.auth.Authorization.IS_CAMUNDA_GROUPS_ENABLED;
+import static io.camunda.zeebe.auth.Authorization.IS_CAMUNDA_USERS_ENABLED;
 import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
 import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
 
@@ -20,24 +22,35 @@ import java.util.Map;
 
 public class BrokerRequestAuthorizationConverter {
 
-  private final boolean isGroupsClaimConfigured;
+  private final boolean camundaGroupsEnabled;
+  private final boolean camundaUsersEnabled;
 
   public BrokerRequestAuthorizationConverter(final SecurityConfiguration securityConfiguration) {
-    isGroupsClaimConfigured = isGroupsClaimConfigured(securityConfiguration);
+    camundaGroupsEnabled = isCamundaGroupsEnabled(securityConfiguration);
+    camundaUsersEnabled = isCamundaUsersEnabled(securityConfiguration);
   }
 
-  protected boolean isGroupsClaimConfigured(final SecurityConfiguration securityConfiguration) {
+  protected boolean isCamundaGroupsEnabled(final SecurityConfiguration securityConfiguration) {
     final var authenticationConfiguration = securityConfiguration.getAuthentication();
-    return authenticationConfiguration.getMethod() == OIDC
-        && authenticationConfiguration.getOidc().isGroupsClaimConfigured();
+    return !(authenticationConfiguration.getMethod() == OIDC
+        && authenticationConfiguration.getOidc().isGroupsClaimConfigured());
+  }
+
+  protected boolean isCamundaUsersEnabled(final SecurityConfiguration securityConfiguration) {
+    final var authenticationConfiguration = securityConfiguration.getAuthentication();
+    return authenticationConfiguration.getMethod() != OIDC;
   }
 
   public Map<String, Object> convert(final CamundaAuthentication authentication) {
-    if (authentication.isAnonymous()) {
-      return Map.of(AUTHORIZED_ANONYMOUS_USER, true);
-    }
 
     final var authorization = new HashMap<String, Object>();
+    authorization.put(IS_CAMUNDA_GROUPS_ENABLED, camundaGroupsEnabled);
+    authorization.put(IS_CAMUNDA_USERS_ENABLED, camundaUsersEnabled);
+    if (authentication.isAnonymous()) {
+      authorization.put(AUTHORIZED_ANONYMOUS_USER, AUTHORIZED_USERNAME);
+      return authorization;
+    }
+
     final var username = authentication.authenticatedUsername();
     final var clientId = authentication.authenticatedClientId();
     final var groups = authentication.authenticatedGroupIds();
@@ -51,7 +64,7 @@ public class BrokerRequestAuthorizationConverter {
       authorization.put(AUTHORIZED_CLIENT_ID, clientId);
     }
 
-    if (isGroupsClaimConfigured) {
+    if (!camundaGroupsEnabled) {
       authorization.put(USER_GROUPS_CLAIMS, groups);
     }
 

--- a/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
@@ -47,7 +47,7 @@ public class BrokerRequestAuthorizationConverter {
     authorization.put(IS_CAMUNDA_GROUPS_ENABLED, camundaGroupsEnabled);
     authorization.put(IS_CAMUNDA_USERS_ENABLED, camundaUsersEnabled);
     if (authentication.isAnonymous()) {
-      authorization.put(AUTHORIZED_ANONYMOUS_USER, AUTHORIZED_USERNAME);
+      authorization.put(AUTHORIZED_ANONYMOUS_USER, true);
       return authorization;
     }
 

--- a/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
@@ -11,6 +11,8 @@ import static io.camunda.security.entity.AuthenticationMethod.OIDC;
 import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_ANONYMOUS_USER;
 import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_CLIENT_ID;
 import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
+import static io.camunda.zeebe.auth.Authorization.IS_CAMUNDA_GROUPS_ENABLED;
+import static io.camunda.zeebe.auth.Authorization.IS_CAMUNDA_USERS_ENABLED;
 import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
 import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,8 +35,10 @@ public class BrokerRequestAuthorizationConverterTest {
     final var brokerRequestAuth = converter.convert(authentication);
 
     // then
-    assertThat(brokerRequestAuth).hasSize(1);
+    assertThat(brokerRequestAuth).hasSize(3);
     assertThat(brokerRequestAuth).containsEntry(AUTHORIZED_ANONYMOUS_USER, true);
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_GROUPS_ENABLED, true);
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_USERS_ENABLED, true);
   }
 
   @Test
@@ -47,22 +51,28 @@ public class BrokerRequestAuthorizationConverterTest {
     final var brokerRequestAuth = converter.convert(authentication);
 
     // then
-    assertThat(brokerRequestAuth).hasSize(1);
+    assertThat(brokerRequestAuth).hasSize(3);
     assertThat(brokerRequestAuth).containsEntry(AUTHORIZED_USERNAME, "foo");
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_GROUPS_ENABLED, true);
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_USERS_ENABLED, true);
   }
 
   @Test
   void shouldContainClientID() {
     // given
     final var authentication = CamundaAuthentication.of(b -> b.clientId("foo"));
-    final var converter = new BrokerRequestAuthorizationConverter(new SecurityConfiguration());
+    final var securityConfiguration = new SecurityConfiguration();
+    securityConfiguration.getAuthentication().setMethod(OIDC);
+    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
 
     // when
     final var brokerRequestAuth = converter.convert(authentication);
 
     // then
-    assertThat(brokerRequestAuth).hasSize(1);
+    assertThat(brokerRequestAuth).hasSize(3);
     assertThat(brokerRequestAuth).containsEntry(AUTHORIZED_CLIENT_ID, "foo");
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_GROUPS_ENABLED, true);
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_USERS_ENABLED, false);
   }
 
   @Test
@@ -70,14 +80,18 @@ public class BrokerRequestAuthorizationConverterTest {
     // given
     final Map<String, Object> claims = Map.of("sub", "foo");
     final var authentication = CamundaAuthentication.of(b -> b.claims(claims));
-    final var converter = new BrokerRequestAuthorizationConverter(new SecurityConfiguration());
+    final var securityConfiguration = new SecurityConfiguration();
+    securityConfiguration.getAuthentication().setMethod(OIDC);
+    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
 
     // when
     final var brokerRequestAuth = converter.convert(authentication);
 
     // then
-    assertThat(brokerRequestAuth).hasSize(1);
+    assertThat(brokerRequestAuth).hasSize(3);
     assertThat(brokerRequestAuth).containsEntry(USER_TOKEN_CLAIMS, claims);
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_GROUPS_ENABLED, true);
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_USERS_ENABLED, false);
   }
 
   @Test
@@ -98,8 +112,10 @@ public class BrokerRequestAuthorizationConverterTest {
     final var brokerRequestAuth = converter.convert(authentication);
 
     // then
-    assertThat(brokerRequestAuth).hasSize(1);
+    assertThat(brokerRequestAuth).hasSize(3);
     assertThat(brokerRequestAuth).containsEntry(USER_GROUPS_CLAIMS, groups);
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_GROUPS_ENABLED, false);
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_USERS_ENABLED, false);
   }
 
   @Test
@@ -119,7 +135,9 @@ public class BrokerRequestAuthorizationConverterTest {
     final var brokerRequestAuth = converter.convert(authentication);
 
     // then
-    assertThat(brokerRequestAuth).hasSize(0);
+    assertThat(brokerRequestAuth).hasSize(2);
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_GROUPS_ENABLED, true);
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_USERS_ENABLED, true);
   }
 
   @Test
@@ -128,12 +146,16 @@ public class BrokerRequestAuthorizationConverterTest {
     final var groups = List.of("group1", "group2");
     final var authentication = CamundaAuthentication.of(b -> b.groupIds(groups));
 
-    final var converter = new BrokerRequestAuthorizationConverter(new SecurityConfiguration());
+    final var securityConfiguration = new SecurityConfiguration();
+    securityConfiguration.getAuthentication().setMethod(OIDC);
+    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
 
     // when
     final var brokerRequestAuth = converter.convert(authentication);
 
     // then
-    assertThat(brokerRequestAuth).hasSize(0);
+    assertThat(brokerRequestAuth).hasSize(2);
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_GROUPS_ENABLED, true);
+    assertThat(brokerRequestAuth).containsEntry(IS_CAMUNDA_USERS_ENABLED, false);
   }
 }

--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/Authorization.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/Authorization.java
@@ -15,4 +15,6 @@ public class Authorization {
   public static final String AUTHORIZED_CLIENT_ID = "authorized_client_id";
   public static final String USER_TOKEN_CLAIMS = "user_token_claims";
   public static final String USER_GROUPS_CLAIMS = "user_groups_claims";
+  public static final String IS_CAMUNDA_USERS_ENABLED = "is_camunda_users_enabled";
+  public static final String IS_CAMUNDA_GROUPS_ENABLED = "is_camunda_groups_enabled";
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -63,8 +63,8 @@ public class AuthorizationCreateProcessor
                     record.getPermissionTypes(),
                     record.getResourceType(),
                     "Expected to create authorization with permission types '%s' and resource type '%s', but these permissions are not supported. Supported permission types are: '%s'"))
-        .flatMap(authorizationRecord -> authorizationEntityChecker.ownerAndResourceExists(command))
         .flatMap(permissionsBehavior::permissionsAlreadyExist)
+        .flatMap(authorizationRecord -> authorizationEntityChecker.ownerAndResourceExists(command))
         .ifRightOrLeft(
             authorizationRecord -> writeEventAndDistribute(command, command.getValue()),
             (rejection) -> {
@@ -75,9 +75,9 @@ public class AuthorizationCreateProcessor
 
   @Override
   public void processDistributedCommand(final TypedRecord<AuthorizationRecord> command) {
-    authorizationEntityChecker
-        .ownerAndResourceExists(command)
-        .flatMap(permissionsBehavior::permissionsAlreadyExist)
+    permissionsBehavior
+        .permissionsAlreadyExist(command.getValue())
+        .flatMap(record -> authorizationEntityChecker.ownerAndResourceExists(command))
         .ifRightOrLeft(
             ignored -> {
               stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityChecker.java
@@ -27,8 +27,8 @@ public class AuthorizationEntityChecker {
       "Expected to create or update authorization with ownerId or resourceId '%s', but a user with this ID does not exist.";
   public static final String GROUP_DOES_NOT_EXIST_ERROR_MESSAGE =
       "Expected to create or update authorization with ownerId or resourceId '%s', but a group with this ID does not exist.";
-  public static final String IS_CAMUNDA_USERS_ENABLED = "IS_CAMUNDA_USERS_ENABLED";
-  public static final String IS_CAMUNDA_GROUPS_ENABLED = "IS_CAMUNDA_GROUPS_ENABLED";
+  public static final String IS_CAMUNDA_USERS_ENABLED = "is_camunda_users_enabled";
+  public static final String IS_CAMUNDA_GROUPS_ENABLED = "is_camunda_groups_enabled";
 
   private final UserState userState;
   private final MappingRuleState mappingRuleState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -79,12 +79,9 @@ public class AuthorizationUpdateProcessor
 
   @Override
   public void processDistributedCommand(final TypedRecord<AuthorizationRecord> command) {
-    authorizationEntityChecker
-        .ownerAndResourceExists(command)
-        .flatMap(
-            s ->
-                permissionsBehavior.authorizationExists(
-                    s, AUTHORIZATION_DOES_NOT_EXIST_ERROR_MESSAGE_UPDATE))
+    permissionsBehavior
+        .authorizationExists(command.getValue(), AUTHORIZATION_DOES_NOT_EXIST_ERROR_MESSAGE_UPDATE)
+        .flatMap(s -> authorizationEntityChecker.ownerAndResourceExists(command))
         .ifRightOrLeft(
             ignored -> {
               stateWriter.appendFollowUpEvent(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -499,6 +499,13 @@ public final class EndpointManager {
   private Map<String, Object> getClaims() throws Exception {
     final Map<String, Object> claims = new HashMap<>();
 
+    claims.put(
+        Authorization.IS_CAMUNDA_GROUPS_ENABLED,
+        Context.current().call(AuthenticationHandler.IS_CAMUNDA_GROUPS_ENABLED::get));
+    claims.put(
+        Authorization.IS_CAMUNDA_USERS_ENABLED,
+        Context.current().call(AuthenticationHandler.IS_CAMUNDA_USERS_ENABLED::get));
+
     // retrieve the user claims from the context and add them to the authorization if present
     final Map<String, Object> userClaims =
         Context.current().call(AuthenticationHandler.Oidc.USER_CLAIMS::get);


### PR DESCRIPTION
## Description

As engine needs to make decision on existing of user or groups when the local user/group management is enabled we need to pass these flags to engine. With current structure the authorizations map in command is the best option.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38527 
