### PR TITLE
feat: Exclude Oracle driver from core Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,6 +150,7 @@ EXPOSE 8080 26500 26501 26502
 VOLUME /tmp
 VOLUME ${ZB_HOME}/data
 VOLUME ${ZB_HOME}/logs
+VOLUME /driver-lib
 
 RUN groupadd --gid 1001 camunda && \
     useradd --system --gid 1001 --uid 1001 --home ${ZB_HOME} camunda && \
@@ -163,6 +164,8 @@ RUN groupadd --gid 1001 camunda && \
 
 COPY --link --chown=1001:0 zeebe/docker/utils/startup.sh /usr/local/bin/startup.sh
 COPY --from=dist --chown=1001:0 /zeebe/camunda-zeebe ${ZB_HOME}
+
+RUN ln -s /driver-lib ${ZB_HOME}/driver-lib
 
 USER 1001:1001
 

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -149,6 +149,7 @@ EXPOSE 8080 26500 26501 26502
 VOLUME /tmp
 VOLUME ${CAMUNDA_HOME}/data
 VOLUME ${CAMUNDA_HOME}/logs
+VOLUME /driver-lib
 
 RUN groupadd --gid 1001 camunda && \
     useradd --system --gid 1001 --uid 1001 --home ${CAMUNDA_HOME} camunda && \
@@ -161,6 +162,8 @@ RUN groupadd --gid 1001 camunda && \
     chmod -R 0775 ${CAMUNDA_HOME}
 
 COPY --from=dist --chown=1001:0 /camunda/camunda-zeebe ${CAMUNDA_HOME}
+
+RUN ln -s /driver-lib ${CAMUNDA_HOME}/driver-lib
 
 USER 1001:1001
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -335,6 +335,7 @@
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc8</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -775,6 +776,8 @@
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
           <extraJvmArguments>-XX:+ExitOnOutOfMemoryError
             -Dfile.encoding=UTF-8 -Xshare:auto</extraJvmArguments>
+          <!-- This will be added to the classpath as /urs/local/camunda/driver-lib/* -->
+          <endorsedDir>driver-lib</endorsedDir>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <platforms>
             <platform>windows</platform>

--- a/dist/src/main/assembly.xml
+++ b/dist/src/main/assembly.xml
@@ -16,6 +16,10 @@
     <fileSet>
       <directory>${project.build.directory}/camunda-zeebe</directory>
       <outputDirectory>/</outputDirectory>
+      <excludes>
+        <!-- We need to exclude Oracle driver from the distribution in any case -->
+        <exclude>lib/ojdbc*.jar</exclude>
+      </excludes>
     </fileSet>
     <fileSet>
       <directory>${maven.multiModuleProjectDirectory}/licenses</directory>


### PR DESCRIPTION
## Description

For licensing reasons we cannot ship Oracle drivers with the Camunda/Zeebe distribution. So we need to exclude Oracle drivers from the Docker images and provide the possibility to load them from an external source instead.

* Exclude Oracle drivers from Docker images
* Mount a `/driver-lib` volume
* Add JARs from `/driver-lib` to `CLASSPATH`

## Related issues

closes #31267

A DockerTest will be added with #39296 when the new SNAPSHOT image is available.
