### PR TITLE
feat: implement preference configuration for username clientid claim

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/config/OidcAuthenticationConfigurationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcAuthenticationConfigurationTest.java
@@ -99,6 +99,14 @@ public class OidcAuthenticationConfigurationTest {
             OidcAuthenticationConfiguration.builder().usernameClaim("sub1").build(),
             true),
         Arguments.of(
+            "preferUsernameClaim is set",
+            OidcAuthenticationConfiguration.builder().preferUsernameClaim(true).build(),
+            true),
+        Arguments.of(
+            "preferUsernameClaim is not set",
+            OidcAuthenticationConfiguration.builder().build(),
+            false),
+        Arguments.of(
             "issuerUri is set",
             OidcAuthenticationConfiguration.builder().issuerUri("issuer").build(),
             true),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/oidc/OverlappingUsernameAndClientIdClaimTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/oidc/OverlappingUsernameAndClientIdClaimTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.oidc;
+
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CredentialsProvider;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.it.util.TestHelper;
+import io.camunda.qa.util.auth.ClientDefinition;
+import io.camunda.qa.util.auth.TestClient;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.security.entity.AuthenticationMethod;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * This class tests that the setting camunda.security.authentication.oidc.preferUsernameClaim
+ * property works correctly when both client id and username claim are present in an access token.
+ *
+ * <p>Note that it uses a CamundaClient to make the API request under test. While in realworld
+ * scenarios these are used by _clients_, the test's setup is so that the request will be treated as
+ * a user in the Orchestration Cluster. This is out of convenice as we lack the ability to perform
+ * the OIDC authorization code flow in our tests and therefore cannot authenticate like a user would
+ * in real-life.
+ *
+ * <p>Since the matching of user/client is decouple from the concept of user/client in OIDC, that's
+ * okay (the OC can match any token, regardless of originating authentication flow, to be either a
+ * user or a client.
+ */
+@MultiDbTest(setupKeycloak = true)
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class OverlappingUsernameAndClientIdClaimTest {
+
+  static final String PRINCIPAL_NAME = "principal";
+
+  @MultiDbTestApplication
+  static final TestCamundaApplication STANDALONE_CAMUNDA =
+      new TestCamundaApplication()
+          .withAuthenticationMethod(AuthenticationMethod.OIDC)
+          .withAuthorizationsEnabled()
+          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(c -> c.getAuthentication().getOidc().setClientIdClaim("client_id"))
+          .withSecurityConfig(c -> c.getAuthentication().getOidc().setUsernameClaim("client_id"))
+          .withSecurityConfig(c -> c.getAuthentication().getOidc().setPreferUsernameClaim(true))
+          .withSecurityConfig(c -> c.getInitialization().getUsers().clear())
+          .withSecurityConfig(
+              c ->
+                  c.getInitialization()
+                      .getDefaultRoles()
+                      .put(
+                          "admin", Map.of("users", List.of("admin"), "clients", List.of("admin"))));
+
+  // Injected by the MultiDbTest extension
+  private static KeycloakContainer keycloak;
+
+  private static long processInstanceKey;
+
+  @ClientDefinition
+  private static final TestClient ADMIN_CLIENT = new TestClient("admin", List.of());
+
+  @ClientDefinition
+  private static final TestClient NON_PRIVILEGED_CLIENT = new TestClient(PRINCIPAL_NAME, List.of());
+
+  @BeforeAll
+  public static void beforeAll(@TempDir final Path tempDir) throws Exception {
+    try (CamundaClient adminClient = createCamundaClient(ADMIN_CLIENT.clientId(), tempDir)) {
+
+      TestHelper.deployResource(adminClient, "process/service_tasks_v1.bpmn");
+
+      processInstanceKey =
+          TestHelper.startProcessInstance(adminClient, "service_tasks_v1").getProcessInstanceKey();
+      TestHelper.waitForProcessInstances(
+          adminClient, q -> q.processInstanceKey(processInstanceKey), 1);
+
+      adminClient
+          .newCreateAuthorizationCommand()
+          .ownerId(PRINCIPAL_NAME)
+          .ownerType(
+              OwnerType
+                  .USER) // important: we are creating the authorization for a user, not a client
+          // so that the test will only succeed if the CamundaClient authenticates
+          // as a user
+          .resourceId("*")
+          .resourceType(ResourceType.PROCESS_DEFINITION)
+          .permissionTypes(PermissionType.READ_PROCESS_INSTANCE)
+          .send()
+          .join();
+
+      Awaitility.await("should wait until authorization is available")
+          .atMost(TIMEOUT_DATA_AVAILABILITY)
+          .ignoreExceptions() // Ignore exceptions and continue retrying
+          .untilAsserted(
+              () ->
+                  assertThat(
+                          adminClient
+                              .newAuthorizationSearchRequest()
+                              .filter(f -> f.ownerId(PRINCIPAL_NAME))
+                              .send()
+                              .join()
+                              .items())
+                      .hasSize(1));
+    }
+  }
+
+  @Test
+  public void shouldTreatOverlappingRequestAsUser(@TempDir final Path tempDir) throws Exception {
+    // given
+    // an authorization for the user (!) principal (see test setup)
+    try (CamundaClient client = createCamundaClient(PRINCIPAL_NAME, tempDir)) {
+
+      // when
+      final List<ProcessInstance> processInstances =
+          client.newProcessInstanceSearchRequest().send().join().items();
+
+      // then
+      // the process instance is returned successfully, because
+      // the request was treated as a user request, not a client request
+      assertThat(processInstances).hasSize(1);
+    }
+  }
+
+  private static CamundaClient createCamundaClient(
+      final String oAuthClientName, final Path tempDir) {
+    return STANDALONE_CAMUNDA
+        .newClientBuilder()
+        .preferRestOverGrpc(true)
+        .credentialsProvider(buildOAuthCredentialsProvider(oAuthClientName, tempDir))
+        .build();
+  }
+
+  private static CredentialsProvider buildOAuthCredentialsProvider(
+      final String oAuthClientName, final Path tempDir) {
+    return new OAuthCredentialsProviderBuilder()
+        .clientId(oAuthClientName)
+        .clientSecret(oAuthClientName) // assumption that they are the same
+        .audience("zeebe")
+        .authorizationServerUrl(
+            keycloak.getAuthServerUrl() + "/realms/camunda/protocol/openid-connect/token")
+        .credentialsCachePath(tempDir.resolve("default").toString())
+        .build();
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -238,6 +238,7 @@ public class OidcAuthenticationConfiguration {
         || audiences != null
         || clientIdClaim != null
         || groupsClaim != null
+        || preferUsernameClaim
         || organizationId != null
         || !CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC.equals(clientAuthenticationMethod)
         || assertionConfiguration.getKeystore().getPath() != null

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -44,6 +44,7 @@ public class OidcAuthenticationConfiguration {
   private String usernameClaim = "sub";
   private String clientIdClaim;
   private String groupsClaim;
+  private boolean preferUsernameClaim;
   private String organizationId;
   private List<String> resource;
   private String clientAuthenticationMethod = CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC;
@@ -196,6 +197,14 @@ public class OidcAuthenticationConfiguration {
     return groupsClaim != null && !groupsClaim.isBlank();
   }
 
+  public boolean isPreferUsernameClaim() {
+    return preferUsernameClaim;
+  }
+
+  public void setPreferUsernameClaim(final boolean preferUsernameClaim) {
+    this.preferUsernameClaim = preferUsernameClaim;
+  }
+
   public String getClientAuthenticationMethod() {
     return clientAuthenticationMethod;
   }
@@ -262,6 +271,7 @@ public class OidcAuthenticationConfiguration {
     private String usernameClaim = "sub";
     private String clientIdClaim;
     private String groupsClaim;
+    private boolean preferUsernameClaim;
     private String organizationId;
     private String clientAuthenticationMethod = CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC;
     private AssertionConfiguration assertionConfiguration = new AssertionConfiguration();
@@ -340,6 +350,11 @@ public class OidcAuthenticationConfiguration {
     public Builder groupsClaim(final String groupsClaim) {
       new OidcGroupsLoader(groupsClaim); // Validation from original setter
       this.groupsClaim = groupsClaim;
+      return this;
+    }
+
+    public Builder preferUsernameClaim(final boolean preferUsernameClaim) {
+      this.preferUsernameClaim = preferUsernameClaim;
       return this;
     }
 

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -390,6 +390,7 @@ public class OidcAuthenticationConfiguration {
       config.setUsernameClaim(usernameClaim);
       config.setClientIdClaim(clientIdClaim);
       config.setGroupsClaim(groupsClaim);
+      config.setPreferUsernameClaim(preferUsernameClaim);
       config.setOrganizationId(organizationId);
       config.setClientAuthenticationMethod(clientAuthenticationMethod);
       config.setAssertion(assertionConfiguration);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -426,42 +426,6 @@ public class AuthenticationInterceptorTest {
   }
 
   @Test
-  public void addsUsernameInPreferenceToClientIdWhenPreferUsernameClaimIsTrue() {
-    // given
-    final Metadata metadata = createAuthHeader();
-    final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
-        new CloseStatusCapturingServerCall();
-
-    // Create a mock JWT with claims
-    final var jwt = mock(org.springframework.security.oauth2.jwt.Jwt.class);
-    final Map<String, Object> claims = Map.of("username", "test-user", "application_id", "app-id");
-    when(jwt.getClaims()).thenReturn(claims);
-
-    // Configure the JwtDecoder to return our mock JWT
-    final var jwtDecoder = mock(JwtDecoder.class);
-    when(jwtDecoder.decode(anyString())).thenReturn(jwt);
-
-    final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
-    oidcAuthenticationConfiguration.setUsernameClaim("username");
-    oidcAuthenticationConfiguration.setClientIdClaim("application_id");
-    oidcAuthenticationConfiguration.setPreferUsernameClaim(true);
-
-    // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
-        .interceptCall(
-            closeStatusCapturingServerCall,
-            metadata,
-            (call, headers) -> {
-              // then
-              assertUsername().isEqualTo("test-user");
-              assertClientId().isNull();
-
-              call.close(Status.OK, headers);
-              return null;
-            });
-  }
-
-  @Test
   public void
       addsUsernameToOidcContextWhenPreferUsernameClaimIsTrueWhenUsernameAndClientIdClaimsArePresent() {
     // given
@@ -516,8 +480,7 @@ public class AuthenticationInterceptorTest {
 
     final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
     oidcAuthenticationConfiguration.setUsernameClaim("username");
-    oidcAuthenticationConfiguration.setClientIdClaim("application_id");
-    oidcAuthenticationConfiguration.setPreferUsernameClaim(true);
+    oidcAuthenticationConfiguration.setClientIdClaim("missing_claim");
 
     // when
     new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -426,7 +426,117 @@ public class AuthenticationInterceptorTest {
   }
 
   @Test
-  public void addsClientIdInPreferenceToUsernameInOidcToContext() {
+  public void addsUsernameInPreferenceToClientIdWhenPreferUsernameClaimIsTrue() {
+    // given
+    final Metadata metadata = createAuthHeader();
+    final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
+        new CloseStatusCapturingServerCall();
+
+    // Create a mock JWT with claims
+    final var jwt = mock(org.springframework.security.oauth2.jwt.Jwt.class);
+    final Map<String, Object> claims = Map.of("username", "test-user", "application_id", "app-id");
+    when(jwt.getClaims()).thenReturn(claims);
+
+    // Configure the JwtDecoder to return our mock JWT
+    final var jwtDecoder = mock(JwtDecoder.class);
+    when(jwtDecoder.decode(anyString())).thenReturn(jwt);
+
+    final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
+    oidcAuthenticationConfiguration.setUsernameClaim("username");
+    oidcAuthenticationConfiguration.setClientIdClaim("application_id");
+    oidcAuthenticationConfiguration.setPreferUsernameClaim(true);
+
+    // when
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+        .interceptCall(
+            closeStatusCapturingServerCall,
+            metadata,
+            (call, headers) -> {
+              // then
+              assertUsername().isEqualTo("test-user");
+              assertClientId().isNull();
+
+              call.close(Status.OK, headers);
+              return null;
+            });
+  }
+
+  @Test
+  public void
+      addsUsernameToOidcContextWhenPreferUsernameClaimIsTrueWhenUsernameAndClientIdClaimsArePresent() {
+    // given
+    final Metadata metadata = createAuthHeader();
+    final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
+        new CloseStatusCapturingServerCall();
+
+    // Create a mock JWT with claims
+    final var jwt = mock(org.springframework.security.oauth2.jwt.Jwt.class);
+    final Map<String, Object> claims = Map.of("username", "test-user", "application_id", "app-id");
+    when(jwt.getClaims()).thenReturn(claims);
+
+    // Configure the JwtDecoder to return our mock JWT
+    final var jwtDecoder = mock(JwtDecoder.class);
+    when(jwtDecoder.decode(anyString())).thenReturn(jwt);
+
+    final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
+    oidcAuthenticationConfiguration.setUsernameClaim("username");
+    oidcAuthenticationConfiguration.setClientIdClaim("application_id");
+    oidcAuthenticationConfiguration.setPreferUsernameClaim(true);
+
+    // when
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+        .interceptCall(
+            closeStatusCapturingServerCall,
+            metadata,
+            (call, headers) -> {
+              // then
+              assertUsername().isEqualTo("test-user");
+              assertClientId().isNull();
+
+              call.close(Status.OK, headers);
+              return null;
+            });
+  }
+
+  @Test
+  public void defaultsToUsernameWhenPreferUsernameClaimIsFalseAndClientIdIsNotPresent() {
+    // given
+    final Metadata metadata = createAuthHeader();
+    final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
+        new CloseStatusCapturingServerCall();
+
+    // Create a mock JWT with claims
+    final var jwt = mock(org.springframework.security.oauth2.jwt.Jwt.class);
+    final Map<String, Object> claims = Map.of("username", "test-user", "application_id", "app-id");
+    when(jwt.getClaims()).thenReturn(claims);
+
+    // Configure the JwtDecoder to return our mock JWT
+    final var jwtDecoder = mock(JwtDecoder.class);
+    when(jwtDecoder.decode(anyString())).thenReturn(jwt);
+
+    final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
+    oidcAuthenticationConfiguration.setUsernameClaim("username");
+    oidcAuthenticationConfiguration.setClientIdClaim("application_id");
+    oidcAuthenticationConfiguration.setPreferUsernameClaim(true);
+
+    // when
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+        .interceptCall(
+            closeStatusCapturingServerCall,
+            metadata,
+            (call, headers) -> {
+              // then
+              assertUsername().isEqualTo("test-user");
+              assertClientId().isNull();
+
+              call.close(Status.OK, headers);
+              return null;
+            });
+  }
+
+  @Test
+  public void
+      addsClientIdToOidcContextWhenPreferUsernameClaimIsFalseWhenUsernameAndClientIdClaimsArePresent() {
     // given
     final Metadata metadata = createAuthHeader();
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

With the merge of https://github.com/camunda/camunda/issues/37473 I altered the login to prefer client ID over username, this works in the case of Keycloak for example where there is a clear claim (`client_id`) that is preset on the client token but not on the user token. An issue was spotted where this logic is not sufficient for MS Entra as the client tokens produced by MS Entra have a complete intersection with user tokens, that is to say that if you configure any claim as the client ID, user tokens would be always treated as clients. In the case of MS Entra the inverse ordering is required such that we first find the username claim (i.e. `preferred_username` which in MS entra is unique to user tokens) and then defer to the client ID.

This PR introduces a configuration option that allows customers the option to reverse the preference ordering whilst maintaining the new preference in default cases. The logic in this PR can be described as:
- Has the user configured a preference for username over client id AND the username is present OR the client id is null?
    - Return the username as the principle
- If the above is false:
    - Return the client ID as the principle

// There are guards in place to check before we use this logic, that at least one of the principle identifiers has been found, this can be found [here](https://github.com/camunda/camunda/blob/main/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java#L41-L46) for REST and [here](https://github.com/camunda/camunda/blob/9670077f6788148484e976d884bf5c0ae233f37c/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java#L109-L116) for GRPC

## Related issues

closes #39049 
