### PR TITLE
Add new Camunda release migration test

### DIFF
--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -206,9 +206,13 @@ jobs:
           cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
           location: ${{ inputs.cluster-region || 'europe-west1-b' }}
       - name: Port-forward to gateway
-        run: kubectl port-forward --namespace "${{ inputs.name || 'release-migration-test' }}" svc/$release-zeebe-gateway 26500 &
+        run: |
+          release="${{ inputs.name || 'release-migration-test' }}"
+          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
       - name: Port-forward to Keycloak
-        run: kubectl port-forward --namespace "${{ inputs.name || 'release-migration-test' }}" svc/$release-keycloak 18080:80 &
+        run: |
+          release="${{ inputs.name || 'release-migration-test' }}"
+          kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
       - name: Install zbctl
         run: |
           # Install zbctl after port-forward - allowing wait for port-forward to be ready
@@ -346,9 +350,13 @@ jobs:
           cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
           location: ${{ inputs.cluster-region || 'europe-west1-b' }}
       - name: Port-forward to gateway
-        run: kubectl port-forward --namespace "${{ inputs.name || 'release-migration-test' }}" svc/$release-zeebe-gateway 26500 &
+        run: |
+          release="${{ inputs.name || 'release-migration-test' }}"
+          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
       - name: Port-forward to Keycloak
-        run: kubectl port-forward --namespace "${{ inputs.name || 'release-migration-test' }}" svc/$release-keycloak 18080:80 &
+        run: |
+          release="${{ inputs.name || 'release-migration-test' }}"
+          kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
       - name: Install zbctl
         run: |
           # Install zbctl after port-forward - allowing wait for port-forward to be ready

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -146,8 +146,7 @@ jobs:
     # the deploy will be run, when build is skipped or successful.
     if: |
       always() &&
-      (needs.build-zeebe-image.result == 'success' || needs.build-zeebe-image.result == 'skipped') &&
-      (needs.build-benchmark-images.result == 'success' || needs.build-benchmark-images.result == 'skipped')
+      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -212,10 +212,10 @@ jobs:
       - name: Add load
         run: |
           release=${{ inputs.name || 'release-migration-test' }}
-          kubectl port-forward svc/$release-zeebe-gateway 26500 &
-          kubectl port-forward svc/$release-keycloak 18080:80 &
+          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
+          kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
           # Get secret for connectors - to communicate with the cluster
-          export CONNECTOR_SECRET=$(kubectl get secrets $release-zeebe-identity-secret -o json | jq -r '.data."zeebe-secret"' | base64 -d)
+          export CONNECTOR_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
           export ZEEBE_CLIENT_ID=zeebe
@@ -270,13 +270,14 @@ jobs:
       - name: Extract secrets
         id: extract-secrets
         run: |
-          export OPTIMIZE_SECRET=$(kubectl get secret "ck-update-test-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
-          export CONNECTORS_SECRET=$(kubectl get secret "ck-update-test-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
-          export ORCHESTRATION_SECRET=$(kubectl get secret "ck-update-test-zeebe-identity-secret" -o jsonpath="{.data.zeebe-secret}" | base64 --decode)
-          export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret "ck-update-test-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
-          export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret "ck-update-test-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
-          export POSTGRESQL_ADMIN_PASSWORD=$(kubectl get secret "ck-update-test-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
-          export POSTGRESQL_KEYCLOAK_PASSWORD=$(kubectl get secret "ck-update-test-postgresql" -o jsonpath="{.data.password}" | base64 --decode)
+          release=${{ inputs.name || 'release-migration-test' }}
+          export OPTIMIZE_SECRET=$(kubectl get secret --namespace "$release" "ck-update-test-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
+          export CONNECTORS_SECRET=$(kubectl get secret --namespace "$release" "ck-update-test-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
+          export ORCHESTRATION_SECRET=$(kubectl get secret --namespace "$release" "ck-update-test-zeebe-identity-secret" -o jsonpath="{.data.zeebe-secret}" | base64 --decode)
+          export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret --namespace "$release" "ck-update-test-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
+          export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret --namespace "$release" "ck-update-test-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
+          export POSTGRESQL_ADMIN_PASSWORD=$(kubectl get secret --namespace "$release" "ck-update-test-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
+          export POSTGRESQL_KEYCLOAK_PASSWORD=$(kubectl get secret --namespace "$release" "ck-update-test-postgresql" -o jsonpath="{.data.password}" | base64 --decode)
           kubectl create secret generic camunda-credentials \
           --from-literal=identity-optimize-client-token=$OPTIMIZE_SECRET \
           --from-literal=identity-connectors-client-token=$CONNECTORS_SECRET \
@@ -348,10 +349,10 @@ jobs:
       - name: Add load
         run: |
           release=${{ inputs.name || 'release-migration-test' }}
-          kubectl port-forward svc/$release-zeebe-gateway 26500 &
-          kubectl port-forward svc/$release-keycloak 18080:80 &
+          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
+          kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
           # Get client secret from camunda credentials - which has been extracted during the upgrade
-          export ZEEBE_CLIENT_SECRET=$(kubectl get secrets camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
+          export ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
           export ZEEBE_CLIENT_ID=zeebe

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -391,7 +391,7 @@ jobs:
           done
           set -e
           # Activate job
-          key=$(./zbctl  activate jobs benchmark-task --insecure --timeout 1s | jq '.jobs[0].key')
+          key=$(./zbctl  activate jobs benchmark-task --insecure --timeout 1s | jq -r '.jobs[0].key')
           # Complete job from 8.7 version
           ./zbctl complete job $key --insecure
       - name: Summarize deployment

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -4,6 +4,7 @@
 name: Camunda Release migration test
 on:
   pull_request:
+
   workflow_dispatch:
     inputs:
       name:
@@ -61,7 +62,7 @@ on:
 
 concurrency:
   cancel-in-progress: true
-  group: ${{ inputs.name }}
+  group: ${{ inputs.name || 'release-migration-test' }}
 
 jobs:
   calculate-image-tag:
@@ -72,11 +73,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || 'release-8.8.0' }}
       - name: Get image tag
         id: image-tag
         run: |
-          echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "image-tag=${{ inputs.name || 'release-migration-test' }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
   build-camunda-image:
     name: Build Zeebe
     needs: calculate-image-tag
@@ -89,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || 'release-8.8.0' }}
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -134,7 +135,7 @@ jobs:
         name: Build Camunda Docker Image
         with:
           repository: 'gcr.io/zeebe-io/zeebe'
-          revision: ${{ inputs.ref }}
+          revision: ${{ inputs.ref || 'release-8.8.0' }}
           push: true
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}
           distball: ${{ steps.build-zeebe.outputs.distball }}
@@ -150,36 +151,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || 'release-8.8.0' }}
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v2.3.4
         with:
