### PR TITLE
[Backport main] fix: add usage metric archiving partition ID handling

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -35,6 +37,7 @@ import org.opensearch.client.opensearch._types.Conflicts;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.Time;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery.Builder;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
@@ -124,7 +127,9 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   public CompletableFuture<ArchiveBatch> getUsageMetricTUNextBatch() {
     final var searchRequest =
         createUsageMetricSearchRequest(
-            usageMetricTUTemplateDescriptor.getFullQualifiedName(), UsageMetricTUTemplate.END_TIME);
+            usageMetricTUTemplateDescriptor.getFullQualifiedName(),
+            UsageMetricTUTemplate.END_TIME,
+            UsageMetricTUTemplate.PARTITION_ID);
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
         .thenComposeAsync(
             response ->
@@ -137,23 +142,15 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   public CompletableFuture<ArchiveBatch> getUsageMetricNextBatch() {
     final var searchRequest =
         createUsageMetricSearchRequest(
-            usageMetricTemplateDescriptor.getFullQualifiedName(), UsageMetricTemplate.END_TIME);
+            usageMetricTemplateDescriptor.getFullQualifiedName(),
+            UsageMetricTemplate.END_TIME,
+            UsageMetricTemplate.PARTITION_ID);
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
         .thenComposeAsync(
             response ->
                 createArchiveBatch(
                     response, UsageMetricTemplate.END_TIME, usageMetricTemplateDescriptor),
             executor);
-  }
-
-  private SearchRequest createUsageMetricSearchRequest(
-      final String indexName, final String endTimeField) {
-    final var endDateQ =
-        QueryBuilders.range()
-            .field(endTimeField)
-            .lte(JsonData.of(config.getArchivingTimePoint()))
-            .build();
-    return createSearchRequest(indexName, endDateQ.toQuery(), endTimeField);
   }
 
   @Override
@@ -266,6 +263,41 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     } catch (final IOException e) {
       return CompletableFuture.failedFuture(e);
     }
+  }
+
+  private SearchRequest createUsageMetricSearchRequest(
+      final String indexName, final String endTimeField, final String partitionIdField) {
+    final var endDateQ =
+        QueryBuilders.range()
+            .field(endTimeField)
+            .lte(JsonData.of(config.getArchivingTimePoint()))
+            .build()
+            .toQuery();
+
+    final Builder boolBuilder = QueryBuilders.bool();
+    boolBuilder.must(endDateQ);
+
+    if (partitionId == START_PARTITION_ID) {
+      // Include -1 for migrated documents without partitionId
+      final List<FieldValue> partitionIds = List.of(FieldValue.of(-1), FieldValue.of(partitionId));
+      final var termsQ =
+          QueryBuilders.terms()
+              .field(partitionIdField)
+              .terms(t -> t.value(partitionIds))
+              .build()
+              .toQuery();
+      boolBuilder.must(termsQ);
+    } else {
+      final var termQ =
+          QueryBuilders.term()
+              .field(partitionIdField)
+              .value(FieldValue.of(partitionId))
+              .build()
+              .toQuery();
+      boolBuilder.must(termQ);
+    }
+
+    return createSearchRequest(indexName, boolBuilder.build().toQuery(), endTimeField);
   }
 
   private Query finishedProcessInstancesQuery(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -569,12 +569,13 @@ final class OpenSearchArchiverRepositoryIT {
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofDays(1))));
   }
 
