### PR TITLE
fix: upgrade netty to 4.1.124.Final

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -58,7 +58,7 @@
     <httpclient.version>4.5.14</httpclient.version>
     <quartz.version>2.3.2</quartz.version>
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
-    <netty.version>4.1.119.Final</netty.version>
+    <netty.version>4.1.124.Final</netty.version>
     <lombok.version>1.18.34</lombok.version>
     <logback.version>1.5.8</logback.version>
     <slf4j.version>2.0.16</slf4j.version>


### PR DESCRIPTION
## Description

I'm updating netty dep to 4.1.124.Final to fix https://nvd.nist.gov/vuln/detail/CVE-2025-55163
https://camunda.slack.com/archives/C08MRKHJ0CD/p1758878008898669
