### PR TITLE
[Backport release-8.8.0] fix: add usage metric archiving partition ID handling

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.archiver;
 
 import static io.camunda.search.schema.SchemaManager.PI_ARCHIVING_BLOCKED_META_KEY;
+import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch._types.Conflicts;
@@ -16,6 +17,7 @@ import co.elastic.clients.elasticsearch._types.Slices;
 import co.elastic.clients.elasticsearch._types.SlicesCalculation;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.Time;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery.Builder;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
@@ -135,7 +137,9 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   public CompletableFuture<ArchiveBatch> getUsageMetricNextBatch() {
     final var searchRequest =
         createUsageMetricSearchRequest(
-            usageMetricTemplateDescriptor.getFullQualifiedName(), UsageMetricTemplate.END_TIME);
+            usageMetricTemplateDescriptor.getFullQualifiedName(),
+            UsageMetricTemplate.END_TIME,
+            UsageMetricTemplate.PARTITION_ID);
 
     final var timer = Timer.start();
     return client
@@ -152,7 +156,9 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   public CompletableFuture<ArchiveBatch> getUsageMetricTUNextBatch() {
     final var searchRequest =
         createUsageMetricSearchRequest(
-            usageMetricTUTemplateDescriptor.getFullQualifiedName(), UsageMetricTUTemplate.END_TIME);
+            usageMetricTUTemplateDescriptor.getFullQualifiedName(),
+            UsageMetricTUTemplate.END_TIME,
+            UsageMetricTUTemplate.PARTITION_ID);
 
     final var timer = Timer.start();
     return client
