### PR TITLE
Fix error when taking a backup with the native file system store

### DIFF
--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FileSetManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FileSetManager.java
@@ -27,12 +27,10 @@ final class FileSetManager {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FileSetManager.class);
 
-  // The path format is constructed by basePath/contents/partitionId/checkpointId/nodeId/nameOfFile
-  private static final String PATH_FORMAT = "%s/contents/%s/%s/%s/%s/";
-  private final String basePath;
+  private final Path contentsPath;
 
-  FileSetManager(final String basePath) {
-    this.basePath = basePath;
+  FileSetManager(final Path contentsPath) {
+    this.contentsPath = contentsPath;
   }
 
   void save(final BackupIdentifier id, final String fileSetName, final NamedFileSet fileSet) {
@@ -119,8 +117,10 @@ final class FileSetManager {
   }
 
   private Path fileSetPath(final BackupIdentifier id, final String fileSetName) {
-    return Path.of(
-        PATH_FORMAT.formatted(
-            basePath, id.partitionId(), id.checkpointId(), id.nodeId(), fileSetName));
+    return contentsPath
+        .resolve(String.valueOf(id.partitionId()))
+        .resolve(String.valueOf(id.checkpointId()))
+        .resolve(String.valueOf(id.nodeId()))
+        .resolve(fileSetName);
   }
 }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -17,6 +17,9 @@ import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -35,13 +38,17 @@ import org.slf4j.event.Level;
  */
 public final class FilesystemBackupStore implements BackupStore {
 
-  public static final String ERROR_MSG_BACKUP_NOT_FOUND =
-      "Expected to restore from backup with id '%s', but does not exist.";
-  public static final String ERROR_MSG_BACKUP_WRONG_STATE_TO_RESTORE =
-      "Expected to restore from completed backup with id '%s', but was in state '%s'";
-  public static final String SNAPSHOT_FILESET_NAME = "snapshot";
-  public static final String SEGMENTS_FILESET_NAME = "segments";
   private static final Logger LOG = LoggerFactory.getLogger(FilesystemBackupStore.class);
+
+  private static final String ERROR_MSG_BACKUP_NOT_FOUND =
+      "Expected to restore from backup with id '%s', but does not exist.";
+  private static final String ERROR_MSG_BACKUP_WRONG_STATE_TO_RESTORE =
+      "Expected to restore from completed backup with id '%s', but was in state '%s'";
+  private static final String SNAPSHOT_FILESET_NAME = "snapshot";
+  private static final String SEGMENTS_FILESET_NAME = "segments";
+  private static final String CONTENTS_PATH = "contents";
+  private static final String MANIFESTS_PATH = "manifests";
+
   private final ExecutorService executor;
   private final FileSetManager fileSetManager;
   private final ManifestManager manifestManager;
@@ -54,8 +61,20 @@ public final class FilesystemBackupStore implements BackupStore {
     validateConfig(config);
 
     this.executor = executor;
-    fileSetManager = new FileSetManager(config.basePath());
-    manifestManager = new ManifestManager(config.basePath());
+
+    final var contentsDir = Path.of(config.basePath()).resolve(CONTENTS_PATH);
+    final var manifestsDir = Path.of(config.basePath()).resolve(MANIFESTS_PATH);
+    try {
+      FileUtil.ensureDirectoryExists(contentsDir);
+      FileUtil.ensureDirectoryExists(manifestsDir);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(
+          "Unable to create backup directory structure; do you have the right permissions or configuration?",
+          e);
+    }
+
+    fileSetManager = new FileSetManager(contentsDir);
+    manifestManager = new ManifestManager(manifestsDir);
   }
 
   @Override

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FileSetManagerTest.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FileSetManagerTest.java
@@ -38,7 +38,7 @@ class FileSetManagerTest {
   void setUp() {
 
     // do not mock the backupIdentifier
-    fileSetManager = new FileSetManager(backupDir.toString());
+    fileSetManager = new FileSetManager(backupDir);
     backupIdentifier = new BackupIdentifierImpl(1337, 0, 42L);
     fileSet = mock(FileSet.class);
   }
@@ -51,13 +51,13 @@ class FileSetManagerTest {
 
     fileSetManager.save(backupIdentifier, "fileSetName", namedFileSet);
 
-    final Path savedFilePath = backupDir.resolve("contents/0/42/1337/fileSetName/testFile.txt");
+    final Path savedFilePath = backupDir.resolve("0/42/1337/fileSetName/testFile.txt");
     assertThat(Files.exists(savedFilePath)).isTrue();
   }
 
   @Test
   void testDelete() throws IOException {
-    final Path fileSetPath = backupDir.resolve("contents/0/42/1337/fileSetName");
+    final Path fileSetPath = backupDir.resolve("0/42/1337/fileSetName");
     Files.createDirectories(fileSetPath);
 
     fileSetManager.delete(backupIdentifier, "fileSetName");
@@ -72,7 +72,7 @@ class FileSetManagerTest {
 
   @Test
   void testRestore() throws IOException {
-    final Path backupFilePath = backupDir.resolve("contents/0/42/1337/fileSetName/testFile.txt");
+    final Path backupFilePath = backupDir.resolve("0/42/1337/fileSetName/testFile.txt");
     Files.createDirectories(backupFilePath.getParent());
     Files.createFile(backupFilePath);
     when(fileSet.files()).thenReturn(List.of(new FileSet.NamedFile("testFile.txt")));
@@ -85,6 +85,6 @@ class FileSetManagerTest {
 
     final Path restoredFilePath = targetFolder.resolve("testFile.txt");
     assertThat(Files.exists(restoredFilePath)).isTrue();
-    assertThat(restoredFileSet.namedFiles().get("testFile.txt")).isEqualTo(restoredFilePath);
+    assertThat(restoredFileSet.namedFiles()).containsEntry("testFile.txt", restoredFilePath);
   }
 }

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
@@ -125,7 +125,7 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
     final var manifest = Manifest.createInProgress(backup);
     final byte[] serializedManifest;
 
-    final ManifestManager manifestManager = new ManifestManager(backupDir.toString());
+    final ManifestManager manifestManager = new ManifestManager(backupDir.resolve("manifests"));
     try {
       final var path = manifestManager.manifestPath(manifest);
       Files.createDirectories(path.getParent());

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
@@ -48,7 +48,7 @@ class ManifestManagerTest {
 
   @BeforeEach
   void setUp() {
-    manifestManager = new ManifestManager(tempDir.toString());
+    manifestManager = new ManifestManager(tempDir);
     backupIdentifier = new BackupIdentifierImpl(1337, 0, 42L);
     backup = createBackup(backupIdentifier);
   }
@@ -61,14 +61,14 @@ class ManifestManagerTest {
   void shouldCreateInitialManifest() throws IOException {
     final var manifest = createInitialManifest();
 
-    final var manifestPath = tempDir.resolve("manifests/0/42/1337/manifest.json");
+    final var manifestPath = tempDir.resolve("0/42/1337/manifest.json");
     assertThat(Files.exists(manifestPath)).isTrue();
     assertThat(manifest.statusCode()).isEqualTo(Manifest.StatusCode.IN_PROGRESS);
   }
 
   @Test
   void shouldFailToCreateManifestIfAlreadyExists() throws IOException {
-    final var manifestPath = tempDir.resolve("manifests/0/42/1337/manifest.json");
+    final var manifestPath = tempDir.resolve("0/42/1337/manifest.json");
     Files.createDirectories(manifestPath.getParent());
     Files.write(manifestPath, "existing content".getBytes(), StandardOpenOption.CREATE_NEW);
 
@@ -79,7 +79,7 @@ class ManifestManagerTest {
 
   @Test
   void shouldFailToCreateManifestIfNotValidJson() throws IOException {
-    final var manifestPath = tempDir.resolve("manifests/0/42/1337/manifest.json");
+    final var manifestPath = tempDir.resolve("0/42/1337/manifest.json");
     Files.createDirectories(manifestPath.getParent());
     Files.write(manifestPath, "invalid json".getBytes(), StandardOpenOption.CREATE_NEW);
 
@@ -93,7 +93,7 @@ class ManifestManagerTest {
     final var inProgressManifest = createInitialManifest();
     manifestManager.completeManifest(inProgressManifest);
 
-    final var manifestPath = tempDir.resolve("manifests/0/42/1337/manifest.json");
+    final var manifestPath = tempDir.resolve("0/42/1337/manifest.json");
     final var completedManifest = manifestManager.getManifest(backupIdentifier);
     assertThat(Files.exists(manifestPath)).isTrue();
     assertThat(completedManifest.statusCode()).isEqualTo(Manifest.StatusCode.COMPLETED);
@@ -116,7 +116,7 @@ class ManifestManagerTest {
 
     manifestManager.deleteManifest(backupIdentifier);
 
-    final var manifestPath = tempDir.resolve("manifests/0/42/1337/manifest.json");
+    final var manifestPath = tempDir.resolve("0/42/1337/manifest.json");
     assertThat(Files.exists(manifestPath)).isFalse();
   }
 

--- a/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
+++ b/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
@@ -9,22 +9,41 @@ package io.camunda.zeebe.backup.testkit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import io.camunda.zeebe.backup.testkit.support.WildcardBackupProvider;
 import io.camunda.zeebe.backup.testkit.support.WildcardBackupProvider.WildcardTestParameter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 public interface ListingBackups {
 
   BackupStore getStore();
+
+  @Test
+  default void canListNoBackupsWhenStoreIsEmpty() {
+    // when
+    final var status =
+        getStore()
+            .list(
+                new BackupIdentifierWildcardImpl(
+                    Optional.empty(), Optional.of(1), CheckpointPattern.of(1)));
+
+    // then
+    assertThat(status).succeedsWithin(Duration.ofSeconds(5));
+    final var result = status.join();
+    assertThat(result).isEmpty();
+  }
 
   @ParameterizedTest
   @ArgumentsSource(WildcardBackupProvider.class)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/FilesystemBackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/FilesystemBackupAcceptanceIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.backup;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+final class FilesystemBackupAcceptanceIT implements BackupAcceptance {
+  private static @TempDir Path tempDir;
+
+  private final Path basePath = tempDir.resolve(UUID.randomUUID().toString());
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(2)
+          .withGatewaysCount(1)
+          .withReplicationFactor(1)
+          .withPartitionsCount(2)
+          .withEmbeddedGateway(false)
+          .withBrokerConfig(this::configureBroker)
+          .build();
+
+  @AutoClose private CamundaClient client;
+
+  @BeforeEach
+  void beforeEach(final @TempDir Path tempDir) throws IOException {
+    client = cluster.newClientBuilder().build();
+  }
+
+  @Override
+  public TestCluster getTestCluster() {
+    return cluster;
+  }
+
+  private void configureBroker(final TestStandaloneBroker broker) {
+    broker.withBrokerConfig(
+        cfg -> {
+          final var backup = cfg.getData().getBackup();
+          backup.setStore(BackupStoreType.FILESYSTEM);
+
+          final var config = new FilesystemBackupStoreConfig();
+          config.setBasePath(basePath.toAbsolutePath().toString());
+          backup.setFilesystem(config);
+        });
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/FilesystemRestoreAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/FilesystemRestoreAcceptanceIT.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.backup;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import java.nio.file.Path;
+import java.util.UUID;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+final class FilesystemRestoreAcceptanceIT implements RestoreAcceptance {
+  private static @TempDir Path tempDir;
+
+  private final Path basePath = tempDir.resolve(UUID.randomUUID().toString());
+
+  @Override
+  public void configureBackupStore(final BrokerCfg cfg) {
+    final var backup = cfg.getData().getBackup();
+    backup.setStore(BackupStoreType.FILESYSTEM);
+
+    final var config = new FilesystemBackupStoreConfig();
+    config.setBasePath(basePath.toAbsolutePath().toString());
+    backup.setFilesystem(config);
+  }
+}


### PR DESCRIPTION
## Description

This PR ensures two things with the native file system backup store:

1. The paths are portable by delegating the creation/resolution to the JVM
2. The paths for contents/manifests are pre-created when the store is set up

## Related issues

closes #38957 
