### PR TITLE
[Backport release-8.8.0] perf: reduce the max terms count to 10_000

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
@@ -21,6 +21,7 @@ public class ElasticsearchProperties {
   public static final String DATE_FORMAT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
 
   public static final String ELS_DATE_FORMAT_DEFAULT = "date_time";
+  public static final int DEFAULT_MAX_TERMS_COUNT = 10_000;
 
   private String clusterName = "elasticsearch";
 
@@ -33,6 +34,7 @@ public class ElasticsearchProperties {
   private String elsDateFormat = ELS_DATE_FORMAT_DEFAULT;
 
   private int batchSize = 200;
+  private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
 
   private Integer socketTimeout;
   private Integer connectTimeout;
@@ -110,6 +112,14 @@ public class ElasticsearchProperties {
 
   public void setBatchSize(final int batchSize) {
     this.batchSize = batchSize;
+  }
+
+  public int getMaxTermsCount() {
+    return maxTermsCount;
+  }
+
+  public void setMaxTermsCount(final int maxTermsCount) {
+    this.maxTermsCount = maxTermsCount;
   }
 
   public boolean isCreateSchema() {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
@@ -21,6 +21,7 @@ public class OpenSearchProperties {
   public static final String DATE_FORMAT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
 
   public static final String ELS_DATE_FORMAT_DEFAULT = "date_time";
+  public static final int DEFAULT_MAX_TERMS_COUNT = 10_000;
 
   private String clusterName = "opensearch-cluster";
 
@@ -33,6 +34,7 @@ public class OpenSearchProperties {
   private String elsDateFormat = ELS_DATE_FORMAT_DEFAULT;
 
   private int batchSize = 200;
+  private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
 
   private Integer socketTimeout;
   private Integer connectTimeout;
@@ -111,6 +113,14 @@ public class OpenSearchProperties {
 
   public void setBatchSize(final int batchSize) {
     this.batchSize = batchSize;
+  }
+
+  public int getMaxTermsCount() {
+    return maxTermsCount;
+  }
+
+  public void setMaxTermsCount(final int maxTermsCount) {
+    this.maxTermsCount = maxTermsCount;
   }
 
   public boolean isCreateSchema() {

--- a/tasklist/els-schema/pom.xml
+++ b/tasklist/els-schema/pom.xml
@@ -116,11 +116,6 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.annotation</groupId>
-      <artifactId>jakarta.annotation-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/VariableStore.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/VariableStore.java
@@ -40,8 +40,6 @@ public interface VariableStore {
   public SnapshotTaskVariableEntity getTaskVariable(
       final String variableId, Set<String> fieldNames);
 
-  void refreshMaxTermsCount();
-
   public List<String> getProcessInstanceIdsWithMatchingVars(
       List<String> varNames, List<String> varValues);
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/DatabaseTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/DatabaseTestExtension.java
@@ -7,15 +7,10 @@
  */
 package io.camunda.tasklist.util;
 
-import java.io.IOException;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.extension.Extension;
 
 public interface DatabaseTestExtension extends Extension {
-
-  void setIndexMaxTermsCount(final String indexName, final int maxTermsCount) throws IOException;
-
-  int getIndexMaxTermsCount(final String indexName) throws IOException;
 
   void assertMaxOpenScrollContexts(final int maxOpenScrollContexts);
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.tasklist.util;
 
-import static io.camunda.tasklist.store.elasticsearch.VariableStoreElasticSearch.MAX_TERMS_COUNT_SETTING;
 import static io.camunda.tasklist.util.ThreadUtil.sleepFor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
@@ -20,18 +19,14 @@ import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.qa.util.TasklistIndexPrefixHolder;
 import io.camunda.tasklist.qa.util.TestSchemaManager;
 import io.camunda.tasklist.qa.util.TestUtil;
-import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
-import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
-import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.common.settings.Settings;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -109,32 +104,6 @@ public class ElasticsearchTestExtension
         .connect()
         .setIndexPrefix(TasklistElasticsearchProperties.DEFAULT_INDEX_PREFIX);
     assertMaxOpenScrollContexts(10);
-  }
-
-  @Override
-  public void setIndexMaxTermsCount(final String indexName, final int maxTermsCount)
-      throws IOException {
-    esClient
-        .indices()
-        .putSettings(
-            new UpdateSettingsRequest()
-                .indices(indexName)
-                .settings(Settings.builder().put(MAX_TERMS_COUNT_SETTING, maxTermsCount).build()),
-            RequestOptions.DEFAULT);
-  }
-
-  @Override
-  public int getIndexMaxTermsCount(final String indexName) throws IOException {
-    return Integer.parseInt(
-        esClient
-            .indices()
-            .getSettings(
-                new GetSettingsRequest()
-                    .indices(indexName)
-                    .includeDefaults(true)
-                    .names(MAX_TERMS_COUNT_SETTING),
-                RequestOptions.DEFAULT)
-            .getSetting(indexName, MAX_TERMS_COUNT_SETTING));
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.tasklist.util;
 
-import static io.camunda.tasklist.store.opensearch.VariableStoreOpenSearch.MAX_TERMS_COUNT_SETTING;
 import static io.camunda.tasklist.util.ThreadUtil.sleepFor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
@@ -30,9 +29,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.indices.FlushRequest;
-import org.opensearch.client.opensearch.indices.GetIndicesSettingsRequest;
-import org.opensearch.client.opensearch.indices.IndexSettings;
-import org.opensearch.client.opensearch.indices.PutIndicesSettingsRequest;
 import org.opensearch.client.opensearch.nodes.Stats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,35 +94,6 @@ public class OpenSearchTestExtension
         .connect()
         .setIndexPrefix(TasklistOpenSearchProperties.DEFAULT_INDEX_PREFIX);
     assertMaxOpenScrollContexts(10);
-  }
-
-  @Override
-  public void setIndexMaxTermsCount(final String indexName, final int maxTermsCount)
-      throws IOException {
-
-    osClient
-        .indices()
-        .putSettings(
-            PutIndicesSettingsRequest.of(
-                f ->
-                    f.index(indexName)
-                        .settings(IndexSettings.of(s -> s.maxTermsCount(maxTermsCount)))));
-  }
-
-  @Override
-  public int getIndexMaxTermsCount(final String indexName) throws IOException {
-    return osClient
-        .indices()
-        .getSettings(
-            new GetIndicesSettingsRequest.Builder()
-                .index(indexName)
-                .includeDefaults(true)
-                .name(MAX_TERMS_COUNT_SETTING)
-                .build())
-        .get(indexName)
-        .settings()
-        .index()
-        .maxTermsCount();
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/VariableSearchTermsQueryChunkIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/VariableSearchTermsQueryChunkIT.java
@@ -12,13 +12,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.queries.TaskByVariables;
-import io.camunda.tasklist.store.VariableStore;
 import io.camunda.tasklist.util.MockMvcHelper;
 import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchResponse;
 import io.camunda.tasklist.webapp.dto.TaskQueryDTO;
 import io.camunda.tasklist.webapp.security.TasklistURIs;
-import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import java.io.IOException;
 import java.time.Duration;
 import org.assertj.core.api.Assertions;
@@ -27,6 +25,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -34,15 +34,17 @@ public class VariableSearchTermsQueryChunkIT extends TasklistZeebeIntegrationTes
 
   @Autowired private ObjectMapper objectMapper;
 
-  @Autowired private VariableTemplate variableTemplate;
-
   @Autowired private WebApplicationContext context;
-
-  @Autowired private VariableStore variableStore;
 
   private MockMvcHelper mockMvcHelper;
 
   private final String benchmarkProcess = "VariableSearch_Process";
+
+  @DynamicPropertySource
+  static void configureProperties(final DynamicPropertyRegistry registry) {
+    registry.add("camunda.tasklist.elasticsearch.max-terms-count", () -> 5);
+    registry.add("camunda.tasklist.opensearch.max-terms-count", () -> 5);
+  }
 
   @BeforeEach
   public void setUp() throws IOException, InterruptedException {
@@ -57,14 +59,6 @@ public class VariableSearchTermsQueryChunkIT extends TasklistZeebeIntegrationTes
         .getProcesses()
         .getFirst()
         .getProcessDefinitionKey();
-
-    databaseTestExtension.setIndexMaxTermsCount(variableTemplate.getFullQualifiedName(), 5);
-
-    org.assertj.core.api.Assertions.assertThat(
-            databaseTestExtension.getIndexMaxTermsCount(variableTemplate.getFullQualifiedName()))
-        .isEqualTo(5);
-
-    variableStore.refreshMaxTermsCount();
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #38760 to `release-8.8.0`.

relates to #38695 camunda/camunda#32600