### PR TITLE
feat: provide new await method for expecting a supplied value

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssertAwaitBehavior.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssertAwaitBehavior.java
@@ -15,15 +15,10 @@
  */
 package io.camunda.process.test.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.time.Duration;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import org.assertj.core.api.SoftAssertionsProvider.ThrowingRunnable;
 
 /**
@@ -33,47 +28,6 @@ import org.assertj.core.api.SoftAssertionsProvider.ThrowingRunnable;
  * Camunda.
  */
 public interface CamundaAssertAwaitBehavior {
-
-  /**
-   * Wait until a non-null object becomes available.
-   *
-   * @param supplier function that eventually returns a non-null object
-   * @return the object
-   * @param <T> type of the object
-   * @throws AssertionError if no object became available before the timeout threshold was reached
-   */
-  default <T> T untilExists(
-      final Supplier<Optional<T>> supplier, final String assertionErrroMessage) {
-
-    return untilExists(supplier, Function.identity(), assertionErrroMessage);
-  }
-
-  /**
-   * Wait until a non-null object becomes available.
-   *
-   * @param supplier function that eventually returns a non-null object
-   * @param transformer transforms the object to a different type
-   * @return the object
-   * @param <T> type of the object
-   * @param <U> target type of the transformed object
-   * @throws AssertionError if no object became available before the timeout threshold was reached
-   */
-  default <T, U> U untilExists(
-      final Supplier<Optional<T>> supplier,
-      final Function<T, U> transformer,
-      final String assertionErrorMessage) {
-
-    final AtomicReference<U> expectedValue = new AtomicReference<>();
-
-    untilAsserted(
-        () -> {
-          final Optional<T> value = supplier.get();
-          assertThat(value).withFailMessage(assertionErrorMessage).isPresent();
-          expectedValue.set(transformer.apply(value.get()));
-        });
-
-    return expectedValue.get();
-  }
 
   /**
    * Wait until the given assertion is satisfied.
@@ -98,6 +52,30 @@ public interface CamundaAssertAwaitBehavior {
           final T value = supplier.call();
           assertion.accept(value);
         });
+  }
+
+  /**
+   * Wait until the given assertion is satisfied and return the value of the supplier.
+   *
+   * @param supplier supplies the value
+   * @param assertion the assertion to be satisfied
+   * @param <T> the value type
+   * @return the value from the supplier
+   * @throws AssertionError if the assertion is not satisfied
+   */
+  default <T> T until(final Callable<T> supplier, final Consumer<T> assertion)
+      throws AssertionError {
+
+    final AtomicReference<T> result = new AtomicReference<>();
+
+    untilAsserted(
+        () -> {
+          final T value = supplier.call();
+          assertion.accept(value);
+          result.set(value);
+        });
+
+    return result.get();
   }
 
   /**

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.process.test.impl.extension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.JsonMapper;
@@ -374,8 +376,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
 
   private UserTask awaitUserTask(
       final UserTaskSelector userTaskSelector, final CamundaClient client) {
-
-    return awaitBehavior.untilExists(
+    return awaitBehavior.until(
         () ->
             client
                 .newUserTaskSearchRequest()
@@ -385,14 +386,18 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
                 .items()
                 .stream()
                 .filter(userTaskSelector::test)
-                .findFirst(),
-        String.format(
-            "Expected to complete user task [%s] but no user task is available.",
-            userTaskSelector.describe()));
+                .findFirst()
+                .orElse(null),
+        userTask ->
+            assertThat(userTask)
+                .withFailMessage(
+                    "Expected to complete user task [%s] but no user task is available.",
+                    userTaskSelector.describe())
+                .isNotNull());
   }
 
   private ActivatedJob getActivatedJob(final String jobType, final CamundaClient client) {
-    return awaitBehavior.untilExists(
+    return awaitBehavior.until(
         () ->
             client
                 .newActivateJobsCommand()
@@ -403,8 +408,13 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
                 .join()
                 .getJobs()
                 .stream()
-                .findFirst(),
-        String.format(
-            "Expected to complete a job with the type '%s' but no job is available.", jobType));
+                .findFirst()
+                .orElse(null),
+        job ->
+            assertThat(job)
+                .withFailMessage(
+                    "Expected to complete a job with the type '%s' but no job is available.",
+                    jobType)
+                .isNotNull());
   }
 }


### PR DESCRIPTION
## Description

Refactors multiple AwaitilityBehavior invocations that expect a value and continue working with said object after the assertion has been completed. The new method `untilExists` returns the value as soon as it becomes available or throws an AssertionError.