### PR TITLE
[Backport stable/8.8] fix: add missing default value for grpc address in unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Grpc.java
+++ b/configuration/src/main/java/io/camunda/configuration/Grpc.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_HOST;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_MANAGEMENT_THREADS;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_PORT;
 
@@ -38,7 +39,7 @@ public class Grpc {
   private Map<String, String> legacyPropertiesMap = LEGACY_BROKER_PROPERTIES;
 
   /** Sets the address the gateway binds to */
-  private String address;
+  private String address = DEFAULT_HOST;
 
   /** Sets the port the gateway binds to */
   private int port = DEFAULT_PORT;

--- a/configuration/src/test/java/io/camunda/configuration/ApiGrpcBrokerPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiGrpcBrokerPropertiesTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_HOST;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_MANAGEMENT_THREADS;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -91,7 +92,7 @@ public class ApiGrpcBrokerPropertiesTest {
 
     @Test
     void shouldNotSetAddressFromLegacyGatewayNetwork() {
-      assertThat(brokerCfg.getGateway().getNetwork().getHost()).isNull();
+      assertThat(brokerCfg.getGateway().getNetwork().getHost()).isEqualTo(DEFAULT_HOST);
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/ApiGrpcGatewayPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ApiGrpcGatewayPropertiesTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_HOST;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_MANAGEMENT_THREADS;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,7 +89,7 @@ public class ApiGrpcGatewayPropertiesTest {
 
     @Test
     void shouldNotSetAddressFromLegacyBrokerNetwork() {
-      assertThat(gatewayCfg.getNetwork().getHost()).isNull();
+      assertThat(gatewayCfg.getNetwork().getHost()).isEqualTo(DEFAULT_HOST);
     }
 
     @Test


### PR DESCRIPTION
# Description
Backport of #38944 to `stable/8.8`.

relates to 