### PR TITLE
fix: update empty process variable panel behavior 

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesContent.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesContent.tsx
@@ -54,6 +54,20 @@ const VariablesContent: React.FC = observer(() => {
     );
   }
 
+  if (displayStatus === 'no-variables') {
+    return (
+      <Content>
+        {scopeId !== null ? (
+          <VariablesFinalForm scopeId={scopeId} />
+        ) : (
+          <EmptyMessageContainer>
+            <EmptyMessage message="The Flow Node has no Variables" />
+          </EmptyMessageContainer>
+        )}
+      </Content>
+    );
+  }
+
   return (
     <Content>
       {displayStatus === 'spinner' && (

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/FlowNodeStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/FlowNodeStates.test.tsx
@@ -144,6 +144,39 @@ describe('VariablePanel', () => {
 
     mockFetchVariables().withSuccess([createVariable()]);
     mockFetchVariables().withSuccess([createVariable()]);
+
+    // Add extra mockSearchVariables calls to handle requests with ADD_TOKEN scope IDs
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithInputOutputMappingsXML,
@@ -368,7 +401,7 @@ describe('VariablePanel', () => {
     ).toBeInTheDocument();
   });
 
-  it.skip('should display correct state for a flow node that has no running or finished tokens on it', async () => {
+  it('should display correct state for a flow node that has no running or finished tokens on it', async () => {
     mockSearchVariables().withSuccess({
       items: [createVariableV2()],
       page: {
@@ -416,6 +449,26 @@ describe('VariablePanel', () => {
     expect(
       screen.getByText('The Flow Node has no Variables'),
     ).toBeInTheDocument();
+
+    // mocks for variables query with the new scope ID
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
 
     // one 'add token' modification is created
     act(() => {
@@ -612,12 +665,9 @@ describe('VariablePanel', () => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
-    mockFetchProcessInstance().withSuccess(mockProcessInstance);
-
     expect(
       screen.getByRole('button', {name: /add variable/i}),
     ).toBeInTheDocument();
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     mockFetchVariables().withSuccess([]);
     mockSearchVariables().withSuccess({
@@ -660,13 +710,35 @@ describe('VariablePanel', () => {
       }),
     );
 
-    // initial state
+    await waitFor(() =>
+      expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument(),
+    );
     expect(
-      await screen.findByText('The Flow Node has no Variables'),
+      await screen.findByText(/the flow node has no variables/i),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole('button', {name: /add variable/i}),
     ).not.toBeInTheDocument();
+
+    // mocks for variables query with the new scope ID
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
 
     // one 'add token' modification is created
     act(() => {
@@ -688,7 +760,7 @@ describe('VariablePanel', () => {
 
     expect(
       await screen.findByText(
-        'To view the Variables, select a single Flow Node Instance in the Instance History.',
+        /to view the variables, select a single flow node instance in the instance history/i,
       ),
     ).toBeInTheDocument();
     expect(
@@ -696,16 +768,22 @@ describe('VariablePanel', () => {
     ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('tab', {name: 'Variables'}));
+    await waitFor(() =>
+      expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument(),
+    );
     expect(
       await screen.findByText(
-        'To view the Variables, select a single Flow Node Instance in the Instance History.',
+        /to view the variables, select a single flow node instance in the instance history/i,
       ),
     ).toBeInTheDocument();
-    expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument();
 
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
 
     // select only one of the scopes
+    mockFetchVariables().withSuccess([]);
+    mockSearchVariables().withSuccess({items: [], page: {totalItems: 0}});
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
     act(() => {
       selectFlowNode(
         {},
@@ -717,8 +795,12 @@ describe('VariablePanel', () => {
       );
     });
 
+    await waitFor(() =>
+      expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument(),
+    );
+
     expect(
-      await screen.findByText('The Flow Node has no Variables'),
+      await screen.findByText(/the flow node has no variables/i),
     ).toBeInTheDocument();
 
     expect(

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/FlowNodeStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/FlowNodeStates.test.tsx
@@ -782,7 +782,6 @@ describe('VariablePanel', () => {
     // select only one of the scopes
     mockFetchVariables().withSuccess([]);
     mockSearchVariables().withSuccess({items: [], page: {totalItems: 0}});
-    mockFetchProcessInstanceListeners().withSuccess(noListeners);
 
     act(() => {
       selectFlowNode(

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
@@ -227,6 +227,12 @@ describe('New Variable Modifications', () => {
         totalItems: 1,
       },
     });
+    mockSearchVariables().withSuccess({
+      items: [createVariableV2()],
+      page: {
+        totalItems: 1,
+      },
+    });
 
     const {user} = render(
       <VariablePanel setListenerTabVisibility={vi.fn()} />,
@@ -294,7 +300,27 @@ describe('New Variable Modifications', () => {
     mockFetchProcessInstanceDeprecated().withSuccess(
       mockProcessInstanceDeprecated,
     );
+
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+
     vi.useFakeTimers({shouldAdvanceTime: true});
     modificationsStore.enableModificationMode();
 
@@ -642,7 +668,7 @@ describe('New Variable Modifications', () => {
     vi.useRealTimers();
   });
 
-  it.skip('should be able to add variable when a flow node that has no tokens on it is selected from the diagram', async () => {
+  it('should be able to add variable when a flow node that has no tokens on it is selected from the diagram', async () => {
     mockFetchProcessInstanceDeprecated().withSuccess(
       mockProcessInstanceDeprecated,
     );
@@ -695,6 +721,18 @@ describe('New Variable Modifications', () => {
 
     expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
 
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+      },
+    });
     mockSearchVariables().withSuccess({
       items: [],
       page: {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/tests/skeleton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/tests/skeleton.test.tsx
@@ -14,6 +14,7 @@ import {VariablePanel} from '../../VariablePanel';
 import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchProcessInstance as mockFetchProcessInstanceDeprecated} from 'modules/mocks/api/processInstances/fetchProcessInstance';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockProcessXml} from 'modules/mocks/mockProcessXml';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 
@@ -34,6 +35,17 @@ describe('Skeleton', () => {
     mockFetchProcessInstanceDeprecated().withSuccess(
       mockProcessInstanceDeprecated,
     );
+    mockFetchProcessInstance().withSuccess({
+      processInstanceKey: '1',
+      state: 'ACTIVE',
+      startDate: '2018-06-21',
+      processDefinitionKey: '2',
+      processDefinitionVersion: 1,
+      processDefinitionId: 'someKey',
+      tenantId: '<default>',
+      processDefinitionName: 'someProcessName',
+      hasIncident: false,
+    });
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [
         {

--- a/operate/client/src/modules/utils/variables.ts
+++ b/operate/client/src/modules/utils/variables.ts
@@ -10,14 +10,36 @@ import type {QueryVariablesResponseBody} from '@camunda/camunda-api-zod-schemas/
 import {variablesStore} from 'modules/stores/variables';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
+import {modificationsStore} from 'modules/stores/modifications';
 import {applyOperation} from 'modules/api/processInstances/operations';
+import {TOKEN_OPERATIONS} from 'modules/constants';
 import type {InfiniteData} from '@tanstack/react-query';
 
 const getScopeId = () => {
   const {selection} = flowNodeSelectionStore.state;
   const {metaData} = flowNodeMetaDataStore.state;
 
-  return selection?.flowNodeInstanceId ?? metaData?.flowNodeInstanceId ?? null;
+  // First try to get actual instance ID
+  const actualInstanceId =
+    selection?.flowNodeInstanceId ?? metaData?.flowNodeInstanceId;
+  if (actualInstanceId) {
+    return actualInstanceId;
+  }
+
+  // In modification mode, if selecting from diagram, check for pending ADD_TOKEN
+  if (modificationsStore.state.status === 'enabled' && selection?.flowNodeId) {
+    const addTokenModification = modificationsStore.flowNodeModifications.find(
+      (modification) =>
+        modification.operation === TOKEN_OPERATIONS.ADD_TOKEN &&
+        modification.flowNode.id === selection.flowNodeId,
+    );
+
+    if (addTokenModification && 'scopeId' in addTokenModification) {
+      return addTokenModification.scopeId;
+    }
+  }
+
+  return null;
 };
 
 const addVariable = async ({


### PR DESCRIPTION
## Description

- extend `getScopeId` logic to support nodes created during modification 
- Update variable panel components behavior for no variable instances

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37187 
