### PR TITLE
feat: add download BPMN XML to process instance operations

### DIFF
--- a/operate/client/src/modules/components/OperationItem/index.tsx
+++ b/operate/client/src/modules/components/OperationItem/index.tsx
@@ -6,14 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Error, Tools, RetryFailed} from '@carbon/react/icons';
+import {Error, Tools, RetryFailed, Calendar} from '@carbon/react/icons';
 import {Button, type ButtonSize, type Icon} from '@carbon/react';
 
 type ItemProps = {
   type:
     | 'RESOLVE_INCIDENT'
     | 'CANCEL_PROCESS_INSTANCE'
-    | 'ENTER_MODIFICATION_MODE';
+    | 'ENTER_MODIFICATION_MODE'
+    | 'DOWNLOAD_BPMN_XML';
   onClick: React.ComponentProps<'button'>['onClick'];
   title: string;
   disabled?: boolean;
@@ -29,6 +30,7 @@ const TYPE_DETAILS: Readonly<
   RESOLVE_INCIDENT: {icon: RetryFailed, testId: 'retry-operation'},
   CANCEL_PROCESS_INSTANCE: {icon: Error, testId: 'cancel-operation'},
   ENTER_MODIFICATION_MODE: {icon: Tools, testId: 'enter-modification-mode'},
+  DOWNLOAD_BPMN_XML: {icon: Calendar, testId: 'download-bpmn-xml'},
 };
 
 const OperationItem: React.FC<ItemProps> = ({

--- a/operate/client/src/modules/components/Operations/OperationRenderer.tsx
+++ b/operate/client/src/modules/components/Operations/OperationRenderer.tsx
@@ -44,6 +44,16 @@ const OperationRenderer: React.FC<Props> = ({
           size="sm"
         />
       );
+    case 'DOWNLOAD_BPMN_XML':
+      return (
+        <OperationItem
+          type="DOWNLOAD_BPMN_XML"
+          onClick={operation.onExecute}
+          title={operation.label || `Download Instance ${processInstanceKey}`}
+          disabled={operation.disabled}
+          size="sm"
+        />
+      );
     default:
       return null;
   }

--- a/operate/client/src/modules/components/Operations/types.ts
+++ b/operate/client/src/modules/components/Operations/types.ts
@@ -10,7 +10,8 @@ type OperationType =
   | 'RESOLVE_INCIDENT'
   | 'CANCEL_PROCESS_INSTANCE'
   | 'DELETE_PROCESS_INSTANCE'
-  | 'ENTER_MODIFICATION_MODE';
+  | 'ENTER_MODIFICATION_MODE'
+  | 'DOWNLOAD_BPMN_XML';
 
 type OperationConfig = {
   type: OperationType;


### PR DESCRIPTION
## Description

A new dummy button (calendar icon) was added at this specific page as shown below.
On click downloads the process instance's bpmn xml.

<img width="1906" height="720" alt="Image" src="https://github.com/user-attachments/assets/24d28e33-8bee-4284-b9fb-ec3c199c5712" />

## Next Steps
- Check if specific permissions are required for this operation
- Check if it is necessary to be added also in Processes view
- Put proper icon
- Refactor code and maybe use custom block of code to write blob etc.

## Related issues

closes #22005
