### PR TITLE
feat: Allow Archiver to be disabled by configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/History.java
+++ b/configuration/src/main/java/io/camunda/configuration/History.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Map;
+import java.util.Set;
+
+public class History {
+
+  private static final boolean DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED = true;
+
+  private static final Map<String, String> LEGACY_BROKER_PROPERTIES =
+      Map.of(
+          "process-instance-enabled",
+          "zeebe.broker.exporters.camundaexporter.args.history.process-instance-enabled");
+
+  private final String prefix;
+
+  private boolean processInstanceEnabled = DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED;
+
+  public History(final String databaseName) {
+    prefix = "camunda.data.secondary-storage.%s.history".formatted(databaseName);
+  }
+
+  public boolean isProcessInstanceEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix + ".process-instance-enabled",
+        processInstanceEnabled,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        Set.of(LEGACY_BROKER_PROPERTIES.get("process-instance-enabled")));
+  }
+
+  public void setProcessInstanceEnabled(final boolean processInstanceEnabled) {
+    this.processInstanceEnabled = processInstanceEnabled;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
@@ -37,7 +37,7 @@ public class SecondaryStorage {
   /** Stores the Elasticsearch configuration, when type is set to 'elasticsearch'. */
   @NestedConfigurationProperty private Elasticsearch elasticsearch = new Elasticsearch();
 
-  /** Stores the Elasticsearch configuration, when type is set to 'elasticsearch'. */
+  /** Stores the Opensearch configuration, when type is set to 'opensearch'. */
   @NestedConfigurationProperty private Opensearch opensearch = new Opensearch();
 
   public boolean getAutoconfigureCamundaExporter() {

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
@@ -9,6 +9,7 @@ package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import java.util.Set;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public abstract class SecondaryStorageDatabase {
 
@@ -18,7 +19,9 @@ public abstract class SecondaryStorageDatabase {
   /** Name of the cluster */
   private String clusterName = databaseName().toLowerCase();
 
-  private Security security = new Security(databaseName());
+  @NestedConfigurationProperty private Security security = new Security(databaseName());
+
+  @NestedConfigurationProperty private History history = new History(databaseName());
 
   /** Username for the database configured as secondary storage. */
   private String username = "";
@@ -116,6 +119,14 @@ public abstract class SecondaryStorageDatabase {
 
   public void setNumberOfShards(final int numberOfShards) {
     this.numberOfShards = numberOfShards;
+  }
+
+  public History getHistory() {
+    return history;
+  }
+
+  public void setHistory(final History history) {
+    this.history = history;
   }
 
   private String prefix() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -565,6 +565,9 @@ public class BrokerBasedPropertiesOverride {
 
     setArg(args, "connect.indexPrefix", database.getIndexPrefix());
     setArg(args, "index.numberOfShards", database.getNumberOfShards());
+
+    setArg(
+        args, "history.processInstanceEnabled", database.getHistory().isProcessInstanceEnabled());
   }
 
   @SuppressWarnings("unchecked")

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -49,6 +49,8 @@ public class SecondaryStorageElasticsearchTest {
 
   private static final int EXPECTED_NUMBER_OF_SHARDS = 3;
 
+  private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
+
   @Nested
   @TestPropertySource(
       properties = {
@@ -58,7 +60,10 @@ public class SecondaryStorageElasticsearchTest {
         "camunda.data.secondary-storage.elasticsearch.password=" + EXPECTED_PASSWORD,
         "camunda.data.secondary-storage.elasticsearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
         "camunda.data.secondary-storage.elasticsearch.index-prefix=" + EXPECTED_INDEX_PREFIX,
-        "camunda.data.secondary-storage.elasticsearch.number-of-shards=" + EXPECTED_NUMBER_OF_SHARDS
+        "camunda.data.secondary-storage.elasticsearch.number-of-shards="
+            + EXPECTED_NUMBER_OF_SHARDS,
+        "camunda.data.secondary-storage.elasticsearch.history.process-instance-enabled="
+            + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
       })
   class WithOnlyUnifiedConfigSet {
     final OperateProperties operateProperties;
@@ -128,6 +133,8 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_INDEX_PREFIX);
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
+      assertThat(exporterConfiguration.getHistory().isProcessInstanceEnabled())
+          .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -49,6 +49,8 @@ public class SecondaryStorageOpensearchTest {
 
   private static final int EXPECTED_NUMBER_OF_SHARDS = 3;
 
+  private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
+
   @Nested
   @TestPropertySource(
       properties = {
@@ -58,7 +60,9 @@ public class SecondaryStorageOpensearchTest {
         "camunda.data.secondary-storage.opensearch.password=" + EXPECTED_PASSWORD,
         "camunda.data.secondary-storage.opensearch.cluster-name=" + EXPECTED_CLUSTER_NAME,
         "camunda.data.secondary-storage.opensearch.index-prefix=" + EXPECTED_INDEX_PREFIX,
-        "camunda.data.secondary-storage.opensearch.number-of-shards=" + EXPECTED_NUMBER_OF_SHARDS
+        "camunda.data.secondary-storage.opensearch.number-of-shards=" + EXPECTED_NUMBER_OF_SHARDS,
+        "camunda.data.secondary-storage.opensearch.history.process-instance-enabled="
+            + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
       })
   class WithOnlyUnifiedConfigSet {
     final OperateProperties operateProperties;
@@ -128,6 +132,8 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_INDEX_PREFIX);
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
+      assertThat(exporterConfiguration.getHistory().isProcessInstanceEnabled())
+          .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
     }
 
     @Test

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -168,6 +168,7 @@ public class ExporterConfiguration {
   }
 
   public static class HistoryConfiguration {
+    private boolean processInstanceEnabled = true;
     private String elsRolloverDateFormat = "date";
     private String rolloverInterval = "1d";
     private int rolloverBatchSize = 100;
@@ -176,6 +177,14 @@ public class ExporterConfiguration {
     private int maxDelayBetweenRuns = 60000;
     private RetentionConfiguration retention = new RetentionConfiguration();
     private boolean trackArchivalMetricsForProcessInstance = true;
+
+    public boolean isProcessInstanceEnabled() {
+      return processInstanceEnabled;
+    }
+
+    public void setProcessInstanceEnabled(final boolean processInstanceEnabled) {
+      this.processInstanceEnabled = processInstanceEnabled;
+    }
 
     public String getElsRolloverDateFormat() {
       return elsRolloverDateFormat;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -229,12 +229,14 @@ public final class BackgroundTaskManagerFactory {
     final List<RunnableTask> tasks = new ArrayList<>();
 
     tasks.add(buildIncidentMarkerTask());
-    tasks.add(buildProcessInstanceArchiverJob());
+    if (config.getHistory().isProcessInstanceEnabled()) {
+      tasks.add(buildProcessInstanceArchiverJob());
+      if (config.getHistory().isTrackArchivalMetricsForProcessInstance()) {
+        tasks.add(buildProcessInstanceToBeArchivedCountJob());
+      }
+    }
     tasks.add(buildUsageMetricsArchiverJob());
     tasks.add(buildUsageMetricsTUArchiverJob());
-    if (config.getHistory().isTrackArchivalMetricsForProcessInstance()) {
-      tasks.add(buildProcessInstanceToBeArchivedCountJob());
-    }
     if (partitionId == START_PARTITION_ID) {
       tasks.add(buildBatchOperationArchiverJob());
       tasks.add(new ApplyRolloverPeriodJob(archiverRepository));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
@@ -112,7 +112,8 @@ class BackgroundTaskManagerFactoryTest {
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
         .as("Should not contain ProcessInstanceToBeArchivedCountJob when PI config is disabled")
-        .noneMatch(task -> isProcessInstanceToBeArchivedCountTask(task));
+        .noneMatch(task -> isProcessInstanceToBeArchivedCountTask(task))
+        .noneMatch(task -> isProcessInstanceArchiverTask(task));
   }
 
   @Test
@@ -147,23 +148,6 @@ class BackgroundTaskManagerFactoryTest {
         .as("Should contain both PI archiver and count tasks when all configs are enabled")
         .anyMatch(task -> isProcessInstanceArchiverTask(task))
         .anyMatch(task -> isProcessInstanceToBeArchivedCountTask(task));
-  }
-
-  @Test
-  void shouldNotScheduleAnyProcessInstanceTasksWhenConfigDisabled() {
-    // given
-    config.getHistory().setProcessInstanceEnabled(false);
-    config.getHistory().setTrackArchivalMetricsForProcessInstance(true);
-
-    // when
-    final var taskManager = factory.build();
-
-    // then
-    final var tasks = getTasksFromManager(taskManager);
-    assertThat(tasks)
-        .as("Should not contain any PI-related tasks when PI config is disabled")
-        .noneMatch(task -> isProcessInstanceArchiverTask(task))
-        .noneMatch(task -> isProcessInstanceToBeArchivedCountTask(task));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ApplyRolloverPeriodJob;
+import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
+import io.camunda.exporter.tasks.archiver.ProcessInstanceArchiverJob;
+import io.camunda.exporter.tasks.archiver.ProcessInstanceToBeArchivedCountJob;
+import io.camunda.exporter.tasks.archiver.UsageMetricArchiverJob;
+import io.camunda.exporter.tasks.archiver.UsageMetricTUArchiverJob;
+import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateTask;
+import io.camunda.exporter.tasks.incident.IncidentUpdateTask;
+import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+class BackgroundTaskManagerFactoryTest {
+
+  private static final int PARTITION_ID = 1;
+  private static final String EXPORTER_ID = "test-exporter";
+
+  private BackgroundTaskManagerFactory factory;
+  private final ExporterConfiguration config = new ExporterConfiguration();
+
+  @BeforeEach
+  void setUp() {
+    factory =
+        new BackgroundTaskManagerFactory(
+            PARTITION_ID,
+            EXPORTER_ID,
+            config,
+            new TestExporterResourceProvider("", true),
+            new CamundaExporterMetrics(new SimpleMeterRegistry()),
+            LoggerFactory.getLogger(BackgroundTaskManagerFactoryTest.class),
+            mock(ExporterMetadata.class),
+            new ObjectMapper(),
+            mock(ExporterEntityCacheImpl.class));
+  }
+
+  @Test
+  void shouldScheduleProcessInstanceArchiverTaskWhenConfigEnabled() {
+    // given
+    config.getHistory().setProcessInstanceEnabled(true);
+
+    // when
+    final var taskManager = factory.build();
+
+    // then
+    final var tasks = getTasksFromManager(taskManager);
+    assertThat(tasks)
+        .as("Should contain ProcessInstancesArchiverJob when config is enabled")
+        .anyMatch(task -> isProcessInstanceArchiverTask(task));
+  }
+
+  @Test
+  void shouldNotScheduleProcessInstanceArchiverTaskWhenConfigDisabled() {
+    // given
+    config.getHistory().setProcessInstanceEnabled(false);
+
+    // when
+    final var taskManager = factory.build();
+
+    // then
+    final var tasks = getTasksFromManager(taskManager);
+    assertThat(tasks)
+        .as("Should not contain ProcessInstancesArchiverJob when config is disabled")
+        .noneMatch(task -> isProcessInstanceArchiverTask(task));
+  }
+
+  @Test
+  void shouldScheduleProcessInstanceCountJobWhenConfigEnabledAndMetricsTrackingEnabled() {
+    // given
+    config.getHistory().setProcessInstanceEnabled(true);
+    config.getHistory().setTrackArchivalMetricsForProcessInstance(true);
+
+    // when
+    final var taskManager = factory.build();
+
+    // then
+    final var tasks = getTasksFromManager(taskManager);
+    assertThat(tasks)
+        .as("Should contain ProcessInstanceToBeArchivedCountJob when both configs are enabled")
+        .anyMatch(task -> isProcessInstanceToBeArchivedCountTask(task));
+  }
+
+  @Test
+  void shouldNotScheduleProcessInstanceCountJobWhenProcessInstanceConfigDisabled() {
+    // given
+    config.getHistory().setProcessInstanceEnabled(false);
+    config.getHistory().setTrackArchivalMetricsForProcessInstance(true);
+
+    // when
+    final var taskManager = factory.build();
+
+    // then
+    final var tasks = getTasksFromManager(taskManager);
+    assertThat(tasks)
+        .as("Should not contain ProcessInstanceToBeArchivedCountJob when PI config is disabled")
+        .noneMatch(task -> isProcessInstanceToBeArchivedCountTask(task));
+  }
+
+  @Test
+  void shouldNotScheduleProcessInstanceCountJobWhenMetricsTrackingDisabled() {
+    // given
+    config.getHistory().setProcessInstanceEnabled(true);
+    config.getHistory().setTrackArchivalMetricsForProcessInstance(false);
+
+    // when
+    final var taskManager = factory.build();
+
+    // then
+    final var tasks = getTasksFromManager(taskManager);
+    assertThat(tasks)
+        .as(
+            "Should not contain ProcessInstanceToBeArchivedCountJob when metrics tracking is disabled")
+        .noneMatch(task -> isProcessInstanceToBeArchivedCountTask(task));
+  }
+
+  @Test
+  void shouldScheduleBothProcessInstanceTasksWhenAllConfigsEnabled() {
+    // given
+    config.getHistory().setProcessInstanceEnabled(true);
+    config.getHistory().setTrackArchivalMetricsForProcessInstance(true);
+
+    // when
+    final var taskManager = factory.build();
+
+    // then
+    final var tasks = getTasksFromManager(taskManager);
+    assertThat(tasks)
+        .as("Should contain both PI archiver and count tasks when all configs are enabled")
+        .anyMatch(task -> isProcessInstanceArchiverTask(task))
+        .anyMatch(task -> isProcessInstanceToBeArchivedCountTask(task));
+  }
+
+  @Test
+  void shouldNotScheduleAnyProcessInstanceTasksWhenConfigDisabled() {
+    // given
+    config.getHistory().setProcessInstanceEnabled(false);
+    config.getHistory().setTrackArchivalMetricsForProcessInstance(true);
+
+    // when
+    final var taskManager = factory.build();
+
+    // then
+    final var tasks = getTasksFromManager(taskManager);
+    assertThat(tasks)
+        .as("Should not contain any PI-related tasks when PI config is disabled")
+        .noneMatch(task -> isProcessInstanceArchiverTask(task))
+        .noneMatch(task -> isProcessInstanceToBeArchivedCountTask(task));
+  }
+
+  @Test
+  void shouldAlwaysScheduleNonProcessInstanceTasks() {
+    // given
+    config.getHistory().setProcessInstanceEnabled(false);
+
+    // when
+    final var taskManager = factory.build();
+
+    // then
+    final var tasks = getTasksFromManager(taskManager);
+    assertThat(tasks)
+        .as("Should always schedule incident and usage metrics tasks regardless of PI config")
+        .hasSize(6)
+        .anyMatch(task -> isTaskOfType(task, IncidentUpdateTask.class))
+        .anyMatch(task -> isTaskOfType(task, UsageMetricArchiverJob.class))
+        .anyMatch(task -> isTaskOfType(task, UsageMetricTUArchiverJob.class))
+        .anyMatch(task -> isTaskOfType(task, BatchOperationArchiverJob.class))
+        .anyMatch(task -> isTaskOfType(task, BatchOperationUpdateTask.class))
+        .anyMatch(task -> task instanceof ApplyRolloverPeriodJob);
+  }
+
+  private List<RunnableTask> getTasksFromManager(final BackgroundTaskManager taskManager) {
+    try {
+      final var field = BackgroundTaskManager.class.getDeclaredField("tasks");
+      field.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      final var tasks = (List<RunnableTask>) field.get(taskManager);
+      return tasks;
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to access tasks field", e);
+    }
+  }
+
+  private boolean isProcessInstanceArchiverTask(final RunnableTask task) {
+    return isTaskOfType(task, ProcessInstanceArchiverJob.class);
+  }
+
+  private boolean isProcessInstanceToBeArchivedCountTask(final RunnableTask task) {
+    return isTaskOfType(task, ProcessInstanceToBeArchivedCountJob.class);
+  }
+
+  private boolean isIncidentUpdateTask(final RunnableTask task) {
+    return isTaskOfType(task, IncidentUpdateTask.class);
+  }
+
+  private boolean isUsageMetricsArchiverTask(final RunnableTask task) {
+    return isTaskOfType(task, UsageMetricArchiverJob.class);
+  }
+
+  private boolean isTaskOfType(final RunnableTask task, final Class<?> type) {
+    if (task instanceof final ReschedulingTask reschedulingTask) {
+      return getWrappedTask(reschedulingTask).getClass().equals(type);
+    }
+    return false;
+  }
+
+  private BackgroundTask getWrappedTask(final ReschedulingTask reschedulingTask) {
+    try {
+      final var field = ReschedulingTask.class.getDeclaredField("task");
+      field.setAccessible(true);
+      return (BackgroundTask) field.get(reschedulingTask);
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to access wrapped task", e);
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This pull request introduces a new configuration option to enable or disable process instance history archiving in secondary storage, and ensures that related background tasks are scheduled only when appropriate.

The property can be defined in the unified configuration:
- `camunda.data.secondary-storage.elasticsearch.history.process-instance-enabled`
- `camunda.data.secondary-storage.opensearch.history.process-instance-enabled`

And also in the camunda exporter configuration:
- `zeebe.broker.exporters.camundaexporter.args.history.processInstanceEnabled`

## Related issues

closes #36331 
