### PR TITLE
feat: remove scaling_enabled feature flag

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -160,11 +160,6 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
         brokerStartupContext.getClusterServices().getCommunicationService(),
         brokerStartupContext.getClusterServices().getMembershipService(),
         brokerStartupContext.getBrokerConfiguration().getCluster().getConfigManager().gossip(),
-        brokerStartupContext
-            .getBrokerConfiguration()
-            .getExperimental()
-            .getFeatures()
-            .isEnablePartitionScaling(),
         clusterChangeExecutor,
         brokerStartupContext.getMeterRegistry());
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -40,8 +40,6 @@ public final class StaticConfigurationGenerator {
   public static StaticConfiguration getStaticConfiguration(
       final BrokerCfg brokerCfg, final MemberId localMemberId) {
     final var clusterCfg = brokerCfg.getCluster();
-    final var enablePartitionScaling =
-        brokerCfg.getExperimental().getFeatures().isEnablePartitionScaling();
     final var partitioningCfg = brokerCfg.getExperimental().getPartitioning();
     final var partitionCount = clusterCfg.getPartitionsCount();
     final var replicationFactor = clusterCfg.getReplicationFactor();
@@ -53,7 +51,6 @@ public final class StaticConfigurationGenerator {
     final var clusterId = clusterCfg.getClusterId();
 
     return new StaticConfiguration(
-        enablePartitionScaling,
         partitionDistributor,
         clusterMembers,
         localMemberId,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -37,7 +37,6 @@ public final class FeatureFlagsCfg {
       DEFAULT_SETTINGS.enableTimerDueDateCheckerAsync();
   private boolean enableStraightThroughProcessingLoopDetector =
       DEFAULT_SETTINGS.enableStraightThroughProcessingLoopDetector();
-  private boolean enablePartitionScaling = DEFAULT_SETTINGS.enablePartitionScaling();
   private boolean enableMessageBodyOnExpired = DEFAULT_SETTINGS.enableMessageBodyOnExpired();
 
   public boolean isEnableYieldingDueDateChecker() {
@@ -81,14 +80,6 @@ public final class FeatureFlagsCfg {
     this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
   }
 
-  public boolean isEnablePartitionScaling() {
-    return enablePartitionScaling;
-  }
-
-  public void setEnablePartitionScaling(final boolean enablePartitionScaling) {
-    this.enablePartitionScaling = enablePartitionScaling;
-  }
-
   public boolean isEnableMessageBodyOnExpired() {
     return enableMessageBodyOnExpired;
   }
@@ -104,7 +95,6 @@ public final class FeatureFlagsCfg {
         enableMessageTtlCheckerAsync,
         enableTimerDueDateCheckerAsync,
         enableStraightThroughProcessingLoopDetector,
-        enablePartitionScaling,
         enableMessageBodyOnExpired
         /*, enableFoo*/ );
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
@@ -164,29 +164,6 @@ final class FeatureFlagsCfgTest {
   }
 
   @Test
-  void shouldSetEnablePartitionScalingFromConfig() {
-    // when
-    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
-    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
-
-    // then
-    assertThat(featureFlagsCfg.isEnablePartitionScaling()).isTrue();
-  }
-
-  @Test
-  void shouldSetEnablePartitionScalingFromEnv() {
-    // given
-    environment.put("zeebe.broker.experimental.features.enablePartitionScaling", "false");
-
-    // when
-    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
-    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
-
-    // then
-    assertThat(featureFlagsCfg.isEnablePartitionScaling()).isFalse();
-  }
-
-  @Test
   void shouldSetEnableMessageBodyOnExpiredFromConfig() {
     // given
     environment.put("zeebe.broker.experimental.features.enableMessageBodyOnExpired", "true");

--- a/zeebe/broker/src/test/resources/system/feature-flags-cfg.yaml
+++ b/zeebe/broker/src/test/resources/system/feature-flags-cfg.yaml
@@ -7,5 +7,4 @@ zeebe:
         enableMessageTTLCheckerAsync: true
         enableTimerDueDateCheckerAsync: true
         enableStraightThroughProcessingLoopDetector: false
-        enablePartitionScaling: true
         enableMessageBodyOnExpired: false

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -67,7 +67,6 @@ public final class ClusterConfigurationManagerService
       final ClusterCommunicationService communicationService,
       final ClusterMembershipService memberShipService,
       final ClusterConfigurationGossiperConfig config,
-      final boolean enablePartitionScaling,
       final ClusterChangeExecutor clusterChangeExecutor,
       final MeterRegistry meterRegistry) {
     this.clusterChangeExecutor = clusterChangeExecutor;
@@ -106,10 +105,7 @@ public final class ClusterConfigurationManagerService
             communicationService,
             new ProtoBufSerializer(),
             new ClusterConfigurationManagementRequestsHandler(
-                configurationChangeCoordinator,
-                localMemberId,
-                managerActor,
-                enablePartitionScaling));
+                configurationChangeCoordinator, localMemberId, managerActor));
 
     clusterConfigurationManager.setConfigurationGossiper(
         clusterConfigurationGossiper::updateClusterConfiguration);
@@ -144,10 +140,7 @@ public final class ClusterConfigurationManagerService
                 staticConfiguration.partitionConfig().exporting().exporters().keySet(),
                 staticConfiguration.localMemberId(),
                 managerActor))
-        .andThen(
-            new RoutingStateInitializer(
-                staticConfiguration.enablePartitionScaling(),
-                staticConfiguration.partitionCount()));
+        .andThen(new RoutingStateInitializer(staticConfiguration.partitionCount()));
     // This initializer does not set the cluster ID, as it is not required for non-coordinators.
     // Non-coordinators will receive the cluster ID from the coordinator via gossip.
   }
@@ -171,9 +164,7 @@ public final class ClusterConfigurationManagerService
                 staticConfiguration.partitionConfig().exporting().exporters().keySet(),
                 staticConfiguration.localMemberId(),
                 managerActor))
