### PR TITLE
fix: copy rest-api.yaml from gateway-protocol

### DIFF
--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -434,6 +434,31 @@
 
   <build>
     <plugins>
+      <!-- Copy rest-api.yaml from gateway-protocol to classpath -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-openapi-spec</id>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${openapi.dir}</directory>
+                  <includes>
+                    <include>rest-api.yaml</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>


### PR DESCRIPTION
## Description

When running zeebe image in SaaS, `rest-api.yaml` file is not available in the classpath which results in "java.io.FileNotFoundException: class path resource [rest-api.yaml] cannot be opened because it does not exist" error log.

This happens because the openAPI spec is only in `gateway-protocol` module and it seems like the SaaS deployment doesn't include `rest-api.yaml` in the JAR.

I'm fixing this by doing a "copy-resource" maven step so we don't rely on transitive dependency packaging.

This causes the SaaS spec to be formatted differently. In SaaS the resources are kebab-cased and not alphabetically ordered.

## SaaS
<img width="1525" height="724" alt="Screenshot 2568-09-30 at 09 58 17" src="https://github.com/user-attachments/assets/20f0063e-6005-4497-895f-c7b5613c823d" />

## SM
<img width="1516" height="795" alt="Screenshot 2568-09-30 at 09 58 03" src="https://github.com/user-attachments/assets/7acd5820-79a7-439a-9e54-871d3a270cae" />

## Related issues

related to #38875
