### PR TITLE
feat: Archive Standalone Decision Instances

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -57,6 +57,12 @@ public class CamundaExporterMetrics implements AutoCloseable {
   /** Count of usage-metrics-task-users that have been archived. */
   private final Counter usageMetricsTUArchived;
 
+  /** Count of standalone-decisions that are in progress of archiving. */
+  private final Counter standaloneDecisionsArchiving;
+
+  /** Count of standalone-decisions that have been archived. */
+  private final Counter standaloneDecisionsArchived;
+
   private final Timer archiverSearchTimer;
   private final Timer archiverDeleteTimer;
   private final Timer archiverReindexTimer;
@@ -129,6 +135,17 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .tag("state", "archiving")
             .description(
                 "Count of completed usage-metrics-task-users that have been found, and are now in progress of archiving.")
+            .register(meterRegistry);
+    standaloneDecisionsArchived =
+        Counter.builder(meterName("archiver.standalone.decisions"))
+            .tag("state", "archived")
+            .description("Count of completed standalone-decisions, that have been archived.")
+            .register(meterRegistry);
+    standaloneDecisionsArchiving =
+        Counter.builder(meterName("archiver.standalone.decisions"))
+            .tag("state", "archiving")
+            .description(
+                "Count of completed standalone-decisions that have been found, and are now in progress of archiving.")
             .register(meterRegistry);
     archiverSearchTimer =
         Timer.builder(meterName("archiver.request.duration"))
@@ -248,6 +265,14 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   public void recordUsageMetricsTUArchiving(final int count) {
     usageMetricsTUArchiving.increment(count);
+  }
+
+  public void recordStandaloneDecisionsArchived(final int count) {
+    standaloneDecisionsArchived.increment(count);
+  }
+
+  public void recordStandaloneDecisionsArchiving(final int count) {
+    standaloneDecisionsArchiving.increment(count);
   }
 
   public void recordFlushFailureType(final String failureType) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -23,6 +23,7 @@ import io.camunda.exporter.tasks.archiver.ElasticsearchArchiverRepository;
 import io.camunda.exporter.tasks.archiver.OpenSearchArchiverRepository;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceToBeArchivedCountJob;
+import io.camunda.exporter.tasks.archiver.StandaloneDecisionArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricTUArchiverJob;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository;
@@ -37,6 +38,7 @@ import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -237,6 +239,7 @@ public final class BackgroundTaskManagerFactory {
     }
     tasks.add(buildUsageMetricsArchiverJob());
     tasks.add(buildUsageMetricsTUArchiverJob());
+    tasks.add(buildStandaloneDecisionArchiverJob());
     if (partitionId == START_PARTITION_ID) {
       tasks.add(buildBatchOperationArchiverJob());
       tasks.add(new ApplyRolloverPeriodJob(archiverRepository));
@@ -335,6 +338,16 @@ public final class BackgroundTaskManagerFactory {
         new UsageMetricTUArchiverJob(
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(UsageMetricTUTemplate.class),
+            metrics,
+            logger,
+            executor));
+  }
+
+  private ReschedulingTask buildStandaloneDecisionArchiverJob() {
+    return buildReschedulingArchiverTask(
+        new StandaloneDecisionArchiverJob(
+            archiverRepository,
+            resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class),
             metrics,
             logger,
             executor));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -35,6 +35,8 @@ public interface ArchiverRepository extends AutoCloseable {
 
   CompletableFuture<ArchiveBatch> getUsageMetricNextBatch();
 
+  CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch();
+
   CompletableFuture<Void> setIndexLifeCycle(final String destinationIndexName);
 
   CompletableFuture<Void> setLifeCycleToAllIndexes();
@@ -91,12 +93,17 @@ public interface ArchiverRepository extends AutoCloseable {
     }
 
     @Override
+    public CompletableFuture<ArchiveBatch> getUsageMetricTUNextBatch() {
+      return CompletableFuture.completedFuture(new ArchiveBatch("2024-01-01", List.of()));
+    }
+
+    @Override
     public CompletableFuture<ArchiveBatch> getUsageMetricNextBatch() {
       return CompletableFuture.completedFuture(new ArchiveBatch("2024-01-01", List.of()));
     }
 
     @Override
-    public CompletableFuture<ArchiveBatch> getUsageMetricTUNextBatch() {
+    public CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch() {
       return CompletableFuture.completedFuture(new ArchiveBatch("2024-01-01", List.of()));
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -39,6 +39,7 @@ import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
@@ -62,6 +63,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   private final IndexTemplateDescriptor batchOperationTemplateDescriptor;
   private final IndexTemplateDescriptor usageMetricTemplateDescriptor;
   private final IndexTemplateDescriptor usageMetricTUTemplateDescriptor;
+  private final IndexTemplateDescriptor decisionInstanceTemplateDescriptor;
   private final Collection<IndexTemplateDescriptor> allTemplatesDescriptors;
   private final CamundaExporterMetrics metrics;
   private String lastHistoricalArchiverDate = null;
@@ -88,6 +90,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         resourceProvider.getIndexTemplateDescriptor(UsageMetricTemplate.class);
     usageMetricTUTemplateDescriptor =
         resourceProvider.getIndexTemplateDescriptor(UsageMetricTUTemplate.class);
+    decisionInstanceTemplateDescriptor =
+        resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class);
     this.metrics = metrics;
   }
 
@@ -121,6 +125,25 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   }
 
   @Override
+  public CompletableFuture<ArchiveBatch> getUsageMetricTUNextBatch() {
+    final var searchRequest =
+        createUsageMetricSearchRequest(
+            usageMetricTUTemplateDescriptor.getFullQualifiedName(),
+            UsageMetricTUTemplate.END_TIME,
+            UsageMetricTUTemplate.PARTITION_ID);
+
+    final var timer = Timer.start();
+    return client
+        .search(searchRequest, Object.class)
+        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .thenComposeAsync(
+            response ->
+                createArchiveBatch(
+                    response, UsageMetricTUTemplate.END_TIME, usageMetricTUTemplateDescriptor),
+            executor);
+  }
+
+  @Override
   public CompletableFuture<ArchiveBatch> getUsageMetricNextBatch() {
     final var searchRequest =
         createUsageMetricSearchRequest(
@@ -140,12 +163,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch> getUsageMetricTUNextBatch() {
-    final var searchRequest =
-        createUsageMetricSearchRequest(
-            usageMetricTUTemplateDescriptor.getFullQualifiedName(),
-            UsageMetricTUTemplate.END_TIME,
-            UsageMetricTUTemplate.PARTITION_ID);
+  public CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch() {
+    final var searchRequest = createStandaloneDecisionSearchRequest();
 
     final var timer = Timer.start();
     return client
@@ -154,7 +173,9 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .thenComposeAsync(
             response ->
                 createArchiveBatch(
-                    response, UsageMetricTUTemplate.END_TIME, usageMetricTUTemplateDescriptor),
+                    response,
+                    DecisionInstanceTemplate.EVALUATION_DATE,
+                    decisionInstanceTemplateDescriptor),
             executor);
   }
 
@@ -397,6 +418,30 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     }
 
     return createSearchRequest(indexName, boolBuilder.build()._toQuery(), endTimeField);
+  }
+
+  private SearchRequest createStandaloneDecisionSearchRequest() {
+    return createSearchRequest(
+        decisionInstanceTemplateDescriptor.getFullQualifiedName(),
+        standaloneDecisionInstancesSearchQuery(config.getArchivingTimePoint(), partitionId),
+        DecisionInstanceTemplate.EVALUATION_DATE);
+  }
+
+  private Query standaloneDecisionInstancesSearchQuery(
+      final String archivingTimePoint, final int partitionId) {
+    final var endDateQ =
+        QueryBuilders.range(
+            q ->
+                q.date(
+                    d ->
+                        d.field(DecisionInstanceTemplate.EVALUATION_DATE).lte(archivingTimePoint)));
+    final var partitionQ =
+        QueryBuilders.term(q -> q.field(DecisionInstanceTemplate.PARTITION_ID).value(partitionId));
+    // standalone decision instances have processInstanceKey = -1
+    final var standaloneDecisionInstanceQ =
+        QueryBuilders.term(q -> q.field(DecisionInstanceTemplate.PROCESS_INSTANCE_KEY).value(-1));
+    return QueryBuilders.bool(
+        q -> q.filter(endDateQ).filter(partitionQ).filter(standaloneDecisionInstanceQ));
   }
 
   private SearchRequest createSearchRequest(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -19,6 +19,7 @@ import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.OpensearchRepository;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
@@ -64,6 +65,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   private final IndexTemplateDescriptor batchOperationTemplateDescriptor;
   private final IndexTemplateDescriptor usageMetricTemplateDescriptor;
   private final IndexTemplateDescriptor usageMetricTUTemplateDescriptor;
+  private final IndexTemplateDescriptor decisionInstanceTemplateDescriptor;
   private final Collection<IndexTemplateDescriptor> allTemplatesDescriptors;
   private final CamundaExporterMetrics metrics;
   private final OpenSearchGenericClient genericClient;
@@ -92,13 +94,15 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         resourceProvider.getIndexTemplateDescriptor(UsageMetricTemplate.class);
     usageMetricTUTemplateDescriptor =
         resourceProvider.getIndexTemplateDescriptor(UsageMetricTUTemplate.class);
+    decisionInstanceTemplateDescriptor =
+        resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class);
     this.metrics = metrics;
     this.genericClient = genericClient;
   }
 
   @Override
   public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
