### PR TITLE
feat: add processing properties

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Camunda.java
+++ b/configuration/src/main/java/io/camunda/configuration/Camunda.java
@@ -23,6 +23,7 @@ public class Camunda {
   @NestedConfigurationProperty private System system = new System();
   @NestedConfigurationProperty private Data data = new Data();
   @NestedConfigurationProperty private Api api = new Api();
+  @NestedConfigurationProperty private Processing processing = new Processing();
 
   public Cluster getCluster() {
     return cluster;
@@ -54,5 +55,13 @@ public class Camunda {
 
   public void setApi(final Api api) {
     this.api = api;
+  }
+
+  public Processing getProcessing() {
+    return processing;
+  }
+
+  public void setProcessing(final Processing processing) {
+    this.processing = processing;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/FlowControl.java
+++ b/configuration/src/main/java/io/camunda/configuration/FlowControl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+public class FlowControl {
+
+  /** Configure rate limit */
+  @NestedConfigurationProperty private Write write = null;
+
+  public Write getWrite() {
+    return write;
+  }
+
+  public void setWrite(final Write write) {
+    this.write = write;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Processing.java
+++ b/configuration/src/main/java/io/camunda/configuration/Processing.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.core.ResolvableType;
+
+public class Processing {
+  private static final String PREFIX = "camunda.processing";
+  private static final int DEFAULT_PROCESSING_BATCH_LIMIT = 100;
+  private static final boolean DEFAULT_ENABLE_ASYNC_SCHEDULED_TASKS = true;
+  private static final Duration DEFAULT_SCHEDULED_TASKS_CHECK_INTERVAL = Duration.ofSeconds(1);
+
+  private static final boolean DEFAULT_ENABLE_PRECONDITIONS_CHECK = false;
+  private static final boolean DEFAULT_ENABLE_FOREIGN_KEY_CHECKS = false;
+
+  private static final boolean DEFAULT_ENABLE_YIELDING_DUEDATE_CHECKER = true;
+  private static final boolean DEFAULT_ENABLE_ASYNC_MESSAGE_TTL_CHECKER = false;
+  private static final boolean DEFAULT_ENABLE_ASYNC_TIMER_DUEDATE_CHECKER = false;
+  private static final boolean DEFAULT_ENABLE_STRAIGHTTHROUGH_PROCESSING_LOOP_DETECTOR = true;
+  private static final boolean DEFAULT_ENABLE_MESSAGE_BODY_ON_EXPIRED = false;
+
+  private static final Set<String> LEGACY_MAX_COMMANDS_IN_BATCH_PROPERTIES =
+      Set.of("zeebe.broker.processingCfg.maxCommandsInBatch");
+  private static final Set<String> LEGACY_ENABLE_ASYNC_SCHEDULED_TASKS_PROPERTIES =
+      Set.of("zeebe.broker.processingCfg.enableAsyncScheduledTasks");
+  private static final Set<String> LEGACY_SCHEDULED_TASKS_CHECK_INTERVAL_PROPERTIES =
+      Set.of("zeebe.broker.processingCfg.scheduledTaskCheckInterval");
+  private static final Set<String> LEGACY_SKIP_POSITIONS_PROPERTIES =
+      Set.of("zeebe.broker.processingCfg.skipPositions");
+
+  private static final Set<String> LEGACY_CONSISTENCY_CHECK_ENABLE_PRECONDITIONS_PROPERTIES =
+      Set.of("zeebe.broker.experimental.consistencyChecks.enablePreconditions");
+  private static final Set<String> LEGACY_CONSISTENCY_CHECK_ENABLE_FOREIGN_KEY_CHECKS_PROPERTIES =
+      Set.of("zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks");
+
+  private static final Set<String> LEGACY_FEATURES_ENABLE_YIELD_DUEDATE_CHECKER_PROPERTIES =
+      Set.of("zeebe.broker.experimental.features.enableYieldingDueDateChecker");
+  private static final Set<String> LEGACY_FEATURES_ENABLE_MESSAGE_TTL_CHECKER_ASYNC_PROPERTIES =
+      Set.of("zeebe.broker.experimental.features.enableMessageTtlCheckerAsync");
+  private static final Set<String> LEGACY_FEATURES_ENABLE_TIMER_DUE_DATE_CHECKER_ASYNC_PROPERTIES =
+      Set.of("zeebe.broker.experimental.features.enableTimerDueDateCheckerAsync");
+  private static final Set<String>
+      LEGACY_FEATURES_ENABLE_STRAIGHT_THROUGH_PROCESSING_LOOP_DETECTOR_PROPERTIES =
+          Set.of("zeebe.broker.experimental.features.enableStraightThroughProcessingLoopDetector");
+  private static final Set<String> LEGACY_FEATURES_ENABLE_MESSAGE_BODY_ON_EXPIRED_PROPERTIES =
+      Set.of("zeebe.broker.experimental.features.enableMessageBodyOnExpired");
+
+  /**
+   * Configure flow control for user requests. This setting takes precedence over the backpressure
+   * configuration.
+   */
+  @NestedConfigurationProperty FlowControl flowControl = new FlowControl();
+
+  /**
+   * Sets the maximum number of commands that processed within one batch. The processor will process
+   * until no more follow up commands are created by the initial command or the configured limit is
+   * reached. By default, up to 100 commands are processed in one batch. Can be set to 1 to disable
+   * batch processing. Must be a positive integer number. Note that the resulting batch size will
+   * contain more entries than this limit because it includes follow up events. When resulting batch
+   * size is too large (see maxMessageSize), processing will be rolled back and retried with a
+   * smaller maximum batch size. Lowering the command limit can reduce the frequency of rollback and
+   * retry.
+   */
+  private Integer maxCommandsInBatch = DEFAULT_PROCESSING_BATCH_LIMIT;
+
+  /**
+   * Allows scheduled processing tasks such as checking for timed-out jobs to run concurrently to
+   * regular processing. This is a performance optimization to ensure that processing is not
+   * interrupted by higher than usual workload for any of the scheduled tasks. This should only be
+   * disabled in case of bugs, for example if one of the scheduled tasks is not safe to run
+   * concurrently to regular processing.
+   *
+   * <p>This replaces the deprecated experimental settings that enable async scheduling for specific
+   * tasks only, for example `enableMessageTTLCheckerAsync`. When `enableAsyncScheduledTasks` is
+   * enabled (which it is by default), the deprecated settings take no effect. When
+   * `enableAsyncScheduledTasks` is disabled, scheduled tasks are only run async if explicitly
+   * enabled by the deprecated setting.
+   */
+  private boolean enableAsyncScheduledTasks = DEFAULT_ENABLE_ASYNC_SCHEDULED_TASKS;
+
+  /**
+   * Configures the rate at which a partition leader checks for expired scheduled tasks such as the
+   * due date checker. The default value is 1 second. Use a lower interval to potentially decrease
+   * delays between requested and actual execution of scheduled tasks. Using a low interval will
+   * result in unnecessary load while idle. We recommend to benchmark any changes to this setting.
+   */
+  private Duration scheduledTasksCheckInterval = DEFAULT_SCHEDULED_TASKS_CHECK_INTERVAL;
+
+  /**
+   * Allows to skip certain commands by their position. This is useful for debugging and data
+   * recovery. It is not recommended to use this in production. The value is a comma-separated list
+   * of positions to skip. Whitespace is ignored.
+   */
+  private Set<Long> skipPositions;
+
+  /**
+   * Configures if the basic operations on RocksDB, such as inserting or deleting key-value pairs,
+   * should check preconditions, for example that a key does not already exist when inserting.
+   */
+  private boolean enablePreconditionsCheck = DEFAULT_ENABLE_PRECONDITIONS_CHECK;
+
+  /**
+   * Configures if inserting or updating key-value pairs on RocksDB should check that foreign keys
+   * exist.
+   */
+  private boolean enableForeignKeyChecks = DEFAULT_ENABLE_FOREIGN_KEY_CHECKS;
+
+  /**
+   * Changes the DueDateTimerChecker to give yield to other processing steps in situations where it
+   * has many (i.e. millions of) timers to process. If set to false (default) the
+   * DueDateTimerChecker will activate all due timers. In the worst case, this can lead to the node
+   * being blocked for indefinite amount of time, being subsequently flagged as unhealthy.
+   * Currently, there is no known way to recover from this situation If set to true, the
+   * DueDateTimerChecker will give yield to other processing steps. This avoids the worst case
+   * described above. However, under consistent high load it may happen that the activated timers
+   * will fall behind real time, if more timers become due than can be activated during a certain
+   * time period.
+   */
+  private boolean enableYieldingDueDateChecker = DEFAULT_ENABLE_YIELDING_DUEDATE_CHECKER;
+
+  /**
+   * While disabled, checking the Time-To-Live of buffered messages blocks all other executions that
+   * occur on the stream processor, including process execution and job activation/completion. When
+   * enabled, the Message TTL Checker will run asynchronous to the Engine's stream processor. This
+   * helps improve throughput and process latency in use cases that publish many messages with a
+   * non-zero TTL. We recommend testing this feature in a non-production environment before enabling
+   * it in production.
+   */
+  private boolean enableAsyncMessageTtlChecker = DEFAULT_ENABLE_ASYNC_MESSAGE_TTL_CHECKER;
+
+  /**
+   * While disabled, checking for due timers blocks all other executions that occur on the stream
+   * processor, including process execution and job activation/completion. When enabled, the Due
+   * Date Checker will run asynchronous to the Engine's stream processor. This helps improve
+   * throughput and process latency when there are a lot of timers. We recommend testing this
+   * feature in a non-production environment before enabling it in production.
+   */
+  private boolean enableAsyncTimerDuedateChecker = DEFAULT_ENABLE_ASYNC_TIMER_DUEDATE_CHECKER;
+
+  private boolean enableStraightthroughProcessingLoopDetector =
+      DEFAULT_ENABLE_STRAIGHTTHROUGH_PROCESSING_LOOP_DETECTOR;
+
+  /**
+   * Controls whether the full message body is included in the follow-up event when a message
+   * expires. When enabled, the system appends the entire message payload during expiration. This is
+   * useful in environments where full visibility into expired messages is needed. Such that full
+   * message details can be exported by configuring the exporter filtering to allow
+   * `Message.EXPIRED` events. However, including the full message body increases the size of each
+   * follow-up event. For large messages (e.g., ~100KB), this may lead to batch size limits being
+   * exceeded earlier. As a result, fewer messages may be expired per batch (e.g., only 40 instead
+   * of more), which requires multiple checker runs to process the full batch. Please be aware that
+   * this may introduce performance regressions or cause the expired message state to grow more
+   * quickly over time. To maintain backward compatibility and avoid performance degradation, the
+   * default value is false, meaning message bodies will not be appended unless explicitly enabled.
+   */
+  private boolean enableMessageBodyOnExpired = DEFAULT_ENABLE_MESSAGE_BODY_ON_EXPIRED;
+
+  public Integer getMaxCommandsInBatch() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".max-commands-in-batch",
+        maxCommandsInBatch,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_COMMANDS_IN_BATCH_PROPERTIES);
+  }
+
+  public void setMaxCommandsInBatch(final Integer maxCommandsInBatch) {
+    this.maxCommandsInBatch = maxCommandsInBatch;
+  }
+
+  public boolean isEnableAsyncScheduledTasks() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enable-async-scheduled-tasks",
+        enableAsyncScheduledTasks,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_ENABLE_ASYNC_SCHEDULED_TASKS_PROPERTIES);
+  }
+
+  public void setEnableAsyncScheduledTasks(final boolean enableAsyncScheduledTasks) {
+    this.enableAsyncScheduledTasks = enableAsyncScheduledTasks;
+  }
+
+  public Duration getScheduledTasksCheckInterval() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".scheduled-tasks-check-interval",
+        scheduledTasksCheckInterval,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_SCHEDULED_TASKS_CHECK_INTERVAL_PROPERTIES);
+  }
+
+  public void setScheduledTasksCheckInterval(final Duration scheduledTasksCheckInterval) {
+    this.scheduledTasksCheckInterval = scheduledTasksCheckInterval;
+  }
+
+  public Set<Long> getSkipPositions() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".skip-positions",
+        skipPositions,
+        ResolvableType.forClassWithGenerics(Set.class, Long.class),
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_SKIP_POSITIONS_PROPERTIES);
+  }
+
+  public void setSkipPositions(final Set<Long> skipPositions) {
+    this.skipPositions = skipPositions;
+  }
+
+  public boolean isEnablePreconditionsCheck() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enable-preconditions-check",
+        enablePreconditionsCheck,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_CONSISTENCY_CHECK_ENABLE_PRECONDITIONS_PROPERTIES);
+  }
+
+  public void setEnablePreconditionsCheck(final boolean enablePreconditionsCheck) {
+    this.enablePreconditionsCheck = enablePreconditionsCheck;
+  }
+
+  public boolean isEnableForeignKeyChecks() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enable-foreign-key-checks",
+        enableForeignKeyChecks,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_CONSISTENCY_CHECK_ENABLE_FOREIGN_KEY_CHECKS_PROPERTIES);
+  }
+
+  public void setEnableForeignKeyChecks(final boolean enableForeignKeyChecks) {
+    this.enableForeignKeyChecks = enableForeignKeyChecks;
+  }
+
+  public boolean isEnableYieldingDueDateChecker() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enable-yielding-duedate-checker",
+        enableYieldingDueDateChecker,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_FEATURES_ENABLE_YIELD_DUEDATE_CHECKER_PROPERTIES);
+  }
+
+  public void setEnableYieldingDueDateChecker(final boolean enableYieldingDueDateChecker) {
+    this.enableYieldingDueDateChecker = enableYieldingDueDateChecker;
+  }
+
+  public boolean isEnableAsyncMessageTtlChecker() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enable-async-message-ttl-checker",
+        enableAsyncMessageTtlChecker,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_FEATURES_ENABLE_MESSAGE_TTL_CHECKER_ASYNC_PROPERTIES);
+  }
+
+  public void setEnableAsyncMessageTtlChecker(final boolean enableAsyncMessageTtlChecker) {
+    this.enableAsyncMessageTtlChecker = enableAsyncMessageTtlChecker;
+  }
+
+  public boolean isEnableAsyncTimerDuedateChecker() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enable-async-timer-duedate-checker",
+        enableAsyncTimerDuedateChecker,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_FEATURES_ENABLE_TIMER_DUE_DATE_CHECKER_ASYNC_PROPERTIES);
+  }
+
+  public void setEnableAsyncTimerDuedateChecker(final boolean enableAsyncTimerDuedateChecker) {
+    this.enableAsyncTimerDuedateChecker = enableAsyncTimerDuedateChecker;
+  }
+
+  public boolean isEnableStraightthroughProcessingLoopDetector() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enable-straightthrough-processing-loop-detector",
+        enableStraightthroughProcessingLoopDetector,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_FEATURES_ENABLE_STRAIGHT_THROUGH_PROCESSING_LOOP_DETECTOR_PROPERTIES);
+  }
+
+  public void setEnableStraightthroughProcessingLoopDetector(
+      final boolean enableStraightthroughProcessingLoopDetector) {
+    this.enableStraightthroughProcessingLoopDetector = enableStraightthroughProcessingLoopDetector;
+  }
+
+  public boolean isEnableMessageBodyOnExpired() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enable-message-body-on-expired",
+        enableMessageBodyOnExpired,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_FEATURES_ENABLE_MESSAGE_BODY_ON_EXPIRED_PROPERTIES);
+  }
+
+  public void setEnableMessageBodyOnExpired(final boolean enableMessageBodyOnExpired) {
+    this.enableMessageBodyOnExpired = enableMessageBodyOnExpired;
+  }
+
+  public FlowControl getFlowControl() {
+    return flowControl;
+  }
+
+  public void setFlowControl(final FlowControl flowControl) {
+    this.flowControl = flowControl;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Throttle.java
+++ b/configuration/src/main/java/io/camunda/configuration/Throttle.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
+public class Throttle {
+
+  private static final String PREFIX = "camunda.processing.flow-control.write.throttle";
+
+  private static final boolean DEFAULT_THROTTLING_ENABLED = false;
+  private static final int DEFAULT_ACCEPTABLE_BACKLOG = 100_000;
+  private static final int DEFAULT_MINIMUM_LIMIT = 100;
+  private static final Duration DEFAULT_RESOLUTION = Duration.ofSeconds(15);
+
+  private static final Set<String> LEGACY_THROTTLING_ENABLED_PROPERTIES =
+      Set.of("zeebe.broker.flowControl.write.throttling.enabled");
+  private static final Set<String> LEGACY_ACCEPTABLE_BACKLOG_PROPERTIES =
+      Set.of("zeebe.broker.flowControl.write.throttling.acceptableBacklog");
+  private static final Set<String> LEGACY_MINIMUM_LIMIT_PROPERTIES =
+      Set.of("zeebe.broker.flowControl.write.throttling.minimumLimit");
+  private static final Set<String> LEGACY_RESOLUTION_PROPERTIES =
+      Set.of("zeebe.broker.flowControl.write.throttling.resolution");
+
+  /** Enable throttling. If enabled, throttle the write rate based on exporting backlog */
+  private boolean enabled = DEFAULT_THROTTLING_ENABLED;
+
+  /**
+   * When exporting is a bottleneck, the write rate is throttled to keep the backlog at this value.
+   */
+  private int acceptableBacklog = DEFAULT_ACCEPTABLE_BACKLOG;
+
+  /** Even when exporting is fully blocked, always allow this many writes per second */
+  private int minimumLimit = DEFAULT_MINIMUM_LIMIT;
+
+  /** How often to adjust the throttling */
+  private Duration resolution = DEFAULT_RESOLUTION;
+
+  public boolean isEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enabled",
+        enabled,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_THROTTLING_ENABLED_PROPERTIES);
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public int getAcceptableBacklog() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".acceptable-backlog",
+        acceptableBacklog,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_ACCEPTABLE_BACKLOG_PROPERTIES);
+  }
+
+  public void setAcceptableBacklog(final int acceptableBacklog) {
+    this.acceptableBacklog = acceptableBacklog;
+  }
+
+  public int getMinimumLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".minimum-limit",
+        minimumLimit,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MINIMUM_LIMIT_PROPERTIES);
+  }
+
+  public void setMinimumLimit(final int minimumLimit) {
+    this.minimumLimit = minimumLimit;
+  }
+
+  public Duration getResolution() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".resolution",
+        resolution,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_RESOLUTION_PROPERTIES);
+  }
+
+  public void setResolution(final Duration resolution) {
+    this.resolution = resolution;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Write.java
+++ b/configuration/src/main/java/io/camunda/configuration/Write.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+public class Write {
+
+  private static final String PREFIX = "camunda.processing.flow-control.write";
+
+  private static final boolean DEFAULT_WRITE_ENABLED = false;
+  private static final int DEFAULT_LIMIT = 0;
+  private static final Duration DEFAULT_RAMP_UP_TIME = Duration.ZERO;
+
+  private static final Set<String> LEGACY_WRITE_ENABLED_PROPERTIES =
+      Set.of("zeebe.broker.flowControl.write.enabled");
+  private static final Set<String> LEGACY_LIMIT_PROPERTIES =
+      Set.of("zeebe.broker.flowControl.write.limit");
+  private static final Set<String> LEGACY_RAMP_UP_TIME_PROPERTIES =
+      Set.of("zeebe.broker.flowControl.write.rampUp");
+
+  /** Enable rate limit */
+  private boolean enabled = DEFAULT_WRITE_ENABLED;
+
+  /** Sets the maximum number of records written per second */
+  private int limit = DEFAULT_LIMIT;
+
+  /** Sets the ramp up time, for example 10s */
+  private Duration rampUp = DEFAULT_RAMP_UP_TIME;
+
+  /** Configure throttling */
+  @NestedConfigurationProperty private Throttle throttle = new Throttle();
+
+  public boolean isEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enabled",
+        enabled,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_WRITE_ENABLED_PROPERTIES);
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public int getLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".limit",
+        limit,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_LIMIT_PROPERTIES);
+  }
+
+  public void setLimit(final int limit) {
+    this.limit = limit;
+  }
+
+  public Duration getRampUp() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".ramp-up",
+        rampUp,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_RAMP_UP_TIME_PROPERTIES);
+  }
+
+  public void setRampUp(final Duration rampUp) {
+    this.rampUp = rampUp;
+  }
+
+  public Throttle getThrottle() {
+    return throttle;
+  }
+
+  public void setThrottle(final Throttle throttle) {
+    this.throttle = throttle;
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/ProcessingPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ProcessingPropertiesTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.ConsistencyCheckCfg;
+import io.camunda.zeebe.broker.system.configuration.FeatureFlagsCfg;
+import io.camunda.zeebe.broker.system.configuration.ProcessingCfg;
+import java.time.Duration;
+import java.util.Set;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class ProcessingPropertiesTest {
+
+  private static final int EXPECTED_MAX_COMMANDS_IN_BATCH = 200;
+  private static final boolean EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS = false;
+  private static final Duration EXPECTED_SCHEDULED_TASKS_CHECK_INTERVAL = Duration.ofSeconds(10);
+  private static final Set<Long> EXPECTED_SKIP_POSITIONS = Set.of(10L, 20L);
+  private static final boolean EXPECTED_ENABLE_PRECONDITIONS_CHECK = true;
+  private static final boolean EXPECTED_ENABLE_FOREIGN_KEY_CHECKS = true;
+  private static final boolean EXPECTED_ENABLE_YIELDING_DUEDATE_CHECKER = false;
+  private static final boolean EXPECTED_ENABLE_ASYNC_MESSAGE_TTL_CHECKER = true;
+  private static final boolean EXPECTED_ENABLE_ASYNC_TIMER_DUEDATE_CHECKER = true;
+  private static final boolean EXPECTED_ENABLE_STRAIGHTTHROUGH_PROCESSING_LOOP_DETECTOR = false;
+  private static final boolean EXPECTED_ENABLE_MESSAGE_BODY_ON_EXPIRED = true;
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.max-commands-in-batch=" + EXPECTED_MAX_COMMANDS_IN_BATCH,
+        "camunda.processing.enable-async-scheduled-tasks=" + EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS,
+        "camunda.processing.scheduled-tasks-check-interval=10s",
+        "camunda.processing.skip-positions=10,20",
+        "camunda.processing.enable-preconditions-check=" + EXPECTED_ENABLE_PRECONDITIONS_CHECK,
+        "camunda.processing.enable-foreign-key-checks=" + EXPECTED_ENABLE_FOREIGN_KEY_CHECKS,
+        "camunda.processing.enable-yielding-duedate-checker="
+            + EXPECTED_ENABLE_YIELDING_DUEDATE_CHECKER,
+        "camunda.processing.enable-async-message-ttl-checker="
+            + EXPECTED_ENABLE_ASYNC_MESSAGE_TTL_CHECKER,
+        "camunda.processing.enable-async-timer-duedate-checker="
+            + EXPECTED_ENABLE_ASYNC_TIMER_DUEDATE_CHECKER,
+        "camunda.processing.enable-straightthrough-processing-loop-detector="
+            + EXPECTED_ENABLE_STRAIGHTTHROUGH_PROCESSING_LOOP_DETECTOR,
+        "camunda.processing.enable-message-body-on-expired="
+            + EXPECTED_ENABLE_MESSAGE_BODY_ON_EXPIRED
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetProcessingProperties() {
+      assertThat(brokerBasedProperties.getProcessing())
+          .returns(EXPECTED_MAX_COMMANDS_IN_BATCH, ProcessingCfg::getMaxCommandsInBatch)
+          .returns(
+              EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS, ProcessingCfg::isEnableAsyncScheduledTasks)
+          .returns(
+              EXPECTED_SCHEDULED_TASKS_CHECK_INTERVAL, ProcessingCfg::getScheduledTaskCheckInterval)
+          .returns(EXPECTED_SKIP_POSITIONS, ProcessingCfg::skipPositions);
+
+      assertThat(brokerBasedProperties.getExperimental().getConsistencyChecks())
+          .returns(EXPECTED_ENABLE_PRECONDITIONS_CHECK, ConsistencyCheckCfg::isEnablePreconditions)
+          .returns(
+              EXPECTED_ENABLE_FOREIGN_KEY_CHECKS, ConsistencyCheckCfg::isEnableForeignKeyChecks);
+
+      assertThat(brokerBasedProperties.getExperimental().getFeatures())
+          .returns(
+              EXPECTED_ENABLE_YIELDING_DUEDATE_CHECKER,
+              FeatureFlagsCfg::isEnableYieldingDueDateChecker)
+          .returns(
+              EXPECTED_ENABLE_ASYNC_MESSAGE_TTL_CHECKER,
+              FeatureFlagsCfg::isEnableMessageTtlCheckerAsync)
+          .returns(
+              EXPECTED_ENABLE_ASYNC_TIMER_DUEDATE_CHECKER,
+              FeatureFlagsCfg::isEnableTimerDueDateCheckerAsync)
+          .returns(
+              EXPECTED_ENABLE_STRAIGHTTHROUGH_PROCESSING_LOOP_DETECTOR,
+              FeatureFlagsCfg::isEnableStraightThroughProcessingLoopDetector)
+          .returns(
+              EXPECTED_ENABLE_MESSAGE_BODY_ON_EXPIRED,
+              FeatureFlagsCfg::isEnableMessageBodyOnExpired);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.processingCfg.maxCommandsInBatch=" + EXPECTED_MAX_COMMANDS_IN_BATCH,
+        "zeebe.broker.processingCfg.enableAsyncScheduledTasks="
+            + EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS,
+        "zeebe.broker.processingCfg.scheduledTaskCheckInterval=10s",
+        "zeebe.broker.processingCfg.skipPositions=10,20",
+        "zeebe.broker.experimental.consistencyChecks.enablePreconditions="
+            + EXPECTED_ENABLE_PRECONDITIONS_CHECK,
+        "zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks="
+            + EXPECTED_ENABLE_FOREIGN_KEY_CHECKS,
+        "zeebe.broker.experimental.features.enableYieldingDueDateChecker="
+            + EXPECTED_ENABLE_YIELDING_DUEDATE_CHECKER,
+        "zeebe.broker.experimental.features.enableMessageTtlCheckerAsync="
+            + EXPECTED_ENABLE_ASYNC_MESSAGE_TTL_CHECKER,
+        "zeebe.broker.experimental.features.enableTimerDueDateCheckerAsync="
+            + EXPECTED_ENABLE_ASYNC_TIMER_DUEDATE_CHECKER,
+        "zeebe.broker.experimental.features.enableStraightThroughProcessingLoopDetector="
+            + EXPECTED_ENABLE_STRAIGHTTHROUGH_PROCESSING_LOOP_DETECTOR,
+        "zeebe.broker.experimental.features.enableMessageBodyOnExpired="
+            + EXPECTED_ENABLE_MESSAGE_BODY_ON_EXPIRED,
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetProcessingPropertiesFromLegacy() {
+      assertThat(brokerBasedProperties.getProcessing())
+          .returns(EXPECTED_MAX_COMMANDS_IN_BATCH, ProcessingCfg::getMaxCommandsInBatch)
+          .returns(
+              EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS, ProcessingCfg::isEnableAsyncScheduledTasks)
+          .returns(
+              EXPECTED_SCHEDULED_TASKS_CHECK_INTERVAL, ProcessingCfg::getScheduledTaskCheckInterval)
+          .returns(EXPECTED_SKIP_POSITIONS, ProcessingCfg::skipPositions);
+
+      assertThat(brokerBasedProperties.getExperimental().getConsistencyChecks())
+          .returns(EXPECTED_ENABLE_PRECONDITIONS_CHECK, ConsistencyCheckCfg::isEnablePreconditions)
+          .returns(
+              EXPECTED_ENABLE_FOREIGN_KEY_CHECKS, ConsistencyCheckCfg::isEnableForeignKeyChecks);
+
+      assertThat(brokerBasedProperties.getExperimental().getFeatures())
+          .returns(
+              EXPECTED_ENABLE_YIELDING_DUEDATE_CHECKER,
+              FeatureFlagsCfg::isEnableYieldingDueDateChecker)
+          .returns(
+              EXPECTED_ENABLE_ASYNC_MESSAGE_TTL_CHECKER,
+              FeatureFlagsCfg::isEnableMessageTtlCheckerAsync)
+          .returns(
+              EXPECTED_ENABLE_ASYNC_TIMER_DUEDATE_CHECKER,
+              FeatureFlagsCfg::isEnableTimerDueDateCheckerAsync)
+          .returns(
+              EXPECTED_ENABLE_STRAIGHTTHROUGH_PROCESSING_LOOP_DETECTOR,
+              FeatureFlagsCfg::isEnableStraightThroughProcessingLoopDetector)
+          .returns(
+              EXPECTED_ENABLE_MESSAGE_BODY_ON_EXPIRED,
+              FeatureFlagsCfg::isEnableMessageBodyOnExpired);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.processing.max-commands-in-batch=" + EXPECTED_MAX_COMMANDS_IN_BATCH,
+        "camunda.processing.enable-async-scheduled-tasks=" + EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS,
+        "camunda.processing.scheduled-tasks-check-interval=10s",
+        "camunda.processing.skip-positions=10,20",
+        "camunda.processing.enable-preconditions-check=" + EXPECTED_ENABLE_PRECONDITIONS_CHECK,
+        "camunda.processing.enable-foreign-key-checks=" + EXPECTED_ENABLE_FOREIGN_KEY_CHECKS,
+        "camunda.processing.enable-yielding-duedate-checker="
+            + EXPECTED_ENABLE_YIELDING_DUEDATE_CHECKER,
+        "camunda.processing.enable-async-message-ttl-checker="
+            + EXPECTED_ENABLE_ASYNC_MESSAGE_TTL_CHECKER,
+        "camunda.processing.enable-async-timer-duedate-checker="
+            + EXPECTED_ENABLE_ASYNC_TIMER_DUEDATE_CHECKER,
+        "camunda.processing.enable-straightthrough-processing-loop-detector="
+            + EXPECTED_ENABLE_STRAIGHTTHROUGH_PROCESSING_LOOP_DETECTOR,
+        "camunda.processing.enable-message-body-on-expired="
+            + EXPECTED_ENABLE_MESSAGE_BODY_ON_EXPIRED,
+
+        // legacy
+        "zeebe.broker.processingCfg.maxCommandsInBatch=1",
+        "zeebe.broker.processingCfg.enableAsyncScheduledTasks=true",
+        "zeebe.broker.processingCfg.scheduledTaskCheckInterval=1s",
+        "zeebe.broker.processingCfg.skipPositions=30,40",
+        "zeebe.broker.experimental.consistencyChecks.enablePreconditions=false",
+        "zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks=false",
+        "zeebe.broker.experimental.features.enableYieldingDueDateChecker=true",
+        "zeebe.broker.experimental.features.enableMessageTtlCheckerAsync=false",
+        "zeebe.broker.experimental.features.enableTimerDueDateCheckerAsync=false",
+        "zeebe.broker.experimental.features.enableStraightThroughProcessingLoopDetector=true",
+        "zeebe.broker.experimental.features.enableMessageBodyOnExpired=false"
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetProcessingPropertiesFromNew() {
+      assertThat(brokerBasedProperties.getProcessing())
+          .returns(EXPECTED_MAX_COMMANDS_IN_BATCH, ProcessingCfg::getMaxCommandsInBatch)
+          .returns(
+              EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS, ProcessingCfg::isEnableAsyncScheduledTasks)
+          .returns(
+              EXPECTED_SCHEDULED_TASKS_CHECK_INTERVAL, ProcessingCfg::getScheduledTaskCheckInterval)
+          .returns(EXPECTED_SKIP_POSITIONS, ProcessingCfg::skipPositions);
+
+      assertThat(brokerBasedProperties.getExperimental().getConsistencyChecks())
+          .returns(EXPECTED_ENABLE_PRECONDITIONS_CHECK, ConsistencyCheckCfg::isEnablePreconditions)
+          .returns(
+              EXPECTED_ENABLE_FOREIGN_KEY_CHECKS, ConsistencyCheckCfg::isEnableForeignKeyChecks);
+
+      assertThat(brokerBasedProperties.getExperimental().getFeatures())
+          .returns(
+              EXPECTED_ENABLE_YIELDING_DUEDATE_CHECKER,
+              FeatureFlagsCfg::isEnableYieldingDueDateChecker)
+          .returns(
+              EXPECTED_ENABLE_ASYNC_MESSAGE_TTL_CHECKER,
+              FeatureFlagsCfg::isEnableMessageTtlCheckerAsync)
+          .returns(
+              EXPECTED_ENABLE_ASYNC_TIMER_DUEDATE_CHECKER,
+              FeatureFlagsCfg::isEnableTimerDueDateCheckerAsync)
+          .returns(
+              EXPECTED_ENABLE_STRAIGHTTHROUGH_PROCESSING_LOOP_DETECTOR,
+              FeatureFlagsCfg::isEnableStraightThroughProcessingLoopDetector)
+          .returns(
+              EXPECTED_ENABLE_MESSAGE_BODY_ON_EXPIRED,
+              FeatureFlagsCfg::isEnableMessageBodyOnExpired);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/ThrottlePropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ThrottlePropertiesTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.backpressure.ThrottleCfg;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class ThrottlePropertiesTest {
+
+  private static final boolean EXPECTED_THROTTLE_ENABLED = true;
+  private static final int EXPECTED_ACCEPTABLE_BACKLOG = 200000;
+  private static final int EXPECTED_MINIMUM_LIMIT = 200;
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.flow-control.write.throttle.enabled=" + EXPECTED_THROTTLE_ENABLED,
+        "camunda.processing.flow-control.write.throttle.acceptable-backlog="
+            + EXPECTED_ACCEPTABLE_BACKLOG,
+        "camunda.processing.flow-control.write.throttle.minimum-limit=" + EXPECTED_MINIMUM_LIMIT,
+        "camunda.processing.flow-control.write.throttle.resolution=100s"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetWriteProperties() {
+      assertThat(brokerBasedProperties.getFlowControl().getWrite().getThrottling())
+          .returns(EXPECTED_THROTTLE_ENABLED, ThrottleCfg::isEnabled)
+          .returns(EXPECTED_ACCEPTABLE_BACKLOG, ThrottleCfg::getAcceptableBacklog)
+          .returns(EXPECTED_MINIMUM_LIMIT, ThrottleCfg::getMinimumLimit)
+          .returns(Duration.ofSeconds(100), ThrottleCfg::getResolution);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.flowControl.write.throttling.enabled=" + EXPECTED_THROTTLE_ENABLED,
+        "zeebe.broker.flowControl.write.throttling.acceptableBacklog="
+            + EXPECTED_ACCEPTABLE_BACKLOG,
+        "zeebe.broker.flowControl.write.throttling.minimumLimit=" + EXPECTED_MINIMUM_LIMIT,
+        "zeebe.broker.flowControl.write.throttling.resolution=100s"
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetProcessingPropertiesFromLegacy() {
+      assertThat(brokerBasedProperties.getFlowControl().getWrite().getThrottling())
+          .returns(EXPECTED_THROTTLE_ENABLED, ThrottleCfg::isEnabled)
+          .returns(EXPECTED_ACCEPTABLE_BACKLOG, ThrottleCfg::getAcceptableBacklog)
+          .returns(EXPECTED_MINIMUM_LIMIT, ThrottleCfg::getMinimumLimit)
+          .returns(Duration.ofSeconds(100), ThrottleCfg::getResolution);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.processing.flow-control.write.throttle.enabled=" + EXPECTED_THROTTLE_ENABLED,
+        "camunda.processing.flow-control.write.throttle.acceptable-backlog="
+            + EXPECTED_ACCEPTABLE_BACKLOG,
+        "camunda.processing.flow-control.write.throttle.minimum-limit=" + EXPECTED_MINIMUM_LIMIT,
+        "camunda.processing.flow-control.write.throttle.resolution=100s",
+        // legacy
+        "zeebe.broker.flowControl.write.throttling.enabled=false",
+        "zeebe.broker.flowControl.write.throttling.acceptableBacklog=300000",
+        "zeebe.broker.flowControl.write.throttling.minimumLimit=300",
+        "zeebe.broker.flowControl.write.throttling.resolution=200s"
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetWriteProperties() {
+      assertThat(brokerBasedProperties.getFlowControl().getWrite().getThrottling())
+          .returns(EXPECTED_THROTTLE_ENABLED, ThrottleCfg::isEnabled)
+          .returns(EXPECTED_ACCEPTABLE_BACKLOG, ThrottleCfg::getAcceptableBacklog)
+          .returns(EXPECTED_MINIMUM_LIMIT, ThrottleCfg::getMinimumLimit)
+          .returns(Duration.ofSeconds(100), ThrottleCfg::getResolution);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/WritePropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/WritePropertiesTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.backpressure.RateLimitCfg;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class WritePropertiesTest {
+
+  private static final boolean EXPECTED_WRITE_ENABLED = true;
+  private static final int EXPECTED_LIMIT = 1000;
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.flow-control.write.enabled=" + EXPECTED_WRITE_ENABLED,
+        "camunda.processing.flow-control.write.limit=" + EXPECTED_LIMIT,
+        "camunda.processing.flow-control.write.ramp-up=10s",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetWriteProperties() {
+      assertThat(brokerBasedProperties.getFlowControl().getWrite())
+          .returns(EXPECTED_WRITE_ENABLED, RateLimitCfg::isEnabled)
+          .returns(EXPECTED_LIMIT, RateLimitCfg::getLimit)
+          .returns(Duration.ofSeconds(10), RateLimitCfg::getRampUp);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.flowControl.write.enabled=" + EXPECTED_WRITE_ENABLED,
+        "zeebe.broker.flowControl.write.limit=" + EXPECTED_LIMIT,
+        "zeebe.broker.flowControl.write.rampUp=10s"
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetProcessingPropertiesFromLegacy() {
+      assertThat(brokerBasedProperties.getFlowControl().getWrite())
+          .returns(EXPECTED_WRITE_ENABLED, RateLimitCfg::isEnabled)
+          .returns(EXPECTED_LIMIT, RateLimitCfg::getLimit)
+          .returns(Duration.ofSeconds(10), RateLimitCfg::getRampUp);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.processing.flow-control.write.enabled=" + EXPECTED_WRITE_ENABLED,
+        "camunda.processing.flow-control.write.limit=" + EXPECTED_LIMIT,
+        "camunda.processing.flow-control.write.ramp-up=10s",
+        // legacy
+        "zeebe.broker.flowControl.write.enabled=false",
+        "zeebe.broker.flowControl.write.limit=0",
+        "zeebe.broker.flowControl.write.rampUp=99s",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetWriteProperties() {
+      assertThat(brokerBasedProperties.getFlowControl().getWrite())
+          .returns(EXPECTED_WRITE_ENABLED, RateLimitCfg::isEnabled)
+          .returns(EXPECTED_LIMIT, RateLimitCfg::getLimit)
+          .returns(Duration.ofSeconds(10), RateLimitCfg::getRampUp);
+    }
+  }
+
+  @Nested
+  class WithoutNewAndLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithoutNewAndLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldNotSetWrite() {
+      assertThat(brokerBasedProperties.getFlowControl().getWrite()).isNull();
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.processing in unified config.

The legacy properties are:
zeebe.broker.processingCfg.maxCommandsInBatch
zeebe.broker.processingCfg.enableAsyncScheduledTasks
zeebe.broker.processingCfg.scheduledTaskCheckInterval
zeebe.broker.processingCfg.skipPositions
zeebe.broker.experimental.consistencyChecks.enablePreconditions
zeebe.broker.experimental.features.enableYieldingDueDateChecker
zeebe.broker.experimental.features.enableMessageTtlCheckerAsync
zeebe.broker.experimental.features.enableTimerDueDateCheckerAsync
zeebe.broker.experimental.features.enableMessageBodyOnExpired

The new properties are:
camunda.processing.max-commands-in-batch
camunda.processing.enable-async-scheduled-tasks
camunda.processing.scheduled-task-check-interval
camunda.processing.skip-positions
camunda.processing.enable-preconditions-check
camunda.processing.enable-foreign-key-checks
camunda.processing.enable-async-message-ttl-checker
camunda.processing.enable-async-timer-duedate-checker
camunda.processing.enable-straightthrough-processing-loop-detector
camunda.processing.enable-message-body-on-expired

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.
## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to 
