### PR TITLE
fix: remove required response field from PI result

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7188,7 +7188,6 @@ components:
         - tenantId
         - processInstanceKey
         - processDefinitionKey
-        - tags
       properties:
         processDefinitionId:
           $ref: "#/components/schemas/ProcessDefinitionId"


### PR DESCRIPTION
## Description

Removes 'tags' from the required response properties in the process instance result.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38988