-    final var request = createFinishedInstancesSearchRequest();
+    final var request = createFinishedProcessInstancesSearchRequest();
 
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(request, Object.class))
@@ -130,7 +134,10 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             usageMetricTUTemplateDescriptor.getFullQualifiedName(),
             UsageMetricTUTemplate.END_TIME,
             UsageMetricTUTemplate.PARTITION_ID);
+
+    final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
+        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             response ->
                 createArchiveBatch(
@@ -145,11 +152,30 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             usageMetricTemplateDescriptor.getFullQualifiedName(),
             UsageMetricTemplate.END_TIME,
             UsageMetricTemplate.PARTITION_ID);
+
+    final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
+        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
         .thenComposeAsync(
             response ->
                 createArchiveBatch(
                     response, UsageMetricTemplate.END_TIME, usageMetricTemplateDescriptor),
+            executor);
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch() {
+    final var searchRequest = createStandaloneDecisionSearchRequest();
+
+    final var timer = Timer.start();
+    return sendRequestAsync(() -> client.search(searchRequest, Object.class))
+        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .thenComposeAsync(
+            response ->
+                createArchiveBatch(
+                    response,
+                    DecisionInstanceTemplate.EVALUATION_DATE,
+                    decisionInstanceTemplateDescriptor),
             executor);
   }
 
