### PR TITLE
[Backport stable/8.8] fix: change IncidentFilter creationTime to OffsetDateTime

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/IncidentFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/IncidentFilter.java
@@ -18,6 +18,7 @@ package io.camunda.client.api.search.filter;
 import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+import java.time.OffsetDateTime;
 
 public interface IncidentFilter extends SearchRequestFilter {
 
@@ -91,7 +92,7 @@ public interface IncidentFilter extends SearchRequestFilter {
    * @param creationTime the creation time of incident
    * @return the updated filter
    */
-  IncidentFilter creationTime(final String creationTime);
+  IncidentFilter creationTime(final OffsetDateTime creationTime);
 
   /**
    * Filters incidents by the state of incident.

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/IncidentFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/IncidentFilterImpl.java
@@ -23,6 +23,7 @@ import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.IncidentFilter.ErrorTypeEnum;
 import io.camunda.client.protocol.rest.IncidentFilter.StateEnum;
+import java.time.OffsetDateTime;
 
 public class IncidentFilterImpl
     extends TypedSearchRequestPropertyProvider<io.camunda.client.protocol.rest.IncidentFilter>
@@ -83,8 +84,12 @@ public class IncidentFilterImpl
   }
 
   @Override
-  public IncidentFilter creationTime(final String creationTime) {
-    filter.setCreationTime(creationTime);
+  public IncidentFilter creationTime(final OffsetDateTime creationTime) {
+    if (creationTime == null) {
+      filter.setCreationTime(null);
+      return this;
+    }
+    filter.setCreationTime(creationTime.toString());
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/IncidentFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/IncidentFilterImpl.java
@@ -85,11 +85,7 @@ public class IncidentFilterImpl
 
   @Override
   public IncidentFilter creationTime(final OffsetDateTime creationTime) {
-    if (creationTime == null) {
-      filter.setCreationTime(null);
-      return this;
-    }
-    filter.setCreationTime(creationTime.toString());
+    filter.setCreationTime(creationTime == null ? null : creationTime.toString());
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
+++ b/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
@@ -87,7 +87,7 @@ public class SearchIncidentTest extends ClientRestTest {
                     .errorMessage("Can't decide")
                     .elementId("element")
                     .elementInstanceKey(4L)
-                    .creationTime("2024-05-23T23:05:00.000+000")
+                    .creationTime(OffsetDateTime.parse("2024-05-23T23:05:00.001Z"))
                     .state(IncidentState.ACTIVE)
                     .jobKey(5L)
                     .tenantId("tenant"))
@@ -104,7 +104,7 @@ public class SearchIncidentTest extends ClientRestTest {
     assertThat(filter.getErrorMessage()).isEqualTo("Can't decide");
     assertThat(filter.getElementId()).isEqualTo("element");
     assertThat(filter.getElementInstanceKey()).isEqualTo("4");
-    assertThat(filter.getCreationTime()).isEqualTo("2024-05-23T23:05:00.000+000");
+    assertThat(filter.getCreationTime()).isEqualTo("2024-05-23T23:05:00.001Z");
     assertThat(filter.getState()).isEqualTo(StateEnum.ACTIVE);
     assertThat(filter.getJobKey()).isEqualTo("5");
     assertThat(filter.getTenantId()).isEqualTo("tenant");


### PR DESCRIPTION
# Description
Backport of #38846 to `stable/8.8`.

relates to #38827