### PR TITLE
[Backport stable/8.8] fix: PVC panel in zeebe's dashboard was not matching against renamed PVC

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -6964,9 +6964,9 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "(kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*zeebe.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*zeebe.*\"})",
+              "expr": "(kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*zeebe.*|.*camunda.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*zeebe.*|.*camunda.*\"})",
               "legendFormat": "{{persistentvolumeclaim}}",
-              "refId": "B"
+              "refId": "A"
             }
           ],
           "title": "PVC Disk Usage",


### PR DESCRIPTION
# Description
Backport of #38845 to `stable/8.8`.

relates to 