### PR TITLE
fix: add missing default value for grpc address in unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Grpc.java
+++ b/configuration/src/main/java/io/camunda/configuration/Grpc.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_HOST;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_MANAGEMENT_THREADS;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_PORT;
 
@@ -35,7 +36,7 @@ public class Grpc {
   private Map<String, String> legacyPropertiesMap = LEGACY_BROKER_PROPERTIES;
 
   /** Sets the address the gateway binds to */
-  private String address;
+  private String address = DEFAULT_HOST;
 
   /** Sets the port the gateway binds to */
   private int port = DEFAULT_PORT;

--- a/configuration/src/test/java/io/camunda/configuration/ApiGrpcBrokerPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiGrpcBrokerPropertiesTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_HOST;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_MANAGEMENT_THREADS;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,7 +86,7 @@ public class ApiGrpcBrokerPropertiesTest {
 
     @Test
     void shouldNotSetAddressFromLegacyGatewayNetwork() {
-      assertThat(brokerCfg.getGateway().getNetwork().getHost()).isNull();
+      assertThat(brokerCfg.getGateway().getNetwork().getHost()).isEqualTo(DEFAULT_HOST);
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/ApiGrpcGatewayPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiGrpcGatewayPropertiesTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_HOST;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_MANAGEMENT_THREADS;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,7 +82,7 @@ public class ApiGrpcGatewayPropertiesTest {
 
     @Test
     void shouldNotSetAddressFromLegacyBrokerNetwork() {
-      assertThat(gatewayCfg.getNetwork().getHost()).isNull();
+      assertThat(gatewayCfg.getNetwork().getHost()).isEqualTo(DEFAULT_HOST);
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR adds the missing default value for the unified configuration property camunda.api.grpc.address.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