@@ -398,11 +404,26 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   }
 
   private SearchRequest createUsageMetricSearchRequest(
-      final String indexName, final String endTimeField) {
+      final String indexName, final String endTimeField, final String partitionIdField) {
     final var endDateQ =
         QueryBuilders.range(
             q -> q.date(d -> d.field(endTimeField).lte(config.getArchivingTimePoint())));
-    return createSearchRequest(indexName, endDateQ, endTimeField);
+
+    final Builder boolBuilder = QueryBuilders.bool();
+    boolBuilder.must(endDateQ);
+
+    if (partitionId == START_PARTITION_ID) {
+      // Include -1 for migrated documents without partitionId
+      final List<FieldValue> partitionIds = List.of(FieldValue.of(-1), FieldValue.of(partitionId));
+      final var termsQ =
+          QueryBuilders.terms(q -> q.field(partitionIdField).terms(t -> t.value(partitionIds)));
+      boolBuilder.must(termsQ);
+    } else {
+      final var termQ = QueryBuilders.term(q -> q.field(partitionIdField).value(partitionId));
+      boolBuilder.must(termQ);
+    }
+
+    return createSearchRequest(indexName, boolBuilder.build()._toQuery(), endTimeField);
   }
 
   private SearchRequest createSearchRequest(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -462,12 +462,13 @@ final class ElasticsearchArchiverRepositoryIT {
     assertThat(batch.finishDate()).isNull();
   }
 
-  @Test
-  void shouldGetUsageMetricNextBatch() throws IOException {
-    // given - 3 usage metric documents, two older than archive threshold, one recent
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2})
+  void shouldGetUsageMetricNextBatch(final int partitionId) throws IOException {
+    // given
     final var now = Instant.now();
     final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
-    final var repository = createRepository();
+    final var repository = createRepository(partitionId);
     final var usageMetricIndex =
         resourceProvider
             .getIndexTemplateDescriptor(UsageMetricTemplate.class)
@@ -475,9 +476,12 @@ final class ElasticsearchArchiverRepositoryIT {
     createUsageMetricIndex(usageMetricIndex);
     final var documents =
         List.of(
-            new TestUsageMetric("1", twoHoursAgo),
-            new TestUsageMetric("2", twoHoursAgo),
-            new TestUsageMetric("3", now.toString()));
+            new TestUsageMetric("1", twoHoursAgo, 1),
+            new TestUsageMetric("2", twoHoursAgo, 1),
+            new TestUsageMetric("3", twoHoursAgo, -1),
+            new TestUsageMetric("5", now.toString(), 1),
+            new TestUsageMetric("20", now.toString(), 2),
+            new TestUsageMetric("21", twoHoursAgo, 2));
     documents.forEach(doc -> index(usageMetricIndex, doc));
     testClient.indices().refresh(r -> r.index(usageMetricIndex));
     config.setRolloverBatchSize(5);
@@ -490,16 +494,21 @@ final class ElasticsearchArchiverRepositoryIT {
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     final var batch = result.join();
-    assertThat(batch.ids()).containsExactly("1", "2");
+    if (partitionId == 1) {
+      assertThat(batch.ids()).containsExactly("1", "2", "3");
+    } else {
+      assertThat(batch.ids()).containsExactly("21");
+    }
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
 
-  @Test
-  void shouldGetUsageMetricTUNextBatch() throws IOException {
-    // given - 3 usage metric TU documents, two older than archive threshold, one recent
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2})
+  void shouldGetUsageMetricTUNextBatch(final int partitionId) throws IOException {
+    // given
     final var now = Instant.now();
     final var twoHoursAgo = now.minus(Duration.ofHours(2)).toString();
-    final var repository = createRepository();
+    final var repository = createRepository(partitionId);
     final var usageMetricTUIndex =
         resourceProvider
             .getIndexTemplateDescriptor(UsageMetricTUTemplate.class)
@@ -507,9 +516,12 @@ final class ElasticsearchArchiverRepositoryIT {
     createUsageMetricTUIndex(usageMetricTUIndex);
     final var documents =
         List.of(
-            new TestUsageMetricTU("10", twoHoursAgo),
-            new TestUsageMetricTU("11", twoHoursAgo),
-            new TestUsageMetricTU("12", now.toString()));
+            new TestUsageMetricTU("10", twoHoursAgo, 1),
+            new TestUsageMetricTU("11", twoHoursAgo, 1),
+            new TestUsageMetricTU("12", twoHoursAgo, -1),
+            new TestUsageMetricTU("14", now.toString(), 1),
+            new TestUsageMetricTU("20", now.toString(), 2),
+            new TestUsageMetricTU("21", twoHoursAgo, 2));
     documents.forEach(doc -> index(usageMetricTUIndex, doc));
     testClient.indices().refresh(r -> r.index(usageMetricTUIndex));
     config.setRolloverBatchSize(5);
@@ -522,7 +534,11 @@ final class ElasticsearchArchiverRepositoryIT {
         DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
     final var batch = result.join();
-    assertThat(batch.ids()).containsExactly("10", "11");
+    if (partitionId == 1) {
+      assertThat(batch.ids()).containsExactly("10", "11", "12");
+    } else {
+      assertThat(batch.ids()).containsExactly("21");
+    }
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
 
@@ -879,11 +895,22 @@ final class ElasticsearchArchiverRepositoryIT {
     return createRepository(client);
   }
 
+  private ElasticsearchArchiverRepository createRepository(final int partitionId) {
+    final var client = new ElasticsearchAsyncClient(transport);
+
+    return createRepository(client, partitionId);
+  }
+
   private ElasticsearchArchiverRepository createRepository(final ElasticsearchAsyncClient client) {
+    return createRepository(client, 1);
+  }
+
+  private ElasticsearchArchiverRepository createRepository(
+      final ElasticsearchAsyncClient client, final int partitionId) {
     final var metrics = new CamundaExporterMetrics(meterRegistry);
 
     return new ElasticsearchArchiverRepository(
-        1, config, resourceProvider, client, Runnable::run, metrics, LOGGER);
+        partitionId, config, resourceProvider, client, Runnable::run, metrics, LOGGER);
   }
 
   private RestClientTransport createRestClient() {
@@ -990,9 +1017,10 @@ final class ElasticsearchArchiverRepositoryIT {
   private record TestProcessInstance(
       String id, String endDate, String joinRelation, int partitionId) implements TDocument {}
 
-  private record TestUsageMetric(String id, String endTime) implements TDocument {}
+  private record TestUsageMetric(String id, String endTime, int partitionId) implements TDocument {}
 
-  private record TestUsageMetricTU(String id, String endTime) implements TDocument {}
+  private record TestUsageMetricTU(String id, String endTime, int partitionId)
+      implements TDocument {}
 
   private interface TDocument {
     String id();


### PR DESCRIPTION
# Description
Backport of #38863 to `release-8.8.0`.

relates to camunda/camunda#38840