### PR TITLE
Add missing `sequenceFlowId` in the response

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstanceSequenceFlow.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstanceSequenceFlow.java
@@ -17,6 +17,9 @@ package io.camunda.client.api.search.response;
 
 public interface ProcessInstanceSequenceFlow {
 
+  /** ID of the sequence flow */
+  String getSequenceFlowId();
+
   /** process instance key for the sequence flow instance */
   String getProcessInstanceKey();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceSequenceFlowImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceSequenceFlowImpl.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 
 public class ProcessInstanceSequenceFlowImpl implements ProcessInstanceSequenceFlow {
 
+  private final String sequenceFlowId;
   private final String processInstanceKey;
   private final String processDefinitionKey;
   private final String processDefinitionId;
@@ -28,6 +29,7 @@ public class ProcessInstanceSequenceFlowImpl implements ProcessInstanceSequenceF
   private final String tenantId;
 
   public ProcessInstanceSequenceFlowImpl(final ProcessInstanceSequenceFlowResult result) {
+    sequenceFlowId = result.getSequenceFlowId();
     processInstanceKey = result.getProcessInstanceKey();
     processDefinitionKey = result.getProcessDefinitionKey();
     processDefinitionId = result.getProcessDefinitionId();
@@ -36,16 +38,23 @@ public class ProcessInstanceSequenceFlowImpl implements ProcessInstanceSequenceF
   }
 
   public ProcessInstanceSequenceFlowImpl(
+      final String sequenceFlowId,
       final String processInstanceKey,
       final String processDefinitionKey,
       final String processDefinitionId,
       final String elementId,
       final String tenantId) {
+    this.sequenceFlowId = sequenceFlowId;
     this.processInstanceKey = processInstanceKey;
     this.processDefinitionKey = processDefinitionKey;
     this.processDefinitionId = processDefinitionId;
     this.elementId = elementId;
     this.tenantId = tenantId;
+  }
+
+  @Override
+  public String getSequenceFlowId() {
+    return sequenceFlowId;
   }
 
   @Override
@@ -85,7 +94,8 @@ public class ProcessInstanceSequenceFlowImpl implements ProcessInstanceSequenceF
       return false;
     }
     final ProcessInstanceSequenceFlowImpl that = (ProcessInstanceSequenceFlowImpl) o;
-    return Objects.equals(processInstanceKey, that.processInstanceKey)
+    return Objects.equals(sequenceFlowId, that.sequenceFlowId)
+        && Objects.equals(processInstanceKey, that.processInstanceKey)
         && Objects.equals(processDefinitionKey, that.processDefinitionKey)
         && Objects.equals(processDefinitionId, that.processDefinitionId)
         && Objects.equals(elementId, that.elementId)
@@ -95,7 +105,12 @@ public class ProcessInstanceSequenceFlowImpl implements ProcessInstanceSequenceF
   @Override
   public String toString() {
     return String.format(
-        "ProcessInstanceSequenceFlowImpl{processInstanceKey='%s', processDefinitionKey='%s', processDefinitionId='%s', elementId='%s', tenantId='%s'}",
-        processInstanceKey, processDefinitionKey, processDefinitionId, elementId, tenantId);
+        "ProcessInstanceSequenceFlowImpl{sequenceFlowId='%s', processInstanceKey='%s', processDefinitionKey='%s', processDefinitionId='%s', elementId='%s', tenantId='%s'}",
+        sequenceFlowId,
+        processInstanceKey,
+        processDefinitionKey,
+        processDefinitionId,
+        elementId,
+        tenantId);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSequenceFlowsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSequenceFlowsTest.java
@@ -10,11 +10,12 @@ package io.camunda.it.client;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.Process;
 import io.camunda.client.api.response.ProcessInstanceEvent;
-import io.camunda.client.impl.search.response.ProcessInstanceSequenceFlowImpl;
+import io.camunda.client.api.search.response.ProcessInstanceSequenceFlow;
 import io.camunda.it.util.TestHelper;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.util.ArrayList;
@@ -101,8 +102,16 @@ public class ProcessInstanceSequenceFlowsTest {
     // then
     assertThat(actual).hasSize(1);
     assertThat(actual)
+        .extracting(
+            ProcessInstanceSequenceFlow::getSequenceFlowId,
+            ProcessInstanceSequenceFlow::getProcessInstanceKey,
+            ProcessInstanceSequenceFlow::getProcessDefinitionKey,
+            ProcessInstanceSequenceFlow::getProcessDefinitionId,
+            ProcessInstanceSequenceFlow::getElementId,
+            ProcessInstanceSequenceFlow::getTenantId)
         .containsExactlyInAnyOrder(
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "sequenceFlow1"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "incident_process_v1",
@@ -124,14 +133,23 @@ public class ProcessInstanceSequenceFlowsTest {
     // then
     assertThat(actual).hasSize(2);
     assertThat(actual)
+        .extracting(
+            ProcessInstanceSequenceFlow::getSequenceFlowId,
+            ProcessInstanceSequenceFlow::getProcessInstanceKey,
+            ProcessInstanceSequenceFlow::getProcessDefinitionKey,
+            ProcessInstanceSequenceFlow::getProcessDefinitionId,
+            ProcessInstanceSequenceFlow::getElementId,
+            ProcessInstanceSequenceFlow::getTenantId)
         .containsExactlyInAnyOrder(
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_00yb6c4"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "processWithSubProcess",
                 "Flow_00yb6c4",
                 "<default>"),
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_14vfmwp"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "processWithSubProcess",
@@ -153,20 +171,30 @@ public class ProcessInstanceSequenceFlowsTest {
     // then
     assertThat(actual).hasSize(3);
     assertThat(actual)
+        .extracting(
+            ProcessInstanceSequenceFlow::getSequenceFlowId,
+            ProcessInstanceSequenceFlow::getProcessInstanceKey,
+            ProcessInstanceSequenceFlow::getProcessDefinitionKey,
+            ProcessInstanceSequenceFlow::getProcessDefinitionId,
+            ProcessInstanceSequenceFlow::getElementId,
+            ProcessInstanceSequenceFlow::getTenantId)
         .containsExactlyInAnyOrder(
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_1xuspnu"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "bpmProcessVariable",
                 "Flow_1xuspnu",
                 "<default>"),
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_03xh6j8"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "bpmProcessVariable",
                 "Flow_03xh6j8",
                 "<default>"),
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_1ffbwjw"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "bpmProcessVariable",
@@ -188,32 +216,44 @@ public class ProcessInstanceSequenceFlowsTest {
     // then
     assertThat(actual).hasSize(5);
     assertThat(actual)
+        .extracting(
+            ProcessInstanceSequenceFlow::getSequenceFlowId,
+            ProcessInstanceSequenceFlow::getProcessInstanceKey,
+            ProcessInstanceSequenceFlow::getProcessDefinitionKey,
+            ProcessInstanceSequenceFlow::getProcessDefinitionId,
+            ProcessInstanceSequenceFlow::getElementId,
+            ProcessInstanceSequenceFlow::getTenantId)
         .containsExactlyInAnyOrder(
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_01h019c"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "multi_instance_subprocess",
                 "Flow_01h019c",
                 "<default>"),
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_08mqnul"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "multi_instance_subprocess",
                 "Flow_08mqnul",
                 "<default>"),
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_1h48f0w"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "multi_instance_subprocess",
                 "Flow_1h48f0w",
                 "<default>"),
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_1gqyehp"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "multi_instance_subprocess",
                 "Flow_1gqyehp",
                 "<default>"),
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_1rlbq9a"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "multi_instance_subprocess",
@@ -235,32 +275,44 @@ public class ProcessInstanceSequenceFlowsTest {
     // then
     assertThat(actual).hasSize(5);
     assertThat(actual)
+        .extracting(
+            ProcessInstanceSequenceFlow::getSequenceFlowId,
+            ProcessInstanceSequenceFlow::getProcessInstanceKey,
+            ProcessInstanceSequenceFlow::getProcessDefinitionKey,
+            ProcessInstanceSequenceFlow::getProcessDefinitionId,
+            ProcessInstanceSequenceFlow::getElementId,
+            ProcessInstanceSequenceFlow::getTenantId)
         .containsExactlyInAnyOrder(
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_01h019c"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "multi_instance_subprocess",
                 "Flow_01h019c",
                 "<default>"),
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_08mqnul"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "multi_instance_subprocess",
                 "Flow_08mqnul",
                 "<default>"),
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_1h48f0w"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "multi_instance_subprocess",
                 "Flow_1h48f0w",
                 "<default>"),
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_1hb4p0z"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "multi_instance_subprocess",
                 "Flow_1hb4p0z",
                 "<default>"),
-            new ProcessInstanceSequenceFlowImpl(
+            tuple(
+                "%s_%s".formatted(processInstanceKey, "Flow_1rlbq9a"),
                 String.valueOf(processInstanceKey),
                 String.valueOf(processDefinitionKey),
                 "multi_instance_subprocess",

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -245,6 +245,7 @@ public final class SearchQueryResponseMapper {
   private static ProcessInstanceSequenceFlowResult toProcessInstanceSequenceFlowResult(
       final SequenceFlowEntity result) {
     return new ProcessInstanceSequenceFlowResult()
+        .sequenceFlowId(result.sequenceFlowId())
         .processInstanceKey(KeyUtil.keyToString(result.processInstanceKey()))
         .processDefinitionKey(KeyUtil.keyToString(result.processDefinitionKey()))
         .processDefinitionId(result.processDefinitionId())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -1550,6 +1550,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         """
             {"items":[
               {
+                "sequenceFlowId": "pi1_sequenceFlow1",
                 "processInstanceKey": "1",
                 "processDefinitionKey": "1",
                 "processDefinitionId": "pd1",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add `sequenceFlowId` to the response of the REST endpoint and the java client command

## Related issues

closes #38789 
