### PR TITLE
[Backport stable/8.8] Adding redirect to `/` to avoid error on concurrent login

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -25,6 +25,7 @@ import io.camunda.authentication.filters.AdminUserCheckFilter;
 import io.camunda.authentication.filters.OAuth2RefreshTokenFilter;
 import io.camunda.authentication.filters.WebComponentAuthorizationCheckFilter;
 import io.camunda.authentication.handler.AuthFailureHandler;
+import io.camunda.authentication.handler.OAuth2AuthenticationExceptionHandler;
 import io.camunda.authentication.service.MembershipService;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
@@ -848,9 +849,7 @@ public class WebSecurityConfig {
                                     authorizationRequestResolver(
                                         clientRegistrationRepository, oidcProviderRepository)))
                         .tokenEndpoint(tokenEndpointCustomizer)
-                        .failureHandler(
-                            (httpServletRequest, httpServletResponse, exception) ->
-                                httpServletResponse.sendRedirect("/"));
+                        .failureHandler(new OAuth2AuthenticationExceptionHandler());
                   })
               .oidcLogout(httpSecurityOidcLogoutConfigurer -> {})
               .logout(

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -847,7 +847,10 @@ public class WebSecurityConfig {
                                 authorization.authorizationRequestResolver(
                                     authorizationRequestResolver(
                                         clientRegistrationRepository, oidcProviderRepository)))
-                        .tokenEndpoint(tokenEndpointCustomizer);
+                        .tokenEndpoint(tokenEndpointCustomizer)
+                        .failureHandler(
+                            (httpServletRequest, httpServletResponse, exception) ->
+                                httpServletResponse.sendRedirect("/"));
                   })
               .oidcLogout(httpSecurityOidcLogoutConfigurer -> {})
               .logout(

--- a/authentication/src/main/java/io/camunda/authentication/handler/OAuth2AuthenticationExceptionHandler.java
+++ b/authentication/src/main/java/io/camunda/authentication/handler/OAuth2AuthenticationExceptionHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+public class OAuth2AuthenticationExceptionHandler implements AuthenticationFailureHandler {
+  private static final String AUTHORIZATION_REQUEST_NOT_FOUND_ERROR_CODE =
+      "authorization_request_not_found";
+
+  @Override
+  public void onAuthenticationFailure(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final AuthenticationException exception)
+      throws IOException {
+
+    if (exception instanceof final OAuth2AuthenticationException e) {
+      if (e.getError() != null
+          && AUTHORIZATION_REQUEST_NOT_FOUND_ERROR_CODE.equals(e.getError().getErrorCode())) {
+        response.sendRedirect("/");
+        return;
+      }
+    }
+
+    throw exception;
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/handler/OAuth2AuthenticationExceptionHandler.java
+++ b/authentication/src/main/java/io/camunda/authentication/handler/OAuth2AuthenticationExceptionHandler.java
@@ -15,7 +15,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 
 public class OAuth2AuthenticationExceptionHandler implements AuthenticationFailureHandler {
-  private static final String AUTHORIZATION_REQUEST_NOT_FOUND_ERROR_CODE =
+  public static final String AUTHORIZATION_REQUEST_NOT_FOUND_ERROR_CODE =
       "authorization_request_not_found";
 
   @Override

--- a/authentication/src/test/java/io/camunda/authentication/AuthorizationRequestFailureTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/AuthorizationRequestFailureTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.authentication.handler.OAuth2AuthenticationExceptionHandler;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
+
+/**
+ * This test ensures that the error code defined in our {@link
+ * io.camunda.authentication.handler.OAuth2AuthenticationExceptionHandler} matches the one used
+ * internally by Spring Security's OAuth2LoginAuthenticationFilter. This is important because if
+ * they diverge, our custom error handling logic may not work as intended.
+ */
+class AuthorizationRequestFailureTest {
+
+  @Test
+  public void shouldSendClientAssertionToTokenEndpointDuringAuthCodeExchange() {
+    final Field springAuthorizationRequestErrorCode;
+    try {
+      springAuthorizationRequestErrorCode =
+          OAuth2LoginAuthenticationFilter.class.getDeclaredField(
+              "AUTHORIZATION_REQUEST_NOT_FOUND_ERROR_CODE");
+      springAuthorizationRequestErrorCode.setAccessible(true);
+      assertThat(springAuthorizationRequestErrorCode.get(String.class))
+          .isEqualTo(
+              OAuth2AuthenticationExceptionHandler.AUTHORIZATION_REQUEST_NOT_FOUND_ERROR_CODE);
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
# Description
Backport of #38637 to `stable/8.8`.

relates to 