### PR TITLE
refactor: Introduce intermediate classes for ES/OS properties

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -11,7 +11,7 @@ import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilit
 import java.util.Map;
 import java.util.Set;
 
-public class History {
+public class DocumentBasedHistory {
 
   private static final boolean DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED = true;
 
@@ -24,7 +24,7 @@ public class History {
 
   private boolean processInstanceEnabled = DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED;
 
-  public History(final String databaseName) {
+  public DocumentBasedHistory(final String databaseName) {
     prefix = "camunda.data.secondary-storage.%s.history".formatted(databaseName);
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+public abstract class DocumentBasedSecondaryStorageDatabase
+    extends SecondaryStorageDatabase<DocumentBasedHistory> {
+
+  /** Prefix to apply to the indexes. */
+  private String indexPrefix = "";
+
+  /** Name of the cluster */
+  private String clusterName = databaseName().toLowerCase();
+
+  /** How many shards Elasticsearch uses for all Tasklist indices. */
+  private int numberOfShards = 1;
+
+  @NestedConfigurationProperty private Security security = new Security(databaseName());
+
+  @NestedConfigurationProperty
+  private DocumentBasedHistory history = new DocumentBasedHistory(databaseName());
+
+  @Override
+  public String getUrl() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".url",
+        super.getUrl(),
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyUrlProperties());
+  }
+
+  @Override
+  public String getUsername() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".username",
+        super.getUsername(),
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyUsernameProperties());
+  }
+
+  @Override
+  public String getPassword() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".password",
+        super.getPassword(),
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyPasswordProperties());
+  }
+
+  @Override
+  public DocumentBasedHistory getHistory() {
+    return history;
+  }
+
+  @Override
+  public void setHistory(final DocumentBasedHistory history) {
+    this.history = history;
+  }
+
+  @Override
+  protected abstract String databaseName();
+
+  public Security getSecurity() {
+    return security;
+  }
+
+  public void setSecurity(final Security security) {
+    this.security = security;
+  }
+
+  public String getClusterName() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".cluster-name",
+        clusterName,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyClusterNameProperties());
+  }
+
+  public void setClusterName(final String clusterName) {
+    this.clusterName = clusterName;
+  }
+
+  public String getIndexPrefix() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".index-prefix",
+        indexPrefix,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        indexPrefixLegacyProperties());
+  }
+
+  public void setIndexPrefix(final String indexPrefix) {
+    this.indexPrefix = indexPrefix;
+  }
+
+  public int getNumberOfShards() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix() + ".number-of-shards",
+        numberOfShards,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        legacyNumberOfShardsProperties());
+  }
+
+  public void setNumberOfShards(final int numberOfShards) {
+    this.numberOfShards = numberOfShards;
+  }
+
+  private String prefix() {
+    return "camunda.data.secondary-storage." + databaseName().toLowerCase();
+  }
+
+  private Set<String> legacyUrlProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.url",
+        "camunda.operate." + dbName + ".url",
+        "camunda.tasklist." + dbName + ".url",
+        "zeebe.broker.exporters.camundaexporter.args.connect.url");
+  }
+
+  private Set<String> legacyClusterNameProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.clusterName",
+        "camunda.operate." + dbName + ".clusterName",
+        "camunda.tasklist." + dbName + ".clusterName",
+        "zeebe.broker.exporters.camundaexporter.args.connect.clusterName");
+  }
+
+  private Set<String> legacyUsernameProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.username",
+        "camunda.operate." + dbName + ".username",
+        "camunda.tasklist." + dbName + ".username",
+        "zeebe.broker.exporters.camundaexporter.args.connect.username");
+  }
+
+  private Set<String> legacyPasswordProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.password",
+        "camunda.operate." + dbName + ".password",
+        "camunda.tasklist." + dbName + ".password",
+        "zeebe.broker.exporters.camundaexporter.args.connect.password");
+  }
+
+  private Set<String> indexPrefixLegacyProperties() {
+    final String dbName = databaseName().toLowerCase();
+    return Set.of(
+        "camunda.database.indexPrefix",
+        "camunda.tasklist." + dbName + ".indexPrefix",
+        "camunda.operate." + dbName + ".indexPrefix",
+        "zeebe.broker.exporters.camundaexporter.args.index.indexPrefix");
+  }
+
+  private Set<String> legacyNumberOfShardsProperties() {
+    return Set.of(
+        "camunda.database.index.numberOfShards",
+        "zeebe.broker.exporters.camundaexporter.args.index.numberOfShards");
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Elasticsearch.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.configuration;
 
-public class Elasticsearch extends SecondaryStorageDatabase {
+public class Elasticsearch extends DocumentBasedSecondaryStorageDatabase {
 
   @Override
   protected String databaseName() {

--- a/configuration/src/main/java/io/camunda/configuration/Opensearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Opensearch.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.configuration;
 
-public class Opensearch extends SecondaryStorageDatabase {
+public class Opensearch extends DocumentBasedSecondaryStorageDatabase {
 
   @Override
   protected String databaseName() {

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
@@ -7,21 +7,18 @@
  */
 package io.camunda.configuration;
 
-import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
-import java.util.Set;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
-
-public abstract class SecondaryStorageDatabase {
+/**
+ * Base class for configuration of databases used as secondary storage.
+ *
+ * <p>Note: For now there only is support for document-based databases, but in the future also
+ * relational databases will be supported.
+ *
+ * @param <T> the type of history configuration this database supports.
+ */
+public abstract class SecondaryStorageDatabase<T> {
 
   /** Endpoint for the database configured as secondary storage. */
   private String url = "http://localhost:9200";
-
-  /** Name of the cluster */
-  private String clusterName = databaseName().toLowerCase();
-
-  @NestedConfigurationProperty private Security security = new Security(databaseName());
-
-  @NestedConfigurationProperty private History history = new History(databaseName());
 
   /** Username for the database configured as secondary storage. */
   private String username = "";
@@ -29,19 +26,8 @@ public abstract class SecondaryStorageDatabase {
   /** Password for the database configured as secondary storage. */
   private String password = "";
 
-  /** Prefix to apply to the indexes. */
-  private String indexPrefix = "";
-
-  /** How many shards Elasticsearch uses for all Tasklist indices. */
-  private int numberOfShards = 1;
-
   public String getUrl() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        prefix() + ".url",
-        url,
-        String.class,
-        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
-        legacyUrlProperties());
+    return url;
   }
 
   public void setUrl(final String url) {
@@ -49,12 +35,7 @@ public abstract class SecondaryStorageDatabase {
   }
 
   public String getUsername() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        prefix() + ".username",
-        username,
-        String.class,
-        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
-        legacyUsernameProperties());
+    return username;
   }
 
   public void setUsername(final String username) {
@@ -62,126 +43,19 @@ public abstract class SecondaryStorageDatabase {
   }
 
   public String getPassword() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        prefix() + ".password",
-        password,
-        String.class,
-        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
-        legacyPasswordProperties());
+    return password;
   }
 
   public void setPassword(final String password) {
     this.password = password;
   }
 
-  public Security getSecurity() {
-    return security;
-  }
+  public abstract T getHistory();
 
-  public void setSecurity(final Security security) {
-    this.security = security;
-  }
-
-  public String getClusterName() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        prefix() + ".cluster-name",
-        clusterName,
-        String.class,
-        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
-        legacyClusterNameProperties());
-  }
-
-  public void setClusterName(final String clusterName) {
-    this.clusterName = clusterName;
-  }
-
-  public String getIndexPrefix() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        prefix() + ".index-prefix",
-        indexPrefix,
-        String.class,
-        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
-        indexPrefixLegacyProperties());
-  }
-
-  public void setIndexPrefix(final String indexPrefix) {
-    this.indexPrefix = indexPrefix;
-  }
-
-  public int getNumberOfShards() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
-        prefix() + ".number-of-shards",
-        numberOfShards,
-        Integer.class,
-        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
-        legacyNumberOfShardsProperties());
-  }
-
-  public void setNumberOfShards(final int numberOfShards) {
-    this.numberOfShards = numberOfShards;
-  }
-
-  public History getHistory() {
-    return history;
-  }
-
-  public void setHistory(final History history) {
-    this.history = history;
-  }
+  public abstract void setHistory(final T history);
 
   private String prefix() {
     return "camunda.data.secondary-storage." + databaseName().toLowerCase();
-  }
-
-  private Set<String> legacyUrlProperties() {
-    final String dbName = databaseName().toLowerCase();
-    return Set.of(
-        "camunda.database.url",
-        "camunda.operate." + dbName + ".url",
-        "camunda.tasklist." + dbName + ".url",
-        "zeebe.broker.exporters.camundaexporter.args.connect.url");
-  }
-
-  private Set<String> legacyClusterNameProperties() {
-    final String dbName = databaseName().toLowerCase();
-    return Set.of(
-        "camunda.database.clusterName",
-        "camunda.operate." + dbName + ".clusterName",
-        "camunda.tasklist." + dbName + ".clusterName",
-        "zeebe.broker.exporters.camundaexporter.args.connect.clusterName");
-  }
-
-  private Set<String> legacyUsernameProperties() {
-    final String dbName = databaseName().toLowerCase();
-    return Set.of(
-        "camunda.database.username",
-        "camunda.operate." + dbName + ".username",
-        "camunda.tasklist." + dbName + ".username",
-        "zeebe.broker.exporters.camundaexporter.args.connect.username");
-  }
-
-  private Set<String> legacyPasswordProperties() {
-    final String dbName = databaseName().toLowerCase();
-    return Set.of(
-        "camunda.database.password",
-        "camunda.operate." + dbName + ".password",
-        "camunda.tasklist." + dbName + ".password",
-        "zeebe.broker.exporters.camundaexporter.args.connect.password");
-  }
-
-  private Set<String> indexPrefixLegacyProperties() {
-    final String dbName = databaseName().toLowerCase();
-    return Set.of(
-        "camunda.database.indexPrefix",
-        "camunda.tasklist." + dbName + ".indexPrefix",
-        "camunda.operate." + dbName + ".indexPrefix",
-        "zeebe.broker.exporters.camundaexporter.args.index.indexPrefix");
-  }
-
-  private Set<String> legacyNumberOfShardsProperties() {
-    return Set.of(
-        "camunda.database.index.numberOfShards",
-        "zeebe.broker.exporters.camundaexporter.args.index.numberOfShards");
   }
 
   protected abstract String databaseName();

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -11,6 +11,8 @@ import io.camunda.configuration.Azure;
 import io.camunda.configuration.Backup;
 import io.camunda.configuration.CommandApi;
 import io.camunda.configuration.Data;