-          cluster_name: ${{ inputs.cluster }}
-          location: ${{ inputs.cluster-region }}
+          cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
+          location: ${{ inputs.cluster-region || 'europe-west1-b' }}
       - name: Clean up existing namespace
         run: |
-          kubectl delete namespace ${{ inputs.name }} --ignore-not-found=true
+          kubectl delete namespace ${{ inputs.name || 'release-migration-test' }} --ignore-not-found=true
       - name: Add camunda helm repo
         run: |
           helm repo add camunda https://helm.camunda.io
           helm repo update
       - name: Helm install
         run: >
-          helm install ${{ inputs.name }} camunda/camunda-platform
+          helm install ${{ inputs.name || 'release-migration-test' }} camunda/camunda-platform
           --wait --timeout 35m0s
-          --namespace ${{ inputs.name }}
+          --namespace ${{ inputs.name || 'release-migration-test' }}
           --create-namespace
           --render-subchart-notes
       - name: Summarize deployment
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Test \`${{ inputs.name }}\` values
+            ## Test \`${{ inputs.name || 'release-migration-test' }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            $(helm get values ${{ inputs.name || 'release-migration-test' }} -n ${{ inputs.name || 'release-migration-test' }})
             \`\`\`
           EOF
 
@@ -195,22 +196,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || 'release-8.8.0' }}
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v2.3.4
         with:
-          cluster_name: ${{ inputs.cluster }}
-          location: ${{ inputs.cluster-region }}
+          cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
+          location: ${{ inputs.cluster-region || 'europe-west1-b' }}
       - name: Install zbctl
         run: |
           wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
           chmod +x zbctl
       - name: Add load
         run: |
-          release=${{ inputs.name }}
+          release=${{ inputs.name || 'release-migration-test' }}
           kubectl port-forward svc/$release-zeebe-gateway 26500 &
           kubectl port-forward svc/$release-keycloak 18080:80 &
           # Get secret for connectors - to communicate with the cluster
@@ -229,9 +230,9 @@ jobs:
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Test \`${{ inputs.name }}\` values
+            ## Test \`${{ inputs.name || 'release-migration-test' }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            $(helm get values ${{ inputs.name || 'release-migration-test' }} -n ${{ inputs.name || 'release-migration-test' }})
             \`\`\`
           EOF
 
@@ -260,8 +261,8 @@ jobs:
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v2.3.4
         with:
-          cluster_name: ${{ inputs.cluster }}
-          location: ${{ inputs.cluster-region }}
+          cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
+          location: ${{ inputs.cluster-region || 'europe-west1-b' }}
       - name: Add camunda helm repo
         run: |
           helm repo add camunda https://helm.camunda.io
@@ -287,9 +288,9 @@ jobs:
       - name: Upgrade platform
         id: upgrade-platform
         run: |
-          helm upgrade ${{ inputs.name }} charts/camunda-platform-8.8/ \
+          helm upgrade ${{ inputs.name || 'release-migration-test' }} charts/camunda-platform-8.8/ \
           --wait --timeout 35m0s \
-          --namespace ${{ inputs.name }} \
+          --namespace ${{ inputs.name || 'release-migration-test' }} \
           --render-subchart-notes \
           --set orchestration.migration.identity.enabled=true \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
@@ -313,9 +314,9 @@ jobs:
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Test \`${{ inputs.name }}\` values
+            ## Test \`${{ inputs.name || 'release-migration-test' }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            $(helm get values ${{ inputs.name || 'release-migration-test' }} -n ${{ inputs.name || 'release-migration-test' }})
             \`\`\`
           EOF
 
@@ -331,22 +332,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || 'release-8.8.0' }}
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v2.3.4
         with:
-          cluster_name: ${{ inputs.cluster }}
-          location: ${{ inputs.cluster-region }}
+          cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
+          location: ${{ inputs.cluster-region || 'europe-west1-b' }}
       - name: Install zbctl
         run: |
           wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
           chmod +x zbctl
       - name: Add load
         run: |
-          release=${{ inputs.name }}
+          release=${{ inputs.name || 'release-migration-test' }}
           kubectl port-forward svc/$release-zeebe-gateway 26500 &
           kubectl port-forward svc/$release-keycloak 18080:80 &
           # Get client secret from camunda credentials - which has been extracted during the upgrade
@@ -366,8 +367,8 @@ jobs:
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Test \`${{ inputs.name }}\` values
+            ## Test \`${{ inputs.name || 'release-migration-test' }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            $(helm get values ${{ inputs.name || 'release-migration-test' }} -n ${{ inputs.name || 'release-migration-test' }})
             \`\`\`
           EOF

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -205,17 +205,14 @@ jobs:
         with:
           cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
           location: ${{ inputs.cluster-region || 'europe-west1-b' }}
-      - name: Install zbctl
-        run: |
-          wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
-          chmod +x zbctl
       - name: Add load
         run: |
           release=${{ inputs.name || 'release-migration-test' }}
           kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
           kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
-          # Wait for port-forward to be ready
-          sleep 5
+          # Install zbctl after port-forward - allowing wait for port-forward to be ready
+          wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
+          chmod +x zbctl
           # Get secret for connectors - to communicate with the cluster
           export CONNECTOR_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
@@ -344,17 +341,14 @@ jobs:
         with:
           cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
           location: ${{ inputs.cluster-region || 'europe-west1-b' }}
-      - name: Install zbctl
-        run: |
-          wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
-          chmod +x zbctl
       - name: Add load
         run: |
           release=${{ inputs.name || 'release-migration-test' }}
           kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
           kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
-          # Wait for port-forward to be ready
-          sleep 5
+          # Install zbctl after port-forward - allowing wait for port-forward to be ready
+          wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
+          chmod +x zbctl
           # Get client secret from camunda credentials - which has been extracted during the upgrade
           export ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
           # Set env vars to get zbctl working with the cluster

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -139,14 +139,6 @@ jobs:
 
   deploy-camunda-cluster-prev-version:
     name: Deploy previous version of Camunda Platform
-    needs:
-      - calculate-image-tag
-      - build-camunda-image
-    # To have the possibility to re-deploy the benchmarks without rebuilding the images,
-    # the deploy will be run, when build is skipped or successful.
-    if: |
-      always() &&
-      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -242,6 +234,10 @@ jobs:
     needs:
       - prev-version-create-instance
       - calculate-image-tag
+      - build-camunda-image
+    # To have the possibility to re-deploy the benchmarks without rebuilding the images,
+    # the deploy will be run, when build is skipped or successful.
+    if: always() && (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -228,8 +228,14 @@ jobs:
           export ZEEBE_CLIENT_ID=zeebe
           export ZEEBE_CLIENT_SECRET=$CONNECTOR_SECRET
           export ZEEBE_TOKEN_AUDIENCE=zeebe-api
-          # Check zbctl status
-          ./zbctl status --insecure
+          # Do not exit on error - as the port-forward might not be ready
+          set +e
+          while ./zbctl status --insecure; [[ $? -ne 0 ]];
+          do
+            echo "Result unsuccessful"
+            sleep 1
+          done
+          set -e
           # Deploy load
           ./zbctl deploy load-tests/load-tester/src/main/resources/bpmn/one_task.bpmn --insecure
           ./zbctl create instance benchmark --insecure
@@ -371,8 +377,14 @@ jobs:
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
           export ZEEBE_CLIENT_ID=zeebe
           export ZEEBE_TOKEN_AUDIENCE=zeebe-api
-          # Check zbctl status
-          ./zbctl status --insecure
+          # Do not exit on error - as the port-forward might not be ready
+          set +e
+          while ./zbctl status --insecure; [[ $? -ne 0 ]];
+          do
+            echo "Result unsuccessful"
+            sleep 1
+          done
+          set -e
           # Activate job
           key=$(./zbctl  activate jobs benchmark-task --insecure --timeout 1s | jq '.jobs[0].key')
           # Complete job from 8.7 version

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -159,6 +159,9 @@ jobs:
         with:
           cluster_name: ${{ inputs.cluster }}
           location: ${{ inputs.cluster-region }}
+      - name: Clean up existing namespace
+        run: |
+          kubectl delete namespace ${{ inputs.name }} --ignore-not-found=true
       - name: Add camunda helm repo
         run: |
           helm repo add camunda https://helm.camunda.io

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -59,6 +59,9 @@ on:
         type: string
         required: false
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ inputs.name }}
 
 jobs:
   calculate-image-tag:

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -1,0 +1,372 @@
+# description: Workflow to run Camunda Platform release migration tests
+# type: CI
+# owner: @Chris
+name: Camunda Release migration test
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Specifies the name of the migration test'
+        default: "release-migration-test"
+        type: string
+        required: false
+      reuse-tag:
+        description: 'Docker image tag, that should be reused for the test. Allows to skip the docker image build step'
+        type: string
+        default: ""
+        required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to benchmark'
+        default: 'release-8.8.0'
+        type: string
+        required: false
+      cluster:
+        description: 'Specifies which cluster to deploy the benchmark on'
+        default: 'zeebe-cluster'
+        type: string
+        required: false
+      cluster-region:
+        description: 'Specifies the cluster region. Needed to retrieve cluster credentials'
+        default: europe-west1-b
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      name:
+        description: 'Specifies the name of the migration test'
+        default: "release-migration-test"
+        type: string
+        required: false
+      reuse-tag:
+        description: 'Docker image tag, that should be reused for the test. Allows to skip the docker image build step'
+        type: string
+        default: ""
+        required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to test the migration to'
+        default: 'release-8.8.0'
+        type: string
+        required: false
+      cluster:
+        description: 'Specifies which cluster to deploy the test on'
+        default: 'zeebe-cluster'
+        type: string
+        required: false
+      cluster-region:
+        description: 'Specifies the cluster region. Needed to retrieve cluster credentials'
+        default: europe-west1-b
+        type: string
+        required: false
+
+
+jobs:
+  calculate-image-tag:
+    name: Calculate Image Tag
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ inputs.reuse-tag != '' && inputs.reuse-tag || steps.image-tag.outputs.image-tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Get image tag
+        id: image-tag
+        run: |
+          echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+  build-camunda-image:
+    name: Build Zeebe
+    needs: calculate-image-tag
+    if: ${{ inputs.reuse-tag == '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: ./.github/actions/build-frontend
+        name: Build Operate Frontend
+        id: build-operate-fe
+        with:
+          directory: ./operate/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Tasklist Frontend
+        id: build-tasklist-fe
+        with:
+          directory: ./tasklist/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Identity Frontend
+        id: build-identity-fe
+        with:
+          directory: ./identity/client
+      - uses: ./.github/actions/build-zeebe
+        name: Build Zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -PskipFrontendBuild -P\!include-optimize -Dmaven.test.skip=true
+      - uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - name: Login to GCR
+        uses: docker/login-action@v3
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+      - uses: ./.github/actions/build-platform-docker
+        name: Build Camunda Docker Image
+        with:
+          repository: 'gcr.io/zeebe-io/zeebe'
+          revision: ${{ inputs.ref }}
+          push: true
+          version: ${{ needs.calculate-image-tag.outputs.image-tag }}
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+          dockerfile: 'camunda.Dockerfile'
+
+  deploy-camunda-cluster-prev-version:
+    name: Deploy previous version of Camunda Platform
+    needs:
+      - calculate-image-tag
+      - build-camunda-image
+    # To have the possibility to re-deploy the benchmarks without rebuilding the images,
+    # the deploy will be run, when build is skipped or successful.
+    if: |
+      always() &&
+      (needs.build-zeebe-image.result == 'success' || needs.build-zeebe-image.result == 'skipped') &&
+      (needs.build-benchmark-images.result == 'success' || needs.build-benchmark-images.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v2.3.4
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Add camunda helm repo
+        run: |
+          helm repo add camunda https://helm.camunda.io
+          helm repo update
+      - name: Helm install
+        run: >
+          helm install ${{ inputs.name }} camunda/camunda-platform
+          --wait --timeout 35m0s
+          --namespace ${{ inputs.name }}
+          --create-namespace
+          --render-subchart-notes
+      - name: Summarize deployment
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Test \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            \`\`\`
+          EOF
+
+  prev-version-create-instance:
+    name: Previous version create instance
+    needs:
+      - deploy-camunda-cluster-prev-version
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v2.3.4
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Install zbctl
+        run: |
+          wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
+          chmod +x zbctl
+      - name: Add load
+        run: |
+          release=${{ inputs.name }}
+          kubectl port-forward svc/$release-zeebe-gateway 26500 &
+          kubectl port-forward svc/$release-keycloak 18080:80 &
+          # Get secret for connectors - to communicate with the cluster
+          export CONNECTOR_SECRET=$(kubectl get secrets $release-zeebe-identity-secret -o json | jq -r '.data."zeebe-secret"' | base64 -d)
+          # Set env vars to get zbctl working with the cluster
+          export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          export ZEEBE_CLIENT_ID=zeebe
+          export ZEEBE_CLIENT_SECRET=$CONNECTOR_SECRET
+          export ZEEBE_TOKEN_AUDIENCE=zeebe-api
+          # Check zbctl status
+          ./zbctl status --insecure
+          # Deploy load
+          ./zbctl deploy load-tests/load-tester/src/main/resources/bpmn/one_task.bpmn --insecure
+          ./zbctl create instance benchmark --insecure
+      - name: Summarize deployment
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Test \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            \`\`\`
+          EOF
+
+  upgrade-camunda-cluster-to-new-version:
+    name: Upgrade previous version of Camunda Platform to new version
+    needs:
+      - prev-version-create-instance
+      - calculate-image-tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'camunda/camunda-platform-helm'
+          ref: 'main'
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v2.3.4
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Add camunda helm repo
+        run: |
+          helm repo add camunda https://helm.camunda.io
+          helm repo update
+      - name: Extract secrets
+        id: extract-secrets
+        run: |
+          export OPTIMIZE_SECRET=$(kubectl get secret "ck-update-test-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
+          export CONNECTORS_SECRET=$(kubectl get secret "ck-update-test-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
+          export ORCHESTRATION_SECRET=$(kubectl get secret "ck-update-test-zeebe-identity-secret" -o jsonpath="{.data.zeebe-secret}" | base64 --decode)
+          export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret "ck-update-test-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
+          export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret "ck-update-test-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
+          export POSTGRESQL_ADMIN_PASSWORD=$(kubectl get secret "ck-update-test-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
+          export POSTGRESQL_KEYCLOAK_PASSWORD=$(kubectl get secret "ck-update-test-postgresql" -o jsonpath="{.data.password}" | base64 --decode)
+          kubectl create secret generic camunda-credentials \
+          --from-literal=identity-optimize-client-token=$OPTIMIZE_SECRET \
+          --from-literal=identity-connectors-client-token=$CONNECTORS_SECRET \
+          --from-literal=identity-orchestration-client-token=$ORCHESTRATION_SECRET \
+          --from-literal=identity-keycloak-admin-password=$KEYCLOAK_ADMIN_SECRET \
+          --from-literal=identity-keycloak-postgresql-admin-password=$POSTGRESQL_ADMIN_PASSWORD \
+          --from-literal=identity-keycloak-postgresql-user-password=$POSTGRESQL_KEYCLOAK_PASSWORD
+
+      - name: Upgrade platform
+        id: upgrade-platform
+        run: |
+          helm upgrade ${{ inputs.name }} charts/camunda-platform-8.8/ \
+          --wait --timeout 35m0s \
+          --namespace ${{ inputs.name }} \
+          --render-subchart-notes \
+          --set orchestration.migration.identity.enabled=true \
+          --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
+          --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \
+          --set identityKeycloak.enabled=true \
+          --set identity.enabled=true \
+          --set identity.firstUser.enabled=false \
+          --set orchestration.security.authentication.method=oidc \
+          --set global.identity.auth.enabled=true \
+          --set orchestration.importer.enabled=true \
+          --set orchestration.migration.data.enabled=true \
+          --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials \
+          --set connectors.security.authentication.oidc.secret.existingSecretKey=identity-connectors-client-token \
+          -f charts/camunda-platform-8.8/values-digest.yaml \
+          --set orchestration.image.registry=gcr.io
+          --set orchestration.image.repository=zeebe-io/zeebe
+          --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set "orchestration.env[0].name=CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK" \
+          --set-string "orchestration.env[0].value=false"
+      - name: Summarize deployment
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Test \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            \`\`\`
+          EOF
+
+  target-version-complete-job:
+    name: Target version - complete job
+    needs:
+      - upgrade-camunda-cluster-to-new-version
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v2.3.4
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Install zbctl
+        run: |
+          wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
+          chmod +x zbctl
+      - name: Add load
+        run: |
+          release=${{ inputs.name }}
+          kubectl port-forward svc/$release-zeebe-gateway 26500 &
+          kubectl port-forward svc/$release-keycloak 18080:80 &
+          # Get client secret from camunda credentials - which has been extracted during the upgrade
+          export ZEEBE_CLIENT_SECRET=$(kubectl get secrets camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
+          # Set env vars to get zbctl working with the cluster
+          export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          export ZEEBE_CLIENT_ID=zeebe
+          export ZEEBE_TOKEN_AUDIENCE=zeebe-api
+          # Check zbctl status
+          ./zbctl status --insecure
+          # Activate job
+          key=$(./zbctl  activate jobs benchmark-task --insecure --timeout 1s | jq '.jobs[0].key')
+
+          # Complete job from 8.7 version
+          ./zbctl complete job $key --insecure
+      - name: Summarize deployment
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Test \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            \`\`\`
+          EOF

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -320,10 +320,11 @@ jobs:
           --set orchestration.migration.data.enabled=true \
           --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set connectors.security.authentication.oidc.secret.existingSecretKey=identity-connectors-client-token \
-          -f charts/camunda-platform-8.8/values-digest.yaml \
           --set orchestration.image.registry=gcr.io
           --set orchestration.image.repository=zeebe-io/zeebe
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set connectors.image.tag=SNAPSHOT
+          --set identity.image.tag=8.8-SNAPSHOT
           --set "orchestration.env[0].name=CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK" \
           --set-string "orchestration.env[0].value=false"
       - name: Summarize deployment

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -320,11 +320,11 @@ jobs:
           --set orchestration.migration.data.enabled=true \
           --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set connectors.security.authentication.oidc.secret.existingSecretKey=identity-connectors-client-token \
-          --set orchestration.image.registry=gcr.io
-          --set orchestration.image.repository=zeebe-io/zeebe
-          --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set connectors.image.tag=SNAPSHOT
-          --set identity.image.tag=8.8-SNAPSHOT
+          --set orchestration.image.registry=gcr.io \
+          --set orchestration.image.repository=zeebe-io/zeebe \
+          --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
+          --set connectors.image.tag=SNAPSHOT \
+          --set identity.image.tag=8.8-SNAPSHOT \
           --set "orchestration.env[0].name=CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK" \
           --set-string "orchestration.env[0].value=false"
       - name: Summarize deployment

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -271,13 +271,13 @@ jobs:
         id: extract-secrets
         run: |
           release=${{ inputs.name || 'release-migration-test' }}
-          export OPTIMIZE_SECRET=$(kubectl get secret --namespace "$release" "ck-update-test-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
-          export CONNECTORS_SECRET=$(kubectl get secret --namespace "$release" "ck-update-test-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
-          export ORCHESTRATION_SECRET=$(kubectl get secret --namespace "$release" "ck-update-test-zeebe-identity-secret" -o jsonpath="{.data.zeebe-secret}" | base64 --decode)
-          export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret --namespace "$release" "ck-update-test-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
-          export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret --namespace "$release" "ck-update-test-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
-          export POSTGRESQL_ADMIN_PASSWORD=$(kubectl get secret --namespace "$release" "ck-update-test-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
-          export POSTGRESQL_KEYCLOAK_PASSWORD=$(kubectl get secret --namespace "$release" "ck-update-test-postgresql" -o jsonpath="{.data.password}" | base64 --decode)
+          export OPTIMIZE_SECRET=$(kubectl get secret --namespace "$release" "$release-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
+          export CONNECTORS_SECRET=$(kubectl get secret --namespace "$release" "$release-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
+          export ORCHESTRATION_SECRET=$(kubectl get secret --namespace "$release" "$release-zeebe-identity-secret" -o jsonpath="{.data.zeebe-secret}" | base64 --decode)
+          export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret --namespace "$release" "$release-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
+          export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret --namespace "$release" "$release-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
+          export POSTGRESQL_ADMIN_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
+          export POSTGRESQL_KEYCLOAK_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.password}" | base64 --decode)
           kubectl create secret generic camunda-credentials \
           --from-literal=identity-optimize-client-token=$OPTIMIZE_SECRET \
           --from-literal=identity-connectors-client-token=$CONNECTORS_SECRET \

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -214,6 +214,8 @@ jobs:
           release=${{ inputs.name || 'release-migration-test' }}
           kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
           kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
+          # Wait for port-forward to be ready
+          sleep 5
           # Get secret for connectors - to communicate with the cluster
           export CONNECTOR_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
@@ -351,6 +353,8 @@ jobs:
           release=${{ inputs.name || 'release-migration-test' }}
           kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
           kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
+          # Wait for port-forward to be ready
+          sleep 5
           # Get client secret from camunda credentials - which has been extracted during the upgrade
           export ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
           # Set env vars to get zbctl working with the cluster

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -224,15 +224,15 @@ jobs:
         run: |
           release="${{ inputs.name || 'release-migration-test' }}"
           # Get secret for connectors - to communicate with the cluster
-          export CONNECTOR_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
           export ZEEBE_CLIENT_ID=zeebe
-          export ZEEBE_CLIENT_SECRET=$CONNECTOR_SECRET
+          export ZEEBE_CLIENT_SECRET
           export ZEEBE_TOKEN_AUDIENCE=zeebe-api
           # Do not exit on error - as the port-forward might not be ready
           set +e
-          while ./zbctl status --insecure; [[ $? -ne 0 ]];
+          while ! ./zbctl status --insecure;
           do
             echo "Result unsuccessful"
             sleep 1
@@ -286,21 +286,28 @@ jobs:
         id: extract-secrets
         run: |
           release=${{ inputs.name || 'release-migration-test' }}
-          export OPTIMIZE_SECRET=$(kubectl get secret --namespace "$release" "$release-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
-          export CONNECTORS_SECRET=$(kubectl get secret --namespace "$release" "$release-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
-          export ORCHESTRATION_SECRET=$(kubectl get secret --namespace "$release" "$release-zeebe-identity-secret" -o jsonpath="{.data.zeebe-secret}" | base64 --decode)
-          export KEYCLOAK_ADMIN_SECRET=$(kubectl get secret --namespace "$release" "$release-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
-          export KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret --namespace "$release" "$release-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
-          export POSTGRESQL_ADMIN_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
-          export POSTGRESQL_KEYCLOAK_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.password}" | base64 --decode)
+          OPTIMIZE_SECRET=$(kubectl get secret --namespace "$release" "$release-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
+          export OPTIMIZE_SECRET
+          CONNECTORS_SECRET=$(kubectl get secret --namespace "$release" "$release-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
+          export CONNECTORS_SECRET
+          ORCHESTRATION_SECRET=$(kubectl get secret --namespace "$release" "$release-zeebe-identity-secret" -o jsonpath="{.data.zeebe-secret}" | base64 --decode)
+          export ORCHESTRATION_SECRET
+          KEYCLOAK_ADMIN_SECRET=$(kubectl get secret --namespace "$release" "$release-keycloak" -o jsonpath="{.data.admin-password}" | base64 --decode)
+          export KEYCLOAK_ADMIN_SECRET
+          KEYCLOAK_MANAGEMENT_SECRET=$(kubectl get secret --namespace "$release" "$release-keycloak" -o jsonpath="{.data.management-password}" | base64 --decode)
+          export KEYCLOAK_MANAGEMENT_SECRET
+          POSTGRESQL_ADMIN_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
+          export POSTGRESQL_ADMIN_PASSWORD
+          POSTGRESQL_KEYCLOAK_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.password}" | base64 --decode)
+          export POSTGRESQL_KEYCLOAK_PASSWORD
           kubectl create secret generic camunda-credentials \
           --namespace $release \
-          --from-literal=identity-optimize-client-token=$OPTIMIZE_SECRET \
-          --from-literal=identity-connectors-client-token=$CONNECTORS_SECRET \
-          --from-literal=identity-orchestration-client-token=$ORCHESTRATION_SECRET \
-          --from-literal=identity-keycloak-admin-password=$KEYCLOAK_ADMIN_SECRET \
-          --from-literal=identity-keycloak-postgresql-admin-password=$POSTGRESQL_ADMIN_PASSWORD \
-          --from-literal=identity-keycloak-postgresql-user-password=$POSTGRESQL_KEYCLOAK_PASSWORD
+          --from-literal=identity-optimize-client-token="$OPTIMIZE_SECRET" \
+          --from-literal=identity-connectors-client-token="$CONNECTORS_SECRET" \
+          --from-literal=identity-orchestration-client-token="$ORCHESTRATION_SECRET" \
+          --from-literal=identity-keycloak-admin-password="$KEYCLOAK_ADMIN_SECRET" \
+          --from-literal=identity-keycloak-postgresql-admin-password="$POSTGRESQL_ADMIN_PASSWORD" \
+          --from-literal=identity-keycloak-postgresql-user-password="$POSTGRESQL_KEYCLOAK_PASSWORD"
 
       - name: Upgrade platform
         id: upgrade-platform
@@ -377,14 +384,15 @@ jobs:
         run: |
           release="${{ inputs.name || 'release-migration-test' }}"
           # Get client secret from camunda credentials - which has been extracted during the upgrade
-          export ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
+          ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
           export ZEEBE_AUTHORIZATION_SERVER_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
           export ZEEBE_CLIENT_ID=zeebe
+          export ZEEBE_CLIENT_SECRET
           export ZEEBE_TOKEN_AUDIENCE=zeebe-api
           # Do not exit on error - as the port-forward might not be ready
           set +e
-          while ./zbctl status --insecure; [[ $? -ne 0 ]];
+          while ! ./zbctl status --insecure;
           do
             echo "Result unsuccessful"
             sleep 1
@@ -393,7 +401,7 @@ jobs:
           # Activate job
           key=$(./zbctl  activate jobs benchmark-task --insecure --timeout 1s | jq -r '.jobs[0].key')
           # Complete job from 8.7 version
-          ./zbctl complete job $key --insecure
+          ./zbctl complete job "$key" --insecure
       - name: Summarize deployment
         if: success()
         run: |

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -303,6 +303,7 @@ jobs:
       - name: Upgrade platform
         id: upgrade-platform
         run: |
+          helm dependency build charts/camunda-platform-8.8/
           helm upgrade ${{ inputs.name || 'release-migration-test' }} charts/camunda-platform-8.8/ \
           --wait --timeout 35m0s \
           --namespace ${{ inputs.name || 'release-migration-test' }} \

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -205,14 +205,18 @@ jobs:
         with:
           cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
           location: ${{ inputs.cluster-region || 'europe-west1-b' }}
-      - name: Add load
+      - name: Port-forward to gateway
+        run: kubectl port-forward --namespace "${{ inputs.name || 'release-migration-test' }}" svc/$release-zeebe-gateway 26500 &
+      - name: Port-forward to Keycloak
+        run: kubectl port-forward --namespace "${{ inputs.name || 'release-migration-test' }}" svc/$release-keycloak 18080:80 &
+      - name: Install zbctl
         run: |
-          release=${{ inputs.name || 'release-migration-test' }}
-          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
-          kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
           # Install zbctl after port-forward - allowing wait for port-forward to be ready
           wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
           chmod +x zbctl
+      - name: Add load
+        run: |
+          release="${{ inputs.name || 'release-migration-test' }}"
           # Get secret for connectors - to communicate with the cluster
           export CONNECTOR_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
@@ -341,14 +345,18 @@ jobs:
         with:
           cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
           location: ${{ inputs.cluster-region || 'europe-west1-b' }}
-      - name: Add load
+      - name: Port-forward to gateway
+        run: kubectl port-forward --namespace "${{ inputs.name || 'release-migration-test' }}" svc/$release-zeebe-gateway 26500 &
+      - name: Port-forward to Keycloak
+        run: kubectl port-forward --namespace "${{ inputs.name || 'release-migration-test' }}" svc/$release-keycloak 18080:80 &
+      - name: Install zbctl
         run: |
-          release=${{ inputs.name || 'release-migration-test' }}
-          kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
-          kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
           # Install zbctl after port-forward - allowing wait for port-forward to be ready
           wget https://github.com/camunda/camunda/releases/download/8.5.8/zbctl
           chmod +x zbctl
+      - name: Add load
+        run: |
+          release="${{ inputs.name || 'release-migration-test' }}"
           # Get client secret from camunda credentials - which has been extracted during the upgrade
           export ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
@@ -359,7 +367,6 @@ jobs:
           ./zbctl status --insecure
           # Activate job
           key=$(./zbctl  activate jobs benchmark-task --insecure --timeout 1s | jq '.jobs[0].key')
-
           # Complete job from 8.7 version
           ./zbctl complete job $key --insecure
       - name: Summarize deployment

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -3,7 +3,6 @@
 # owner: @Chris
 name: Camunda Release migration test
 on:
-  pull_request:
   schedule:
     # Runs at 04:00. every day https://crontab.guru/#0_4_*_*_*
     - cron: 0 4 * * *

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -196,7 +196,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || 'release-8.8.0' }}
+          ref: main
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -403,3 +403,34 @@ jobs:
             $(helm get values ${{ inputs.name || 'release-migration-test' }} -n ${{ inputs.name || 'release-migration-test' }})
             \`\`\`
           EOF
+  notify:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    needs: [ target-version-complete-job ]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v4
+      - id: slack-notify
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: *Daily Camunda migration test failed:*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "@zeebe-medic Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -4,7 +4,9 @@
 name: Camunda Release migration test
 on:
   pull_request:
-
+  schedule:
+    # Runs at 04:00. every day https://crontab.guru/#0_4_*_*_*
+    - cron: 0 4 * * *
   workflow_dispatch:
     inputs:
       name:

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -292,6 +292,7 @@ jobs:
           export POSTGRESQL_ADMIN_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.postgres-password}" | base64 --decode)
           export POSTGRESQL_KEYCLOAK_PASSWORD=$(kubectl get secret --namespace "$release" "$release-postgresql" -o jsonpath="{.data.password}" | base64 --decode)
           kubectl create secret generic camunda-credentials \
+          --namespace $release \
           --from-literal=identity-optimize-client-token=$OPTIMIZE_SECRET \
           --from-literal=identity-connectors-client-token=$CONNECTORS_SECRET \
           --from-literal=identity-orchestration-client-token=$ORCHESTRATION_SECRET \


### PR DESCRIPTION
## Description

<img width="2488" height="601" alt="2025-10-02_16-51" src="https://github.com/user-attachments/assets/610d2c86-fec5-4513-911f-4e24878ff370" />


 * Add a new GitHub workflow to test the migration of Camunda (from 8.7 to 8.8).
   * This workflow is extensible and customizable to also test other migrations to different branches
 * This allows us to test completely the integration of the latest Helm changes with the release branch of the mono repo

### Scenario of the test

- We are starting with the current 8.7 Helm chart installation (default Helm install 12.x)
- We deploy a process and create an instance via `zbctl` (using OIDC)
- We extract secrets and create a new `camunda-credentials` secret
- We upgrade to the 8.8 chart from the Helm repository, with the pre-built custom Camunda image
- That can be referenced on workflow start - by default, it uses the release branch `release-8.8.0`
- After the upgrade, we complete the existing Camunda Job via `zbctl` (using OIDC)

## Related issues

Context: https://app.slack.com/client/T0PM0P1SA/C09J1F6NJJ0

> We are missing good integration between our mono repo branches, release artifacts, and the Helm chart deliverables

This PR tries to overcome this.
