### PR TITLE
chore: add validation against illegal index prefix characters

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationValidator.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationValidator.java
@@ -7,9 +7,30 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
+import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
+import java.util.regex.Pattern;
+
 public class ConfigurationValidator {
+
+  private static final Pattern INVALID_INDEX_PREFIX_CHARS = Pattern.compile("[\\\\/*?\"<>| _]");
 
   public void validate(final ConfigurationService configurationService) {
     configurationService.getEmailAuthenticationConfiguration().validate();
+
+    validateIndexPrefix(configurationService.getElasticSearchConfiguration().getIndexPrefix());
+    validateIndexPrefix(configurationService.getOpenSearchConfiguration().getIndexPrefix());
+  }
+
+  private void validateIndexPrefix(final String indexPrefix) {
+    if (indexPrefix != null) {
+      if (INVALID_INDEX_PREFIX_CHARS.matcher(indexPrefix).find()) {
+        throw new OptimizeConfigurationException(
+            "Optimize indexPrefix must not contain invalid characters [\\ / * ? \" < > | space _].");
+      }
+      if (indexPrefix.startsWith(".") || indexPrefix.startsWith("+")) {
+        throw new OptimizeConfigurationException(
+            "Optimize indexPrefix must not begin with invalid characters [. +].");
+      }
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationValidator.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationValidator.java
@@ -22,15 +22,16 @@ public class ConfigurationValidator {
   }
 
   private void validateIndexPrefix(final String indexPrefix) {
-    if (indexPrefix != null) {
-      if (INVALID_INDEX_PREFIX_CHARS.matcher(indexPrefix).find()) {
-        throw new OptimizeConfigurationException(
-            "Optimize indexPrefix must not contain invalid characters [\\ / * ? \" < > | space _].");
-      }
-      if (indexPrefix.startsWith(".") || indexPrefix.startsWith("+")) {
-        throw new OptimizeConfigurationException(
-            "Optimize indexPrefix must not begin with invalid characters [. +].");
-      }
+    if (indexPrefix == null) {
+      return;
+    }
+    if (INVALID_INDEX_PREFIX_CHARS.matcher(indexPrefix).find()) {
+      throw new OptimizeConfigurationException(
+          "Optimize indexPrefix must not contain invalid characters [\\ / * ? \" < > | space _].");
+    }
+    if (indexPrefix.startsWith(".") || indexPrefix.startsWith("+")) {
+      throw new OptimizeConfigurationException(
+          "Optimize indexPrefix must not begin with invalid characters [. +].");
     }
   }
 }

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceTest.java
@@ -114,9 +114,11 @@ public class ConfigurationServiceTest {
       defaultConfigFile(),
       "config-samples/certificate-authorities/wrong-ca-auth-format-throws-error.yaml"
     };
-    final ConfigurationService underTest = createConfiguration(locations);
     assertThatThrownBy(
-            () -> underTest.getElasticSearchConfiguration().getSecuritySSLCertificateAuthorities())
+            () ->
+                createConfiguration(locations)
+                    .getElasticSearchConfiguration()
+                    .getSecuritySSLCertificateAuthorities())
         .isInstanceOf(MappingException.class);
   }
 
@@ -126,9 +128,11 @@ public class ConfigurationServiceTest {
       defaultConfigFile(),
       "config-samples/certificate-authorities/wrong-ca-auth-list-format-throws-error.yaml"
     };
-    final ConfigurationService underTest = createConfiguration(locations);
     assertThatThrownBy(
-            () -> underTest.getElasticSearchConfiguration().getSecuritySSLCertificateAuthorities())
+            () ->
+                createConfiguration(locations)
+                    .getElasticSearchConfiguration()
+                    .getSecuritySSLCertificateAuthorities())
         .isInstanceOf(MappingException.class);
   }
 
@@ -140,7 +144,7 @@ public class ConfigurationServiceTest {
     for (final String configLocation : possibilitiesToDisableHttpPortConnection) {
       // given
       final ConfigurationService underTest =
-          createConfiguration(new String[] {defaultConfigFile(), configLocation});
+          createConfiguration(defaultConfigFile(), configLocation);
 
       // when
       final Optional<Integer> containerHttpPort = underTest.getContainerHttpPort();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We observed in a test environment that we have problems during template creation when illegal characters are defined as index prefixes. Given that we know which characters are and are not allowed by ES/OS already, and that we already validate in the Exporter against use of an underscore, this PR extends the validation to also prevent character usage that would be rejected by ES/OS at the time of template/index creation.

Additional context in the related [issue](https://github.com/camunda/camunda/issues/38393).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38393 
