### PR TITLE
[Backport stable/8.8] fix: remove duplicate RoleDeletedHandler added to exporter handler

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -180,7 +180,6 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
             new RoleMemberRemovedHandler(
                 indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
-            new RoleDeletedHandler(indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
             new UserCreatedUpdatedHandler(
                 indexDescriptors.get(UserIndex.class).getFullQualifiedName()),
             new UserDeletedHandler(indexDescriptors.get(UserIndex.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedItemHandler;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
@@ -104,6 +105,31 @@ public class DefaultExporterResourceProviderTest {
                 .filter(BatchOperationChunkCreatedItemHandler.class::isInstance)
                 .toList())
         .isEmpty();
+  }
+
+  @Test
+  void shouldNotAddSameHandlerMultipleTimes() {
+    // given
+    final var config = new ExporterConfiguration();
+    config.getBatchOperation().setExportItemsOnCreation(true);
+
+    // when
+    final var provider = new DefaultExporterResourceProvider();
+    provider.init(
+        config,
+        mock(ExporterEntityCacheProvider.class),
+        new SimpleMeterRegistry(),
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
+
+    // then
+    assertThat(provider.getExportHandlers())
+        .hasSize(
+            (int)
+                provider.getExportHandlers().stream()
+                    .map(ExportHandler::getClass)
+                    .distinct()
+                    .count());
   }
 
   static Stream<ExporterConfiguration> configProvider() {


### PR DESCRIPTION
# Description
Backport of #38981 to `stable/8.8`.

relates to 