### PR TITLE
fix: expose advanced filters for ProcessDefinitionFilter

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessDefinitionFilter.java
@@ -15,7 +15,9 @@
  */
 package io.camunda.client.api.search.filter;
 
+import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+import java.util.function.Consumer;
 
 public interface ProcessDefinitionFilter extends SearchRequestFilter {
 
@@ -41,6 +43,14 @@ public interface ProcessDefinitionFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   ProcessDefinitionFilter name(final String name);
+
+  /**
+   * Filters process definitions by the specified name using {@link StringProperty} consumer.
+   *
+   * @param fn the name {@link StringProperty} consumer of the process definition
+   * @return the updated filter
+   */
+  ProcessDefinitionFilter name(final Consumer<StringProperty> fn);
 
   /**
    * Filters process definitions by the specified resource name.
@@ -73,6 +83,15 @@ public interface ProcessDefinitionFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   ProcessDefinitionFilter processDefinitionId(final String processDefinitionId);
+
+  /**
+   * Filters process definitions by the specified processDefinitionId using {@link StringProperty}
+   * consumer.
+   *
+   * @param fn the processDefinitionId {@link StringProperty} consumer of the process definition
+   * @return the updated filter
+   */
+  ProcessDefinitionFilter processDefinitionId(final Consumer<StringProperty> fn);
 
   /**
    * Filters process definitions by the specified tenant id.

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
@@ -51,6 +51,14 @@ public class ProcessDefinitionFilterImpl
   }
 
   @Override
+  public ProcessDefinitionFilter name(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setName(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public ProcessDefinitionFilter resourceName(final String resourceName) {
     filter.setResourceName(resourceName);
     return this;
@@ -74,6 +82,14 @@ public class ProcessDefinitionFilterImpl
   }
 
   @Override
+  public ProcessDefinitionFilter processDefinitionId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setProcessDefinitionId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public ProcessDefinitionFilter tenantId(final String tenantId) {
     filter.setTenantId(tenantId);
     return this;
@@ -82,20 +98,6 @@ public class ProcessDefinitionFilterImpl
   @Override
   public ProcessDefinitionFilter hasStartForm(final boolean hasStartForm) {
     filter.hasStartForm(hasStartForm);
-    return this;
-  }
-
-  public ProcessDefinitionFilter name(final Consumer<StringProperty> fn) {
-    final StringProperty property = new StringPropertyImpl();
-    fn.accept(property);
-    filter.setName(provideSearchRequestProperty(property));
-    return this;
-  }
-
-  public ProcessDefinitionFilter processDefinitionId(final Consumer<StringProperty> fn) {
-    final StringProperty property = new StringPropertyImpl();
-    fn.accept(property);
-    filter.setProcessDefinitionId(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessDefinitionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessDefinitionTest.java
@@ -103,11 +103,11 @@ public class QueryProcessDefinitionTest extends ClientRestTest {
         .filter(
             f ->
                 f.processDefinitionKey(5L)
-                    .name("Order process")
+                    .name(sp -> sp.eq("Order process"))
                     .resourceName("usertest/complex-process.bpmn")
                     .version(2)
                     .versionTag("alpha")
-                    .processDefinitionId("orderProcess")
+                    .processDefinitionId(sp -> sp.eq("orderProcess"))
                     .tenantId("<default>"))
         .send()
         .join();


### PR DESCRIPTION
## Description

The `name` and `processDefinitionId` fields actually support advanced filters see [API docs](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/search-process-definitions/).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38780 
