### PR TITLE
feat: use static cache for definition XML hooks

### DIFF
--- a/operate/client/src/modules/queries/decisionDefinitions/useDecisionDefinitionXml.ts
+++ b/operate/client/src/modules/queries/decisionDefinitions/useDecisionDefinitionXml.ts
@@ -25,6 +25,7 @@ function useDecisionDefinitionXmlOptions({
     {
       queryKey,
       enabled,
+      staleTime: 'static',
     },
   );
 }

--- a/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionXml.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionXml.ts
@@ -56,7 +56,7 @@ function useProcessDefinitionXml<T = ParsedXmlData>({
           }
         : skipToken,
     select,
-    staleTime: Infinity,
+    staleTime: 'static',
     refetchOnWindowFocus: false,
     retryOnMount: false,
     refetchOnMount: (query) => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Definition XMLs are immutable so we can cache than as long as the Tanstack Query garbage collector allows it
