### PR TITLE
docs: unified config: add notes to the bean override classes

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beans/ActorClockControlledProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/ActorClockControlledProperties.java
@@ -7,4 +7,9 @@
  */
 package io.camunda.configuration.beans;
 
+/**
+ * NOTE: Some of the fields of this object are overridden with values coming from the Unified
+ * Configuration system, from the object
+ * io.camunda.configuration.beanoverrides.ActorClockControlledPropertiesOverride
+ */
 public record ActorClockControlledProperties(boolean controlled) {}

--- a/configuration/src/main/java/io/camunda/configuration/beans/BrokerBasedProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/BrokerBasedProperties.java
@@ -10,17 +10,23 @@ package io.camunda.configuration.beans;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 
-// NOTE: This class has been moved away from dist. The reason for this is that as, for now,
-//  we're storing the unified configuration objects and beans in the configuration module,
-//  the fact that dist depends on configuration doesn't allow us to declare that configuration
-//  depends on dist, to extend and override these classes. Nevertheless, depending on dist is
-//  a conceptual misrepresentation of what the configuration module belongs to.
-//
-//  As we are planning, as a future refactoring, to move all the configuration classes and beans
-//  within dist (reason: configuration should be part of the Presentation layer of the app), when
-//  such refactoring happens, we can bring back GatewayBasedProperties within dist, as there will
-//  be no more circular dependency issues.
-
+/**
+ * NOTE #1: Some of the fields of this object are overridden with values coming from the Unified
+ * Configuration system, from the object
+ * io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride
+ *
+ * <p>NOTE #2: This class has been moved away from dist. The reason for this is that as, for now,
+ * we're storing the unified configuration objects and beans in the configuration module, the fact
+ * that dist depends on configuration doesn't allow us to declare that configuration depends on
+ * dist, to extend and override these classes. Nevertheless, depending on dist is a conceptual
+ * misrepresentation of what the configuration module belongs to.
+ *
+ * <p>As we are planning, as a future refactoring, to move all the configuration classes and beans
+ * within dist (reason: configuration should be part of the Presentation layer of the app), when
+ * such refactoring happens, we can bring back BrokerBasedProperties within dist, as there will be
+ * no more circular dependency issues. This work is expected to be investigated and to happen with
+ * https://github.com/camunda/camunda/issues/39045
+ */
 public class BrokerBasedProperties extends BrokerCfg {
 
   public ExporterCfg getCamundaExporter() {

--- a/configuration/src/main/java/io/camunda/configuration/beans/GatewayBasedProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/GatewayBasedProperties.java
@@ -9,15 +9,21 @@ package io.camunda.configuration.beans;
 
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 
-// NOTE: This class has been moved away from dist. The reason for this is that as, for now,
-//  we're storing the unified configuration objects and beans in the configuration module,
-//  the fact that dist depends on configuration doesn't allow us to declare that configuration
-//  depends on dist, to extend and override these classes. Nevertheless, depending on dist is
-//  a conceptual misreprentation of what the configuration module belongs to.
-//
-//  As we are planning, as a future refactoring, to move all the configuration classes and beans
-//  within dist (reason: configuration should be part of the Presentation layer of the app), when
-//  such refactoring happens, we can bring back GatewayBasedProperties within dist, as there will
-//  be no more circular dependency issues.
-
+/**
+ * NOTE #1: Some of the fields of this object are overridden with values coming from the Unified
+ * Configuration system, from the object
+ * io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride
+ *
+ * <p>NOTE #2: This class has been moved away from dist. The reason for this is that as, for now,
+ * we're storing the unified configuration objects and beans in the configuration module, the fact
+ * that dist depends on configuration doesn't allow us to declare that configuration depends on
+ * dist, to extend and override these classes. Nevertheless, depending on dist is a conceptual
+ * misrepresentation of what the configuration module belongs to.
+ *
+ * <p>As we are planning, as a future refactoring, to move all the configuration classes and beans
+ * within dist (reason: configuration should be part of the Presentation layer of the app), when
+ * such refactoring happens, we can bring back GatewayBasedProperties within dist, as there will be
+ * no more circular dependency issues. This work is expected to be investigated and to happen with
+ * https://github.com/camunda/camunda/issues/39045
+ */
 public class GatewayBasedProperties extends GatewayCfg {}

--- a/configuration/src/main/java/io/camunda/configuration/beans/GatewayRestProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/GatewayRestProperties.java
@@ -9,15 +9,21 @@ package io.camunda.configuration.beans;
 
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 
-// NOTE: This class has been moved away from dist. The reason for this is that as, for now,
-//  we're storing the unified configuration objects and beans in the configuration module,
-//  the fact that dist depends on configuration doesn't allow us to declare that configuration
-//  depends on dist, to extend and override these classes. Nevertheless, depending on dist is
-//  a conceptual misrepresentation of what the configuration module belongs to.
-//
-//  As we are planning, as a future refactoring, to move all the configuration classes and beans
-//  within dist (reason: configuration should be part of the Presentation layer of the app), when
-//  such refactoring happens, we can bring back GatewayBasedProperties within dist, as there will
-//  be no more circular dependency issues.
-
+/**
+ * NOTE #1: Some of the fields of this object are overridden with values coming from the Unified
+ * Configuration system, from the object
+ * io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride
+ *
+ * <p>NOTE #2: This class has been moved away from dist. The reason for this is that as, for now,
+ * we're storing the unified configuration objects and beans in the configuration module, the fact
+ * that dist depends on configuration doesn't allow us to declare that configuration depends on
+ * dist, to extend and override these classes. Nevertheless, depending on dist is a conceptual
+ * misrepresentation of what the configuration module belongs to.
+ *
+ * <p>As we are planning, as a future refactoring, to move all the configuration classes and beans
+ * within dist (reason: configuration should be part of the Presentation layer of the app), when
+ * such refactoring happens, we can bring back GatewayRestProperties within dist, as there will be
+ * no more circular dependency issues. This work is expected to be investigated and to happen with
+ * https://github.com/camunda/camunda/issues/39045
+ */
 public class GatewayRestProperties extends GatewayRestConfiguration {}

--- a/configuration/src/main/java/io/camunda/configuration/beans/IdleStrategyBasedProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/IdleStrategyBasedProperties.java
@@ -24,6 +24,9 @@ import org.springframework.lang.Nullable;
  *     default value from {@link ActorSchedulerBuilder#DEFAULT_MIN_PARK_PERIOD_NS}
  * @param maxParkPeriod the maximum duration the strategy will park a thread. If null, uses the
  *     default value from {@link ActorSchedulerBuilder#DEFAULT_MAX_PARK_PERIOD_NS}
+ *     <p>NOTE: Some of the fields of this object are overridden with values coming from the Unified
+ *     Configuration system, from the object
+ *     io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride
  */
 public record IdleStrategyBasedProperties(
     @Nullable Long maxSpins,

--- a/configuration/src/main/java/io/camunda/configuration/beans/SearchEngineConnectProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/SearchEngineConnectProperties.java
@@ -9,4 +9,9 @@ package io.camunda.configuration.beans;
 
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 
+/**
+ * NOTE: Some of the fields of this object are overridden with values coming from the Unified
+ * Configuration system, from the object
+ * io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride
+ */
 public class SearchEngineConnectProperties extends ConnectConfiguration {}

--- a/configuration/src/main/java/io/camunda/configuration/beans/SearchEngineIndexProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/SearchEngineIndexProperties.java
@@ -9,4 +9,9 @@ package io.camunda.configuration.beans;
 
 import io.camunda.search.schema.config.IndexConfiguration;
 
+/**
+ * NOTE: Some of the fields of this object are overridden with values coming from the Unified
+ * Configuration system, from the object
+ * io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride
+ */
 public class SearchEngineIndexProperties extends IndexConfiguration {}

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -12,7 +12,13 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-/** This class contains all project configuration parameters. */
+/**
+ * This class contains all project configuration parameters.
+ *
+ * <p>NOTE: Some of the fields of this object are overridden with values coming from the Unified
+ * Configuration system, from the object
+ * io.camunda.configuration.beanoverrides.OperatePropertiesOverride
+ */
 public class OperateProperties {
 
   public static final String PREFIX = "camunda.operate";

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistProperties.java
@@ -11,7 +11,13 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-/** This class contains all project configuration parameters. */
+/**
+ * This class contains all project configuration parameters.
+ *
+ * <p>NOTE: Some of the fields of this object are overridden with values coming from the Unified
+ * Configuration system, from the object
+ * io.camunda.configuration.beanoverrides.TasklistPropertiesOverride
+ */
 public class TasklistProperties {
 
   public static final String PREFIX = "camunda.tasklist";


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR adds some documentation to the classes that are being overridden by the unified configuration system, so that visibility is added in places of the code where what happens is not obvious at first sight.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
