### PR TITLE
fix: remove duplicate RoleDeletedHandler added to exporter handler

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -179,7 +179,6 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
             new RoleMemberRemovedHandler(
                 indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
-            new RoleDeletedHandler(indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
             new UserCreatedUpdatedHandler(
                 indexDescriptors.get(UserIndex.class).getFullQualifiedName()),
             new UserDeletedHandler(indexDescriptors.get(UserIndex.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedItemHandler;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
@@ -104,6 +105,31 @@ public class DefaultExporterResourceProviderTest {
                 .filter(BatchOperationChunkCreatedItemHandler.class::isInstance)
                 .toList())
         .isEmpty();
+  }
+
+  @Test
+  void shouldNotAddSameHandlerMultipleTimes() {
+    // given
+    final var config = new ExporterConfiguration();
+    config.getBatchOperation().setExportItemsOnCreation(true);
+
+    // when
+    final var provider = new DefaultExporterResourceProvider();
+    provider.init(
+        config,
+        mock(ExporterEntityCacheProvider.class),
+        new SimpleMeterRegistry(),
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
+
+    // then
+    assertThat(provider.getExportHandlers())
+        .hasSize(
+            (int)
+                provider.getExportHandlers().stream()
+                    .map(ExportHandler::getClass)
+                    .distinct()
+                    .count());
   }
 
   static Stream<ExporterConfiguration> configProvider() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

`RoleDeletedHandler` is added twice to the list of exporter handlers

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
