### PR TITLE
fix: replace reflection methods with basic equals and hashCode

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/metrics/MetricResponseDto.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/metrics/MetricResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.metrics;
 
 import io.micrometer.core.instrument.Statistic;
 import java.util.List;
+import java.util.Objects;
 
 public class MetricResponseDto {
 
@@ -65,13 +66,21 @@ public class MetricResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MetricResponseDto that = (MetricResponseDto) o;
+    return Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(baseUnit, that.baseUnit)
+        && Objects.equals(measurements, that.measurements)
+        && Objects.equals(availableTags, that.availableTags);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(name, description, baseUnit, measurements, availableTags);
   }
 
   @Override
@@ -117,13 +126,17 @@ public class MetricResponseDto {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final StatisticDto that = (StatisticDto) o;
+      return statistic == that.statistic && Objects.equals(value, that.value);
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(statistic, value);
     }
 
     @Override
@@ -164,13 +177,17 @@ public class MetricResponseDto {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final TagDto tagDto = (TagDto) o;
+      return Objects.equals(tag, tagDto.tag) && Objects.equals(values, tagDto.values);
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(tag, values);
     }
 
     @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/AuthenticationResultDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/AuthenticationResultDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.engine;
 
+import java.util.Objects;
+
 public class AuthenticationResultDto {
 
   private String authenticatedUser;
@@ -65,12 +67,22 @@ public class AuthenticationResultDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(authenticatedUser, isAuthenticated, engineAlias, errorMessage);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AuthenticationResultDto that = (AuthenticationResultDto) o;
+    return isAuthenticated == that.isAuthenticated
+        && Objects.equals(authenticatedUser, that.authenticatedUser)
+        && Objects.equals(engineAlias, that.engineAlias)
+        && Objects.equals(errorMessage, that.errorMessage);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/CountDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/CountDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.engine;
 
+import java.util.Objects;
+
 public class CountDto {
 
   protected long count;
@@ -27,12 +29,19 @@ public class CountDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(count);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CountDto that = (CountDto) o;
+    return count == that.count;
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/CredentialsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/CredentialsDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.engine;
 
+import java.util.Objects;
+
 public class CredentialsDto {
 
   protected String username;
@@ -36,12 +38,19 @@ public class CredentialsDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(username, password);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CredentialsDto that = (CredentialsDto) o;
+    return Objects.equals(username, that.username) && Objects.equals(password, that.password);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/EngineGroupDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/EngineGroupDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.engine;
 
+import java.util.Objects;
+
 public class EngineGroupDto {
 
   private String id;
@@ -45,12 +47,21 @@ public class EngineGroupDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, name, type);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EngineGroupDto that = (EngineGroupDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/EngineListUserDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/EngineListUserDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.engine;
 
+import java.util.Objects;
+
 public class EngineListUserDto {
 
   private String id;
@@ -62,12 +64,22 @@ public class EngineListUserDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, firstName, lastName, email);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EngineListUserDto that = (EngineListUserDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(firstName, that.firstName)
+        && Objects.equals(lastName, that.lastName)
+        && Objects.equals(email, that.email);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/DecisionInstanceDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/DecisionInstanceDto.java
@@ -12,6 +12,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class DecisionInstanceDto implements OptimizeDto {
@@ -209,16 +210,54 @@ public class DecisionInstanceDto implements OptimizeDto {
     this.tenantId = tenantId;
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionInstanceDto that = (DecisionInstanceDto) o;
+    return Objects.equals(decisionInstanceId, that.decisionInstanceId)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(decisionDefinitionId, that.decisionDefinitionId)
+        && Objects.equals(decisionDefinitionKey, that.decisionDefinitionKey)
+        && Objects.equals(decisionDefinitionVersion, that.decisionDefinitionVersion)
+        && Objects.equals(evaluationDateTime, that.evaluationDateTime)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(rootProcessInstanceId, that.rootProcessInstanceId)
+        && Objects.equals(activityId, that.activityId)
+        && Objects.equals(collectResultValue, that.collectResultValue)
+        && Objects.equals(rootDecisionInstanceId, that.rootDecisionInstanceId)
+        && Objects.equals(inputs, that.inputs)
+        && Objects.equals(outputs, that.outputs)
+        && Objects.equals(matchedRules, that.matchedRules)
+        && Objects.equals(engine, that.engine)
+        && Objects.equals(tenantId, that.tenantId);
   }
 
-  protected boolean canEqual(final Object other) {
-    return other instanceof DecisionInstanceDto;
-  }
-
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        decisionInstanceId,
+        processDefinitionId,
+        processDefinitionKey,
+        decisionDefinitionId,
+        decisionDefinitionKey,
+        decisionDefinitionVersion,
+        evaluationDateTime,
+        processInstanceId,
+        rootProcessInstanceId,
+        activityId,
+        collectResultValue,
+        rootDecisionInstanceId,
+        inputs,
+        outputs,
+        matchedRules,
+        engine,
+        tenantId);
   }
 
   public String toString() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/FlowNodeEventDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/FlowNodeEventDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.importing;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 public class FlowNodeEventDto implements Serializable, OptimizeDto {
 
@@ -211,13 +212,50 @@ public class FlowNodeEventDto implements Serializable, OptimizeDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FlowNodeEventDto that = (FlowNodeEventDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(activityId, that.activityId)
+        && Objects.equals(activityType, that.activityType)
+        && Objects.equals(activityName, that.activityName)
+        && Objects.equals(timestamp, that.timestamp)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersion, that.processDefinitionVersion)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(engineAlias, that.engineAlias)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(startDate, that.startDate)
+        && Objects.equals(endDate, that.endDate)
+        && Objects.equals(durationInMs, that.durationInMs)
+        && Objects.equals(orderCounter, that.orderCounter)
+        && Objects.equals(canceled, that.canceled)
+        && Objects.equals(taskId, that.taskId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        activityId,
+        activityType,
+        activityName,
+        timestamp,
+        processDefinitionId,
+        processDefinitionKey,
+        processDefinitionVersion,
+        tenantId,
+        engineAlias,
+        processInstanceId,
+        startDate,
+        endDate,
+        durationInMs,
+        orderCounter,
+        canceled,
+        taskId);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/LastKpiEvaluationResultsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/LastKpiEvaluationResultsDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.importing;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.util.Map;
+import java.util.Objects;
 
 public class LastKpiEvaluationResultsDto implements OptimizeDto {
 
@@ -27,12 +28,16 @@ public class LastKpiEvaluationResultsDto implements OptimizeDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final LastKpiEvaluationResultsDto that = (LastKpiEvaluationResultsDto) o;
+    return Objects.equals(reportIdToValue, that.reportIdToValue);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(reportIdToValue);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/EntityIdResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/EntityIdResponseDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query;
 
 import io.camunda.optimize.dto.optimize.query.entity.EntityType;
+import java.util.Objects;
 
 public class EntityIdResponseDto {
 
@@ -43,12 +44,19 @@ public class EntityIdResponseDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, entityType);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntityIdResponseDto that = (EntityIdResponseDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(entityType, that.entityType);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/IdResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/IdResponseDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query;
 
+import java.util.Objects;
+
 public class IdResponseDto {
 
   protected String id;
@@ -31,12 +33,19 @@ public class IdResponseDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IdResponseDto that = (IdResponseDto) o;
+    return Objects.equals(id, that.id);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/IdentitySearchResultResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/IdentitySearchResultResponseDto.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.IdentityWithMetadataResponseDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.apache.lucene.search.ScoreDoc;
 
 public class IdentitySearchResultResponseDto {
@@ -58,12 +59,19 @@ public class IdentitySearchResultResponseDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(result, scoreDoc);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IdentitySearchResultResponseDto that = (IdentitySearchResultResponseDto) o;
+    return Objects.equals(result, that.result) && Objects.equals(scoreDoc, that.scoreDoc);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/PageResultDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/PageResultDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class PageResultDto<T> {
 
@@ -73,13 +74,19 @@ public class PageResultDto<T> {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PageResultDto<?> that = (PageResultDto<?>) o;
+    return limit == that.limit
+        && Objects.equals(pagingState, that.pagingState)
+        && Objects.equals(entities, that.entities);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(pagingState, limit, entities);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/TokenDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/TokenDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query;
 
+import java.util.Objects;
+
 public class TokenDto {
 
   protected String token;
@@ -30,13 +32,17 @@ public class TokenDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TokenDto tokenDto = (TokenDto) o;
+    return Objects.equals(token, tokenDto.token);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(token);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/BranchAnalysisOutcomeDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/BranchAnalysisOutcomeDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.analysis;
 
+import java.util.Objects;
+
 public class BranchAnalysisOutcomeDto {
 
   protected Long activitiesReached;
@@ -45,12 +47,21 @@ public class BranchAnalysisOutcomeDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(activitiesReached, activityCount, activityId);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BranchAnalysisOutcomeDto that = (BranchAnalysisOutcomeDto) o;
+    return Objects.equals(activitiesReached, that.activitiesReached)
+        && Objects.equals(activityCount, that.activityCount)
+        && Objects.equals(activityId, that.activityId);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/BranchAnalysisRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/BranchAnalysisRequestDto.java
@@ -14,6 +14,7 @@ import io.camunda.optimize.service.util.TenantListHandlingUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class BranchAnalysisRequestDto {
 
@@ -86,12 +87,25 @@ public class BranchAnalysisRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        end, gateway, processDefinitionKey, processDefinitionVersions, tenantIds, filter);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BranchAnalysisRequestDto that = (BranchAnalysisRequestDto) o;
+    return Objects.equals(end, that.end)
+        && Objects.equals(gateway, that.gateway)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersions, that.processDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds)
+        && Objects.equals(filter, that.filter);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/BranchAnalysisResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/BranchAnalysisResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.analysis;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class BranchAnalysisResponseDto {
 
@@ -53,12 +54,21 @@ public class BranchAnalysisResponseDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(endEvent, total, followingNodes);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BranchAnalysisResponseDto that = (BranchAnalysisResponseDto) o;
+    return Objects.equals(endEvent, that.endEvent)
+        && Objects.equals(total, that.total)
+        && Objects.equals(followingNodes, that.followingNodes);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/DurationChartEntryDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/DurationChartEntryDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.analysis;
 
+import java.util.Objects;
+
 public class DurationChartEntryDto {
 
   private Long key;
@@ -50,13 +52,19 @@ public class DurationChartEntryDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DurationChartEntryDto that = (DurationChartEntryDto) o;
+    return outlier == that.outlier
+        && Objects.equals(key, that.key)
+        && Objects.equals(value, that.value);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(key, value, outlier);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/FindingsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/FindingsDto.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.dto.optimize.query.analysis;
 
+import java.util.Objects;
 import java.util.Optional;
 
 public class FindingsDto {
@@ -88,13 +89,23 @@ public class FindingsDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FindingsDto that = (FindingsDto) o;
+    return Objects.equals(lowerOutlier, that.lowerOutlier)
+        && Objects.equals(higherOutlier, that.higherOutlier)
+        && Objects.equals(lowerOutlierHeat, that.lowerOutlierHeat)
+        && Objects.equals(higherOutlierHeat, that.higherOutlierHeat)
+        && Objects.equals(heat, that.heat)
+        && Objects.equals(totalCount, that.totalCount);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        lowerOutlier, higherOutlier, lowerOutlierHeat, higherOutlierHeat, heat, totalCount);
   }
 
   @Override
@@ -168,13 +179,20 @@ public class FindingsDto {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Finding finding = (Finding) o;
+      return Objects.equals(boundValue, finding.boundValue)
+          && Objects.equals(percentile, finding.percentile)
+          && Objects.equals(relation, finding.relation)
+          && Objects.equals(count, finding.count);
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(boundValue, percentile, relation, count);
     }
 
     @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/FlowNodeOutlierParametersDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/FlowNodeOutlierParametersDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.analysis;
 
+import java.util.Objects;
+
 public class FlowNodeOutlierParametersDto extends ProcessDefinitionParametersDto {
 
   protected String flowNodeId;
@@ -52,16 +54,25 @@ public class FlowNodeOutlierParametersDto extends ProcessDefinitionParametersDto
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final FlowNodeOutlierParametersDto that = (FlowNodeOutlierParametersDto) o;
+    return Objects.equals(flowNodeId, that.flowNodeId)
+        && Objects.equals(lowerOutlierBound, that.lowerOutlierBound)
+        && Objects.equals(higherOutlierBound, that.higherOutlierBound);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), flowNodeId, lowerOutlierBound, higherOutlierBound);
   }
 
   @Override
   protected boolean canEqual(final Object other) {
     return other instanceof FlowNodeOutlierParametersDto;
-  }
-
-  @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/FlowNodeOutlierVariableParametersDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/FlowNodeOutlierVariableParametersDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.analysis;
 
+import java.util.Objects;
+
 public class FlowNodeOutlierVariableParametersDto extends FlowNodeOutlierParametersDto {
 
   protected String variableName;
@@ -41,16 +43,24 @@ public class FlowNodeOutlierVariableParametersDto extends FlowNodeOutlierParamet
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final FlowNodeOutlierVariableParametersDto that = (FlowNodeOutlierVariableParametersDto) o;
+    return Objects.equals(variableName, that.variableName)
+        && Objects.equals(variableTerm, that.variableTerm);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), variableName, variableTerm);
   }
 
   @Override
   protected boolean canEqual(final Object other) {
     return other instanceof FlowNodeOutlierVariableParametersDto;
-  }
-
-  @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/OutlierAnalysisServiceParameters.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/OutlierAnalysisServiceParameters.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.analysis;
 
 import java.time.ZoneId;
+import java.util.Objects;
 
 public class OutlierAnalysisServiceParameters<T extends ProcessDefinitionParametersDto> {
 
@@ -51,13 +52,19 @@ public class OutlierAnalysisServiceParameters<T extends ProcessDefinitionParamet
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OutlierAnalysisServiceParameters<?> that = (OutlierAnalysisServiceParameters<?>) o;
+    return Objects.equals(processDefinitionParametersDto, that.processDefinitionParametersDto)
+        && Objects.equals(zoneId, that.zoneId)
+        && Objects.equals(userId, that.userId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(processDefinitionParametersDto, zoneId, userId);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/ProcessDefinitionParametersDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/ProcessDefinitionParametersDto.java
@@ -14,6 +14,7 @@ import io.camunda.optimize.rest.queryparam.QueryParamUtil;
 import io.camunda.optimize.service.util.TenantListHandlingUtil;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ProcessDefinitionParametersDto {
@@ -91,13 +92,28 @@ public class ProcessDefinitionParametersDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessDefinitionParametersDto that = (ProcessDefinitionParametersDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersions, that.processDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds)
+        && Objects.equals(minimumDeviationFromAvg, that.minimumDeviationFromAvg)
+        && Objects.equals(disconsiderAutomatedTasks, that.disconsiderAutomatedTasks)
+        && Objects.equals(filters, that.filters);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        processDefinitionKey,
+        processDefinitionVersions,
+        tenantIds,
+        minimumDeviationFromAvg,
+        disconsiderAutomatedTasks,
+        filters);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/VariableTermDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/VariableTermDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.analysis;
 
+import java.util.Objects;
+
 public class VariableTermDto {
 
   private String variableName;
@@ -86,13 +88,28 @@ public class VariableTermDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableTermDto that = (VariableTermDto) o;
+    return Objects.equals(variableName, that.variableName)
+        && Objects.equals(variableTerm, that.variableTerm)
+        && Objects.equals(instanceCount, that.instanceCount)
+        && Objects.equals(outlierRatio, that.outlierRatio)
+        && Objects.equals(nonOutlierRatio, that.nonOutlierRatio)
+        && Objects.equals(outlierToAllInstancesRatio, that.outlierToAllInstancesRatio);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        variableName,
+        variableTerm,
+        instanceCount,
+        outlierRatio,
+        nonOutlierRatio,
+        outlierToAllInstancesRatio);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionDefinitionUpdateDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionDefinitionUpdateDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.collection;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CollectionDefinitionUpdateDto {
@@ -67,12 +68,23 @@ public class CollectionDefinitionUpdateDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(name, lastModified, owner, lastModifier, data);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionDefinitionUpdateDto that = (CollectionDefinitionUpdateDto) o;
+    return Objects.equals(name, that.name)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && Objects.equals(data, that.data);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/collection/PartialCollectionDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/collection/PartialCollectionDataDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.collection;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PartialCollectionDataDto {
@@ -29,13 +30,17 @@ public class PartialCollectionDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PartialCollectionDataDto that = (PartialCollectionDataDto) o;
+    return Objects.equals(configuration, that.configuration);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(configuration);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/collection/PartialCollectionDefinitionRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/collection/PartialCollectionDefinitionRequestDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.collection;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PartialCollectionDefinitionRequestDto {
@@ -62,13 +63,19 @@ public class PartialCollectionDefinitionRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PartialCollectionDefinitionRequestDto that = (PartialCollectionDefinitionRequestDto) o;
+    return Objects.equals(ownerId, that.ownerId)
+        && Objects.equals(name, that.name)
+        && Objects.equals(data, that.data);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(ownerId, name, data);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/DashboardDefinitionUpdateDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/DashboardDefinitionUpdateDto.java
@@ -13,6 +13,7 @@ import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTile
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DashboardDefinitionUpdateDto {
@@ -97,13 +98,35 @@ public class DashboardDefinitionUpdateDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardDefinitionUpdateDto that = (DashboardDefinitionUpdateDto) o;
+    return Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && Objects.equals(tiles, that.tiles)
+        && Objects.equals(collectionId, that.collectionId)
+        && Objects.equals(availableFilters, that.availableFilters)
+        && Objects.equals(refreshRateSeconds, that.refreshRateSeconds);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        name,
+        description,
+        lastModified,
+        lastModifier,
+        tiles,
+        collectionId,
+        availableFilters,
+        refreshRateSeconds);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/AssigneeCandidateGroupDefinitionSearchRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/AssigneeCandidateGroupDefinitionSearchRequestDto.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class AssigneeCandidateGroupDefinitionSearchRequestDto {
@@ -72,12 +73,23 @@ public class AssigneeCandidateGroupDefinitionSearchRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(terms, limit, processDefinitionKey, tenantIds);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AssigneeCandidateGroupDefinitionSearchRequestDto that =
+        (AssigneeCandidateGroupDefinitionSearchRequestDto) o;
+    return limit == that.limit
+        && Objects.equals(terms, that.terms)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(tenantIds, that.tenantIds);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/AssigneeCandidateGroupReportSearchRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/AssigneeCandidateGroupReportSearchRequestDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.definition;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class AssigneeCandidateGroupReportSearchRequestDto {
@@ -56,13 +57,20 @@ public class AssigneeCandidateGroupReportSearchRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AssigneeCandidateGroupReportSearchRequestDto that =
+        (AssigneeCandidateGroupReportSearchRequestDto) o;
+    return limit == that.limit
+        && Objects.equals(terms, that.terms)
+        && Objects.equals(reportIds, that.reportIds);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(terms, limit, reportIds);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DecisionDefinitionGroupOptimizeDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DecisionDefinitionGroupOptimizeDto.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 public class DecisionDefinitionGroupOptimizeDto {
 
@@ -54,13 +55,20 @@ public class DecisionDefinitionGroupOptimizeDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionDefinitionGroupOptimizeDto that = (DecisionDefinitionGroupOptimizeDto) o;
+    return Objects.equals(key, that.key) && Objects.equals(versions, that.versions);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(key, versions);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionKeyResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionKeyResponseDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.definition;
 
+import java.util.Objects;
+
 public class DefinitionKeyResponseDto {
 
   private String key;
@@ -40,13 +42,17 @@ public class DefinitionKeyResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionKeyResponseDto that = (DefinitionKeyResponseDto) o;
+    return Objects.equals(key, that.key) && Objects.equals(name, that.name);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(key, name);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionResponseDto.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.dto.optimize.SimpleDefinitionDto;
 import io.camunda.optimize.dto.optimize.TenantDto;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class DefinitionResponseDto extends SimpleDefinitionDto {
@@ -101,13 +102,20 @@ public class DefinitionResponseDto extends SimpleDefinitionDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DefinitionResponseDto that = (DefinitionResponseDto) o;
+    return Objects.equals(tenants, that.tenants);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), tenants);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionVersionWithTenantsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionVersionWithTenantsDto.java
@@ -13,6 +13,7 @@ import io.camunda.optimize.dto.optimize.SimpleDefinitionDto;
 import io.camunda.optimize.dto.optimize.TenantDto;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 public class DefinitionVersionWithTenantsDto extends SimpleDefinitionDto {
 
@@ -79,13 +80,22 @@ public class DefinitionVersionWithTenantsDto extends SimpleDefinitionDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DefinitionVersionWithTenantsDto that = (DefinitionVersionWithTenantsDto) o;
+    return Objects.equals(version, that.version)
+        && Objects.equals(versionTag, that.versionTag)
+        && Objects.equals(tenants, that.tenants);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), version, versionTag, tenants);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionWithTenantIdsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionWithTenantIdsDto.java
@@ -11,6 +11,7 @@ import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.SimpleDefinitionDto;
 import io.camunda.optimize.service.util.TenantListHandlingUtil;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class DefinitionWithTenantIdsDto extends SimpleDefinitionDto {
@@ -64,13 +65,20 @@ public class DefinitionWithTenantIdsDto extends SimpleDefinitionDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DefinitionWithTenantIdsDto that = (DefinitionWithTenantIdsDto) o;
+    return Objects.equals(tenantIds, that.tenantIds);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), tenantIds);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/ProcessDefinitionGroupOptimizeDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/ProcessDefinitionGroupOptimizeDto.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 public class ProcessDefinitionGroupOptimizeDto {
 
@@ -54,13 +55,17 @@ public class ProcessDefinitionGroupOptimizeDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessDefinitionGroupOptimizeDto that = (ProcessDefinitionGroupOptimizeDto) o;
+    return Objects.equals(key, that.key) && Objects.equals(versions, that.versions);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(key, versions);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/TenantIdWithDefinitionsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/TenantIdWithDefinitionsDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.definition;
 
 import io.camunda.optimize.dto.optimize.SimpleDefinitionDto;
 import java.util.List;
+import java.util.Objects;
 
 public class TenantIdWithDefinitionsDto {
 
@@ -51,13 +52,17 @@ public class TenantIdWithDefinitionsDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TenantIdWithDefinitionsDto that = (TenantIdWithDefinitionsDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(definitions, that.definitions);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, definitions);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/TenantWithDefinitionsResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/TenantWithDefinitionsResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.definition;
 
 import io.camunda.optimize.dto.optimize.SimpleDefinitionDto;
 import java.util.List;
+import java.util.Objects;
 
 public class TenantWithDefinitionsResponseDto {
 
@@ -62,13 +63,19 @@ public class TenantWithDefinitionsResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TenantWithDefinitionsResponseDto that = (TenantWithDefinitionsResponseDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(definitions, that.definitions);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, name, definitions);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/report/CombinedReportEvaluationResult.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/report/CombinedReportEvaluationResult.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -84,12 +85,23 @@ public class CombinedReportEvaluationResult extends ReportEvaluationResult {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), reportEvaluationResults, instanceCount);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final CombinedReportEvaluationResult that = (CombinedReportEvaluationResult) o;
+    return instanceCount == that.instanceCount
+        && Objects.equals(reportEvaluationResults, that.reportEvaluationResults);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/report/CommandEvaluationResult.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/report/CommandEvaluationResult.java
@@ -16,6 +16,7 @@ import io.camunda.optimize.dto.optimize.rest.pagination.PaginationDto;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public abstract class CommandEvaluationResult<T> {
 
@@ -189,12 +190,24 @@ public abstract class CommandEvaluationResult<T> {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        instanceCount, instanceCountWithoutFilters, measures, reportData, pagination);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CommandEvaluationResult<?> that = (CommandEvaluationResult<?>) o;
+    return instanceCount == that.instanceCount
+        && instanceCountWithoutFilters == that.instanceCountWithoutFilters
+        && Objects.equals(measures, that.measures)
+        && Objects.equals(reportData, that.reportData)
+        && Objects.equals(pagination, that.pagination);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/report/SingleReportEvaluationResult.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/report/SingleReportEvaluationResult.java
@@ -14,6 +14,7 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class SingleReportEvaluationResult<T> extends ReportEvaluationResult {
@@ -85,13 +86,20 @@ public class SingleReportEvaluationResult<T> extends ReportEvaluationResult {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final SingleReportEvaluationResult<?> that = (SingleReportEvaluationResult<?>) o;
+    return Objects.equals(commandEvaluationResults, that.commandEvaluationResults);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), commandEvaluationResults);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/security/CredentialsRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/security/CredentialsRequestDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.security;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class CredentialsRequestDto implements Serializable {
 
@@ -42,13 +43,20 @@ public class CredentialsRequestDto implements Serializable {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CredentialsRequestDto that = (CredentialsRequestDto) o;
+    return Objects.equals(username, that.username) && Objects.equals(password, that.password);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(username, password);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/DashboardShareRestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/DashboardShareRestDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.sharing;
 
 import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTileDto;
 import java.util.List;
+import java.util.Objects;
 
 public class DashboardShareRestDto {
 
@@ -48,12 +49,21 @@ public class DashboardShareRestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, dashboardId, tileShares);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardShareRestDto that = (DashboardShareRestDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(dashboardId, that.dashboardId)
+        && Objects.equals(tileShares, that.tileShares);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ReportShareRestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ReportShareRestDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.sharing;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class ReportShareRestDto implements Serializable {
 
@@ -37,13 +38,17 @@ public class ReportShareRestDto implements Serializable {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportShareRestDto that = (ReportShareRestDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(reportId, that.reportId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, reportId);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ShareSearchRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ShareSearchRequestDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.sharing;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class ShareSearchRequestDto {
 
@@ -38,13 +39,17 @@ public class ShareSearchRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ShareSearchRequestDto that = (ShareSearchRequestDto) o;
+    return Objects.equals(reports, that.reports) && Objects.equals(dashboards, that.dashboards);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(reports, dashboards);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ShareSearchResultResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ShareSearchResultResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.sharing;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class ShareSearchResultResponseDto {
 
@@ -38,13 +39,17 @@ public class ShareSearchResultResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ShareSearchResultResponseDto that = (ShareSearchResultResponseDto) o;
+    return Objects.equals(reports, that.reports) && Objects.equals(dashboards, that.dashboards);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(reports, dashboards);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/AlertEmailValidationResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/AlertEmailValidationResponseDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.rest;
 
 import io.camunda.optimize.service.exceptions.OptimizeAlertEmailValidationException;
+import java.util.Objects;
 
 public class AlertEmailValidationResponseDto extends ErrorResponseDto {
 
@@ -33,17 +34,24 @@ public class AlertEmailValidationResponseDto extends ErrorResponseDto {
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AlertEmailValidationResponseDto that = (AlertEmailValidationResponseDto) o;
+    return Objects.equals(invalidAlertEmails, that.invalidAlertEmails);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), invalidAlertEmails);
   }
 
   @Override
   protected boolean canEqual(final Object other) {
     return other instanceof AlertEmailValidationResponseDto;
-  }
-
-  @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 
   @SuppressWarnings("checkstyle:ConstantName")

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ConflictResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ConflictResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -53,16 +54,23 @@ public class ConflictResponseDto extends ErrorResponseDto {
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ConflictResponseDto that = (ConflictResponseDto) o;
+    return Objects.equals(conflictedItems, that.conflictedItems);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), conflictedItems);
   }
 
   @Override
   protected boolean canEqual(final Object other) {
     return other instanceof ConflictResponseDto;
-  }
-
-  @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionExceptionItemDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionExceptionItemDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.rest;
 import io.camunda.optimize.dto.optimize.DefinitionType;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 
 public class DefinitionExceptionItemDto implements Serializable {
 
@@ -52,13 +53,20 @@ public class DefinitionExceptionItemDto implements Serializable {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionExceptionItemDto that = (DefinitionExceptionItemDto) o;
+    return type == that.type
+        && Objects.equals(key, that.key)
+        && Objects.equals(versions, that.versions)
+        && Objects.equals(tenantIds, that.tenantIds);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(type, key, versions, tenantIds);
   }
 
   public static DefinitionExceptionItemDtoBuilder builder() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionExceptionResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionExceptionResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -43,13 +44,20 @@ public class DefinitionExceptionResponseDto extends ErrorResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DefinitionExceptionResponseDto that = (DefinitionExceptionResponseDto) o;
+    return Objects.equals(definitions, that.definitions);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), definitions);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionTenantsRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionTenantsRequestDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class DefinitionTenantsRequestDto {
 
@@ -45,13 +46,18 @@ public class DefinitionTenantsRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionTenantsRequestDto that = (DefinitionTenantsRequestDto) o;
+    return Objects.equals(versions, that.versions)
+        && Objects.equals(filterByCollectionScope, that.filterByCollectionScope);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(versions, filterByCollectionScope);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionVersionResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionVersionResponseDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.rest;
 
+import java.util.Objects;
+
 public class DefinitionVersionResponseDto {
 
   private String version;
@@ -40,13 +42,17 @@ public class DefinitionVersionResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionVersionResponseDto that = (DefinitionVersionResponseDto) o;
+    return Objects.equals(version, that.version) && Objects.equals(versionTag, that.versionTag);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(version, versionTag);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ErrorResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ErrorResponseDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.rest;
 
+import java.util.Objects;
+
 public class ErrorResponseDto {
 
   private String errorCode;
@@ -80,13 +82,20 @@ public class ErrorResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ErrorResponseDto that = (ErrorResponseDto) o;
+    return Objects.equals(errorCode, that.errorCode)
+        && Objects.equals(errorMessage, that.errorMessage)
+        && Objects.equals(detailedMessage, that.detailedMessage)
+        && Objects.equals(reportDefinition, that.reportDefinition);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(errorCode, errorMessage, detailedMessage, reportDefinition);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/FlowNodeIdsToNamesRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/FlowNodeIdsToNamesRequestDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.rest;
 
 import java.util.List;
+import java.util.Objects;
 
 public class FlowNodeIdsToNamesRequestDto {
 
@@ -55,13 +56,20 @@ public class FlowNodeIdsToNamesRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FlowNodeIdsToNamesRequestDto that = (FlowNodeIdsToNamesRequestDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersion, that.processDefinitionVersion)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(nodeIds, that.nodeIds);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(processDefinitionKey, processDefinitionVersion, tenantId, nodeIds);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/FlowNodeNamesResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/FlowNodeNamesResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class FlowNodeNamesResponseDto {
 
@@ -29,13 +30,17 @@ public class FlowNodeNamesResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FlowNodeNamesResponseDto that = (FlowNodeNamesResponseDto) o;
+    return Objects.equals(flowNodeNames, that.flowNodeNames);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(flowNodeNames);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/GetVariableNamesForReportsRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/GetVariableNamesForReportsRequestDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.rest;
 
 import java.util.List;
+import java.util.Objects;
 
 public class GetVariableNamesForReportsRequestDto {
 
@@ -28,13 +29,17 @@ public class GetVariableNamesForReportsRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final GetVariableNamesForReportsRequestDto that = (GetVariableNamesForReportsRequestDto) o;
+    return Objects.equals(reportIds, that.reportIds);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(reportIds);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ImportIndexMismatchDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ImportIndexMismatchDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.rest;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class ImportIndexMismatchDto implements Serializable {
 
@@ -42,12 +43,21 @@ public class ImportIndexMismatchDto implements Serializable {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(indexName, sourceIndexVersion, targetIndexVersion);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ImportIndexMismatchDto that = (ImportIndexMismatchDto) o;
+    return sourceIndexVersion == that.sourceIndexVersion
+        && targetIndexVersion == that.targetIndexVersion
+        && Objects.equals(indexName, that.indexName);
   }
 
   public static ImportIndexMismatchDtoBuilder builder() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ImportedIndexMismatchResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ImportedIndexMismatchResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -43,13 +44,20 @@ public class ImportedIndexMismatchResponseDto extends ErrorResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ImportedIndexMismatchResponseDto that = (ImportedIndexMismatchResponseDto) o;
+    return Objects.equals(mismatchingIndices, that.mismatchingIndices);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), mismatchingIndices);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ProcessRawDataCsvExportRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ProcessRawDataCsvExportRequestDto.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class ProcessRawDataCsvExportRequestDto {
 
@@ -82,13 +83,22 @@ public class ProcessRawDataCsvExportRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessRawDataCsvExportRequestDto that = (ProcessRawDataCsvExportRequestDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersions, that.processDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds)
+        && Objects.equals(filter, that.filter)
+        && Objects.equals(includedColumns, that.includedColumns);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        processDefinitionKey, processDefinitionVersions, tenantIds, filter, includedColumns);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/TenantResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/TenantResponseDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.rest;
 
+import java.util.Objects;
+
 public class TenantResponseDto {
 
   private String id;
@@ -40,13 +42,17 @@ public class TenantResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TenantResponseDto that = (TenantResponseDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(name, that.name);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, name);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/UserResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/UserResponseDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.rest;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.camunda.optimize.dto.optimize.UserDto;
 import java.util.List;
+import java.util.Objects;
 
 public class UserResponseDto {
 
@@ -45,13 +46,18 @@ public class UserResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UserResponseDto that = (UserResponseDto) o;
+    return Objects.equals(userDto, that.userDto)
+        && Objects.equals(authorizations, that.authorizations);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(userDto, authorizations);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ValidationErrorResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ValidationErrorResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ValidationErrorResponseDto extends ErrorResponseDto {
@@ -37,18 +38,25 @@ public class ValidationErrorResponseDto extends ErrorResponseDto {
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  @Override
   protected boolean canEqual(final Object other) {
     return other instanceof ValidationErrorResponseDto;
   }
 
   @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ValidationErrorResponseDto that = (ValidationErrorResponseDto) o;
+    return Objects.equals(validationErrors, that.validationErrors);
+  }
+
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), validationErrors);
   }
 
   public static class ValidationError {
@@ -85,12 +93,20 @@ public class ValidationErrorResponseDto extends ErrorResponseDto {
 
     @Override
     public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+      return Objects.hash(property, errorMessage);
     }
 
     @Override
     public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final ValidationError that = (ValidationError) o;
+      return Objects.equals(property, that.property)
+          && Objects.equals(errorMessage, that.errorMessage);
     }
 
     @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/collection/CollectionScopeEntryResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/collection/CollectionScopeEntryResponseDto.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.dto.optimize.TenantDto;
 import io.camunda.optimize.dto.optimize.query.collection.CollectionScopeEntryDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class CollectionScopeEntryResponseDto {
@@ -80,7 +81,18 @@ public class CollectionScopeEntryResponseDto {
   }
 
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionScopeEntryResponseDto that = (CollectionScopeEntryResponseDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(definitionType, that.definitionType)
+        && Objects.equals(definitionKey, that.definitionKey)
+        && Objects.equals(definitionName, that.definitionName)
+        && Objects.equals(tenants, that.tenants);
   }
 
   protected boolean canEqual(final Object other) {
@@ -88,7 +100,7 @@ public class CollectionScopeEntryResponseDto {
   }
 
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, definitionType, definitionKey, definitionName, tenants);
   }
 
   public String toString() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/definition/DefinitionWithTenantsResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/definition/DefinitionWithTenantsResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest.definition;
 
 import io.camunda.optimize.dto.optimize.rest.TenantResponseDto;
 import java.util.List;
+import java.util.Objects;
 
 public class DefinitionWithTenantsResponseDto {
 
@@ -55,12 +56,21 @@ public class DefinitionWithTenantsResponseDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(key, versions, tenants);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionWithTenantsResponseDto that = (DefinitionWithTenantsResponseDto) o;
+    return Objects.equals(key, that.key)
+        && Objects.equals(versions, that.versions)
+        && Objects.equals(tenants, that.tenants);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/definition/MultiDefinitionTenantsRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/definition/MultiDefinitionTenantsRequestDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.rest.definition;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class MultiDefinitionTenantsRequestDto {
 
@@ -49,13 +50,18 @@ public class MultiDefinitionTenantsRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MultiDefinitionTenantsRequestDto that = (MultiDefinitionTenantsRequestDto) o;
+    return Objects.equals(definitions, that.definitions)
+        && Objects.equals(filterByCollectionScope, that.filterByCollectionScope);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(definitions, filterByCollectionScope);
   }
 
   @Override
@@ -100,13 +106,17 @@ public class MultiDefinitionTenantsRequestDto {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final DefinitionDto that = (DefinitionDto) o;
+      return Objects.equals(key, that.key) && Objects.equals(versions, that.versions);
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(key, versions);
     }
 
     @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/OptimizeEntityExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/OptimizeEntityExportDto.java
@@ -19,6 +19,7 @@ import io.camunda.optimize.dto.optimize.rest.export.report.CombinedProcessReport
 import io.camunda.optimize.dto.optimize.rest.export.report.SingleDecisionReportDefinitionExportDto;
 import io.camunda.optimize.dto.optimize.rest.export.report.SingleProcessReportDefinitionExportDto;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -105,13 +106,21 @@ public abstract class OptimizeEntityExportDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OptimizeEntityExportDto that = (OptimizeEntityExportDto) o;
+    return sourceIndexVersion == that.sourceIndexVersion
+        && Objects.equals(id, that.id)
+        && exportEntityType == that.exportEntityType
+        && Objects.equals(name, that.name)
+        && Objects.equals(description, that.description);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, exportEntityType, name, description, sourceIndexVersion);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/dashboard/DashboardDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/dashboard/DashboardDefinitionExportDto.java
@@ -20,6 +20,7 @@ import io.camunda.optimize.service.util.IdGenerator;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
@@ -98,12 +99,26 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        super.hashCode(), tiles, availableFilters, collectionId, isInstantPreviewDashboard);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardDefinitionExportDto that = (DashboardDefinitionExportDto) o;
+    return isInstantPreviewDashboard == that.isInstantPreviewDashboard
+        && Objects.equals(tiles, that.tiles)
+        && Objects.equals(availableFilters, that.availableFilters)
+        && Objects.equals(collectionId, that.collectionId);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/CombinedProcessReportDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/CombinedProcessReportDefinitionExportDto.java
@@ -14,6 +14,7 @@ import io.camunda.optimize.dto.optimize.query.report.combined.CombinedReportDefi
 import io.camunda.optimize.dto.optimize.rest.export.ExportEntityType;
 import io.camunda.optimize.service.db.schema.index.report.CombinedReportIndex;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 
 public class CombinedProcessReportDefinitionExportDto extends ReportDefinitionExportDto {
 
@@ -56,17 +57,25 @@ public class CombinedProcessReportDefinitionExportDto extends ReportDefinitionEx
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  @Override
   protected boolean canEqual(final Object other) {
     return other instanceof CombinedProcessReportDefinitionExportDto;
   }
 
   @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final CombinedProcessReportDefinitionExportDto that =
+        (CombinedProcessReportDefinitionExportDto) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), data);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/ReportDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/ReportDefinitionExportDto.java
@@ -14,6 +14,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.decision.SingleDecis
 import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProcessReportDefinitionRequestDto;
 import io.camunda.optimize.dto.optimize.rest.export.ExportEntityType;
 import io.camunda.optimize.dto.optimize.rest.export.OptimizeEntityExportDto;
+import java.util.Objects;
 
 public abstract class ReportDefinitionExportDto extends OptimizeEntityExportDto {
 
@@ -61,13 +62,20 @@ public abstract class ReportDefinitionExportDto extends OptimizeEntityExportDto 
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ReportDefinitionExportDto that = (ReportDefinitionExportDto) o;
+    return Objects.equals(collectionId, that.collectionId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), collectionId);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/SingleDecisionReportDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/SingleDecisionReportDefinitionExportDto.java
@@ -14,6 +14,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.decision.SingleDecis
 import io.camunda.optimize.dto.optimize.rest.export.ExportEntityType;
 import io.camunda.optimize.service.db.schema.index.report.SingleDecisionReportIndex;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 
 public class SingleDecisionReportDefinitionExportDto extends ReportDefinitionExportDto {
 
@@ -56,13 +57,21 @@ public class SingleDecisionReportDefinitionExportDto extends ReportDefinitionExp
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final SingleDecisionReportDefinitionExportDto that =
+        (SingleDecisionReportDefinitionExportDto) o;
+    return Objects.equals(data, that.data);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), data);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/SingleProcessReportDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/SingleProcessReportDefinitionExportDto.java
@@ -14,6 +14,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProces
 import io.camunda.optimize.dto.optimize.rest.export.ExportEntityType;
 import io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 
 public class SingleProcessReportDefinitionExportDto extends ReportDefinitionExportDto {
 
@@ -56,17 +57,24 @@ public class SingleProcessReportDefinitionExportDto extends ReportDefinitionExpo
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  @Override
   protected boolean canEqual(final Object other) {
     return other instanceof SingleProcessReportDefinitionExportDto;
   }
 
   @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final SingleProcessReportDefinitionExportDto that = (SingleProcessReportDefinitionExportDto) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), data);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedCombinedReportEvaluationResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedCombinedReportEvaluationResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest.report;
 
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.report.combined.CombinedReportDefinitionRequestDto;
+import java.util.Objects;
 
 public class AuthorizedCombinedReportEvaluationResponseDto<T>
     extends AuthorizedReportEvaluationResponseDto<CombinedReportDefinitionRequestDto> {
@@ -40,12 +41,23 @@ public class AuthorizedCombinedReportEvaluationResponseDto<T>
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), result);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedCombinedReportEvaluationResponseDto<?> that =
+        (AuthorizedCombinedReportEvaluationResponseDto<?>) o;
+    return Objects.equals(result, that.result);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedReportEvaluationResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedReportEvaluationResponseDto.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.camunda.optimize.dto.optimize.AuthorizedEntityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
+import java.util.Objects;
 
 public class AuthorizedReportEvaluationResponseDto<D extends ReportDefinitionDto<?>>
     extends AuthorizedEntityDto {
@@ -41,12 +42,23 @@ public class AuthorizedReportEvaluationResponseDto<D extends ReportDefinitionDto
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), reportDefinition);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedReportEvaluationResponseDto<?> that =
+        (AuthorizedReportEvaluationResponseDto<?>) o;
+    return Objects.equals(reportDefinition, that.reportDefinition);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedSingleReportEvaluationResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedSingleReportEvaluationResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest.report;
 
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
+import java.util.Objects;
 
 public class AuthorizedSingleReportEvaluationResponseDto<T, D extends ReportDefinitionDto<?>>
     extends AuthorizedReportEvaluationResponseDto<D> {
@@ -40,12 +41,23 @@ public class AuthorizedSingleReportEvaluationResponseDto<T, D extends ReportDefi
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), result);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedSingleReportEvaluationResponseDto<?, ?> that =
+        (AuthorizedSingleReportEvaluationResponseDto<?, ?>) o;
+    return Objects.equals(result, that.result);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/CombinedProcessReportResultDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/CombinedProcessReportResultDataDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.rest.report;
 
 import java.util.Map;
+import java.util.Objects;
 
 public class CombinedProcessReportResultDataDto<T> {
 
@@ -45,12 +46,19 @@ public class CombinedProcessReportResultDataDto<T> {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(data, instanceCount);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CombinedProcessReportResultDataDto<?> that = (CombinedProcessReportResultDataDto<?>) o;
+    return instanceCount == that.instanceCount && Objects.equals(data, that.data);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/ReportResultResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/ReportResultResponseDto.java
@@ -13,6 +13,7 @@ import io.camunda.optimize.dto.optimize.rest.pagination.PaginationDto;
 import io.camunda.optimize.dto.optimize.rest.report.measure.MeasureResponseDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class ReportResultResponseDto<T> {
 
@@ -90,13 +91,20 @@ public class ReportResultResponseDto<T> {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportResultResponseDto<?> that = (ReportResultResponseDto<?>) o;
+    return instanceCount == that.instanceCount
+        && instanceCountWithoutFilters == that.instanceCountWithoutFilters
+        && Objects.equals(measures, that.measures)
+        && Objects.equals(pagination, that.pagination);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(instanceCount, instanceCountWithoutFilters, measures, pagination);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/measure/MeasureResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/measure/MeasureResponseDto.java
@@ -18,6 +18,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.UserTaskDurationTime;
 import io.camunda.optimize.dto.optimize.query.report.single.result.ResultType;
+import java.util.Objects;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -92,16 +93,26 @@ public class MeasureResponseDto<T> {
     this.type = type;
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MeasureResponseDto<?> that = (MeasureResponseDto<?>) o;
+    return Objects.equals(property, that.property)
+        && Objects.equals(aggregationType, that.aggregationType)
+        && userTaskDurationTime == that.userTaskDurationTime
+        && Objects.equals(data, that.data)
+        && type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(property, aggregationType, userTaskDurationTime, data, type);
   }
 
   protected boolean canEqual(final Object other) {
     return other instanceof MeasureResponseDto;
-  }
-
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 
   public String toString() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Map;
+import java.util.Objects;
 
 public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends Intent>
     implements Record<VALUE> {
@@ -199,12 +200,48 @@ public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends I
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        position,
+        sequence,
+        sourceRecordPosition,
+        key,
+        timestamp,
+        partitionId,
+        recordType,
+        rejectionType,
+        rejectionReason,
+        brokerVersion,
+        valueType,
+        value,
+        intent,
+        authorizations,
+        operationReference);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeRecordDto<?, ?> that = (ZeebeRecordDto<?, ?>) o;
+    return position == that.position
+        && sourceRecordPosition == that.sourceRecordPosition
+        && key == that.key
+        && timestamp == that.timestamp
+        && partitionId == that.partitionId
+        && operationReference == that.operationReference
+        && Objects.equals(sequence, that.sequence)
+        && Objects.equals(recordType, that.recordType)
+        && Objects.equals(rejectionType, that.rejectionType)
+        && Objects.equals(rejectionReason, that.rejectionReason)
+        && Objects.equals(brokerVersion, that.brokerVersion)
+        && Objects.equals(valueType, that.valueType)
+        && Objects.equals(value, that.value)
+        && Objects.equals(intent, that.intent)
+        && Objects.equals(authorizations, that.authorizations);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionDataDto.java
@@ -10,6 +10,8 @@ package io.camunda.optimize.dto.zeebe.definition;
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import java.util.Arrays;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
@@ -126,15 +128,36 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
         + ")";
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeProcessDefinitionDataDto that = (ZeebeProcessDefinitionDataDto) o;
+    return processDefinitionKey == that.processDefinitionKey
+        && version == that.version
+        && Objects.deepEquals(resource, that.resource)
+        && Objects.deepEquals(checksum, that.checksum)
+        && Objects.equals(resourceName, that.resourceName)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(versionTag, that.versionTag);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        Arrays.hashCode(resource),
+        processDefinitionKey,
+        version,
+        Arrays.hashCode(checksum),
+        resourceName,
+        bpmnProcessId,
+        tenantId,
+        versionTag);
   }
 
   protected boolean canEqual(final Object other) {
     return other instanceof ZeebeProcessDefinitionDataDto;
-  }
-
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionRecordDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.zeebe.definition;
 
 import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import java.util.Objects;
 
 public class ZeebeProcessDefinitionRecordDto
     extends ZeebeRecordDto<ZeebeProcessDefinitionDataDto, ProcessIntent> {
@@ -20,11 +21,17 @@ public class ZeebeProcessDefinitionRecordDto
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentDataDto.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import java.util.List;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 public class ZeebeIncidentDataDto implements IncidentRecordValue {
@@ -158,16 +159,40 @@ public class ZeebeIncidentDataDto implements IncidentRecordValue {
         + ")";
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeIncidentDataDto that = (ZeebeIncidentDataDto) o;
+    return elementInstanceKey == that.elementInstanceKey
+        && processInstanceKey == that.processInstanceKey
+        && processDefinitionKey == that.processDefinitionKey
+        && jobKey == that.jobKey
+        && variableScopeKey == that.variableScopeKey
+        && Objects.equals(errorMessage, that.errorMessage)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(elementId, that.elementId)
+        && Objects.equals(errorType, that.errorType)
+        && Objects.equals(tenantId, that.tenantId);
   }
 
-  protected boolean canEqual(final Object other) {
-    return other instanceof ZeebeIncidentDataDto;
-  }
-
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        errorMessage,
+        bpmnProcessId,
+        elementId,
+        elementInstanceKey,
+        processInstanceKey,
+        processDefinitionKey,
+        jobKey,
+        errorType,
+        variableScopeKey,
+        tenantId);
   }
 
   @SuppressWarnings("checkstyle:ConstantName")

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentRecordDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.zeebe.incident;
 
 import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import java.util.Objects;
 
 public class ZeebeIncidentRecordDto extends ZeebeRecordDto<ZeebeIncidentDataDto, IncidentIntent> {
 
@@ -19,11 +20,17 @@ public class ZeebeIncidentRecordDto extends ZeebeRecordDto<ZeebeIncidentDataDto,
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
@@ -163,12 +164,38 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        version,
+        bpmnProcessId,
+        processDefinitionKey,
+        flowScopeKey,
+        bpmnElementType,
+        parentProcessInstanceKey,
+        parentElementInstanceKey,
+        elementId,
+        processInstanceKey,
+        tenantId);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeProcessInstanceDataDto that = (ZeebeProcessInstanceDataDto) o;
+    return version == that.version
+        && processDefinitionKey == that.processDefinitionKey
+        && flowScopeKey == that.flowScopeKey
+        && parentProcessInstanceKey == that.parentProcessInstanceKey
+        && parentElementInstanceKey == that.parentElementInstanceKey
+        && processInstanceKey == that.processInstanceKey
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(bpmnElementType, that.bpmnElementType)
+        && Objects.equals(elementId, that.elementId)
+        && Objects.equals(tenantId, that.tenantId);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceRecordDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.zeebe.process;
 
 import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import java.util.Objects;
 
 public class ZeebeProcessInstanceRecordDto
     extends ZeebeRecordDto<ZeebeProcessInstanceDataDto, ProcessInstanceIntent> {
@@ -20,11 +21,17 @@ public class ZeebeProcessInstanceRecordDto
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.slf4j.Logger;
 
 public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
@@ -243,13 +244,56 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeUserTaskDataDto that = (ZeebeUserTaskDataDto) o;
+    return userTaskKey == that.userTaskKey
+        && elementInstanceKey == that.elementInstanceKey
+        && processDefinitionVersion == that.processDefinitionVersion
+        && processDefinitionKey == that.processDefinitionKey
+        && processInstanceKey == that.processInstanceKey
+        && formKey == that.formKey
+        && creationTimestamp == that.creationTimestamp
+        && Objects.equals(assignee, that.assignee)
+        && Objects.equals(candidateGroupsList, that.candidateGroupsList)
+        && Objects.equals(candidateUsersList, that.candidateUsersList)
+        && Objects.equals(dueDate, that.dueDate)
+        && Objects.equals(elementId, that.elementId)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(changedAttributes, that.changedAttributes)
+        && Objects.equals(variables, that.variables)
+        && Objects.equals(followUpDate, that.followUpDate)
+        && Objects.equals(action, that.action)
+        && Objects.equals(externalFormReference, that.externalFormReference)
+        && Objects.equals(customHeaders, that.customHeaders);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        userTaskKey,
+        assignee,
+        candidateGroupsList,
+        candidateUsersList,
+        dueDate,
+        elementId,
+        elementInstanceKey,
+        bpmnProcessId,
+        processDefinitionVersion,
+        processDefinitionKey,
+        processInstanceKey,
+        tenantId,
+        changedAttributes,
+        variables,
+        followUpDate,
+        formKey,
+        action,
+        externalFormReference,
+        customHeaders,
+        creationTimestamp);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.zeebe.variable;
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 public class ZeebeVariableDataDto implements VariableRecordValue {
@@ -97,13 +98,24 @@ public class ZeebeVariableDataDto implements VariableRecordValue {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeVariableDataDto that = (ZeebeVariableDataDto) o;
+    return scopeKey == that.scopeKey
+        && processInstanceKey == that.processInstanceKey
+        && processDefinitionKey == that.processDefinitionKey
+        && Objects.equals(name, that.name)
+        && Objects.equals(value, that.value)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(tenantId, that.tenantId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        name, value, scopeKey, processInstanceKey, processDefinitionKey, bpmnProcessId, tenantId);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableRecordDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.zeebe.variable;
 
 import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import java.util.Objects;
 
 public class ZeebeVariableRecordDto extends ZeebeRecordDto<ZeebeVariableDataDto, VariableIntent> {
 
@@ -19,11 +20,17 @@ public class ZeebeVariableRecordDto extends ZeebeRecordDto<ZeebeVariableDataDto,
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/cloud/CCSaaSOrganizationsClient.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/cloud/CCSaaSOrganizationsClient.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.CCSaaSCondition;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -83,13 +84,17 @@ public class CCSaaSOrganizationsClient extends AbstractCCSaaSClient {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AccountsOrganisationResponse that = (AccountsOrganisationResponse) o;
+      return Objects.equals(salesPlan, that.salesPlan);
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hashCode(salesPlan);
     }
 
     @Override
@@ -123,13 +128,17 @@ public class CCSaaSOrganizationsClient extends AbstractCCSaaSClient {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AccountsSalesPlanDto that = (AccountsSalesPlanDto) o;
+      return Objects.equals(type, that.type);
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hashCode(type);
     }
 
     @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/cloud/CCSaasClusterClient.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/cloud/CCSaasClusterClient.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -143,13 +144,17 @@ public class CCSaasClusterClient extends AbstractCCSaaSClient {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final ClusterMetadata that = (ClusterMetadata) o;
+      return Objects.equals(uuid, that.uuid) && Objects.equals(urls, that.urls);
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(uuid, urls);
     }
 
     @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/KpiService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/KpiService.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -272,13 +273,17 @@ public class KpiService {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final TargetAndUnit that = (TargetAndUnit) o;
+      return Objects.equals(target, that.target) && targetValueUnit == that.targetValueUnit;
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(target, targetValueUnit);
     }
 
     @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/context/VariableAggregationContextES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/context/VariableAggregationContextES.java
@@ -12,6 +12,7 @@ import co.elastic.clients.elasticsearch._types.aggregations.Aggregation.Builder.
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import io.camunda.optimize.service.db.report.context.VariableAggregationContext;
 import java.util.Map;
+import java.util.Objects;
 
 public class VariableAggregationContextES extends VariableAggregationContext {
 
@@ -32,16 +33,26 @@ public class VariableAggregationContextES extends VariableAggregationContext {
     return this.subAggregations;
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final VariableAggregationContextES that = (VariableAggregationContextES) o;
+    return Objects.equals(baseQueryForMinMaxStats, that.baseQueryForMinMaxStats)
+        && Objects.equals(subAggregations, that.subAggregations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), baseQueryForMinMaxStats, subAggregations);
   }
 
   protected boolean canEqual(final Object other) {
     return other instanceof VariableAggregationContextES;
-  }
-
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 
   public String toString() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/filter/FilterContext.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/filter/FilterContext.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.db.filter;
 
 import java.time.ZoneId;
+import java.util.Objects;
 
 public final class FilterContext {
 
@@ -28,13 +29,17 @@ public final class FilterContext {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FilterContext that = (FilterContext) o;
+    return userTaskReport == that.userTaskReport && Objects.equals(timezone, that.timezone);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(timezone, userTaskReport);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/context/VariableAggregationContextOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/context/VariableAggregationContextOS.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.db.os.report.context;
 
 import io.camunda.optimize.service.db.report.context.VariableAggregationContext;
 import java.util.Map;
+import java.util.Objects;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 
@@ -31,16 +32,26 @@ public class VariableAggregationContextOS extends VariableAggregationContext {
     return this.subAggregations;
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final VariableAggregationContextOS that = (VariableAggregationContextOS) o;
+    return Objects.equals(baseQueryForMinMaxStats, that.baseQueryForMinMaxStats)
+        && Objects.equals(subAggregations, that.subAggregations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), baseQueryForMinMaxStats, subAggregations);
   }
 
   protected boolean canEqual(final Object other) {
     return other instanceof VariableAggregationContextOS;
-  }
-
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 
   public String toString() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ExecutionContext.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ExecutionContext.java
@@ -20,6 +20,7 @@ import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -205,16 +206,47 @@ public class ExecutionContext<D extends SingleReportDataDto, P extends Execution
     this.multiIndexAlias = multiIndexAlias;
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExecutionContext<?, ?> that = (ExecutionContext<?, ?>) o;
+    return unfilteredTotalInstanceCount == that.unfilteredTotalInstanceCount
+        && isCsvExport == that.isCsvExport
+        && isJsonExport == that.isJsonExport
+        && multiIndexAlias == that.multiIndexAlias
+        && Objects.equals(plan, that.plan)
+        && Objects.equals(reportData, that.reportData)
+        && Objects.equals(timezone, that.timezone)
+        && Objects.equals(pagination, that.pagination)
+        && Objects.equals(combinedRangeMinMaxStats, that.combinedRangeMinMaxStats)
+        && Objects.equals(allDistributedByKeysAndLabels, that.allDistributedByKeysAndLabels)
+        && Objects.equals(allVariablesNames, that.allVariablesNames)
+        && Objects.equals(hiddenFlowNodeIds, that.hiddenFlowNodeIds)
+        && Objects.equals(filterContext, that.filterContext);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        plan,
+        reportData,
+        timezone,
+        unfilteredTotalInstanceCount,
+        pagination,
+        isCsvExport,
+        isJsonExport,
+        combinedRangeMinMaxStats,
+        allDistributedByKeysAndLabels,
+        allVariablesNames,
+        hiddenFlowNodeIds,
+        filterContext,
+        multiIndexAlias);
   }
 
   protected boolean canEqual(final Object other) {
     return other instanceof ExecutionContext;
-  }
-
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 
   public String toString() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationContext.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationContext.java
@@ -12,6 +12,7 @@ import static io.camunda.optimize.util.SuppressionConstants.UNCHECKED_CAST;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
 import io.camunda.optimize.dto.optimize.rest.pagination.PaginationDto;
 import java.time.ZoneId;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -101,16 +102,35 @@ public class ReportEvaluationContext<R extends ReportDefinitionDto<?>> {
     this.timezone = timezone;
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportEvaluationContext<?> that = (ReportEvaluationContext<?>) o;
+    return isCsvExport == that.isCsvExport
+        && isJsonExport == that.isJsonExport
+        && Objects.equals(reportDefinition, that.reportDefinition)
+        && Objects.equals(pagination, that.pagination)
+        && Objects.equals(hiddenFlowNodeIds, that.hiddenFlowNodeIds)
+        && Objects.equals(combinedRangeMinMaxStats, that.combinedRangeMinMaxStats)
+        && Objects.equals(timezone, that.timezone);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        reportDefinition,
+        pagination,
+        isCsvExport,
+        isJsonExport,
+        hiddenFlowNodeIds,
+        combinedRangeMinMaxStats,
+        timezone);
   }
 
   protected boolean canEqual(final Object other) {
     return other instanceof ReportEvaluationContext;
-  }
-
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 
   public String toString() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/context/VariableAggregationContext.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/context/VariableAggregationContext.java
@@ -13,6 +13,8 @@ import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import io.camunda.optimize.service.db.filter.FilterContext;
 import io.camunda.optimize.service.db.report.MinMaxStatDto;
 import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 
 public class VariableAggregationContext {
@@ -104,16 +106,45 @@ public class VariableAggregationContext {
     this.variableRangeMinMaxStats = variableRangeMinMaxStats;
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableAggregationContext that = (VariableAggregationContext) o;
+    return Objects.equals(variableName, that.variableName)
+        && variableType == that.variableType
+        && Objects.equals(variablePath, that.variablePath)
+        && Objects.equals(nestedVariableNameField, that.nestedVariableNameField)
+        && Objects.equals(nestedVariableValueFieldLabel, that.nestedVariableValueFieldLabel)
+        && Objects.equals(timezone, that.timezone)
+        && Objects.equals(customBucketDto, that.customBucketDto)
+        && dateUnit == that.dateUnit
+        && Objects.deepEquals(indexNames, that.indexNames)
+        && Objects.equals(variableRangeMinMaxStats, that.variableRangeMinMaxStats)
+        && Objects.equals(combinedRangeMinMaxStats, that.combinedRangeMinMaxStats)
+        && Objects.equals(filterContext, that.filterContext);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        variableName,
+        variableType,
+        variablePath,
+        nestedVariableNameField,
+        nestedVariableValueFieldLabel,
+        timezone,
+        customBucketDto,
+        dateUnit,
+        Arrays.hashCode(indexNames),
+        variableRangeMinMaxStats,
+        combinedRangeMinMaxStats,
+        filterContext);
   }
 
   protected boolean canEqual(final Object other) {
     return other instanceof VariableAggregationContext;
-  }
-
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 
   public String toString() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/result/CompositeCommandResult.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/result/CompositeCommandResult.java
@@ -40,6 +40,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -450,13 +451,32 @@ public class CompositeCommandResult {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CompositeCommandResult that = (CompositeCommandResult) o;
+    return isGroupByKeyOfNumericType == that.isGroupByKeyOfNumericType
+        && isDistributedByKeyOfNumericType == that.isDistributedByKeyOfNumericType
+        && Objects.equals(reportDataDto, that.reportDataDto)
+        && Objects.equals(viewProperty, that.viewProperty)
+        && Objects.equals(groupBySorting, that.groupBySorting)
+        && Objects.equals(distributedBySorting, that.distributedBySorting)
+        && Objects.equals(defaultNumberValueSupplier, that.defaultNumberValueSupplier)
+        && Objects.equals(groups, that.groups);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        reportDataDto,
+        viewProperty,
+        groupBySorting,
+        distributedBySorting,
+        isGroupByKeyOfNumericType,
+        isDistributedByKeyOfNumericType,
+        defaultNumberValueSupplier,
+        groups);
   }
 
   @Override
@@ -541,13 +561,19 @@ public class CompositeCommandResult {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final GroupByResult that = (GroupByResult) o;
+      return Objects.equals(key, that.key)
+          && Objects.equals(label, that.label)
+          && Objects.equals(distributions, that.distributions);
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(key, label, distributions);
     }
 
     @Override
@@ -625,13 +651,19 @@ public class CompositeCommandResult {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final DistributedByResult that = (DistributedByResult) o;
+      return Objects.equals(key, that.key)
+          && Objects.equals(label, that.label)
+          && Objects.equals(viewResult, that.viewResult);
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(key, label, viewResult);
     }
 
     @Override
@@ -682,13 +714,18 @@ public class CompositeCommandResult {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final ViewResult that = (ViewResult) o;
+      return Objects.equals(viewMeasures, that.viewMeasures)
+          && Objects.equals(rawData, that.rawData);
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(viewMeasures, rawData);
     }
 
     @Override
@@ -818,13 +855,19 @@ public class CompositeCommandResult {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final ViewMeasure that = (ViewMeasure) o;
+      return Objects.equals(aggregationType, that.aggregationType)
+          && userTaskDurationTime == that.userTaskDurationTime
+          && Objects.equals(value, that.value);
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(aggregationType, userTaskDurationTime, value);
     }
 
     @Override
@@ -917,13 +960,18 @@ public class CompositeCommandResult {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final ViewMeasureIdentifier that = (ViewMeasureIdentifier) o;
+      return Objects.equals(aggregationType, that.aggregationType)
+          && userTaskDurationTime == that.userTaskDurationTime;
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(aggregationType, userTaskDurationTime);
     }
 
     @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/digest/DigestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/digest/DigestService.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 import org.apache.commons.lang3.StringUtils;
@@ -479,13 +480,25 @@ public class DigestService implements ConfigurationReloadable {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final DigestTemplateKpiSummaryDto that = (DigestTemplateKpiSummaryDto) o;
+      return targetMet == that.targetMet
+          && Objects.equals(reportName, that.reportName)
+          && Objects.equals(reportLink, that.reportLink)
+          && Objects.equals(kpiType, that.kpiType)
+          && Objects.equals(target, that.target)
+          && Objects.equals(current, that.current)
+          && Objects.equals(changeInPercent, that.changeInPercent)
+          && changeType == that.changeType;
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(
+          reportName, reportLink, kpiType, targetMet, target, current, changeInPercent, changeType);
     }
 
     @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/page/PositionBasedImportPage.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/page/PositionBasedImportPage.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.importing.page;
 
+import java.util.Objects;
+
 public class PositionBasedImportPage implements ImportPage {
 
   private Long position = 0L;
@@ -44,13 +46,19 @@ public class PositionBasedImportPage implements ImportPage {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PositionBasedImportPage that = (PositionBasedImportPage) o;
+    return hasSeenSequenceField == that.hasSeenSequenceField
+        && Objects.equals(position, that.position)
+        && Objects.equals(sequence, that.sequence);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(position, sequence, hasSeenSequenceField);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelEntityEventProperties.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelEntityEventProperties.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.mixpanel.client;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class MixpanelEntityEventProperties extends MixpanelEventProperties {
 
@@ -38,13 +39,20 @@ public class MixpanelEntityEventProperties extends MixpanelEventProperties {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final MixpanelEntityEventProperties that = (MixpanelEntityEventProperties) o;
+    return Objects.equals(entityId, that.entityId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), entityId);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelEvent.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelEvent.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.mixpanel.client;
 
+import java.util.Objects;
+
 public class MixpanelEvent {
 
   public static final String EVENT_NAME_PREFIX = "optimize:";
@@ -48,13 +50,17 @@ public class MixpanelEvent {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MixpanelEvent that = (MixpanelEvent) o;
+    return Objects.equals(event, that.event) && Objects.equals(properties, that.properties);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(event, properties);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelEventProperties.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelEventProperties.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.mixpanel.client;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import java.util.UUID;
 
 public class MixpanelEventProperties {
@@ -137,13 +138,25 @@ public class MixpanelEventProperties {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MixpanelEventProperties that = (MixpanelEventProperties) o;
+    return time == that.time
+        && Objects.equals(distinctId, that.distinctId)
+        && Objects.equals(insertId, that.insertId)
+        && Objects.equals(product, that.product)
+        && Objects.equals(organizationId, that.organizationId)
+        && Objects.equals(stage, that.stage)
+        && Objects.equals(userId, that.userId)
+        && Objects.equals(clusterId, that.clusterId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        time, distinctId, insertId, product, organizationId, stage, userId, clusterId);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelHeartbeatMetrics.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelHeartbeatMetrics.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.mixpanel.client;
 
+import java.util.Objects;
+
 public class MixpanelHeartbeatMetrics {
 
   private long processReportCount;
@@ -95,13 +97,30 @@ public class MixpanelHeartbeatMetrics {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MixpanelHeartbeatMetrics that = (MixpanelHeartbeatMetrics) o;
+    return processReportCount == that.processReportCount
+        && decisionReportCount == that.decisionReportCount
+        && dashboardCount == that.dashboardCount
+        && reportShareCount == that.reportShareCount
+        && dashboardShareCount == that.dashboardShareCount
+        && alertCount == that.alertCount
+        && taskReportCount == that.taskReportCount;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        processReportCount,
+        decisionReportCount,
+        dashboardCount,
+        reportShareCount,
+        dashboardShareCount,
+        alertCount,
+        taskReportCount);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelHeartbeatProperties.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelHeartbeatProperties.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.mixpanel.client;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class MixpanelHeartbeatProperties extends MixpanelEventProperties {
 
@@ -116,13 +117,34 @@ public class MixpanelHeartbeatProperties extends MixpanelEventProperties {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final MixpanelHeartbeatProperties that = (MixpanelHeartbeatProperties) o;
+    return processReportCount == that.processReportCount
+        && decisionReportCount == that.decisionReportCount
+        && dashboardCount == that.dashboardCount
+        && reportShareCount == that.reportShareCount
+        && dashboardShareCount == that.dashboardShareCount
+        && alertCount == that.alertCount
+        && taskReportCount == that.taskReportCount;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(),
+        processReportCount,
+        decisionReportCount,
+        dashboardCount,
+        reportShareCount,
+        dashboardShareCount,
+        alertCount,
+        taskReportCount);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelImportResponse.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelImportResponse.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.mixpanel.client;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 public class MixpanelImportResponse {
@@ -49,13 +50,18 @@ public class MixpanelImportResponse {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MixpanelImportResponse that = (MixpanelImportResponse) o;
+    return numberOfRecordsImported == that.numberOfRecordsImported
+        && Objects.equals(error, that.error);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(error, numberOfRecordsImported);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/onboarding/OnboardingSchedulerService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/onboarding/OnboardingSchedulerService.java
@@ -19,6 +19,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -244,13 +245,42 @@ public class OnboardingSchedulerService extends AbstractScheduledService
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OnboardingSchedulerService that = (OnboardingSchedulerService) o;
+    return intervalToCheckForOnboardingDataInSeconds
+            == that.intervalToCheckForOnboardingDataInSeconds
+        && Objects.equals(processDefinitionReader, that.processDefinitionReader)
+        && Objects.equals(processDefinitionWriter, that.processDefinitionWriter)
+        && Objects.equals(processInstanceReader, that.processInstanceReader)
+        && Objects.equals(configurationService, that.configurationService)
+        && Objects.equals(
+            onboardingEmailNotificationService, that.onboardingEmailNotificationService)
+        && Objects.equals(processOverviewService, that.processOverviewService)
+        && Objects.equals(onboardingDataService, that.onboardingDataService)
+        && Objects.equals(saaSPanelNotificationService, that.saaSPanelNotificationService)
+        && Objects.equals(applicationContext, that.applicationContext)
+        && Objects.equals(emailNotificationHandler, that.emailNotificationHandler)
+        && Objects.equals(panelNotificationHandler, that.panelNotificationHandler);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        processDefinitionReader,
+        processDefinitionWriter,
+        processInstanceReader,
+        configurationService,
+        onboardingEmailNotificationService,
+        processOverviewService,
+        onboardingDataService,
+        saaSPanelNotificationService,
+        applicationContext,
+        intervalToCheckForOnboardingDataInSeconds,
+        emailNotificationHandler,
+        panelNotificationHandler);
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/EngineUserDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/EngineUserDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
+import java.util.Objects;
+
 public class EngineUserDto {
 
   private UserProfileDto profile;
@@ -40,13 +42,17 @@ public class EngineUserDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EngineUserDto that = (EngineUserDto) o;
+    return Objects.equals(profile, that.profile) && Objects.equals(credentials, that.credentials);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(profile, credentials);
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/ExecutionDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/ExecutionDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
+import java.util.Objects;
+
 public class ExecutionDto {
 
   private String id;
@@ -35,13 +37,17 @@ public class ExecutionDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExecutionDto that = (ExecutionDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(processInstanceId, that.processInstanceId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, processInstanceId);
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/ExternalTaskEngineDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/ExternalTaskEngineDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
+import java.util.Objects;
+
 public class ExternalTaskEngineDto {
 
   protected String id;
@@ -35,13 +37,17 @@ public class ExternalTaskEngineDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExternalTaskEngineDto that = (ExternalTaskEngineDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(processInstanceId, that.processInstanceId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, processInstanceId);
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/GroupDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/GroupDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
+import java.util.Objects;
+
 public class GroupDto {
 
   private String id;
@@ -50,13 +52,19 @@ public class GroupDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final GroupDto groupDto = (GroupDto) o;
+    return Objects.equals(id, groupDto.id)
+        && Objects.equals(name, groupDto.name)
+        && Objects.equals(type, groupDto.type);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, name, type);
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/JobEngineDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/JobEngineDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
+import java.util.Objects;
+
 public class JobEngineDto {
 
   protected String id;
@@ -27,12 +29,19 @@ public class JobEngineDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final JobEngineDto that = (JobEngineDto) o;
+    return Objects.equals(id, that.id);
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/UserCredentialsDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/UserCredentialsDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
+import java.util.Objects;
+
 public class UserCredentialsDto {
 
   private String password;
@@ -31,12 +33,19 @@ public class UserCredentialsDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(password);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UserCredentialsDto that = (UserCredentialsDto) o;
+    return Objects.equals(password, that.password);
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/UserProfileDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/UserProfileDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
+import java.util.Objects;
+
 public class UserProfileDto {
 
   protected String id;
@@ -62,12 +64,22 @@ public class UserProfileDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, firstName, lastName, email);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UserProfileDto that = (UserProfileDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(firstName, that.firstName)
+        && Objects.equals(lastName, that.lastName)
+        && Objects.equals(email, that.email);
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/EngineIncidentDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/EngineIncidentDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.test.util.client.dto;
 
 import java.util.Date;
+import java.util.Objects;
 
 public class EngineIncidentDto {
 
@@ -145,13 +146,44 @@ public class EngineIncidentDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EngineIncidentDto that = (EngineIncidentDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(executionId, that.executionId)
+        && Objects.equals(incidentTimestamp, that.incidentTimestamp)
+        && Objects.equals(incidentType, that.incidentType)
+        && Objects.equals(activityId, that.activityId)
+        && Objects.equals(failedActivityId, that.failedActivityId)
+        && Objects.equals(causeIncidentId, that.causeIncidentId)
+        && Objects.equals(rootCauseIncidentId, that.rootCauseIncidentId)
+        && Objects.equals(configuration, that.configuration)
+        && Objects.equals(incidentMessage, that.incidentMessage)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(jobDefinitionId, that.jobDefinitionId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        processDefinitionId,
+        processInstanceId,
+        executionId,
+        incidentTimestamp,
+        incidentType,
+        activityId,
+        failedActivityId,
+        causeIncidentId,
+        rootCauseIncidentId,
+        configuration,
+        incidentMessage,
+        tenantId,
+        jobDefinitionId);
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/MessageCorrelationDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/MessageCorrelationDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.test.util.client.dto;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class MessageCorrelationDto {
 
@@ -47,13 +48,19 @@ public class MessageCorrelationDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MessageCorrelationDto that = (MessageCorrelationDto) o;
+    return all == that.all
+        && Objects.equals(processVariables, that.processVariables)
+        && Objects.equals(messageName, that.messageName);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(processVariables, messageName, all);
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/TaskDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/TaskDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.test.util.client.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TaskDto {
@@ -48,13 +49,19 @@ public class TaskDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TaskDto taskDto = (TaskDto) o;
+    return Objects.equals(id, taskDto.id)
+        && Objects.equals(created, taskDto.created)
+        && Objects.equals(processInstanceId, taskDto.processInstanceId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, created, processInstanceId);
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/VariableValueDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/VariableValueDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.test.util.client.dto;
 
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
+import java.util.Objects;
 
 public class VariableValueDto {
 
@@ -42,13 +43,17 @@ public class VariableValueDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableValueDto that = (VariableValueDto) o;
+    return Objects.equals(value, that.value) && type == that.type;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(value, type);
   }
 
   @Override

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/service/UpgradeStepLogEntryDto.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/service/UpgradeStepLogEntryDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.upgrade.service;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
 import java.time.Instant;
+import java.util.Objects;
 
 public class UpgradeStepLogEntryDto {
 
@@ -116,13 +117,21 @@ public class UpgradeStepLogEntryDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UpgradeStepLogEntryDto that = (UpgradeStepLogEntryDto) o;
+    return Objects.equals(indexName, that.indexName)
+        && Objects.equals(optimizeVersion, that.optimizeVersion)
+        && stepType == that.stepType
+        && Objects.equals(stepNumber, that.stepNumber)
+        && Objects.equals(appliedDate, that.appliedDate);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(indexName, optimizeVersion, stepType, stepNumber, appliedDate);
   }
 
   @Override

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/UpgradeStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/UpgradeStep.java
@@ -11,6 +11,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.camunda.optimize.service.db.schema.IndexLookupUtil;
 import io.camunda.optimize.service.db.schema.IndexMappingCreator;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
+import java.util.Objects;
 
 public abstract class UpgradeStep {
 
@@ -63,13 +64,17 @@ public abstract class UpgradeStep {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UpgradeStep that = (UpgradeStep) o;
+    return skipIndexConversion == that.skipIndexConversion && Objects.equals(index, that.index);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(index, skipIndexConversion);
   }
 
   @Override

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/document/DeleteDataStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/document/DeleteDataStep.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.service.db.schema.IndexMappingCreator;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
+import java.util.Objects;
 
 public class DeleteDataStep extends UpgradeStep {
 
@@ -38,12 +39,19 @@ public class DeleteDataStep extends UpgradeStep {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DeleteDataStep that = (DeleteDataStep) o;
+    return Objects.equals(queryWrapper, that.queryWrapper);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), queryWrapper);
   }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/document/InsertDataStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/document/InsertDataStep.java
@@ -11,6 +11,7 @@ import io.camunda.optimize.service.db.schema.IndexMappingCreator;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
+import java.util.Objects;
 
 public class InsertDataStep extends UpgradeStep {
 
@@ -37,12 +38,19 @@ public class InsertDataStep extends UpgradeStep {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final InsertDataStep that = (InsertDataStep) o;
+    return Objects.equals(data, that.data);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), data);
   }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/document/UpdateDataStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/document/UpdateDataStep.java
@@ -14,6 +14,7 @@ import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 
 public class UpdateDataStep extends UpgradeStep {
@@ -74,12 +75,22 @@ public class UpdateDataStep extends UpgradeStep {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final UpdateDataStep that = (UpdateDataStep) o;
+    return Objects.equals(queryWrapper, that.queryWrapper)
+        && Objects.equals(updateScript, that.updateScript)
+        && Objects.equals(parameters, that.parameters)
+        && Objects.equals(paramMapProvider, that.paramMapProvider);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), queryWrapper, updateScript, parameters, paramMapProvider);
   }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/CreateIndexStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/CreateIndexStep.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 public class CreateIndexStep extends UpgradeStep {
@@ -43,12 +44,19 @@ public class CreateIndexStep extends UpgradeStep {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final CreateIndexStep that = (CreateIndexStep) o;
+    return Objects.equals(readOnlyAliases, that.readOnlyAliases);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), readOnlyAliases);
   }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/DeleteIndexIfExistsStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/DeleteIndexIfExistsStep.java
@@ -11,6 +11,7 @@ import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
+import java.util.Objects;
 
 public class DeleteIndexIfExistsStep extends UpgradeStep {
 
@@ -45,18 +46,25 @@ public class DeleteIndexIfExistsStep extends UpgradeStep {
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  @Override
   protected boolean canEqual(final Object other) {
     return other instanceof DeleteIndexIfExistsStep;
   }
 
   @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DeleteIndexIfExistsStep that = (DeleteIndexIfExistsStep) o;
+    return indexVersion == that.indexVersion && Objects.equals(indexName, that.indexName);
+  }
+
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), indexName, indexVersion);
   }
 
   public String getIndexName() {

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/DeleteIndexTemplateIfExistsStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/DeleteIndexTemplateIfExistsStep.java
@@ -15,6 +15,7 @@ import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.exception.UpgradeRuntimeException;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
+import java.util.Objects;
 
 public class DeleteIndexTemplateIfExistsStep extends UpgradeStep {
 
@@ -57,18 +58,26 @@ public class DeleteIndexTemplateIfExistsStep extends UpgradeStep {
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  @Override
   protected boolean canEqual(final Object other) {
     return other instanceof DeleteIndexTemplateIfExistsStep;
   }
 
   @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DeleteIndexTemplateIfExistsStep that = (DeleteIndexTemplateIfExistsStep) o;
+    return templateVersion == that.templateVersion
+        && Objects.equals(templateName, that.templateName);
+  }
+
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), templateName, templateVersion);
   }
 
   public String getTemplateName() {

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/ReindexStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/ReindexStep.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.service.db.schema.IndexMappingCreator;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
+import java.util.Objects;
 
 public class ReindexStep extends UpgradeStep {
 
@@ -54,13 +55,23 @@ public class ReindexStep extends UpgradeStep {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ReindexStep that = (ReindexStep) o;
+    return Objects.equals(sourceIndex, that.sourceIndex)
+        && Objects.equals(targetIndex, that.targetIndex)
+        && Objects.equals(queryWrapper, that.queryWrapper)
+        && Objects.equals(mappingScript, that.mappingScript);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), sourceIndex, targetIndex, queryWrapper, mappingScript);
   }
 
   public IndexMappingCreator getSourceIndex() {

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/UpdateMappingIndexStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/UpdateMappingIndexStep.java
@@ -11,6 +11,7 @@ import io.camunda.optimize.service.db.schema.IndexMappingCreator;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
+import java.util.Objects;
 
 public class UpdateMappingIndexStep extends UpgradeStep {
 
@@ -35,11 +36,18 @@ public class UpdateMappingIndexStep extends UpgradeStep {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(index);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UpdateMappingIndexStep that = (UpdateMappingIndexStep) o;
+    return Objects.equals(index, that.index);
   }
 }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/db/indices/UserTestDto.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/db/indices/UserTestDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.upgrade.db.indices;
 
+import java.util.Objects;
+
 public class UserTestDto {
 
   String username;
@@ -36,12 +38,19 @@ public class UserTestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(username, password);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UserTestDto that = (UserTestDto) o;
+    return Objects.equals(username, that.username) && Objects.equals(password, that.password);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/AuthorizedEntityDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/AuthorizedEntityDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize;
 
+import java.util.Objects;
+
 // supposed to be called from entity specific subclasses only
 public class AuthorizedEntityDto {
 
@@ -31,13 +33,17 @@ public class AuthorizedEntityDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AuthorizedEntityDto that = (AuthorizedEntityDto) o;
+    return currentUserRole == that.currentUserRole;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(currentUserRole);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DecisionDefinitionOptimizeDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DecisionDefinitionOptimizeDto.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.dto.optimize.datasource.EngineDataSourceDto;
 import io.camunda.optimize.dto.optimize.query.variable.DecisionVariableNameResponseDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class DecisionDefinitionOptimizeDto extends DefinitionOptimizeResponseDto {
 
@@ -95,13 +96,22 @@ public class DecisionDefinitionOptimizeDto extends DefinitionOptimizeResponseDto
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DecisionDefinitionOptimizeDto that = (DecisionDefinitionOptimizeDto) o;
+    return Objects.equals(dmn10Xml, that.dmn10Xml)
+        && Objects.equals(inputVariableNames, that.inputVariableNames)
+        && Objects.equals(outputVariableNames, that.outputVariableNames);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), dmn10Xml, inputVariableNames, outputVariableNames);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DefinitionOptimizeResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DefinitionOptimizeResponseDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.datasource.DataSourceDto;
 import java.io.Serializable;
+import java.util.Objects;
 
 public abstract class DefinitionOptimizeResponseDto implements Serializable, OptimizeDto {
 
@@ -129,13 +130,25 @@ public abstract class DefinitionOptimizeResponseDto implements Serializable, Opt
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionOptimizeResponseDto that = (DefinitionOptimizeResponseDto) o;
+    return deleted == that.deleted
+        && Objects.equals(id, that.id)
+        && Objects.equals(key, that.key)
+        && Objects.equals(version, that.version)
+        && Objects.equals(versionTag, that.versionTag)
+        && Objects.equals(name, that.name)
+        && Objects.equals(dataSource, that.dataSource)
+        && Objects.equals(tenantId, that.tenantId)
+        && type == that.type;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, key, version, versionTag, name, dataSource, tenantId, deleted, type);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/FlowNodeDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/FlowNodeDataDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class FlowNodeDataDto implements Serializable {
 
@@ -52,13 +53,19 @@ public class FlowNodeDataDto implements Serializable {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FlowNodeDataDto that = (FlowNodeDataDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, name, type);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/FlowNodeTotalDurationDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/FlowNodeTotalDurationDataDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize;
 
+import java.util.Objects;
+
 public class FlowNodeTotalDurationDataDto {
 
   String name;
@@ -40,13 +42,17 @@ public class FlowNodeTotalDurationDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FlowNodeTotalDurationDataDto that = (FlowNodeTotalDurationDataDto) o;
+    return value == that.value && Objects.equals(name, that.name);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(name, value);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/GroupDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/GroupDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -57,12 +58,22 @@ public class GroupDto extends IdentityWithMetadataResponseDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), memberCount);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final GroupDto groupDto = (GroupDto) o;
+    return Objects.equals(memberCount, groupDto.memberCount);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/IdentityDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/IdentityDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize;
 
+import java.util.Objects;
+
 public class IdentityDto {
 
   private String id;
@@ -49,12 +51,19 @@ public class IdentityDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, type);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IdentityDto that = (IdentityDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(type, that.type);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/IdentityWithMetadataResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/IdentityWithMetadataResponseDto.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 
@@ -71,12 +72,22 @@ public abstract class IdentityWithMetadataResponseDto extends IdentityDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), name);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final IdentityWithMetadataResponseDto that = (IdentityWithMetadataResponseDto) o;
+    return Objects.equals(name, that.name);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ImportRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ImportRequestDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize;
 
 import io.camunda.optimize.service.db.schema.ScriptData;
+import java.util.Objects;
 
 public class ImportRequestDto {
 
@@ -98,12 +99,25 @@ public class ImportRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(importName, indexName, scriptData, id, source, type, retryNumberOnConflict);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ImportRequestDto that = (ImportRequestDto) o;
+    return retryNumberOnConflict == that.retryNumberOnConflict
+        && Objects.equals(importName, that.importName)
+        && Objects.equals(indexName, that.indexName)
+        && Objects.equals(scriptData, that.scriptData)
+        && Objects.equals(id, that.id)
+        && Objects.equals(source, that.source)
+        && Objects.equals(type, that.type);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessDefinitionOptimizeDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessDefinitionOptimizeDto.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto {
 
@@ -132,12 +133,25 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), bpmn20Xml, flowNodeData, userTaskNames, onboarded);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ProcessDefinitionOptimizeDto that = (ProcessDefinitionOptimizeDto) o;
+    return onboarded == that.onboarded
+        && Objects.equals(bpmn20Xml, that.bpmn20Xml)
+        && Objects.equals(flowNodeData, that.flowNodeData)
+        && Objects.equals(userTaskNames, that.userTaskNames);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessInstanceDto.java
@@ -17,6 +17,7 @@ import io.camunda.optimize.dto.optimize.query.variable.SimpleProcessVariableDto;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class ProcessInstanceDto implements OptimizeDto {
 
@@ -222,12 +223,46 @@ public class ProcessInstanceDto implements OptimizeDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        processDefinitionKey,
+        processDefinitionVersion,
+        processDefinitionId,
+        processInstanceId,
+        businessKey,
+        startDate,
+        endDate,
+        duration,
+        state,
+        flowNodeInstances,
+        variables,
+        incidents,
+        dataSource,
+        tenantId);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessInstanceDto that = (ProcessInstanceDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersion, that.processDefinitionVersion)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(businessKey, that.businessKey)
+        && Objects.equals(startDate, that.startDate)
+        && Objects.equals(endDate, that.endDate)
+        && Objects.equals(duration, that.duration)
+        && Objects.equals(state, that.state)
+        && Objects.equals(flowNodeInstances, that.flowNodeInstances)
+        && Objects.equals(variables, that.variables)
+        && Objects.equals(incidents, that.incidents)
+        && Objects.equals(dataSource, that.dataSource)
+        && Objects.equals(tenantId, that.tenantId);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/SettingsDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/SettingsDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize;
 
 import java.time.OffsetDateTime;
+import java.util.Objects;
 import java.util.Optional;
 
 public class SettingsDto {
@@ -44,13 +45,18 @@ public class SettingsDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SettingsDto that = (SettingsDto) o;
+    return Objects.equals(sharingEnabled, that.sharingEnabled)
+        && Objects.equals(lastModified, that.lastModified);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(sharingEnabled, lastModified);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/SimpleDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/SimpleDefinitionDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 public class SimpleDefinitionDto {
@@ -104,13 +105,20 @@ public class SimpleDefinitionDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SimpleDefinitionDto that = (SimpleDefinitionDto) o;
+    return Objects.equals(key, that.key)
+        && Objects.equals(name, that.name)
+        && type == that.type
+        && Objects.equals(engines, that.engines);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(key, name, type, engines);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/TenantDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/TenantDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize;
 
+import java.util.Objects;
+
 public class TenantDto implements OptimizeDto {
 
   private String id;
@@ -51,12 +53,21 @@ public class TenantDto implements OptimizeDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, name, engine);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TenantDto that = (TenantDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(engine, that.engine);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/UserDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/UserDto.java
@@ -120,13 +120,23 @@ public class UserDto extends IdentityWithMetadataResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final UserDto userDto = (UserDto) o;
+    return Objects.equals(firstName, userDto.firstName)
+        && Objects.equals(lastName, userDto.lastName)
+        && Objects.equals(email, userDto.email)
+        && Objects.equals(roles, userDto.roles);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), firstName, lastName, email, roles);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ZeebeConfigDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ZeebeConfigDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize;
 
+import java.util.Objects;
+
 public class ZeebeConfigDto implements SchedulerConfig {
 
   private String name;
@@ -39,12 +41,19 @@ public class ZeebeConfigDto implements SchedulerConfig {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(name, partitionCount);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeConfigDto that = (ZeebeConfigDto) o;
+    return partitionCount == that.partitionCount && Objects.equals(name, that.name);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/alert/AlertNotificationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/alert/AlertNotificationDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.alert;
 
 import io.camunda.optimize.dto.optimize.query.alert.AlertDefinitionDto;
+import java.util.Objects;
 
 public class AlertNotificationDto {
 
@@ -55,13 +56,21 @@ public class AlertNotificationDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AlertNotificationDto that = (AlertNotificationDto) o;
+    return Objects.equals(alert, that.alert)
+        && Objects.equals(currentValue, that.currentValue)
+        && type == that.type
+        && Objects.equals(alertMessage, that.alertMessage)
+        && Objects.equals(reportLink, that.reportLink);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(alert, currentValue, type, alertMessage, reportLink);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/CloudUserDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/CloudUserDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.cloud;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 public class CloudUserDto {
@@ -61,12 +62,22 @@ public class CloudUserDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(userId, name, email, roles);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CloudUserDto that = (CloudUserDto) o;
+    return Objects.equals(userId, that.userId)
+        && Objects.equals(name, that.name)
+        && Objects.equals(email, that.email)
+        && Objects.equals(roles, that.roles);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/TokenRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/TokenRequestDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.cloud;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class TokenRequestDto {
 
@@ -78,12 +79,22 @@ public class TokenRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(clientId, clientSecret, audience, grantType);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TokenRequestDto that = (TokenRequestDto) o;
+    return Objects.equals(clientId, that.clientId)
+        && Objects.equals(clientSecret, that.clientSecret)
+        && Objects.equals(audience, that.audience)
+        && Objects.equals(grantType, that.grantType);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/TokenResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/TokenResponseDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.cloud;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class TokenResponseDto {
 
@@ -67,12 +68,22 @@ public class TokenResponseDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(accessToken, tokenType, expiresIn, scope);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TokenResponseDto that = (TokenResponseDto) o;
+    return expiresIn == that.expiresIn
+        && Objects.equals(accessToken, that.accessToken)
+        && Objects.equals(tokenType, that.tokenType)
+        && Objects.equals(scope, that.scope);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/panelnotifications/PanelNotificationDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/panelnotifications/PanelNotificationDataDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.cloud.panelnotifications;
 
+import java.util.Objects;
+
 public final class PanelNotificationDataDto {
 
   private final String uniqueId;
@@ -68,12 +70,25 @@ public final class PanelNotificationDataDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(uniqueId, source, type, orgId, title, description, meta);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PanelNotificationDataDto that = (PanelNotificationDataDto) o;
+    return Objects.equals(uniqueId, that.uniqueId)
+        && Objects.equals(source, that.source)
+        && Objects.equals(type, that.type)
+        && Objects.equals(orgId, that.orgId)
+        && Objects.equals(title, that.title)
+        && Objects.equals(description, that.description)
+        && Objects.equals(meta, that.meta);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/panelnotifications/PanelNotificationMetaDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/panelnotifications/PanelNotificationMetaDataDto.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.optimize.dto.optimize.cloud.panelnotifications;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 public final class PanelNotificationMetaDataDto {
 
   private final String identifier;
@@ -44,12 +47,22 @@ public final class PanelNotificationMetaDataDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(identifier, Arrays.hashCode(permissions), href, label);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PanelNotificationMetaDataDto that = (PanelNotificationMetaDataDto) o;
+    return Objects.equals(identifier, that.identifier)
+        && Arrays.equals(permissions, that.permissions)
+        && Objects.equals(href, that.href)
+        && Objects.equals(label, that.label);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/panelnotifications/PanelNotificationRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/panelnotifications/PanelNotificationRequestDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.cloud.panelnotifications;
 
+import java.util.Objects;
+
 public final class PanelNotificationRequestDto {
 
   private final PanelNotificationDataDto notification;
@@ -25,12 +27,19 @@ public final class PanelNotificationRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(notification);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PanelNotificationRequestDto that = (PanelNotificationRequestDto) o;
+    return Objects.equals(notification, that.notification);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/DataSourceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/DataSourceDto.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.DataImportSourceType;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.io.Serializable;
+import java.util.Objects;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -56,12 +57,19 @@ public abstract class DataSourceDto implements OptimizeDto, Serializable {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(type, name);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DataSourceDto that = (DataSourceDto) o;
+    return Objects.equals(type, that.type) && Objects.equals(name, that.name);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/EngineDataSourceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/EngineDataSourceDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.datasource;
 
 import io.camunda.optimize.dto.optimize.DataImportSourceType;
 import io.camunda.optimize.dto.optimize.SchedulerConfig;
+import java.util.Objects;
 
 public class EngineDataSourceDto extends DataSourceDto implements SchedulerConfig {
 
@@ -27,12 +28,18 @@ public class EngineDataSourceDto extends DataSourceDto implements SchedulerConfi
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/IngestedDataSourceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/IngestedDataSourceDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.datasource;
 
 import io.camunda.optimize.dto.optimize.DataImportSourceType;
 import io.camunda.optimize.dto.optimize.SchedulerConfig;
+import java.util.Objects;
 
 public class IngestedDataSourceDto extends DataSourceDto implements SchedulerConfig {
 
@@ -27,12 +28,18 @@ public class IngestedDataSourceDto extends DataSourceDto implements SchedulerCon
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/ZeebeDataSourceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/ZeebeDataSourceDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.datasource;
 
 import io.camunda.optimize.dto.optimize.DataImportSourceType;
+import java.util.Objects;
 
 public class ZeebeDataSourceDto extends DataSourceDto {
 
@@ -33,12 +34,22 @@ public class ZeebeDataSourceDto extends DataSourceDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), partitionId);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ZeebeDataSourceDto that = (ZeebeDataSourceDto) o;
+    return partitionId == that.partitionId;
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/ImportIndexDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/ImportIndexDto.java
@@ -13,6 +13,7 @@ import io.camunda.optimize.dto.optimize.datasource.DataSourceDto;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.Objects;
 
 public abstract class ImportIndexDto<T extends DataSourceDto> implements OptimizeDto {
 
@@ -75,12 +76,23 @@ public abstract class ImportIndexDto<T extends DataSourceDto> implements Optimiz
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        lastImportExecutionTimestamp, timestampOfLastEntity, dbTypeIndexRefersTo, dataSource);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ImportIndexDto<?> that = (ImportIndexDto<?>) o;
+    return Objects.equals(lastImportExecutionTimestamp, that.lastImportExecutionTimestamp)
+        && Objects.equals(timestampOfLastEntity, that.timestampOfLastEntity)
+        && Objects.equals(dbTypeIndexRefersTo, that.dbTypeIndexRefersTo)
+        && Objects.equals(dataSource, that.dataSource);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/PositionBasedImportIndexDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/PositionBasedImportIndexDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.index;
 
 import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
+import java.util.Objects;
 
 public class PositionBasedImportIndexDto extends ImportIndexDto<ZeebeDataSourceDto> {
 
@@ -49,12 +50,25 @@ public class PositionBasedImportIndexDto extends ImportIndexDto<ZeebeDataSourceD
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        super.hashCode(), positionOfLastEntity, sequenceOfLastEntity, hasSeenSequenceField);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final PositionBasedImportIndexDto that = (PositionBasedImportIndexDto) o;
+    return positionOfLastEntity == that.positionOfLastEntity
+        && sequenceOfLastEntity == that.sequenceOfLastEntity
+        && hasSeenSequenceField == that.hasSeenSequenceField;
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/TimestampBasedImportIndexDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/TimestampBasedImportIndexDto.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import io.camunda.optimize.dto.optimize.datasource.IngestedDataSourceDto;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 public class TimestampBasedImportIndexDto extends ImportIndexDto<IngestedDataSourceDto>
     implements OptimizeDto {
@@ -36,12 +37,18 @@ public class TimestampBasedImportIndexDto extends ImportIndexDto<IngestedDataSou
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/AssigneeOperationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/AssigneeOperationDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.persistence;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 public class AssigneeOperationDto implements OptimizeDto, Serializable {
 
@@ -76,16 +77,24 @@ public class AssigneeOperationDto implements OptimizeDto, Serializable {
         + ")";
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AssigneeOperationDto that = (AssigneeOperationDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(userId, that.userId)
+        && Objects.equals(operationType, that.operationType)
+        && Objects.equals(timestamp, that.timestamp);
   }
 
-  protected boolean canEqual(final Object other) {
-    return other instanceof AssigneeOperationDto;
-  }
-
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, userId, operationType, timestamp);
   }
 
   @SuppressWarnings("checkstyle:ConstantName")

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/BusinessKeyDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/BusinessKeyDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.persistence;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
+import java.util.Objects;
 
 public class BusinessKeyDto implements OptimizeDto {
 
@@ -35,12 +36,20 @@ public class BusinessKeyDto implements OptimizeDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(processInstanceId, businessKey);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BusinessKeyDto that = (BusinessKeyDto) o;
+    return Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(businessKey, that.businessKey);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/CandidateGroupOperationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/CandidateGroupOperationDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.persistence;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 public class CandidateGroupOperationDto implements OptimizeDto, Serializable {
 
@@ -69,12 +70,22 @@ public class CandidateGroupOperationDto implements OptimizeDto, Serializable {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, groupId, operationType, timestamp);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CandidateGroupOperationDto that = (CandidateGroupOperationDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(groupId, that.groupId)
+        && Objects.equals(operationType, that.operationType)
+        && Objects.equals(timestamp, that.timestamp);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/incident/IncidentDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/incident/IncidentDto.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 public class IncidentDto implements Serializable, OptimizeDto {
 
@@ -176,16 +177,52 @@ public class IncidentDto implements Serializable, OptimizeDto {
     this.engineAlias = engineAlias;
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IncidentDto that = (IncidentDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(createTime, that.createTime)
+        && Objects.equals(endTime, that.endTime)
+        && Objects.equals(durationInMs, that.durationInMs)
+        && Objects.equals(incidentType, that.incidentType)
+        && Objects.equals(activityId, that.activityId)
+        && Objects.equals(failedActivityId, that.failedActivityId)
+        && Objects.equals(incidentMessage, that.incidentMessage)
+        && Objects.equals(incidentStatus, that.incidentStatus)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(definitionKey, that.definitionKey)
+        && Objects.equals(definitionVersion, that.definitionVersion)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(engineAlias, that.engineAlias);
   }
 
   protected boolean canEqual(final Object other) {
     return other instanceof IncidentDto;
   }
 
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        id,
+        createTime,
+        endTime,
+        durationInMs,
+        incidentType,
+        activityId,
+        failedActivityId,
+        incidentMessage,
+        incidentStatus,
+        processInstanceId,
+        definitionKey,
+        definitionVersion,
+        tenantId,
+        engineAlias);
   }
 
   public String toString() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/incident/IncidentType.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/incident/IncidentType.java
@@ -12,6 +12,7 @@ import static io.camunda.optimize.service.util.importing.ZeebeConstants.FAILED_J
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import java.util.Objects;
 import org.slf4j.Logger;
 
 public class IncidentType {
@@ -54,12 +55,19 @@ public class IncidentType {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IncidentType that = (IncidentType) o;
+    return Objects.equals(id, that.id);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/MetadataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/MetadataDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.io.Serializable;
+import java.util.Objects;
 
 public class MetadataDto implements OptimizeDto, Serializable {
 
@@ -43,13 +44,18 @@ public class MetadataDto implements OptimizeDto, Serializable {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MetadataDto that = (MetadataDto) o;
+    return Objects.equals(schemaVersion, that.schemaVersion)
+        && Objects.equals(installationId, that.installationId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(schemaVersion, installationId);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertCreationRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertCreationRequestDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.alert;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class AlertCreationRequestDto {
 
@@ -92,13 +93,32 @@ public class AlertCreationRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AlertCreationRequestDto that = (AlertCreationRequestDto) o;
+    return fixNotification == that.fixNotification
+        && Objects.equals(name, that.name)
+        && Objects.equals(checkInterval, that.checkInterval)
+        && Objects.equals(reportId, that.reportId)
+        && Objects.equals(threshold, that.threshold)
+        && thresholdOperator == that.thresholdOperator
+        && Objects.equals(reminder, that.reminder)
+        && Objects.equals(emails, that.emails);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        name,
+        checkInterval,
+        reportId,
+        threshold,
+        thresholdOperator,
+        fixNotification,
+        reminder,
+        emails);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertDefinitionDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.alert;
 
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 public class AlertDefinitionDto extends AlertCreationRequestDto {
 
@@ -74,13 +75,26 @@ public class AlertDefinitionDto extends AlertCreationRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AlertDefinitionDto that = (AlertDefinitionDto) o;
+    return triggered == that.triggered
+        && Objects.equals(id, that.id)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(created, that.created)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(), id, lastModified, created, owner, lastModifier, triggered);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertInterval.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertInterval.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.alert;
 
+import java.util.Objects;
+
 public class AlertInterval {
 
   private int value;
@@ -40,13 +42,17 @@ public class AlertInterval {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AlertInterval that = (AlertInterval) o;
+    return value == that.value && unit == that.unit;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(value, unit);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/BaseCollectionDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/BaseCollectionDefinitionDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.collection;
 
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 public class BaseCollectionDefinitionDto<DATA_TYPE> {
 
@@ -92,12 +93,27 @@ public class BaseCollectionDefinitionDto<DATA_TYPE> {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        id, name, lastModified, created, owner, lastModifier, data, automaticallyCreated);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BaseCollectionDefinitionDto<?> that = (BaseCollectionDefinitionDto<?>) o;
+    return automaticallyCreated == that.automaticallyCreated
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(created, that.created)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && Objects.equals(data, that.data);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionDataDto.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CollectionDataDto {
@@ -51,12 +52,21 @@ public class CollectionDataDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(configuration, roles, scope);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionDataDto that = (CollectionDataDto) o;
+    return Objects.equals(configuration, that.configuration)
+        && Objects.equals(roles, that.roles)
+        && Objects.equals(scope, that.scope);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleRequestDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.collection;
 
 import io.camunda.optimize.dto.optimize.IdentityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
+import java.util.Objects;
 import java.util.Optional;
 
 public class CollectionRoleRequestDto {
@@ -62,12 +63,21 @@ public class CollectionRoleRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, identity, role);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionRoleRequestDto that = (CollectionRoleRequestDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(identity, that.identity)
+        && Objects.equals(role, that.role);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleResponseDto.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.dto.optimize.IdentityType;
 import io.camunda.optimize.dto.optimize.IdentityWithMetadataResponseDto;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.UserDto;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 public class CollectionRoleResponseDto implements Comparable<CollectionRoleResponseDto> {
@@ -99,12 +100,21 @@ public class CollectionRoleResponseDto implements Comparable<CollectionRoleRespo
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, identity, role);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionRoleResponseDto that = (CollectionRoleResponseDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(identity, that.identity)
+        && Objects.equals(role, that.role);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleUpdateRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleUpdateRequestDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.collection;
 
 import io.camunda.optimize.dto.optimize.RoleType;
+import java.util.Objects;
 
 public class CollectionRoleUpdateRequestDto {
 
@@ -33,12 +34,19 @@ public class CollectionRoleUpdateRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(role);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionRoleUpdateRequestDto that = (CollectionRoleUpdateRequestDto) o;
+    return Objects.equals(role, that.role);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionScopeEntryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionScopeEntryDto.java
@@ -14,6 +14,7 @@ import static io.camunda.optimize.dto.optimize.query.collection.ScopeComplianceT
 import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.ReportConstants;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class CollectionScopeEntryDto {
@@ -115,12 +116,22 @@ public class CollectionScopeEntryDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, definitionType, definitionKey, tenants);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionScopeEntryDto that = (CollectionScopeEntryDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(definitionType, that.definitionType)
+        && Objects.equals(definitionKey, that.definitionKey)
+        && Objects.equals(tenants, that.tenants);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionScopeEntryUpdateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionScopeEntryUpdateDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.collection;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class CollectionScopeEntryUpdateDto {
 
@@ -38,12 +39,19 @@ public class CollectionScopeEntryUpdateDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(tenants);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionScopeEntryUpdateDto that = (CollectionScopeEntryUpdateDto) o;
+    return Objects.equals(tenants, that.tenants);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/BaseDashboardDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/BaseDashboardDefinitionDto.java
@@ -11,6 +11,7 @@ import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardFilterDt
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class BaseDashboardDefinitionDto {
 
@@ -130,13 +131,40 @@ public class BaseDashboardDefinitionDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BaseDashboardDefinitionDto that = (BaseDashboardDefinitionDto) o;
+    return managementDashboard == that.managementDashboard
+        && instantPreviewDashboard == that.instantPreviewDashboard
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(created, that.created)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && Objects.equals(collectionId, that.collectionId)
+        && Objects.equals(availableFilters, that.availableFilters)
+        && Objects.equals(refreshRateSeconds, that.refreshRateSeconds);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        name,
+        description,
+        lastModified,
+        created,
+        owner,
+        lastModifier,
+        collectionId,
+        managementDashboard,
+        instantPreviewDashboard,
+        availableFilters,
+        refreshRateSeconds);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/DashboardDefinitionRestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/DashboardDefinitionRestDto.java
@@ -21,6 +21,7 @@ import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public class DashboardDefinitionRestDto extends BaseDashboardDefinitionDto
@@ -71,18 +72,25 @@ public class DashboardDefinitionRestDto extends BaseDashboardDefinitionDto
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  @Override
   protected boolean canEqual(final Object other) {
     return other instanceof DashboardDefinitionRestDto;
   }
 
   @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardDefinitionRestDto that = (DashboardDefinitionRestDto) o;
+    return Objects.equals(tiles, that.tiles);
+  }
+
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), tiles);
   }
 
   @SuppressWarnings("checkstyle:ConstantName")

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/InstantDashboardDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/InstantDashboardDataDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.dashboard;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -68,13 +69,22 @@ public class InstantDashboardDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final InstantDashboardDataDto that = (InstantDashboardDataDto) o;
+    return templateHash == that.templateHash
+        && Objects.equals(instantDashboardId, that.instantDashboardId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(templateName, that.templateName)
+        && Objects.equals(dashboardId, that.dashboardId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        instantDashboardId, processDefinitionKey, templateName, templateHash, dashboardId);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/DashboardFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/DashboardFilterDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
+import java.util.Objects;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
@@ -43,13 +44,17 @@ public abstract class DashboardFilterDto<DATA extends FilterDataDto> {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardFilterDto<?> that = (DashboardFilterDto<?>) o;
+    return Objects.equals(data, that.data);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(data);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardBooleanVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardBooleanVariableFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.List;
+import java.util.Objects;
 
 public class DashboardBooleanVariableFilterDataDto extends DashboardVariableFilterDataDto {
 
@@ -45,13 +46,20 @@ public class DashboardBooleanVariableFilterDataDto extends DashboardVariableFilt
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardBooleanVariableFilterDataDto that = (DashboardBooleanVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDateFilterDataDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterDataDto;
+import java.util.Objects;
 
 public class DashboardDateFilterDataDto implements FilterDataDto {
 
@@ -33,13 +34,17 @@ public class DashboardDateFilterDataDto implements FilterDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardDateFilterDataDto that = (DashboardDateFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(defaultValues);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDateVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDateVariableFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
+import java.util.Objects;
 
 public class DashboardDateVariableFilterDataDto extends DashboardVariableFilterDataDto {
 
@@ -45,13 +46,20 @@ public class DashboardDateVariableFilterDataDto extends DashboardVariableFilterD
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardDateVariableFilterDataDto that = (DashboardDateVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDoubleVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDoubleVariableFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.List;
+import java.util.Objects;
 
 public class DashboardDoubleVariableFilterDataDto extends DashboardVariableFilterDataDto {
 
@@ -46,13 +47,20 @@ public class DashboardDoubleVariableFilterDataDto extends DashboardVariableFilte
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardDoubleVariableFilterDataDto that = (DashboardDoubleVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardIdentityFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardIdentityFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.operator.MembershipFilterOperator;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.data.IdentityLinkFilterDataDto;
 import java.util.List;
+import java.util.Objects;
 
 public class DashboardIdentityFilterDataDto extends IdentityLinkFilterDataDto {
 
@@ -58,13 +59,21 @@ public class DashboardIdentityFilterDataDto extends IdentityLinkFilterDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardIdentityFilterDataDto that = (DashboardIdentityFilterDataDto) o;
+    return allowCustomValues == that.allowCustomValues
+        && Objects.equals(defaultValues, that.defaultValues);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), allowCustomValues, defaultValues);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardIntegerVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardIntegerVariableFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.List;
+import java.util.Objects;
 
 public class DashboardIntegerVariableFilterDataDto extends DashboardVariableFilterDataDto {
 
@@ -46,13 +47,23 @@ public class DashboardIntegerVariableFilterDataDto extends DashboardVariableFilt
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardIntegerVariableFilterDataDto that = (DashboardIntegerVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardLongVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardLongVariableFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.List;
+import java.util.Objects;
 
 public class DashboardLongVariableFilterDataDto extends DashboardVariableFilterDataDto {
 
@@ -46,13 +47,20 @@ public class DashboardLongVariableFilterDataDto extends DashboardVariableFilterD
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardLongVariableFilterDataDto that = (DashboardLongVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardShortVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardShortVariableFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.List;
+import java.util.Objects;
 
 public class DashboardShortVariableFilterDataDto extends DashboardVariableFilterDataDto {
 
@@ -46,13 +47,20 @@ public class DashboardShortVariableFilterDataDto extends DashboardVariableFilter
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardShortVariableFilterDataDto that = (DashboardShortVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardStateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardStateFilterDataDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import java.util.List;
+import java.util.Objects;
 
 public class DashboardStateFilterDataDto implements FilterDataDto {
 
@@ -33,13 +34,17 @@ public class DashboardStateFilterDataDto implements FilterDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardStateFilterDataDto that = (DashboardStateFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(defaultValues);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardStringVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardStringVariableFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.List;
+import java.util.Objects;
 
 public class DashboardStringVariableFilterDataDto extends DashboardVariableFilterDataDto {
 
@@ -46,13 +47,20 @@ public class DashboardStringVariableFilterDataDto extends DashboardVariableFilte
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardStringVariableFilterDataDto that = (DashboardStringVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardVariableFilterDataDto.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
+import java.util.Objects;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -102,13 +103,17 @@ public abstract class DashboardVariableFilterDataDto implements FilterDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardVariableFilterDataDto that = (DashboardVariableFilterDataDto) o;
+    return type == that.type && Objects.equals(name, that.name) && Objects.equals(data, that.data);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(type, name, data);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/DashboardReportTileDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/DashboardReportTileDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.dashboard.tile;
 
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 
 public class DashboardReportTileDto {
 
@@ -77,13 +78,21 @@ public class DashboardReportTileDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardReportTileDto that = (DashboardReportTileDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(position, that.position)
+        && Objects.equals(dimensions, that.dimensions)
+        && type == that.type
+        && Objects.equals(configuration, that.configuration);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, position, dimensions, type, configuration);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/DimensionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/DimensionDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.dashboard.tile;
 
+import java.util.Objects;
+
 public class DimensionDto {
 
   protected int width;
@@ -40,13 +42,17 @@ public class DimensionDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DimensionDto that = (DimensionDto) o;
+    return width == that.width && height == that.height;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(width, height);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/PositionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/PositionDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.dashboard.tile;
 
+import java.util.Objects;
+
 public class PositionDto {
 
   protected int x;
@@ -40,13 +42,17 @@ public class PositionDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PositionDto that = (PositionDto) o;
+    return x == that.x && y == that.y;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(x, y);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntitiesDeleteRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntitiesDeleteRequestDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.entity;
 
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Objects;
 
 public class EntitiesDeleteRequestDto {
 
@@ -56,13 +57,19 @@ public class EntitiesDeleteRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntitiesDeleteRequestDto that = (EntitiesDeleteRequestDto) o;
+    return Objects.equals(reports, that.reports)
+        && Objects.equals(collections, that.collections)
+        && Objects.equals(dashboards, that.dashboards);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(reports, collections, dashboards);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityData.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityData.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.entity;
 import io.camunda.optimize.dto.optimize.IdentityType;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class EntityData {
 
@@ -49,13 +50,18 @@ public class EntityData {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntityData that = (EntityData) o;
+    return Objects.equals(subEntityCounts, that.subEntityCounts)
+        && Objects.equals(roleCounts, that.roleCounts);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(subEntityCounts, roleCounts);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityNameRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityNameRequestDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.entity;
 
+import java.util.Objects;
+
 public class EntityNameRequestDto {
 
   private String collectionId;
@@ -53,13 +55,19 @@ public class EntityNameRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntityNameRequestDto that = (EntityNameRequestDto) o;
+    return Objects.equals(collectionId, that.collectionId)
+        && Objects.equals(dashboardId, that.dashboardId)
+        && Objects.equals(reportId, that.reportId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(collectionId, dashboardId, reportId);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityNameResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityNameResponseDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.entity;
 
+import java.util.Objects;
+
 public class EntityNameResponseDto {
 
   private String collectionName;
@@ -51,13 +53,19 @@ public class EntityNameResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntityNameResponseDto that = (EntityNameResponseDto) o;
+    return Objects.equals(collectionName, that.collectionName)
+        && Objects.equals(dashboardName, that.dashboardName)
+        && Objects.equals(reportName, that.reportName);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(collectionName, dashboardName, reportName);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityResponseDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.entity;
 import io.camunda.optimize.dto.optimize.ReportType;
 import io.camunda.optimize.dto.optimize.RoleType;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 public class EntityResponseDto {
 
@@ -209,13 +210,40 @@ public class EntityResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntityResponseDto that = (EntityResponseDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(created, that.created)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && entityType == that.entityType
+        && Objects.equals(data, that.data)
+        && Objects.equals(combined, that.combined)
+        && reportType == that.reportType
+        && currentUserRole == that.currentUserRole;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        name,
+        description,
+        lastModified,
+        created,
+        owner,
+        lastModifier,
+        entityType,
+        data,
+        combined,
+        reportType,
+        currentUserRole);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/process/FlowNodeInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/process/FlowNodeInstanceDto.java
@@ -17,6 +17,7 @@ import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class FlowNodeInstanceDto implements Serializable, OptimizeDto {
 
@@ -416,13 +417,58 @@ public class FlowNodeInstanceDto implements Serializable, OptimizeDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FlowNodeInstanceDto that = (FlowNodeInstanceDto) o;
+    return Objects.equals(flowNodeInstanceId, that.flowNodeInstanceId)
+        && Objects.equals(flowNodeId, that.flowNodeId)
+        && Objects.equals(flowNodeType, that.flowNodeType)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(totalDurationInMs, that.totalDurationInMs)
+        && Objects.equals(startDate, that.startDate)
+        && Objects.equals(endDate, that.endDate)
+        && Objects.equals(canceled, that.canceled)
+        && Objects.equals(definitionKey, that.definitionKey)
+        && Objects.equals(definitionVersion, that.definitionVersion)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(engine, that.engine)
+        && Objects.equals(userTaskInstanceId, that.userTaskInstanceId)
+        && Objects.equals(dueDate, that.dueDate)
+        && Objects.equals(deleteReason, that.deleteReason)
+        && Objects.equals(assignee, that.assignee)
+        && Objects.equals(candidateGroups, that.candidateGroups)
+        && Objects.equals(assigneeOperations, that.assigneeOperations)
+        && Objects.equals(candidateGroupOperations, that.candidateGroupOperations)
+        && Objects.equals(idleDurationInMs, that.idleDurationInMs)
+        && Objects.equals(workDurationInMs, that.workDurationInMs);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        flowNodeInstanceId,
+        flowNodeId,
+        flowNodeType,
+        processInstanceId,
+        totalDurationInMs,
+        startDate,
+        endDate,
+        canceled,
+        definitionKey,
+        definitionVersion,
+        tenantId,
+        engine,
+        userTaskInstanceId,
+        dueDate,
+        deleteReason,
+        assignee,
+        candidateGroups,
+        assigneeOperations,
+        candidateGroupOperations,
+        idleDurationInMs,
+        workDurationInMs);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/InitialProcessOwnerDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/InitialProcessOwnerDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.processoverview;
 
+import java.util.Objects;
+
 public class InitialProcessOwnerDto {
 
   private String processDefinitionKey;
@@ -40,13 +42,18 @@ public class InitialProcessOwnerDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final InitialProcessOwnerDto that = (InitialProcessOwnerDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(owner, that.owner);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(processDefinitionKey, owner);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/KpiResultDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/KpiResultDto.java
@@ -16,6 +16,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.time.Duration;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 public class KpiResultDto {
@@ -142,13 +143,26 @@ public class KpiResultDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final KpiResultDto that = (KpiResultDto) o;
+    return isBelow == that.isBelow
+        && Objects.equals(reportId, that.reportId)
+        && Objects.equals(collectionId, that.collectionId)
+        && Objects.equals(reportName, that.reportName)
+        && Objects.equals(value, that.value)
+        && Objects.equals(target, that.target)
+        && type == that.type
+        && Objects.equals(measure, that.measure)
+        && unit == that.unit;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        reportId, collectionId, reportName, value, target, isBelow, type, measure, unit);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import java.util.Map;
+import java.util.Objects;
 
 public class ProcessDigestDto extends ProcessDigestResponseDto {
 
@@ -40,13 +41,20 @@ public class ProcessDigestDto extends ProcessDigestResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ProcessDigestDto that = (ProcessDigestDto) o;
+    return Objects.equals(kpiReportResults, that.kpiReportResults);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), kpiReportResults);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestRequestDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class ProcessDigestRequestDto {
 
@@ -34,13 +35,17 @@ public class ProcessDigestRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessDigestRequestDto that = (ProcessDigestRequestDto) o;
+    return enabled == that.enabled;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(enabled);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestResponseDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
+import java.util.Objects;
 
 public class ProcessDigestResponseDto implements OptimizeDto {
 
@@ -35,13 +36,17 @@ public class ProcessDigestResponseDto implements OptimizeDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessDigestResponseDto that = (ProcessDigestResponseDto) o;
+    return enabled == that.enabled;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(enabled);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOverviewDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOverviewDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.util.Map;
+import java.util.Objects;
 
 public class ProcessOverviewDto implements OptimizeDto {
 
@@ -67,13 +68,20 @@ public class ProcessOverviewDto implements OptimizeDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessOverviewDto that = (ProcessOverviewDto) o;
+    return Objects.equals(owner, that.owner)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(digest, that.digest)
+        && Objects.equals(lastKpiEvaluationResults, that.lastKpiEvaluationResults);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(owner, processDefinitionKey, digest, lastKpiEvaluationResults);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOverviewResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOverviewResponseDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import java.util.List;
+import java.util.Objects;
 
 public class ProcessOverviewResponseDto {
 
@@ -77,13 +78,21 @@ public class ProcessOverviewResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessOverviewResponseDto that = (ProcessOverviewResponseDto) o;
+    return Objects.equals(processDefinitionName, that.processDefinitionName)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(digest, that.digest)
+        && Objects.equals(kpis, that.kpis);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(processDefinitionName, processDefinitionKey, owner, digest, kpis);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOwnerResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOwnerResponseDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
+import java.util.Objects;
 
 public class ProcessOwnerResponseDto implements OptimizeDto {
 
@@ -42,13 +43,17 @@ public class ProcessOwnerResponseDto implements OptimizeDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessOwnerResponseDto that = (ProcessOwnerResponseDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(name, that.name);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, name);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessUpdateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessUpdateDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 
 public class ProcessUpdateDto implements OptimizeDto {
 
@@ -44,13 +45,18 @@ public class ProcessUpdateDto implements OptimizeDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessUpdateDto that = (ProcessUpdateDto) o;
+    return Objects.equals(ownerId, that.ownerId)
+        && Objects.equals(processDigest, that.processDigest);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(ownerId, processDigest);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/AdditionalProcessReportEvaluationFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/AdditionalProcessReportEvaluationFilterDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class AdditionalProcessReportEvaluationFilterDto {
 
@@ -34,13 +35,18 @@ public class AdditionalProcessReportEvaluationFilterDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AdditionalProcessReportEvaluationFilterDto that =
+        (AdditionalProcessReportEvaluationFilterDto) o;
+    return Objects.equals(filter, that.filter);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(filter);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/AuthorizedReportEvaluationResult.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/AuthorizedReportEvaluationResult.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.report;
 
 import io.camunda.optimize.dto.optimize.AuthorizedEntityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
+import java.util.Objects;
 
 public class AuthorizedReportEvaluationResult extends AuthorizedEntityDto {
 
@@ -34,13 +35,20 @@ public class AuthorizedReportEvaluationResult extends AuthorizedEntityDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedReportEvaluationResult that = (AuthorizedReportEvaluationResult) o;
+    return Objects.equals(evaluationResult, that.evaluationResult);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), evaluationResult);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportDefinitionDto.java
@@ -16,6 +16,7 @@ import io.camunda.optimize.dto.optimize.query.entity.EntityResponseDto;
 import io.camunda.optimize.dto.optimize.query.entity.EntityType;
 import jakarta.validation.Valid;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 public class ReportDefinitionDto<D extends ReportDataDto> implements CollectionEntity {
 
@@ -190,13 +191,38 @@ public class ReportDefinitionDto<D extends ReportDataDto> implements CollectionE
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportDefinitionDto<?> that = (ReportDefinitionDto<?>) o;
+    return combined == that.combined
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(created, that.created)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && Objects.equals(collectionId, that.collectionId)
+        && Objects.equals(data, that.data)
+        && reportType == that.reportType;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        name,
+        description,
+        lastModified,
+        created,
+        owner,
+        lastModifier,
+        collectionId,
+        data,
+        combined,
+        reportType);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportDefinitionUpdateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportDefinitionUpdateDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.report;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReportDefinitionUpdateDto {
@@ -93,13 +94,25 @@ public class ReportDefinitionUpdateDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportDefinitionUpdateDto that = (ReportDefinitionUpdateDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(created, that.created)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && Objects.equals(collectionId, that.collectionId);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        id, name, description, lastModified, created, owner, lastModifier, collectionId);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportEvaluationResult.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportEvaluationResult.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report;
 import io.camunda.optimize.dto.optimize.rest.pagination.PaginatedDataExportDto;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Objects;
 
 public abstract class ReportEvaluationResult {
 
@@ -51,13 +52,17 @@ public abstract class ReportEvaluationResult {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportEvaluationResult that = (ReportEvaluationResult) o;
+    return Objects.equals(reportDefinition, that.reportDefinition);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(reportDefinition);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedProcessReportDefinitionUpdateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedProcessReportDefinitionUpdateDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.report.combined;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionUpdateDto;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CombinedProcessReportDefinitionUpdateDto extends ReportDefinitionUpdateDto {
@@ -31,13 +32,21 @@ public class CombinedProcessReportDefinitionUpdateDto extends ReportDefinitionUp
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final CombinedProcessReportDefinitionUpdateDto that =
+        (CombinedProcessReportDefinitionUpdateDto) o;
+    return Objects.equals(data, that.data);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), data);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedReportDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedReportDataDto.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -84,13 +85,19 @@ public class CombinedReportDataDto implements ReportDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CombinedReportDataDto that = (CombinedReportDataDto) o;
+    return Objects.equals(configuration, that.configuration)
+        && visualization == that.visualization
+        && Objects.equals(reports, that.reports);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(configuration, visualization, reports);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedReportItemDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedReportItemDto.java
@@ -9,6 +9,8 @@ package io.camunda.optimize.dto.optimize.query.report.combined;
 
 import static io.camunda.optimize.dto.optimize.ReportConstants.DEFAULT_CONFIGURATION_COLOR;
 
+import java.util.Objects;
+
 public class CombinedReportItemDto {
 
   private String id;
@@ -46,13 +48,17 @@ public class CombinedReportItemDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CombinedReportItemDto that = (CombinedReportItemDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(color, that.color);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, color);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/CombinedReportConfigurationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/CombinedReportConfigurationDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.report.combined.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.dto.optimize.query.report.combined.configuration.target_value.CombinedReportTargetValueDto;
+import java.util.Objects;
 
 public class CombinedReportConfigurationDto {
 
@@ -29,13 +30,32 @@ public class CombinedReportConfigurationDto {
   private CombinedReportTargetValueDto targetValue = new CombinedReportTargetValueDto();
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CombinedReportConfigurationDto that = (CombinedReportConfigurationDto) o;
+    return Objects.equals(pointMarkers, that.pointMarkers)
+        && Objects.equals(hideRelativeValue, that.hideRelativeValue)
+        && Objects.equals(hideAbsoluteValue, that.hideAbsoluteValue)
+        && Objects.equals(yLabel, that.yLabel)
+        && Objects.equals(xLabel, that.xLabel)
+        && Objects.equals(alwaysShowRelative, that.alwaysShowRelative)
+        && Objects.equals(alwaysShowAbsolute, that.alwaysShowAbsolute)
+        && Objects.equals(targetValue, that.targetValue);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        pointMarkers,
+        hideRelativeValue,
+        hideAbsoluteValue,
+        yLabel,
+        xLabel,
+        alwaysShowRelative,
+        alwaysShowAbsolute,
+        targetValue);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/target_value/CombinedReportCountChartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/target_value/CombinedReportCountChartDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.combined.configuration.target_value;
 
+import java.util.Objects;
+
 public class CombinedReportCountChartDto {
 
   private Boolean isBelow = false;
@@ -20,13 +22,17 @@ public class CombinedReportCountChartDto {
   public CombinedReportCountChartDto() {}
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CombinedReportCountChartDto that = (CombinedReportCountChartDto) o;
+    return Objects.equals(isBelow, that.isBelow) && Objects.equals(value, that.value);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(isBelow, value);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/target_value/CombinedReportDurationChartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/target_value/CombinedReportDurationChartDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.combined.configuration.target_value;
 
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
+import java.util.Objects;
 
 public class CombinedReportDurationChartDto {
 
@@ -25,13 +26,19 @@ public class CombinedReportDurationChartDto {
   public CombinedReportDurationChartDto() {}
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CombinedReportDurationChartDto that = (CombinedReportDurationChartDto) o;
+    return unit == that.unit
+        && Objects.equals(isBelow, that.isBelow)
+        && Objects.equals(value, that.value);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(unit, isBelow, value);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/target_value/CombinedReportTargetValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/target_value/CombinedReportTargetValueDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.combined.configuration.target_value;
 
+import java.util.Objects;
+
 public class CombinedReportTargetValueDto {
 
   private CombinedReportCountChartDto countChart = new CombinedReportCountChartDto();
@@ -25,13 +27,19 @@ public class CombinedReportTargetValueDto {
   public CombinedReportTargetValueDto() {}
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CombinedReportTargetValueDto that = (CombinedReportTargetValueDto) o;
+    return Objects.equals(countChart, that.countChart)
+        && Objects.equals(active, that.active)
+        && Objects.equals(durationChart, that.durationChart);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(countChart, active, durationChart);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ReportDataDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ReportDataDefinitionDto.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.ReportConstants;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 public class ReportDataDefinitionDto {
@@ -158,13 +159,22 @@ public class ReportDataDefinitionDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportDataDefinitionDto that = (ReportDataDefinitionDto) o;
+    return Objects.equals(identifier, that.identifier)
+        && Objects.equals(key, that.key)
+        && Objects.equals(name, that.name)
+        && Objects.equals(displayName, that.displayName)
+        && Objects.equals(versions, that.versions)
+        && Objects.equals(tenantIds, that.tenantIds);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(identifier, key, name, displayName, versions, tenantIds);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ViewProperty.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ViewProperty.java
@@ -21,6 +21,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.view.StringV
 import io.camunda.optimize.dto.optimize.query.report.single.process.view.TypedViewPropertyDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.view.VariableViewPropertyDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
+import java.util.Objects;
 import java.util.Optional;
 
 public class ViewProperty implements Combinable {
@@ -76,13 +77,17 @@ public class ViewProperty implements Combinable {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ViewProperty that = (ViewProperty) o;
+    return Objects.equals(viewPropertyDto, that.viewPropertyDto);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(viewPropertyDto);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/AggregationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/AggregationDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
+import java.util.Objects;
 
 public class AggregationDto implements OptimizeDto {
 
@@ -46,13 +47,17 @@ public class AggregationDto implements OptimizeDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AggregationDto that = (AggregationDto) o;
+    return type == that.type && Objects.equals(value, that.value);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(type, value);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/MeasureVisualizationsDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/MeasureVisualizationsDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration;
 
 import io.camunda.optimize.dto.optimize.ReportConstants;
+import java.util.Objects;
 
 public class MeasureVisualizationsDto {
 
@@ -37,13 +38,17 @@ public class MeasureVisualizationsDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MeasureVisualizationsDto that = (MeasureVisualizationsDto) o;
+    return Objects.equals(frequency, that.frequency) && Objects.equals(duration, that.duration);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(frequency, duration);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/SingleReportConfigurationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/SingleReportConfigurationDto.java
@@ -20,6 +20,7 @@ import io.camunda.optimize.dto.optimize.query.sorting.ReportSortingDto;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -385,13 +386,70 @@ public class SingleReportConfigurationDto implements Combinable {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SingleReportConfigurationDto that = (SingleReportConfigurationDto) o;
+    return Objects.equals(color, that.color)
+        && Objects.equals(aggregationTypes, that.aggregationTypes)
+        && Objects.equals(userTaskDurationTimes, that.userTaskDurationTimes)
+        && Objects.equals(showInstanceCount, that.showInstanceCount)
+        && Objects.equals(pointMarkers, that.pointMarkers)
+        && Objects.equals(precision, that.precision)
+        && Objects.equals(hideRelativeValue, that.hideRelativeValue)
+        && Objects.equals(hideAbsoluteValue, that.hideAbsoluteValue)
+        && Objects.equals(yLabel, that.yLabel)
+        && Objects.equals(xLabel, that.xLabel)
+        && Objects.equals(alwaysShowRelative, that.alwaysShowRelative)
+        && Objects.equals(alwaysShowAbsolute, that.alwaysShowAbsolute)
+        && Objects.equals(showGradientBars, that.showGradientBars)
+        && Objects.equals(xml, that.xml)
+        && Objects.equals(tableColumns, that.tableColumns)
+        && Objects.equals(targetValue, that.targetValue)
+        && Objects.equals(heatmapTargetValue, that.heatmapTargetValue)
+        && groupByDateVariableUnit == that.groupByDateVariableUnit
+        && distributeByDateVariableUnit == that.distributeByDateVariableUnit
+        && Objects.equals(customBucket, that.customBucket)
+        && Objects.equals(distributeByCustomBucket, that.distributeByCustomBucket)
+        && Objects.equals(sorting, that.sorting)
+        && Objects.equals(processPart, that.processPart)
+        && Objects.equals(measureVisualizations, that.measureVisualizations)
+        && Objects.equals(stackedBar, that.stackedBar)
+        && Objects.equals(horizontalBar, that.horizontalBar)
+        && Objects.equals(logScale, that.logScale);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        color,
+        aggregationTypes,
+        userTaskDurationTimes,
+        showInstanceCount,
+        pointMarkers,
+        precision,
+        hideRelativeValue,
+        hideAbsoluteValue,
+        yLabel,
+        xLabel,
+        alwaysShowRelative,
+        alwaysShowAbsolute,
+        showGradientBars,
+        xml,
+        tableColumns,
+        targetValue,
+        heatmapTargetValue,
+        groupByDateVariableUnit,
+        distributeByDateVariableUnit,
+        customBucket,
+        distributeByCustomBucket,
+        sorting,
+        processPart,
+        measureVisualizations,
+        stackedBar,
+        horizontalBar,
+        logScale);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/TableColumnDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/TableColumnDto.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 
@@ -197,13 +198,20 @@ public class TableColumnDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TableColumnDto that = (TableColumnDto) o;
+    return includeNewVariables == that.includeNewVariables
+        && Objects.equals(excludedColumns, that.excludedColumns)
+        && Objects.equals(includedColumns, that.includedColumns)
+        && Objects.equals(columnOrder, that.columnOrder);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(includeNewVariables, excludedColumns, includedColumns, columnOrder);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/custom_buckets/CustomBucketDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/custom_buckets/CustomBucketDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.configuration.custo
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 import java.util.Optional;
 
 public class CustomBucketDto {
@@ -144,13 +145,21 @@ public class CustomBucketDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CustomBucketDto that = (CustomBucketDto) o;
+    return active == that.active
+        && Objects.equals(bucketSize, that.bucketSize)
+        && bucketSizeUnit == that.bucketSizeUnit
+        && Objects.equals(baseline, that.baseline)
+        && baselineUnit == that.baselineUnit;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(active, bucketSize, bucketSizeUnit, baseline, baselineUnit);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/heatmap_target_value/HeatmapTargetValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/heatmap_target_value/HeatmapTargetValueDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.configuration.heatm
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class HeatmapTargetValueDto {
 
@@ -38,13 +39,17 @@ public class HeatmapTargetValueDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final HeatmapTargetValueDto that = (HeatmapTargetValueDto) o;
+    return Objects.equals(active, that.active) && Objects.equals(values, that.values);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(active, values);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/heatmap_target_value/HeatmapTargetValueEntryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/heatmap_target_value/HeatmapTargetValueEntryDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.heatmap_target_value;
 
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
+import java.util.Objects;
 
 public class HeatmapTargetValueEntryDto {
 
@@ -42,13 +43,17 @@ public class HeatmapTargetValueEntryDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final HeatmapTargetValueEntryDto that = (HeatmapTargetValueEntryDto) o;
+    return unit == that.unit && Objects.equals(value, that.value);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(unit, value);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/BaseLineDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/BaseLineDto.java
@@ -7,19 +7,25 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
+import java.util.Objects;
+
 public class BaseLineDto {
 
   private TargetValueUnit unit = TargetValueUnit.HOURS;
   private String value = "0";
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BaseLineDto that = (BaseLineDto) o;
+    return unit == that.unit && Objects.equals(value, that.value);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(unit, value);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/CountProgressDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/CountProgressDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
+import java.util.Objects;
+
 public class CountProgressDto {
 
   private String baseline = "0";
@@ -14,13 +16,19 @@ public class CountProgressDto {
   private Boolean isBelow = false;
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CountProgressDto that = (CountProgressDto) o;
+    return Objects.equals(baseline, that.baseline)
+        && Objects.equals(target, that.target)
+        && Objects.equals(isBelow, that.isBelow);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(baseline, target, isBelow);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/DurationProgressDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/DurationProgressDto.java
@@ -7,19 +7,25 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
+import java.util.Objects;
+
 public class DurationProgressDto {
 
   private BaseLineDto baseline = new BaseLineDto();
   private TargetDto target = new TargetDto();
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DurationProgressDto that = (DurationProgressDto) o;
+    return Objects.equals(baseline, that.baseline) && Objects.equals(target, that.target);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(baseline, target);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportCountChartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportCountChartDto.java
@@ -7,19 +7,25 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
+import java.util.Objects;
+
 public class SingleReportCountChartDto {
 
   private Boolean isBelow = false;
   private String value = "100";
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SingleReportCountChartDto that = (SingleReportCountChartDto) o;
+    return Objects.equals(isBelow, that.isBelow) && Objects.equals(value, that.value);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(isBelow, value);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportDurationChartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportDurationChartDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
+import java.util.Objects;
+
 public class SingleReportDurationChartDto {
 
   private TargetValueUnit unit = TargetValueUnit.HOURS;
@@ -14,13 +16,19 @@ public class SingleReportDurationChartDto {
   private String value = "2";
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SingleReportDurationChartDto that = (SingleReportDurationChartDto) o;
+    return unit == that.unit
+        && Objects.equals(isBelow, that.isBelow)
+        && Objects.equals(value, that.value);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(unit, isBelow, value);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportTargetValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportTargetValueDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
+import java.util.Objects;
+
 public class SingleReportTargetValueDto {
 
   private SingleReportCountChartDto countChart = new SingleReportCountChartDto();
@@ -71,13 +73,22 @@ public class SingleReportTargetValueDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SingleReportTargetValueDto that = (SingleReportTargetValueDto) o;
+    return Objects.equals(countChart, that.countChart)
+        && Objects.equals(durationProgress, that.durationProgress)
+        && Objects.equals(active, that.active)
+        && Objects.equals(countProgress, that.countProgress)
+        && Objects.equals(durationChart, that.durationChart)
+        && Objects.equals(isKpi, that.isKpi);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(countChart, durationProgress, active, countProgress, durationChart, isKpi);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/TargetDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/TargetDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
+import java.util.Objects;
+
 public class TargetDto {
 
   private TargetValueUnit unit = TargetValueUnit.HOURS;
@@ -14,13 +16,19 @@ public class TargetDto {
   private Boolean isBelow = false;
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TargetDto targetDto = (TargetDto) o;
+    return unit == targetDto.unit
+        && Objects.equals(value, targetDto.value)
+        && Objects.equals(isBelow, targetDto.isBelow);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(unit, value, isBelow);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/DecisionReportDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/DecisionReportDataDto.java
@@ -21,6 +21,7 @@ import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 @DecisionFiltersMustReferenceExistingDefinitionsConstraint
 public class DecisionReportDataDto extends SingleReportDataDto {
@@ -172,13 +173,21 @@ public class DecisionReportDataDto extends SingleReportDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionReportDataDto that = (DecisionReportDataDto) o;
+    return Objects.equals(filter, that.filter)
+        && Objects.equals(view, that.view)
+        && Objects.equals(groupBy, that.groupBy)
+        && Objects.equals(distributedBy, that.distributedBy)
+        && visualization == that.visualization;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(filter, view, groupBy, distributedBy, visualization);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/filter/DecisionFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/filter/DecisionFilterDto.java
@@ -13,6 +13,7 @@ import io.camunda.optimize.dto.optimize.ReportConstants;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
+import java.util.Objects;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
@@ -58,13 +59,17 @@ public abstract class DecisionFilterDto<DATA extends FilterDataDto> {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionFilterDto<?> that = (DecisionFilterDto<?>) o;
+    return Objects.equals(data, that.data) && Objects.equals(appliedTo, that.appliedTo);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(data, appliedTo);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/group/DecisionGroupByDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/group/DecisionGroupByDto.java
@@ -85,13 +85,17 @@ public abstract class DecisionGroupByDto<VALUE extends DecisionGroupByValueDto>
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionGroupByDto<?> that = (DecisionGroupByDto<?>) o;
+    return type == that.type && Objects.equals(value, that.value);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(type, value);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/group/value/DecisionGroupByEvaluationDateTimeValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/group/value/DecisionGroupByEvaluationDateTimeValueDto.java
@@ -42,13 +42,18 @@ public class DecisionGroupByEvaluationDateTimeValueDto implements DecisionGroupB
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionGroupByEvaluationDateTimeValueDto that =
+        (DecisionGroupByEvaluationDateTimeValueDto) o;
+    return unit == that.unit;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(unit);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/InputVariableEntry.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/InputVariableEntry.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.decision.result.raw;
 
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
+import java.util.Objects;
 
 public class InputVariableEntry extends VariableEntry {
 
@@ -22,13 +23,20 @@ public class InputVariableEntry extends VariableEntry {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final InputVariableEntry that = (InputVariableEntry) o;
+    return Objects.equals(value, that.value);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), value);
   }
 
   public Object getValue() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/OutputVariableEntry.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/OutputVariableEntry.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public class OutputVariableEntry extends VariableEntry {
 
@@ -43,13 +44,20 @@ public class OutputVariableEntry extends VariableEntry {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final OutputVariableEntry that = (OutputVariableEntry) o;
+    return Objects.equals(values, that.values);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), values);
   }
 
   public List<Object> getValues() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/RawDataDecisionInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/RawDataDecisionInstanceDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.decision.result.raw
 import io.camunda.optimize.dto.optimize.query.report.single.RawDataInstanceDto;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.Objects;
 
 public class RawDataDecisionInstanceDto implements RawDataInstanceDto {
 
@@ -123,13 +124,34 @@ public class RawDataDecisionInstanceDto implements RawDataInstanceDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RawDataDecisionInstanceDto that = (RawDataDecisionInstanceDto) o;
+    return Objects.equals(decisionDefinitionKey, that.decisionDefinitionKey)
+        && Objects.equals(decisionDefinitionId, that.decisionDefinitionId)
+        && Objects.equals(decisionInstanceId, that.decisionInstanceId)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(evaluationDateTime, that.evaluationDateTime)
+        && Objects.equals(engineName, that.engineName)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(inputVariables, that.inputVariables)
+        && Objects.equals(outputVariables, that.outputVariables);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        decisionDefinitionKey,
+        decisionDefinitionId,
+        decisionInstanceId,
+        processInstanceId,
+        evaluationDateTime,
+        engineName,
+        tenantId,
+        inputVariables,
+        outputVariables);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/VariableEntry.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/VariableEntry.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.decision.result.raw;
 
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
+import java.util.Objects;
 
 public class VariableEntry {
 
@@ -24,13 +25,17 @@ public class VariableEntry {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableEntry that = (VariableEntry) o;
+    return Objects.equals(id, that.id) && Objects.equals(name, that.name) && type == that.type;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, name, type);
   }
 
   public String getId() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/view/DecisionViewDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/view/DecisionViewDto.java
@@ -13,6 +13,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public class DecisionViewDto {
 
@@ -51,13 +52,17 @@ public class DecisionViewDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionViewDto that = (DecisionViewDto) o;
+    return Objects.equals(properties, that.properties);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(properties);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/OperatorMultipleValuesFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/OperatorMultipleValuesFilterDataDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.filter.data;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class OperatorMultipleValuesFilterDataDto {
@@ -45,13 +46,17 @@ public class OperatorMultipleValuesFilterDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OperatorMultipleValuesFilterDataDto that = (OperatorMultipleValuesFilterDataDto) o;
+    return operator == that.operator && Objects.equals(values, that.values);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(operator, values);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/DateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/DateFilterDataDto.java
@@ -18,6 +18,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.ins
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.instance.RelativeDateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.instance.RollingDateFilterDataDto;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 /**
  * Abstract class that contains a hidden "type" field to distinguish which filter type the jackson
@@ -89,16 +90,26 @@ public abstract class DateFilterDataDto<START> implements FilterDataDto {
     this.excludeUndefined = excludeUndefined;
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DateFilterDataDto<?> that = (DateFilterDataDto<?>) o;
+    return includeUndefined == that.includeUndefined
+        && excludeUndefined == that.excludeUndefined
+        && type == that.type
+        && Objects.equals(start, that.start)
+        && Objects.equals(end, that.end);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, start, end, includeUndefined, excludeUndefined);
   }
 
   protected boolean canEqual(final Object other) {
     return other instanceof DateFilterDataDto;
-  }
-
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 
   @SuppressWarnings("checkstyle:ConstantName")

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/RelativeDateFilterStartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/RelativeDateFilterStartDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.filter.data.date;
 
+import java.util.Objects;
+
 public class RelativeDateFilterStartDto {
 
   protected Long value;
@@ -40,13 +42,17 @@ public class RelativeDateFilterStartDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RelativeDateFilterStartDto that = (RelativeDateFilterStartDto) o;
+    return Objects.equals(value, that.value) && unit == that.unit;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(value, unit);
   }
 
   @SuppressWarnings("checkstyle:ConstantName")

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/RollingDateFilterStartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/RollingDateFilterStartDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.filter.data.date;
 
+import java.util.Objects;
+
 public class RollingDateFilterStartDto {
 
   protected Long value;
@@ -40,13 +42,17 @@ public class RollingDateFilterStartDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RollingDateFilterStartDto that = (RollingDateFilterStartDto) o;
+    return Objects.equals(value, that.value) && unit == that.unit;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(value, unit);
   }
 
   @SuppressWarnings("checkstyle:ConstantName")

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/FixedFlowNodeDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/FixedFlowNodeDateFilterDataDto.java
@@ -12,6 +12,7 @@ import static io.camunda.optimize.util.SuppressionConstants.UNUSED;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 
 public class FixedFlowNodeDateFilterDataDto extends FlowNodeDateFilterDataDto<OffsetDateTime> {
 
@@ -32,11 +33,17 @@ public class FixedFlowNodeDateFilterDataDto extends FlowNodeDateFilterDataDto<Of
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/FlowNodeDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/FlowNodeDateFilterDataDto.java
@@ -17,6 +17,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.Dat
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -54,13 +55,20 @@ public abstract class FlowNodeDateFilterDataDto<START> extends DateFilterDataDto
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final FlowNodeDateFilterDataDto<?> that = (FlowNodeDateFilterDataDto<?>) o;
+    return Objects.equals(flowNodeIds, that.flowNodeIds);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), flowNodeIds);
   }
 
   @SuppressWarnings("checkstyle:ConstantName")

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/RelativeFlowNodeDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/RelativeFlowNodeDateFilterDataDto.java
@@ -12,6 +12,7 @@ import static io.camunda.optimize.util.SuppressionConstants.UNUSED;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RelativeDateFilterStartDto;
 import java.util.List;
+import java.util.Objects;
 
 public class RelativeFlowNodeDateFilterDataDto
     extends FlowNodeDateFilterDataDto<RelativeDateFilterStartDto> {
@@ -33,11 +34,17 @@ public class RelativeFlowNodeDateFilterDataDto
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/RollingFlowNodeDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/RollingFlowNodeDateFilterDataDto.java
@@ -12,6 +12,7 @@ import static io.camunda.optimize.util.SuppressionConstants.UNUSED;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
 import java.util.List;
+import java.util.Objects;
 
 public class RollingFlowNodeDateFilterDataDto
     extends FlowNodeDateFilterDataDto<RollingDateFilterStartDto> {
@@ -33,11 +34,17 @@ public class RollingFlowNodeDateFilterDataDto
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/instance/FixedDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/instance/FixedDateFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.in
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 public class FixedDateFilterDataDto extends DateFilterDataDto<OffsetDateTime> {
 
@@ -28,11 +29,17 @@ public class FixedDateFilterDataDto extends DateFilterDataDto<OffsetDateTime> {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/instance/RelativeDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/instance/RelativeDateFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.in
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RelativeDateFilterStartDto;
+import java.util.Objects;
 
 public class RelativeDateFilterDataDto extends DateFilterDataDto<RelativeDateFilterStartDto> {
 
@@ -28,11 +29,17 @@ public class RelativeDateFilterDataDto extends DateFilterDataDto<RelativeDateFil
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/instance/RollingDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/instance/RollingDateFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.in
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
+import java.util.Objects;
 
 public class RollingDateFilterDataDto extends DateFilterDataDto<RollingDateFilterStartDto> {
 
@@ -28,11 +29,17 @@ public class RollingDateFilterDataDto extends DateFilterDataDto<RollingDateFilte
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/MultipleVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/MultipleVariableFilterDataDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.filter.data.variabl
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import java.util.List;
+import java.util.Objects;
 
 public class MultipleVariableFilterDataDto implements FilterDataDto {
 
@@ -33,13 +34,17 @@ public class MultipleVariableFilterDataDto implements FilterDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MultipleVariableFilterDataDto that = (MultipleVariableFilterDataDto) o;
+    return Objects.equals(data, that.data);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(data);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/VariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/VariableFilterDataDto.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
+import java.util.Objects;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -88,13 +89,17 @@ public abstract class VariableFilterDataDto<DATA> implements FilterDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableFilterDataDto<?> that = (VariableFilterDataDto<?>) o;
+    return type == that.type && Objects.equals(name, that.name) && Objects.equals(data, that.data);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(type, name, data);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/data/BooleanVariableFilterSubDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/data/BooleanVariableFilterSubDataDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data;
 
 import java.util.List;
+import java.util.Objects;
 
 public class BooleanVariableFilterSubDataDto {
 
@@ -32,13 +33,17 @@ public class BooleanVariableFilterSubDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BooleanVariableFilterSubDataDto that = (BooleanVariableFilterSubDataDto) o;
+    return Objects.equals(values, that.values);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(values);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/data/DashboardVariableFilterSubDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/data/DashboardVariableFilterSubDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.filter.data.variabl
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterOperator;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.OperatorMultipleValuesFilterDataDto;
 import java.util.List;
+import java.util.Objects;
 
 public class DashboardVariableFilterSubDataDto extends OperatorMultipleValuesFilterDataDto {
 
@@ -37,13 +38,20 @@ public class DashboardVariableFilterSubDataDto extends OperatorMultipleValuesFil
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardVariableFilterSubDataDto that = (DashboardVariableFilterSubDataDto) o;
+    return allowCustomValues == that.allowCustomValues;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), allowCustomValues);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessReportDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessReportDataDto.java
@@ -355,13 +355,30 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessReportDataDto that = (ProcessReportDataDto) o;
+    return managementReport == that.managementReport
+        && instantPreviewReport == that.instantPreviewReport
+        && Objects.equals(filter, that.filter)
+        && Objects.equals(view, that.view)
+        && Objects.equals(groupBy, that.groupBy)
+        && Objects.equals(distributedBy, that.distributedBy)
+        && visualization == that.visualization;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        filter,
+        view,
+        groupBy,
+        distributedBy,
+        visualization,
+        managementReport,
+        instantPreviewReport);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/SingleProcessReportDefinitionUpdateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/SingleProcessReportDefinitionUpdateDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.process;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionUpdateDto;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SingleProcessReportDefinitionUpdateDto extends ReportDefinitionUpdateDto {
@@ -31,13 +32,20 @@ public class SingleProcessReportDefinitionUpdateDto extends ReportDefinitionUpda
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final SingleProcessReportDefinitionUpdateDto that = (SingleProcessReportDefinitionUpdateDto) o;
+    return Objects.equals(data, that.data);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), data);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/ProcessReportDistributedByDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/ProcessReportDistributedByDto.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.query.report.Combinable;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.DistributedByType;
 import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.value.ProcessReportDistributedByValueDto;
+import java.util.Objects;
 
 /**
  * Abstract class that contains a hidden "type" field to distinguish which distributed by type the
@@ -87,13 +88,17 @@ public class ProcessReportDistributedByDto<VALUE extends ProcessReportDistribute
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessReportDistributedByDto<?> that = (ProcessReportDistributedByDto<?>) o;
+    return type == that.type && Objects.equals(value, that.value);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(type, value);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/value/DateDistributedByValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/value/DateDistributedByValueDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.process.distributed.value;
 
 import io.camunda.optimize.dto.optimize.query.report.single.group.AggregateByDateUnit;
+import java.util.Objects;
 
 public class DateDistributedByValueDto implements ProcessReportDistributedByValueDto {
 
@@ -28,13 +29,17 @@ public class DateDistributedByValueDto implements ProcessReportDistributedByValu
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DateDistributedByValueDto that = (DateDistributedByValueDto) o;
+    return unit == that.unit;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(unit);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/value/VariableDistributedByValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/value/VariableDistributedByValueDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.process.distributed.value;
 
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
+import java.util.Objects;
 
 public class VariableDistributedByValueDto implements ProcessReportDistributedByValueDto {
 
@@ -37,13 +38,17 @@ public class VariableDistributedByValueDto implements ProcessReportDistributedBy
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableDistributedByValueDto that = (VariableDistributedByValueDto) o;
+    return Objects.equals(name, that.name) && type == that.type;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(name, type);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/FlowNodeStartDateFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/FlowNodeStartDateFilterDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter;
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.flownode.FlowNodeDateFilterDataDto;
 import java.util.List;
+import java.util.Objects;
 
 public class FlowNodeStartDateFilterDto extends ProcessFilterDto<FlowNodeDateFilterDataDto<?>> {
 
@@ -26,11 +27,17 @@ public class FlowNodeStartDateFilterDto extends ProcessFilterDto<FlowNodeDateFil
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/ProcessFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/ProcessFilterDto.java
@@ -14,6 +14,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDa
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Abstract class that contains a hidden "type" field to distinguish, which filter type the jackson
@@ -106,13 +107,19 @@ public abstract class ProcessFilterDto<DATA extends FilterDataDto> {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessFilterDto<?> that = (ProcessFilterDto<?>) o;
+    return Objects.equals(data, that.data)
+        && filterLevel == that.filterLevel
+        && Objects.equals(appliedTo, that.appliedTo);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(data, filterLevel, appliedTo);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/CanceledFlowNodeFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/CanceledFlowNodeFilterDataDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import java.util.List;
+import java.util.Objects;
 
 public class CanceledFlowNodeFilterDataDto implements FilterDataDto {
 
@@ -29,13 +30,17 @@ public class CanceledFlowNodeFilterDataDto implements FilterDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CanceledFlowNodeFilterDataDto that = (CanceledFlowNodeFilterDataDto) o;
+    return Objects.equals(values, that.values);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(values);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/DurationFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/DurationFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DurationUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.operator.ComparisonOperator;
+import java.util.Objects;
 
 public class DurationFilterDataDto implements FilterDataDto {
 
@@ -68,13 +69,20 @@ public class DurationFilterDataDto implements FilterDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DurationFilterDataDto that = (DurationFilterDataDto) o;
+    return includeNull == that.includeNull
+        && Objects.equals(value, that.value)
+        && unit == that.unit
+        && operator == that.operator;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(value, unit, operator, includeNull);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/ExecutedFlowNodeFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/ExecutedFlowNodeFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.operator.MembershipFilterOperator;
 import java.util.List;
+import java.util.Objects;
 
 public class ExecutedFlowNodeFilterDataDto implements FilterDataDto {
 
@@ -39,13 +40,17 @@ public class ExecutedFlowNodeFilterDataDto implements FilterDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExecutedFlowNodeFilterDataDto that = (ExecutedFlowNodeFilterDataDto) o;
+    return operator == that.operator && Objects.equals(values, that.values);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(operator, values);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/ExecutingFlowNodeFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/ExecutingFlowNodeFilterDataDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import java.util.List;
+import java.util.Objects;
 
 public class ExecutingFlowNodeFilterDataDto implements FilterDataDto {
 
@@ -29,13 +30,17 @@ public class ExecutingFlowNodeFilterDataDto implements FilterDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExecutingFlowNodeFilterDataDto that = (ExecutingFlowNodeFilterDataDto) o;
+    return Objects.equals(values, that.values);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(values);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/FlowNodeDurationFiltersDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/FlowNodeDurationFiltersDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class FlowNodeDurationFiltersDataDto extends HashMap<String, DurationFilterDataDto>
     implements FilterDataDto {
@@ -23,13 +24,19 @@ public class FlowNodeDurationFiltersDataDto extends HashMap<String, DurationFilt
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/IdentityLinkFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/IdentityLinkFilterDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.operator.MembershipFilterOperator;
 import java.util.List;
+import java.util.Objects;
 
 public class IdentityLinkFilterDataDto implements FilterDataDto {
 
@@ -45,13 +46,17 @@ public class IdentityLinkFilterDataDto implements FilterDataDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IdentityLinkFilterDataDto that = (IdentityLinkFilterDataDto) o;
+    return operator == that.operator && Objects.equals(values, that.values);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(operator, values);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessGroupByDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessGroupByDto.java
@@ -97,13 +97,17 @@ public abstract class ProcessGroupByDto<VALUE extends ProcessGroupByValueDto>
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessGroupByDto<?> that = (ProcessGroupByDto<?>) o;
+    return type == that.type && Objects.equals(value, that.value);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(type, value);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/value/DateGroupByValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/value/DateGroupByValueDto.java
@@ -45,13 +45,17 @@ public class DateGroupByValueDto implements ProcessGroupByValueDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DateGroupByValueDto that = (DateGroupByValueDto) o;
+    return unit == that.unit;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(unit);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/value/VariableGroupByValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/value/VariableGroupByValueDto.java
@@ -50,13 +50,17 @@ public class VariableGroupByValueDto implements ProcessGroupByValueDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableGroupByValueDto that = (VariableGroupByValueDto) o;
+    return Objects.equals(name, that.name) && type == that.type;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(name, type);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataCountDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataCountDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.process.result.raw;
 
 import io.camunda.optimize.dto.optimize.query.report.single.RawDataInstanceDto;
+import java.util.Objects;
 
 public class RawDataCountDto implements RawDataInstanceDto {
 
@@ -52,13 +53,19 @@ public class RawDataCountDto implements RawDataInstanceDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RawDataCountDto that = (RawDataCountDto) o;
+    return incidents == that.incidents
+        && openIncidents == that.openIncidents
+        && userTasks == that.userTasks;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(incidents, openIncidents, userTasks);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataFlowNodeDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataFlowNodeDataDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.result.raw;
 
 import io.camunda.optimize.dto.optimize.query.report.single.RawDataInstanceDto;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 public class RawDataFlowNodeDataDto implements RawDataInstanceDto {
 
@@ -67,13 +68,20 @@ public class RawDataFlowNodeDataDto implements RawDataInstanceDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RawDataFlowNodeDataDto that = (RawDataFlowNodeDataDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(startDate, that.startDate)
+        && Objects.equals(endDate, that.endDate);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(id, name, startDate, endDate);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataProcessInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataProcessInstanceDto.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.RawDataInstanceDto;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class RawDataProcessInstanceDto implements RawDataInstanceDto {
 
@@ -177,13 +178,42 @@ public class RawDataProcessInstanceDto implements RawDataInstanceDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RawDataProcessInstanceDto that = (RawDataProcessInstanceDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(counts, that.counts)
+        && Objects.equals(flowNodeDurations, that.flowNodeDurations)
+        && Objects.equals(businessKey, that.businessKey)
+        && Objects.equals(startDate, that.startDate)
+        && Objects.equals(endDate, that.endDate)
+        && Objects.equals(duration, that.duration)
+        && Objects.equals(engineName, that.engineName)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(variables, that.variables)
+        && Objects.equals(flowNodeInstances, that.flowNodeInstances);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        processDefinitionKey,
+        processDefinitionId,
+        processInstanceId,
+        counts,
+        flowNodeDurations,
+        businessKey,
+        startDate,
+        endDate,
+        duration,
+        engineName,
+        tenantId,
+        variables,
+        flowNodeInstances);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/ProcessViewDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/ProcessViewDto.java
@@ -113,13 +113,17 @@ public class ProcessViewDto implements Combinable {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessViewDto that = (ProcessViewDto) o;
+    return entity == that.entity && Objects.equals(properties, that.properties);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(entity, properties);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/StringViewPropertyDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/StringViewPropertyDto.java
@@ -40,13 +40,17 @@ public class StringViewPropertyDto implements TypedViewPropertyDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final StringViewPropertyDto that = (StringViewPropertyDto) o;
+    return Objects.equals(id, that.id);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(id);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/VariableViewPropertyDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/VariableViewPropertyDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.process.view;
 
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
+import java.util.Objects;
 
 public class VariableViewPropertyDto implements TypedViewPropertyDto {
 
@@ -37,13 +38,17 @@ public class VariableViewPropertyDto implements TypedViewPropertyDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableViewPropertyDto that = (VariableViewPropertyDto) o;
+    return Objects.equals(name, that.name) && type == that.type;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(name, type);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/result/MeasureDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/result/MeasureDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report.single.result;
 import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.UserTaskDurationTime;
+import java.util.Objects;
 
 public class MeasureDto<T> {
 
@@ -84,13 +85,20 @@ public class MeasureDto<T> {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MeasureDto<?> that = (MeasureDto<?>) o;
+    return Objects.equals(property, that.property)
+        && Objects.equals(aggregationType, that.aggregationType)
+        && userTaskDurationTime == that.userTaskDurationTime
+        && Objects.equals(data, that.data);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(property, aggregationType, userTaskDurationTime, data);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/result/hyper/HyperMapResultEntryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/result/hyper/HyperMapResultEntryDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.result.hyper;
 
 import java.util.List;
+import java.util.Objects;
 
 public class HyperMapResultEntryDto {
 
@@ -53,13 +54,19 @@ public class HyperMapResultEntryDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final HyperMapResultEntryDto that = (HyperMapResultEntryDto) o;
+    return Objects.equals(key, that.key)
+        && Objects.equals(value, that.value)
+        && Objects.equals(label, that.label);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(key, value, label);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/result/hyper/MapResultEntryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/result/hyper/MapResultEntryDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.result.hyper;
 
+import java.util.Objects;
+
 public class MapResultEntryDto {
 
   // @formatter:off
@@ -50,13 +52,19 @@ public class MapResultEntryDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MapResultEntryDto that = (MapResultEntryDto) o;
+    return Objects.equals(key, that.key)
+        && Objects.equals(value, that.value)
+        && Objects.equals(label, that.label);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(key, value, label);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/sorting/ReportSortingDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/sorting/ReportSortingDto.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.dto.optimize.query.sorting;
 
+import java.util.Objects;
 import java.util.Optional;
 
 public class ReportSortingDto {
@@ -47,12 +48,19 @@ public class ReportSortingDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(by, order);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportSortingDto that = (ReportSortingDto) o;
+    return Objects.equals(by, that.by) && Objects.equals(order, that.order);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/MixpanelConfigResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/MixpanelConfigResponseDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.ui_configuration;
 
+import java.util.Objects;
+
 public class MixpanelConfigResponseDto {
 
   private boolean enabled;
@@ -98,12 +100,25 @@ public class MixpanelConfigResponseDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(enabled, token, apiHost, organizationId, clusterId, stage, osanoScriptUrl);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MixpanelConfigResponseDto that = (MixpanelConfigResponseDto) o;
+    return enabled == that.enabled
+        && Objects.equals(token, that.token)
+        && Objects.equals(apiHost, that.apiHost)
+        && Objects.equals(organizationId, that.organizationId)
+        && Objects.equals(clusterId, that.clusterId)
+        && Objects.equals(stage, that.stage)
+        && Objects.equals(osanoScriptUrl, that.osanoScriptUrl);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/OnboardingResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/OnboardingResponseDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.ui_configuration;
 
+import java.util.Objects;
+
 public class OnboardingResponseDto {
 
   private boolean enabled;
@@ -76,12 +78,23 @@ public class OnboardingResponseDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(enabled, appCuesScriptUrl, orgId, clusterId, salesPlanType);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OnboardingResponseDto that = (OnboardingResponseDto) o;
+    return enabled == that.enabled
+        && Objects.equals(appCuesScriptUrl, that.appCuesScriptUrl)
+        && Objects.equals(orgId, that.orgId)
+        && Objects.equals(clusterId, that.clusterId)
+        && Objects.equals(salesPlanType, that.salesPlanType);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/UIConfigurationResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/UIConfigurationResponseDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.ui_configuration;
 import io.camunda.optimize.service.util.configuration.DatabaseType;
 import io.camunda.optimize.service.util.configuration.OptimizeProfile;
 import java.util.Map;
+import java.util.Objects;
 
 public class UIConfigurationResponseDto {
 
@@ -254,12 +255,46 @@ public class UIConfigurationResponseDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        logoutHidden,
+        maxNumDataSourcesForReport,
+        userTaskAssigneeAnalyticsEnabled,
+        emailEnabled,
+        sharingEnabled,
+        mixpanel,
+        onboarding,
+        optimizeVersion,
+        optimizeProfile,
+        validLicense,
+        licenseType,
+        isCommercial,
+        expiresAt,
+        notificationsUrl,
+        webappsLinks);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UIConfigurationResponseDto that = (UIConfigurationResponseDto) o;
+    return logoutHidden == that.logoutHidden
+        && maxNumDataSourcesForReport == that.maxNumDataSourcesForReport
+        && userTaskAssigneeAnalyticsEnabled == that.userTaskAssigneeAnalyticsEnabled
+        && emailEnabled == that.emailEnabled
+        && sharingEnabled == that.sharingEnabled
+        && validLicense == that.validLicense
+        && isCommercial == that.isCommercial
+        && Objects.equals(mixpanel, that.mixpanel)
+        && Objects.equals(onboarding, that.onboarding)
+        && Objects.equals(optimizeVersion, that.optimizeVersion)
+        && Objects.equals(optimizeProfile, that.optimizeProfile)
+        && Objects.equals(notificationsUrl, that.notificationsUrl)
+        && Objects.equals(webappsLinks, that.webappsLinks);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DecisionVariableNameRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DecisionVariableNameRequestDto.java
@@ -16,6 +16,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class DecisionVariableNameRequestDto {
 
@@ -81,12 +82,21 @@ public class DecisionVariableNameRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(decisionDefinitionKey, decisionDefinitionVersions, tenantIds);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionVariableNameRequestDto that = (DecisionVariableNameRequestDto) o;
+    return Objects.equals(decisionDefinitionKey, that.decisionDefinitionKey)
+        && Objects.equals(decisionDefinitionVersions, that.decisionDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DecisionVariableNameResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DecisionVariableNameResponseDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.variable;
 
+import java.util.Objects;
+
 public class DecisionVariableNameResponseDto {
 
   protected String id;
@@ -52,12 +54,21 @@ public class DecisionVariableNameResponseDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, name, type);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionVariableNameResponseDto that = (DecisionVariableNameResponseDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DecisionVariableValueRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DecisionVariableValueRequestDto.java
@@ -15,6 +15,7 @@ import io.camunda.optimize.service.util.TenantListHandlingUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class DecisionVariableValueRequestDto {
 
@@ -104,12 +105,34 @@ public class DecisionVariableValueRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        decisionDefinitionKey,
+        decisionDefinitionVersions,
+        tenantIds,
+        variableId,
+        variableType,
+        valueFilter,
+        resultOffset,
+        numResults);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionVariableValueRequestDto that = (DecisionVariableValueRequestDto) o;
+    return Objects.equals(decisionDefinitionKey, that.decisionDefinitionKey)
+        && Objects.equals(decisionDefinitionVersions, that.decisionDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds)
+        && Objects.equals(variableId, that.variableId)
+        && Objects.equals(variableType, that.variableType)
+        && Objects.equals(valueFilter, that.valueFilter)
+        && Objects.equals(resultOffset, that.resultOffset)
+        && Objects.equals(numResults, that.numResults);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DefinitionVariableLabelsDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DefinitionVariableLabelsDto.java
@@ -11,6 +11,7 @@ import io.camunda.optimize.dto.optimize.OptimizeDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
+import java.util.Objects;
 
 public class DefinitionVariableLabelsDto implements OptimizeDto {
 
@@ -48,12 +49,19 @@ public class DefinitionVariableLabelsDto implements OptimizeDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(definitionKey, labels);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionVariableLabelsDto that = (DefinitionVariableLabelsDto) o;
+    return Objects.equals(definitionKey, that.definitionKey) && Objects.equals(labels, that.labels);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ExternalProcessVariableDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ExternalProcessVariableDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.variable;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
+import java.util.Objects;
 
 public class ExternalProcessVariableDto implements OptimizeDto {
 
@@ -86,16 +87,36 @@ public class ExternalProcessVariableDto implements OptimizeDto {
     this.serializationDataFormat = serializationDataFormat;
   }
 
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  protected boolean canEqual(final Object other) {
-    return other instanceof ExternalProcessVariableDto;
-  }
-
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        variableId,
+        variableName,
+        variableValue,
+        variableType,
+        ingestionTimestamp,
+        processInstanceId,
+        processDefinitionKey,
+        serializationDataFormat);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExternalProcessVariableDto that = (ExternalProcessVariableDto) o;
+    return Objects.equals(variableId, that.variableId)
+        && Objects.equals(variableName, that.variableName)
+        && Objects.equals(variableValue, that.variableValue)
+        && Objects.equals(variableType, that.variableType)
+        && Objects.equals(ingestionTimestamp, that.ingestionTimestamp)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(serializationDataFormat, that.serializationDataFormat);
   }
 
   public String toString() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ExternalProcessVariableRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ExternalProcessVariableRequestDto.java
@@ -11,6 +11,7 @@ import io.camunda.optimize.dto.optimize.OptimizeDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Objects;
 
 public class ExternalProcessVariableRequestDto implements OptimizeDto {
 
@@ -101,16 +102,28 @@ public class ExternalProcessVariableRequestDto implements OptimizeDto {
     this.serializationDataFormat = serializationDataFormat;
   }
 
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  protected boolean canEqual(final Object other) {
-    return other instanceof ExternalProcessVariableRequestDto;
-  }
-
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        id, name, value, type, processInstanceId, processDefinitionKey, serializationDataFormat);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExternalProcessVariableRequestDto that = (ExternalProcessVariableRequestDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(value, that.value)
+        && Objects.equals(type, that.type)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(serializationDataFormat, that.serializationDataFormat);
   }
 
   public String toString() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/LabelDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/LabelDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.variable;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 
 public class LabelDto implements OptimizeDto {
 
@@ -58,12 +59,21 @@ public class LabelDto implements OptimizeDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(variableLabel, variableName, variableType);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final LabelDto that = (LabelDto) o;
+    return Objects.equals(variableLabel, that.variableLabel)
+        && Objects.equals(variableName, that.variableName)
+        && Objects.equals(variableType, that.variableType);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessToQueryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessToQueryDto.java
@@ -15,6 +15,7 @@ import io.camunda.optimize.service.util.TenantListHandlingUtil;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class ProcessToQueryDto {
 
@@ -68,12 +69,21 @@ public class ProcessToQueryDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(processDefinitionKey, processDefinitionVersions, tenantIds);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessToQueryDto that = (ProcessToQueryDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersions, that.processDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableDto.java
@@ -11,6 +11,7 @@ import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class ProcessVariableDto implements OptimizeDto {
 
@@ -152,16 +153,44 @@ public class ProcessVariableDto implements OptimizeDto {
     this.tenantId = tenantId;
   }
 
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  protected boolean canEqual(final Object other) {
-    return other instanceof ProcessVariableDto;
-  }
-
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        id,
+        name,
+        type,
+        value,
+        timestamp,
+        valueInfo,
+        processDefinitionKey,
+        processDefinitionId,
+        processInstanceId,
+        version,
+        engineAlias,
+        tenantId);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableDto that = (ProcessVariableDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(value, that.value)
+        && Objects.equals(timestamp, that.timestamp)
+        && Objects.equals(valueInfo, that.valueInfo)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(version, that.version)
+        && Objects.equals(engineAlias, that.engineAlias)
+        && Objects.equals(tenantId, that.tenantId);
   }
 
   public String toString() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableNameRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableNameRequestDto.java
@@ -13,6 +13,7 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class ProcessVariableNameRequestDto {
 
@@ -65,12 +66,21 @@ public class ProcessVariableNameRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(processesToQuery, filter, timezone);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableNameRequestDto that = (ProcessVariableNameRequestDto) o;
+    return Objects.equals(processesToQuery, that.processesToQuery)
+        && Objects.equals(filter, that.filter)
+        && Objects.equals(timezone, that.timezone);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableNameResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableNameResponseDto.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.variable;
 
+import java.util.Objects;
+
 public class ProcessVariableNameResponseDto {
 
   protected String name;
@@ -52,12 +54,21 @@ public class ProcessVariableNameResponseDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(name, type, label);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableNameResponseDto that = (ProcessVariableNameResponseDto) o;
+    return Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(label, that.label);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableReportValuesRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableReportValuesRequestDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.variable;
 import static io.camunda.optimize.service.db.DatabaseConstants.MAX_RESPONSE_SIZE_LIMIT;
 
 import java.util.List;
+import java.util.Objects;
 
 public class ProcessVariableReportValuesRequestDto {
 
@@ -76,12 +77,24 @@ public class ProcessVariableReportValuesRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(reportIds, name, type, valueFilter, resultOffset, numResults);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableReportValuesRequestDto that = (ProcessVariableReportValuesRequestDto) o;
+    return Objects.equals(reportIds, that.reportIds)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(valueFilter, that.valueFilter)
+        && Objects.equals(resultOffset, that.resultOffset)
+        && Objects.equals(numResults, that.numResults);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableSourceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableSourceDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.optimize.query.variable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class ProcessVariableSourceDto {
 
@@ -68,12 +69,23 @@ public class ProcessVariableSourceDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        processInstanceId, processDefinitionKey, processDefinitionVersions, tenantIds);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableSourceDto that = (ProcessVariableSourceDto) o;
+    return Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersions, that.processDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableValueRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableValueRequestDto.java
@@ -15,6 +15,7 @@ import io.camunda.optimize.service.util.TenantListHandlingUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class ProcessVariableValueRequestDto {
 
@@ -113,12 +114,36 @@ public class ProcessVariableValueRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        processInstanceId,
+        processDefinitionKey,
+        processDefinitionVersions,
+        tenantIds,
+        name,
+        type,
+        valueFilter,
+        resultOffset,
+        numResults);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableValueRequestDto that = (ProcessVariableValueRequestDto) o;
+    return Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersions, that.processDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(valueFilter, that.valueFilter)
+        && Objects.equals(resultOffset, that.resultOffset)
+        && Objects.equals(numResults, that.numResults);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableValuesQueryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableValuesQueryDto.java
@@ -13,6 +13,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.SingleReportDataDto;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ProcessVariableValuesQueryDto {
@@ -141,12 +142,24 @@ public class ProcessVariableValuesQueryDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(processVariableSources, name, type, valueFilter, resultOffset, numResults);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableValuesQueryDto that = (ProcessVariableValuesQueryDto) o;
+    return Objects.equals(processVariableSources, that.processVariableSources)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(valueFilter, that.valueFilter)
+        && Objects.equals(resultOffset, that.resultOffset)
+        && Objects.equals(numResults, that.numResults);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/SimpleProcessVariableDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/SimpleProcessVariableDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.variable;
 
 import java.util.List;
+import java.util.Objects;
 
 public class SimpleProcessVariableDto {
 
@@ -78,12 +79,23 @@ public class SimpleProcessVariableDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(id, name, type, value, version);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SimpleProcessVariableDto that = (SimpleProcessVariableDto) o;
+    return version == that.version
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(value, that.value);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedCollectionDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedCollectionDefinitionDto.java
@@ -13,6 +13,7 @@ import io.camunda.optimize.dto.optimize.AuthorizedEntityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.collection.CollectionDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.entity.EntityResponseDto;
+import java.util.Objects;
 
 public class AuthorizedCollectionDefinitionDto extends AuthorizedEntityDto {
 
@@ -62,12 +63,22 @@ public class AuthorizedCollectionDefinitionDto extends AuthorizedEntityDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), definitionDto);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedCollectionDefinitionDto that = (AuthorizedCollectionDefinitionDto) o;
+    return Objects.equals(definitionDto, that.definitionDto);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedCollectionDefinitionRestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedCollectionDefinitionRestDto.java
@@ -12,6 +12,7 @@ import io.camunda.optimize.dto.optimize.AuthorizedEntityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.collection.CollectionDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.collection.CollectionDefinitionRestDto;
+import java.util.Objects;
 
 public class AuthorizedCollectionDefinitionRestDto extends AuthorizedEntityDto {
 
@@ -60,12 +61,22 @@ public class AuthorizedCollectionDefinitionRestDto extends AuthorizedEntityDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), definitionDto);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedCollectionDefinitionRestDto that = (AuthorizedCollectionDefinitionRestDto) o;
+    return Objects.equals(definitionDto, that.definitionDto);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedDashboardDefinitionResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedDashboardDefinitionResponseDto.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.camunda.optimize.dto.optimize.AuthorizedEntityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
+import java.util.Objects;
 
 public class AuthorizedDashboardDefinitionResponseDto extends AuthorizedEntityDto {
 
@@ -40,12 +41,23 @@ public class AuthorizedDashboardDefinitionResponseDto extends AuthorizedEntityDt
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), definitionDto);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedDashboardDefinitionResponseDto that =
+        (AuthorizedDashboardDefinitionResponseDto) o;
+    return Objects.equals(definitionDto, that.definitionDto);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedReportDefinitionResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedReportDefinitionResponseDto.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.camunda.optimize.dto.optimize.AuthorizedEntityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
+import java.util.Objects;
 
 public class AuthorizedReportDefinitionResponseDto extends AuthorizedEntityDto {
 
@@ -40,12 +41,22 @@ public class AuthorizedReportDefinitionResponseDto extends AuthorizedEntityDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(super.hashCode(), definitionDto);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedReportDefinitionResponseDto that = (AuthorizedReportDefinitionResponseDto) o;
+    return Objects.equals(definitionDto, that.definitionDto);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/BackupInfoDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/BackupInfoDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import io.camunda.optimize.dto.optimize.BackupState;
 import java.util.List;
+import java.util.Objects;
 
 public class BackupInfoDto {
 
@@ -68,12 +69,22 @@ public class BackupInfoDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(backupId, failureReason, state, details);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BackupInfoDto that = (BackupInfoDto) o;
+    return backupId == that.backupId
+        && Objects.equals(failureReason, that.failureReason)
+        && Objects.equals(state, that.state)
+        && Objects.equals(details, that.details);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/BackupRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/BackupRequestDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 
 public class BackupRequestDto {
 
@@ -36,12 +37,19 @@ public class BackupRequestDto {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(backupId);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BackupRequestDto that = (BackupRequestDto) o;
+    return Objects.equals(backupId, that.backupId);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/Page.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/Page.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import io.camunda.optimize.dto.optimize.query.sorting.SortOrder;
 import java.util.List;
+import java.util.Objects;
 
 public class Page<T> {
 
@@ -90,12 +91,24 @@ public class Page<T> {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(offset, limit, total, sortBy, sortOrder, results);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final Page<?> page = (Page<?>) o;
+    return Objects.equals(offset, page.offset)
+        && Objects.equals(limit, page.limit)
+        && Objects.equals(total, page.total)
+        && Objects.equals(sortBy, page.sortBy)
+        && Objects.equals(sortOrder, page.sortOrder)
+        && Objects.equals(results, page.results);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/SnapshotInfoDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/SnapshotInfoDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 
 public class SnapshotInfoDto {
 
@@ -62,16 +63,23 @@ public class SnapshotInfoDto {
     this.failures = failures;
   }
 
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  protected boolean canEqual(final Object other) {
-    return other instanceof SnapshotInfoDto;
-  }
-
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(snapshotName, state, failures);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SnapshotInfoDto that = (SnapshotInfoDto) o;
+    return Objects.equals(snapshotName, that.snapshotName)
+        && Objects.equals(state, that.state)
+        && Objects.equals(failures, that.failures);
   }
 
   public String toString() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginatedDataExportDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginatedDataExportDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.optimize.rest.pagination;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Collection;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PaginatedDataExportDto {
@@ -97,13 +98,23 @@ public class PaginatedDataExportDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PaginatedDataExportDto that = (PaginatedDataExportDto) o;
+    return totalNumberOfRecords == that.totalNumberOfRecords
+        && Objects.equals(searchRequestId, that.searchRequestId)
+        && Objects.equals(message, that.message)
+        && Objects.equals(numberOfRecordsInResponse, that.numberOfRecordsInResponse)
+        && Objects.equals(reportId, that.reportId)
+        && Objects.equals(data, that.data);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        searchRequestId, message, numberOfRecordsInResponse, totalNumberOfRecords, reportId, data);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.rest.pagination;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Objects;
 
 public class PaginationDto {
 
@@ -55,13 +56,17 @@ public class PaginationDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PaginationDto that = (PaginationDto) o;
+    return Objects.equals(limit, that.limit) && Objects.equals(offset, that.offset);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(limit, offset);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationRequestDto.java
@@ -11,6 +11,7 @@ import static io.camunda.optimize.service.db.DatabaseConstants.MAX_RESPONSE_SIZE
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.util.Objects;
 
 public class PaginationRequestDto {
 
@@ -53,13 +54,17 @@ public class PaginationRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PaginationRequestDto that = (PaginationRequestDto) o;
+    return Objects.equals(limit, that.limit) && Objects.equals(offset, that.offset);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(limit, offset);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationScrollableDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationScrollableDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.rest.pagination;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Objects;
 
 public class PaginationScrollableDto extends PaginationDto {
 
@@ -72,13 +73,21 @@ public class PaginationScrollableDto extends PaginationDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final PaginationScrollableDto that = (PaginationScrollableDto) o;
+    return Objects.equals(scrollId, that.scrollId)
+        && Objects.equals(scrollTimeout, that.scrollTimeout);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), scrollId, scrollTimeout);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationScrollableRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationScrollableRequestDto.java
@@ -11,6 +11,7 @@ import static io.camunda.optimize.service.db.DatabaseConstants.MAX_RESPONSE_SIZE
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.util.Objects;
 
 public class PaginationScrollableRequestDto {
   @Min(0)
@@ -62,13 +63,19 @@ public class PaginationScrollableRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PaginationScrollableRequestDto that = (PaginationScrollableRequestDto) o;
+    return Objects.equals(limit, that.limit)
+        && Objects.equals(searchRequestId, that.searchRequestId)
+        && Objects.equals(paginationTimeout, that.paginationTimeout);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(limit, searchRequestId, paginationTimeout);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/sorting/SortRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/sorting/SortRequestDto.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.dto.optimize.rest.sorting;
 
 import io.camunda.optimize.dto.optimize.query.sorting.SortOrder;
+import java.util.Objects;
 import java.util.Optional;
 
 public class SortRequestDto {
@@ -47,13 +48,17 @@ public class SortRequestDto {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SortRequestDto that = (SortRequestDto) o;
+    return Objects.equals(sortBy, that.sortBy) && sortOrder == that.sortOrder;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(sortBy, sortOrder);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/CacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/CacheConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
+import java.util.Objects;
+
 public class CacheConfiguration {
 
   private int maxSize;
@@ -36,12 +38,20 @@ public class CacheConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(defaultTtlMillis, maxSize);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CacheConfiguration that = (CacheConfiguration) o;
+    return Objects.equals(defaultTtlMillis, that.defaultTtlMillis)
+        && Objects.equals(maxSize, that.maxSize);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/CloudUserCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/CloudUserCacheConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
+import java.util.Objects;
+
 public class CloudUserCacheConfiguration {
 
   private int maxSize;
@@ -36,12 +38,20 @@ public class CloudUserCacheConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(minFetchIntervalSeconds, maxSize);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CloudUserCacheConfiguration that = (CloudUserCacheConfiguration) o;
+    return Objects.equals(minFetchIntervalSeconds, that.minFetchIntervalSeconds)
+        && Objects.equals(maxSize, that.maxSize);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/CsvConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/CsvConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.util.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.util.configuration.users.AuthorizedUserType;
+import java.util.Objects;
 
 public class CsvConfiguration {
 
@@ -56,12 +57,21 @@ public class CsvConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(exportCsvDelimiter, exportCsvLimit, authorizedUserType);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CsvConfiguration that = (CsvConfiguration) o;
+    return Objects.equals(exportCsvDelimiter, that.exportCsvDelimiter)
+        && Objects.equals(exportCsvLimit, that.exportCsvLimit)
+        && Objects.equals(authorizedUserType, that.authorizedUserType);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ElasticSearchConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ElasticSearchConfiguration.java
@@ -20,6 +20,7 @@ import io.camunda.search.connect.plugin.PluginConfiguration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 public class ElasticSearchConfiguration {
@@ -225,16 +226,27 @@ public class ElasticSearchConfiguration {
     this.interceptorPlugins = interceptorPlugins;
   }
 
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  protected boolean canEqual(final Object other) {
-    return other instanceof ElasticSearchConfiguration;
-  }
-
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        connection, backup, security, scrollTimeoutInSeconds, settings, interceptorPlugins);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ElasticSearchConfiguration that = (ElasticSearchConfiguration) o;
+    return scrollTimeoutInSeconds == that.scrollTimeoutInSeconds
+        && Objects.equals(connection, that.connection)
+        && Objects.equals(backup, that.backup)
+        && Objects.equals(security, that.security)
+        && Objects.equals(settings, that.settings)
+        && Objects.equals(interceptorPlugins, that.interceptorPlugins);
   }
 
   public String toString() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/EmailAuthenticationConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/EmailAuthenticationConfiguration.java
@@ -11,6 +11,7 @@ import static io.camunda.optimize.service.util.configuration.ConfigurationServic
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
+import java.util.Objects;
 
 public class EmailAuthenticationConfiguration {
 
@@ -77,12 +78,22 @@ public class EmailAuthenticationConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(enabled, username, password, securityProtocol);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EmailAuthenticationConfiguration that = (EmailAuthenticationConfiguration) o;
+    return Objects.equals(enabled, that.enabled)
+        && Objects.equals(username, that.username)
+        && Objects.equals(password, that.password)
+        && Objects.equals(securityProtocol, that.securityProtocol);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/EntityConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/EntityConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.util.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.util.configuration.users.AuthorizedUserType;
+import java.util.Objects;
 
 public class EntityConfiguration {
 
@@ -52,12 +53,21 @@ public class EntityConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(authorizedUserType, kpiRefreshInterval, createOnStartup);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntityConfiguration that = (EntityConfiguration) o;
+    return Objects.equals(authorizedUserType, that.authorizedUserType)
+        && Objects.equals(kpiRefreshInterval, that.kpiRefreshInterval)
+        && Objects.equals(createOnStartup, that.createOnStartup);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ExternalVariableConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ExternalVariableConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.util.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class ExternalVariableConfiguration {
 
@@ -32,12 +33,19 @@ public class ExternalVariableConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(importConfiguration);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExternalVariableConfiguration that = (ExternalVariableConfiguration) o;
+    return Objects.equals(importConfiguration, that.importConfiguration);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ExternalVariableImportConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ExternalVariableImportConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
+import java.util.Objects;
+
 public class ExternalVariableImportConfiguration {
 
   private boolean enabled;
@@ -36,12 +38,19 @@ public class ExternalVariableImportConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(enabled, maxPageSize);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExternalVariableImportConfiguration that = (ExternalVariableImportConfiguration) o;
+    return enabled == that.enabled && maxPageSize == that.maxPageSize;
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/GlobalCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/GlobalCacheConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
+import java.util.Objects;
+
 public class GlobalCacheConfiguration {
 
   private CacheConfiguration definitions;
@@ -62,13 +64,22 @@ public class GlobalCacheConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final GlobalCacheConfiguration that = (GlobalCacheConfiguration) o;
+    return Objects.equals(definitions, that.definitions)
+        && Objects.equals(definitionEngines, that.definitionEngines)
+        && Objects.equals(cloudUsers, that.cloudUsers)
+        && Objects.equals(cloudTenantAuthorizations, that.cloudTenantAuthorizations)
+        && Objects.equals(users, that.users);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        definitions, definitionEngines, cloudUsers, cloudTenantAuthorizations, users);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/M2mAuth0ClientConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/M2mAuth0ClientConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
+import java.util.Objects;
+
 public class M2mAuth0ClientConfiguration {
 
   private String m2mClientId;
@@ -35,13 +37,18 @@ public class M2mAuth0ClientConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final M2mAuth0ClientConfiguration that = (M2mAuth0ClientConfiguration) o;
+    return Objects.equals(m2mClientId, that.m2mClientId)
+        && Objects.equals(m2mClientSecret, that.m2mClientSecret);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(m2mClientId, m2mClientSecret);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OnboardingConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OnboardingConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.util.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.j2objc.annotations.Property;
+import java.util.Objects;
 
 public class OnboardingConfiguration {
 
@@ -88,13 +89,29 @@ public class OnboardingConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OnboardingConfiguration that = (OnboardingConfiguration) o;
+    return enabled == that.enabled
+        && scheduleProcessOnboardingChecks == that.scheduleProcessOnboardingChecks
+        && enableOnboardingEmails == that.enableOnboardingEmails
+        && intervalForCheckingTriggerForOnboardingEmails
+            == that.intervalForCheckingTriggerForOnboardingEmails
+        && Objects.equals(appCuesScriptUrl, that.appCuesScriptUrl)
+        && Objects.equals(properties, that.properties);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        enabled,
+        appCuesScriptUrl,
+        scheduleProcessOnboardingChecks,
+        enableOnboardingEmails,
+        intervalForCheckingTriggerForOnboardingEmails,
+        properties);
   }
 
   @Override
@@ -152,13 +169,18 @@ public class OnboardingConfiguration {
     }
 
     @Override
-    public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Properties that = (Properties) o;
+      return Objects.equals(organizationId, that.organizationId)
+          && Objects.equals(clusterId, that.clusterId);
     }
 
     @Override
-    public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    public int hashCode() {
+      return Objects.hash(organizationId, clusterId);
     }
 
     @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OpenSearchConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OpenSearchConfiguration.java
@@ -20,6 +20,7 @@ import io.camunda.search.connect.plugin.PluginConfiguration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -217,16 +218,28 @@ public class OpenSearchConfiguration {
     this.interceptorPlugins = interceptorPlugins;
   }
 
+  @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OpenSearchConfiguration that = (OpenSearchConfiguration) o;
+    return scrollTimeoutInSeconds == that.scrollTimeoutInSeconds
+        && Objects.equals(connection, that.connection)
+        && Objects.equals(backup, that.backup)
+        && Objects.equals(security, that.security)
+        && Objects.equals(settings, that.settings)
+        && Objects.equals(interceptorPlugins, that.interceptorPlugins);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        connection, backup, security, scrollTimeoutInSeconds, settings, interceptorPlugins);
   }
 
   protected boolean canEqual(final Object other) {
     return other instanceof OpenSearchConfiguration;
-  }
-
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 
   public String toString() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OptimizeApiConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OptimizeApiConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.util.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class OptimizeApiConfiguration {
 
@@ -54,13 +55,19 @@ public class OptimizeApiConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OptimizeApiConfiguration that = (OptimizeApiConfiguration) o;
+    return Objects.equals(accessToken, that.accessToken)
+        && Objects.equals(jwtSetUri, that.jwtSetUri)
+        && Objects.equals(audience, that.audience);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(accessToken, jwtSetUri, audience);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/PanelNotificationConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/PanelNotificationConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
+import java.util.Objects;
+
 public class PanelNotificationConfiguration {
 
   private String url;
@@ -44,13 +46,19 @@ public class PanelNotificationConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PanelNotificationConfiguration that = (PanelNotificationConfiguration) o;
+    return enabled == that.enabled
+        && Objects.equals(url, that.url)
+        && Objects.equals(m2mTokenAudience, that.m2mTokenAudience);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(url, enabled, m2mTokenAudience);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ProxyConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ProxyConfiguration.java
@@ -12,6 +12,7 @@ import static io.camunda.optimize.service.util.configuration.ConfigurationServic
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
+import java.util.Objects;
 
 @JsonIgnoreProperties
 public class ProxyConfiguration {
@@ -92,13 +93,20 @@ public class ProxyConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProxyConfiguration that = (ProxyConfiguration) o;
+    return enabled == that.enabled
+        && sslEnabled == that.sslEnabled
+        && Objects.equals(host, that.host)
+        && Objects.equals(port, that.port);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(enabled, host, port, sslEnabled);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/TelemetryConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/TelemetryConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.util.configuration;
 import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.TELEMETRY_CONFIGURATION;
 
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
+import java.util.Objects;
 
 public class TelemetryConfiguration {
 
@@ -54,13 +55,18 @@ public class TelemetryConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TelemetryConfiguration that = (TelemetryConfiguration) o;
+    return initializeTelemetry == that.initializeTelemetry
+        && reportingIntervalInHours == that.reportingIntervalInHours;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(initializeTelemetry, reportingIntervalInHours);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ZeebeConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ZeebeConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
+import java.util.Objects;
+
 public class ZeebeConfiguration {
 
   private boolean enabled;
@@ -97,13 +99,30 @@ public class ZeebeConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeConfiguration that = (ZeebeConfiguration) o;
+    return enabled == that.enabled
+        && partitionCount == that.partitionCount
+        && maxImportPageSize == that.maxImportPageSize
+        && includeObjectVariableValue == that.includeObjectVariableValue
+        && variableImportEnabled == that.variableImportEnabled
+        && Objects.equals(name, that.name)
+        && Objects.equals(importConfig, that.importConfig);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        enabled,
+        name,
+        partitionCount,
+        maxImportPageSize,
+        includeObjectVariableValue,
+        variableImportEnabled,
+        importConfig);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ZeebeImportConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ZeebeImportConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
+import java.util.Objects;
+
 public class ZeebeImportConfiguration {
 
   private int dynamicBatchSuccessAttempts;
@@ -41,13 +43,18 @@ public class ZeebeImportConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeImportConfiguration that = (ZeebeImportConfiguration) o;
+    return dynamicBatchSuccessAttempts == that.dynamicBatchSuccessAttempts
+        && maxEmptyPagesToImport == that.maxEmptyPagesToImport;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(dynamicBatchSuccessAttempts, maxEmptyPagesToImport);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/analytics/AnalyticsConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/analytics/AnalyticsConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.util.configuration.analytics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class AnalyticsConfiguration {
 
@@ -62,12 +63,19 @@ public class AnalyticsConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(mixpanel, osano);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AnalyticsConfiguration that = (AnalyticsConfiguration) o;
+    return Objects.equals(mixpanel, that.mixpanel) && Objects.equals(osano, that.osano);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/analytics/MixpanelConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/analytics/MixpanelConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.util.configuration.analytics;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class MixpanelConfiguration {
 
@@ -112,12 +113,24 @@ public class MixpanelConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(apiHost, importPath, token, projectId, properties, serviceAccount);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MixpanelConfiguration that = (MixpanelConfiguration) o;
+    return Objects.equals(apiHost, that.apiHost)
+        && Objects.equals(importPath, that.importPath)
+        && Objects.equals(token, that.token)
+        && Objects.equals(projectId, that.projectId)
+        && Objects.equals(properties, that.properties)
+        && Objects.equals(serviceAccount, that.serviceAccount);
   }
 
   @Override
@@ -190,12 +203,21 @@ public class MixpanelConfiguration {
 
     @Override
     public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+      return Objects.hash(stage, organizationId, clusterId);
     }
 
     @Override
     public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final TrackingProperties that = (TrackingProperties) o;
+      return Objects.equals(stage, that.stage)
+          && Objects.equals(organizationId, that.organizationId)
+          && Objects.equals(clusterId, that.clusterId);
     }
 
     @Override
@@ -249,12 +271,19 @@ public class MixpanelConfiguration {
 
     @Override
     public int hashCode() {
-      return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+      return Objects.hash(username, secret);
     }
 
     @Override
     public boolean equals(final Object o) {
-      return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final ServiceAccount that = (ServiceAccount) o;
+      return Objects.equals(username, that.username) && Objects.equals(secret, that.secret);
     }
 
     @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/analytics/OsanoConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/analytics/OsanoConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.util.configuration.analytics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import java.util.Optional;
 
 public class OsanoConfiguration {
@@ -36,12 +37,19 @@ public class OsanoConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(scriptUrl);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OsanoConfiguration that = (OsanoConfiguration) o;
+    return Objects.equals(scriptUrl, that.scriptUrl);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/cleanup/CleanupConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/cleanup/CleanupConfiguration.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
 import io.camunda.optimize.service.util.CronNormalizerUtil;
 import java.time.Period;
+import java.util.Objects;
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -122,12 +123,24 @@ public class CleanupConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        cronTrigger, ttl, processDataCleanupConfiguration, externalVariableCleanupConfiguration);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CleanupConfiguration that = (CleanupConfiguration) o;
+    return Objects.equals(cronTrigger, that.cronTrigger)
+        && Objects.equals(ttl, that.ttl)
+        && Objects.equals(processDataCleanupConfiguration, that.processDataCleanupConfiguration)
+        && Objects.equals(
+            externalVariableCleanupConfiguration, that.externalVariableCleanupConfiguration);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/cleanup/ExternalVariableCleanupConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/cleanup/ExternalVariableCleanupConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.util.configuration.cleanup;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class ExternalVariableCleanupConfiguration {
 
@@ -35,12 +36,19 @@ public class ExternalVariableCleanupConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(enabled);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExternalVariableCleanupConfiguration that = (ExternalVariableCleanupConfiguration) o;
+    return enabled == that.enabled;
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/cleanup/ProcessCleanupConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/cleanup/ProcessCleanupConfiguration.java
@@ -16,6 +16,7 @@ import io.camunda.optimize.util.SuppressionConstants;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -103,12 +104,23 @@ public class ProcessCleanupConfiguration {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(enabled, cleanupMode, batchSize, processDefinitionSpecificConfiguration);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessCleanupConfiguration that = (ProcessCleanupConfiguration) o;
+    return enabled == that.enabled
+        && Objects.equals(cleanupMode, that.cleanupMode)
+        && Objects.equals(batchSize, that.batchSize)
+        && Objects.equals(
+            processDefinitionSpecificConfiguration, that.processDefinitionSpecificConfiguration);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseBackup.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseBackup.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.util.configuration.db;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class DatabaseBackup {
 
@@ -31,12 +32,19 @@ public class DatabaseBackup {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(snapshotRepositoryName);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseBackup that = (DatabaseBackup) o;
+    return Objects.equals(snapshotRepositoryName, that.snapshotRepositoryName);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseConnection.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseConnection.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.util.configuration.ProxyConfiguration;
 import io.camunda.optimize.service.util.configuration.elasticsearch.DatabaseConnectionNodeConfiguration;
 import java.util.List;
+import java.util.Objects;
 
 public class DatabaseConnection {
 
@@ -89,16 +90,32 @@ public class DatabaseConnection {
     this.awsEnabled = awsEnabled;
   }
 
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  protected boolean canEqual(final Object other) {
-    return other instanceof DatabaseConnection;
-  }
-
+  @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        connectionNodes,
+        timeout,
+        responseConsumerBufferLimitInMb,
+        skipHostnameVerification,
+        pathPrefix,
+        proxy);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseConnection that = (DatabaseConnection) o;
+    return Objects.equals(timeout, that.timeout)
+        && Objects.equals(responseConsumerBufferLimitInMb, that.responseConsumerBufferLimitInMb)
+        && Objects.equals(skipHostnameVerification, that.skipHostnameVerification)
+        && Objects.equals(connectionNodes, that.connectionNodes)
+        && Objects.equals(pathPrefix, that.pathPrefix)
+        && Objects.equals(proxy, that.proxy);
   }
 
   public Boolean isClusterTaskCheckingEnabled() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseIndex.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.util.configuration.db;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class DatabaseIndex {
 
@@ -77,12 +78,24 @@ public class DatabaseIndex {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(
+        prefix, numberOfShards, numberOfReplicas, refreshInterval, nestedDocumentsLimit);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseIndex that = (DatabaseIndex) o;
+    return Objects.equals(numberOfShards, that.numberOfShards)
+        && Objects.equals(numberOfReplicas, that.numberOfReplicas)
+        && Objects.equals(nestedDocumentsLimit, that.nestedDocumentsLimit)
+        && Objects.equals(prefix, that.prefix)
+        && Objects.equals(refreshInterval, that.refreshInterval);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseSSLConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseSSLConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.util.configuration.db;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Objects;
 
 public class DatabaseSSLConfiguration {
 
@@ -59,13 +60,20 @@ public class DatabaseSSLConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseSSLConfiguration that = (DatabaseSSLConfiguration) o;
+    return Objects.equals(enabled, that.enabled)
+        && Objects.equals(selfSigned, that.selfSigned)
+        && Objects.equals(certificate, that.certificate)
+        && Objects.equals(certificateAuthorities, that.certificateAuthorities);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(enabled, selfSigned, certificate, certificateAuthorities);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseSecurity.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseSecurity.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration.db;
 
+import java.util.Objects;
+
 public class DatabaseSecurity {
 
   private String username;
@@ -45,12 +47,21 @@ public class DatabaseSecurity {
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(username, password, ssl);
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseSecurity that = (DatabaseSecurity) o;
+    return Objects.equals(username, that.username)
+        && Objects.equals(password, that.password)
+        && Objects.equals(ssl, that.ssl);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseSettings.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseSettings.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration.db;
 
+import java.util.Objects;
+
 public class DatabaseSettings {
 
   private DatabaseIndex index;
@@ -35,13 +37,18 @@ public class DatabaseSettings {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseSettings that = (DatabaseSettings) o;
+    return Objects.equals(index, that.index)
+        && Objects.equals(aggregationBucketLimit, that.aggregationBucketLimit);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(index, aggregationBucketLimit);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/elasticsearch/DatabaseConnectionNodeConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/elasticsearch/DatabaseConnectionNodeConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration.elasticsearch;
 
+import java.util.Objects;
+
 public class DatabaseConnectionNodeConfiguration {
 
   private String host;
@@ -35,13 +37,17 @@ public class DatabaseConnectionNodeConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseConnectionNodeConfiguration that = (DatabaseConnectionNodeConfiguration) o;
+    return Objects.equals(host, that.host) && Objects.equals(httpPort, that.httpPort);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(host, httpPort);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/EventIngestionConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/EventIngestionConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.util.configuration.engine;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class EventIngestionConfiguration {
 
@@ -42,13 +43,17 @@ public class EventIngestionConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EventIngestionConfiguration that = (EventIngestionConfiguration) o;
+    return maxBatchRequestBytes == that.maxBatchRequestBytes && maxRequests == that.maxRequests;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(maxBatchRequestBytes, maxRequests);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/IdentityCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/IdentityCacheConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.util.configuration.engine;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
 import io.camunda.optimize.service.util.CronNormalizerUtil;
+import java.util.Objects;
 import java.util.Optional;
 
 public abstract class IdentityCacheConfiguration {
@@ -78,13 +79,22 @@ public abstract class IdentityCacheConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IdentityCacheConfiguration that = (IdentityCacheConfiguration) o;
+    return includeUserMetaData == that.includeUserMetaData
+        && collectionRoleCleanupEnabled == that.collectionRoleCleanupEnabled
+        && maxPageSize == that.maxPageSize
+        && maxEntryLimit == that.maxEntryLimit
+        && Objects.equals(cronTrigger, that.cronTrigger);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        includeUserMetaData, collectionRoleCleanupEnabled, cronTrigger, maxPageSize, maxEntryLimit);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/UserIdentityCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/UserIdentityCacheConfiguration.java
@@ -9,6 +9,8 @@ package io.camunda.optimize.service.util.configuration.engine;
 
 import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.IDENTITY_SYNC_CONFIGURATION;
 
+import java.util.Objects;
+
 public class UserIdentityCacheConfiguration extends IdentityCacheConfiguration {
 
   public UserIdentityCacheConfiguration() {}
@@ -19,18 +21,24 @@ public class UserIdentityCacheConfiguration extends IdentityCacheConfiguration {
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
-  @Override
   protected boolean canEqual(final Object other) {
     return other instanceof UserIdentityCacheConfiguration;
   }
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/UserTaskIdentityCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/UserTaskIdentityCacheConfiguration.java
@@ -9,6 +9,8 @@ package io.camunda.optimize.service.util.configuration.engine;
 
 import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.IMPORT_USER_TASK_IDENTITY_META_DATA;
 
+import java.util.Objects;
+
 public class UserTaskIdentityCacheConfiguration extends IdentityCacheConfiguration {
 
   public UserTaskIdentityCacheConfiguration() {}
@@ -25,12 +27,18 @@ public class UserTaskIdentityCacheConfiguration extends IdentityCacheConfigurati
 
   @Override
   public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(getClass(), super.hashCode());
   }
 
   @Override
   public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/AuthConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/AuthConfiguration.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.util.SuppressionConstants;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 public class AuthConfiguration {
@@ -94,13 +95,26 @@ public class AuthConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AuthConfiguration that = (AuthConfiguration) o;
+    return Objects.equals(cloudAuthConfiguration, that.cloudAuthConfiguration)
+        && Objects.equals(ccsmAuthConfiguration, that.ccsmAuthConfiguration)
+        && Objects.equals(tokenLifeTime, that.tokenLifeTime)
+        && Objects.equals(tokenSecret, that.tokenSecret)
+        && Objects.equals(cookieConfiguration, that.cookieConfiguration);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        cloudAuthConfiguration,
+        ccsmAuthConfiguration,
+        tokenLifeTime,
+        tokenSecret,
+        cookieConfiguration);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/CCSMAuthConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/CCSMAuthConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration.security;
 
+import java.util.Objects;
+
 public class CCSMAuthConfiguration {
 
   // the url to Identity
@@ -86,13 +88,24 @@ public class CCSMAuthConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CCSMAuthConfiguration that = (CCSMAuthConfiguration) o;
+    return Objects.equals(issuerUrl, that.issuerUrl)
+        && Objects.equals(issuerBackendUrl, that.issuerBackendUrl)
+        && Objects.equals(redirectRootUrl, that.redirectRootUrl)
+        && Objects.equals(clientId, that.clientId)
+        && Objects.equals(clientSecret, that.clientSecret)
+        && Objects.equals(audience, that.audience)
+        && Objects.equals(baseUrl, that.baseUrl);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        issuerUrl, issuerBackendUrl, redirectRootUrl, clientId, clientSecret, audience, baseUrl);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/CloudAuthConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/CloudAuthConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.util.configuration.security;
 
+import java.util.Objects;
 import java.util.Optional;
 
 public class CloudAuthConfiguration {
@@ -129,13 +130,38 @@ public class CloudAuthConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CloudAuthConfiguration that = (CloudAuthConfiguration) o;
+    return Objects.equals(clientId, that.clientId)
+        && Objects.equals(clientSecret, that.clientSecret)
+        && Objects.equals(domain, that.domain)
+        && Objects.equals(customDomain, that.customDomain)
+        && Objects.equals(userIdAttributeName, that.userIdAttributeName)
+        && Objects.equals(organizationClaimName, that.organizationClaimName)
+        && Objects.equals(organizationId, that.organizationId)
+        && Objects.equals(clusterId, that.clusterId)
+        && Objects.equals(audience, that.audience)
+        && Objects.equals(userAccessTokenAudience, that.userAccessTokenAudience)
+        && Objects.equals(tokenUrl, that.tokenUrl);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        clientId,
+        clientSecret,
+        domain,
+        customDomain,
+        userIdAttributeName,
+        organizationClaimName,
+        organizationId,
+        clusterId,
+        audience,
+        userAccessTokenAudience,
+        tokenUrl);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/CookieConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/CookieConfiguration.java
@@ -13,6 +13,7 @@ import io.camunda.optimize.rest.constants.RestConstants;
 import io.camunda.optimize.util.SuppressionConstants;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 public class CookieConfiguration {
@@ -72,13 +73,19 @@ public class CookieConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CookieConfiguration that = (CookieConfiguration) o;
+    return sameSiteFlagEnabled == that.sameSiteFlagEnabled
+        && cookieSecureMode == that.cookieSecureMode
+        && Objects.equals(maxSize, that.maxSize);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(sameSiteFlagEnabled, cookieSecureMode, maxSize);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/LicenseConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/LicenseConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.util.configuration.security;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class LicenseConfiguration {
 
@@ -30,13 +31,17 @@ public class LicenseConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final LicenseConfiguration that = (LicenseConfiguration) o;
+    return enterprise == that.enterprise;
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(enterprise);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/ResponseHeadersConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/ResponseHeadersConfiguration.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class ResponseHeadersConfiguration {
 
@@ -103,13 +104,28 @@ public class ResponseHeadersConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ResponseHeadersConfiguration that = (ResponseHeadersConfiguration) o;
+    return Objects.equals(httpStrictTransportSecurityMaxAge, that.httpStrictTransportSecurityMaxAge)
+        && Objects.equals(
+            httpStrictTransportSecurityIncludeSubdomains,
+            that.httpStrictTransportSecurityIncludeSubdomains)
+        && Objects.equals(xsssProtection, that.xsssProtection)
+        && Objects.equals(xContentTypeOptions, that.xContentTypeOptions)
+        && Objects.equals(contentSecurityPolicy, that.contentSecurityPolicy);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        httpStrictTransportSecurityMaxAge,
+        httpStrictTransportSecurityIncludeSubdomains,
+        xsssProtection,
+        xContentTypeOptions,
+        contentSecurityPolicy);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/SecurityConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/SecurityConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration.security;
 
+import java.util.Objects;
+
 public class SecurityConfiguration {
 
   private AuthConfiguration auth;
@@ -44,13 +46,19 @@ public class SecurityConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SecurityConfiguration that = (SecurityConfiguration) o;
+    return Objects.equals(auth, that.auth)
+        && Objects.equals(license, that.license)
+        && Objects.equals(responseHeaders, that.responseHeaders);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(auth, license, responseHeaders);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ui/UIConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ui/UIConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.util.configuration.ui;
 
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
+import java.util.Objects;
 
 public class UIConfiguration {
 
@@ -93,13 +94,28 @@ public class UIConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UIConfiguration that = (UIConfiguration) o;
+    return logoutHidden == that.logoutHidden
+        && maxNumDataSourcesForReport == that.maxNumDataSourcesForReport
+        && userTaskAssigneeAnalyticsEnabled == that.userTaskAssigneeAnalyticsEnabled
+        && Objects.equals(mixpanelToken, that.mixpanelToken)
+        && Objects.equals(consoleUrl, that.consoleUrl)
+        && Objects.equals(modelerUrl, that.modelerUrl);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hash(
+        logoutHidden,
+        mixpanelToken,
+        maxNumDataSourcesForReport,
+        userTaskAssigneeAnalyticsEnabled,
+        consoleUrl,
+        modelerUrl);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/users/CloudUsersConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/users/CloudUsersConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.util.configuration.users;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudUsersConfiguration {
@@ -35,13 +36,17 @@ public class CloudUsersConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CloudUsersConfiguration that = (CloudUsersConfiguration) o;
+    return Objects.equals(accountsUrl, that.accountsUrl);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(accountsUrl);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/users/UsersConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/users/UsersConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration.users;
 
+import java.util.Objects;
+
 public class UsersConfiguration {
 
   private CloudUsersConfiguration cloud;
@@ -26,13 +28,17 @@ public class UsersConfiguration {
   }
 
   @Override
-  public int hashCode() {
-    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UsersConfiguration that = (UsersConfiguration) o;
+    return Objects.equals(cloud, that.cloud);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  public int hashCode() {
+    return Objects.hashCode(cloud);
   }
 
   @Override


### PR DESCRIPTION
## Description

### Issue

1. Object mapper tries to readValue into a `Set` on [EntityImportService](https://github.com/camunda/camunda/blob/fd7f9d149d00fde3c5346ec61863496d3806f175/optimize/backend/src/main/java/io/camunda/optimize/service/entities/EntityImportService.java#L138-L139)
2. Then different Object org.apache.commons.lang3.builder.* equals and hashCode methods are called
3. Non accessible java base fields trying to be accessed through reflection leading to following issue (java 16+ made this more strict)
``` json
{
"errorCode": "serverError",
"errorMessage": "An internal server error occurred.",
"detailedMessage": "Could not import entities because the provided file is not a valid list of OptimizeEntityExportDtos. Error:Unable to make field static final int java.util.HashMap.DEFAULT_INITIAL_CAPACITY accessible: module java.base does not "opens java.util" to unnamed module @49b0b76 (through reference chain: java.util.HashSet[5])",
"reportDefinition": null
}
```

### Solution
Change:
- org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
- org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
 
Replace with equals and hashCode methods using Objects java 7+ 

### Alternative Solution
Enhance VM opts adding **--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED**
`OPTIMIZE_JAVA_OPTS="-Xms1024m -Xmx1024m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=256m --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED"`

but it is mentioned [here](https://github.com/camunda/camunda/issues/38860#issuecomment-3346281535) to fix "in a way that it does not try to gain access to fields that are owned by the JVM".

### Note
Jackson updated to latest version and tested but that wasn't the case

## Related issues

closes #38860
