### PR TITLE
deps: update spring and spring-security

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -101,8 +101,8 @@
     <version.feel-scala>1.19.3</version.feel-scala>
     <version.dmn-scala>1.10.1</version.dmn-scala>
     <version.rest-assured>5.5.5</version.rest-assured>
-    <version.spring>6.2.8</version.spring>
-    <version.spring-security>6.5.2</version.spring-security>
+    <version.spring>6.2.11</version.spring>
+    <version.spring-security>6.5.5</version.spring-security>
     <version.spring-boot>3.5.5</version.spring-boot>
     <version.tomcat>10.1.44</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Updates spring to 6.2.11 (latest patch) to fix CVE-2025-4124.
Also updated the spring security version to the latest patch.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/37092
