### PR TITLE
fix: do not setup a web server on data migration apps

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneDataMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneDataMigration.java
@@ -43,7 +43,7 @@ public class StandaloneDataMigration implements ApplicationListener<MigrationFin
     final SpringApplication application =
         new SpringApplicationBuilder()
             .logStartupInfo(true)
-            .web(WebApplicationType.SERVLET)
+            .web(WebApplicationType.NONE)
             .sources(
                 StandaloneDataMigration.class,
                 AsyncMigrationsRunner.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneProcessMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneProcessMigration.java
@@ -41,7 +41,7 @@ public class StandaloneProcessMigration implements ApplicationListener<Migration
     final SpringApplication application =
         new SpringApplicationBuilder()
             .logStartupInfo(true)
-            .web(WebApplicationType.SERVLET)
+            .web(WebApplicationType.NONE)
             .sources(
                 StandaloneProcessMigration.class,
                 AsyncMigrationsRunner.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneTaskMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneTaskMigration.java
@@ -41,7 +41,7 @@ public class StandaloneTaskMigration implements ApplicationListener<MigrationFin
     final SpringApplication application =
         new SpringApplicationBuilder()
             .logStartupInfo(true)
-            .web(WebApplicationType.SERVLET)
+            .web(WebApplicationType.NONE)
             .sources(
                 StandaloneTaskMigration.class,
                 AsyncMigrationsRunner.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneUsageMetricMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneUsageMetricMigration.java
@@ -44,7 +44,7 @@ public class StandaloneUsageMetricMigration implements ApplicationListener<Migra
     final SpringApplication application =
         new SpringApplicationBuilder()
             .logStartupInfo(true)
-            .web(WebApplicationType.SERVLET)
+            .web(WebApplicationType.NONE)
             .sources(
                 StandaloneUsageMetricMigration.class,
                 AsyncMigrationsRunner.class,


### PR DESCRIPTION
## Description

The data migration apps are not expected to start a spring web server. Can we just disable that?

Context see https://docs.google.com/document/d/10NknVyaSRmofAd4r2Z-3npf2Rx1o6lvwE35WYu851O8/edit?tab=t.0#bookmark=id.o9dizk51fgk5

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
