### PR TITLE
feat: Archive Standalone Decision Instances (backport stable/8.8)

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -40,12 +40,18 @@ public class CamundaExporterMetrics implements AutoCloseable {
    */
   private final Counter processInstancesArchiving;
 
-  /**
-   * Count of completed batch operations that have been found, and are now in progress of archiving.
-   */
+  /** Count of completed batch operations that are in progress of archiving. */
   private final Counter batchOperationsArchiving;
 
+  /** Count of completed batch operations that have been archived. */
   private final Counter batchOperationsArchived;
+
+  /** Count of standalone-decisions that are in progress of archiving. */
+  private final Counter standaloneDecisionsArchiving;
+
+  /** Count of standalone-decisions that have been archived. */
+  private final Counter standaloneDecisionsArchived;
+
   private final Timer archiverSearchTimer;
   private final Timer archiverDeleteTimer;
   private final Timer archiverReindexTimer;
@@ -96,6 +102,17 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .tag("state", "archiving")
             .description(
                 "Count of completed batch operations that have been found, and are now in progress of archiving.")
+            .register(meterRegistry);
+    standaloneDecisionsArchived =
+        Counter.builder(meterName("archiver.standalone.decisions"))
+            .tag("state", "archived")
+            .description("Count of completed standalone-decisions, that have been archived.")
+            .register(meterRegistry);
+    standaloneDecisionsArchiving =
+        Counter.builder(meterName("archiver.standalone.decisions"))
+            .tag("state", "archiving")
+            .description(
+                "Count of completed standalone-decisions that have been found, and are now in progress of archiving.")
             .register(meterRegistry);
     archiverSearchTimer =
         Timer.builder(meterName("archiver.request.duration"))
@@ -199,6 +216,14 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   public void recordBatchOperationsArchiving(final int count) {
     batchOperationsArchiving.increment(count);
+  }
+
+  public void recordStandaloneDecisionsArchived(final int count) {
+    standaloneDecisionsArchived.increment(count);
+  }
+
+  public void recordStandaloneDecisionsArchiving(final int count) {
+    standaloneDecisionsArchiving.increment(count);
   }
 
   public void recordFlushFailureType(final String failureType) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -46,6 +46,18 @@ public class CamundaExporterMetrics implements AutoCloseable {
   /** Count of completed batch operations that have been archived. */
   private final Counter batchOperationsArchived;
 
+  /** Count of usage-metrics that are in progress of archiving. */
+  private final Counter usageMetricsArchiving;
+
+  /** Count of usage-metrics that have been archived. */
+  private final Counter usageMetricsArchived;
+
+  /** Count of usage-metrics-task-users that are in progress of archiving. */
+  private final Counter usageMetricsTUArchiving;
+
+  /** Count of usage-metrics-task-users that have been archived. */
+  private final Counter usageMetricsTUArchived;
+
   /** Count of standalone-decisions that are in progress of archiving. */
   private final Counter standaloneDecisionsArchiving;
 
@@ -102,6 +114,28 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .tag("state", "archiving")
             .description(
                 "Count of completed batch operations that have been found, and are now in progress of archiving.")
+            .register(meterRegistry);
+    usageMetricsArchived =
+        Counter.builder(meterName("archiver.usage.metrics"))
+            .tag("state", "archived")
+            .description("Count of completed usage-metrics, that have been archived.")
+            .register(meterRegistry);
+    usageMetricsArchiving =
+        Counter.builder(meterName("archiver.usage.metrics"))
+            .tag("state", "archiving")
+            .description(
+                "Count of completed usage-metrics that have been found, and are now in progress of archiving.")
+            .register(meterRegistry);
+    usageMetricsTUArchived =
+        Counter.builder(meterName("archiver.usage.metrics.tu"))
+            .tag("state", "archived")
+            .description("Count of completed usage-metrics-task-users, that have been archived.")
+            .register(meterRegistry);
+    usageMetricsTUArchiving =
+        Counter.builder(meterName("archiver.usage.metrics.tu"))
+            .tag("state", "archiving")
+            .description(
+                "Count of completed usage-metrics-task-users that have been found, and are now in progress of archiving.")
             .register(meterRegistry);
     standaloneDecisionsArchived =
         Counter.builder(meterName("archiver.standalone.decisions"))
@@ -216,6 +250,22 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   public void recordBatchOperationsArchiving(final int count) {
     batchOperationsArchiving.increment(count);
+  }
+
+  public void recordUsageMetricsArchived(final int count) {
+    usageMetricsArchived.increment(count);
+  }
+
+  public void recordUsageMetricsArchiving(final int count) {
+    usageMetricsArchiving.increment(count);
+  }
+
+  public void recordUsageMetricsTUArchived(final int count) {
+    usageMetricsTUArchived.increment(count);
+  }
+
+  public void recordUsageMetricsTUArchiving(final int count) {
+    usageMetricsTUArchiving.increment(count);
   }
 
   public void recordStandaloneDecisionsArchived(final int count) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -323,9 +323,10 @@ public final class BackgroundTaskManagerFactory {
     return buildReschedulingArchiverTask(
         new UsageMetricsArchiverJob(
             archiverRepository,
-            logger,
             resourceProvider.getIndexTemplateDescriptor(UsageMetricTemplate.class),
             resourceProvider.getIndexTemplateDescriptor(UsageMetricTUTemplate.class),
+            metrics,
+            logger,
             executor));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -23,6 +23,7 @@ import io.camunda.exporter.tasks.archiver.ElasticsearchArchiverRepository;
 import io.camunda.exporter.tasks.archiver.OpenSearchArchiverRepository;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceToBeArchivedCountJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstancesArchiverJob;
+import io.camunda.exporter.tasks.archiver.StandaloneDecisionArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricsArchiverJob;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateTask;
@@ -36,6 +37,7 @@ import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -230,6 +232,7 @@ public final class BackgroundTaskManagerFactory {
     tasks.add(buildIncidentMarkerTask());
     tasks.add(buildProcessInstanceArchiverJob());
     tasks.add(buildUsageMetricsArchiverJob());
+    tasks.add(buildStandaloneDecisionArchiverJob());
     if (config.getHistory().isTrackArchivalMetricsForProcessInstance()) {
       tasks.add(buildProcessInstanceToBeArchivedCountJob());
     }
@@ -323,6 +326,16 @@ public final class BackgroundTaskManagerFactory {
             logger,
             resourceProvider.getIndexTemplateDescriptor(UsageMetricTemplate.class),
             resourceProvider.getIndexTemplateDescriptor(UsageMetricTUTemplate.class),
+            executor));
+  }
+
+  private ReschedulingTask buildStandaloneDecisionArchiverJob() {
+    return buildReschedulingArchiverTask(
+        new StandaloneDecisionArchiverJob(
+            archiverRepository,
+            resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class),
+            metrics,
+            logger,
             executor));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -35,6 +35,8 @@ public interface ArchiverRepository extends AutoCloseable {
 
   CompletableFuture<ArchiveBatch> getUsageMetricNextBatch();
 
+  CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch();
+
   CompletableFuture<Void> setIndexLifeCycle(final String destinationIndexName);
 
   CompletableFuture<Void> setLifeCycleToAllIndexes();
@@ -91,12 +93,17 @@ public interface ArchiverRepository extends AutoCloseable {
     }
 
     @Override
+    public CompletableFuture<ArchiveBatch> getUsageMetricTUNextBatch() {
+      return CompletableFuture.completedFuture(new ArchiveBatch("2024-01-01", List.of()));
+    }
+
+    @Override
     public CompletableFuture<ArchiveBatch> getUsageMetricNextBatch() {
       return CompletableFuture.completedFuture(new ArchiveBatch("2024-01-01", List.of()));
     }
 
     @Override
-    public CompletableFuture<ArchiveBatch> getUsageMetricTUNextBatch() {
+    public CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch() {
       return CompletableFuture.completedFuture(new ArchiveBatch("2024-01-01", List.of()));
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
+import io.camunda.zeebe.util.FunctionUtil;
+import io.micrometer.core.instrument.Timer;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+
+public class StandaloneDecisionArchiverJob implements ArchiverJob {
+
+  private final ArchiverRepository repository;
+  private final DecisionInstanceTemplate decisionInstanceTemplate;
+  private final CamundaExporterMetrics metrics;
+  private final Logger logger;
+  private final Executor executor;
+
+  public StandaloneDecisionArchiverJob(
+      final ArchiverRepository repository,
+      final DecisionInstanceTemplate decisionInstanceTemplate,
+      final CamundaExporterMetrics metrics,
+      final Logger logger,
+      final Executor executor) {
+    this.repository = repository;
+    this.metrics = metrics;
+    this.decisionInstanceTemplate = decisionInstanceTemplate;
+    this.logger = logger;
+    this.executor = executor;
+  }
+
+  @Override
+  public CompletionStage<Integer> archiveNextBatch() {
+    final var timer = Timer.start();
+    return repository
+        .getStandaloneDecisionNextBatch()
+        .thenComposeAsync(this::archiveBatch, executor)
+        // we schedule us after the archiveBatch future - to correctly measure
+        // the time it takes all in all, including searching, reindexing, deletion
+        // There is some overhead with the scheduling at the executor, but this should be
+        // negligible
+        .thenComposeAsync(
+            count -> {
+              metrics.measureArchivingDuration(timer);
+              return CompletableFuture.completedFuture(count);
+            },
+            executor);
+  }
+
+  private CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
+    if (archiveBatch != null && !(archiveBatch.ids() == null || archiveBatch.ids().isEmpty())) {
+      logger.trace(
+          "Following standalone decision instances are found for archiving: {}", archiveBatch);
+      metrics.recordStandaloneDecisionsArchiving(archiveBatch.ids().size());
+
+      return moveBatch(archiveBatch.finishDate(), archiveBatch.ids())
+          .thenApplyAsync(FunctionUtil.peek(metrics::recordStandaloneDecisionsArchived), executor);
+    }
+
+    logger.trace("Nothing to archive");
+    return CompletableFuture.completedFuture(0);
+  }
+
+  private CompletableFuture<Integer> moveBatch(final String finishDate, final List<String> ids) {
+    return repository
+        .moveDocuments(
+            decisionInstanceTemplate.getFullQualifiedName(),
+            decisionInstanceTemplate.getFullQualifiedName() + finishDate,
+            DecisionInstanceTemplate.ID,
+            ids,
+            executor)
+        .thenApplyAsync(ok -> ids.size(), executor);
+  }
+
+  @Override
+  public String toString() {
+    return "Standalone decision instances archiver job";
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -42,6 +42,7 @@ import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
@@ -83,7 +84,7 @@ final class ElasticsearchArchiverRepositoryIT {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ElasticsearchArchiverRepositoryIT.class);
 
-  @RegisterExtension private static SearchDBExtension searchDB = SearchDBExtension.create();
+  @RegisterExtension private static final SearchDBExtension SEARCH_DB = SearchDBExtension.create();
 
   @AutoClose private final RestClientTransport transport = createRestClient();
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -574,6 +575,45 @@ final class ElasticsearchArchiverRepositoryIT {
   }
 
   @Test
+  void shouldGetStandaloneDecisionNextBatch() throws IOException {
+    // given - 5 documents, two of which were created over an hour ago and should be archived,
+    // one of which was created recently, one on a different partition and one with a different
+    // process instance key
+    final var now = Instant.now();
+    final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(
+            new TestStandaloneDecision("1", twoHoursAgo, 1, -1),
+            new TestStandaloneDecision("2", twoHoursAgo, 1, -1),
+            new TestStandaloneDecision("3", twoHoursAgo, 2, -1),
+            new TestStandaloneDecision("4", twoHoursAgo, 1, 12345),
+            new TestStandaloneDecision("5", now.toString(), 1, -1));
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    final var standaloneDecisionIndex =
+        resourceProvider
+            .getIndexTemplateDescriptor(DecisionInstanceTemplate.class)
+            .getFullQualifiedName();
+    createStandaloneDecisionIndex(standaloneDecisionIndex);
+    documents.forEach(doc -> index(standaloneDecisionIndex, doc));
+    testClient.indices().refresh(r -> r.index(standaloneDecisionIndex));
+    config.setRolloverBatchSize(3);
+
+    // when
+    final var result = repository.getStandaloneDecisionNextBatch();
+
+    // then - we expect only the first two documents created two hours ago to be returned
+    final var dateFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    final var batch = result.join();
+    assertThat(batch.ids()).containsExactly("1", "2");
+    assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
+  }
+
+  @Test
   void shouldSetTheCorrectFinishDateWithRollover() throws IOException {
     // given a rollover of 3 days:
     config.setRolloverInterval("3d");
@@ -856,7 +896,7 @@ final class ElasticsearchArchiverRepositoryIT {
     final var connectConfig = new ConnectConfiguration();
     connectConfig.setIndexPrefix(indexPrefix);
     connectConfig.setType(DatabaseType.ELASTICSEARCH.toString());
-    connectConfig.setUrl(searchDB.esUrl());
+    connectConfig.setUrl(SEARCH_DB.esUrl());
     final var schemaManagerConfig = new SchemaManagerConfiguration();
     schemaManagerConfig.getRetry().setMaxRetries(1);
     final SearchEngineConfiguration searchEngineConfiguration =
@@ -914,7 +954,7 @@ final class ElasticsearchArchiverRepositoryIT {
   }
 
   private RestClientTransport createRestClient() {
-    final var restClient = RestClient.builder(HttpHost.create(searchDB.esUrl())).build();
+    final var restClient = RestClient.builder(HttpHost.create(SEARCH_DB.esUrl())).build();
     return new RestClientTransport(restClient, new JacksonJsonpMapper());
   }
 
@@ -1010,6 +1050,29 @@ final class ElasticsearchArchiverRepositoryIT {
                     .aliases(usageMetricTUIndex + "alias", a -> a.isWriteIndex(false)));
   }
 
+  private void createStandaloneDecisionIndex(final String standaloneDecisionIndex)
+      throws IOException {
+    final var idProp = Property.of(p -> p.keyword(k -> k.index(true)));
+    final var evaluationDateProp =
+        Property.of(p -> p.date(d -> d.index(true).format("date_time || epoch_millis")));
+    final var properties =
+        TypeMapping.of(
+            m ->
+                m.properties(
+                    Map.of(
+                        DecisionInstanceTemplate.ID,
+                        idProp,
+                        DecisionInstanceTemplate.EVALUATION_DATE,
+                        evaluationDateProp)));
+    testClient
+        .indices()
+        .create(
+            r ->
+                r.index(standaloneDecisionIndex)
+                    .mappings(properties)
+                    .aliases(standaloneDecisionIndex + "alias", a -> a.isWriteIndex(false)));
+  }
+
   private record TestDocument(String id) implements TDocument {}
 
   private record TestBatchOperation(String id, String endDate) implements TDocument {}
@@ -1020,6 +1083,10 @@ final class ElasticsearchArchiverRepositoryIT {
   private record TestUsageMetric(String id, String endTime, int partitionId) implements TDocument {}
 
   private record TestUsageMetricTU(String id, String endTime, int partitionId)
+      implements TDocument {}
+
+  private record TestStandaloneDecision(
+      String id, String evaluationDate, int partitionId, int processInstanceKey)
       implements TDocument {}
 
   private interface TDocument {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
+import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class StandaloneDecisionArchiverJobTest {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(StandaloneDecisionArchiverJobTest.class);
+
+  private final Executor executor = Runnable::run;
+  private final TestRepository repository = new TestRepository();
+  private final DecisionInstanceTemplate decisionInstanceTemplate =
+      new DecisionInstanceTemplate("", true);
+  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
+  private final StandaloneDecisionArchiverJob job =
+      new StandaloneDecisionArchiverJob(
+          repository, decisionInstanceTemplate, metrics, LOGGER, executor);
+
+  @Test
+  void shouldReturnZeroIfNoBatchGiven() {
+    // given - when
+    final var result = job.archiveNextBatch();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+    assertThat(repository.moves).isEmpty();
+  }
+
+  @Test
+  void shouldReturnZeroIfNoStandaloneDecisionIdsGiven() {
+    // given
+    repository.batch = new ArchiveBatch("2024-01-01", List.of());
+
+    // when
+    final var result = job.archiveNextBatch();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+    assertThat(repository.moves).isEmpty();
+  }
+
+  @Test
+  void shouldMoveStandaloneDecisionInstances() {
+    // given
+    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+
+    // when
+    final var result = job.archiveNextBatch();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(3);
+    assertThat(repository.moves)
+        .contains(
+            new DocumentMove(
+                decisionInstanceTemplate.getFullQualifiedName(),
+                decisionInstanceTemplate.getFullQualifiedName() + "2024-01-01",
+                DecisionInstanceTemplate.ID,
+                List.of("1", "2", "3"),
+                executor));
+  }
+
+  @Test
+  void shouldRecordStandaloneDecisionInstancesIncrease() {
+    // given
+    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+
+    // when
+    final var count =
+        job.archiveNextBatch().toCompletableFuture().join()
+            + job.archiveNextBatch().toCompletableFuture().join();
+
+    // then
+    assertThat(
+            meterRegistry
+                .counter(
+                    "zeebe.camunda.exporter.archiver.standalone.decisions", "state", "archiving")
+                .count())
+        .isEqualTo(6)
+        .isEqualTo(count);
+    assertThat(
+            meterRegistry
+                .counter(
+                    "zeebe.camunda.exporter.archiver.standalone.decisions", "state", "archived")
+                .count())
+        .isEqualTo(6)
+        .isEqualTo(count);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
@@ -28,6 +28,21 @@ final class TestRepository extends NoopArchiverRepository {
   }
 
   @Override
+  public CompletableFuture<ArchiveBatch> getUsageMetricTUNextBatch() {
+    return CompletableFuture.completedFuture(batch);
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getUsageMetricNextBatch() {
+    return CompletableFuture.completedFuture(batch);
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch() {
+    return CompletableFuture.completedFuture(batch);
+  }
+
+  @Override
   public CompletableFuture<Void> moveDocuments(
       final String sourceIndexName,
       final String destinationIndexName,


### PR DESCRIPTION
## Description

Whilst we are archiving decision instances attached to a process via the linked processInstanceKey of the decision instances, the standalone evaluations are never moved, which can result in building completed data in the hot indexes. This adds a specialised archiver job that would move any standalone decision instances evaluated prior to the archive window, and move them to their dated indexes.

Add gathering recording metrics counters for the usage metrics archiving job. 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/35555
