### PR TITLE
[Backport release-8.8.0] fix: handle >8KB vars with full value

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -1749,5 +1749,92 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
       // then
       assertThat(errorResult).hasHttpStatus(HttpStatus.NO_CONTENT);
     }
+
+    @Test
+    public void searchTasksShouldReturnFullLargeVariableValueWhenRequested() throws Exception {
+      // given
+      final String bpmnProcessId = "largeVariableTestProcess";
+      final String flowNodeBpmnId = "taskLargeVariable_".concat(UUID.randomUUID().toString());
+      final String largeValue = "x".repeat(10_000); // Simulate a large variable value
+
+      createTask(bpmnProcessId, flowNodeBpmnId, 1)
+          .claimAndCompleteHumanTask(flowNodeBpmnId, "largeVariable", "\"" + largeValue + "\"");
+
+      final var variablesRequest =
+          new TaskSearchRequest()
+              .setIncludeVariables(
+                  new IncludeVariable[] {
+                    new IncludeVariable().setName("largeVariable").setAlwaysReturnFullValue(true)
+                  });
+
+      // when
+      final var result =
+          mockMvcHelper.doRequest(
+              post(TasklistURIs.TASKS_URL_V1.concat("/search")), variablesRequest);
+
+      // then
+      assertThat(result)
+          .hasOkHttpStatus()
+          .hasApplicationJsonContentType()
+          .extractingListContent(objectMapper, TaskSearchResponse.class)
+          .satisfies(
+              tasks -> {
+                assertThat(tasks).hasSize(1);
+                tasks.forEach(
+                    task -> {
+                      assertThat(task.getVariables()).hasSize(1);
+                      final var variable = task.getVariables()[0];
+                      assertThat(variable.getName()).isEqualTo("largeVariable");
+                      assertThat(variable.getValue()).isEqualTo("\"" + largeValue + "\"");
+                      assertThat(variable.getIsValueTruncated()).isTrue();
+                      assertThat(variable.getPreviewValue().length())
+                          .isLessThan(largeValue.length());
+                    });
+              });
+    }
+
+    @Test
+    public void searchTasksShouldReturnTruncatedLargeVariableValueOnlyWhenNotRequested()
+        throws Exception {
+      // given
+      final String bpmnProcessId = "largeVariableTestProcess";
+      final String flowNodeBpmnId = "taskLargeVariable_".concat(UUID.randomUUID().toString());
+      final String largeValue = "x".repeat(10_000); // Simulate a large variable value
+
+      createTask(bpmnProcessId, flowNodeBpmnId, 1)
+          .claimAndCompleteHumanTask(flowNodeBpmnId, "largeVariable", "\"" + largeValue + "\"");
+
+      final var variablesRequest =
+          new TaskSearchRequest()
+              .setIncludeVariables(
+                  new IncludeVariable[] {
+                    new IncludeVariable().setName("largeVariable").setAlwaysReturnFullValue(false)
+                  });
+
+      // when
+      final var result =
+          mockMvcHelper.doRequest(
+              post(TasklistURIs.TASKS_URL_V1.concat("/search")), variablesRequest);
+
+      // then
+      assertThat(result)
+          .hasOkHttpStatus()
+          .hasApplicationJsonContentType()
+          .extractingListContent(objectMapper, TaskSearchResponse.class)
+          .satisfies(
+              tasks -> {
+                assertThat(tasks).hasSize(1);
+                tasks.forEach(
+                    task -> {
+                      assertThat(task.getVariables()).hasSize(1);
+                      final var variable = task.getVariables()[0];
+                      assertThat(variable.getName()).isEqualTo("largeVariable");
+                      assertThat(variable.getValue()).isNull();
+                      assertThat(variable.getIsValueTruncated()).isTrue();
+                      assertThat(variable.getPreviewValue().length())
+                          .isLessThan(largeValue.length());
+                    });
+              });
+    }
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/mapper/TaskMapper.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/mapper/TaskMapper.java
@@ -75,7 +75,11 @@ public class TaskMapper {
       String taskDescriptions =
           Arrays.stream(allVariables)
               .filter(variable -> variable.getName().equals(TASK_DESCRIPTION))
-              .map(VariableSearchResponse::getValue)
+              .map(
+                  variable ->
+                      variable.getIsValueTruncated()
+                          ? variable.getValue()
+                          : variable.getPreviewValue())
               .map(value -> value.replaceAll("\"", "")) // Remove quotes for FE
               .collect(Collectors.joining());
 
@@ -96,13 +100,8 @@ public class TaskMapper {
         .setName(variableDTO.getName())
         .setValue(
             variableDTO.getIsValueTruncated()
-                ? null
-                : variableDTO
-                    .getPreviewValue()) // Currently, for big variables, only truncated values are
-        // included in the Task Search response. So, we avoid
-        // retrieving the fullValue from the database and populate
-        // the output value with previewValue if it is not
-        // truncated.
+                ? variableDTO.getValue()
+                : variableDTO.getPreviewValue())
         .setIsValueTruncated(variableDTO.getIsValueTruncated())
         .setPreviewValue(variableDTO.getPreviewValue());
   }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/mapper/TaskMapperTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/mapper/TaskMapperTest.java
