### PR TITLE
fix: send a request to all partitions before marking scaling as completed

### DIFF
--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/scaling/GetScaleUpProgress.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/scaling/GetScaleUpProgress.java
@@ -24,6 +24,11 @@ public class GetScaleUpProgress extends BrokerExecuteCommand<ScaleRecord> {
     setPartitionId(Protocol.DEPLOYMENT_PARTITION);
   }
 
+  public GetScaleUpProgress(final int partitionId) {
+    super(ValueType.SCALE, ScaleIntent.STATUS);
+    setPartitionId(partitionId);
+  }
+
   @Override
   public BufferWriter getRequestWriter() {
     return requestDto;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import java.util.Set;
 
 public class WhiteListedCommands {
@@ -25,6 +26,7 @@ public class WhiteListedCommands {
           DeploymentIntent.CREATE,
           DeploymentIntent.DISTRIBUTE,
           DeploymentDistributionIntent.COMPLETE,
+          ScaleIntent.STATUS,
           CommandDistributionIntent.ACKNOWLEDGE);
 
   public static boolean isWhitelisted(final Intent intent) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -514,7 +514,7 @@ public class ScaleUpPartitionsTest {
     final var scalingTimeMs = afterScaling.toEpochMilli() - beforeScaling.toEpochMilli();
     LOG.info("Scaling took {}", Duration.ofMillis(scalingTimeMs));
 
-    assertThat(scalingTimeMs).isLessThan(30_000);
+    assertThat(scalingTimeMs).isLessThan(40_000);
   }
 
   public void assertThatRoutingStateMatches(final RoutingState routingState) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -105,6 +105,11 @@ public class ScaleUpPartitionsTest {
                                 .getMembership()
                                 .setSyncInterval(Duration.ofSeconds(1))
                                 .setGossipInterval(Duration.ofMillis(500));
+
+                            final var engineDistribution =
+                                bb.getExperimental().getEngine().getDistribution();
+                            engineDistribution.setMaxBackoffDuration(Duration.ofSeconds(1));
+                            engineDistribution.setRedistributionInterval(Duration.ofMillis(200));
                           }))
           .build();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -393,14 +393,7 @@ public class ScaleUpPartitionsTest {
 
     final var routingStateAfterScaling = clusterActuator.getTopology().getRouting();
 
-    // TODO: Remove awaitility after fixing the bug https://github.com/camunda/camunda/issues/37004
-    Awaitility.await()
-        .atMost(Duration.ofMinutes(1))
-        .pollInterval(Duration.ofSeconds(10))
-        .untilAsserted(
-            () ->
-                assertThatNoException()
-                    .isThrownBy(() -> backupActuator.take(backupId.incrementAndGet())));
+    assertThatNoException().isThrownBy(() -> backupActuator.take(backupId.incrementAndGet()));
 
     final var successfulBackupId = backupId.get();
     assertBackupIsCompleted(successfulBackupId);

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/future/CompletableActorFutureTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/future/CompletableActorFutureTest.java
@@ -10,12 +10,12 @@ package io.camunda.zeebe.scheduler.future;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,22 +42,19 @@ public class CompletableActorFutureTest {
     public void shouldRunAllFuturesSequentially() {
       // given
       final var count = 1000;
-      final var map = new CopyOnWriteArrayList<>();
-      final var elements = new ArrayList<Integer>(count);
-      for (int i = 0; i < count; i++) {
-        elements.add(i);
-      }
+      final var list = new ArrayBlockingQueue<>(count);
+      final var elements = IntStream.range(0, count).boxed().toList();
       // when
       CompletableActorFuture.traverseIgnoring(
               elements,
               i -> {
-                map.add(i);
+                list.add(i);
                 return CompletableActorFuture.completed();
               },
               EXECUTOR)
           .join();
       // then
-      assertThat(map).containsExactlyElementsOf(elements);
+      assertThat(list).containsExactlyElementsOf(elements);
     }
 
     @Test

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/future/CompletableActorFutureTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/future/CompletableActorFutureTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.scheduler.future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class CompletableActorFutureTest {
+
+  @AutoClose private static final ExecutorService EXECUTOR = Executors.newWorkStealingPool();
+
+  @Nested
+  class TraverseIgnoring {
+    @Test
+    public void shouldReturnCompletedFutureWhenCollectionIsEmpty() {
+      assertThat(
+              CompletableActorFuture.traverseIgnoring(
+                  List.of(),
+                  a ->
+                      CompletableActorFuture.<Void>completedExceptionally(
+                          new RuntimeException("Expected")),
+                  EXECUTOR))
+          .isDone();
+    }
+
+    @Test
+    public void shouldRunAllFuturesSequentially() {
+      // given
+      final var count = 1000;
+      final var map = new CopyOnWriteArrayList<>();
+      final var elements = new ArrayList<Integer>(count);
+      for (int i = 0; i < count; i++) {
+        elements.add(i);
+      }
+      // when
+      CompletableActorFuture.traverseIgnoring(
+              elements,
+              i -> {
+                map.add(i);
+                return CompletableActorFuture.completed();
+              },
+              EXECUTOR)
+          .join();
+      // then
+      assertThat(map).containsExactlyElementsOf(elements);
+    }
+
+    @Test
+    public void shouldStopAndReturnErrorIfAFutureFails() {
+      // given
+      final var map = new ConcurrentHashMap<>();
+      // when
+      final var future =
+          CompletableActorFuture.traverseIgnoring(
+              List.of(1, 2, 3),
+              i -> {
+                if (i % 2 == 0) {
+                  return CompletableActorFuture.completedExceptionally(
+                      new RuntimeException("Expected"));
+                }
+                map.put(i, i);
+                return CompletableActorFuture.completed();
+              },
+              EXECUTOR);
+      // then
+      assertThat(future)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableThat()
+          .withMessageContaining("Expected");
+      // does not contain 3 as the computation is not spawned
+      assertThat(map.keySet()).containsExactly(1);
+    }
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/concurrent/FuturesUtilTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/concurrent/FuturesUtilTest.java
@@ -76,7 +76,7 @@ public class FuturesUtilTest {
   }
 
   @Nested
-  class ParTraversse {
+  class ParTraverse {
 
     @Test
     public void shouldReturnCompletedFutureWhenCollectionIsEmpty() {


### PR DESCRIPTION
## Description

To avoid having a partition not being aware of the new partitions, check
that the routing state is up to date in all partitions.

Start from Protocol.DEPLOYMENT_PARTITION and stop with the newly started
partitions.
The requests are sent one at a time, following the partitionId order, so
that the first partition is invoked first.
If the first partition is not ready yet, requests to other partitions
are not sent.

### New api in `CompletableActorFuture`

`CompletableActorFuture.traverseIgnoring` has been added, following what's already available in `FuturesUtil` for `java.util.concurrent.CompletableFuture`. 

However, it's not easy to port this functionality to `ActorFuture` since it's a static method.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #37004 
