### PR TITLE
ci: slight increase of RDBMS IT job timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,7 +686,7 @@ jobs:
     if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'
     needs: [ detect-changes ]
     name: "General / Integration / RDBMS ITs"
-    timeout-minutes: 7
+    timeout-minutes: 10
     runs-on: gcp-perf-core-8-default
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}


### PR DESCRIPTION
## Description

On `main` we have actually many cancellations of this job because it barely goes over the timeout. We have room to increase it still and stay within our SLO:

* https://github.com/camunda/camunda/actions/runs/18156958135/job/51679001137
* https://github.com/camunda/camunda/actions/runs/18153133230/job/51667529525

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None, discovered as medic
