### PR TITLE
fix: do not enforce write limits for whitelisted commands

### DIFF
--- a/zeebe/logstreams/pom.xml
+++ b/zeebe/logstreams/pom.xml
@@ -127,6 +127,11 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.awaitility</groupId>

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RequestLimiter.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RequestLimiter.java
@@ -9,26 +9,11 @@ package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
 import com.netflix.concurrency.limits.limiter.AbstractLimiter;
 import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
-import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
-import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
-import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import java.util.Optional;
-import java.util.Set;
 
 public final class RequestLimiter extends AbstractLimiter<Intent> {
 
-  private static final Set<? extends Intent> WHITE_LISTED_COMMANDS =
-      Set.of(
-          JobIntent.COMPLETE,
-          JobIntent.FAIL,
-          ProcessInstanceIntent.CANCEL,
-          DeploymentIntent.CREATE,
-          DeploymentIntent.DISTRIBUTE,
-          DeploymentDistributionIntent.COMPLETE,
-          CommandDistributionIntent.ACKNOWLEDGE);
   private final LogStreamMetrics metrics;
 
   private RequestLimiter(final CommandRateLimiterBuilder builder, final LogStreamMetrics metrics) {
@@ -40,7 +25,7 @@ public final class RequestLimiter extends AbstractLimiter<Intent> {
 
   @Override
   public Optional<Listener> acquire(final Intent intent) {
-    if (getInflight() >= getLimit() && !WHITE_LISTED_COMMANDS.contains(intent)) {
+    if (getInflight() >= getLimit() && !WhiteListedCommands.isWhitelisted(intent)) {
       return createRejectedListener();
     }
     final Listener listener = createListener();

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.logstreams.impl.flowcontrol;
+
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import java.util.Set;
+
+public class WhiteListedCommands {
+
+  private static final Set<? extends Intent> WHITE_LISTED_COMMANDS =
+      Set.of(
+          JobIntent.COMPLETE,
+          JobIntent.FAIL,
+          ProcessInstanceIntent.CANCEL,
+          DeploymentIntent.CREATE,
+          DeploymentIntent.DISTRIBUTE,
+          DeploymentDistributionIntent.COMPLETE,
+          CommandDistributionIntent.ACKNOWLEDGE);
+
+  public static boolean isWhitelisted(final Intent intent) {
+    return WHITE_LISTED_COMMANDS.contains(intent);
+  }
+}

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.logstreams.impl.flowcontrol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
+import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl.Rejection;
+import io.camunda.zeebe.logstreams.impl.flowcontrol.RateLimit.Throttling;
+import io.camunda.zeebe.logstreams.impl.log.LogAppendEntryMetadata;
+import io.camunda.zeebe.logstreams.log.WriteContext;
+import io.camunda.zeebe.logstreams.log.WriteContext.UserCommand;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.util.Either;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class FlowControlTest {
+
+  @AutoClose MeterRegistry meterRegistry;
+  FlowControl flowControl;
+
+  @BeforeEach
+  public void setup() {
+    meterRegistry = new SimpleMeterRegistry();
+    final var logStreamMetrics = new LogStreamMetrics(meterRegistry);
+    final var writeRateLimit =
+        new RateLimit(
+            true, 1, Duration.ofSeconds(10), new Throttling(true, 1L, 0L, Duration.ofSeconds(1)));
+    flowControl =
+        new FlowControl(
+            logStreamMetrics, StabilizingAIMDLimit.newBuilder().build(), writeRateLimit);
+  }
+
+  static Stream<Intent> intentClassesProvider() {
+    return Intent.INTENT_CLASSES.stream().flatMap(c -> Arrays.stream(c.getEnumConstants()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("intentClassesProvider")
+  public void shouldBlockCommandsBasedOnIntent(final Intent intent) {
+    // given
+    final var writeContext = new UserCommand(intent);
+
+    // when
+    final var permits =
+        acquireMultiplePermits(writeContext, writeContext.intent(), ValueType.JOB, 10);
+
+    // then
+    assertThat(permits).first().satisfies(first -> EitherAssert.assertThat(first).isRight());
+    assertThat(permits.subList(1, permits.size()))
+        .allSatisfy(
+            permit -> {
+              if (WhiteListedCommands.isWhitelisted(intent)) {
+                EitherAssert.assertThat(permit).isRight();
+              } else {
+                EitherAssert.assertThat(permit)
+                    .isLeft()
+                    .left()
+                    .satisfies(r -> assertThat(r).isEqualTo(Rejection.WriteRateLimitExhausted));
+              }
+            });
+  }
+
+  @ParameterizedTest
+  @MethodSource("intentClassesProvider")
+  public void shouldNeverBlockInternalCommands(final Intent intent) {
+    // given
+    final var writeContext = WriteContext.internal();
+
+    // when
+    final var permits = acquireMultiplePermits(writeContext, intent, ValueType.JOB, 10);
+
+    // then
+    assertThat(permits).first().satisfies(first -> EitherAssert.assertThat(first).isRight());
+    assertThat(permits.subList(1, permits.size()))
+        .allSatisfy(permit -> EitherAssert.assertThat(permit).isRight());
+  }
+
+  private List<Either<FlowControl.Rejection, InFlightEntry>> acquireMultiplePermits(
+      final WriteContext writeContext,
+      final Intent intent,
+      final ValueType valueType,
+      final int n) {
+    return IntStream.range(1, n)
+        .mapToObj(
+            i ->
+                flowControl.tryAcquire(
+                    writeContext,
+                    List.of(new LogAppendEntryMetadata(RecordType.COMMAND, valueType, intent))))
+        .toList();
+  }
+}


### PR DESCRIPTION

## Description

When write limits were introduced, the intent of the command was not used to determine wether the command should bypass the write limit.

Whitelisted commands are always allowed to write, even if they breach the limit.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues


closes #38454
