### PR TITLE
[Backport stable/8.6] ci: ensure all matrix jobs have unique job names

### DIFF
--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -112,6 +112,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          job_name: "integration-tests/${{ matrix.database }}"
           build_status: ${{ job.status }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
# Description
Backport of #38810 to `stable/8.6`.

relates to camunda/camunda#36994