### PR TITLE
[Backport stable/8.8] fix: skip snapshot when nothing processed and not forced

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -222,6 +222,12 @@ public final class AsyncSnapshotDirector extends Actor
               } else {
                 inProgressSnapshot.lowerBoundSnapshotPosition =
                     position == StreamProcessor.UNSET_POSITION ? 0L : position;
+                if (inProgressSnapshot.lowerBoundSnapshotPosition == 0 && !forceSnapshot) {
+                  LOG.debug(
+                      "We will skip taking this snapshot, because we haven't processed anything yet.");
+                  snapshotFuture.complete(null);
+                  return;
+                }
                 snapshot(inProgressSnapshot, forceSnapshot).onComplete(snapshotFuture);
               }
             });


### PR DESCRIPTION
# Description
Backport of #38624 to `stable/8.8`.

relates to #38484