-        .andThen(
-            new RoutingStateInitializer(
-                staticConfiguration.enablePartitionScaling(), staticConfiguration.partitionCount()))
+        .andThen(new RoutingStateInitializer(staticConfiguration.partitionCount()))
         .andThen(new ClusterIdInitializer(staticConfiguration.clusterId()));
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
@@ -20,18 +20,15 @@ import java.util.Optional;
  */
 public class RoutingStateInitializer implements ClusterConfigurationModifier {
 
-  private final boolean enablePartitionScaling;
   private final int staticPartitionCount;
 
-  public RoutingStateInitializer(
-      final boolean enablePartitionScaling, final int staticPartitionCount) {
-    this.enablePartitionScaling = enablePartitionScaling;
+  public RoutingStateInitializer(final int staticPartitionCount) {
     this.staticPartitionCount = staticPartitionCount;
   }
 
   @Override
   public ActorFuture<ClusterConfiguration> modify(final ClusterConfiguration configuration) {
-    if (configuration.routingState().isPresent() || !enablePartitionScaling) {
+    if (configuration.routingState().isPresent()) {
       return CompletableActorFuture.completed(configuration);
     }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Set;
 
 public record StaticConfiguration(
-    boolean enablePartitionScaling,
     PartitionDistributor partitionDistributor,
     Set<MemberId> clusterMembers,
     MemberId localMemberId,
@@ -33,7 +32,7 @@ public record StaticConfiguration(
   public ClusterConfiguration generateTopology() {
     final Set<PartitionMetadata> partitionDistribution = generatePartitionDistribution();
     return ConfigurationUtil.getClusterConfigFrom(
-        enablePartitionScaling, partitionDistribution, partitionConfig, clusterId);
+        partitionDistribution, partitionConfig, clusterId);
   }
 
   public Set<PartitionMetadata> generatePartitionDistribution() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -46,17 +46,14 @@ public final class ClusterConfigurationManagementRequestsHandler
   private final ConfigurationChangeCoordinator coordinator;
   private final ConcurrencyControl executor;
   private final MemberId localMemberId;
-  private final boolean enablePartitionScaling;
 
   public ClusterConfigurationManagementRequestsHandler(
       final ConfigurationChangeCoordinator coordinator,
       final MemberId localMemberId,
-      final ConcurrencyControl executor,
-      final boolean enablePartitionScaling) {
+      final ConcurrencyControl executor) {
     this.coordinator = coordinator;
     this.executor = executor;
     this.localMemberId = localMemberId;
-    this.enablePartitionScaling = enablePartitionScaling;
   }
 
   @Override
@@ -143,13 +140,6 @@ public final class ClusterConfigurationManagementRequestsHandler
   public ActorFuture<ClusterConfigurationChangeResponse> scaleCluster(
       final ClusterScaleRequest clusterScaleRequest) {
 
-    if (!enablePartitionScaling && clusterScaleRequest.newPartitionCount().isPresent()) {
-      final var failedFuture = executor.<ClusterConfigurationChangeResponse>createFuture();
-      failedFuture.completeExceptionally(
-          new UnsupportedOperationException("Partition scaling is not enabled."));
-      return failedFuture;
-    }
-
     return handleRequest(
         clusterScaleRequest.dryRun(),
         new ClusterScaleRequestTransformer(
@@ -161,13 +151,6 @@ public final class ClusterConfigurationManagementRequestsHandler
   @Override
   public ActorFuture<ClusterConfigurationChangeResponse> patchCluster(
       final ClusterPatchRequest clusterPatchRequest) {
-
-    if (!enablePartitionScaling && clusterPatchRequest.newPartitionCount().isPresent()) {
-      final var failedFuture = executor.<ClusterConfigurationChangeResponse>createFuture();
-      failedFuture.completeExceptionally(
-          new UnsupportedOperationException("Partition scaling is not enabled."));
-      return failedFuture;
-    }
 
     return handleRequest(
         clusterPatchRequest.dryRun(),
@@ -183,8 +166,7 @@ public final class ClusterConfigurationManagementRequestsHandler
       final UpdateRoutingStateRequest updateRoutingStateRequest) {
     return handleRequest(
         updateRoutingStateRequest.dryRun(),
-        new UpdateRoutingStateTransformer(
-            enablePartitionScaling, updateRoutingStateRequest.routingState()));
+        new UpdateRoutingStateTransformer(updateRoutingStateRequest.routingState()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformer.java
@@ -18,22 +18,15 @@ import java.util.Optional;
 
 public class UpdateRoutingStateTransformer implements ConfigurationChangeRequest {
 
-  private final boolean enablePartitionScaling;
   private final Optional<RoutingState> routingState;
 
-  public UpdateRoutingStateTransformer(
-      final boolean enablePartitionScaling, final Optional<RoutingState> routingState) {
-    this.enablePartitionScaling = enablePartitionScaling;
+  public UpdateRoutingStateTransformer(final Optional<RoutingState> routingState) {
     this.routingState = routingState;
   }
 
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
-    if (!enablePartitionScaling) {
-      return Either.left(
-          new IllegalStateException("Partition scaling is disabled. Cannot update routing state."));
-    }
     final var coordinatorSupplier =
         ClusterConfigurationCoordinatorSupplier.of(() -> clusterConfiguration);
     final var coordinator = coordinatorSupplier.getDefaultCoordinator();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -28,7 +28,6 @@ public final class ConfigurationUtil {
   private ConfigurationUtil() {}
 
   public static ClusterConfiguration getClusterConfigFrom(
-      final boolean enablePartitionScaling,
       final Set<PartitionMetadata> partitionDistribution,
       final DynamicPartitionConfig partitionConfig,
       final String clusterId) {
@@ -48,9 +47,7 @@ public final class ConfigurationUtil {
     }
 
     final var routingState =
-        enablePartitionScaling
-            ? Optional.of(RoutingState.initializeWithPartitionCount(partitionDistribution.size()))
-            : Optional.<RoutingState>empty();
+        Optional.of(RoutingState.initializeWithPartitionCount(partitionDistribution.size()));
 
     return new ClusterConfiguration(
         ClusterConfiguration.INITIAL_VERSION,

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -206,7 +206,6 @@ final class ClusterConfigurationInitializerTest {
                 PartitionId.from("test", 1), Set.of(member), Map.of(member, 1), 1, member));
     return new StaticInitializer(
         new StaticConfiguration(
-            false,
             new ControllablePartitionDistributor().withPartitions(partitions),
             Set.of(member),
             member,

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -256,7 +256,6 @@ class ClusterConfigurationManagementIntegrationTest {
             cluster.getMembershipService(),
             new ClusterConfigurationGossiperConfig(
                 Duration.ofSeconds(1), Duration.ofMillis(100), 2),
-            true,
             new NoopClusterChangeExecutor(),
             meterRegistry);
     return new TestNode(cluster, service);
@@ -307,7 +306,6 @@ class ClusterConfigurationManagementIntegrationTest {
           service.start(
               actorScheduler,
               new StaticConfiguration(
-                  false,
                   new ControllablePartitionDistributor().withPartitions(partitions),
                   clusterMembers,
                   cluster.getMembershipService().getLocalMember().id(),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
@@ -49,21 +49,9 @@ final class ClusterConfigurationModifierTest {
                             1, new DynamicPartitionConfig(new ExportersConfig(Map.of()))))));
 
     @Test
-    void shouldNotInitializeRoutingStateIfPartitionScalingIsDisabled() {
-      // given
-      final var routingStateInitializer = new RoutingStateInitializer(false, 3);
-
-      // when
-      final var newConfiguration = routingStateInitializer.modify(currentConfiguration).join();
-
-      // then
-      ClusterConfigurationAssert.assertThatClusterTopology(newConfiguration).hasNoRoutingState();
-    }
-
-    @Test
     void shouldInitializeRoutingStateIfPartitionScalingIsEnabled() {
       // given
-      final var routingStateInitializer = new RoutingStateInitializer(true, 5);
+      final var routingStateInitializer = new RoutingStateInitializer(5);
 
       // when
       final var newConfiguration = routingStateInitializer.modify(currentConfiguration).join();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -105,7 +105,7 @@ final class ClusterConfigurationManagementApiTest {
             coordinator.getCommunicationService(),
             new ProtoBufSerializer(),
             new ClusterConfigurationManagementRequestsHandler(
-                recordingCoordinator, id0, new TestConcurrencyControl(), true));
+                recordingCoordinator, id0, new TestConcurrencyControl()));
 
     requestServer.start();
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -166,7 +166,7 @@ final class ClusterPatchRequestTransformerTest {
             .addMember(id1, MemberState.initializeAsActive(Map.of()))
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
             .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
-    currentTopology = new RoutingStateInitializer(true, 2).modify(currentTopology).join();
+    currentTopology = new RoutingStateInitializer(2).modify(currentTopology).join();
 
     // when
     final int newPartitionCount = 4;
@@ -197,7 +197,7 @@ final class ClusterPatchRequestTransformerTest {
             .addMember(id1, MemberState.initializeAsActive(Map.of()))
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
             .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
-    currentTopology = new RoutingStateInitializer(true, 2).modify(currentTopology).join();
+    currentTopology = new RoutingStateInitializer(2).modify(currentTopology).join();
 
     // when
     final int newPartitionCount = 4;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -135,7 +135,7 @@ final class ClusterScaleRequestTransformerTest {
                 getSortedPartitionIds(oldPartitionCount),
                 oldReplicationFactor);
     ClusterConfiguration oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig, "clusterId");
+        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig, "clusterId");
     for (final MemberId member : getClusterMembers(oldClusterSize)) {
       if (!oldClusterTopology.hasMember(member)) {
         oldClusterTopology =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
@@ -120,7 +120,7 @@ class PartitionReassignRequestTransformerTest {
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
     var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig, "clusterId");
+        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig, "clusterId");
     for (int i = 0; i < max(oldClusterSize, newClusterSize); i++) {
       oldClusterTopology =
           oldClusterTopology.updateMember(
@@ -188,7 +188,7 @@ class PartitionReassignRequestTransformerTest {
                 getSortedPartitionIds(oldPartitionCount),
                 oldReplicationFactor);
     var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig, "clusterId");
+        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig, "clusterId");
     for (int i = 0; i < max(oldClusterSize, newClusterSize); i++) {
       oldClusterTopology =
           oldClusterTopology.updateMember(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -128,7 +128,7 @@ class ScaleRequestTransformerTest {
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
     final var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig, "clusterId");
+        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig, "clusterId");
 
     //  when
     final var operationsEither =
@@ -162,7 +162,7 @@ class ScaleRequestTransformerTest {
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
     final var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig, "clusterId");
+        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig, "clusterId");
 
     // when
     final var operations =
@@ -211,7 +211,7 @@ class ScaleRequestTransformerTest {
                     .toList(),
                 replicationFactor);
     final var config =
-        ConfigurationUtil.getClusterConfigFrom(true, distribution, partitionConfig, "clusterId");
+        ConfigurationUtil.getClusterConfigFrom(distribution, partitionConfig, "clusterId");
     final var transformer =
         new ScaleRequestTransformer(
             getClusterMembers(clusterSize), Optional.of(3), Optional.of(desiredPartitionCount));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformerTest.java
@@ -26,24 +26,6 @@ class UpdateRoutingStateTransformerTest {
           .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()));
 
   @Test
-  void shouldReturnErrorWhenPartitionScalingIsDisabled() {
-    // given
-    final var transformer =
-        new UpdateRoutingStateTransformer(
-            false, // partition scaling disabled
-            Optional.empty());
-
-    // when
-    final var result = transformer.operations(currentTopology);
-
-    // then
-    EitherAssert.assertThat(result).isLeft();
-    assertThat(result.getLeft())
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Partition scaling is disabled. Cannot update routing state.");
-  }
-
-  @Test
   void shouldGenerateUpdateRoutingStateOperationWhenEnabled() {
     // given
     final var routingState =
@@ -52,10 +34,7 @@ class UpdateRoutingStateTransformerTest {
                 1L,
                 new RoutingState.RequestHandling.AllPartitions(3),
                 new RoutingState.MessageCorrelation.HashMod(3)));
-    final var transformer =
-        new UpdateRoutingStateTransformer(
-            true, // partition scaling enabled
-            routingState);
+    final var transformer = new UpdateRoutingStateTransformer(routingState);
 
     // when
     final var result = transformer.operations(currentTopology);
@@ -71,10 +50,7 @@ class UpdateRoutingStateTransformerTest {
   @Test
   void shouldGenerateUpdateRoutingStateOperationWithEmptyRoutingState() {
     // given
-    final var transformer =
-        new UpdateRoutingStateTransformer(
-            true, // partition scaling enabled
-            Optional.empty());
+    final var transformer = new UpdateRoutingStateTransformer(Optional.empty());
 
     // when
     final var result = transformer.operations(currentTopology);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
@@ -56,8 +56,7 @@ class ConfigurationUtilTest {
 
     // when
     final var topology =
-        ConfigurationUtil.getClusterConfigFrom(
-            true, partitionDistribution, partitionConfig, "clusterId");
+        ConfigurationUtil.getClusterConfigFrom(partitionDistribution, partitionConfig, "clusterId");
 
     // then
     ClusterConfigurationAssert.assertThatClusterTopology(topology)
@@ -247,8 +246,7 @@ class ConfigurationUtilTest {
 
     // when
     final var topology =
-        ConfigurationUtil.getClusterConfigFrom(
-            true, partitionDistribution, partitionConfig, "clusterId");
+        ConfigurationUtil.getClusterConfigFrom(partitionDistribution, partitionConfig, "clusterId");
 
     // then
     ClusterConfigurationAssert.assertThatClusterTopology(topology)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ConcurrentBackupScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ConcurrentBackupScalingIT.java
@@ -51,7 +51,6 @@ final class ConcurrentBackupScalingIT {
               b ->
                   b.withBrokerConfig(
                       bb -> {
-                        bb.getExperimental().getFeatures().setEnablePartitionScaling(true);
                         bb.getCluster()
                             .getMembership()
                             .setSyncInterval(Duration.ofSeconds(1))

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointResponseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointResponseIT.java
@@ -29,7 +29,6 @@ final class ClusterEndpointResponseIT {
         new TestStandaloneBroker()
             .withBrokerConfig(
                 cfg -> {
-                  cfg.getExperimental().getFeatures().setEnablePartitionScaling(true);
                   cfg.getCluster().setClusterId("cluster-id");
                 });
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterRoutingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterRoutingEndpointIT.java
@@ -28,10 +28,7 @@ public class ClusterRoutingEndpointIT {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneBroker() {
-    broker =
-        new TestStandaloneBroker()
-            .withBrokerConfig(
-                cfg -> cfg.getExperimental().getFeatures().setEnablePartitionScaling(true));
+    broker = new TestStandaloneBroker();
   }
 
   @ParameterizedTest

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -100,7 +100,6 @@ public class ScaleUpPartitionsTest {
                   b.withBrokerConfig(this::configureBackupStore)
                       .withBrokerConfig(
                           bb -> {
-                            bb.getExperimental().getFeatures().setEnablePartitionScaling(true);
                             bb.getCluster()
                                 .getMembership()
                                 .setSyncInterval(Duration.ofSeconds(1))

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -235,8 +235,6 @@ final class ClusterEndpointIT {
         .withBrokersCount(BROKER_COUNT)
         .withPartitionsCount(PARTITION_COUNT)
         .withReplicationFactor(replicationFactor)
-        .withBrokerConfig(
-            b -> b.brokerConfig().getExperimental().getFeatures().setEnablePartitionScaling(true))
         .build()
         .start();
   }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -45,7 +45,6 @@ public final class FeatureFlags {
   private static final boolean ENABLE_MSG_TTL_CHECKER_ASYNC = false;
   private static final boolean ENABLE_DUE_DATE_CHECKER_ASYNC = false;
   private static final boolean ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR = true;
-  private static final boolean ENABLE_PARTITION_SCALING = true;
   private static final boolean ENABLE_IDENTITY_SETUP = true;
   private static final boolean ENABLE_MESSAGE_BODY_ON_EXPIRED = false;
 
@@ -54,7 +53,6 @@ public final class FeatureFlags {
   private boolean enableMessageTTLCheckerAsync;
   private boolean enableTimerDueDateCheckerAsync;
   private boolean enableStraightThroughProcessingLoopDetector;
-  private boolean enablePartitionScaling;
   private boolean enableMessageBodyOnExpired;
 
   public FeatureFlags(
@@ -63,7 +61,6 @@ public final class FeatureFlags {
       final boolean enableMessageTTLCheckerAsync,
       final boolean enableTimerDueDateCheckerAsync,
       final boolean enableStraightThroughProcessingLoopDetector,
-      final boolean enablePartitionScaling,
       final boolean enableMessageBodyOnExpired
       /*, boolean foo*/ ) {
     this.yieldingDueDateChecker = yieldingDueDateChecker;
@@ -71,7 +68,6 @@ public final class FeatureFlags {
     this.enableMessageTTLCheckerAsync = enableMessageTTLCheckerAsync;
     this.enableTimerDueDateCheckerAsync = enableTimerDueDateCheckerAsync;
     this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
-    this.enablePartitionScaling = enablePartitionScaling;
     this.enableMessageBodyOnExpired = enableMessageBodyOnExpired;
   }
 
@@ -82,7 +78,6 @@ public final class FeatureFlags {
         ENABLE_MSG_TTL_CHECKER_ASYNC,
         ENABLE_DUE_DATE_CHECKER_ASYNC,
         ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR,
-        ENABLE_PARTITION_SCALING,
         ENABLE_MESSAGE_BODY_ON_EXPIRED
         /*, FOO_DEFAULT*/ );
   }
@@ -99,7 +94,6 @@ public final class FeatureFlags {
         true, /* ENABLE_MSG_TTL_CHECKER_ASYNC */
         true, /* ENABLE_DUE_DATE_CHECKER_ASYNC */
         true, /* ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR */
-        true, /* ENABLE_PARTITION_SCALING */
         false /* ENABLE_MESSAGE_BODY_ON_EXPIRED */
         /*, FOO_DEFAULT*/ );
   }
@@ -122,10 +116,6 @@ public final class FeatureFlags {
 
   public boolean enableStraightThroughProcessingLoopDetector() {
     return enableStraightThroughProcessingLoopDetector;
-  }
-
-  public boolean enablePartitionScaling() {
-    return enablePartitionScaling;
   }
 
   public boolean enableMessageBodyOnExpired() {
@@ -151,10 +141,6 @@ public final class FeatureFlags {
   public void setEnableStraightThroughProcessingLoopDetector(
       final boolean enableStraightThroughProcessingLoopDetector) {
     this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
-  }
-
-  public void setEnablePartitionScaling(final boolean enablePartitionScaling) {
-    this.enablePartitionScaling = enablePartitionScaling;
   }
 
   public void setEnableMessageBodyOnExpired(final boolean enableMessageBodyOnExpired) {

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
@@ -22,7 +22,6 @@ class FeatureFlagsTest {
     assertThat(sut.yieldingDueDateChecker()).isTrue();
     assertThat(sut.enableActorMetrics()).isFalse();
     assertThat(sut.enableMessageTTLCheckerAsync()).isFalse();
-    assertThat(sut.enablePartitionScaling()).isTrue();
     assertThat(sut.enableMessageBodyOnExpired()).isFalse();
   }
 
@@ -34,7 +33,6 @@ class FeatureFlagsTest {
     // then
     assertThat(sut.yieldingDueDateChecker()).isTrue();
     assertThat(sut.enableMessageTTLCheckerAsync()).isTrue();
-    assertThat(sut.enablePartitionScaling()).isTrue();
     assertThat(sut.enableMessageBodyOnExpired()).isFalse();
   }
 }


### PR DESCRIPTION
## Description
The feature flag `scaling_enabled` has been completely removed from everywhere, inlining the `true` value in the code paths that were using it.

## Checklist
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34197
