### PR TITLE
[Backport release-8.8.0] fix: add rest-api.yaml to JAR for swagger

### DIFF
--- a/zeebe/gateway-protocol/pom.xml
+++ b/zeebe/gateway-protocol/pom.xml
@@ -26,6 +26,7 @@
         <includes>
           <include>**/*.proto</include>
           <include>internal/generation-spec.yaml</include>
+          <include>rest-api.yaml</include>
         </includes>
       </resource>
     </resources>


### PR DESCRIPTION
# Description
Backport of #39023 to `release-8.8.0`.

relates to camunda/camunda#38875 #38440