### PR TITLE
fix: remove exporter="elasticsearch" in Number of records not exported dashboard

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -2417,7 +2417,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max (zeebe_log_appender_last_committed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}) by (partition) - max (zeebe_exporter_last_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", exporter=\"elasticsearch\"}) by (partition)",
+              "expr": "max (zeebe_log_appender_last_committed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}) by (partition) - max (zeebe_exporter_last_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}) by (partition)",
               "format": "time_series",
               "instant": false,
               "interval": "",


### PR DESCRIPTION
## Description
Exporter tag is not present anymore in the metrics: it was removed from the numerator, but not from the denominator

