### PR TITLE
ci: include main as base ref, and enhance label gathering

### DIFF
--- a/.github/workflows/release-branch-notifications.yml
+++ b/.github/workflows/release-branch-notifications.yml
@@ -6,12 +6,13 @@ name: Release Branch Notifications
 
 on:
   pull_request:
-    branches: ['release-*']
-    types: [labeled, closed]
-  pull_request_target:
     types: [labeled]
+    branches:
+      - main
+      - stable/**
   push:
-    branches: ['release-*']
+    branches:
+      - release-*
 
 jobs:
   validate-event:
@@ -42,14 +43,9 @@ jobs:
           # Regex for release branches: release-X.Y.Z or release-X.Y.Z-alphaK
           RELEASE_REGEX="^release-[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+)?$"
 
-          if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "pull_request_target" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             # Direct release branch PRs
-            if [[ "$PR_BASE_REF" =~ $RELEASE_REGEX ]]; then
-              if [[ "$GITHUB_EVENT_ACTION" == "closed" && "$PR_MERGED" == "true" ]]; then
-                VALID="true"
-              fi
-            # Backport PRs to main or stable branches
-            elif [[ "$PR_BASE_REF" == "main" ]] || [[ "$PR_BASE_REF" =~ ^stable/[0-9]+\.[0-9]+$ ]]; then
+            if [[ "$PR_BASE_REF" == "main" ]] || [[ "$PR_BASE_REF" =~ ^stable/[0-9]+\.[0-9]+$ ]]; then
               if [[ "$GITHUB_EVENT_ACTION" == "labeled" && ("$PR_LABEL" =~ ^backport\ release-[0-9]+\.[0-9]+\.[0-9]+) ]]; then
                 VALID="true"
               fi
@@ -60,6 +56,7 @@ jobs:
             fi
           fi
 
+          echo "🔍 Validation result: $VALID"
           echo "valid=$VALID" >> "$GITHUB_OUTPUT"
   notify-release-activity:
     name: Send Slack notification for release branch activity
@@ -103,7 +100,7 @@ jobs:
           echo "🔍 Processing event: $GITHUB_EVENT_NAME - $GITHUB_EVENT_ACTION"
 
           # Determine event type and extract data
-          if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "pull_request_target" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             BRANCH_NAME="$PR_BASE_REF"
             AUTHOR="$PR_AUTHOR"
 
@@ -112,36 +109,50 @@ jobs:
               PR_TITLE="${PR_TITLE:0:77}..."
             fi
 
-            if [[ "$GITHUB_EVENT_ACTION" == "closed" && "$PR_MERGED" == "true" ]]; then
-              ACTION_TYPE="MERGE COMPLETED"
-              LINK_TEXT="Merged PR: #$PR_NUMBER - $PR_TITLE"
-              LINK_URL="$PR_URL"
-            elif [[ "$GITHUB_EVENT_ACTION" == "labeled" ]]; then
-              ACTION_TYPE="BACKPORTING"
-              LINK_TEXT="PR: #$PR_NUMBER - $PR_TITLE (Label: $PR_LABEL)"
-              LINK_URL="$PR_URL"
-            fi
+            ACTION_TYPE="BACKPORTING"
+            LINK_TEXT="PR: #$PR_NUMBER - $PR_TITLE (Label: $PR_LABEL)"
+            LINK_URL="$PR_URL"
 
           elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            ACTION_TYPE="DIRECT PUSH to release branch"
             BRANCH_NAME="$GITHUB_REF_NAME"
             AUTHOR="$PUSH_AUTHOR"
 
-            COMMIT_MSG=""
-            COMMIT_SHA=""
-
-            if [[ -n "$HEAD_COMMIT_SHA" ]]; then
-              COMMIT_MSG="$HEAD_COMMIT_MSG"
-              COMMIT_SHA="$HEAD_COMMIT_SHA"
-
-              if [[ ${#COMMIT_MSG} -gt 60 ]]; then
-                COMMIT_MSG="${COMMIT_MSG:0:57}..."
+            # Check if this is a merge commit (typically has "Merge pull request" in commit message)
+            if [[ -n "$HEAD_COMMIT_MSG" && "$HEAD_COMMIT_MSG" =~ ^Merge\ pull\ request\ #([0-9]+) ]]; then
+              ACTION_TYPE="MERGE COMPLETED"
+              PR_NUMBER="${BASH_REMATCH[1]}"
+              
+              # Extract PR title from commit message if available
+              # Merge commit format: "Merge pull request #123 from branch\n\nPR Title"
+              if [[ "$HEAD_COMMIT_MSG" =~ $'\n\n'(.+) ]]; then
+                PR_TITLE_FROM_COMMIT="${BASH_REMATCH[1]}"
+                # Truncate long titles
+                if [[ ${#PR_TITLE_FROM_COMMIT} -gt 60 ]]; then
+                  PR_TITLE_FROM_COMMIT="${PR_TITLE_FROM_COMMIT:0:57}..."
+                fi
+                LINK_TEXT="Merged PR: #$PR_NUMBER - $PR_TITLE_FROM_COMMIT"
+              else
+                LINK_TEXT="Merged PR: #$PR_NUMBER"
               fi
-              LINK_TEXT="Commit: ${COMMIT_SHA:0:7} - $COMMIT_MSG"
-              LINK_URL="$HEAD_COMMIT_URL"
+              
+              LINK_URL="$REPO_URL/pull/$PR_NUMBER"
             else
-              LINK_TEXT="Push to release branch"
-              LINK_URL="${COMPARE_URL:-$REPO_URL/tree/$GITHUB_REF_NAME}"
+              # This is a direct push
+              ACTION_TYPE="DIRECT PUSH to release branch"
+              
+              if [[ -n "$HEAD_COMMIT_SHA" ]]; then
+                COMMIT_MSG="$HEAD_COMMIT_MSG"
+                COMMIT_SHA="$HEAD_COMMIT_SHA"
+
+                if [[ ${#COMMIT_MSG} -gt 60 ]]; then
+                  COMMIT_MSG="${COMMIT_MSG:0:57}..."
+                fi
+                LINK_TEXT="Commit: ${COMMIT_SHA:0:7} - $COMMIT_MSG"
+                LINK_URL="$HEAD_COMMIT_URL"
+              else
+                LINK_TEXT="Push to release branch"
+                LINK_URL="${COMPARE_URL:-$REPO_URL/tree/$GITHUB_REF_NAME}"
+              fi
             fi
           fi
 

--- a/.github/workflows/release-branch-notifications.yml
+++ b/.github/workflows/release-branch-notifications.yml
@@ -43,13 +43,15 @@ jobs:
           RELEASE_REGEX="^release-[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+)?$"
 
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "pull_request_target" ]]; then
+            # Direct release branch PRs
             if [[ "$PR_BASE_REF" =~ $RELEASE_REGEX ]]; then
               if [[ "$GITHUB_EVENT_ACTION" == "closed" && "$PR_MERGED" == "true" ]]; then
                 VALID="true"
               fi
-            elif [[ "$PR_BASE_REF" == "main" ]]; then
+            # Backport PRs to main or stable branches
+            elif [[ "$PR_BASE_REF" == "main" ]] || [[ "$PR_BASE_REF" =~ ^stable/[0-9]+\.[0-9]+$ ]]; then
               if [[ "$GITHUB_EVENT_ACTION" == "labeled" && ("$PR_LABEL" =~ ^backport\ release-[0-9]+\.[0-9]+\.[0-9]+) ]]; then
-              VALID="true"
+                VALID="true"
               fi
             fi
           elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then

--- a/.github/workflows/release-branch-notifications.yml
+++ b/.github/workflows/release-branch-notifications.yml
@@ -46,8 +46,10 @@ jobs:
             if [[ "$PR_BASE_REF" =~ $RELEASE_REGEX ]]; then
               if [[ "$GITHUB_EVENT_ACTION" == "closed" && "$PR_MERGED" == "true" ]]; then
                 VALID="true"
-              elif [[ "$GITHUB_EVENT_ACTION" == "labeled" && "$PR_LABEL" == "backport/release" ]]; then
-                VALID="true"
+              fi
+            elif [[ "$PR_BASE_REF" == "main" ]]; then
+              if [[ "$GITHUB_EVENT_ACTION" == "labeled" && ("$PR_LABEL" =~ ^backport\ release-[0-9]+\.[0-9]+\.[0-9]+) ]]; then
+              VALID="true"
               fi
             fi
           elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
@@ -182,7 +184,7 @@ jobs:
       - name: Send Slack notification
         id: slack-notification
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        continue-on-error: true  # Don't fail the workflow if Slack is down
+        continue-on-error: true # Don't fail the workflow if Slack is down
         with:
           webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Description

This pull request updates the logic for validating pull request events in the `.github/workflows/release-branch-notifications.yml` workflow. The main change is a refinement of the conditions under which the workflow will consider an event valid, especially for backport labeling.

Validation logic improvements:

* Changed the validation for pull requests targeting the `main` branch to only consider events labeled with a specific release backport pattern (e.g., `backport release-x.y.z`) as valid.
* Removed the previous condition that only checked for the `backport/release` label when the base branch matched the release regex, ensuring more precise handling of labeling events.

Reasoning:
After the workflow introduction it was able to run, but never notified when PR to main had backport to release label. https://camunda.slack.com/archives/C06UWQNCU7M/p1758799829173949?thread_ts=1756835707.654149&cid=C06UWQNCU7M

Example made in a private repository:
<img width="1363" height="903" alt="image" src="https://github.com/user-attachments/assets/eb7190be-1d36-410e-9a04-eff1a1ba960c" />
<img width="1363" height="903" alt="image" src="https://github.com/user-attachments/assets/55f3dcce-f411-46ce-aad2-427267a66164" />
<img width="1363" height="903" alt="image" src="https://github.com/user-attachments/assets/b30928f7-3062-4b91-ac19-13d9f4e09176" />

Related to [#35244](https://github.com/camunda/camunda/issues/35244)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