+import io.camunda.configuration.DocumentBasedHistory;
+import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.Export;
 import io.camunda.configuration.Filesystem;
 import io.camunda.configuration.Filter;
@@ -24,7 +26,6 @@ import io.camunda.configuration.S3;
 import io.camunda.configuration.SasToken;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.configuration.SecondaryStorageDatabase;
 import io.camunda.configuration.Ssl;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.BrokerBasedProperties;
@@ -518,7 +519,7 @@ public class BrokerBasedPropertiesOverride {
       return;
     }
 
-    final SecondaryStorageDatabase database;
+    final DocumentBasedSecondaryStorageDatabase database;
     if (SecondaryStorageType.elasticsearch == secondaryStorage.getType()) {
       database =
           unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getElasticsearch();
@@ -567,7 +568,9 @@ public class BrokerBasedPropertiesOverride {
     setArg(args, "index.numberOfShards", database.getNumberOfShards());
 
     setArg(
-        args, "history.processInstanceEnabled", database.getHistory().isProcessInstanceEnabled());
+        args,
+        "history.processInstanceEnabled",
+        ((DocumentBasedHistory) database.getHistory()).isProcessInstanceEnabled());
   }
 
   @SuppressWarnings("unchecked")

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.configuration.SecondaryStorageDatabase;
 import io.camunda.configuration.Security;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.LegacySearchEngineConnectProperties;