@@ -363,6 +389,13 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             executor);
   }
 
+  private SearchRequest createFinishedProcessInstancesSearchRequest() {
+    return createSearchRequest(
+        listViewTemplateDescriptor.getFullQualifiedName(),
+        finishedProcessInstancesQuery(config.getArchivingTimePoint(), partitionId),
+        ListViewTemplate.END_DATE);
+  }
+
   private SearchRequest createFinishedBatchOperationsSearchRequest() {
     final var endDateQ =
         QueryBuilders.range()
@@ -374,6 +407,39 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         batchOperationTemplateDescriptor.getFullQualifiedName(),
         endDateQ.toQuery(),
         BatchOperationTemplate.END_DATE);
+  }
+
+  private SearchRequest createStandaloneDecisionSearchRequest() {
+    return createSearchRequest(
+        decisionInstanceTemplateDescriptor.getFullQualifiedName(),
+        standaloneDecisionInstancesSearchQuery(config.getArchivingTimePoint(), partitionId),
+        DecisionInstanceTemplate.EVALUATION_DATE);
+  }
+
+  private Query standaloneDecisionInstancesSearchQuery(
+      final String archivingTimePoint, final int partitionId) {
+    final var endDateQ =
+        QueryBuilders.range()
+            .field(DecisionInstanceTemplate.EVALUATION_DATE)
+            .lte(JsonData.of(archivingTimePoint))
+            .build();
+    final var partitionQ =
+        QueryBuilders.term()
+            .field(DecisionInstanceTemplate.PARTITION_ID)
+            .value(FieldValue.of(partitionId))
+            .build();
+    // standalone decision instances have processInstanceKey = -1
+    final var standaloneDecisionInstanceQ =
+        QueryBuilders.term()
+            .field(DecisionInstanceTemplate.PROCESS_INSTANCE_KEY)
+            .value(FieldValue.of(-1))
+            .build();
+    return QueryBuilders.bool()
+        .filter(endDateQ.toQuery())
+        .filter(partitionQ.toQuery())
+        .filter(standaloneDecisionInstanceQ.toQuery())
+        .build()
+        .toQuery();
   }
 
   private CompletableFuture<ArchiveBatch> createArchiveBatch(
@@ -435,13 +501,6 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
           new ExporterException(
               "Failed to send request, likely because we failed to parse the request", e));
     }