@@ -169,4 +169,49 @@ class TaskMapperTest {
     // Then
     assertThat(result).isEqualTo(expectedTaskQuery);
   }
+
+  @Test
+  void toTaskSearchResponseSetsVariableValueToFullValue() {
+    // Given
+    final var variableFull =
+        new io.camunda.tasklist.webapp.dto.VariableDTO()
+            .setId("var1")
+            .setName("varName1")
+            .setValue("fullValue")
+            .setIsValueTruncated(false)
+            .setPreviewValue("previewValue");
+    final var variableTruncated =
+        new io.camunda.tasklist.webapp.dto.VariableDTO()
+            .setId("var2")
+            .setName("varName2")
+            .setValue("truncatedFullValue")
+            .setIsValueTruncated(true)
+            .setPreviewValue("truncatedPreviewValue");
+    final var providedTask =
+        new TaskDTO()
+            .setId("111111")
+            .setFlowNodeBpmnId("flowNodeBpmnId")
+            .setBpmnProcessId("bpmnProcessId")
+            .setProcessDefinitionId("processDefinitionId")
+            .setVariables(
+                new io.camunda.tasklist.webapp.dto.VariableDTO[] {variableFull, variableTruncated});
+    when(processCache.getTaskName("processDefinitionId", "flowNodeBpmnId")).thenReturn("taskName");
+    when(processCache.getProcessName("processDefinitionId")).thenReturn("processName");
+
+    // When
+    final var result = instance.toTaskSearchResponse(providedTask);
+
+    // Then
+    assertThat(result.getVariables()).hasSize(2);
+    assertThat(result.getVariables()[0].getId()).isEqualTo("var1");
+    assertThat(result.getVariables()[0].getName()).isEqualTo("varName1");
+    assertThat(result.getVariables()[0].getValue()).isEqualTo("previewValue");
+    assertThat(result.getVariables()[0].getIsValueTruncated()).isFalse();
+    assertThat(result.getVariables()[0].getPreviewValue()).isEqualTo("previewValue");
+    assertThat(result.getVariables()[1].getId()).isEqualTo("var2");
+    assertThat(result.getVariables()[1].getName()).isEqualTo("varName2");
+    assertThat(result.getVariables()[1].getIsValueTruncated()).isTrue();
+    assertThat(result.getVariables()[1].getPreviewValue()).isEqualTo("truncatedPreviewValue");
+    assertThat(result.getVariables()[1].getValue()).isEqualTo("truncatedFullValue");
+  }
 }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
@@ -574,7 +574,7 @@ class TaskServiceTest {
     assertThat(result).isEqualTo(TaskDTO.createFrom(assignedTask, objectMapper));
   }
 
-  protected void setAuthenticatedClient(String id) {
+  protected void setAuthenticatedClient(final String id) {
 
     final var authentication = CamundaAuthentication.of(b -> b.clientId(id));
     when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);


### PR DESCRIPTION
# Description
Backport of #37771 to `release-8.8.0`.

relates to #37767