-  @Test
-  void shouldGetUsageMetricNextBatch() throws IOException {
-    // given - 3 documents, two older than archive threshold, one recent
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2})
+  void shouldGetUsageMetricNextBatch(final int partitionId) throws IOException {
+    // given
     final var now = Instant.now();
     final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
-    final var repository = createRepository();
+    final var repository = createRepository(partitionId);
     final var usageMetricIndex =
         resourceProvider
             .getIndexTemplateDescriptor(UsageMetricTemplate.class)
@@ -582,9 +583,12 @@ final class OpenSearchArchiverRepositoryIT {
     createUsageMetricIndex(usageMetricIndex);
     final var documents =
         List.of(
-            new TestUsageMetric("1", twoHoursAgo),
-            new TestUsageMetric("2", twoHoursAgo),
-            new TestUsageMetric("3", now.toString()));
+            new TestUsageMetric("1", twoHoursAgo, 1),
+            new TestUsageMetric("2", twoHoursAgo, 1),
+            new TestUsageMetric("3", twoHoursAgo, -1),
+            new TestUsageMetric("4", twoHoursAgo, 21),
+            new TestUsageMetric("20", now.toString(), 2),
+            new TestUsageMetric("21", twoHoursAgo, 2));
     documents.forEach(doc -> index(usageMetricIndex, doc));
     testClient.indices().refresh(r -> r.index(usageMetricIndex));
     config.setRolloverBatchSize(5);
@@ -597,16 +601,21 @@ final class OpenSearchArchiverRepositoryIT {
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     final var batch = result.join();
-    assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2");
+    if (partitionId == 1) {
+      assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2", "3");
+    } else {
+      assertThat(batch.ids()).containsExactlyInAnyOrder("21");
+    }
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
 
-  @Test
-  void shouldGetUsageMetricTUNextBatch() throws IOException {
-    // given - 3 TU documents, two older than archive threshold, one recent
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2})
+  void shouldGetUsageMetricTUNextBatch(final int partitionId) throws IOException {
+    // given
     final var now = Instant.now();
     final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
-    final var repository = createRepository();
+    final var repository = createRepository(partitionId);
     final var usageMetricTUIndex =
         resourceProvider
             .getIndexTemplateDescriptor(UsageMetricTUTemplate.class)
@@ -614,9 +623,12 @@ final class OpenSearchArchiverRepositoryIT {
     createUsageMetricTUIndex(usageMetricTUIndex);
     final var documents =
         List.of(
-            new TestUsageMetricTU("10", twoHoursAgo),
-            new TestUsageMetricTU("11", twoHoursAgo),
-            new TestUsageMetricTU("12", now.toString()));
+            new TestUsageMetricTU("10", twoHoursAgo, 1),
+            new TestUsageMetricTU("11", twoHoursAgo, 1),
+            new TestUsageMetricTU("12", twoHoursAgo, -1),
+            new TestUsageMetricTU("14", now.toString(), 1),
+            new TestUsageMetricTU("20", now.toString(), 2),
+            new TestUsageMetricTU("21", twoHoursAgo, 2));
     documents.forEach(doc -> index(usageMetricTUIndex, doc));
     testClient.indices().refresh(r -> r.index(usageMetricTUIndex));
     config.setRolloverBatchSize(5);
@@ -629,7 +641,11 @@ final class OpenSearchArchiverRepositoryIT {
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     final var batch = result.join();
-    assertThat(batch.ids()).containsExactlyInAnyOrder("10", "11");
+    if (partitionId == 1) {
+      assertThat(batch.ids()).containsExactlyInAnyOrder("10", "11", "12");
+    } else {
+      assertThat(batch.ids()).containsExactlyInAnyOrder("21");
+    }
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
 
@@ -908,19 +924,35 @@ final class OpenSearchArchiverRepositoryIT {
 
   // no need to close resource returned here, since the transport is closed above anyway
   private OpenSearchArchiverRepository createRepository() {
+    return createRepository(1);
+  }
+
+  private OpenSearchArchiverRepository createRepository(final int partitionId) {
     final var client = createOpenSearchAsyncClient();
 
     return createRepository(
-        new OpenSearchGenericClient(client._transport(), client._transportOptions()));
+        new OpenSearchGenericClient(client._transport(), client._transportOptions()), partitionId);
   }
 
   private OpenSearchArchiverRepository createRepository(
       final OpenSearchGenericClient genericClient) {
+    return createRepository(genericClient, 1);
+  }
+
+  private OpenSearchArchiverRepository createRepository(
+      final OpenSearchGenericClient genericClient, final int partitionId) {
     final var client = createOpenSearchAsyncClient();
     final var metrics = new CamundaExporterMetrics(meterRegistry);
 
     return new OpenSearchArchiverRepository(
-        1, config, resourceProvider, client, genericClient, Runnable::run, metrics, LOGGER);
+        partitionId,
+        config,
+        resourceProvider,
+        client,
+        genericClient,
+        Runnable::run,
+        metrics,
+        LOGGER);
   }
 
   private void createProcessInstanceIndex() throws IOException {
@@ -1071,9 +1103,10 @@ final class OpenSearchArchiverRepositoryIT {
   private record TestProcessInstance(
       String id, String endDate, String joinRelation, int partitionId) implements TDocument {}
 
-  private record TestUsageMetric(String id, String endTime) implements TDocument {}
+  private record TestUsageMetric(String id, String endTime, int partitionId) implements TDocument {}
 
-  private record TestUsageMetricTU(String id, String endTime) implements TDocument {}
+  private record TestUsageMetricTU(String id, String endTime, int partitionId)
+      implements TDocument {}
 
   private interface TDocument {
     String id();


### PR DESCRIPTION
# Description
Backport of #38863 to `main`.

relates to camunda/camunda#38840