### PR TITLE
ci: only add-to-project when issue labeled explicitly

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -113,14 +113,13 @@ jobs:
           github.event.action != 'labeled'
             || github.event.label.name == 'component/build-pipeline'
             || github.event.label.name == 'component/release'
-            || github.event.label.name == 'area/build'
         name: Add to Monorepo DevOps Team project
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/camunda/projects/115
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           # any of the following labels:
-          labeled: component/build-pipeline, component/release, area/build
+          labeled: component/build-pipeline, component/release
 
       - id: add-to-camunda-ex
         if: >

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -13,41 +13,55 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: add-to-zdp
+        if: github.event.action != 'labeled' || github.event.label.name == 'component/zeebe'
         name: Add to ZDP project
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/camunda/projects/92
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/zeebe
+
       - id: add-operate-to-core-features
+        if: github.event.action != 'labeled' || github.event.label.name == 'component/operate'
         name: Add Operate issues to Core Features project
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/camunda/projects/173
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/operate
+
       - id: add-tasklist-to-core-features
+        if: github.event.action != 'labeled' || github.event.label.name == 'component/tasklist'
         name: Add Tasklist issues to Core Features project
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/camunda/projects/173
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/tasklist
+
       - id: add-optimize-to-core-features
+        if: github.event.action != 'labeled' || github.event.label.name == 'component/optimize'
         name: Add Optimize issues to Core Features project
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/camunda/projects/173
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/optimize
+
       - id: add-to-data-layer
+        if: github.event.action != 'labeled' || github.event.label.name == 'component/data-layer'
         name: Add to Data Layer project
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/camunda/projects/184
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/data-layer
+
       - id: add-to-api
+        if: >
+          github.event.action != 'labeled' ||
+            (github.event.label.name == 'component/c8-api'
+              && github.event.label.name == 'kind/proposal')
         name: Add to C8 Rest API Proposals
         uses: actions/add-to-project@v1.0.2
         with:
@@ -55,14 +69,21 @@ jobs:
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/c8-api, kind/proposal
           label-operator: AND
+
       - id: add-to-connectors
+        if: github.event.action != 'labeled' || github.event.label.name == 'component/connectors'
         name: Add to Connectors project
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/camunda/projects/23
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/connectors
+
       - id: add-to-identity
+        if: >
+          github.event.action != 'labeled'
+            || github.event.label.name == 'component/identity'
+            || github.event.label.name == 'component/management-identity'
         name: Add to Identity project
         uses: actions/add-to-project@v1.0.2
         with:
@@ -70,20 +91,29 @@ jobs:
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/identity, component/management-identity
       - id: add-to-distribution
+        if: github.event.action != 'labeled' || github.event.label.name == 'component/c8run'
         name: Add to Distribution Team project
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/camunda/projects/33
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/c8run
+
       - id: add-to-feel
+        if: github.event.action != 'labeled' || github.event.label.name == 'component/feel-js'
         name: Add to Feel Team project
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/camunda/projects/79
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/feel-js
+
       - id: add-to-devops
+        if: >
+          github.event.action != 'labeled'
+            || github.event.label.name == 'component/build-pipeline'
+            || github.event.label.name == 'component/release'
+            || github.event.label.name == 'area/build'
         name: Add to Monorepo DevOps Team project
         uses: actions/add-to-project@v1.0.2
         with:
@@ -91,7 +121,14 @@ jobs:
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           # any of the following labels:
           labeled: component/build-pipeline, component/release, area/build
+
       - id: add-to-camunda-ex
+        if: >
+          github.event.action != 'labeled'
+            || github.event.label.name == 'component/clients'
+            || github.event.label.name == 'component/spring-boot-starter'
+            || github.event.label.name == 'component/camunda-process-test'
+            || github.event.label.name == 'component/c8-api'
         name: Add to CamundaEx Team project
         uses: actions/add-to-project@v1.0.2
         with:
@@ -99,10 +136,12 @@ jobs:
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           # any of the following labels:
           labeled: component/clients, component/spring-boot-starter, component/camunda-process-test, component/c8-api
+
       - id: add-bug-to-quality-board
+        if: github.event.action != 'labeled' || github.event.label.name == 'kind/bug'
         name: Add issue to Quality Board
         uses: camunda/infra-global-github-actions/add-bug-to-quality-board@main
         with:
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           project-number: "187"
-        if: contains(github.event.issue.labels.*.name, 'kind/bug')
+          labeled: kind/bug


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Previously this workflow would add the issue to a particular project on the labeled event if the issue already had the needed label but the newly added label was actually a different one.

This led to annoying interactions if the issue should not be part of a particular project, where the workflow would re-add the issue to the project and the user then has to remove it again.

We can restrict these runs to the following:
- if event is not labeled (then it was just reopened or transferred)
- otherwise if it was explicitly labeled

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38919
