### PR TITLE
feat: Archive Standalone Decision Instances (backport stable/8.7)

### DIFF
--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
@@ -60,9 +60,13 @@ public class Archiver {
         final List<Integer> partitionIdsSubset =
             CollectionUtil.splitAndGetSublist(partitionIds, threadsCount, i);
         if (!partitionIdsSubset.isEmpty()) {
-          final var archiverJob =
+          final var processInstancesArchiverJob =
               beanFactory.getBean(ProcessInstancesArchiverJob.class, this, partitionIdsSubset);
-          archiverExecutor.execute(archiverJob);
+          archiverExecutor.execute(processInstancesArchiverJob);
+
+          final var standaloneDecisionArchiverJob =
+              beanFactory.getBean(StandaloneDecisionArchiverJob.class, this, partitionIdsSubset);
+          archiverExecutor.execute(standaloneDecisionArchiverJob);
         }
         if (partitionIdsSubset.contains(1)) {
           final var batchOperationArchiverJob =

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ArchiverRepository.java
@@ -15,6 +15,8 @@ public interface ArchiverRepository {
 
   CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch(List<Integer> partitionIds);
 
+  CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch(List<Integer> partitionIds);
+
   void setIndexLifeCycle(final String destinationIndexName);
 
   CompletableFuture<Void> deleteDocuments(

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -28,6 +28,7 @@ import io.camunda.operate.exceptions.ArchiverException;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.templates.BatchOperationTemplate;
+import io.camunda.operate.schema.templates.DecisionInstanceTemplate;
 import io.camunda.operate.schema.templates.ListViewTemplate;
 import io.camunda.operate.util.Either;
 import io.camunda.operate.util.ElasticsearchUtil;
@@ -85,6 +86,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
 
   @Autowired private BatchOperationTemplate batchOperationTemplate;
   @Autowired private ListViewTemplate processInstanceTemplate;
+  @Autowired private DecisionInstanceTemplate decisionInstanceTemplate;
   @Autowired private OperateProperties operateProperties;
   @Autowired private Metrics metrics;
   @Autowired private RestHighLevelClient esClient;
@@ -159,6 +161,20 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         t ->
             format(
                 "Exception occurred, while obtaining finished batch operations: %s",
+                t.getMessage());
+    return searchAsync(searchRequest, errorMessage);
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch(
+      final List<Integer> partitionIds) {
+    final var aggregation = createStandaloneDecisionInstancesAggregation(DATES_AGG, INSTANCES_AGG);
+    final var searchRequest =
+        createStandaloneDecisionInstancesSearchRequest(aggregation, partitionIds);
+    final Function<Throwable, String> errorMessage =
+        t ->
+            format(
+                "Exception occurred, while obtaining finished standalone decision evaluations: %s",
                 t.getMessage());
     return searchAsync(searchRequest, errorMessage);
   }
@@ -350,6 +366,58 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                 .size(operateProperties.getArchiver().getRolloverBatchSize())
                 .sort(ListViewTemplate.ID, SortOrder.ASC)
                 .fetchSource(ListViewTemplate.ID, null));
+  }
+
+  private AggregationBuilder createStandaloneDecisionInstancesAggregation(
+      final String datesAggName, final String instancesAggName) {
+    return dateHistogram(datesAggName)
+        .field(DecisionInstanceTemplate.EVALUATION_DATE)
+        .calendarInterval(
+            new DateHistogramInterval(operateProperties.getArchiver().getRolloverInterval()))
+        .format(operateProperties.getArchiver().getElsRolloverDateFormat())
+        .keyed(true) // get result as a map (not an array)
+        // we want to get only one bucket at a time
+        .subAggregation(
+            bucketSort("datesSortedAgg", Arrays.asList(new FieldSortBuilder("_key"))).size(1))
+        // we need process instance ids, also taking into account batch size
+        .subAggregation(
+            topHits(instancesAggName)
+                .size(operateProperties.getArchiver().getRolloverBatchSize())
+                .sort(DecisionInstanceTemplate.ID, SortOrder.ASC)
+                .fetchSource(DecisionInstanceTemplate.ID, null));
+  }
+
+  private SearchRequest createStandaloneDecisionInstancesSearchRequest(
+      final AggregationBuilder agg, final List<Integer> partitionIds) {
+    final QueryBuilder endDateQ =
+        rangeQuery(DecisionInstanceTemplate.EVALUATION_DATE)
+            .lte(operateProperties.getArchiver().getArchivingTimepoint());
+    final TermsQueryBuilder partitionQ =
+        termsQuery(DecisionInstanceTemplate.PARTITION_ID, partitionIds);
+    // standalone decision instances have processInstanceKey = -1
+    final TermQueryBuilder standaloneDecisionInstanceQ =
+        termQuery(DecisionInstanceTemplate.PROCESS_INSTANCE_KEY, -1);
+
+    final ConstantScoreQueryBuilder q =
+        constantScoreQuery(
+            ElasticsearchUtil.joinWithAnd(endDateQ, partitionQ, standaloneDecisionInstanceQ));
+
+    final SearchRequest searchRequest =
+        new SearchRequest(decisionInstanceTemplate.getFullQualifiedName())
+            .source(
+                new SearchSourceBuilder()
+                    .query(q)
+                    .aggregation(agg)
+                    .fetchSource(false)
+                    .size(0)
+                    .sort(DecisionInstanceTemplate.EVALUATION_DATE, SortOrder.ASC))
+            .requestCache(false); // we don't need to cache this, as each time we need new data
+
+    LOGGER.debug(
+        "Finished standalone decision evaluations for archiving request: \n{}\n and aggregation: \n{}",
+        q,
+        agg.toString());
+    return searchRequest;
   }
 
   private ReindexRequest createReindexRequestWithDefaults() {

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesArchiverJob.java
@@ -61,7 +61,7 @@ public class ProcessInstancesArchiverJob extends AbstractArchiverJob {
               })
           .thenAccept(
               (i) -> {
-                metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVED, i);
+                metrics.recordCounts(Metrics.COUNTER_NAME_PROCESS_INSTANCES_ARCHIVED, i);
                 archiveBatchFuture.complete(i);
               })
           .exceptionally(

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -49,7 +49,10 @@ public class Metrics {
   public static final String COUNTER_NAME_EVENTS_PROCESSED_FINISHED_WI =
       "events.processed.finished.process.instances";
   public static final String COUNTER_NAME_COMMANDS = "commands";
-  public static final String COUNTER_NAME_ARCHIVED = "archived.process.instances";
+  public static final String COUNTER_NAME_PROCESS_INSTANCES_ARCHIVED = "archived.process.instances";
+  public static final String COUNTER_NAME_BATCH_OPERATIONS_ARCHIVED = "archiver.batch.operations";
+  public static final String COUNTER_NAME_STANDALONE_DECISIONS_ARCHIVED =
+      "archiver.standalone.decisions";
   public static final String COUNTER_NAME_IMPORT_FNI_TREE_PATH_CACHE_RESULT =
       "import.fni.tree.path.cache.result";
   public static final String COUNTER_NAME_REINDEX_FAILURES = "archival.reindex.failures";

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateTester.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateTester.java
@@ -91,6 +91,7 @@ public class OperateTester {
   private Long processInstanceKey;
   private Long jobKey;
   private JwtDecoder jwtDecoder;
+  private long decisionInstanceKey;
 
   @Autowired(required = false)
   private IdentityJwt2AuthenticationTokenConverter jwtAuthenticationConverter;
@@ -243,6 +244,10 @@ public class OperateTester {
     return operationReader.getOperationsByBatchOperationId(operation.getId());
   }
 
+  public long getDecisionInstanceKey() {
+    return decisionInstanceKey;
+  }
+
   public OperateTester createAndDeploySimpleProcess(
       final String processId, final String activityId) {
     final BpmnModelInstance process =
@@ -366,6 +371,14 @@ public class OperateTester {
 
   public OperateTester processInstanceIsCanceled() {
     searchTestRule.processAllRecordsAndWait(processInstanceIsCanceledCheck, processInstanceKey);
+    return this;
+  }
+
+  public OperateTester evaluateDecisionInstance(
+      final String decisionId, final Map<String, Object> variables) {
+    LOGGER.info("Evaluating decision instance id '{}'  with variables '{}'", decisionId, variables);
+    decisionInstanceKey =
+        ZeebeTestUtil.evaluateDecisionInstance(zeebeClient, decisionId, variables);
     return this;
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
@@ -46,6 +46,7 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -192,6 +193,15 @@ public abstract class OperateZeebeAbstractIT extends OperateAbstractIT {
   @Autowired protected OperateProperties operateProperties;
   @Autowired protected OperationExecutor operationExecutor;
   protected OperateTester tester;
+
+  @Autowired
+  @Qualifier("decisionsAreDeployedCheck")
+  private Predicate<Object[]> decisionsAreDeployedCheck;
+
+  @Autowired
+  @Qualifier("decisionInstancesAreCreated")
+  private Predicate<Object[]> decisionInstancesAreCreated;
+
   private ZeebeContainer zeebeContainer;
   @Autowired private TestSearchRepository testSearchRepository;
   private final HttpClient httpClient = HttpClient.newHttpClient();
@@ -286,6 +296,23 @@ public abstract class OperateZeebeAbstractIT extends OperateAbstractIT {
     final Long processId = ZeebeTestUtil.deployProcess(getClient(), null, process, resourceName);
     searchTestRule.processAllRecordsAndWait(processIsDeployedCheck, processId);
     return processId;
+  }
+
+  protected void deployDecision(final String... classpathResources) {
+    ZeebeTestUtil.deployDecision(getClient(), null, classpathResources);
+  }
+
+  public void decisionsAreDeployed(final int count) {
+    searchTestRule.processAllRecordsAndWait(decisionsAreDeployedCheck, count);
+  }
+
+  public long evaluateDecisionInstance(
+      final String decisionId, final Map<String, Object> variables) {
+    return ZeebeTestUtil.evaluateDecisionInstance(getClient(), decisionId, variables);
+  }
+
+  public void decisionInstancesAreCreated(final int count) {
+    searchTestRule.processAllRecordsAndWait(decisionInstancesAreCreated, count);
   }
 
   protected void cancelProcessInstance(final long processInstanceKey) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestSearchRepository.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestSearchRepository.java
@@ -9,6 +9,7 @@ package io.camunda.operate.util.searchrepository;
 
 import io.camunda.operate.entities.BatchOperationEntity;
 import io.camunda.operate.entities.VariableEntity;
+import io.camunda.operate.entities.dmn.DecisionInstanceEntity;
 import io.camunda.operate.entities.listview.ProcessInstanceForListViewEntity;
 import java.io.IOException;
 import java.util.List;
@@ -80,6 +81,19 @@ public interface TestSearchRepository {
 
   List<ProcessInstanceForListViewEntity> getProcessInstances(String indexName, List<Long> ids)
       throws IOException;
+
+  default List<DecisionInstanceEntity> getDecisionInstancesByKeys(
+      final String indexName, final List<Long> decisionInstanceKeys) throws IOException {
+    return getDecisionInstances(indexName, decisionInstanceKeys, List.of());
+  }
+
+  default List<DecisionInstanceEntity> getDecisionInstancesByIds(
+      final String indexName, final List<String> ids) throws IOException {
+    return getDecisionInstances(indexName, List.of(), ids);
+  }
+
+  List<DecisionInstanceEntity> getDecisionInstances(
+      String indexName, List<Long> decisionInstanceKeys, List<String> ids) throws IOException;
 
   Optional<List<Long>> getIds(
       String indexName, String idFieldName, List<Long> ids, boolean ignoreAbsentIndex)


### PR DESCRIPTION
## Description

Whilst we are archiving decision instances attached to a process via the linked processInstanceKey of the decision instances, the standalone evaluations are never moved, which can result in building completed data in the hot indexes. This adds a specialised archiver job that would move any standalone decision instances evaluated prior to the archive window, and move them to their dated indexes.

Also adding tests for this and a few others that were missing.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #35555 