-  }
-
-  private SearchRequest createFinishedInstancesSearchRequest() {
-    return createSearchRequest(
-        listViewTemplateDescriptor.getFullQualifiedName(),
-        finishedProcessInstancesQuery(config.getArchivingTimePoint(), partitionId),
-        ListViewTemplate.END_DATE);
   }
 
   private SearchRequest createSearchRequest(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+
+public class StandaloneDecisionArchiverJob extends ArchiverJob {
+
+  private final DecisionInstanceTemplate decisionInstanceTemplate;
+
+  public StandaloneDecisionArchiverJob(
+      final ArchiverRepository repository,
+      final DecisionInstanceTemplate decisionInstanceTemplate,
+      final CamundaExporterMetrics metrics,
+      final Logger logger,
+      final Executor executor) {
+    super(
+        repository,
+        metrics,
+        logger,
+        executor,
+        metrics::recordStandaloneDecisionsArchiving,
+        metrics::recordStandaloneDecisionsArchived);
+    this.decisionInstanceTemplate = decisionInstanceTemplate;
+  }
+
+  @Override
+  String getJobName() {
+    return "standalone-decision";
+  }
+
+  @Override
+  CompletableFuture<ArchiveBatch> getNextBatch() {
+    return getArchiverRepository().getStandaloneDecisionNextBatch();
+  }
+
+  @Override
+  String getSourceIndexName() {
+    return decisionInstanceTemplate.getFullQualifiedName();
+  }
+
+  @Override
+  String getIdFieldName() {
+    return DecisionInstanceTemplate.ID;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
@@ -18,6 +18,7 @@ import io.camunda.exporter.tasks.archiver.ApplyRolloverPeriodJob;
 import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceToBeArchivedCountJob;
+import io.camunda.exporter.tasks.archiver.StandaloneDecisionArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricTUArchiverJob;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateTask;
@@ -162,10 +163,11 @@ class BackgroundTaskManagerFactoryTest {
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
         .as("Should always schedule incident and usage metrics tasks regardless of PI config")
-        .hasSize(6)
+        .hasSize(7)
         .anyMatch(task -> isTaskOfType(task, IncidentUpdateTask.class))
         .anyMatch(task -> isTaskOfType(task, UsageMetricArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, UsageMetricTUArchiverJob.class))
+        .anyMatch(task -> isTaskOfType(task, StandaloneDecisionArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, BatchOperationArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, BatchOperationUpdateTask.class))
         .anyMatch(task -> task instanceof ApplyRolloverPeriodJob);
@@ -189,14 +191,6 @@ class BackgroundTaskManagerFactoryTest {
 
   private boolean isProcessInstanceToBeArchivedCountTask(final RunnableTask task) {
     return isTaskOfType(task, ProcessInstanceToBeArchivedCountJob.class);
-  }
-
-  private boolean isIncidentUpdateTask(final RunnableTask task) {
-    return isTaskOfType(task, IncidentUpdateTask.class);
-  }
-
-  private boolean isUsageMetricsArchiverTask(final RunnableTask task) {
-    return isTaskOfType(task, UsageMetricArchiverJob.class);
   }
 
   private boolean isTaskOfType(final RunnableTask task, final Class<?> type) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -36,6 +36,7 @@ import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
@@ -77,7 +78,7 @@ final class ElasticsearchArchiverRepositoryIT {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ElasticsearchArchiverRepositoryIT.class);
 
-  @RegisterExtension private static SearchDBExtension searchDB = SearchDBExtension.create();
+  @RegisterExtension private static final SearchDBExtension SEARCH_DB = SearchDBExtension.create();
 
   @AutoClose private final RestClientTransport transport = createRestClient();
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -524,6 +525,45 @@ final class ElasticsearchArchiverRepositoryIT {
   }
 
   @Test
+  void shouldGetStandaloneDecisionNextBatch() throws IOException {
+    // given - 5 documents, two of which were created over an hour ago and should be archived,
+    // one of which was created recently, one on a different partition and one with a different
+    // process instance key
+    final var now = Instant.now();
+    final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(
+            new TestStandaloneDecision("1", twoHoursAgo, 1, -1),
+            new TestStandaloneDecision("2", twoHoursAgo, 1, -1),
+            new TestStandaloneDecision("3", twoHoursAgo, 2, -1),
+            new TestStandaloneDecision("4", twoHoursAgo, 1, 12345),
+            new TestStandaloneDecision("5", now.toString(), 1, -1));
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    final var standaloneDecisionIndex =
+        resourceProvider
+            .getIndexTemplateDescriptor(DecisionInstanceTemplate.class)
+            .getFullQualifiedName();
+    createStandaloneDecisionIndex(standaloneDecisionIndex);
+    documents.forEach(doc -> index(standaloneDecisionIndex, doc));
+    testClient.indices().refresh(r -> r.index(standaloneDecisionIndex));
+    config.setRolloverBatchSize(3);
+
+    // when
+    final var result = repository.getStandaloneDecisionNextBatch();
+
+    // then - we expect only the first two documents created two hours ago to be returned
+    final var dateFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    final var batch = result.join();
+    assertThat(batch.ids()).containsExactly("1", "2");
+    assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
+  }
+
+  @Test
   void shouldSetTheCorrectFinishDateWithRollover() throws IOException {
     // given a rollover of 3 days:
     config.setRolloverInterval("3d");
@@ -806,7 +846,7 @@ final class ElasticsearchArchiverRepositoryIT {
     final var connectConfig = new ConnectConfiguration();
     connectConfig.setIndexPrefix(indexPrefix);
     connectConfig.setType(DatabaseType.ELASTICSEARCH.toString());
-    connectConfig.setUrl(searchDB.esUrl());
+    connectConfig.setUrl(SEARCH_DB.esUrl());
     final var schemaManagerConfig = new SchemaManagerConfiguration();
     schemaManagerConfig.getRetry().setMaxRetries(1);
     final SearchEngineConfiguration searchEngineConfiguration =
@@ -864,7 +904,7 @@ final class ElasticsearchArchiverRepositoryIT {
   }
 
   private RestClientTransport createRestClient() {
-    final var restClient = RestClient.builder(HttpHost.create(searchDB.esUrl())).build();
+    final var restClient = RestClient.builder(HttpHost.create(SEARCH_DB.esUrl())).build();
     return new RestClientTransport(restClient, new JacksonJsonpMapper());
   }
 
@@ -959,6 +999,29 @@ final class ElasticsearchArchiverRepositoryIT {
                     .aliases(usageMetricTUIndex + "alias", a -> a.isWriteIndex(false)));
   }
 
+  private void createStandaloneDecisionIndex(final String standaloneDecisionIndex)
+      throws IOException {
+    final var idProp = Property.of(p -> p.keyword(k -> k.index(true)));
+    final var evaluationDateProp =
+        Property.of(p -> p.date(d -> d.index(true).format("date_time || epoch_millis")));
+    final var properties =
+        TypeMapping.of(
+            m ->
+                m.properties(
+                    Map.of(
+                        DecisionInstanceTemplate.ID,
+                        idProp,
+                        DecisionInstanceTemplate.EVALUATION_DATE,
+                        evaluationDateProp)));
+    testClient
+        .indices()
+        .create(
+            r ->
+                r.index(standaloneDecisionIndex)
+                    .mappings(properties)
+                    .aliases(standaloneDecisionIndex + "alias", a -> a.isWriteIndex(false)));
+  }
+
   private record TestDocument(String id) implements TDocument {}
 
   private record TestBatchOperation(String id, String endDate) implements TDocument {}
@@ -969,6 +1032,10 @@ final class ElasticsearchArchiverRepositoryIT {
   private record TestUsageMetric(String id, String endTime, int partitionId) implements TDocument {}
 
   private record TestUsageMetricTU(String id, String endTime, int partitionId)
+      implements TDocument {}
+
+  private record TestStandaloneDecision(
+      String id, String evaluationDate, int partitionId, int processInstanceKey)
       implements TDocument {}
 
   private interface TDocument {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -31,6 +31,7 @@ import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
@@ -423,6 +424,45 @@ final class OpenSearchArchiverRepositoryIT {
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     final var batch = result.join();
     assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2");
+    assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
+  }
+
+  @Test
+  void shouldGetStandaloneDecisionNextBatch() throws IOException {
+    // given - 5 documents, two of which were created over an hour ago and should be archived,
+    // one of which was created recently, one on a different partition and one with a different
+    // process instance key
+    final var now = Instant.now();
+    final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(
+            new TestStandaloneDecision("1", twoHoursAgo, 1, -1),
+            new TestStandaloneDecision("2", twoHoursAgo, 1, -1),
+            new TestStandaloneDecision("3", twoHoursAgo, 2, -1),
+            new TestStandaloneDecision("4", twoHoursAgo, 1, 12345),
+            new TestStandaloneDecision("5", now.toString(), 1, -1));
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    final var standaloneDecisionIndex =
+        resourceProvider
+            .getIndexTemplateDescriptor(DecisionInstanceTemplate.class)
+            .getFullQualifiedName();
+    createStandaloneDecisionIndex(standaloneDecisionIndex);
+    documents.forEach(doc -> index(standaloneDecisionIndex, doc));
+    testClient.indices().refresh(r -> r.index(standaloneDecisionIndex));
+    config.setRolloverBatchSize(3);
+
+    // when
+    final var result = repository.getStandaloneDecisionNextBatch();
+
+    // then - we expect only the first two documents created two hours ago to be returned
+    final var dateFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    final var batch = result.join();
+    assertThat(batch.ids()).containsExactly("1", "2");
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
 
@@ -870,6 +910,29 @@ final class OpenSearchArchiverRepositoryIT {
                     .aliases(usageMetricTUIndex + "alias", a -> a.isWriteIndex(false)));
   }
 
+  private void createStandaloneDecisionIndex(final String standaloneDecisionIndex)
+      throws IOException {
+    final var idProp = Property.of(p -> p.keyword(k -> k.index(true)));
+    final var evaluationDateProp =
+        Property.of(p -> p.date(d -> d.index(true).format("date_time || epoch_millis")));
+    final var properties =
+        TypeMapping.of(
+            m ->
+                m.properties(
+                    Map.of(
+                        DecisionInstanceTemplate.ID,
+                        idProp,
+                        DecisionInstanceTemplate.EVALUATION_DATE,
+                        evaluationDateProp)));
+    testClient
+        .indices()
+        .create(
+            r ->
+                r.index(standaloneDecisionIndex)
+                    .mappings(properties)
+                    .aliases(standaloneDecisionIndex + "alias", a -> a.isWriteIndex(false)));
+  }
+
   private <T extends TDocument> void index(final String index, final T document) {
     try {
       testClient.index(b -> b.index(index).document(document).id(document.id()));
@@ -1106,6 +1169,10 @@ final class OpenSearchArchiverRepositoryIT {
   private record TestUsageMetric(String id, String endTime, int partitionId) implements TDocument {}
 
   private record TestUsageMetricTU(String id, String endTime, int partitionId)
+      implements TDocument {}
+
+  private record TestStandaloneDecision(
+      String id, String evaluationDate, int partitionId, int processInstanceKey)
       implements TDocument {}
 
   private interface TDocument {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetricsAbstractTest {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(StandaloneDecisionArchiverJobTest.class);
+
+  private final Executor executor = Runnable::run;
+
+  private final TestRepository repository = new TestRepository();
+  private final DecisionInstanceTemplate decisionInstanceTemplate =
+      new DecisionInstanceTemplate("", true);
+  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
+
+  private final StandaloneDecisionArchiverJob job =
+      new StandaloneDecisionArchiverJob(
+          repository, decisionInstanceTemplate, metrics, LOGGER, executor);
+
+  @BeforeEach
+  void setUp() {
+    // given
+    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+  }
+
+  @AfterEach
+  void cleanUp() {
+    meterRegistry.clear();
+  }
+
+  @Override
+  ArchiverJob getArchiverJob() {
+    return job;
+  }
+
+  @Override
+  SimpleMeterRegistry getMeterRegistry() {
+    return meterRegistry;
+  }
+
+  @Override
+  String getJobMetricName() {
+    return "zeebe.camunda.exporter.archiver.standalone.decisions";
+  }
+
+  @Test
+  void shouldMoveStandaloneDecisionInstances() {
+    // when
+    final int count = job.execute().toCompletableFuture().join();
+
+    // then
+    assertThat(count).isEqualTo(3); // batch has 3 ids
+    assertArchivingCounts(count); // asserted as 3 above
+    assertArchiverTimer(1);
+
+    // then should move
+    assertThat(repository.moves)
+        .containsExactly(
+            new DocumentMove(
+                decisionInstanceTemplate.getFullQualifiedName(),
+                decisionInstanceTemplate.getFullQualifiedName() + "2024-01-01",
+                DecisionInstanceTemplate.ID,
+                List.of("1", "2", "3"),
+                executor));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
@@ -32,12 +32,17 @@ final class TestRepository extends NoopArchiverRepository {
   }
 
   @Override
+  public CompletableFuture<ArchiveBatch> getUsageMetricTUNextBatch() {
+    return CompletableFuture.completedFuture(batch);
+  }
+
+  @Override
   public CompletableFuture<ArchiveBatch> getUsageMetricNextBatch() {
     return CompletableFuture.completedFuture(batch);
   }
 
   @Override
-  public CompletableFuture<ArchiveBatch> getUsageMetricTUNextBatch() {
+  public CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch() {
     return CompletableFuture.completedFuture(batch);
   }
 


### PR DESCRIPTION
## Description

Whilst we are archiving decision instances attached to a process via the linked `processInstanceKey` of the decision instances, the standalone evaluations are never moved, which can result in building completed data in the hot indexes. This adds a specialised archiver job that would move any standalone decision instances evaluated prior to the archive window, and move them to their dated indexes.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Merge https://github.com/camunda/camunda/pull/38728 and rebase 

## Related issues

closes #35555 