### PR TITLE
fix: reserve latest snapshot as soon as possible

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -111,8 +111,8 @@ final class BackupServiceImpl {
       case DOES_NOT_EXIST ->
           inProgressBackup
               .findValidSnapshot()
-              .andThen(inProgressBackup::findSegmentFiles, concurrencyControl)
               .andThen(ok -> inProgressBackup.reserveSnapshot(), concurrencyControl)
+              .andThen(inProgressBackup::findSegmentFiles, concurrencyControl)
               .andThen(ok -> inProgressBackup.findSnapshotFiles(), concurrencyControl)
               .onComplete(
                   (result, error) -> {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -180,12 +180,8 @@ final class InProgressBackupImpl implements InProgressBackup {
     final ActorFuture<Void> filesCollected = concurrencyControl.createFuture();
     try {
       long maxIndex = 0L;
-      if (availableValidSnapshots != null) {
-        maxIndex =
-            availableValidSnapshots.stream()
-                .mapToLong(PersistedSnapshot::getIndex)
-                .max()
-                .orElse(0L);
+      if (reservedSnapshot != null) {
+        maxIndex = reservedSnapshot.getIndex();
       }
       final var segments = journalInfoProvider.getTailSegments(maxIndex);
       segments.whenComplete(


### PR DESCRIPTION
## Description
The snapshot reservation is performed as soon as possible, i.e. just after fetching the list of snapshots.

Because the selected snapshot is known earlier, we can use its index to select the right segments: before, we would use the maximum index of the valid segments. In general the two should be identical, since in the past we started reserving the snapshot from the most recent one.
However, if the most recent snapshot was not available, we would reserved one before, resulting in a potential mismatch between the log files & the snapshot.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #33499 