@@ -51,7 +51,7 @@ public class SearchEngineConnectPropertiesOverride {
     final SecondaryStorage secondaryStorage =
         unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
 
-    final SecondaryStorageDatabase database =
+    final DocumentBasedSecondaryStorageDatabase database =
         (secondaryStorage.getType() == SecondaryStorageType.elasticsearch)
             ? secondaryStorage.getElasticsearch()
             : secondaryStorage.getOpensearch();

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.configuration.SecondaryStorageDatabase;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.LegacySearchEngineIndexProperties;
 import io.camunda.configuration.beans.SearchEngineIndexProperties;
@@ -50,7 +50,7 @@ public class SearchEngineIndexPropertiesOverride {
     final SecondaryStorage secondaryStorage =
         unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
 
-    final SecondaryStorageDatabase database =
+    final DocumentBasedSecondaryStorageDatabase database =
         (secondaryStorage.getType() == SecondaryStorageType.elasticsearch)
             ? secondaryStorage.getElasticsearch()
             : secondaryStorage.getOpensearch();


### PR DESCRIPTION
## Description

* Introduce intermediate classes to hold properties which are specific to document based secondary storages (like Elasticsearch/Opensearch)
* This will make it easier to integrate RDBMS as a secondary storage in the next step

## Related issues

Part of #37905
