### PR TITLE
test: relax assertion timeout to 30s instead of 10s

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
@@ -193,7 +193,7 @@ final class ScaleUpBrokersTest {
         .brokerHasPartition(0, 1);
 
     // Changes are reflected in the topology returned by grpc query
-    cluster.awaitCompleteTopology(newClusterSize, 3, 1, Duration.ofSeconds(10));
+    cluster.awaitCompleteTopology(newClusterSize, 3, 1, Duration.ofSeconds(30));
   }
 
   @Test


### PR DESCRIPTION
## Description
Previous failures indicated that a partition was still UNHEALTHY, relaxing the timeout alleviates the issue. 
In my local tests, the partition would eventually become HEALTHY after ~8-9s after the `SnapshotException` was raised, which is probably why it was failing that often
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #38881
