### PR TITLE
fix: add rest-api.yaml to JAR for swagger

### DIFF
--- a/zeebe/gateway-protocol/pom.xml
+++ b/zeebe/gateway-protocol/pom.xml
@@ -26,6 +26,7 @@
         <includes>
           <include>**/*.proto</include>
           <include>internal/generation-spec.yaml</include>
+          <include>rest-api.yaml</include>
         </includes>
       </resource>
     </resources>


### PR DESCRIPTION
## Description

When running zeebe image in SaaS, `rest-api.yaml` file is not available in the classpath which results in "java.io.FileNotFoundException: class path resource [rest-api.yaml] cannot be opened because it does not exist" error log.

This happens because the openAPI spec is only in `gateway-protocol` module and it seems like the SaaS deployment doesn't include `rest-api.yaml` in the JAR. This was caused by a recent PR merged in 8.8 #38440

I'm adding `rest-api.yaml` back into proto resources so `gateway-rest` can read it from `gateway-protocol` JAR

## SaaS
<img width="1525" height="724" alt="Screenshot 2568-09-30 at 09 58 17" src="https://github.com/user-attachments/assets/20f0063e-6005-4497-895f-c7b5613c823d" />

## SM
<img width="1516" height="795" alt="Screenshot 2568-09-30 at 09 58 03" src="https://github.com/user-attachments/assets/7acd5820-79a7-439a-9e54-871d3a270cae" />

## Related issues

closes https://github.com/camunda/camunda/issues/38875
