### PR TITLE
fix: lower log level of CsrfProtectionRequestMatcher

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
+++ b/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
@@ -37,7 +37,7 @@ public class CsrfProtectionRequestMatcher implements RequestMatcher {
     allowedPaths.add(WebSecurityConfig.LOGIN_URL);
     allowedPaths.add(WebSecurityConfig.LOGOUT_URL);
     allowedPathsPattern = allowedPathsToPattern(allowedPaths);
-    LOG.info("CSRF protection configuration - allowed paths pattern: {}", allowedPathsPattern);
+    LOG.debug("CSRF protection configuration - allowed paths pattern: {}", allowedPathsPattern);
   }
 
   @Override


### PR DESCRIPTION
## Description

Reduce the log level of  `CsrfProtectionRequestMatcher` from `info` to `debug` in accordance with <https://github.com/camunda/camunda/blob/main/docs/observability/logging.md#levels> as the statement in question provides additional context during application start)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35621 
