### PR TITLE
feat: setup query and add schema for message subscriptions

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.6
+
+### 🚀 Enhancements
+
+- add message subscription endpoints ([#39031](https://github.com/camunda/camunda/pull/39031))
+
+### ❤️ Contributors
+
+- Yuliia Saienko ([@juliasaienko](https://github.com/juliasaienko))
+
 ## v0.0.5
 
 ### 🩹 Fixes

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/decision-instance.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/decision-instance.ts
@@ -65,7 +65,7 @@ const queryDecisionInstancesRequestBodySchema = getQueryRequestBodySchema({
 			evaluationDate: advancedDateTimeFilterSchema,
 			decisionDefinitionKey: basicStringFilterSchema,
 			...decisionInstanceSchema.pick({
-        decisionEvaluationInstanceKey: true,
+				decisionEvaluationInstanceKey: true,
 				state: true,
 				evaluationFailure: true,
 				decisionDefinitionId: true,

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/index.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/index.ts
@@ -62,7 +62,7 @@ import {
 	queryMappingRules,
 } from './mapping-rule';
 import {publishMessage, correlateMessage} from './message';
-import {queryMessageSubscriptions} from './message-subscriptions';
+import {queryMessageSubscriptions, queryCorrelatedMessageSubscriptions} from './message-subscriptions';
 import {
 	createProcessInstance,
 	getProcessInstance,
@@ -206,6 +206,7 @@ const endpoints = {
 	publishMessage,
 	correlateMessage,
 	queryMessageSubscriptions,
+	queryCorrelatedMessageSubscriptions,
 	getUserTask,
 	queryUserTasks,
 	getUserTaskForm,
@@ -532,10 +533,16 @@ export {
 	messageSubscriptionSchema,
 	queryMessageSubscriptionRequestBodySchema,
 	queryMessageSubscriptionsResponseBodySchema,
+	correlatedMessageSubscriptionSchema,
+	queryCorrelatedMessageSubscriptionRequestBodySchema,
+	queryCorrelatedMessageSubscriptionsResponseBodySchema,
 	type MessageSubscriptionState,
 	type MessageSubscription,
 	type QueryMessageSubscriptionsRequestBody,
 	type QueryMessageSubscriptionsResponseBody,
+	type CorrelatedMessageSubscription,
+	type QueryCorrelatedMessageSubscriptionsRequestBody,
+	type QueryCorrelatedMessageSubscriptionsResponseBody,
 } from './message-subscriptions';
 export {
 	createMappingRuleRequestBodySchema,

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/index.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/index.ts
@@ -62,6 +62,7 @@ import {
 	queryMappingRules,
 } from './mapping-rule';
 import {publishMessage, correlateMessage} from './message';
+import {queryMessageSubscriptions} from './message-subscriptions';
 import {
 	createProcessInstance,
 	getProcessInstance,
@@ -204,6 +205,7 @@ const endpoints = {
 	queryMappingRules,
 	publishMessage,
 	correlateMessage,
+	queryMessageSubscriptions,
 	getUserTask,
 	queryUserTasks,
 	getUserTaskForm,
@@ -526,6 +528,15 @@ export {
 	type CorrelateMessageRequestBody,
 	type CorrelateMessageResponseBody,
 } from './message';
+export {
+	messageSubscriptionSchema,
+	queryMessageSubscriptionRequestBodySchema,
+	queryMessageSubscriptionsResponseBodySchema,
+	type MessageSubscriptionState,
+	type MessageSubscription,
+	type QueryMessageSubscriptionsRequestBody,
+	type QueryMessageSubscriptionsResponseBody,
+} from './message-subscriptions';
 export {
 	createMappingRuleRequestBodySchema,
 	createMappingRuleResponseBodySchema,

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/message-subscriptions.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/message-subscriptions.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {z} from 'zod';
+import {
+	advancedDateTimeFilterSchema,
+	advancedStringFilterSchema,
+	API_VERSION,
+	type Endpoint,
+	getEnumFilterSchema,
+	getQueryRequestBodySchema,
+	getQueryResponseBodySchema,
+} from './common';
+
+const messageSubscriptionStateSchema = z.enum(['CORRELATED', 'CREATED', 'DELETED', 'MIGRATED']);
+type MessageSubscriptionState = z.infer<typeof messageSubscriptionStateSchema>;
+
+const messageSubscriptionSchema = z.object({
+	messageSubscriptionKey: z.string(),
+	processDefinitionId: z.string(),
+	processDefinitionKey: z.string(),
+	processInstanceKey: z.string(),
+	elementId: z.string(),
+	elementInstanceKey: z.string(),
+	messageSubscriptionState: messageSubscriptionStateSchema,
+	lastUpdatedDate: z.string(),
+	messageName: z.string(),
+	correlationKey: z.string(),
+	tenantId: z.string(),
+});
+type MessageSubscription = z.infer<typeof messageSubscriptionSchema>;
+
+const queryMessageSubscriptionRequestBodySchema = getQueryRequestBodySchema({
+	sortFields: [
+		'messageSubscriptionKey',
+		'processDefinitionId',
+		'processInstanceKey',
+		'elementId',
+		'elementInstanceKey',
+		'messageSubscriptionState',
+		'lastUpdatedDate',
+		'messageName',
+		'correlationKey',
+		'tenantId',
+	] as const,
+	filter: z
+		.object({
+			messageSubscriptionState: getEnumFilterSchema(messageSubscriptionStateSchema),
+			messageSubscriptionKey: advancedStringFilterSchema,
+			processDefinitionId: advancedStringFilterSchema,
+			lastUpdatedDate: advancedDateTimeFilterSchema,
+			processInstanceKey: advancedStringFilterSchema,
+			elementId: advancedStringFilterSchema,
+			elementInstanceKey: advancedStringFilterSchema,
+			messageName: advancedStringFilterSchema,
+			correlationKey: advancedStringFilterSchema,
+			tenantId: advancedStringFilterSchema,
+		})
+		.partial(),
+});
+
+type QueryMessageSubscriptionsRequestBody = z.infer<typeof queryMessageSubscriptionRequestBodySchema>;
+
+const queryMessageSubscriptionsResponseBodySchema = getQueryResponseBodySchema(messageSubscriptionSchema);
+type QueryMessageSubscriptionsResponseBody = z.infer<typeof queryMessageSubscriptionsResponseBodySchema>;
+
+const queryMessageSubscriptions: Endpoint = {
+	method: 'POST',
+	getUrl() {
+		return `/${API_VERSION}/message-subscriptions/search`;
+	},
+};
+
+export {
+	queryMessageSubscriptions,
+	queryMessageSubscriptionRequestBodySchema,
+	queryMessageSubscriptionsResponseBodySchema,
+	messageSubscriptionSchema,
+};
+
+export type {
+	MessageSubscriptionState,
+	MessageSubscription,
+	QueryMessageSubscriptionsRequestBody,
+	QueryMessageSubscriptionsResponseBody,
+};

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/message-subscriptions.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/message-subscriptions.ts
@@ -9,6 +9,7 @@
 import {z} from 'zod';
 import {
 	advancedDateTimeFilterSchema,
+	advancedIntegerFilterSchema,
 	advancedStringFilterSchema,
 	API_VERSION,
 	type Endpoint,
@@ -76,11 +77,83 @@ const queryMessageSubscriptions: Endpoint = {
 	},
 };
 
+const correlatedMessageSubscriptionSchema = z.object({
+	subscriptionKey: z.string(),
+	processDefinitionId: z.string(),
+	processDefinitionKey: z.string(),
+	processInstanceKey: z.string(),
+	elementId: z.string(),
+	elementInstanceKey: z.string(),
+	messageSubscriptionState: messageSubscriptionStateSchema,
+	correlationTime: z.string(),
+	messageName: z.string(),
+	correlationKey: z.string(),
+	messageKey: z.string(),
+	partitionId: z.number().int(),
+	tenantId: z.string(),
+});
+type CorrelatedMessageSubscription = z.infer<typeof correlatedMessageSubscriptionSchema>;
+
+const queryCorrelatedMessageSubscriptionRequestBodySchema = getQueryRequestBodySchema({
+	sortFields: [
+		'correlationKey',
+		'correlationTime',
+		'elementId',
+		'elementInstanceKey',
+		'messageKey',
+		'messageName',
+		'partitionId',
+		'processDefinitionId',
+		'processDefinitionKey',
+		'processInstanceKey',
+		'subscriptionKey',
+		'tenantId',
+	] as const,
+	filter: z
+		.object({
+			correlationKey: advancedStringFilterSchema,
+			correlationTime: advancedDateTimeFilterSchema,
+			elementId: advancedStringFilterSchema,
+			elementInstanceKey: advancedStringFilterSchema,
+			messageKey: advancedStringFilterSchema,
+			messageName: advancedStringFilterSchema,
+			partitionId: advancedIntegerFilterSchema,
+			processDefinitionId: advancedStringFilterSchema,
+			processDefinitionKey: advancedStringFilterSchema,
+			processInstanceKey: advancedStringFilterSchema,
+			subscriptionKey: advancedStringFilterSchema,
+			tenantId: advancedStringFilterSchema,
+		})
+		.partial(),
+});
+
+type QueryCorrelatedMessageSubscriptionsRequestBody = z.infer<
+	typeof queryCorrelatedMessageSubscriptionRequestBodySchema
+>;
+
+const queryCorrelatedMessageSubscriptionsResponseBodySchema = getQueryResponseBodySchema(
+	correlatedMessageSubscriptionSchema,
+);
+type QueryCorrelatedMessageSubscriptionsResponseBody = z.infer<
+	typeof queryCorrelatedMessageSubscriptionsResponseBodySchema
+>;
+
+const queryCorrelatedMessageSubscriptions: Endpoint = {
+	method: 'POST',
+	getUrl() {
+		return `/${API_VERSION}/correlated-message-subscriptions/search`;
+	},
+};
+
 export {
 	queryMessageSubscriptions,
 	queryMessageSubscriptionRequestBodySchema,
 	queryMessageSubscriptionsResponseBodySchema,
 	messageSubscriptionSchema,
+	correlatedMessageSubscriptionSchema,
+	queryCorrelatedMessageSubscriptionRequestBodySchema,
+	queryCorrelatedMessageSubscriptionsResponseBodySchema,
+	queryCorrelatedMessageSubscriptions,
 };
 
 export type {
@@ -88,4 +161,7 @@ export type {
 	MessageSubscription,
 	QueryMessageSubscriptionsRequestBody,
 	QueryMessageSubscriptionsResponseBody,
+	CorrelatedMessageSubscription,
+	QueryCorrelatedMessageSubscriptionsRequestBody,
+	QueryCorrelatedMessageSubscriptionsResponseBody,
 };

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.10.2",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.5",
+        "@camunda/camunda-api-zod-schemas": "0.0.6",
         "@camunda/camunda-composite-components": "0.19.1",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.57.0",
@@ -557,9 +557,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.5.tgz",
-      "integrity": "sha512-VZJ4CO51NFR97zhScNRXl3ur3roWcp1nXGpXF+o8Ea8lCYcWtcC8EGlVAmg/mNFFFoQFWbci+84PKJPiwai6Cg==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.6.tgz",
+      "integrity": "sha512-d5RaWtUD+AuIt0ZT6oLKiGkGZPyb8N7VI1rPwXqmY9In1SSeyOI4O2mfs1sJl4nxq6PWRd1zPPMAg2oWRwM3ug==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.10.2",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.5",
+    "@camunda/camunda-api-zod-schemas": "0.0.6",
     "@camunda/camunda-composite-components": "0.19.1",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.57.0",

--- a/operate/client/src/modules/api/v2/messageSubscriptions/searchMessageSubscriptions.ts
+++ b/operate/client/src/modules/api/v2/messageSubscriptions/searchMessageSubscriptions.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type QueryMessageSubscriptionsRequestBody,
+  type QueryMessageSubscriptionsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import {requestWithThrow} from 'modules/request';
+
+const searchMessageSubscriptions = async (
+  payload: QueryMessageSubscriptionsRequestBody,
+) => {
+  return requestWithThrow<QueryMessageSubscriptionsResponseBody>({
+    url: endpoints.queryMessageSubscriptions.getUrl(),
+    method: endpoints.queryMessageSubscriptions.method,
+    body: payload,
+  });
+};
+
+export {searchMessageSubscriptions};

--- a/operate/client/src/modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions.ts
+++ b/operate/client/src/modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPostRequest} from '../../mockRequest';
+import {
+  type QueryMessageSubscriptionsResponseBody,
+  endpoints,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+
+const mockSearchMessageSubscriptions = () =>
+  mockPostRequest<QueryMessageSubscriptionsResponseBody>(
+    endpoints.queryMessageSubscriptions.getUrl(),
+  );
+
+export {mockSearchMessageSubscriptions};

--- a/operate/client/src/modules/queries/messageSubscriptions/useSearchMessageSubscriptions.ts
+++ b/operate/client/src/modules/queries/messageSubscriptions/useSearchMessageSubscriptions.ts
@@ -7,13 +7,8 @@
  */
 
 import {useQuery} from '@tanstack/react-query';
-import {
-  type QueryMessageSubscriptionsRequestBody,
-  type QueryUserTasksRequestBody,
-} from '@camunda/camunda-api-zod-schemas/8.8';
+import {type QueryMessageSubscriptionsRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
 import {searchMessageSubscriptions} from 'modules/api/v2/messageSubscriptions/searchMessageSubscriptions';
-
-const MESSAGE_SUBSCRIPTION_SEARCH_QUERY_KEY = 'incidentsSearch';
 
 const useSearchMessageSubscriptions = (
   payload: QueryMessageSubscriptionsRequestBody,
@@ -22,7 +17,7 @@ const useSearchMessageSubscriptions = (
   const {enabled = true} = options ?? {};
 
   return useQuery({
-    queryKey: [MESSAGE_SUBSCRIPTION_SEARCH_QUERY_KEY, payload],
+    queryKey: ['incidentsSearch', payload],
     queryFn: async () => {
       const {response, error} = await searchMessageSubscriptions(payload);
       if (response !== null) {

--- a/operate/client/src/modules/queries/messageSubscriptions/useSearchMessageSubscriptions.ts
+++ b/operate/client/src/modules/queries/messageSubscriptions/useSearchMessageSubscriptions.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import {
+  type QueryMessageSubscriptionsRequestBody,
+  type QueryUserTasksRequestBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import {searchMessageSubscriptions} from 'modules/api/v2/messageSubscriptions/searchMessageSubscriptions';
+
+const MESSAGE_SUBSCRIPTION_SEARCH_QUERY_KEY = 'incidentsSearch';
+
+const useSearchMessageSubscriptions = (
+  payload: QueryMessageSubscriptionsRequestBody,
+  options?: {enabled?: boolean},
+) => {
+  const {enabled = true} = options ?? {};
+
+  return useQuery({
+    queryKey: [MESSAGE_SUBSCRIPTION_SEARCH_QUERY_KEY, payload],
+    queryFn: async () => {
+      const {response, error} = await searchMessageSubscriptions(payload);
+      if (response !== null) {
+        return response;
+      }
+      throw error;
+    },
+    enabled,
+  });
+};
+
+export {useSearchMessageSubscriptions};

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.16.0",
         "@bpmn-io/form-js-viewer": "1.16.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.5",
+        "@camunda/camunda-api-zod-schemas": "0.0.6",
         "@camunda/camunda-composite-components": "0.20.2",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.87.1",
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.5.tgz",
-      "integrity": "sha512-VZJ4CO51NFR97zhScNRXl3ur3roWcp1nXGpXF+o8Ea8lCYcWtcC8EGlVAmg/mNFFFoQFWbci+84PKJPiwai6Cg==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.6.tgz",
+      "integrity": "sha512-d5RaWtUD+AuIt0ZT6oLKiGkGZPyb8N7VI1rPwXqmY9In1SSeyOI4O2mfs1sJl4nxq6PWRd1zPPMAg2oWRwM3ug==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.16.0",
     "@bpmn-io/form-js-viewer": "1.16.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.5",
+    "@camunda/camunda-api-zod-schemas": "0.0.6",
     "@camunda/camunda-composite-components": "0.20.2",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.87.1",


### PR DESCRIPTION
## Description

- Added schema for message subscriptions endpoint
- Created TanStack queries to prepare the migration of the message subscriptions in MetadataPopover


## Related issues

closes #33206 
