### PR TITLE
[Backport release-8.8.0] fix: reserve latest snapshot as soon as possible

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -111,8 +111,8 @@ final class BackupServiceImpl {
       case DOES_NOT_EXIST ->
           inProgressBackup
               .findValidSnapshot()
-              .andThen(inProgressBackup::findSegmentFiles, concurrencyControl)
               .andThen(ok -> inProgressBackup.reserveSnapshot(), concurrencyControl)
+              .andThen(inProgressBackup::findSegmentFiles, concurrencyControl)
               .andThen(ok -> inProgressBackup.findSnapshotFiles(), concurrencyControl)
               .onComplete(
                   (result, error) -> {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -180,12 +180,8 @@ final class InProgressBackupImpl implements InProgressBackup {
     final ActorFuture<Void> filesCollected = concurrencyControl.createFuture();
     try {
       long maxIndex = 0L;
-      if (availableValidSnapshots != null) {
-        maxIndex =
-            availableValidSnapshots.stream()
-                .mapToLong(PersistedSnapshot::getIndex)
-                .max()
-                .orElse(0L);
+      if (reservedSnapshot != null) {
+        maxIndex = reservedSnapshot.getIndex();
       }
       final var segments = journalInfoProvider.getTailSegments(maxIndex);
       segments.whenComplete(


### PR DESCRIPTION
# Description
Backport of #38882 to `release-8.8.0`.

relates to #33499