### PR TITLE
test: use 30 seconds timeout for awaiting complete topology

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
@@ -91,7 +91,7 @@ final class ScaleUpBrokersTest {
             () ->
                 TopologyAssert.assertThat(camundaClient.newTopologyRequest().send().join())
                     .hasLeaderForPartition(2, 1));
-    cluster.awaitCompleteTopology(newClusterSize, 3, 1, Duration.ofSeconds(10));
+    cluster.awaitCompleteTopology(newClusterSize, 3, 1, Duration.ofSeconds(30));
 
     // then - verify the cluster can still process
     assertThatAllJobsCanBeCompleted(processInstanceKeys, camundaClient, JOB_TYPE);
@@ -123,7 +123,7 @@ final class ScaleUpBrokersTest {
             () ->
                 TopologyAssert.assertThat(camundaClient.newTopologyRequest().send().join())
                     .hasLeaderForPartition(3, 2));
-    cluster.awaitCompleteTopology(finalClusterSize, 3, 1, Duration.ofSeconds(10));
+    cluster.awaitCompleteTopology(finalClusterSize, 3, 1, Duration.ofSeconds(30));
   }
 
   @Test
@@ -148,7 +148,7 @@ final class ScaleUpBrokersTest {
                 TopologyAssert.assertThat(camundaClient.newTopologyRequest().send().join())
                     .hasLeaderForPartition(2, 1)
                     .hasLeaderForPartition(3, 2));
-    cluster.awaitCompleteTopology(newClusterSize, 3, 1, Duration.ofSeconds(10));
+    cluster.awaitCompleteTopology(newClusterSize, 3, 1, Duration.ofSeconds(30));
 
     // then - verify the cluster can still process
     assertThatAllJobsCanBeCompleted(processInstanceKeys, camundaClient, JOB_TYPE);
@@ -191,7 +191,7 @@ final class ScaleUpBrokersTest {
         .brokerHasPartition(0, 1);
 
     // Changes are reflected in the topology returned by grpc query
-    cluster.awaitCompleteTopology(newClusterSize, 3, 1, Duration.ofSeconds(10));
+    cluster.awaitCompleteTopology(newClusterSize, 3, 1, Duration.ofSeconds(30));
   }
 
   @Test


### PR DESCRIPTION
## Description
A timeout of 30 seconds is used every time we need to `awaitCompleteTopology` as it become flaky.

Compare to PR #38951 for branches `stable/8.6`, `stable/8.7`, this PR relaxes the timeout on all `awaitCompleteTopology` as they all seem to pop up in the reports.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

