### PR TITLE
[Backport release-8.8.0] fix: unified config: Camunda exporter args are not set when created for the first time

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -431,27 +431,24 @@ public class BrokerBasedPropertiesOverride {
 
     /* Load exporter config map */
 
-    final List<ExporterCfg> exporters =
-        override.getExporters().values().stream()
-            .filter(e -> e.getClassName().equals(CAMUNDA_EXPORTER_CLASS_NAME))
-            .toList();
-
-    final ExporterCfg exporter;
-    if (exporters.isEmpty()) {
+    ExporterCfg exporter = override.getCamundaExporter();
+    if (exporter == null) {
       exporter = new ExporterCfg();
       exporter.setClassName(CAMUNDA_EXPORTER_CLASS_NAME);
       exporter.setArgs(new LinkedHashMap<>());
       override.getExporters().put(CAMUNDA_EXPORTER_NAME, exporter);
-    } else {
-      exporter = exporters.getFirst();
     }
 
     /* Override config map values */
 
     // https://github.com/camunda/camunda/issues/37880
     // it is possible to have an exporter with no args defined
-    final Map<String, Object> args =
-        exporter.getArgs() == null ? new LinkedHashMap<>() : exporter.getArgs();
+    Map<String, Object> args = exporter.getArgs();
+    if (args == null) {
+      args = new LinkedHashMap<>();
+      exporter.setArgs(args);
+    }
+
     setArg(args, "connect.type", secondaryStorage.getType().name());
     setArg(args, "connect.url", database.getUrl());
     setArg(args, "connect.clusterName", database.getClusterName());

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -281,8 +281,13 @@ public class SecondaryStorageElasticsearchTest {
     void testSecondaryStorageExporterCanWorkWithoutArgs() {
       final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
       assertThat(camundaExporter).isNotNull();
+
       final Map<String, Object> args = camundaExporter.getArgs();
-      assertThat(args).isNull();
+      assertThat(args).isNotNull();
+
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToExporterConfiguration(args);
+      assertThat(exporterConfiguration.getConnect().getUrl()).isEqualTo("http://matching-url:4321");
     }
   }
 


### PR DESCRIPTION
# Description
Backport of #38732 to `release-8.8.0`.

relates to camunda/camunda#38731 camunda/camunda#38731