### PR TITLE
feat: use dns name resolution & round_robin load balancing policy in client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -429,14 +429,15 @@ public final class CamundaClientImpl implements CamundaClient {
     final URI address;
     address = config.getGrpcAddress();
 
-    final NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forAddress(address.getHost(), address.getPort());
+    final String target = String.format("dns:///%s:%d", address.getHost(), address.getPort());
+    final NettyChannelBuilder channelBuilder = NettyChannelBuilder.forTarget(target);
 
     configureConnectionSecurity(config, channelBuilder);
     channelBuilder.keepAliveTime(config.getKeepAlive().toMillis(), TimeUnit.MILLISECONDS);
     channelBuilder.userAgent("camunda-client-java/" + VersionUtil.getVersion());
     channelBuilder.maxInboundMessageSize(config.getMaxMessageSize());
     channelBuilder.maxInboundMetadataSize(config.getMaxMetadataSize());
+    channelBuilder.defaultLoadBalancingPolicy("round_robin");
 
     if (config.useDefaultRetryPolicy()) {
       final Map<String, Object> serviceConfig = defaultServiceConfig();


### PR DESCRIPTION
## Description
With these changes, the java client will leverage gRPC `round_robin` load balancing policy, using the nodes from the DNS query.

We should probably make this configurable so that the end user can choose the appropriate load balancing policy, depending on their use cases.

Note that for this to work in k8s, the gateway service must be configured as headless, otherwise only a single IP is returned from the DNS query.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #9870
