### PR TITLE
fix: restore app can start successfully

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -11,6 +11,9 @@ import io.camunda.application.MainSupport;
 import io.camunda.application.Profile;
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -30,7 +33,16 @@ import org.springframework.context.annotation.Import;
 
 @SpringBootApplication(scanBasePackages = {"io.camunda.zeebe.restore"})
 @ConfigurationPropertiesScan(basePackages = {"io.camunda.zeebe.restore"})
-@Import(value = {BrokerBasedConfiguration.class, WorkingDirectoryConfiguration.class})
+@Import(
+    value = {
+      // Unified Configuration classes
+      UnifiedConfigurationHelper.class,
+      UnifiedConfiguration.class,
+      BrokerBasedPropertiesOverride.class,
+      // ---
+      BrokerBasedConfiguration.class,
+      WorkingDirectoryConfiguration.class
+    })
 public class RestoreApp implements ApplicationRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(RestoreApp.class);

--- a/dist/src/test/java/io/camunda/zeebe/restore/RestoreAppTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/restore/RestoreAppTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.restore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("restore")
+@SpringBootTest(
+    classes = RestoreApp.class,
+    properties = {
+      "camunda.data.backup.store=filesystem",
+      "camunda.data.backup.filesystem.basepath=/tmp",
+      "camunda.cluster.node-id=26",
+      "backupId=27"
+    })
+public class RestoreAppTest {
+
+  @Autowired private BrokerBasedProperties brokerBasedProperties;
+
+  @Test
+  void testUnifiedConfigurationClassesLoadSuccessfully() {
+    assertThat(brokerBasedProperties).isNotNull();
+    assertThat(brokerBasedProperties.getCluster()).isNotNull();
+    assertThat(brokerBasedProperties.getCluster().getNodeId()).isEqualTo(26);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/AzureRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/AzureRestoreAcceptanceIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.it.backup;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
@@ -28,5 +29,14 @@ final class AzureRestoreAcceptanceIT implements RestoreAcceptance {
     azureBackupStoreConfig.setConnectionString(AZURITE_CONTAINER.getConnectString());
     azureBackupStoreConfig.setBasePath(CONTAINER_NAME);
     backup.setAzure(azureBackupStoreConfig);
+  }
+
+  @Override
+  public void configureBackupStore(final Camunda cfg) {
+    final var backup = cfg.getData().getBackup();
+    backup.setStore(io.camunda.configuration.Backup.BackupStoreType.AZURE);
+    final var azure = backup.getAzure();
+    azure.setConnectionString(AZURITE_CONTAINER.getConnectString());
+    azure.setBasePath(CONTAINER_NAME);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ClusteredBackupRestoreTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ClusteredBackupRestoreTest.java
@@ -11,6 +11,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import com.google.cloud.storage.BucketInfo;
+import io.camunda.configuration.Backup;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Gcs;
 import io.camunda.management.backups.BackupInfo;
 import io.camunda.management.backups.StateCode;
 import io.camunda.management.backups.TakeBackupRuntimeResponse;
@@ -99,12 +102,12 @@ public class ClusteredBackupRestoreTest {
     // then -- restoring with one broker is successful
     try (final var restoreApp =
         new TestRestoreApp()
-            .withBrokerConfig(
-                brokerCfg -> {
-                  configureBackupStore(brokerCfg);
-                  brokerCfg.getCluster().setClusterSize(1);
-                  brokerCfg.getCluster().setPartitionsCount(3);
-                  brokerCfg.getCluster().setReplicationFactor(1);
+            .withConfig(
+                config -> {
+                  configureBackupStore(config);
+                  config.getCluster().setSize(1);
+                  config.getCluster().setPartitionCount(3);
+                  config.getCluster().setReplicationFactor(1);
                 })
             .withBackupId(backupId)) {
 
@@ -121,6 +124,18 @@ public class ClusteredBackupRestoreTest {
     storeConfig.setHost(GCS.externalEndpoint());
 
     backup.setStore(BackupStoreType.GCS);
+    backup.setGcs(storeConfig);
+  }
+
+  private static void configureBackupStore(final Camunda config) {
+    final var backup = config.getData().getBackup();
+
+    final var storeConfig = new Gcs();
+    storeConfig.setAuth(Gcs.GcsBackupStoreAuth.NONE);
+    storeConfig.setBucketName(BUCKET_NAME);
+    storeConfig.setHost(GCS.externalEndpoint());
+
+    backup.setStore(Backup.BackupStoreType.GCS);
     backup.setGcs(storeConfig);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
@@ -13,6 +13,9 @@ import static org.awaitility.Awaitility.await;
 
 import com.google.cloud.storage.BucketInfo;
 import io.camunda.client.CamundaClient;
+import io.camunda.configuration.Backup;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Gcs;
 import io.camunda.management.backups.StateCode;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
@@ -128,7 +131,7 @@ final class ContinuousBackupIT {
     FileUtil.ensureDirectoryExists(dataDirectory);
     final var restore =
         new TestRestoreApp()
-            .withBrokerConfig(this::configureBroker)
+            .withConfig(this::configureRestoreApp)
             .withWorkingDirectory(dataDirectory)
             .withBackupId(1, 2, 3)
             .start();
@@ -171,7 +174,7 @@ final class ContinuousBackupIT {
     FileUtil.ensureDirectoryExists(dataDirectory);
     final var restore =
         new TestRestoreApp()
-            .withBrokerConfig(this::configureBroker)
+            .withConfig(this::configureRestoreApp)
             .withWorkingDirectory(dataDirectory)
             .withBackupId(1, 3);
 
@@ -254,5 +257,15 @@ final class ContinuousBackupIT {
     cfg.getData().getBackup().setStore(BackupStoreType.GCS);
     cfg.getData().setLogSegmentSize(DataSize.ofMegabytes(1));
     cfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(500));
+  }
+
+  private void configureRestoreApp(final Camunda cfg) {
+    final var gcsConfig = new Gcs();
+    gcsConfig.setAuth(Gcs.GcsBackupStoreAuth.NONE);
+    gcsConfig.setBasePath(basePath);
+    gcsConfig.setBucketName(BUCKET_NAME);
+    gcsConfig.setHost(GCS.externalEndpoint());
+    cfg.getData().getBackup().setGcs(gcsConfig);
+    cfg.getData().getBackup().setStore(Backup.BackupStoreType.GCS.GCS);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/FilesystemRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/FilesystemRestoreAcceptanceIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.it.backup;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
@@ -29,6 +30,16 @@ final class FilesystemRestoreAcceptanceIT implements RestoreAcceptance {
     backup.setStore(BackupStoreType.FILESYSTEM);
 
     final var config = new FilesystemBackupStoreConfig();
+    config.setBasePath(basePath.toAbsolutePath().toString());
+    backup.setFilesystem(config);
+  }
+
+  @Override
+  public void configureBackupStore(final Camunda cfg) {
+    final var backup = cfg.getData().getBackup();
+    backup.setStore(io.camunda.configuration.Backup.BackupStoreType.FILESYSTEM);
+
+    final var config = backup.getFilesystem();
     config.setBasePath(basePath.toAbsolutePath().toString());
     backup.setFilesystem(config);
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsRestoreAcceptanceIT.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.it.backup;
 
 import com.google.cloud.storage.BucketInfo;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Gcs;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -50,5 +52,16 @@ final class GcsRestoreAcceptanceIT implements RestoreAcceptance {
     config.setBucketName(BUCKET_NAME);
     config.setHost(GCS.externalEndpoint());
     backup.setGcs(config);
+  }
+
+  @Override
+  public void configureBackupStore(final Camunda cfg) {
+    final var backup = cfg.getData().getBackup();
+    backup.setStore(io.camunda.configuration.Backup.BackupStoreType.GCS);
+
+    final var config = backup.getGcs();
+    config.setAuth(Gcs.GcsBackupStoreAuth.NONE);
+    config.setBucketName(BUCKET_NAME);
+    config.setHost(GCS.externalEndpoint());
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.management.backups.BackupInfo;
 import io.camunda.management.backups.StateCode;
 import io.camunda.management.backups.TakeBackupRuntimeResponse;
@@ -80,12 +81,13 @@ public interface RestoreAcceptance {
 
   private void restoreBackup(final long backupId) {
     final var restore =
-        new TestRestoreApp()
-            .withBrokerConfig(this::configureBackupStore)
-            .withBackupId(backupId)
-            .start();
+        new TestRestoreApp().withConfig(this::configureBackupStore).withBackupId(backupId).start();
     restore.close();
   }
 
+  /** All configuration must be duplicated in configureBackupStore(UnifiedConfiguration) as well. */
   void configureBackupStore(final BrokerCfg cfg);
+
+  /** RestoreApp can only be configured via UnifiedConfiguration */
+  void configureBackupStore(final Camunda cfg);
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3RestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3RestoreAcceptanceIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.it.backup;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -48,6 +49,20 @@ final class S3RestoreAcceptanceIT implements RestoreAcceptance {
   public void configureBackupStore(final BrokerCfg cfg) {
     final var backup = cfg.getData().getBackup();
     backup.setStore(BackupStoreType.S3);
+
+    final var s3 = backup.getS3();
+    s3.setRegion(MINIO.region());
+    s3.setSecretKey(MINIO.secretKey());
+    s3.setBucketName(BUCKET_NAME);
+    s3.setEndpoint(MINIO.externalEndpoint());
+    s3.setAccessKey(MINIO.accessKey());
+    s3.setForcePathStyleAccess(true);
+  }
+
+  @Override
+  public void configureBackupStore(final Camunda cfg) {
+    final var backup = cfg.getData().getBackup();
+    backup.setStore(io.camunda.configuration.Backup.BackupStoreType.S3);
 
     final var s3 = backup.getS3();
     s3.setRegion(MINIO.region());

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
@@ -9,8 +9,7 @@ package io.camunda.zeebe.qa.util.cluster;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
-import io.camunda.configuration.beans.BrokerBasedProperties;
-import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.configuration.Camunda;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.restore.RestoreApp;
 import java.util.Arrays;
@@ -21,19 +20,19 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 
 /** Represents an instance of the {@link RestoreApp} Spring application. */
 public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> {
-  private final BrokerBasedProperties config;
+  private final Camunda config;
   private long[] backupId;
 
   public TestRestoreApp() {
-    this(new BrokerBasedProperties());
+    this(new Camunda());
   }
 
-  public TestRestoreApp(final BrokerBasedProperties config) {
+  public TestRestoreApp(final Camunda config) {
     super(RestoreApp.class);
     this.config = config;
 
     //noinspection resource
-    withBean("config", config, BrokerBasedProperties.class).withAdditionalProfile(Profile.RESTORE);
+    withBean("config", config, Camunda.class).withAdditionalProfile(Profile.RESTORE);
   }
 
   @Override
@@ -71,7 +70,7 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
     return super.createSpringBuilder().web(WebApplicationType.NONE);
   }
 
-  public TestRestoreApp withBrokerConfig(final Consumer<BrokerCfg> modifier) {
+  public TestRestoreApp withConfig(final Consumer<Camunda> modifier) {
     modifier.accept(config);
     return this;
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The application `RestoreApp` is missing the imports related to the Unified Configuration system.
This PR adds the imports. It also adds a test that makes sure that the app starts correctly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37544
