### PR TITLE
ci: try increasing Zeebe QA Integration test timeout to 30min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -746,7 +746,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "${{ matrix.module }} / Integration / ${{ matrix.name }} ITs"
     needs: [ detect-changes ]
-    timeout-minutes: 25
+    timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runs-on }}
     outputs:


### PR DESCRIPTION
## Description

The Zeebe `integration-tests/qa-integration` GHA job is e.g. causing the most merge queue evictions this week so far, all due to cancellation due to timeouts of 25min.

We don't know if the job has an actual test failure that is in a loop or would work more reliably with a little bit more time - this PR is trying to (dis-)prove this hypothesis for `main`.

After the experiment, we can revert this PR again and (preferably) focus on speeding up the job.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

None
