### PR TITLE
feat: add exporters to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Data.java
+++ b/configuration/src/main/java/io/camunda/configuration/Data.java
@@ -9,6 +9,8 @@ package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
@@ -31,6 +33,9 @@ public class Data {
 
   /** This section allows to configure Zeebe's secondary storage. */
   @NestedConfigurationProperty private SecondaryStorage secondaryStorage = new SecondaryStorage();
+
+  /** This section allows configuring exporters */
+  private Map<String, Exporter> exporters = new HashMap<>();
 
   public Duration getSnapshotPeriod() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
@@ -75,5 +80,13 @@ public class Data {
 
   public void setSecondaryStorage(final SecondaryStorage secondaryStorage) {
     this.secondaryStorage = secondaryStorage;
+  }
+
+  public Map<String, Exporter> getExporters() {
+    return exporters;
+  }
+
+  public void setExporters(final Map<String, Exporter> exporters) {
+    this.exporters = exporters;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Exporter.java
+++ b/configuration/src/main/java/io/camunda/configuration/Exporter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.Map;
+
+public class Exporter {
+
+  /**
+   * path to the JAR file containing the exporter class
+   *
+   * <p>optional field: if missing, will lookup the class in the zeebe classpath
+   */
+  private String jarPath;
+
+  /** fully qualified class name pointing to the class implementing the exporter interface */
+  private String className;
+
+  /** map of arguments to use when instantiating the exporter */
+  private Map<String, Object> args;
+
+  public String getJarPath() {
+    return jarPath;
+  }
+
+  public void setJarPath(final String jarPath) {
+    this.jarPath = jarPath;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public void setClassName(final String className) {
+    this.className = className;
+  }
+
+  public Map<String, Object> getArgs() {
+    return args;
+  }
+
+  public void setArgs(final Map<String, Object> args) {
+    this.args = args;
+  }
+
+  public ExporterCfg toExporterCfg() {
+    final var exporterCfg = new ExporterCfg();
+    exporterCfg.setClassName(className);
+    exporterCfg.setJarPath(jarPath);
+    exporterCfg.setArgs(args);
+    return exporterCfg;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -13,6 +13,7 @@ import io.camunda.configuration.CommandApi;
 import io.camunda.configuration.Data;
 import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.Export;
+import io.camunda.configuration.Exporter;
 import io.camunda.configuration.Filesystem;
 import io.camunda.configuration.Filter;
 import io.camunda.configuration.Gcs;
@@ -121,6 +122,8 @@ public class BrokerBasedPropertiesOverride {
     } else {
       populateCamundaExporter(override);
     }
+
+    populateFromExporters(override);
 
     // TODO: Populate the rest of the bean using unifiedConfiguration
     //  override.setSampleField(unifiedConfiguration.getSampleField());
@@ -706,5 +709,22 @@ public class BrokerBasedPropertiesOverride {
       cursor = (Map<String, Object>) cursor.computeIfAbsent(keys[i], k -> new LinkedHashMap<>());
     }
     cursor.put(keys[keys.length - 1], value);
+  }
+
+  private void populateFromExporters(final BrokerBasedProperties override) {
+    final Map<String, Exporter> exporters =
+        unifiedConfiguration.getCamunda().getData().getExporters();
+
+    // Log common legacy exporters warning instead of using UnifiedConfigurationHelper logging.
+    if (!override.getExporters().isEmpty()) {
+      final String warningMessage =
+          String.format(
+              "The following legacy property is no longer supported and should be removed in favor of '%s': %s",
+              "camunda.data.exporters", "zeebe.broker.exporters");
+      LOGGER.warn(warningMessage);
+    }
+
+    exporters.forEach(
+        (name, exporter) -> override.getExporters().put(name, exporter.toExporterCfg()));
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DataExportersTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataExportersTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+class DataExportersTest {
+
+  private ExporterCfg expectedExporterCfg;
+
+  @BeforeEach
+  void setUp() {
+    expectedExporterCfg = new ExporterCfg();
+    expectedExporterCfg.setClassName("class-name");
+    expectedExporterCfg.setJarPath("jar-path");
+    expectedExporterCfg.setArgs(Map.of("arg1", "value1", "arg2", "value2"));
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.exporters.foo.class-name=class-name",
+        "camunda.data.exporters.foo.jar-path=jar-path",
+        "camunda.data.exporters.foo.args.arg1=value1",
+        "camunda.data.exporters.foo.args.arg2=value2"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetExporters() {
+      assertThat(brokerCfg.getExporters())
+          .hasSize(2)
+          .containsKeys("camundaexporter", "foo")
+          .containsEntry("foo", expectedExporterCfg);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.exporters.foo.className=class-name",
+        "zeebe.broker.exporters.foo.jarPath=jar-path",
+        "zeebe.broker.exporters.foo.args.arg1=value1",
+        "zeebe.broker.exporters.foo.args.arg2=value2",
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetExportersFromLegacy() {
+      assertThat(brokerCfg.getExporters())
+          .hasSize(2)
+          .containsKeys("camundaexporter", "foo")
+          .containsEntry("foo", expectedExporterCfg);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.data.exporters.foo.class-name=class-name",
+        "camunda.data.exporters.foo.jar-path=jar-path",
+        "camunda.data.exporters.foo.args.arg1=value1",
+        "camunda.data.exporters.foo.args.arg2=value2",
+        // legacy
+        "zeebe.broker.exporters.foo.className=classNameLegacy",
+        "zeebe.broker.exporters.foo.jarPath=jarPathLegacy",
+        "zeebe.broker.exporters.foo.args.arg1=value1Legacy",
+        "zeebe.broker.exporters.foo.args.arg2=value2Legacy",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetExportersFromNew() {
+      assertThat(brokerCfg.getExporters())
+          .hasSize(2)
+          .containsKeys("camundaexporter", "foo")
+          .containsEntry("foo", expectedExporterCfg);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.data.exporters to unified configuration.

The legacy properties are:
zeebe.broker.exporters.[exporter name].class-name
zeebe.broker.exporters.[exporter name].jar.path
zeebe.broker.exporters.[exporter name].args.[key]

The new properties are:
camunda.data.exporters.[exporter name].class-name
camunda.data.exporters.[exporter name].jar-path
camunda.data.exporters.[exporters].args.[key]

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.

## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34912