### PR TITLE
feat: add history to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -17,6 +17,7 @@ public class DocumentBasedHistory {
   public static final Duration DEFAULT_HISTORY_MAX_DELAY_BETWEEN_RUNS = Duration.ofMillis(60000);
   private static final Duration DEFAULT_HISTORY_DELAY_BETWEEN_RUNS = Duration.ofMillis(2000);
   private static final boolean DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED = true;
+  private static final String DEFAULT_HISTORY_POLICY_NAME = "camunda-retention-policy";
   private static final String DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "date";
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
   private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
@@ -61,6 +62,9 @@ public class DocumentBasedHistory {
 
   /** Maximum millisecond interval between archiver runs due to failure backoffs */
   private Duration maxDelayBetweenRuns = DEFAULT_HISTORY_MAX_DELAY_BETWEEN_RUNS;
+
+  /** Defines the name of the created and applied ILM policy. */
+  private String policyName = DEFAULT_HISTORY_POLICY_NAME;
 
   public DocumentBasedHistory(final String databaseName) {
     prefix = "camunda.data.secondary-storage.%s.history".formatted(databaseName);
@@ -159,5 +163,24 @@ public class DocumentBasedHistory {
 
   public void setMaxDelayBetweenRuns(final Duration maxDelayBetweenRuns) {
     this.maxDelayBetweenRuns = maxDelayBetweenRuns;
+  }
+
+  public String getPolicyName() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix + ".policy-name",
+        policyName,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyPolicyNameProperties());
+  }
+
+  public void setPolicyName(final String policyName) {
+    this.policyName = policyName;
+  }
+
+  private Set<String> legacyPolicyNameProperties() {
+    return Set.of(
+        "camunda.database.retention.policyName",
+        "zeebe.broker.exporters.camundaexporter.args.history.retention.policyName");
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -678,6 +678,8 @@ public class BrokerBasedPropertiesOverride {
 
     setArg(
         args, "history.processInstanceEnabled", database.getHistory().isProcessInstanceEnabled());
+
+    setArg(args, "history.retention.policyName", database.getHistory().getPolicyName());
     setArg(args, "history.elsRolloverDateFormat", database.getHistory().getElsRolloverDateFormat());
     setArg(args, "history.rolloverInterval", database.getHistory().getRolloverInterval());
     setArg(args, "history.rolloverBatchSize", database.getHistory().getRolloverBatchSize());

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineRetentionPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineRetentionPropertiesOverride.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
+import io.camunda.configuration.SecondaryStorage;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beans.LegacySearchEngineRetentionProperties;
+import io.camunda.configuration.beans.SearchEngineRetentionProperties;
+import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@EnableConfigurationProperties(LegacySearchEngineRetentionProperties.class)
+@DependsOn("unifiedConfigurationHelper")
+@ConditionalOnSecondaryStorageType({
+  SecondaryStorageType.elasticsearch,
+  SecondaryStorageType.opensearch
+})
+public class SearchEngineRetentionPropertiesOverride {
+
+  private final UnifiedConfiguration unifiedConfiguration;
+  private final LegacySearchEngineRetentionProperties legacySearchEngineRetentionProperties;
+
+  public SearchEngineRetentionPropertiesOverride(
+      @Autowired final UnifiedConfiguration unifiedConfiguration,
+      @Autowired
+          final LegacySearchEngineRetentionProperties legacySearchEngineRetentionProperties) {
+    this.unifiedConfiguration = unifiedConfiguration;
+    this.legacySearchEngineRetentionProperties = legacySearchEngineRetentionProperties;
+  }
+
+  @Bean
+  @Primary
+  public SearchEngineRetentionProperties searchEngineRetentionProperties() {
+    final SearchEngineRetentionProperties override = new SearchEngineRetentionProperties();
+    BeanUtils.copyProperties(legacySearchEngineRetentionProperties, override);
+
+    final SecondaryStorage secondaryStorage =
+        unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
+
+    final DocumentBasedSecondaryStorageDatabase database =
+        switch (secondaryStorage.getType()) {
+          case elasticsearch -> secondaryStorage.getElasticsearch();
+          case opensearch -> secondaryStorage.getOpensearch();
+          default -> null;
+        };
+
+    if (database == null) {
+      return override;
+    }
+
+    override.setPolicyName(database.getHistory().getPolicyName());
+
+    return override;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beans/LegacySearchEngineRetentionProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/LegacySearchEngineRetentionProperties.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.search.schema.config.RetentionConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("camunda.database.retention")
+public class LegacySearchEngineRetentionProperties extends RetentionConfiguration {}

--- a/configuration/src/main/java/io/camunda/configuration/beans/SearchEngineRetentionProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/SearchEngineRetentionProperties.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.search.schema.config.RetentionConfiguration;
+
+/**
+ * NOTE: Some of the fields of this object are overridden with values coming from the Unified
+ * Configuration system, from the object
+ * io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride
+ */
+public class SearchEngineRetentionProperties extends RetentionConfiguration {}

--- a/configuration/src/test/java/io/camunda/configuration/HistoryElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/HistoryElasticsearchTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.beans.SearchEngineRetentionProperties;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.search.schema.config.RetentionConfiguration;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@ActiveProfiles({"broker"})
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  SearchEngineRetentionPropertiesOverride.class,
+  BrokerBasedPropertiesOverride.class,
+})
+public class HistoryElasticsearchTest {
+
+  private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
+  private static final String EXPECTED_HISTORY_POLICY_NAME = "policy-name-foo";
+
+  private ExporterConfiguration getExporterConfiguration(
+      final BrokerBasedProperties brokerBasedProperties) {
+
+    final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+    assertThat(camundaExporter).isNotNull();
+
+    final Map<String, Object> args = camundaExporter.getArgs();
+    assertThat(args).isNotNull();
+
+    return UnifiedConfigurationHelper.argsToCamundaExporterConfiguration(args);
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.secondary-storage.elasticsearch.history.process-instance-enabled="
+            + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
+        "camunda.data.secondary-storage.elasticsearch.history.policy-name="
+            + EXPECTED_HISTORY_POLICY_NAME
+      })
+  class WithOnlyUnifiedConfigSet {
+    final SearchEngineRetentionProperties searchEngineRetentionProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyUnifiedConfigSet(
+        @Autowired final SearchEngineRetentionProperties searchEngineRetentionProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.searchEngineRetentionProperties = searchEngineRetentionProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void testCamundaSearchEngineRetentionProperties() {
+      assertThat(searchEngineRetentionProperties)
+          .returns(EXPECTED_HISTORY_POLICY_NAME, SearchEngineRetentionProperties::getPolicyName);
+    }
+
+    @Test
+    void testCamundaExporterProperties() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getHistory().isProcessInstanceEnabled())
+          .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
+      assertThat(exporterConfiguration.getHistory().getRetention())
+          .returns(EXPECTED_HISTORY_POLICY_NAME, RetentionConfiguration::getPolicyName);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        // policy name
+        "camunda.data.secondary-storage.elasticsearch.history.policy-name="
+            + EXPECTED_HISTORY_POLICY_NAME,
+        "camunda.database.retention.policyName=" + EXPECTED_HISTORY_POLICY_NAME
+      })
+  class WithNewAndLegacySet {
+    final SearchEngineRetentionProperties searchEngineRetentionProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithNewAndLegacySet(
+        @Autowired final SearchEngineRetentionProperties searchEngineRetentionProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.searchEngineRetentionProperties = searchEngineRetentionProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void testCamundaSearchEngineRetentionProperties() {
+      assertThat(searchEngineRetentionProperties)
+          .returns(EXPECTED_HISTORY_POLICY_NAME, SearchEngineRetentionProperties::getPolicyName);
+    }
+
+    @Test
+    void testCamundaExporterProperties() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getHistory().getRetention().getPolicyName())
+          .isEqualTo(EXPECTED_HISTORY_POLICY_NAME);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/HistoryOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/HistoryOpensearchTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.beans.SearchEngineRetentionProperties;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.search.schema.config.RetentionConfiguration;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@ActiveProfiles({"broker"})
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  UnifiedConfigurationHelper.class,
+  SearchEngineRetentionPropertiesOverride.class,
+  BrokerBasedPropertiesOverride.class,
+})
+public class HistoryOpensearchTest {
+
+  private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
+  private static final String EXPECTED_HISTORY_POLICY_NAME = "policy-name-foo";
+
+  private ExporterConfiguration getExporterConfiguration(
+      final BrokerBasedProperties brokerBasedProperties) {
+
+    final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+    assertThat(camundaExporter).isNotNull();
+
+    final Map<String, Object> args = camundaExporter.getArgs();
+    assertThat(args).isNotNull();
+
+    return UnifiedConfigurationHelper.argsToCamundaExporterConfiguration(args);
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=opensearch",
+        "camunda.data.secondary-storage.opensearch.history.process-instance-enabled="
+            + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
+        "camunda.data.secondary-storage.opensearch.history.policy-name="
+            + EXPECTED_HISTORY_POLICY_NAME
+      })
+  class WithOnlyUnifiedConfigSet {
+    final SearchEngineRetentionProperties searchEngineRetentionProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyUnifiedConfigSet(
+        @Autowired final SearchEngineRetentionProperties searchEngineRetentionProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.searchEngineRetentionProperties = searchEngineRetentionProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void testCamundaSearchEngineRetentionProperties() {
+      assertThat(searchEngineRetentionProperties)
+          .returns(EXPECTED_HISTORY_POLICY_NAME, SearchEngineRetentionProperties::getPolicyName);
+    }
+
+    @Test
+    void testCamundaExporterProperties() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getHistory().isProcessInstanceEnabled())
+          .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
+      assertThat(exporterConfiguration.getHistory().getRetention().getPolicyName())
+          .isEqualTo(EXPECTED_HISTORY_POLICY_NAME);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=opensearch",
+        // policy name
+        "camunda.data.secondary-storage.opensearch.history.policy-name="
+            + EXPECTED_HISTORY_POLICY_NAME,
+        "camunda.database.retention.policyName=" + EXPECTED_HISTORY_POLICY_NAME
+      })
+  class WithNewAndLegacySet {
+    final SearchEngineRetentionProperties searchEngineRetentionProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithNewAndLegacySet(
+        @Autowired final SearchEngineRetentionProperties searchEngineRetentionProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.searchEngineRetentionProperties = searchEngineRetentionProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void testCamundaSearchEngineRetentionProperties() {
+      assertThat(searchEngineRetentionProperties)
+          .returns(EXPECTED_HISTORY_POLICY_NAME, SearchEngineRetentionProperties::getPolicyName);
+    }
+
+    @Test
+    void testCamundaExporterProperties() {
+      final ExporterConfiguration exporterConfiguration =
+          getExporterConfiguration(brokerBasedProperties);
+
+      assertThat(exporterConfiguration.getHistory().getRetention())
+          .returns(EXPECTED_HISTORY_POLICY_NAME, RetentionConfiguration::getPolicyName);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -15,6 +15,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.webapps.backup.BackupRepository;
@@ -98,6 +99,7 @@ public class StandaloneBackupManager implements CommandLineRunner {
             UnifiedConfiguration.class,
             SearchEngineConnectPropertiesOverride.class,
             SearchEngineIndexPropertiesOverride.class,
+            SearchEngineRetentionPropertiesOverride.class,
             // ---
             BackupManagerConfiguration.class,
             StandaloneBackupManager.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBroker.java
@@ -17,6 +17,7 @@ import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import org.springframework.boot.SpringBootConfiguration;
 
@@ -39,6 +40,7 @@ public class StandaloneBroker {
                 IdleStrategyPropertiesOverride.class,
                 SearchEngineConnectPropertiesOverride.class,
                 SearchEngineIndexPropertiesOverride.class,
+                SearchEngineRetentionPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 GatewayRestPropertiesOverride.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -24,6 +24,7 @@ import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.identity.IdentityModuleConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
@@ -69,6 +70,7 @@ public class StandaloneCamunda {
                 GatewayRestPropertiesOverride.class,
                 SearchEngineConnectPropertiesOverride.class,
                 SearchEngineIndexPropertiesOverride.class,
+                SearchEngineRetentionPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 OperateModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneGateway.java
@@ -15,6 +15,7 @@ import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
 import org.springframework.boot.SpringBootConfiguration;
 
@@ -35,6 +36,7 @@ public class StandaloneGateway {
                 GatewayBasedPropertiesOverride.class,
                 SearchEngineConnectPropertiesOverride.class,
                 SearchEngineIndexPropertiesOverride.class,
+                SearchEngineRetentionPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 GatewayModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneOperate.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneOperate.java
@@ -18,6 +18,7 @@ import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import java.util.HashMap;
@@ -54,6 +55,7 @@ public class StandaloneOperate {
                 GatewayRestPropertiesOverride.class,
                 SearchEngineConnectPropertiesOverride.class,
                 SearchEngineIndexPropertiesOverride.class,
+                SearchEngineRetentionPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 OperateModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
@@ -15,6 +15,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beans.LegacyBrokerBasedProperties;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
@@ -86,6 +87,7 @@ public class StandaloneSchemaManager implements CommandLineRunner {
             UnifiedConfiguration.class,
             SearchEngineConnectPropertiesOverride.class,
             SearchEngineIndexPropertiesOverride.class,
+            SearchEngineRetentionPropertiesOverride.class,
             // ---
             StandaloneSchemaManagerConfiguration.class)
         .initializers(new StandaloneSchemaManagerInitializer())

--- a/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
@@ -17,6 +17,7 @@ import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -49,6 +50,7 @@ public class StandaloneTasklist {
                 GatewayRestPropertiesOverride.class,
                 SearchEngineConnectPropertiesOverride.class,
                 SearchEngineIndexPropertiesOverride.class,
+                SearchEngineRetentionPropertiesOverride.class,
                 // ---
                 CommonsModuleConfiguration.class,
                 TasklistModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -7,15 +7,14 @@
  */
 package io.camunda.application.commons.search;
 
-import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineRetentionProperties;
 import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.configuration.beans.SearchEngineIndexProperties;
+import io.camunda.configuration.beans.SearchEngineRetentionProperties;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.connect.configuration.DatabaseType;
-import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.search.schema.config.SchemaManagerConfiguration;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.zeebe.broker.Broker;
@@ -34,7 +33,6 @@ import org.springframework.context.annotation.Configuration;
   SecondaryStorageType.opensearch
 })
 @EnableConfigurationProperties({
-  SearchEngineRetentionProperties.class,
   SearchEngineSchemaManagerProperties.class,
 })
 public class SearchEngineDatabaseConfiguration {
@@ -71,9 +69,6 @@ public class SearchEngineDatabaseConfiguration {
                 .retention(searchEngineRetentionProperties)
                 .schemaManager(searchEngineSchemaManagerProperties));
   }
-
-  @ConfigurationProperties("camunda.database.retention")
-  public static final class SearchEngineRetentionProperties extends RetentionConfiguration {}
 
   @ConfigurationProperties("camunda.database.schema-manager")
   public static final class SearchEngineSchemaManagerProperties extends SchemaManagerConfiguration {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
@@ -14,6 +14,7 @@ import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import org.springframework.boot.SpringApplication;
@@ -44,6 +45,7 @@ import org.springframework.context.annotation.Import;
   GatewayBasedPropertiesOverride.class,
   SearchEngineConnectPropertiesOverride.class,
   SearchEngineIndexPropertiesOverride.class,
+  SearchEngineRetentionPropertiesOverride.class
 })
 public class TestApplication {
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
@@ -14,6 +14,7 @@ import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.operate.util.TestApplication;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -53,6 +54,7 @@ import org.springframework.context.annotation.Import;
   UnifiedConfiguration.class,
   SearchEngineConnectPropertiesOverride.class,
   SearchEngineIndexPropertiesOverride.class,
+  SearchEngineRetentionPropertiesOverride.class,
   OperatePropertiesOverride.class,
   GatewayBasedPropertiesOverride.class,
   GatewayRestPropertiesOverride.class,

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -24,6 +24,7 @@ import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.identity.IdentityModuleConfiguration;
@@ -78,6 +79,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         OperatePropertiesOverride.class,
         SearchEngineConnectPropertiesOverride.class,
         SearchEngineIndexPropertiesOverride.class,
+        SearchEngineRetentionPropertiesOverride.class,
         GatewayRestPropertiesOverride.class,
         // ---
         CommonsModuleConfiguration.class,
@@ -336,7 +338,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
     return new TestRestOperateClient(restAddress(), username, password);
   }
 
-  public TestRestOperateClient newOperateClient(CredentialsProvider credentialsProvider) {
+  public TestRestOperateClient newOperateClient(final CredentialsProvider credentialsProvider) {
     return new TestRestOperateClient(restAddress(), credentialsProvider);
   }
 
@@ -344,7 +346,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
     return new TestRestTasklistClient(restAddress());
   }
 
-  public TestRestTasklistClient newTasklistClient(CredentialsProvider credentialsProvider) {
+  public TestRestTasklistClient newTasklistClient(final CredentialsProvider credentialsProvider) {
     return new TestRestTasklistClient(restAddress(), credentialsProvider);
   }
 

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
@@ -16,6 +16,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator.NoopHealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
@@ -34,6 +35,7 @@ public class TestStandaloneBackupManager
         UnifiedConfiguration.class,
         SearchEngineConnectPropertiesOverride.class,
         SearchEngineIndexPropertiesOverride.class,
+        SearchEngineRetentionPropertiesOverride.class,
         // ---
         BackupManagerConfiguration.class,
         StandaloneBackupManager.class);

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -89,7 +89,8 @@ public class MultiDbConfigurator {
     /* Camunda */
     elasticsearchProperties.put(
         "camunda.database.retention.enabled", Boolean.toString(retentionEnabled));
-    elasticsearchProperties.put("camunda.database.retention.policyName", indexPrefix + "-ilm");
+    elasticsearchProperties.put(
+        "camunda.data.secondary-storage.elasticsearch.history.policy-name", indexPrefix + "-ilm");
     // 0s causes ILM to move data asap - it is normally the default
     // https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
     elasticsearchProperties.put("camunda.database.retention.minimumAge", "0s");
@@ -208,7 +209,8 @@ public class MultiDbConfigurator {
     opensearchProperties.put("camunda.database.url", opensearchUrl);
     opensearchProperties.put(
         "camunda.database.retention.enabled", Boolean.toString(retentionEnabled));
-    opensearchProperties.put("camunda.database.retention.policyName", indexPrefix + "-ilm");
+    opensearchProperties.put(
+        "camunda.data.secondary-storage.opensearch.history.policy-name", indexPrefix + "-ilm");
     opensearchProperties.put("camunda.database.retention.minimumAge", "0s");
     opensearchProperties.put(CREATE_SCHEMA_PROPERTY, true);
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModuleIntegrationTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModuleIntegrationTest.java
@@ -11,6 +11,7 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.apps.modules.ModulesTestApplication;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +29,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       UnifiedConfiguration.class,
       SearchEngineConnectPropertiesOverride.class,
       SearchEngineIndexPropertiesOverride.class,
+      SearchEngineRetentionPropertiesOverride.class
     },
     properties = {TasklistProperties.PREFIX + ".zeebe.compatibility.enabled = true"},
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
@@ -14,6 +14,7 @@ import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
@@ -52,6 +53,7 @@ import org.springframework.context.annotation.Profile;
   GatewayBasedPropertiesOverride.class,
   SearchEngineConnectPropertiesOverride.class,
   SearchEngineIndexPropertiesOverride.class,
+  SearchEngineRetentionPropertiesOverride.class
 })
 public class TestApplication {
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -20,6 +20,7 @@ import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayRestPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.configuration.beans.SearchEngineIndexProperties;
@@ -67,7 +68,8 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
         UnifiedConfiguration.class,
         GatewayRestPropertiesOverride.class,
         SearchEngineConnectPropertiesOverride.class,
-        SearchEngineIndexPropertiesOverride.class);
+        SearchEngineIndexPropertiesOverride.class,
+        SearchEngineRetentionPropertiesOverride.class);
 
     config = new BrokerBasedProperties();
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -20,6 +20,7 @@ import io.camunda.configuration.beanoverrides.IdleStrategyPropertiesOverride;
 import io.camunda.configuration.beanoverrides.OperatePropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
@@ -46,6 +47,7 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
         IdleStrategyPropertiesOverride.class,
         SearchEngineConnectPropertiesOverride.class,
         SearchEngineIndexPropertiesOverride.class,
+        SearchEngineRetentionPropertiesOverride.class,
         // ---
         GatewayModuleConfiguration.class,
         CommonsModuleConfiguration.class);


### PR DESCRIPTION
## Description

This PR MUST NOT BE MERGED until the dependent teams have implemented the properties, as these properties introduce breaking changes.

This PR adds the properties from section camunda.data.secondary-storage.elasticsearch/opensearch.history to unified configuration.

The legacy properties are:
camunda.database.retention.policyName
zeebe.broker.exporters.camundaexporter.args.history.retention.policyName

The new properties are:
camunda.data.secondary-storage.elasticsearch.history.policy-name
camunda.data.secondary-storage.opensearch.history.policy-name

Backwards compatibility is not supported. That means, new properties need to be available and must match with legacy values.

## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34902