### PR TITLE
[Backport stable/8.8] fix: remove required response field from PI result

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7188,7 +7188,6 @@ components:
         - tenantId
         - processInstanceKey
         - processDefinitionKey
-        - tags
       properties:
         processDefinitionId:
           $ref: "#/components/schemas/ProcessDefinitionId"


### PR DESCRIPTION
# Description
Backport of #38989 to `stable/8.8`.

relates to #38988