### PR TITLE
[Backport stable/optimize-8.6] fix: replace reflection methods with basic equals and hashCode

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/metrics/MetricResponseDto.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/metrics/MetricResponseDto.java
@@ -9,29 +9,190 @@ package io.camunda.optimize.service.metrics;
 
 import io.micrometer.core.instrument.Statistic;
 import java.util.List;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
 public class MetricResponseDto {
+
   private String name;
   private String description;
   private String baseUnit;
   private List<StatisticDto> measurements;
   private List<TagDto> availableTags;
 
-  @Data
-  @NoArgsConstructor
-  public static class StatisticDto {
-    private Statistic statistic;
-    private Double value;
+  public MetricResponseDto() {}
+
+  public String getName() {
+    return name;
   }
 
-  @Data
-  @NoArgsConstructor
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
+  }
+
+  public String getBaseUnit() {
+    return baseUnit;
+  }
+
+  public void setBaseUnit(final String baseUnit) {
+    this.baseUnit = baseUnit;
+  }
+
+  public List<StatisticDto> getMeasurements() {
+    return measurements;
+  }
+
+  public void setMeasurements(final List<StatisticDto> measurements) {
+    this.measurements = measurements;
+  }
+
+  public List<TagDto> getAvailableTags() {
+    return availableTags;
+  }
+
+  public void setAvailableTags(final List<TagDto> availableTags) {
+    this.availableTags = availableTags;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MetricResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MetricResponseDto that = (MetricResponseDto) o;
+    return Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(baseUnit, that.baseUnit)
+        && Objects.equals(measurements, that.measurements)
+        && Objects.equals(availableTags, that.availableTags);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, description, baseUnit, measurements, availableTags);
+  }
+
+  @Override
+  public String toString() {
+    return "MetricResponseDto(name="
+        + getName()
+        + ", description="
+        + getDescription()
+        + ", baseUnit="
+        + getBaseUnit()
+        + ", measurements="
+        + getMeasurements()
+        + ", availableTags="
+        + getAvailableTags()
+        + ")";
+  }
+
+  public static class StatisticDto {
+
+    private Statistic statistic;
+    private Double value;
+
+    public StatisticDto() {}
+
+    public Statistic getStatistic() {
+      return statistic;
+    }
+
+    public void setStatistic(final Statistic statistic) {
+      this.statistic = statistic;
+    }
+
+    public Double getValue() {
+      return value;
+    }
+
+    public void setValue(final Double value) {
+      this.value = value;
+    }
+
+    protected boolean canEqual(final Object other) {
+      return other instanceof StatisticDto;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final StatisticDto that = (StatisticDto) o;
+      return statistic == that.statistic && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(statistic, value);
+    }
+
+    @Override
+    public String toString() {
+      return "MetricResponseDto.StatisticDto(statistic="
+          + getStatistic()
+          + ", value="
+          + getValue()
+          + ")";
+    }
+  }
+
   public static class TagDto {
+
     private String tag;
     private List<String> values;
+
+    public TagDto() {}
+
+    public String getTag() {
+      return tag;
+    }
+
+    public void setTag(final String tag) {
+      this.tag = tag;
+    }
+
+    public List<String> getValues() {
+      return values;
+    }
+
+    public void setValues(final List<String> values) {
+      this.values = values;
+    }
+
+    protected boolean canEqual(final Object other) {
+      return other instanceof TagDto;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final TagDto tagDto = (TagDto) o;
+      return Objects.equals(tag, tagDto.tag) && Objects.equals(values, tagDto.values);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(tag, values);
+    }
+
+    @Override
+    public String toString() {
+      return "MetricResponseDto.TagDto(tag=" + getTag() + ", values=" + getValues() + ")";
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/AuthenticationResultDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/AuthenticationResultDto.java
@@ -7,20 +7,146 @@
  */
 package io.camunda.optimize.dto.engine;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Builder
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class AuthenticationResultDto {
 
   private String authenticatedUser;
   private boolean isAuthenticated;
   private String engineAlias;
   private String errorMessage;
+
+  public AuthenticationResultDto(
+      final String authenticatedUser,
+      final boolean isAuthenticated,
+      final String engineAlias,
+      final String errorMessage) {
+    this.authenticatedUser = authenticatedUser;
+    this.isAuthenticated = isAuthenticated;
+    this.engineAlias = engineAlias;
+    this.errorMessage = errorMessage;
+  }
+
+  protected AuthenticationResultDto() {}
+
+  public String getAuthenticatedUser() {
+    return authenticatedUser;
+  }
+
+  public void setAuthenticatedUser(final String authenticatedUser) {
+    this.authenticatedUser = authenticatedUser;
+  }
+
+  public boolean isAuthenticated() {
+    return isAuthenticated;
+  }
+
+  public void setAuthenticated(final boolean isAuthenticated) {
+    this.isAuthenticated = isAuthenticated;
+  }
+
+  public String getEngineAlias() {
+    return engineAlias;
+  }
+
+  public void setEngineAlias(final String engineAlias) {
+    this.engineAlias = engineAlias;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public void setErrorMessage(final String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof AuthenticationResultDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(authenticatedUser, isAuthenticated, engineAlias, errorMessage);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AuthenticationResultDto that = (AuthenticationResultDto) o;
+    return isAuthenticated == that.isAuthenticated
+        && Objects.equals(authenticatedUser, that.authenticatedUser)
+        && Objects.equals(engineAlias, that.engineAlias)
+        && Objects.equals(errorMessage, that.errorMessage);
+  }
+
+  @Override
+  public String toString() {
+    return "AuthenticationResultDto(authenticatedUser="
+        + getAuthenticatedUser()
+        + ", isAuthenticated="
+        + isAuthenticated()
+        + ", engineAlias="
+        + getEngineAlias()
+        + ", errorMessage="
+        + getErrorMessage()
+        + ")";
+  }
+
+  public static AuthenticationResultDtoBuilder builder() {
+    return new AuthenticationResultDtoBuilder();
+  }
+
+  public static class AuthenticationResultDtoBuilder {
+
+    private String authenticatedUser;
+    private boolean isAuthenticated;
+    private String engineAlias;
+    private String errorMessage;
+
+    AuthenticationResultDtoBuilder() {}
+
+    public AuthenticationResultDtoBuilder authenticatedUser(final String authenticatedUser) {
+      this.authenticatedUser = authenticatedUser;
+      return this;
+    }
+
+    public AuthenticationResultDtoBuilder isAuthenticated(final boolean isAuthenticated) {
+      this.isAuthenticated = isAuthenticated;
+      return this;
+    }
+
+    public AuthenticationResultDtoBuilder engineAlias(final String engineAlias) {
+      this.engineAlias = engineAlias;
+      return this;
+    }
+
+    public AuthenticationResultDtoBuilder errorMessage(final String errorMessage) {
+      this.errorMessage = errorMessage;
+      return this;
+    }
+
+    public AuthenticationResultDto build() {
+      return new AuthenticationResultDto(
+          authenticatedUser, isAuthenticated, engineAlias, errorMessage);
+    }
+
+    @Override
+    public String toString() {
+      return "AuthenticationResultDto.AuthenticationResultDtoBuilder(authenticatedUser="
+          + authenticatedUser
+          + ", isAuthenticated="
+          + isAuthenticated
+          + ", engineAlias="
+          + engineAlias
+          + ", errorMessage="
+          + errorMessage
+          + ")";
+    }
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/CountDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/CountDto.java
@@ -7,10 +7,45 @@
  */
 package io.camunda.optimize.dto.engine;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class CountDto {
 
   protected long count;
+
+  public CountDto() {}
+
+  public long getCount() {
+    return count;
+  }
+
+  public void setCount(final long count) {
+    this.count = count;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CountDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(count);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CountDto that = (CountDto) o;
+    return count == that.count;
+  }
+
+  @Override
+  public String toString() {
+    return "CountDto(count=" + getCount() + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/CredentialsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/CredentialsDto.java
@@ -7,11 +7,54 @@
  */
 package io.camunda.optimize.dto.engine;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class CredentialsDto {
 
   protected String username;
   protected String password;
+
+  public CredentialsDto() {}
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(final String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(final String password) {
+    this.password = password;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CredentialsDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(username, password);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CredentialsDto that = (CredentialsDto) o;
+    return Objects.equals(username, that.username) && Objects.equals(password, that.password);
+  }
+
+  @Override
+  public String toString() {
+    return "CredentialsDto(username=" + getUsername() + ", password=" + getPassword() + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/EngineGroupDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/EngineGroupDto.java
@@ -7,14 +7,65 @@
  */
 package io.camunda.optimize.dto.engine;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(of = {"id"})
 public class EngineGroupDto {
 
   private String id;
   private String name;
   private String type;
+
+  public EngineGroupDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EngineGroupDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, type);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EngineGroupDto that = (EngineGroupDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type);
+  }
+
+  @Override
+  public String toString() {
+    return "EngineGroupDto(id=" + getId() + ", name=" + getName() + ", type=" + getType() + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/EngineListUserDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/engine/EngineListUserDto.java
@@ -7,22 +7,142 @@
  */
 package io.camunda.optimize.dto.engine;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Builder
-@Data
-@EqualsAndHashCode(of = {"id"})
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class EngineListUserDto {
 
   private String id;
   private String firstName;
   private String lastName;
   private String email;
+
+  public EngineListUserDto(
+      final String id, final String firstName, final String lastName, final String email) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.email = email;
+  }
+
+  protected EngineListUserDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(final String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(final String lastName) {
+    this.lastName = lastName;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(final String email) {
+    this.email = email;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EngineListUserDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, firstName, lastName, email);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EngineListUserDto that = (EngineListUserDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(firstName, that.firstName)
+        && Objects.equals(lastName, that.lastName)
+        && Objects.equals(email, that.email);
+  }
+
+  @Override
+  public String toString() {
+    return "EngineListUserDto(id="
+        + getId()
+        + ", firstName="
+        + getFirstName()
+        + ", lastName="
+        + getLastName()
+        + ", email="
+        + getEmail()
+        + ")";
+  }
+
+  public static EngineListUserDtoBuilder builder() {
+    return new EngineListUserDtoBuilder();
+  }
+
+  public static class EngineListUserDtoBuilder {
+
+    private String id;
+    private String firstName;
+    private String lastName;
+    private String email;
+
+    EngineListUserDtoBuilder() {}
+
+    public EngineListUserDtoBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public EngineListUserDtoBuilder firstName(final String firstName) {
+      this.firstName = firstName;
+      return this;
+    }
+
+    public EngineListUserDtoBuilder lastName(final String lastName) {
+      this.lastName = lastName;
+      return this;
+    }
+
+    public EngineListUserDtoBuilder email(final String email) {
+      this.email = email;
+      return this;
+    }
+
+    public EngineListUserDto build() {
+      return new EngineListUserDto(id, firstName, lastName, email);
+    }
+
+    @Override
+    public String toString() {
+      return "EngineListUserDto.EngineListUserDtoBuilder(id="
+          + id
+          + ", firstName="
+          + firstName
+          + ", lastName="
+          + lastName
+          + ", email="
+          + email
+          + ")";
+    }
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/DecisionInstanceDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/DecisionInstanceDto.java
@@ -12,14 +12,9 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class DecisionInstanceDto implements OptimizeDto {
 
   private String decisionInstanceId;
@@ -40,6 +35,270 @@ public class DecisionInstanceDto implements OptimizeDto {
   private String engine;
   private String tenantId;
 
+  public DecisionInstanceDto(
+      final String decisionInstanceId,
+      final String processDefinitionId,
+      final String processDefinitionKey,
+      final String decisionDefinitionId,
+      final String decisionDefinitionKey,
+      final String decisionDefinitionVersion,
+      final OffsetDateTime evaluationDateTime,
+      final String processInstanceId,
+      final String rootProcessInstanceId,
+      final String activityId,
+      final Double collectResultValue,
+      final String rootDecisionInstanceId,
+      final List<InputInstanceDto> inputs,
+      final List<OutputInstanceDto> outputs,
+      final Set<String> matchedRules,
+      final String engine,
+      final String tenantId) {
+    this.decisionInstanceId = decisionInstanceId;
+    this.processDefinitionId = processDefinitionId;
+    this.processDefinitionKey = processDefinitionKey;
+    this.decisionDefinitionId = decisionDefinitionId;
+    this.decisionDefinitionKey = decisionDefinitionKey;
+    this.decisionDefinitionVersion = decisionDefinitionVersion;
+    this.evaluationDateTime = evaluationDateTime;
+    this.processInstanceId = processInstanceId;
+    this.rootProcessInstanceId = rootProcessInstanceId;
+    this.activityId = activityId;
+    this.collectResultValue = collectResultValue;
+    this.rootDecisionInstanceId = rootDecisionInstanceId;
+    this.inputs = inputs;
+    this.outputs = outputs;
+    this.matchedRules = matchedRules;
+    this.engine = engine;
+    this.tenantId = tenantId;
+  }
+
+  public DecisionInstanceDto() {}
+
+  public String getDecisionInstanceId() {
+    return this.decisionInstanceId;
+  }
+
+  public String getProcessDefinitionId() {
+    return this.processDefinitionId;
+  }
+
+  public String getProcessDefinitionKey() {
+    return this.processDefinitionKey;
+  }
+
+  public String getDecisionDefinitionId() {
+    return this.decisionDefinitionId;
+  }
+
+  public String getDecisionDefinitionKey() {
+    return this.decisionDefinitionKey;
+  }
+
+  public String getDecisionDefinitionVersion() {
+    return this.decisionDefinitionVersion;
+  }
+
+  public OffsetDateTime getEvaluationDateTime() {
+    return this.evaluationDateTime;
+  }
+
+  public String getProcessInstanceId() {
+    return this.processInstanceId;
+  }
+
+  public String getRootProcessInstanceId() {
+    return this.rootProcessInstanceId;
+  }
+
+  public String getActivityId() {
+    return this.activityId;
+  }
+
+  public Double getCollectResultValue() {
+    return this.collectResultValue;
+  }
+
+  public String getRootDecisionInstanceId() {
+    return this.rootDecisionInstanceId;
+  }
+
+  public List<InputInstanceDto> getInputs() {
+    return this.inputs;
+  }
+
+  public List<OutputInstanceDto> getOutputs() {
+    return this.outputs;
+  }
+
+  public Set<String> getMatchedRules() {
+    return this.matchedRules;
+  }
+
+  public String getEngine() {
+    return this.engine;
+  }
+
+  public String getTenantId() {
+    return this.tenantId;
+  }
+
+  public void setDecisionInstanceId(final String decisionInstanceId) {
+    this.decisionInstanceId = decisionInstanceId;
+  }
+
+  public void setProcessDefinitionId(final String processDefinitionId) {
+    this.processDefinitionId = processDefinitionId;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public void setDecisionDefinitionId(final String decisionDefinitionId) {
+    this.decisionDefinitionId = decisionDefinitionId;
+  }
+
+  public void setDecisionDefinitionKey(final String decisionDefinitionKey) {
+    this.decisionDefinitionKey = decisionDefinitionKey;
+  }
+
+  public void setDecisionDefinitionVersion(final String decisionDefinitionVersion) {
+    this.decisionDefinitionVersion = decisionDefinitionVersion;
+  }
+
+  public void setEvaluationDateTime(final OffsetDateTime evaluationDateTime) {
+    this.evaluationDateTime = evaluationDateTime;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public void setRootProcessInstanceId(final String rootProcessInstanceId) {
+    this.rootProcessInstanceId = rootProcessInstanceId;
+  }
+
+  public void setActivityId(final String activityId) {
+    this.activityId = activityId;
+  }
+
+  public void setCollectResultValue(final Double collectResultValue) {
+    this.collectResultValue = collectResultValue;
+  }
+
+  public void setRootDecisionInstanceId(final String rootDecisionInstanceId) {
+    this.rootDecisionInstanceId = rootDecisionInstanceId;
+  }
+
+  public void setInputs(final List<InputInstanceDto> inputs) {
+    this.inputs = inputs;
+  }
+
+  public void setOutputs(final List<OutputInstanceDto> outputs) {
+    this.outputs = outputs;
+  }
+
+  public void setMatchedRules(final Set<String> matchedRules) {
+    this.matchedRules = matchedRules;
+  }
+
+  public void setEngine(final String engine) {
+    this.engine = engine;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionInstanceDto that = (DecisionInstanceDto) o;
+    return Objects.equals(decisionInstanceId, that.decisionInstanceId)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(decisionDefinitionId, that.decisionDefinitionId)
+        && Objects.equals(decisionDefinitionKey, that.decisionDefinitionKey)
+        && Objects.equals(decisionDefinitionVersion, that.decisionDefinitionVersion)
+        && Objects.equals(evaluationDateTime, that.evaluationDateTime)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(rootProcessInstanceId, that.rootProcessInstanceId)
+        && Objects.equals(activityId, that.activityId)
+        && Objects.equals(collectResultValue, that.collectResultValue)
+        && Objects.equals(rootDecisionInstanceId, that.rootDecisionInstanceId)
+        && Objects.equals(inputs, that.inputs)
+        && Objects.equals(outputs, that.outputs)
+        && Objects.equals(matchedRules, that.matchedRules)
+        && Objects.equals(engine, that.engine)
+        && Objects.equals(tenantId, that.tenantId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        decisionInstanceId,
+        processDefinitionId,
+        processDefinitionKey,
+        decisionDefinitionId,
+        decisionDefinitionKey,
+        decisionDefinitionVersion,
+        evaluationDateTime,
+        processInstanceId,
+        rootProcessInstanceId,
+        activityId,
+        collectResultValue,
+        rootDecisionInstanceId,
+        inputs,
+        outputs,
+        matchedRules,
+        engine,
+        tenantId);
+  }
+
+  public String toString() {
+    return "DecisionInstanceDto(decisionInstanceId="
+        + this.getDecisionInstanceId()
+        + ", processDefinitionId="
+        + this.getProcessDefinitionId()
+        + ", processDefinitionKey="
+        + this.getProcessDefinitionKey()
+        + ", decisionDefinitionId="
+        + this.getDecisionDefinitionId()
+        + ", decisionDefinitionKey="
+        + this.getDecisionDefinitionKey()
+        + ", decisionDefinitionVersion="
+        + this.getDecisionDefinitionVersion()
+        + ", evaluationDateTime="
+        + this.getEvaluationDateTime()
+        + ", processInstanceId="
+        + this.getProcessInstanceId()
+        + ", rootProcessInstanceId="
+        + this.getRootProcessInstanceId()
+        + ", activityId="
+        + this.getActivityId()
+        + ", collectResultValue="
+        + this.getCollectResultValue()
+        + ", rootDecisionInstanceId="
+        + this.getRootDecisionInstanceId()
+        + ", inputs="
+        + this.getInputs()
+        + ", outputs="
+        + this.getOutputs()
+        + ", matchedRules="
+        + this.getMatchedRules()
+        + ", engine="
+        + this.getEngine()
+        + ", tenantId="
+        + this.getTenantId()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String decisionInstanceId = "decisionInstanceId";

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/FlowNodeEventDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/FlowNodeEventDto.java
@@ -10,14 +10,10 @@ package io.camunda.optimize.dto.optimize.importing;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class FlowNodeEventDto implements Serializable, OptimizeDto {
+
   private String id; // == FlowNodeInstanceDto.flowNodeInstanceId
   private String activityId; // == FlowNodeInstanceDto.flowNodeID
   private String activityType;
@@ -35,4 +31,269 @@ public class FlowNodeEventDto implements Serializable, OptimizeDto {
   private Long orderCounter;
   private Boolean canceled;
   private String taskId; // == FlowNodeInstanceDto.userTaskId (null if flowNode is not a userTask)
+
+  public FlowNodeEventDto(
+      final String id,
+      final String activityId,
+      final String activityType,
+      final String activityName,
+      final OffsetDateTime timestamp,
+      final String processDefinitionId,
+      final String processDefinitionKey,
+      final String processDefinitionVersion,
+      final String tenantId,
+      final String engineAlias,
+      final String processInstanceId,
+      final OffsetDateTime startDate,
+      final OffsetDateTime endDate,
+      final Long durationInMs,
+      final Long orderCounter,
+      final Boolean canceled,
+      final String taskId) {
+    this.id = id;
+    this.activityId = activityId;
+    this.activityType = activityType;
+    this.activityName = activityName;
+    this.timestamp = timestamp;
+    this.processDefinitionId = processDefinitionId;
+    this.processDefinitionKey = processDefinitionKey;
+    this.processDefinitionVersion = processDefinitionVersion;
+    this.tenantId = tenantId;
+    this.engineAlias = engineAlias;
+    this.processInstanceId = processInstanceId;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.durationInMs = durationInMs;
+    this.orderCounter = orderCounter;
+    this.canceled = canceled;
+    this.taskId = taskId;
+  }
+
+  public FlowNodeEventDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getActivityId() {
+    return activityId;
+  }
+
+  public void setActivityId(final String activityId) {
+    this.activityId = activityId;
+  }
+
+  public String getActivityType() {
+    return activityType;
+  }
+
+  public void setActivityType(final String activityType) {
+    this.activityType = activityType;
+  }
+
+  public String getActivityName() {
+    return activityName;
+  }
+
+  public void setActivityName(final String activityName) {
+    this.activityName = activityName;
+  }
+
+  public OffsetDateTime getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(final OffsetDateTime timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public String getProcessDefinitionId() {
+    return processDefinitionId;
+  }
+
+  public void setProcessDefinitionId(final String processDefinitionId) {
+    this.processDefinitionId = processDefinitionId;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
+
+  public void setProcessDefinitionVersion(final String processDefinitionVersion) {
+    this.processDefinitionVersion = processDefinitionVersion;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public String getEngineAlias() {
+    return engineAlias;
+  }
+
+  public void setEngineAlias(final String engineAlias) {
+    this.engineAlias = engineAlias;
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public OffsetDateTime getStartDate() {
+    return startDate;
+  }
+
+  public void setStartDate(final OffsetDateTime startDate) {
+    this.startDate = startDate;
+  }
+
+  public OffsetDateTime getEndDate() {
+    return endDate;
+  }
+
+  public void setEndDate(final OffsetDateTime endDate) {
+    this.endDate = endDate;
+  }
+
+  public Long getDurationInMs() {
+    return durationInMs;
+  }
+
+  public void setDurationInMs(final Long durationInMs) {
+    this.durationInMs = durationInMs;
+  }
+
+  public Long getOrderCounter() {
+    return orderCounter;
+  }
+
+  public void setOrderCounter(final Long orderCounter) {
+    this.orderCounter = orderCounter;
+  }
+
+  public Boolean getCanceled() {
+    return canceled;
+  }
+
+  public void setCanceled(final Boolean canceled) {
+    this.canceled = canceled;
+  }
+
+  public String getTaskId() {
+    return taskId;
+  }
+
+  public void setTaskId(final String taskId) {
+    this.taskId = taskId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof FlowNodeEventDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FlowNodeEventDto that = (FlowNodeEventDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(activityId, that.activityId)
+        && Objects.equals(activityType, that.activityType)
+        && Objects.equals(activityName, that.activityName)
+        && Objects.equals(timestamp, that.timestamp)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersion, that.processDefinitionVersion)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(engineAlias, that.engineAlias)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(startDate, that.startDate)
+        && Objects.equals(endDate, that.endDate)
+        && Objects.equals(durationInMs, that.durationInMs)
+        && Objects.equals(orderCounter, that.orderCounter)
+        && Objects.equals(canceled, that.canceled)
+        && Objects.equals(taskId, that.taskId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        activityId,
+        activityType,
+        activityName,
+        timestamp,
+        processDefinitionId,
+        processDefinitionKey,
+        processDefinitionVersion,
+        tenantId,
+        engineAlias,
+        processInstanceId,
+        startDate,
+        endDate,
+        durationInMs,
+        orderCounter,
+        canceled,
+        taskId);
+  }
+
+  @Override
+  public String toString() {
+    return "FlowNodeEventDto(id="
+        + getId()
+        + ", activityId="
+        + getActivityId()
+        + ", activityType="
+        + getActivityType()
+        + ", activityName="
+        + getActivityName()
+        + ", timestamp="
+        + getTimestamp()
+        + ", processDefinitionId="
+        + getProcessDefinitionId()
+        + ", processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", processDefinitionVersion="
+        + getProcessDefinitionVersion()
+        + ", tenantId="
+        + getTenantId()
+        + ", engineAlias="
+        + getEngineAlias()
+        + ", processInstanceId="
+        + getProcessInstanceId()
+        + ", startDate="
+        + getStartDate()
+        + ", endDate="
+        + getEndDate()
+        + ", durationInMs="
+        + getDurationInMs()
+        + ", orderCounter="
+        + getOrderCounter()
+        + ", canceled="
+        + getCanceled()
+        + ", taskId="
+        + getTaskId()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/LastKpiEvaluationResultsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/LastKpiEvaluationResultsDto.java
@@ -9,11 +9,35 @@ package io.camunda.optimize.dto.optimize.importing;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
 public class LastKpiEvaluationResultsDto implements OptimizeDto {
+
   final Map<String, String> reportIdToValue;
+
+  public LastKpiEvaluationResultsDto(final Map<String, String> reportIdToValue) {
+    this.reportIdToValue = reportIdToValue;
+  }
+
+  public Map<String, String> getReportIdToValue() {
+    return reportIdToValue;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof LastKpiEvaluationResultsDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final LastKpiEvaluationResultsDto that = (LastKpiEvaluationResultsDto) o;
+    return Objects.equals(reportIdToValue, that.reportIdToValue);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(reportIdToValue);
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/EntityIdResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/EntityIdResponseDto.java
@@ -8,16 +8,59 @@
 package io.camunda.optimize.dto.optimize.query;
 
 import io.camunda.optimize.dto.optimize.query.entity.EntityType;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class EntityIdResponseDto {
 
   private String id;
   private EntityType entityType;
+
+  public EntityIdResponseDto(final String id, final EntityType entityType) {
+    this.id = id;
+    this.entityType = entityType;
+  }
+
+  protected EntityIdResponseDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public EntityType getEntityType() {
+    return entityType;
+  }
+
+  public void setEntityType(final EntityType entityType) {
+    this.entityType = entityType;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EntityIdResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, entityType);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntityIdResponseDto that = (EntityIdResponseDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(entityType, that.entityType);
+  }
+
+  @Override
+  public String toString() {
+    return "EntityIdResponseDto(id=" + getId() + ", entityType=" + getEntityType() + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/IdResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/IdResponseDto.java
@@ -7,15 +7,49 @@
  */
 package io.camunda.optimize.dto.optimize.query;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class IdResponseDto {
 
   protected String id;
+
+  public IdResponseDto(final String id) {
+    this.id = id;
+  }
+
+  protected IdResponseDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof IdResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IdResponseDto that = (IdResponseDto) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public String toString() {
+    return "IdResponseDto(id=" + getId() + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/IdentitySearchResultResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/IdentitySearchResultResponseDto.java
@@ -11,15 +11,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.IdentityWithMetadataResponseDto;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 import org.apache.lucene.search.ScoreDoc;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class IdentitySearchResultResponseDto {
+
   private List<IdentityWithMetadataResponseDto> result = new ArrayList<>();
 
   /**
@@ -30,5 +26,60 @@ public class IdentitySearchResultResponseDto {
 
   public IdentitySearchResultResponseDto(final List<IdentityWithMetadataResponseDto> result) {
     this.result = result;
+  }
+
+  public IdentitySearchResultResponseDto(
+      final List<IdentityWithMetadataResponseDto> result, final ScoreDoc scoreDoc) {
+    this.result = result;
+    this.scoreDoc = scoreDoc;
+  }
+
+  public IdentitySearchResultResponseDto() {}
+
+  public List<IdentityWithMetadataResponseDto> getResult() {
+    return result;
+  }
+
+  public void setResult(final List<IdentityWithMetadataResponseDto> result) {
+    this.result = result;
+  }
+
+  public ScoreDoc getScoreDoc() {
+    return scoreDoc;
+  }
+
+  @JsonIgnore
+  public void setScoreDoc(final ScoreDoc scoreDoc) {
+    this.scoreDoc = scoreDoc;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof IdentitySearchResultResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(result, scoreDoc);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IdentitySearchResultResponseDto that = (IdentitySearchResultResponseDto) o;
+    return Objects.equals(result, that.result) && Objects.equals(scoreDoc, that.scoreDoc);
+  }
+
+  @Override
+  public String toString() {
+    return "IdentitySearchResultResponseDto(result="
+        + getResult()
+        + ", scoreDoc="
+        + getScoreDoc()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/PageResultDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/PageResultDto.java
@@ -9,29 +9,94 @@ package io.camunda.optimize.dto.optimize.query;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PageResultDto<T> {
+
   private String pagingState;
   private int limit;
-  @NonNull private List<T> entities = new ArrayList<>();
+  private List<T> entities = new ArrayList<>();
 
   public PageResultDto(final int limit) {
     this.limit = limit;
   }
 
+  public PageResultDto(final String pagingState, final int limit, final List<T> entities) {
+    if (entities == null) {
+      throw new IllegalArgumentException("entities cannot be null");
+    }
+
+    this.pagingState = pagingState;
+    this.limit = limit;
+    this.entities = entities;
+  }
+
+  protected PageResultDto() {}
+
   public boolean isEmpty() {
-    return this.entities.isEmpty();
+    return entities.isEmpty();
   }
 
   public boolean isLastPage() {
     return pagingState == null;
+  }
+
+  public String getPagingState() {
+    return pagingState;
+  }
+
+  public void setPagingState(final String pagingState) {
+    this.pagingState = pagingState;
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+
+  public void setLimit(final int limit) {
+    this.limit = limit;
+  }
+
+  public List<T> getEntities() {
+    return entities;
+  }
+
+  public void setEntities(final List<T> entities) {
+    if (entities == null) {
+      throw new IllegalArgumentException("entities cannot be null");
+    }
+
+    this.entities = entities;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PageResultDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PageResultDto<?> that = (PageResultDto<?>) o;
+    return limit == that.limit
+        && Objects.equals(pagingState, that.pagingState)
+        && Objects.equals(entities, that.entities);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pagingState, limit, entities);
+  }
+
+  @Override
+  public String toString() {
+    return "PageResultDto(pagingState="
+        + getPagingState()
+        + ", limit="
+        + getLimit()
+        + ", entities="
+        + getEntities()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/TokenDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/TokenDto.java
@@ -7,13 +7,46 @@
  */
 package io.camunda.optimize.dto.optimize.query;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class TokenDto {
+
   protected String token;
+
+  public TokenDto(final String token) {
+    this.token = token;
+  }
+
+  public TokenDto() {}
+
+  public String getToken() {
+    return token;
+  }
+
+  public void setToken(final String token) {
+    this.token = token;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof TokenDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TokenDto tokenDto = (TokenDto) o;
+    return Objects.equals(token, tokenDto.token);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(token);
+  }
+
+  @Override
+  public String toString() {
+    return "TokenDto(token=" + getToken() + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/BranchAnalysisOutcomeDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/BranchAnalysisOutcomeDto.java
@@ -7,11 +7,71 @@
  */
 package io.camunda.optimize.dto.optimize.query.analysis;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class BranchAnalysisOutcomeDto {
+
   protected Long activitiesReached;
   protected Long activityCount;
   protected String activityId;
+
+  public BranchAnalysisOutcomeDto() {}
+
+  public Long getActivitiesReached() {
+    return activitiesReached;
+  }
+
+  public void setActivitiesReached(final Long activitiesReached) {
+    this.activitiesReached = activitiesReached;
+  }
+
+  public Long getActivityCount() {
+    return activityCount;
+  }
+
+  public void setActivityCount(final Long activityCount) {
+    this.activityCount = activityCount;
+  }
+
+  public String getActivityId() {
+    return activityId;
+  }
+
+  public void setActivityId(final String activityId) {
+    this.activityId = activityId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof BranchAnalysisOutcomeDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(activitiesReached, activityCount, activityId);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BranchAnalysisOutcomeDto that = (BranchAnalysisOutcomeDto) o;
+    return Objects.equals(activitiesReached, that.activitiesReached)
+        && Objects.equals(activityCount, that.activityCount)
+        && Objects.equals(activityId, that.activityId);
+  }
+
+  @Override
+  public String toString() {
+    return "BranchAnalysisOutcomeDto(activitiesReached="
+        + getActivitiesReached()
+        + ", activityCount="
+        + getActivityCount()
+        + ", activityId="
+        + getActivityId()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/BranchAnalysisRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/BranchAnalysisRequestDto.java
@@ -14,10 +14,10 @@ import io.camunda.optimize.service.util.TenantListHandlingUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class BranchAnalysisRequestDto {
+
   private String end;
   private String gateway;
   private String processDefinitionKey;
@@ -26,12 +26,102 @@ public class BranchAnalysisRequestDto {
 
   private List<ProcessFilterDto<?>> filter = new ArrayList<>();
 
+  public BranchAnalysisRequestDto() {}
+
   @JsonIgnore
-  public void setProcessDefinitionVersion(String definitionVersion) {
-    this.processDefinitionVersions = Lists.newArrayList(definitionVersion);
+  public void setProcessDefinitionVersion(final String definitionVersion) {
+    processDefinitionVersions = Lists.newArrayList(definitionVersion);
   }
 
   public List<String> getTenantIds() {
     return TenantListHandlingUtil.sortAndReturnTenantIdList(tenantIds);
+  }
+
+  public void setTenantIds(final List<String> tenantIds) {
+    this.tenantIds = tenantIds;
+  }
+
+  public String getEnd() {
+    return end;
+  }
+
+  public void setEnd(final String end) {
+    this.end = end;
+  }
+
+  public String getGateway() {
+    return gateway;
+  }
+
+  public void setGateway(final String gateway) {
+    this.gateway = gateway;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public List<String> getProcessDefinitionVersions() {
+    return processDefinitionVersions;
+  }
+
+  public void setProcessDefinitionVersions(final List<String> processDefinitionVersions) {
+    this.processDefinitionVersions = processDefinitionVersions;
+  }
+
+  public List<ProcessFilterDto<?>> getFilter() {
+    return filter;
+  }
+
+  public void setFilter(final List<ProcessFilterDto<?>> filter) {
+    this.filter = filter;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof BranchAnalysisRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        end, gateway, processDefinitionKey, processDefinitionVersions, tenantIds, filter);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BranchAnalysisRequestDto that = (BranchAnalysisRequestDto) o;
+    return Objects.equals(end, that.end)
+        && Objects.equals(gateway, that.gateway)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersions, that.processDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds)
+        && Objects.equals(filter, that.filter);
+  }
+
+  @Override
+  public String toString() {
+    return "BranchAnalysisRequestDto(end="
+        + getEnd()
+        + ", gateway="
+        + getGateway()
+        + ", processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", processDefinitionVersions="
+        + getProcessDefinitionVersions()
+        + ", tenantIds="
+        + getTenantIds()
+        + ", filter="
+        + getFilter()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/BranchAnalysisResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/BranchAnalysisResponseDto.java
@@ -9,10 +9,10 @@ package io.camunda.optimize.dto.optimize.query.analysis;
 
 import java.util.HashMap;
 import java.util.Map;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class BranchAnalysisResponseDto {
+
   /** The end event the branch analysis is referred to. */
   protected String endEvent;
 
@@ -21,4 +21,64 @@ public class BranchAnalysisResponseDto {
 
   /** All branch analysis information of the flow nodes from the gateway to the end event. */
   protected Map<String, BranchAnalysisOutcomeDto> followingNodes = new HashMap<>();
+
+  public BranchAnalysisResponseDto() {}
+
+  public String getEndEvent() {
+    return endEvent;
+  }
+
+  public void setEndEvent(final String endEvent) {
+    this.endEvent = endEvent;
+  }
+
+  public Long getTotal() {
+    return total;
+  }
+
+  public void setTotal(final Long total) {
+    this.total = total;
+  }
+
+  public Map<String, BranchAnalysisOutcomeDto> getFollowingNodes() {
+    return followingNodes;
+  }
+
+  public void setFollowingNodes(final Map<String, BranchAnalysisOutcomeDto> followingNodes) {
+    this.followingNodes = followingNodes;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof BranchAnalysisResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(endEvent, total, followingNodes);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BranchAnalysisResponseDto that = (BranchAnalysisResponseDto) o;
+    return Objects.equals(endEvent, that.endEvent)
+        && Objects.equals(total, that.total)
+        && Objects.equals(followingNodes, that.followingNodes);
+  }
+
+  @Override
+  public String toString() {
+    return "BranchAnalysisResponseDto(endEvent="
+        + getEndEvent()
+        + ", total="
+        + getTotal()
+        + ", followingNodes="
+        + getFollowingNodes()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/DurationChartEntryDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/DurationChartEntryDto.java
@@ -7,15 +7,74 @@
  */
 package io.camunda.optimize.dto.optimize.query.analysis;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class DurationChartEntryDto {
+
   private Long key;
   private Long value;
   private boolean outlier;
+
+  public DurationChartEntryDto(final Long key, final Long value, final boolean outlier) {
+    this.key = key;
+    this.value = value;
+    this.outlier = outlier;
+  }
+
+  public DurationChartEntryDto() {}
+
+  public Long getKey() {
+    return key;
+  }
+
+  public void setKey(final Long key) {
+    this.key = key;
+  }
+
+  public Long getValue() {
+    return value;
+  }
+
+  public void setValue(final Long value) {
+    this.value = value;
+  }
+
+  public boolean isOutlier() {
+    return outlier;
+  }
+
+  public void setOutlier(final boolean outlier) {
+    this.outlier = outlier;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DurationChartEntryDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DurationChartEntryDto that = (DurationChartEntryDto) o;
+    return outlier == that.outlier
+        && Objects.equals(key, that.key)
+        && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, value, outlier);
+  }
+
+  @Override
+  public String toString() {
+    return "DurationChartEntryDto(key="
+        + getKey()
+        + ", value="
+        + getValue()
+        + ", outlier="
+        + isOutlier()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/FindingsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/FindingsDto.java
@@ -7,13 +7,11 @@
  */
 package io.camunda.optimize.dto.optimize.query.analysis;
 
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
 public class FindingsDto {
+
   private Finding lowerOutlier;
   private Finding higherOutlier;
   private Double lowerOutlierHeat = 0.0D;
@@ -21,20 +19,32 @@ public class FindingsDto {
   private Double heat = 0.0D;
   private Long totalCount;
 
+  public FindingsDto() {}
+
   public Optional<Finding> getLowerOutlier() {
     return Optional.ofNullable(lowerOutlier);
+  }
+
+  public void setLowerOutlier(final Finding lowerOutlier) {
+    this.lowerOutlier = lowerOutlier;
   }
 
   public Optional<Finding> getHigherOutlier() {
     return Optional.ofNullable(higherOutlier);
   }
 
-  public void setLowerOutlier(Long boundValue, Double percentile, Double relation, Long count) {
-    this.lowerOutlier = new Finding(boundValue, percentile, relation, count);
+  public void setHigherOutlier(final Finding higherOutlier) {
+    this.higherOutlier = higherOutlier;
   }
 
-  public void setHigherOutlier(Long boundValue, Double percentile, Double relation, Long count) {
-    this.higherOutlier = new Finding(boundValue, percentile, relation, count);
+  public void setLowerOutlier(
+      final Long boundValue, final Double percentile, final Double relation, final Long count) {
+    lowerOutlier = new Finding(boundValue, percentile, relation, count);
+  }
+
+  public void setHigherOutlier(
+      final Long boundValue, final Double percentile, final Double relation, final Long count) {
+    higherOutlier = new Finding(boundValue, percentile, relation, count);
   }
 
   public Long getOutlierCount() {
@@ -42,13 +52,160 @@ public class FindingsDto {
         + Optional.ofNullable(higherOutlier).map(Finding::getCount).orElse(0L);
   }
 
-  @Data
-  @NoArgsConstructor
-  @AllArgsConstructor
+  public Double getLowerOutlierHeat() {
+    return lowerOutlierHeat;
+  }
+
+  public void setLowerOutlierHeat(final Double lowerOutlierHeat) {
+    this.lowerOutlierHeat = lowerOutlierHeat;
+  }
+
+  public Double getHigherOutlierHeat() {
+    return higherOutlierHeat;
+  }
+
+  public void setHigherOutlierHeat(final Double higherOutlierHeat) {
+    this.higherOutlierHeat = higherOutlierHeat;
+  }
+
+  public Double getHeat() {
+    return heat;
+  }
+
+  public void setHeat(final Double heat) {
+    this.heat = heat;
+  }
+
+  public Long getTotalCount() {
+    return totalCount;
+  }
+
+  public void setTotalCount(final Long totalCount) {
+    this.totalCount = totalCount;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof FindingsDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FindingsDto that = (FindingsDto) o;
+    return Objects.equals(lowerOutlier, that.lowerOutlier)
+        && Objects.equals(higherOutlier, that.higherOutlier)
+        && Objects.equals(lowerOutlierHeat, that.lowerOutlierHeat)
+        && Objects.equals(higherOutlierHeat, that.higherOutlierHeat)
+        && Objects.equals(heat, that.heat)
+        && Objects.equals(totalCount, that.totalCount);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        lowerOutlier, higherOutlier, lowerOutlierHeat, higherOutlierHeat, heat, totalCount);
+  }
+
+  @Override
+  public String toString() {
+    return "FindingsDto(lowerOutlier="
+        + getLowerOutlier()
+        + ", higherOutlier="
+        + getHigherOutlier()
+        + ", lowerOutlierHeat="
+        + getLowerOutlierHeat()
+        + ", higherOutlierHeat="
+        + getHigherOutlierHeat()
+        + ", heat="
+        + getHeat()
+        + ", totalCount="
+        + getTotalCount()
+        + ")";
+  }
+
   public class Finding {
+
     private Long boundValue;
     private Double percentile;
     private Double relation;
     private Long count = 0L;
+
+    public Finding(
+        final Long boundValue, final Double percentile, final Double relation, final Long count) {
+      this.boundValue = boundValue;
+      this.percentile = percentile;
+      this.relation = relation;
+      this.count = count;
+    }
+
+    public Finding() {}
+
+    public Long getBoundValue() {
+      return boundValue;
+    }
+
+    public void setBoundValue(final Long boundValue) {
+      this.boundValue = boundValue;
+    }
+
+    public Double getPercentile() {
+      return percentile;
+    }
+
+    public void setPercentile(final Double percentile) {
+      this.percentile = percentile;
+    }
+
+    public Double getRelation() {
+      return relation;
+    }
+
+    public void setRelation(final Double relation) {
+      this.relation = relation;
+    }
+
+    public Long getCount() {
+      return count;
+    }
+
+    public void setCount(final Long count) {
+      this.count = count;
+    }
+
+    protected boolean canEqual(final Object other) {
+      return other instanceof Finding;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Finding finding = (Finding) o;
+      return Objects.equals(boundValue, finding.boundValue)
+          && Objects.equals(percentile, finding.percentile)
+          && Objects.equals(relation, finding.relation)
+          && Objects.equals(count, finding.count);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(boundValue, percentile, relation, count);
+    }
+
+    @Override
+    public String toString() {
+      return "FindingsDto.Finding(boundValue="
+          + getBoundValue()
+          + ", percentile="
+          + getPercentile()
+          + ", relation="
+          + getRelation()
+          + ", count="
+          + getCount()
+          + ")";
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/FlowNodeOutlierParametersDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/FlowNodeOutlierParametersDto.java
@@ -7,13 +7,72 @@
  */
 package io.camunda.optimize.dto.optimize.query.analysis;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class FlowNodeOutlierParametersDto extends ProcessDefinitionParametersDto {
+
   protected String flowNodeId;
   protected Long lowerOutlierBound;
   protected Long higherOutlierBound;
+
+  public FlowNodeOutlierParametersDto() {}
+
+  public String getFlowNodeId() {
+    return flowNodeId;
+  }
+
+  public void setFlowNodeId(final String flowNodeId) {
+    this.flowNodeId = flowNodeId;
+  }
+
+  public Long getLowerOutlierBound() {
+    return lowerOutlierBound;
+  }
+
+  public void setLowerOutlierBound(final Long lowerOutlierBound) {
+    this.lowerOutlierBound = lowerOutlierBound;
+  }
+
+  public Long getHigherOutlierBound() {
+    return higherOutlierBound;
+  }
+
+  public void setHigherOutlierBound(final Long higherOutlierBound) {
+    this.higherOutlierBound = higherOutlierBound;
+  }
+
+  @Override
+  public String toString() {
+    return "FlowNodeOutlierParametersDto(flowNodeId="
+        + getFlowNodeId()
+        + ", lowerOutlierBound="
+        + getLowerOutlierBound()
+        + ", higherOutlierBound="
+        + getHigherOutlierBound()
+        + ")";
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final FlowNodeOutlierParametersDto that = (FlowNodeOutlierParametersDto) o;
+    return Objects.equals(flowNodeId, that.flowNodeId)
+        && Objects.equals(lowerOutlierBound, that.lowerOutlierBound)
+        && Objects.equals(higherOutlierBound, that.higherOutlierBound);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), flowNodeId, lowerOutlierBound, higherOutlierBound);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof FlowNodeOutlierParametersDto;
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/FlowNodeOutlierVariableParametersDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/FlowNodeOutlierVariableParametersDto.java
@@ -7,12 +7,60 @@
  */
 package io.camunda.optimize.dto.optimize.query.analysis;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class FlowNodeOutlierVariableParametersDto extends FlowNodeOutlierParametersDto {
+
   protected String variableName;
   protected String variableTerm;
+
+  public FlowNodeOutlierVariableParametersDto() {}
+
+  public String getVariableName() {
+    return variableName;
+  }
+
+  public void setVariableName(final String variableName) {
+    this.variableName = variableName;
+  }
+
+  public String getVariableTerm() {
+    return variableTerm;
+  }
+
+  public void setVariableTerm(final String variableTerm) {
+    this.variableTerm = variableTerm;
+  }
+
+  @Override
+  public String toString() {
+    return "FlowNodeOutlierVariableParametersDto(variableName="
+        + getVariableName()
+        + ", variableTerm="
+        + getVariableTerm()
+        + ")";
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final FlowNodeOutlierVariableParametersDto that = (FlowNodeOutlierVariableParametersDto) o;
+    return Objects.equals(variableName, that.variableName)
+        && Objects.equals(variableTerm, that.variableTerm);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), variableName, variableTerm);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof FlowNodeOutlierVariableParametersDto;
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/OutlierAnalysisServiceParameters.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/OutlierAnalysisServiceParameters.java
@@ -8,14 +8,73 @@
 package io.camunda.optimize.dto.optimize.query.analysis;
 
 import java.time.ZoneId;
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
 public class OutlierAnalysisServiceParameters<T extends ProcessDefinitionParametersDto> {
 
   private T processDefinitionParametersDto;
   private ZoneId zoneId;
   private String userId;
+
+  public OutlierAnalysisServiceParameters(
+      final T processDefinitionParametersDto, final ZoneId zoneId, final String userId) {
+    this.processDefinitionParametersDto = processDefinitionParametersDto;
+    this.zoneId = zoneId;
+    this.userId = userId;
+  }
+
+  public T getProcessDefinitionParametersDto() {
+    return processDefinitionParametersDto;
+  }
+
+  public void setProcessDefinitionParametersDto(final T processDefinitionParametersDto) {
+    this.processDefinitionParametersDto = processDefinitionParametersDto;
+  }
+
+  public ZoneId getZoneId() {
+    return zoneId;
+  }
+
+  public void setZoneId(final ZoneId zoneId) {
+    this.zoneId = zoneId;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public void setUserId(final String userId) {
+    this.userId = userId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof OutlierAnalysisServiceParameters;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OutlierAnalysisServiceParameters<?> that = (OutlierAnalysisServiceParameters<?>) o;
+    return Objects.equals(processDefinitionParametersDto, that.processDefinitionParametersDto)
+        && Objects.equals(zoneId, that.zoneId)
+        && Objects.equals(userId, that.userId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processDefinitionParametersDto, zoneId, userId);
+  }
+
+  @Override
+  public String toString() {
+    return "OutlierAnalysisServiceParameters(processDefinitionParametersDto="
+        + getProcessDefinitionParametersDto()
+        + ", zoneId="
+        + getZoneId()
+        + ", userId="
+        + getUserId()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/ProcessDefinitionParametersDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/ProcessDefinitionParametersDto.java
@@ -14,10 +14,9 @@ import io.camunda.optimize.rest.queryparam.QueryParamUtil;
 import io.camunda.optimize.service.util.TenantListHandlingUtil;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
-import lombok.Data;
 
-@Data
 public class ProcessDefinitionParametersDto {
 
   protected String processDefinitionKey;
@@ -27,9 +26,7 @@ public class ProcessDefinitionParametersDto {
   protected Boolean disconsiderAutomatedTasks = false;
   protected List<ProcessFilterDto<?>> filters = new ArrayList<>();
 
-  public void setTenantIds(final List<String> tenantIds) {
-    this.tenantIds = normalizeTenants(tenantIds);
-  }
+  public ProcessDefinitionParametersDto() {}
 
   protected List<String> normalizeNullTenants(final List<String> tenantIds) {
     return tenantIds.stream()
@@ -44,5 +41,95 @@ public class ProcessDefinitionParametersDto {
 
   public List<String> getTenantIds() {
     return TenantListHandlingUtil.sortAndReturnTenantIdList(tenantIds);
+  }
+
+  public void setTenantIds(final List<String> tenantIds) {
+    this.tenantIds = normalizeTenants(tenantIds);
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public List<String> getProcessDefinitionVersions() {
+    return processDefinitionVersions;
+  }
+
+  public void setProcessDefinitionVersions(final List<String> processDefinitionVersions) {
+    this.processDefinitionVersions = processDefinitionVersions;
+  }
+
+  public Long getMinimumDeviationFromAvg() {
+    return minimumDeviationFromAvg;
+  }
+
+  public void setMinimumDeviationFromAvg(final Long minimumDeviationFromAvg) {
+    this.minimumDeviationFromAvg = minimumDeviationFromAvg;
+  }
+
+  public Boolean getDisconsiderAutomatedTasks() {
+    return disconsiderAutomatedTasks;
+  }
+
+  public void setDisconsiderAutomatedTasks(final Boolean disconsiderAutomatedTasks) {
+    this.disconsiderAutomatedTasks = disconsiderAutomatedTasks;
+  }
+
+  public List<ProcessFilterDto<?>> getFilters() {
+    return filters;
+  }
+
+  public void setFilters(final List<ProcessFilterDto<?>> filters) {
+    this.filters = filters;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessDefinitionParametersDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessDefinitionParametersDto that = (ProcessDefinitionParametersDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersions, that.processDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds)
+        && Objects.equals(minimumDeviationFromAvg, that.minimumDeviationFromAvg)
+        && Objects.equals(disconsiderAutomatedTasks, that.disconsiderAutomatedTasks)
+        && Objects.equals(filters, that.filters);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        processDefinitionKey,
+        processDefinitionVersions,
+        tenantIds,
+        minimumDeviationFromAvg,
+        disconsiderAutomatedTasks,
+        filters);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessDefinitionParametersDto(processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", processDefinitionVersions="
+        + getProcessDefinitionVersions()
+        + ", tenantIds="
+        + getTenantIds()
+        + ", minimumDeviationFromAvg="
+        + getMinimumDeviationFromAvg()
+        + ", disconsiderAutomatedTasks="
+        + getDisconsiderAutomatedTasks()
+        + ", filters="
+        + getFilters()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/VariableTermDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/analysis/VariableTermDto.java
@@ -7,18 +7,125 @@
  */
 package io.camunda.optimize.dto.optimize.query.analysis;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Data
 public class VariableTermDto {
+
   private String variableName;
   private String variableTerm;
   private Long instanceCount;
   private Double outlierRatio;
   private Double nonOutlierRatio;
   private Double outlierToAllInstancesRatio;
+
+  public VariableTermDto(
+      final String variableName,
+      final String variableTerm,
+      final Long instanceCount,
+      final Double outlierRatio,
+      final Double nonOutlierRatio,
+      final Double outlierToAllInstancesRatio) {
+    this.variableName = variableName;
+    this.variableTerm = variableTerm;
+    this.instanceCount = instanceCount;
+    this.outlierRatio = outlierRatio;
+    this.nonOutlierRatio = nonOutlierRatio;
+    this.outlierToAllInstancesRatio = outlierToAllInstancesRatio;
+  }
+
+  public VariableTermDto() {}
+
+  public String getVariableName() {
+    return variableName;
+  }
+
+  public void setVariableName(final String variableName) {
+    this.variableName = variableName;
+  }
+
+  public String getVariableTerm() {
+    return variableTerm;
+  }
+
+  public void setVariableTerm(final String variableTerm) {
+    this.variableTerm = variableTerm;
+  }
+
+  public Long getInstanceCount() {
+    return instanceCount;
+  }
+
+  public void setInstanceCount(final Long instanceCount) {
+    this.instanceCount = instanceCount;
+  }
+
+  public Double getOutlierRatio() {
+    return outlierRatio;
+  }
+
+  public void setOutlierRatio(final Double outlierRatio) {
+    this.outlierRatio = outlierRatio;
+  }
+
+  public Double getNonOutlierRatio() {
+    return nonOutlierRatio;
+  }
+
+  public void setNonOutlierRatio(final Double nonOutlierRatio) {
+    this.nonOutlierRatio = nonOutlierRatio;
+  }
+
+  public Double getOutlierToAllInstancesRatio() {
+    return outlierToAllInstancesRatio;
+  }
+
+  public void setOutlierToAllInstancesRatio(final Double outlierToAllInstancesRatio) {
+    this.outlierToAllInstancesRatio = outlierToAllInstancesRatio;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof VariableTermDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableTermDto that = (VariableTermDto) o;
+    return Objects.equals(variableName, that.variableName)
+        && Objects.equals(variableTerm, that.variableTerm)
+        && Objects.equals(instanceCount, that.instanceCount)
+        && Objects.equals(outlierRatio, that.outlierRatio)
+        && Objects.equals(nonOutlierRatio, that.nonOutlierRatio)
+        && Objects.equals(outlierToAllInstancesRatio, that.outlierToAllInstancesRatio);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        variableName,
+        variableTerm,
+        instanceCount,
+        outlierRatio,
+        nonOutlierRatio,
+        outlierToAllInstancesRatio);
+  }
+
+  @Override
+  public String toString() {
+    return "VariableTermDto(variableName="
+        + getVariableName()
+        + ", variableTerm="
+        + getVariableTerm()
+        + ", instanceCount="
+        + getInstanceCount()
+        + ", outlierRatio="
+        + getOutlierRatio()
+        + ", nonOutlierRatio="
+        + getNonOutlierRatio()
+        + ", outlierToAllInstancesRatio="
+        + getOutlierToAllInstancesRatio()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionDefinitionUpdateDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionDefinitionUpdateDto.java
@@ -9,16 +9,96 @@ package io.camunda.optimize.dto.optimize.query.collection;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.OffsetDateTime;
-import lombok.Data;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Data
 public class CollectionDefinitionUpdateDto {
 
   protected String name;
   protected OffsetDateTime lastModified;
   protected String owner;
   protected String lastModifier;
-
   protected PartialCollectionDataDto data;
+
+  public CollectionDefinitionUpdateDto() {}
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public OffsetDateTime getLastModified() {
+    return lastModified;
+  }
+
+  public void setLastModified(final OffsetDateTime lastModified) {
+    this.lastModified = lastModified;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(final String owner) {
+    this.owner = owner;
+  }
+
+  public String getLastModifier() {
+    return lastModifier;
+  }
+
+  public void setLastModifier(final String lastModifier) {
+    this.lastModifier = lastModifier;
+  }
+
+  public PartialCollectionDataDto getData() {
+    return data;
+  }
+
+  public void setData(final PartialCollectionDataDto data) {
+    this.data = data;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CollectionDefinitionUpdateDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, lastModified, owner, lastModifier, data);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionDefinitionUpdateDto that = (CollectionDefinitionUpdateDto) o;
+    return Objects.equals(name, that.name)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public String toString() {
+    return "CollectionDefinitionUpdateDto(name="
+        + getName()
+        + ", lastModified="
+        + getLastModified()
+        + ", owner="
+        + getOwner()
+        + ", lastModifier="
+        + getLastModifier()
+        + ", data="
+        + getData()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/collection/PartialCollectionDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/collection/PartialCollectionDataDto.java
@@ -8,11 +8,43 @@
 package io.camunda.optimize.dto.optimize.query.collection;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.Data;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Data
 public class PartialCollectionDataDto {
 
   protected Object configuration;
+
+  public PartialCollectionDataDto() {}
+
+  public Object getConfiguration() {
+    return configuration;
+  }
+
+  public void setConfiguration(final Object configuration) {
+    this.configuration = configuration;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PartialCollectionDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PartialCollectionDataDto that = (PartialCollectionDataDto) o;
+    return Objects.equals(configuration, that.configuration);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(configuration);
+  }
+
+  @Override
+  public String toString() {
+    return "PartialCollectionDataDto(configuration=" + getConfiguration() + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/collection/PartialCollectionDefinitionRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/collection/PartialCollectionDefinitionRequestDto.java
@@ -8,19 +8,85 @@
 package io.camunda.optimize.dto.optimize.query.collection;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Data
 public class PartialCollectionDefinitionRequestDto {
+
+  protected String ownerId;
   protected String name;
   protected PartialCollectionDataDto data;
 
   public PartialCollectionDefinitionRequestDto(final String name) {
     this.name = name;
+  }
+
+  public PartialCollectionDefinitionRequestDto(
+      final String name, final PartialCollectionDataDto data) {
+    this.name = name;
+    this.data = data;
+  }
+
+  public PartialCollectionDefinitionRequestDto(final String name, final String ownerId) {
+    this.name = name;
+    this.ownerId = ownerId;
+  }
+
+  public PartialCollectionDefinitionRequestDto() {}
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getOwnerId() {
+    return ownerId;
+  }
+
+  public void setOwnerId(final String ownerId) {
+    this.ownerId = ownerId;
+  }
+
+  public PartialCollectionDataDto getData() {
+    return data;
+  }
+
+  public void setData(final PartialCollectionDataDto data) {
+    this.data = data;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PartialCollectionDefinitionRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PartialCollectionDefinitionRequestDto that = (PartialCollectionDefinitionRequestDto) o;
+    return Objects.equals(ownerId, that.ownerId)
+        && Objects.equals(name, that.name)
+        && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(ownerId, name, data);
+  }
+
+  @Override
+  public String toString() {
+    return "PartialCollectionDefinitionRequestDto("
+        + "ownerId="
+        + getOwnerId()
+        + ", name="
+        + getName()
+        + ", data="
+        + getData()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/DashboardDefinitionUpdateDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/DashboardDefinitionUpdateDto.java
@@ -13,11 +13,11 @@ import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTile
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Data
 public class DashboardDefinitionUpdateDto {
+
   protected String name;
   @JsonInclude protected String description;
   protected OffsetDateTime lastModified;
@@ -26,4 +26,127 @@ public class DashboardDefinitionUpdateDto {
   protected String collectionId;
   protected List<DashboardFilterDto<?>> availableFilters = new ArrayList<>();
   @JsonInclude protected Long refreshRateSeconds;
+
+  public DashboardDefinitionUpdateDto() {}
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
+  }
+
+  public OffsetDateTime getLastModified() {
+    return lastModified;
+  }
+
+  public void setLastModified(final OffsetDateTime lastModified) {
+    this.lastModified = lastModified;
+  }
+
+  public String getLastModifier() {
+    return lastModifier;
+  }
+
+  public void setLastModifier(final String lastModifier) {
+    this.lastModifier = lastModifier;
+  }
+
+  public List<DashboardReportTileDto> getTiles() {
+    return tiles;
+  }
+
+  public void setTiles(final List<DashboardReportTileDto> tiles) {
+    this.tiles = tiles;
+  }
+
+  public String getCollectionId() {
+    return collectionId;
+  }
+
+  public void setCollectionId(final String collectionId) {
+    this.collectionId = collectionId;
+  }
+
+  public List<DashboardFilterDto<?>> getAvailableFilters() {
+    return availableFilters;
+  }
+
+  public void setAvailableFilters(final List<DashboardFilterDto<?>> availableFilters) {
+    this.availableFilters = availableFilters;
+  }
+
+  public Long getRefreshRateSeconds() {
+    return refreshRateSeconds;
+  }
+
+  public void setRefreshRateSeconds(final Long refreshRateSeconds) {
+    this.refreshRateSeconds = refreshRateSeconds;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardDefinitionUpdateDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardDefinitionUpdateDto that = (DashboardDefinitionUpdateDto) o;
+    return Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && Objects.equals(tiles, that.tiles)
+        && Objects.equals(collectionId, that.collectionId)
+        && Objects.equals(availableFilters, that.availableFilters)
+        && Objects.equals(refreshRateSeconds, that.refreshRateSeconds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        name,
+        description,
+        lastModified,
+        lastModifier,
+        tiles,
+        collectionId,
+        availableFilters,
+        refreshRateSeconds);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardDefinitionUpdateDto(name="
+        + getName()
+        + ", description="
+        + getDescription()
+        + ", lastModified="
+        + getLastModified()
+        + ", lastModifier="
+        + getLastModifier()
+        + ", tiles="
+        + getTiles()
+        + ", collectionId="
+        + getCollectionId()
+        + ", availableFilters="
+        + getAvailableFilters()
+        + ", refreshRateSeconds="
+        + getRefreshRateSeconds()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/AssigneeCandidateGroupDefinitionSearchRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/AssigneeCandidateGroupDefinitionSearchRequestDto.java
@@ -11,25 +11,171 @@ import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
-@Builder
 public class AssigneeCandidateGroupDefinitionSearchRequestDto {
+
   private String terms;
-  @Builder.Default private int limit = 25;
+  private int limit = 25;
   @NotNull private String processDefinitionKey;
 
-  @Builder.Default
   private List<String> tenantIds = new ArrayList<>(Collections.singletonList(null));
+
+  public AssigneeCandidateGroupDefinitionSearchRequestDto(
+      final String terms,
+      final int limit,
+      @NotNull final String processDefinitionKey,
+      final List<String> tenantIds) {
+    this.terms = terms;
+    this.limit = limit;
+    this.processDefinitionKey = processDefinitionKey;
+    this.tenantIds = tenantIds;
+  }
+
+  public AssigneeCandidateGroupDefinitionSearchRequestDto() {}
 
   public Optional<String> getTerms() {
     return Optional.ofNullable(terms);
+  }
+
+  public void setTerms(final String terms) {
+    this.terms = terms;
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+
+  public void setLimit(final int limit) {
+    this.limit = limit;
+  }
+
+  public @NotNull String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(@NotNull final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public List<String> getTenantIds() {
+    return tenantIds;
+  }
+
+  public void setTenantIds(final List<String> tenantIds) {
+    this.tenantIds = tenantIds;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof AssigneeCandidateGroupDefinitionSearchRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(terms, limit, processDefinitionKey, tenantIds);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AssigneeCandidateGroupDefinitionSearchRequestDto that =
+        (AssigneeCandidateGroupDefinitionSearchRequestDto) o;
+    return limit == that.limit
+        && Objects.equals(terms, that.terms)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(tenantIds, that.tenantIds);
+  }
+
+  @Override
+  public String toString() {
+    return "AssigneeCandidateGroupDefinitionSearchRequestDto(terms="
+        + getTerms()
+        + ", limit="
+        + getLimit()
+        + ", processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", tenantIds="
+        + getTenantIds()
+        + ")";
+  }
+
+  private static int defaultLimit() {
+    return 25;
+  }
+
+  private static List<String> defaultTenantIds() {
+    return new ArrayList<>(Collections.singletonList(null));
+  }
+
+  public static AssigneeCandidateGroupDefinitionSearchRequestDtoBuilder builder() {
+    return new AssigneeCandidateGroupDefinitionSearchRequestDtoBuilder();
+  }
+
+  public static class AssigneeCandidateGroupDefinitionSearchRequestDtoBuilder {
+
+    private String terms;
+    private int limitValue;
+    private boolean limitSet;
+    private @NotNull String processDefinitionKey;
+    private List<String> tenantIdsValue;
+    private boolean tenantIdsSet;
+
+    AssigneeCandidateGroupDefinitionSearchRequestDtoBuilder() {}
+
+    public AssigneeCandidateGroupDefinitionSearchRequestDtoBuilder terms(final String terms) {
+      this.terms = terms;
+      return this;
+    }
+
+    public AssigneeCandidateGroupDefinitionSearchRequestDtoBuilder limit(final int limit) {
+      limitValue = limit;
+      limitSet = true;
+      return this;
+    }
+
+    public AssigneeCandidateGroupDefinitionSearchRequestDtoBuilder processDefinitionKey(
+        @NotNull final String processDefinitionKey) {
+      this.processDefinitionKey = processDefinitionKey;
+      return this;
+    }
+
+    public AssigneeCandidateGroupDefinitionSearchRequestDtoBuilder tenantIds(
+        final List<String> tenantIds) {
+      tenantIdsValue = tenantIds;
+      tenantIdsSet = true;
+      return this;
+    }
+
+    public AssigneeCandidateGroupDefinitionSearchRequestDto build() {
+      int limitValue = this.limitValue;
+      if (!limitSet) {
+        limitValue = AssigneeCandidateGroupDefinitionSearchRequestDto.defaultLimit();
+      }
+      List<String> tenantIdsValue = this.tenantIdsValue;
+      if (!tenantIdsSet) {
+        tenantIdsValue = AssigneeCandidateGroupDefinitionSearchRequestDto.defaultTenantIds();
+      }
+      return new AssigneeCandidateGroupDefinitionSearchRequestDto(
+          terms, limitValue, processDefinitionKey, tenantIdsValue);
+    }
+
+    @Override
+    public String toString() {
+      return "AssigneeCandidateGroupDefinitionSearchRequestDto.AssigneeCandidateGroupDefinitionSearchRequestDtoBuilder(terms="
+          + terms
+          + ", limitValue="
+          + limitValue
+          + ", processDefinitionKey="
+          + processDefinitionKey
+          + ", tenantIdsValue="
+          + tenantIdsValue
+          + ")";
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/AssigneeCandidateGroupReportSearchRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/AssigneeCandidateGroupReportSearchRequestDto.java
@@ -10,22 +10,131 @@ package io.camunda.optimize.dto.optimize.query.definition;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
-@Builder
 public class AssigneeCandidateGroupReportSearchRequestDto {
+
   private String terms;
-  @Builder.Default private int limit = 25;
+  private int limit = 25;
   @NotNull @NotEmpty private List<String> reportIds;
+
+  public AssigneeCandidateGroupReportSearchRequestDto(
+      final String terms, final int limit, @NotNull @NotEmpty final List<String> reportIds) {
+    this.terms = terms;
+    this.limit = limit;
+    this.reportIds = reportIds;
+  }
+
+  public AssigneeCandidateGroupReportSearchRequestDto() {}
 
   public Optional<String> getTerms() {
     return Optional.ofNullable(terms);
+  }
+
+  public void setTerms(final String terms) {
+    this.terms = terms;
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+
+  public void setLimit(final int limit) {
+    this.limit = limit;
+  }
+
+  public @NotNull @NotEmpty List<String> getReportIds() {
+    return reportIds;
+  }
+
+  public void setReportIds(@NotNull @NotEmpty final List<String> reportIds) {
+    this.reportIds = reportIds;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof AssigneeCandidateGroupReportSearchRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AssigneeCandidateGroupReportSearchRequestDto that =
+        (AssigneeCandidateGroupReportSearchRequestDto) o;
+    return limit == that.limit
+        && Objects.equals(terms, that.terms)
+        && Objects.equals(reportIds, that.reportIds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(terms, limit, reportIds);
+  }
+
+  @Override
+  public String toString() {
+    return "AssigneeCandidateGroupReportSearchRequestDto(terms="
+        + getTerms()
+        + ", limit="
+        + getLimit()
+        + ", reportIds="
+        + getReportIds()
+        + ")";
+  }
+
+  private static int defaultLimit() {
+    return 25;
+  }
+
+  public static AssigneeCandidateGroupReportSearchRequestDtoBuilder builder() {
+    return new AssigneeCandidateGroupReportSearchRequestDtoBuilder();
+  }
+
+  public static class AssigneeCandidateGroupReportSearchRequestDtoBuilder {
+
+    private String terms;
+    private int limitValue;
+    private boolean limitSet;
+    private @NotNull @NotEmpty List<String> reportIds;
+
+    AssigneeCandidateGroupReportSearchRequestDtoBuilder() {}
+
+    public AssigneeCandidateGroupReportSearchRequestDtoBuilder terms(final String terms) {
+      this.terms = terms;
+      return this;
+    }
+
+    public AssigneeCandidateGroupReportSearchRequestDtoBuilder limit(final int limit) {
+      limitValue = limit;
+      limitSet = true;
+      return this;
+    }
+
+    public AssigneeCandidateGroupReportSearchRequestDtoBuilder reportIds(
+        @NotNull @NotEmpty final List<String> reportIds) {
+      this.reportIds = reportIds;
+      return this;
+    }
+
+    public AssigneeCandidateGroupReportSearchRequestDto build() {
+      int limitValue = this.limitValue;
+      if (!limitSet) {
+        limitValue = AssigneeCandidateGroupReportSearchRequestDto.defaultLimit();
+      }
+      return new AssigneeCandidateGroupReportSearchRequestDto(terms, limitValue, reportIds);
+    }
+
+    @Override
+    public String toString() {
+      return "AssigneeCandidateGroupReportSearchRequestDto.AssigneeCandidateGroupReportSearchRequestDtoBuilder(terms="
+          + terms
+          + ", limitValue="
+          + limitValue
+          + ", reportIds="
+          + reportIds
+          + ")";
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DecisionDefinitionGroupOptimizeDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DecisionDefinitionGroupOptimizeDto.java
@@ -12,13 +12,14 @@ import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class DecisionDefinitionGroupOptimizeDto {
 
   private String key;
   private List<DecisionDefinitionOptimizeDto> versions = new ArrayList<>();
+
+  public DecisionDefinitionGroupOptimizeDto() {}
 
   public void sort() {
     try {
@@ -31,5 +32,51 @@ public class DecisionDefinitionGroupOptimizeDto {
           "Error while trying to parse version numbers for sorting decision definition groups: "
               + versions);
     }
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(final String key) {
+    this.key = key;
+  }
+
+  public List<DecisionDefinitionOptimizeDto> getVersions() {
+    return versions;
+  }
+
+  public void setVersions(final List<DecisionDefinitionOptimizeDto> versions) {
+    this.versions = versions;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DecisionDefinitionGroupOptimizeDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionDefinitionGroupOptimizeDto that = (DecisionDefinitionGroupOptimizeDto) o;
+    return Objects.equals(key, that.key) && Objects.equals(versions, that.versions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, versions);
+  }
+
+  @Override
+  public String toString() {
+    return "DecisionDefinitionGroupOptimizeDto(key="
+        + getKey()
+        + ", versions="
+        + getVersions()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionKeyResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionKeyResponseDto.java
@@ -7,17 +7,91 @@
  */
 package io.camunda.optimize.dto.optimize.query.definition;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Builder
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DefinitionKeyResponseDto {
+
   private String key;
   private String name;
+
+  public DefinitionKeyResponseDto(final String key, final String name) {
+    this.key = key;
+    this.name = name;
+  }
+
+  protected DefinitionKeyResponseDto() {}
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(final String key) {
+    this.key = key;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DefinitionKeyResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionKeyResponseDto that = (DefinitionKeyResponseDto) o;
+    return Objects.equals(key, that.key) && Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, name);
+  }
+
+  @Override
+  public String toString() {
+    return "DefinitionKeyResponseDto(key=" + getKey() + ", name=" + getName() + ")";
+  }
+
+  public static DefinitionKeyResponseDtoBuilder builder() {
+    return new DefinitionKeyResponseDtoBuilder();
+  }
+
+  public static class DefinitionKeyResponseDtoBuilder {
+
+    private String key;
+    private String name;
+
+    DefinitionKeyResponseDtoBuilder() {}
+
+    public DefinitionKeyResponseDtoBuilder key(final String key) {
+      this.key = key;
+      return this;
+    }
+
+    public DefinitionKeyResponseDtoBuilder name(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public DefinitionKeyResponseDto build() {
+      return new DefinitionKeyResponseDto(key, name);
+    }
+
+    @Override
+    public String toString() {
+      return "DefinitionKeyResponseDto.DefinitionKeyResponseDtoBuilder(key="
+          + key
+          + ", name="
+          + name
+          + ")";
+    }
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionResponseDto.java
@@ -12,40 +12,66 @@ import io.camunda.optimize.dto.optimize.SimpleDefinitionDto;
 import io.camunda.optimize.dto.optimize.TenantDto;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.ToString;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
-@EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
 public class DefinitionResponseDto extends SimpleDefinitionDto {
-  @NonNull private List<TenantDto> tenants;
+
+  private List<TenantDto> tenants;
 
   public DefinitionResponseDto(
-      @NonNull final String key,
+      final String key,
       final String name,
-      @NonNull final DefinitionType type,
-      @NonNull final List<TenantDto> tenants,
-      @NonNull final String engine) {
+      final DefinitionType type,
+      final List<TenantDto> tenants,
+      final String engine) {
     super(key, name, type, Collections.singleton(engine));
+    if (key == null) {
+      throw new IllegalArgumentException("Key cannot be null");
+    }
+
+    if (type == null) {
+      throw new IllegalArgumentException("Type cannot be null");
+    }
+
+    if (tenants == null) {
+      throw new IllegalArgumentException("Tenants cannot be null");
+    }
+
+    if (engine == null) {
+      throw new IllegalArgumentException("Engine cannot be null");
+    }
+
     this.tenants = tenants;
   }
 
   public DefinitionResponseDto(
-      @NonNull final String key,
+      final String key,
       final String name,
-      @NonNull final DefinitionType type,
-      @NonNull final List<TenantDto> tenants,
-      @NonNull final Set<String> engines) {
+      final DefinitionType type,
+      final List<TenantDto> tenants,
+      final Set<String> engines) {
     super(key, name, type, engines);
+    if (key == null) {
+      throw new IllegalArgumentException("Key cannot be null");
+    }
+
+    if (type == null) {
+      throw new IllegalArgumentException("Type cannot be null");
+    }
+
+    if (tenants == null) {
+      throw new IllegalArgumentException("Tenants cannot be null");
+    }
+
+    if (engines == null) {
+      throw new IllegalArgumentException("Engines cannot be null");
+    }
+
     this.tenants = tenants;
   }
+
+  protected DefinitionResponseDto() {}
 
   public static DefinitionResponseDto from(
       final DefinitionWithTenantIdsDto definitionWithTenantIdsDto,
@@ -56,5 +82,44 @@ public class DefinitionResponseDto extends SimpleDefinitionDto {
         definitionWithTenantIdsDto.getType(),
         authorizedTenants,
         definitionWithTenantIdsDto.getEngines());
+  }
+
+  public List<TenantDto> getTenants() {
+    return tenants;
+  }
+
+  public void setTenants(final List<TenantDto> tenants) {
+    if (tenants == null) {
+      throw new IllegalArgumentException("Tenants cannot be null");
+    }
+
+    this.tenants = tenants;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DefinitionResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DefinitionResponseDto that = (DefinitionResponseDto) o;
+    return Objects.equals(tenants, that.tenants);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), tenants);
+  }
+
+  @Override
+  public String toString() {
+    return "DefinitionResponseDto(super=" + super.toString() + ", tenants=" + getTenants() + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionVersionWithTenantsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionVersionWithTenantsDto.java
@@ -13,23 +13,99 @@ import io.camunda.optimize.dto.optimize.SimpleDefinitionDto;
 import io.camunda.optimize.dto.optimize.TenantDto;
 import java.util.Comparator;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class DefinitionVersionWithTenantsDto extends SimpleDefinitionDto {
-  @NonNull private String version;
+
+  private String version;
   private String versionTag;
-  @NonNull private List<TenantDto> tenants;
+  private List<TenantDto> tenants;
+
+  public DefinitionVersionWithTenantsDto(
+      final String version, final String versionTag, final List<TenantDto> tenants) {
+    if (version == null) {
+      throw new IllegalArgumentException("version cannot be null");
+    }
+
+    if (tenants == null) {
+      throw new IllegalArgumentException("tenants cannot be null");
+    }
+
+    this.version = version;
+    this.versionTag = versionTag;
+    this.tenants = tenants;
+  }
+
+  protected DefinitionVersionWithTenantsDto() {}
 
   public void sort() {
     tenants.sort(Comparator.comparing(TenantDto::getId, Comparator.nullsFirst(naturalOrder())));
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(final String version) {
+    if (version == null) {
+      throw new IllegalArgumentException("version cannot be null");
+    }
+
+    this.version = version;
+  }
+
+  public String getVersionTag() {
+    return versionTag;
+  }
+
+  public void setVersionTag(final String versionTag) {
+    this.versionTag = versionTag;
+  }
+
+  public List<TenantDto> getTenants() {
+    return tenants;
+  }
+
+  public void setTenants(final List<TenantDto> tenants) {
+    if (tenants == null) {
+      throw new IllegalArgumentException("tenants cannot be null");
+    }
+
+    this.tenants = tenants;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DefinitionVersionWithTenantsDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DefinitionVersionWithTenantsDto that = (DefinitionVersionWithTenantsDto) o;
+    return Objects.equals(version, that.version)
+        && Objects.equals(versionTag, that.versionTag)
+        && Objects.equals(tenants, that.tenants);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), version, versionTag, tenants);
+  }
+
+  @Override
+  public String toString() {
+    return "DefinitionVersionWithTenantsDto(version="
+        + getVersion()
+        + ", versionTag="
+        + getVersionTag()
+        + ", tenants="
+        + getTenants()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionWithTenantIdsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/DefinitionWithTenantIdsDto.java
@@ -11,32 +11,78 @@ import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.SimpleDefinitionDto;
 import io.camunda.optimize.service.util.TenantListHandlingUtil;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class DefinitionWithTenantIdsDto extends SimpleDefinitionDto {
-  @NonNull private List<String> tenantIds;
+
+  private List<String> tenantIds;
 
   public DefinitionWithTenantIdsDto(
-      @NonNull final String key,
+      final String key,
       final String name,
-      @NonNull final DefinitionType type,
-      @NonNull final List<String> tenantIds,
-      @NonNull final Set<String> engines) {
+      final DefinitionType type,
+      final List<String> tenantIds,
+      final Set<String> engines) {
     super(key, name, type, engines);
+    if (key == null) {
+      throw new IllegalArgumentException("Key cannot be null");
+    }
+    if (type == null) {
+      throw new IllegalArgumentException("Type cannot be null");
+    }
+    if (tenantIds == null) {
+      throw new IllegalArgumentException("TenantIds cannot be null");
+    }
+    if (engines == null) {
+      throw new IllegalArgumentException("Engines cannot be null");
+    }
+
     this.tenantIds = tenantIds;
   }
 
+  public DefinitionWithTenantIdsDto(final List<String> tenantIds) {
+    this.tenantIds = tenantIds;
+  }
+
+  protected DefinitionWithTenantIdsDto() {}
+
   public List<String> getTenantIds() {
     return TenantListHandlingUtil.sortAndReturnTenantIdList(tenantIds);
+  }
+
+  public void setTenantIds(final List<String> tenantIds) {
+    if (tenantIds == null) {
+      throw new IllegalArgumentException("TenantIds cannot be null");
+    }
+
+    this.tenantIds = tenantIds;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DefinitionWithTenantIdsDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DefinitionWithTenantIdsDto that = (DefinitionWithTenantIdsDto) o;
+    return Objects.equals(tenantIds, that.tenantIds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), tenantIds);
+  }
+
+  @Override
+  public String toString() {
+    return "DefinitionWithTenantIdsDto(tenantIds=" + getTenantIds() + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/ProcessDefinitionGroupOptimizeDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/ProcessDefinitionGroupOptimizeDto.java
@@ -12,13 +12,14 @@ import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ProcessDefinitionGroupOptimizeDto {
 
   private String key;
   private List<ProcessDefinitionOptimizeDto> versions = new ArrayList<>();
+
+  public ProcessDefinitionGroupOptimizeDto() {}
 
   public void sort() {
     try {
@@ -31,5 +32,48 @@ public class ProcessDefinitionGroupOptimizeDto {
           "Error while trying to parse version numbers for sorting process definition groups: "
               + versions);
     }
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(final String key) {
+    this.key = key;
+  }
+
+  public List<ProcessDefinitionOptimizeDto> getVersions() {
+    return versions;
+  }
+
+  public void setVersions(final List<ProcessDefinitionOptimizeDto> versions) {
+    this.versions = versions;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessDefinitionGroupOptimizeDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessDefinitionGroupOptimizeDto that = (ProcessDefinitionGroupOptimizeDto) o;
+    return Objects.equals(key, that.key) && Objects.equals(versions, that.versions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, versions);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessDefinitionGroupOptimizeDto(key="
+        + getKey()
+        + ", versions="
+        + getVersions()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/TenantIdWithDefinitionsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/TenantIdWithDefinitionsDto.java
@@ -9,16 +9,64 @@ package io.camunda.optimize.dto.optimize.query.definition;
 
 import io.camunda.optimize.dto.optimize.SimpleDefinitionDto;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
 public class TenantIdWithDefinitionsDto {
+
   private String id;
-  @NonNull private List<SimpleDefinitionDto> definitions;
+  private List<SimpleDefinitionDto> definitions;
+
+  public TenantIdWithDefinitionsDto(final String id, final List<SimpleDefinitionDto> definitions) {
+    if (definitions == null) {
+      throw new IllegalArgumentException("definitions cannot be null");
+    }
+
+    this.id = id;
+    this.definitions = definitions;
+  }
+
+  protected TenantIdWithDefinitionsDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public List<SimpleDefinitionDto> getDefinitions() {
+    return definitions;
+  }
+
+  public void setDefinitions(final List<SimpleDefinitionDto> definitions) {
+    if (definitions == null) {
+      throw new IllegalArgumentException("definitions cannot be null");
+    }
+
+    this.definitions = definitions;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof TenantIdWithDefinitionsDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TenantIdWithDefinitionsDto that = (TenantIdWithDefinitionsDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(definitions, that.definitions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, definitions);
+  }
+
+  @Override
+  public String toString() {
+    return "TenantIdWithDefinitionsDto(id=" + getId() + ", definitions=" + getDefinitions() + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/TenantWithDefinitionsResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/definition/TenantWithDefinitionsResponseDto.java
@@ -9,17 +9,83 @@ package io.camunda.optimize.dto.optimize.query.definition;
 
 import io.camunda.optimize.dto.optimize.SimpleDefinitionDto;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
 public class TenantWithDefinitionsResponseDto {
+
   private String id;
   private String name;
-  @NonNull private List<SimpleDefinitionDto> definitions;
+  private List<SimpleDefinitionDto> definitions;
+
+  public TenantWithDefinitionsResponseDto(
+      final String id, final String name, final List<SimpleDefinitionDto> definitions) {
+    if (definitions == null) {
+      throw new IllegalArgumentException("definitions cannot be null");
+    }
+
+    this.id = id;
+    this.name = name;
+    this.definitions = definitions;
+  }
+
+  protected TenantWithDefinitionsResponseDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public List<SimpleDefinitionDto> getDefinitions() {
+    return definitions;
+  }
+
+  public void setDefinitions(final List<SimpleDefinitionDto> definitions) {
+    if (definitions == null) {
+      throw new IllegalArgumentException("definitions cannot be null");
+    }
+
+    this.definitions = definitions;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof TenantWithDefinitionsResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TenantWithDefinitionsResponseDto that = (TenantWithDefinitionsResponseDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(definitions, that.definitions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, definitions);
+  }
+
+  @Override
+  public String toString() {
+    return "TenantWithDefinitionsResponseDto(id="
+        + getId()
+        + ", name="
+        + getName()
+        + ", definitions="
+        + getDefinitions()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/report/CommandEvaluationResult.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/report/CommandEvaluationResult.java
@@ -16,26 +16,26 @@ import io.camunda.optimize.dto.optimize.rest.pagination.PaginationDto;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@RequiredArgsConstructor
-@NoArgsConstructor
-@Data
 public abstract class CommandEvaluationResult<T> {
 
   protected long instanceCount;
   protected long instanceCountWithoutFilters;
-  @NonNull protected List<MeasureDto<T>> measures = new ArrayList<>();
-  @NonNull protected ReportDataDto reportData;
-  @NonNull protected PaginationDto pagination = new PaginationDto(null, null);
+  protected List<MeasureDto<T>> measures = new ArrayList<>();
+  protected ReportDataDto reportData;
+  protected PaginationDto pagination = new PaginationDto(null, null);
 
   protected CommandEvaluationResult(
-      @NonNull final List<MeasureDto<T>> measures, @NonNull final ReportDataDto reportData) {
+      final List<MeasureDto<T>> measures, final ReportDataDto reportData) {
+    if (measures == null) {
+      throw new IllegalArgumentException("measures cannot be null");
+    }
+
+    if (reportData == null) {
+      throw new IllegalArgumentException("reportData cannot be null");
+    }
+
     this.measures = measures;
     this.reportData = reportData;
   }
@@ -43,24 +43,67 @@ public abstract class CommandEvaluationResult<T> {
   protected CommandEvaluationResult(
       final long instanceCount,
       final long instanceCountWithoutFilters,
-      @NonNull final List<MeasureDto<T>> measures,
-      @NonNull final ReportDataDto reportData) {
+      final List<MeasureDto<T>> measures,
+      final ReportDataDto reportData) {
+    if (measures == null) {
+      throw new IllegalArgumentException("measures cannot be null");
+    }
+
+    if (reportData == null) {
+      throw new IllegalArgumentException("reportData cannot be null");
+    }
+
     this.instanceCount = instanceCount;
     this.instanceCountWithoutFilters = instanceCountWithoutFilters;
     this.measures = measures;
     this.reportData = reportData;
   }
 
-  public <R extends ReportDataDto> R getReportDataAs(Class<R> reportDataType) {
+  public CommandEvaluationResult(final ReportDataDto reportData) {
+    if (reportData == null) {
+      throw new IllegalArgumentException("reportData cannot be null");
+    }
+
+    this.reportData = reportData;
+  }
+
+  public CommandEvaluationResult(
+      final long instanceCount,
+      final long instanceCountWithoutFilters,
+      final List<MeasureDto<T>> measures,
+      final ReportDataDto reportData,
+      final PaginationDto pagination) {
+    if (measures == null) {
+      throw new IllegalArgumentException("measures cannot be null");
+    }
+
+    if (reportData == null) {
+      throw new IllegalArgumentException("reportData cannot be null");
+    }
+
+    if (pagination == null) {
+      throw new IllegalArgumentException("pagination cannot be null");
+    }
+
+    this.instanceCount = instanceCount;
+    this.instanceCountWithoutFilters = instanceCountWithoutFilters;
+    this.measures = measures;
+    this.reportData = reportData;
+    this.pagination = pagination;
+  }
+
+  public CommandEvaluationResult() {}
+
+  public <R extends ReportDataDto> R getReportDataAs(final Class<R> reportDataType) {
     return reportDataType.cast(reportData);
   }
 
   public T getFirstMeasureData() {
-    return this.measures.stream().findFirst().map(MeasureDto::getData).orElse(null);
+    return measures.stream().findFirst().map(MeasureDto::getData).orElse(null);
   }
 
   public void addMeasure(final MeasureDto<T> measureDto) {
-    this.measures.add(measureDto);
+    measures.add(measureDto);
   }
 
   public abstract List<String[]> getResultAsCsv(
@@ -87,5 +130,98 @@ public abstract class CommandEvaluationResult<T> {
     } else {
       return ((DecisionReportDataDto) reportData).getView().createCommandKey().replace("-", "_");
     }
+  }
+
+  public long getInstanceCount() {
+    return instanceCount;
+  }
+
+  public void setInstanceCount(final long instanceCount) {
+    this.instanceCount = instanceCount;
+  }
+
+  public long getInstanceCountWithoutFilters() {
+    return instanceCountWithoutFilters;
+  }
+
+  public void setInstanceCountWithoutFilters(final long instanceCountWithoutFilters) {
+    this.instanceCountWithoutFilters = instanceCountWithoutFilters;
+  }
+
+  public List<MeasureDto<T>> getMeasures() {
+    return measures;
+  }
+
+  public void setMeasures(final List<MeasureDto<T>> measures) {
+    if (measures == null) {
+      throw new IllegalArgumentException("measures cannot be null");
+    }
+
+    this.measures = measures;
+  }
+
+  public ReportDataDto getReportData() {
+    return reportData;
+  }
+
+  public void setReportData(final ReportDataDto reportData) {
+    if (reportData == null) {
+      throw new IllegalArgumentException("reportData cannot be null");
+    }
+
+    this.reportData = reportData;
+  }
+
+  public PaginationDto getPagination() {
+    return pagination;
+  }
+
+  public void setPagination(final PaginationDto pagination) {
+    if (pagination == null) {
+      throw new IllegalArgumentException("pagination cannot be null");
+    }
+
+    this.pagination = pagination;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CommandEvaluationResult;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        instanceCount, instanceCountWithoutFilters, measures, reportData, pagination);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CommandEvaluationResult<?> that = (CommandEvaluationResult<?>) o;
+    return instanceCount == that.instanceCount
+        && instanceCountWithoutFilters == that.instanceCountWithoutFilters
+        && Objects.equals(measures, that.measures)
+        && Objects.equals(reportData, that.reportData)
+        && Objects.equals(pagination, that.pagination);
+  }
+
+  @Override
+  public String toString() {
+    return "CommandEvaluationResult(instanceCount="
+        + getInstanceCount()
+        + ", instanceCountWithoutFilters="
+        + getInstanceCountWithoutFilters()
+        + ", measures="
+        + getMeasures()
+        + ", reportData="
+        + getReportData()
+        + ", pagination="
+        + getPagination()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/report/SingleReportEvaluationResult.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/report/SingleReportEvaluationResult.java
@@ -9,32 +9,43 @@ package io.camunda.optimize.dto.optimize.query.report;
 
 import io.camunda.optimize.dto.optimize.rest.pagination.PaginatedDataExportDto;
 import io.camunda.optimize.dto.optimize.rest.pagination.PaginationScrollableDto;
-import io.camunda.optimize.service.db.es.report.result.RawDataCommandResult;
+import io.camunda.optimize.service.db.report.result.RawDataCommandResult;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NonNull;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class SingleReportEvaluationResult<T> extends ReportEvaluationResult {
-  @NonNull private List<CommandEvaluationResult<T>> commandEvaluationResults;
+
+  private List<CommandEvaluationResult<T>> commandEvaluationResults;
 
   public SingleReportEvaluationResult(
-      @NonNull final SingleReportDefinitionDto<?> reportDefinition,
-      @NonNull final CommandEvaluationResult<T> commandEvaluationResult) {
+      final SingleReportDefinitionDto<?> reportDefinition,
+      final CommandEvaluationResult<T> commandEvaluationResult) {
     super(reportDefinition);
-    this.commandEvaluationResults = Collections.singletonList(commandEvaluationResult);
+    if (reportDefinition == null) {
+      throw new IllegalArgumentException("reportDefinition cannot be null");
+    }
+    if (commandEvaluationResult == null) {
+      throw new IllegalArgumentException("commandEvaluationResult cannot be null");
+    }
+
+    commandEvaluationResults = Collections.singletonList(commandEvaluationResult);
   }
 
   public SingleReportEvaluationResult(
-      @NonNull final ReportDefinitionDto<?> reportDefinition,
-      @NonNull final List<CommandEvaluationResult<T>> commandEvaluationResults) {
+      final ReportDefinitionDto<?> reportDefinition,
+      final List<CommandEvaluationResult<T>> commandEvaluationResults) {
     super(reportDefinition);
+    if (reportDefinition == null) {
+      throw new IllegalArgumentException("reportDefinition cannot be null");
+    }
+    if (commandEvaluationResults == null) {
+      throw new IllegalArgumentException("commandEvaluationResult cannot be null");
+    }
+
     this.commandEvaluationResults = commandEvaluationResults;
   }
 
@@ -51,7 +62,7 @@ public class SingleReportEvaluationResult<T> extends ReportEvaluationResult {
   @Override
   public PaginatedDataExportDto getResult() {
     final CommandEvaluationResult<?> commandResult = getFirstCommandResult();
-    PaginatedDataExportDto result = new PaginatedDataExportDto();
+    final PaginatedDataExportDto result = new PaginatedDataExportDto();
     result.setData(commandResult.getResult());
     if (commandResult instanceof RawDataCommandResult) {
       result.setTotalNumberOfRecords(commandResult.getInstanceCount());
@@ -62,10 +73,52 @@ public class SingleReportEvaluationResult<T> extends ReportEvaluationResult {
         result.setSearchRequestId(null);
       }
     } else {
-      Object data = Optional.ofNullable(result.getData()).orElse(new ArrayList<>());
-      int payloadSize = (data instanceof List ? ((List<?>) data).size() : 1);
+      final Object data = Optional.ofNullable(result.getData()).orElse(new ArrayList<>());
+      final int payloadSize = (data instanceof List ? ((List<?>) data).size() : 1);
       result.setTotalNumberOfRecords(payloadSize);
     }
     return result;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof SingleReportEvaluationResult;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final SingleReportEvaluationResult<?> that = (SingleReportEvaluationResult<?>) o;
+    return Objects.equals(commandEvaluationResults, that.commandEvaluationResults);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), commandEvaluationResults);
+  }
+
+  @Override
+  public String toString() {
+    return "SingleReportEvaluationResult(commandEvaluationResults="
+        + getCommandEvaluationResults()
+        + ")";
+  }
+
+  public List<CommandEvaluationResult<T>> getCommandEvaluationResults() {
+    return commandEvaluationResults;
+  }
+
+  public void setCommandEvaluationResults(
+      final List<CommandEvaluationResult<T>> commandEvaluationResults) {
+    if (commandEvaluationResults == null) {
+      throw new IllegalArgumentException("commandEvaluationResults cannot be null");
+    }
+
+    this.commandEvaluationResults = commandEvaluationResults;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/security/CredentialsRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/security/CredentialsRequestDto.java
@@ -8,18 +8,56 @@
 package io.camunda.optimize.dto.optimize.query.security;
 
 import java.io.Serializable;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class CredentialsRequestDto implements Serializable {
 
   protected String username;
   protected String password;
+
+  public CredentialsRequestDto(final String username, final String password) {
+    this.username = username;
+    this.password = password;
+  }
+
+  protected CredentialsRequestDto() {}
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(final String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(final String password) {
+    this.password = password;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CredentialsRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CredentialsRequestDto that = (CredentialsRequestDto) o;
+    return Objects.equals(username, that.username) && Objects.equals(password, that.password);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(username, password);
+  }
 
   @Override
   public String toString() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/DashboardShareRestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/DashboardShareRestDto.java
@@ -9,12 +9,71 @@ package io.camunda.optimize.dto.optimize.query.sharing;
 
 import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTileDto;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class DashboardShareRestDto {
 
   private String id;
   private String dashboardId;
   private List<DashboardReportTileDto> tileShares;
+
+  public DashboardShareRestDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getDashboardId() {
+    return dashboardId;
+  }
+
+  public void setDashboardId(final String dashboardId) {
+    this.dashboardId = dashboardId;
+  }
+
+  public List<DashboardReportTileDto> getTileShares() {
+    return tileShares;
+  }
+
+  public void setTileShares(final List<DashboardReportTileDto> tileShares) {
+    this.tileShares = tileShares;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardShareRestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, dashboardId, tileShares);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardShareRestDto that = (DashboardShareRestDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(dashboardId, that.dashboardId)
+        && Objects.equals(tileShares, that.tileShares);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardShareRestDto(id="
+        + getId()
+        + ", dashboardId="
+        + getDashboardId()
+        + ", tileShares="
+        + getTileShares()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ReportShareRestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ReportShareRestDto.java
@@ -8,14 +8,55 @@
 package io.camunda.optimize.dto.optimize.query.sharing;
 
 import java.io.Serializable;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ReportShareRestDto implements Serializable {
 
   private String id;
   private String reportId;
 
+  public ReportShareRestDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getReportId() {
+    return reportId;
+  }
+
+  public void setReportId(final String reportId) {
+    this.reportId = reportId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ReportShareRestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportShareRestDto that = (ReportShareRestDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(reportId, that.reportId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, reportId);
+  }
+
+  @Override
+  public String toString() {
+    return "ReportShareRestDto(id=" + getId() + ", reportId=" + getReportId() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ShareSearchRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ShareSearchRequestDto.java
@@ -9,10 +9,55 @@ package io.camunda.optimize.dto.optimize.query.sharing;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ShareSearchRequestDto {
+
   private List<String> reports = new ArrayList<>();
   private List<String> dashboards = new ArrayList<>();
+
+  public ShareSearchRequestDto() {}
+
+  public List<String> getReports() {
+    return reports;
+  }
+
+  public void setReports(final List<String> reports) {
+    this.reports = reports;
+  }
+
+  public List<String> getDashboards() {
+    return dashboards;
+  }
+
+  public void setDashboards(final List<String> dashboards) {
+    this.dashboards = dashboards;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ShareSearchRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ShareSearchRequestDto that = (ShareSearchRequestDto) o;
+    return Objects.equals(reports, that.reports) && Objects.equals(dashboards, that.dashboards);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(reports, dashboards);
+  }
+
+  @Override
+  public String toString() {
+    return "ShareSearchRequestDto(reports="
+        + getReports()
+        + ", dashboards="
+        + getDashboards()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ShareSearchResultResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ShareSearchResultResponseDto.java
@@ -9,10 +9,55 @@ package io.camunda.optimize.dto.optimize.query.sharing;
 
 import java.util.HashMap;
 import java.util.Map;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ShareSearchResultResponseDto {
+
   private Map<String, Boolean> reports = new HashMap<>();
   private Map<String, Boolean> dashboards = new HashMap<>();
+
+  public ShareSearchResultResponseDto() {}
+
+  public Map<String, Boolean> getReports() {
+    return reports;
+  }
+
+  public void setReports(final Map<String, Boolean> reports) {
+    this.reports = reports;
+  }
+
+  public Map<String, Boolean> getDashboards() {
+    return dashboards;
+  }
+
+  public void setDashboards(final Map<String, Boolean> dashboards) {
+    this.dashboards = dashboards;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ShareSearchResultResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ShareSearchResultResponseDto that = (ShareSearchResultResponseDto) o;
+    return Objects.equals(reports, that.reports) && Objects.equals(dashboards, that.dashboards);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(reports, dashboards);
+  }
+
+  @Override
+  public String toString() {
+    return "ShareSearchResultResponseDto(reports="
+        + getReports()
+        + ", dashboards="
+        + getDashboards()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/AlertEmailValidationResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/AlertEmailValidationResponseDto.java
@@ -8,11 +8,8 @@
 package io.camunda.optimize.dto.optimize.rest;
 
 import io.camunda.optimize.service.exceptions.OptimizeAlertEmailValidationException;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class AlertEmailValidationResponseDto extends ErrorResponseDto {
 
   private final String invalidAlertEmails;
@@ -26,6 +23,38 @@ public class AlertEmailValidationResponseDto extends ErrorResponseDto {
     invalidAlertEmails = String.join(", ", optimizeAlertEmailValidationException.getAlertEmails());
   }
 
+  public String getInvalidAlertEmails() {
+    return invalidAlertEmails;
+  }
+
+  @Override
+  public String toString() {
+    return "AlertEmailValidationResponseDto(invalidAlertEmails=" + getInvalidAlertEmails() + ")";
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AlertEmailValidationResponseDto that = (AlertEmailValidationResponseDto) o;
+    return Objects.equals(invalidAlertEmails, that.invalidAlertEmails);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), invalidAlertEmails);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof AlertEmailValidationResponseDto;
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String invalidAlertEmails = "invalidAlertEmails";

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ConflictResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ConflictResponseDto.java
@@ -9,14 +9,12 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ConflictResponseDto extends ErrorResponseDto {
+
   private Set<ConflictedItemDto> conflictedItems;
 
   protected ConflictResponseDto() {
@@ -39,5 +37,40 @@ public class ConflictResponseDto extends ErrorResponseDto {
       final Set<ConflictedItemDto> conflictedItems) {
     super(errorCode, errorMessage, detailedErrorMessage);
     this.conflictedItems = conflictedItems;
+  }
+
+  public Set<ConflictedItemDto> getConflictedItems() {
+    return conflictedItems;
+  }
+
+  public void setConflictedItems(final Set<ConflictedItemDto> conflictedItems) {
+    this.conflictedItems = conflictedItems;
+  }
+
+  @Override
+  public String toString() {
+    return "ConflictResponseDto(conflictedItems=" + getConflictedItems() + ")";
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ConflictResponseDto that = (ConflictResponseDto) o;
+    return Objects.equals(conflictedItems, that.conflictedItems);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), conflictedItems);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ConflictResponseDto;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionExceptionItemDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionExceptionItemDto.java
@@ -10,20 +10,113 @@ package io.camunda.optimize.dto.optimize.rest;
 import io.camunda.optimize.dto.optimize.DefinitionType;
 import java.io.Serializable;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-@EqualsAndHashCode
 public class DefinitionExceptionItemDto implements Serializable {
+
   private DefinitionType type;
   private String key;
   private List<String> versions;
   private List<String> tenantIds;
+
+  public DefinitionExceptionItemDto(
+      final DefinitionType type,
+      final String key,
+      final List<String> versions,
+      final List<String> tenantIds) {
+    this.type = type;
+    this.key = key;
+    this.versions = versions;
+    this.tenantIds = tenantIds;
+  }
+
+  public DefinitionExceptionItemDto() {}
+
+  public DefinitionType getType() {
+    return type;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public List<String> getVersions() {
+    return versions;
+  }
+
+  public List<String> getTenantIds() {
+    return tenantIds;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DefinitionExceptionItemDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionExceptionItemDto that = (DefinitionExceptionItemDto) o;
+    return type == that.type
+        && Objects.equals(key, that.key)
+        && Objects.equals(versions, that.versions)
+        && Objects.equals(tenantIds, that.tenantIds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, key, versions, tenantIds);
+  }
+
+  public static DefinitionExceptionItemDtoBuilder builder() {
+    return new DefinitionExceptionItemDtoBuilder();
+  }
+
+  public static class DefinitionExceptionItemDtoBuilder {
+
+    private DefinitionType type;
+    private String key;
+    private List<String> versions;
+    private List<String> tenantIds;
+
+    DefinitionExceptionItemDtoBuilder() {}
+
+    public DefinitionExceptionItemDtoBuilder type(final DefinitionType type) {
+      this.type = type;
+      return this;
+    }
+
+    public DefinitionExceptionItemDtoBuilder key(final String key) {
+      this.key = key;
+      return this;
+    }
+
+    public DefinitionExceptionItemDtoBuilder versions(final List<String> versions) {
+      this.versions = versions;
+      return this;
+    }
+
+    public DefinitionExceptionItemDtoBuilder tenantIds(final List<String> tenantIds) {
+      this.tenantIds = tenantIds;
+      return this;
+    }
+
+    public DefinitionExceptionItemDto build() {
+      return new DefinitionExceptionItemDto(type, key, versions, tenantIds);
+    }
+
+    @Override
+    public String toString() {
+      return "DefinitionExceptionItemDto.DefinitionExceptionItemDtoBuilder(type="
+          + type
+          + ", key="
+          + key
+          + ", versions="
+          + versions
+          + ", tenantIds="
+          + tenantIds
+          + ")";
+    }
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionExceptionResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionExceptionResponseDto.java
@@ -9,14 +9,12 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DefinitionExceptionResponseDto extends ErrorResponseDto {
+
   private Set<DefinitionExceptionItemDto> definitions;
 
   protected DefinitionExceptionResponseDto() {
@@ -30,5 +28,40 @@ public class DefinitionExceptionResponseDto extends ErrorResponseDto {
       final Set<DefinitionExceptionItemDto> definitions) {
     super(errorCode, errorMessage, detailedErrorMessage);
     this.definitions = definitions;
+  }
+
+  public Set<DefinitionExceptionItemDto> getDefinitions() {
+    return definitions;
+  }
+
+  public void setDefinitions(final Set<DefinitionExceptionItemDto> definitions) {
+    this.definitions = definitions;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DefinitionExceptionResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DefinitionExceptionResponseDto that = (DefinitionExceptionResponseDto) o;
+    return Objects.equals(definitions, that.definitions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), definitions);
+  }
+
+  @Override
+  public String toString() {
+    return "DefinitionExceptionResponseDto(definitions=" + getDefinitions() + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionTenantsRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionTenantsRequestDto.java
@@ -9,18 +9,109 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Builder
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DefinitionTenantsRequestDto {
-  @Builder.Default private List<String> versions = new ArrayList<>();
+
+  private List<String> versions = new ArrayList<>();
 
   private String filterByCollectionScope;
+
+  public DefinitionTenantsRequestDto(
+      final List<String> versions, final String filterByCollectionScope) {
+    this.versions = versions;
+    this.filterByCollectionScope = filterByCollectionScope;
+  }
+
+  protected DefinitionTenantsRequestDto() {}
+
+  public List<String> getVersions() {
+    return versions;
+  }
+
+  public void setVersions(final List<String> versions) {
+    this.versions = versions;
+  }
+
+  public String getFilterByCollectionScope() {
+    return filterByCollectionScope;
+  }
+
+  public void setFilterByCollectionScope(final String filterByCollectionScope) {
+    this.filterByCollectionScope = filterByCollectionScope;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DefinitionTenantsRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionTenantsRequestDto that = (DefinitionTenantsRequestDto) o;
+    return Objects.equals(versions, that.versions)
+        && Objects.equals(filterByCollectionScope, that.filterByCollectionScope);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(versions, filterByCollectionScope);
+  }
+
+  @Override
+  public String toString() {
+    return "DefinitionTenantsRequestDto(versions="
+        + getVersions()
+        + ", filterByCollectionScope="
+        + getFilterByCollectionScope()
+        + ")";
+  }
+
+  private static List<String> defaultVersions() {
+    return new ArrayList<>();
+  }
+
+  public static DefinitionTenantsRequestDtoBuilder builder() {
+    return new DefinitionTenantsRequestDtoBuilder();
+  }
+
+  public static class DefinitionTenantsRequestDtoBuilder {
+
+    private List<String> versionsValue;
+    private boolean versionsSet;
+    private String filterByCollectionScope;
+
+    DefinitionTenantsRequestDtoBuilder() {}
+
+    public DefinitionTenantsRequestDtoBuilder versions(final List<String> versions) {
+      versionsValue = versions;
+      versionsSet = true;
+      return this;
+    }
+
+    public DefinitionTenantsRequestDtoBuilder filterByCollectionScope(
+        final String filterByCollectionScope) {
+      this.filterByCollectionScope = filterByCollectionScope;
+      return this;
+    }
+
+    public DefinitionTenantsRequestDto build() {
+      List<String> versionsValue = this.versionsValue;
+      if (!versionsSet) {
+        versionsValue = DefinitionTenantsRequestDto.defaultVersions();
+      }
+      return new DefinitionTenantsRequestDto(versionsValue, filterByCollectionScope);
+    }
+
+    @Override
+    public String toString() {
+      return "DefinitionTenantsRequestDto.DefinitionTenantsRequestDtoBuilder(versionsValue="
+          + versionsValue
+          + ", filterByCollectionScope="
+          + filterByCollectionScope
+          + ")";
+    }
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionVersionResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/DefinitionVersionResponseDto.java
@@ -7,17 +7,95 @@
  */
 package io.camunda.optimize.dto.optimize.rest;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Builder
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DefinitionVersionResponseDto {
+
   private String version;
   private String versionTag;
+
+  public DefinitionVersionResponseDto(final String version, final String versionTag) {
+    this.version = version;
+    this.versionTag = versionTag;
+  }
+
+  protected DefinitionVersionResponseDto() {}
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(final String version) {
+    this.version = version;
+  }
+
+  public String getVersionTag() {
+    return versionTag;
+  }
+
+  public void setVersionTag(final String versionTag) {
+    this.versionTag = versionTag;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DefinitionVersionResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionVersionResponseDto that = (DefinitionVersionResponseDto) o;
+    return Objects.equals(version, that.version) && Objects.equals(versionTag, that.versionTag);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version, versionTag);
+  }
+
+  @Override
+  public String toString() {
+    return "DefinitionVersionResponseDto(version="
+        + getVersion()
+        + ", versionTag="
+        + getVersionTag()
+        + ")";
+  }
+
+  public static DefinitionVersionResponseDtoBuilder builder() {
+    return new DefinitionVersionResponseDtoBuilder();
+  }
+
+  public static class DefinitionVersionResponseDtoBuilder {
+
+    private String version;
+    private String versionTag;
+
+    DefinitionVersionResponseDtoBuilder() {}
+
+    public DefinitionVersionResponseDtoBuilder version(final String version) {
+      this.version = version;
+      return this;
+    }
+
+    public DefinitionVersionResponseDtoBuilder versionTag(final String versionTag) {
+      this.versionTag = versionTag;
+      return this;
+    }
+
+    public DefinitionVersionResponseDto build() {
+      return new DefinitionVersionResponseDto(version, versionTag);
+    }
+
+    @Override
+    public String toString() {
+      return "DefinitionVersionResponseDto.DefinitionVersionResponseDtoBuilder(version="
+          + version
+          + ", versionTag="
+          + versionTag
+          + ")";
+    }
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ErrorResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ErrorResponseDto.java
@@ -7,9 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.rest;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ErrorResponseDto {
 
   private String errorCode;
@@ -46,6 +45,73 @@ public class ErrorResponseDto {
     this.detailedMessage = detailedMessage;
   }
 
+  public String getErrorCode() {
+    return errorCode;
+  }
+
+  public void setErrorCode(final String errorCode) {
+    this.errorCode = errorCode;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public void setErrorMessage(final String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+
+  public String getDetailedMessage() {
+    return detailedMessage;
+  }
+
+  public void setDetailedMessage(final String detailedMessage) {
+    this.detailedMessage = detailedMessage;
+  }
+
+  public AuthorizedReportDefinitionResponseDto getReportDefinition() {
+    return reportDefinition;
+  }
+
+  public void setReportDefinition(final AuthorizedReportDefinitionResponseDto reportDefinition) {
+    this.reportDefinition = reportDefinition;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ErrorResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ErrorResponseDto that = (ErrorResponseDto) o;
+    return Objects.equals(errorCode, that.errorCode)
+        && Objects.equals(errorMessage, that.errorMessage)
+        && Objects.equals(detailedMessage, that.detailedMessage)
+        && Objects.equals(reportDefinition, that.reportDefinition);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(errorCode, errorMessage, detailedMessage, reportDefinition);
+  }
+
+  @Override
+  public String toString() {
+    return "ErrorResponseDto(errorCode="
+        + getErrorCode()
+        + ", errorMessage="
+        + getErrorMessage()
+        + ", detailedMessage="
+        + getDetailedMessage()
+        + ", reportDefinition="
+        + getReportDefinition()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String errorCode = "errorCode";

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/FlowNodeIdsToNamesRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/FlowNodeIdsToNamesRequestDto.java
@@ -8,13 +8,80 @@
 package io.camunda.optimize.dto.optimize.rest;
 
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class FlowNodeIdsToNamesRequestDto {
 
   protected String processDefinitionKey;
   protected String processDefinitionVersion;
   protected String tenantId;
   protected List<String> nodeIds;
+
+  public FlowNodeIdsToNamesRequestDto() {}
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
+
+  public void setProcessDefinitionVersion(final String processDefinitionVersion) {
+    this.processDefinitionVersion = processDefinitionVersion;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public List<String> getNodeIds() {
+    return nodeIds;
+  }
+
+  public void setNodeIds(final List<String> nodeIds) {
+    this.nodeIds = nodeIds;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof FlowNodeIdsToNamesRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FlowNodeIdsToNamesRequestDto that = (FlowNodeIdsToNamesRequestDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersion, that.processDefinitionVersion)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(nodeIds, that.nodeIds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processDefinitionKey, processDefinitionVersion, tenantId, nodeIds);
+  }
+
+  @Override
+  public String toString() {
+    return "FlowNodeIdsToNamesRequestDto(processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", processDefinitionVersion="
+        + getProcessDefinitionVersion()
+        + ", tenantId="
+        + getTenantId()
+        + ", nodeIds="
+        + getNodeIds()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/FlowNodeNamesResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/FlowNodeNamesResponseDto.java
@@ -9,9 +9,42 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import java.util.HashMap;
 import java.util.Map;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class FlowNodeNamesResponseDto {
+
   private Map<String, String> flowNodeNames = new HashMap<>();
+
+  public FlowNodeNamesResponseDto() {}
+
+  public Map<String, String> getFlowNodeNames() {
+    return flowNodeNames;
+  }
+
+  public void setFlowNodeNames(final Map<String, String> flowNodeNames) {
+    this.flowNodeNames = flowNodeNames;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof FlowNodeNamesResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FlowNodeNamesResponseDto that = (FlowNodeNamesResponseDto) o;
+    return Objects.equals(flowNodeNames, that.flowNodeNames);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(flowNodeNames);
+  }
+
+  @Override
+  public String toString() {
+    return "FlowNodeNamesResponseDto(flowNodeNames=" + getFlowNodeNames() + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/GetVariableNamesForReportsRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/GetVariableNamesForReportsRequestDto.java
@@ -8,10 +8,42 @@
 package io.camunda.optimize.dto.optimize.rest;
 
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class GetVariableNamesForReportsRequestDto {
 
   private List<String> reportIds;
+
+  public GetVariableNamesForReportsRequestDto() {}
+
+  public List<String> getReportIds() {
+    return reportIds;
+  }
+
+  public void setReportIds(final List<String> reportIds) {
+    this.reportIds = reportIds;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof GetVariableNamesForReportsRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final GetVariableNamesForReportsRequestDto that = (GetVariableNamesForReportsRequestDto) o;
+    return Objects.equals(reportIds, that.reportIds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(reportIds);
+  }
+
+  @Override
+  public String toString() {
+    return "GetVariableNamesForReportsRequestDto(reportIds=" + getReportIds() + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ImportIndexMismatchDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ImportIndexMismatchDto.java
@@ -8,19 +8,98 @@
 package io.camunda.optimize.dto.optimize.rest;
 
 import java.io.Serializable;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-@EqualsAndHashCode
 public class ImportIndexMismatchDto implements Serializable {
+
   private String indexName;
   private int sourceIndexVersion;
   private int targetIndexVersion;
+
+  public ImportIndexMismatchDto(
+      final String indexName, final int sourceIndexVersion, final int targetIndexVersion) {
+    this.indexName = indexName;
+    this.sourceIndexVersion = sourceIndexVersion;
+    this.targetIndexVersion = targetIndexVersion;
+  }
+
+  public ImportIndexMismatchDto() {}
+
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public int getSourceIndexVersion() {
+    return sourceIndexVersion;
+  }
+
+  public int getTargetIndexVersion() {
+    return targetIndexVersion;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ImportIndexMismatchDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(indexName, sourceIndexVersion, targetIndexVersion);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ImportIndexMismatchDto that = (ImportIndexMismatchDto) o;
+    return sourceIndexVersion == that.sourceIndexVersion
+        && targetIndexVersion == that.targetIndexVersion
+        && Objects.equals(indexName, that.indexName);
+  }
+
+  public static ImportIndexMismatchDtoBuilder builder() {
+    return new ImportIndexMismatchDtoBuilder();
+  }
+
+  public static class ImportIndexMismatchDtoBuilder {
+
+    private String indexName;
+    private int sourceIndexVersion;
+    private int targetIndexVersion;
+
+    ImportIndexMismatchDtoBuilder() {}
+
+    public ImportIndexMismatchDtoBuilder indexName(final String indexName) {
+      this.indexName = indexName;
+      return this;
+    }
+
+    public ImportIndexMismatchDtoBuilder sourceIndexVersion(final int sourceIndexVersion) {
+      this.sourceIndexVersion = sourceIndexVersion;
+      return this;
+    }
+
+    public ImportIndexMismatchDtoBuilder targetIndexVersion(final int targetIndexVersion) {
+      this.targetIndexVersion = targetIndexVersion;
+      return this;
+    }
+
+    public ImportIndexMismatchDto build() {
+      return new ImportIndexMismatchDto(indexName, sourceIndexVersion, targetIndexVersion);
+    }
+
+    @Override
+    public String toString() {
+      return "ImportIndexMismatchDto.ImportIndexMismatchDtoBuilder(indexName="
+          + indexName
+          + ", sourceIndexVersion="
+          + sourceIndexVersion
+          + ", targetIndexVersion="
+          + targetIndexVersion
+          + ")";
+    }
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ImportedIndexMismatchResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ImportedIndexMismatchResponseDto.java
@@ -9,14 +9,12 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ImportedIndexMismatchResponseDto extends ErrorResponseDto {
+
   private Set<ImportIndexMismatchDto> mismatchingIndices;
 
   protected ImportedIndexMismatchResponseDto() {
@@ -30,5 +28,40 @@ public class ImportedIndexMismatchResponseDto extends ErrorResponseDto {
       final Set<ImportIndexMismatchDto> mismatchingIndices) {
     super(errorCode, errorMessage, detailedErrorMessage);
     this.mismatchingIndices = mismatchingIndices;
+  }
+
+  public Set<ImportIndexMismatchDto> getMismatchingIndices() {
+    return mismatchingIndices;
+  }
+
+  public void setMismatchingIndices(final Set<ImportIndexMismatchDto> mismatchingIndices) {
+    this.mismatchingIndices = mismatchingIndices;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ImportedIndexMismatchResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ImportedIndexMismatchResponseDto that = (ImportedIndexMismatchResponseDto) o;
+    return Objects.equals(mismatchingIndices, that.mismatchingIndices);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), mismatchingIndices);
+  }
+
+  @Override
+  public String toString() {
+    return "ImportedIndexMismatchResponseDto(mismatchingIndices=" + getMismatchingIndices() + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ProcessRawDataCsvExportRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ProcessRawDataCsvExportRequestDto.java
@@ -13,20 +13,220 @@ import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Builder
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProcessRawDataCsvExportRequestDto {
+
   @NotNull private String processDefinitionKey;
-  @NotEmpty @Builder.Default private List<String> processDefinitionVersions = new ArrayList<>();
-  @NotNull @Builder.Default private List<String> tenantIds = Collections.singletonList(null);
-  @Builder.Default @NotNull private List<ProcessFilterDto<?>> filter = new ArrayList<>();
-  @NotEmpty @Builder.Default private List<String> includedColumns = new ArrayList<>();
+  @NotEmpty private List<String> processDefinitionVersions = new ArrayList<>();
+  @NotNull private List<String> tenantIds = Collections.singletonList(null);
+  @NotNull private List<ProcessFilterDto<?>> filter = new ArrayList<>();
+  @NotEmpty private List<String> includedColumns = new ArrayList<>();
+
+  public ProcessRawDataCsvExportRequestDto(
+      @NotNull final String processDefinitionKey,
+      @NotEmpty final List<String> processDefinitionVersions,
+      @NotNull final List<String> tenantIds,
+      @NotNull final List<ProcessFilterDto<?>> filter,
+      @NotEmpty final List<String> includedColumns) {
+    this.processDefinitionKey = processDefinitionKey;
+    this.processDefinitionVersions = processDefinitionVersions;
+    this.tenantIds = tenantIds;
+    this.filter = filter;
+    this.includedColumns = includedColumns;
+  }
+
+  protected ProcessRawDataCsvExportRequestDto() {}
+
+  public @NotNull String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(@NotNull final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public @NotEmpty List<String> getProcessDefinitionVersions() {
+    return processDefinitionVersions;
+  }
+
+  public void setProcessDefinitionVersions(@NotEmpty final List<String> processDefinitionVersions) {
+    this.processDefinitionVersions = processDefinitionVersions;
+  }
+
+  public @NotNull List<String> getTenantIds() {
+    return tenantIds;
+  }
+
+  public void setTenantIds(@NotNull final List<String> tenantIds) {
+    this.tenantIds = tenantIds;
+  }
+
+  public @NotNull List<ProcessFilterDto<?>> getFilter() {
+    return filter;
+  }
+
+  public void setFilter(@NotNull final List<ProcessFilterDto<?>> filter) {
+    this.filter = filter;
+  }
+
+  public @NotEmpty List<String> getIncludedColumns() {
+    return includedColumns;
+  }
+
+  public void setIncludedColumns(@NotEmpty final List<String> includedColumns) {
+    this.includedColumns = includedColumns;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessRawDataCsvExportRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessRawDataCsvExportRequestDto that = (ProcessRawDataCsvExportRequestDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersions, that.processDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds)
+        && Objects.equals(filter, that.filter)
+        && Objects.equals(includedColumns, that.includedColumns);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        processDefinitionKey, processDefinitionVersions, tenantIds, filter, includedColumns);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessRawDataCsvExportRequestDto(processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", processDefinitionVersions="
+        + getProcessDefinitionVersions()
+        + ", tenantIds="
+        + getTenantIds()
+        + ", filter="
+        + getFilter()
+        + ", includedColumns="
+        + getIncludedColumns()
+        + ")";
+  }
+
+  @NotEmpty
+  private static List<String> defaultProcessDefinitionVersions() {
+    return new ArrayList<>();
+  }
+
+  @NotNull
+  private static List<String> defaultTenantIds() {
+    return Collections.singletonList(null);
+  }
+
+  @NotNull
+  private static List<ProcessFilterDto<?>> defaultFilter() {
+    return new ArrayList<>();
+  }
+
+  @NotEmpty
+  private static List<String> defaultIncludedColumns() {
+    return new ArrayList<>();
+  }
+
+  public static ProcessRawDataCsvExportRequestDtoBuilder builder() {
+    return new ProcessRawDataCsvExportRequestDtoBuilder();
+  }
+
+  public static class ProcessRawDataCsvExportRequestDtoBuilder {
+
+    private @NotNull String processDefinitionKey;
+    private @NotEmpty List<String> processDefinitionVersionsValue;
+    private boolean processDefinitionVersionsSet;
+    private @NotNull List<String> tenantIdsValue;
+    private boolean tenantIdsSet;
+    private @NotNull List<ProcessFilterDto<?>> filterValue;
+    private boolean filterSet;
+    private @NotEmpty List<String> includedColumnsValue;
+    private boolean includedColumnsSet;
+
+    ProcessRawDataCsvExportRequestDtoBuilder() {}
+
+    public ProcessRawDataCsvExportRequestDtoBuilder processDefinitionKey(
+        @NotNull final String processDefinitionKey) {
+      this.processDefinitionKey = processDefinitionKey;
+      return this;
+    }
+
+    public ProcessRawDataCsvExportRequestDtoBuilder processDefinitionVersions(
+        @NotEmpty final List<String> processDefinitionVersions) {
+      processDefinitionVersionsValue = processDefinitionVersions;
+      processDefinitionVersionsSet = true;
+      return this;
+    }
+
+    public ProcessRawDataCsvExportRequestDtoBuilder tenantIds(
+        @NotNull final List<String> tenantIds) {
+      tenantIdsValue = tenantIds;
+      tenantIdsSet = true;
+      return this;
+    }
+
+    public ProcessRawDataCsvExportRequestDtoBuilder filter(
+        @NotNull final List<ProcessFilterDto<?>> filter) {
+      filterValue = filter;
+      filterSet = true;
+      return this;
+    }
+
+    public ProcessRawDataCsvExportRequestDtoBuilder includedColumns(
+        @NotEmpty final List<String> includedColumns) {
+      includedColumnsValue = includedColumns;
+      includedColumnsSet = true;
+      return this;
+    }
+
+    public ProcessRawDataCsvExportRequestDto build() {
+      List<String> processDefinitionVersionsValue = this.processDefinitionVersionsValue;
+      if (!processDefinitionVersionsSet) {
+        processDefinitionVersionsValue =
+            ProcessRawDataCsvExportRequestDto.defaultProcessDefinitionVersions();
+      }
+      List<String> tenantIdsValue = this.tenantIdsValue;
+      if (!tenantIdsSet) {
+        tenantIdsValue = ProcessRawDataCsvExportRequestDto.defaultTenantIds();
+      }
+      List<ProcessFilterDto<?>> filterValue = this.filterValue;
+      if (!filterSet) {
+        filterValue = ProcessRawDataCsvExportRequestDto.defaultFilter();
+      }
+      List<String> includedColumnsValue = this.includedColumnsValue;
+      if (!includedColumnsSet) {
+        includedColumnsValue = ProcessRawDataCsvExportRequestDto.defaultIncludedColumns();
+      }
+      return new ProcessRawDataCsvExportRequestDto(
+          processDefinitionKey,
+          processDefinitionVersionsValue,
+          tenantIdsValue,
+          filterValue,
+          includedColumnsValue);
+    }
+
+    @Override
+    public String toString() {
+      return "ProcessRawDataCsvExportRequestDto.ProcessRawDataCsvExportRequestDtoBuilder(processDefinitionKey="
+          + processDefinitionKey
+          + ", processDefinitionVersionsValue="
+          + processDefinitionVersionsValue
+          + ", tenantIdsValue="
+          + tenantIdsValue
+          + ", filterValue="
+          + filterValue
+          + ", includedColumnsValue="
+          + includedColumnsValue
+          + ")";
+    }
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/TenantResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/TenantResponseDto.java
@@ -7,15 +7,56 @@
  */
 package io.camunda.optimize.dto.optimize.rest;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TenantResponseDto {
+
   private String id;
   private String name;
+
+  public TenantResponseDto(final String id, final String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  protected TenantResponseDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof TenantResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TenantResponseDto that = (TenantResponseDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name);
+  }
+
+  @Override
+  public String toString() {
+    return "TenantResponseDto(id=" + getId() + ", name=" + getName() + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/UserResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/UserResponseDto.java
@@ -10,14 +10,62 @@ package io.camunda.optimize.dto.optimize.rest;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.camunda.optimize.dto.optimize.UserDto;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class UserResponseDto {
+
   @JsonUnwrapped private UserDto userDto;
   private List<AuthorizationType> authorizations;
+
+  public UserResponseDto(final UserDto userDto, final List<AuthorizationType> authorizations) {
+    this.userDto = userDto;
+    this.authorizations = authorizations;
+  }
+
+  public UserResponseDto() {}
+
+  public UserDto getUserDto() {
+    return userDto;
+  }
+
+  @JsonUnwrapped
+  public void setUserDto(final UserDto userDto) {
+    this.userDto = userDto;
+  }
+
+  public List<AuthorizationType> getAuthorizations() {
+    return authorizations;
+  }
+
+  public void setAuthorizations(final List<AuthorizationType> authorizations) {
+    this.authorizations = authorizations;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof UserResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UserResponseDto that = (UserResponseDto) o;
+    return Objects.equals(userDto, that.userDto)
+        && Objects.equals(authorizations, that.authorizations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(userDto, authorizations);
+  }
+
+  @Override
+  public String toString() {
+    return "UserResponseDto(userDto="
+        + getUserDto()
+        + ", authorizations="
+        + getAuthorizations()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ValidationErrorResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ValidationErrorResponseDto.java
@@ -9,17 +9,11 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ValidationErrorResponseDto extends ErrorResponseDto {
+
   private List<ValidationError> validationErrors;
 
   public ValidationErrorResponseDto(
@@ -28,11 +22,100 @@ public class ValidationErrorResponseDto extends ErrorResponseDto {
     this.validationErrors = validationErrors;
   }
 
-  @Data
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
-  @AllArgsConstructor
+  protected ValidationErrorResponseDto() {}
+
+  public List<ValidationError> getValidationErrors() {
+    return validationErrors;
+  }
+
+  public void setValidationErrors(final List<ValidationError> validationErrors) {
+    this.validationErrors = validationErrors;
+  }
+
+  @Override
+  public String toString() {
+    return "ValidationErrorResponseDto(validationErrors=" + getValidationErrors() + ")";
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ValidationErrorResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ValidationErrorResponseDto that = (ValidationErrorResponseDto) o;
+    return Objects.equals(validationErrors, that.validationErrors);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), validationErrors);
+  }
+
   public static class ValidationError {
+
     private String property;
     private String errorMessage;
+
+    public ValidationError(final String property, final String errorMessage) {
+      this.property = property;
+      this.errorMessage = errorMessage;
+    }
+
+    protected ValidationError() {}
+
+    public String getProperty() {
+      return property;
+    }
+
+    public void setProperty(final String property) {
+      this.property = property;
+    }
+
+    public String getErrorMessage() {
+      return errorMessage;
+    }
+
+    public void setErrorMessage(final String errorMessage) {
+      this.errorMessage = errorMessage;
+    }
+
+    protected boolean canEqual(final Object other) {
+      return other instanceof ValidationError;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(property, errorMessage);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final ValidationError that = (ValidationError) o;
+      return Objects.equals(property, that.property)
+          && Objects.equals(errorMessage, that.errorMessage);
+    }
+
+    @Override
+    public String toString() {
+      return "ValidationErrorResponseDto.ValidationError(property="
+          + getProperty()
+          + ", errorMessage="
+          + getErrorMessage()
+          + ")";
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/collection/CollectionScopeEntryResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/collection/CollectionScopeEntryResponseDto.java
@@ -12,10 +12,9 @@ import io.camunda.optimize.dto.optimize.TenantDto;
 import io.camunda.optimize.dto.optimize.query.collection.CollectionScopeEntryDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
-import lombok.Data;
 
-@Data
 public class CollectionScopeEntryResponseDto {
 
   private String id;
@@ -23,6 +22,8 @@ public class CollectionScopeEntryResponseDto {
   private String definitionKey;
   private String definitionName;
   private List<TenantDto> tenants = new ArrayList<>();
+
+  public CollectionScopeEntryResponseDto() {}
 
   public String getDefinitionName() {
     return definitionName == null ? definitionKey : definitionName;
@@ -41,5 +42,78 @@ public class CollectionScopeEntryResponseDto {
     collectionScopeEntryResponseDto.setDefinitionType(scope.getDefinitionType());
     collectionScopeEntryResponseDto.setTenants(authorizedTenantDtos);
     return collectionScopeEntryResponseDto;
+  }
+
+  public String getId() {
+    return this.id;
+  }
+
+  public DefinitionType getDefinitionType() {
+    return this.definitionType;
+  }
+
+  public String getDefinitionKey() {
+    return this.definitionKey;
+  }
+
+  public List<TenantDto> getTenants() {
+    return this.tenants;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public void setDefinitionType(final DefinitionType definitionType) {
+    this.definitionType = definitionType;
+  }
+
+  public void setDefinitionKey(final String definitionKey) {
+    this.definitionKey = definitionKey;
+  }
+
+  public void setDefinitionName(final String definitionName) {
+    this.definitionName = definitionName;
+  }
+
+  public void setTenants(final List<TenantDto> tenants) {
+    this.tenants = tenants;
+  }
+
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionScopeEntryResponseDto that = (CollectionScopeEntryResponseDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(definitionType, that.definitionType)
+        && Objects.equals(definitionKey, that.definitionKey)
+        && Objects.equals(definitionName, that.definitionName)
+        && Objects.equals(tenants, that.tenants);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CollectionScopeEntryResponseDto;
+  }
+
+  public int hashCode() {
+    return Objects.hash(id, definitionType, definitionKey, definitionName, tenants);
+  }
+
+  public String toString() {
+    return "CollectionScopeEntryResponseDto(id="
+        + this.getId()
+        + ", definitionType="
+        + this.getDefinitionType()
+        + ", definitionKey="
+        + this.getDefinitionKey()
+        + ", definitionName="
+        + this.getDefinitionName()
+        + ", tenants="
+        + this.getTenants()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/definition/DefinitionWithTenantsResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/definition/DefinitionWithTenantsResponseDto.java
@@ -9,16 +9,78 @@ package io.camunda.optimize.dto.optimize.rest.definition;
 
 import io.camunda.optimize.dto.optimize.rest.TenantResponseDto;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DefinitionWithTenantsResponseDto {
+
   private String key;
   private List<String> versions;
   private List<TenantResponseDto> tenants;
+
+  public DefinitionWithTenantsResponseDto(
+      final String key, final List<String> versions, final List<TenantResponseDto> tenants) {
+    this.key = key;
+    this.versions = versions;
+    this.tenants = tenants;
+  }
+
+  protected DefinitionWithTenantsResponseDto() {}
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(final String key) {
+    this.key = key;
+  }
+
+  public List<String> getVersions() {
+    return versions;
+  }
+
+  public void setVersions(final List<String> versions) {
+    this.versions = versions;
+  }
+
+  public List<TenantResponseDto> getTenants() {
+    return tenants;
+  }
+
+  public void setTenants(final List<TenantResponseDto> tenants) {
+    this.tenants = tenants;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DefinitionWithTenantsResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, versions, tenants);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionWithTenantsResponseDto that = (DefinitionWithTenantsResponseDto) o;
+    return Objects.equals(key, that.key)
+        && Objects.equals(versions, that.versions)
+        && Objects.equals(tenants, that.tenants);
+  }
+
+  @Override
+  public String toString() {
+    return "DefinitionWithTenantsResponseDto(key="
+        + getKey()
+        + ", versions="
+        + getVersions()
+        + ", tenants="
+        + getTenants()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/definition/MultiDefinitionTenantsRequestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/definition/MultiDefinitionTenantsRequestDto.java
@@ -10,27 +10,122 @@ package io.camunda.optimize.dto.optimize.rest.definition;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
-@NoArgsConstructor
 public class MultiDefinitionTenantsRequestDto {
-
-  public MultiDefinitionTenantsRequestDto(final List<DefinitionDto> definitionDtos) {
-    this.definitions = definitionDtos;
-  }
 
   private List<DefinitionDto> definitions = new ArrayList<>();
   private String filterByCollectionScope;
 
-  @AllArgsConstructor
-  @Data
-  @NoArgsConstructor
+  public MultiDefinitionTenantsRequestDto(final List<DefinitionDto> definitionDtos) {
+    definitions = definitionDtos;
+  }
+
+  public MultiDefinitionTenantsRequestDto(
+      final List<DefinitionDto> definitions, final String filterByCollectionScope) {
+    this.definitions = definitions;
+    this.filterByCollectionScope = filterByCollectionScope;
+  }
+
+  public MultiDefinitionTenantsRequestDto() {}
+
+  public List<DefinitionDto> getDefinitions() {
+    return definitions;
+  }
+
+  public void setDefinitions(final List<DefinitionDto> definitions) {
+    this.definitions = definitions;
+  }
+
+  public String getFilterByCollectionScope() {
+    return filterByCollectionScope;
+  }
+
+  public void setFilterByCollectionScope(final String filterByCollectionScope) {
+    this.filterByCollectionScope = filterByCollectionScope;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MultiDefinitionTenantsRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MultiDefinitionTenantsRequestDto that = (MultiDefinitionTenantsRequestDto) o;
+    return Objects.equals(definitions, that.definitions)
+        && Objects.equals(filterByCollectionScope, that.filterByCollectionScope);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(definitions, filterByCollectionScope);
+  }
+
+  @Override
+  public String toString() {
+    return "MultiDefinitionTenantsRequestDto(definitions="
+        + getDefinitions()
+        + ", filterByCollectionScope="
+        + getFilterByCollectionScope()
+        + ")";
+  }
+
   public static class DefinitionDto {
+
     @NotNull private String key;
     @NotNull private List<String> versions = new ArrayList<>();
+
+    public DefinitionDto(@NotNull final String key, @NotNull final List<String> versions) {
+      this.key = key;
+      this.versions = versions;
+    }
+
+    public DefinitionDto() {}
+
+    public @NotNull String getKey() {
+      return key;
+    }
+
+    public void setKey(@NotNull final String key) {
+      this.key = key;
+    }
+
+    public @NotNull List<String> getVersions() {
+      return versions;
+    }
+
+    public void setVersions(@NotNull final List<String> versions) {
+      this.versions = versions;
+    }
+
+    protected boolean canEqual(final Object other) {
+      return other instanceof DefinitionDto;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final DefinitionDto that = (DefinitionDto) o;
+      return Objects.equals(key, that.key) && Objects.equals(versions, that.versions);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(key, versions);
+    }
+
+    @Override
+    public String toString() {
+      return "MultiDefinitionTenantsRequestDto.DefinitionDto(key="
+          + getKey()
+          + ", versions="
+          + getVersions()
+          + ")";
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/OptimizeEntityExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/OptimizeEntityExportDto.java
@@ -19,13 +19,8 @@ import io.camunda.optimize.dto.optimize.rest.export.report.CombinedProcessReport
 import io.camunda.optimize.dto.optimize.rest.export.report.SingleDecisionReportDefinitionExportDto;
 import io.camunda.optimize.dto.optimize.rest.export.report.SingleProcessReportDefinitionExportDto;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Data
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
@@ -51,6 +46,99 @@ public abstract class OptimizeEntityExportDto {
   private String description;
   private int sourceIndexVersion;
 
+  public OptimizeEntityExportDto(
+      @NotNull final String id,
+      @NotNull final ExportEntityType exportEntityType,
+      @NotNull final String name,
+      final String description,
+      final int sourceIndexVersion) {
+    this.id = id;
+    this.exportEntityType = exportEntityType;
+    this.name = name;
+    this.description = description;
+    this.sourceIndexVersion = sourceIndexVersion;
+  }
+
+  public OptimizeEntityExportDto() {}
+
+  public @NotNull String getId() {
+    return id;
+  }
+
+  public void setId(@NotNull final String id) {
+    this.id = id;
+  }
+
+  public @NotNull ExportEntityType getExportEntityType() {
+    return exportEntityType;
+  }
+
+  public void setExportEntityType(@NotNull final ExportEntityType exportEntityType) {
+    this.exportEntityType = exportEntityType;
+  }
+
+  public @NotNull String getName() {
+    return name;
+  }
+
+  public void setName(@NotNull final String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
+  }
+
+  public int getSourceIndexVersion() {
+    return sourceIndexVersion;
+  }
+
+  public void setSourceIndexVersion(final int sourceIndexVersion) {
+    this.sourceIndexVersion = sourceIndexVersion;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof OptimizeEntityExportDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OptimizeEntityExportDto that = (OptimizeEntityExportDto) o;
+    return sourceIndexVersion == that.sourceIndexVersion
+        && Objects.equals(id, that.id)
+        && exportEntityType == that.exportEntityType
+        && Objects.equals(name, that.name)
+        && Objects.equals(description, that.description);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, exportEntityType, name, description, sourceIndexVersion);
+  }
+
+  @Override
+  public String toString() {
+    return "OptimizeEntityExportDto(id="
+        + getId()
+        + ", exportEntityType="
+        + getExportEntityType()
+        + ", name="
+        + getName()
+        + ", description="
+        + getDescription()
+        + ", sourceIndexVersion="
+        + getSourceIndexVersion()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/dashboard/DashboardDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/dashboard/DashboardDefinitionExportDto.java
@@ -20,14 +20,9 @@ import io.camunda.optimize.service.util.IdGenerator;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
 
   @NotNull private List<DashboardReportTileDto> tiles = new ArrayList<>();
@@ -47,6 +42,8 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
     collectionId = dashboardDefinition.getCollectionId();
   }
 
+  public DashboardDefinitionExportDto() {}
+
   @JsonIgnore
   public Set<String> getTileIds() {
     return tiles.stream()
@@ -63,6 +60,81 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
         .collect(toSet());
   }
 
+  public @NotNull List<DashboardReportTileDto> getTiles() {
+    return tiles;
+  }
+
+  public void setTiles(@NotNull final List<DashboardReportTileDto> tiles) {
+    this.tiles = tiles;
+  }
+
+  public @NotNull List<DashboardFilterDto<?>> getAvailableFilters() {
+    return availableFilters;
+  }
+
+  public void setAvailableFilters(@NotNull final List<DashboardFilterDto<?>> availableFilters) {
+    this.availableFilters = availableFilters;
+  }
+
+  public String getCollectionId() {
+    return collectionId;
+  }
+
+  public void setCollectionId(final String collectionId) {
+    this.collectionId = collectionId;
+  }
+
+  public boolean isInstantPreviewDashboard() {
+    return isInstantPreviewDashboard;
+  }
+
+  public void setInstantPreviewDashboard(final boolean isInstantPreviewDashboard) {
+    this.isInstantPreviewDashboard = isInstantPreviewDashboard;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardDefinitionExportDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(), tiles, availableFilters, collectionId, isInstantPreviewDashboard);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardDefinitionExportDto that = (DashboardDefinitionExportDto) o;
+    return isInstantPreviewDashboard == that.isInstantPreviewDashboard
+        && Objects.equals(tiles, that.tiles)
+        && Objects.equals(availableFilters, that.availableFilters)
+        && Objects.equals(collectionId, that.collectionId);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardDefinitionExportDto(tiles="
+        + getTiles()
+        + ", availableFilters="
+        + getAvailableFilters()
+        + ", collectionId="
+        + getCollectionId()
+        + ", isInstantPreviewDashboard="
+        + isInstantPreviewDashboard()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String tiles = "tiles";

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/CombinedProcessReportDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/CombinedProcessReportDefinitionExportDto.java
@@ -14,16 +14,10 @@ import io.camunda.optimize.dto.optimize.query.report.combined.CombinedReportDefi
 import io.camunda.optimize.dto.optimize.rest.export.ExportEntityType;
 import io.camunda.optimize.service.db.schema.index.report.CombinedReportIndex;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-@Data
 public class CombinedProcessReportDefinitionExportDto extends ReportDefinitionExportDto {
+
   @NotNull private CombinedReportDataDto data;
 
   public CombinedProcessReportDefinitionExportDto(
@@ -35,11 +29,53 @@ public class CombinedProcessReportDefinitionExportDto extends ReportDefinitionEx
         reportDefinition.getName(),
         reportDefinition.getDescription(),
         reportDefinition.getCollectionId());
-    this.data = reportDefinition.getData();
+    data = reportDefinition.getData();
   }
+
+  public CombinedProcessReportDefinitionExportDto(@NotNull final CombinedReportDataDto data) {
+    this.data = data;
+  }
+
+  public CombinedProcessReportDefinitionExportDto() {}
 
   @Override
   public ExportEntityType getExportEntityType() {
     return COMBINED_REPORT;
+  }
+
+  public @NotNull CombinedReportDataDto getData() {
+    return data;
+  }
+
+  public void setData(@NotNull final CombinedReportDataDto data) {
+    this.data = data;
+  }
+
+  @Override
+  public String toString() {
+    return "CombinedProcessReportDefinitionExportDto(data=" + getData() + ")";
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof CombinedProcessReportDefinitionExportDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final CombinedProcessReportDefinitionExportDto that =
+        (CombinedProcessReportDefinitionExportDto) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), data);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/ReportDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/ReportDefinitionExportDto.java
@@ -14,13 +14,8 @@ import io.camunda.optimize.dto.optimize.query.report.single.decision.SingleDecis
 import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProcessReportDefinitionRequestDto;
 import io.camunda.optimize.dto.optimize.rest.export.ExportEntityType;
 import io.camunda.optimize.dto.optimize.rest.export.OptimizeEntityExportDto;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@Data
-@EqualsAndHashCode(callSuper = true)
 public abstract class ReportDefinitionExportDto extends OptimizeEntityExportDto {
 
   private String collectionId;
@@ -35,6 +30,8 @@ public abstract class ReportDefinitionExportDto extends OptimizeEntityExportDto 
     super(id, exportEntityType, name, description, sourceIndexVersion);
     this.collectionId = collectionId;
   }
+
+  public ReportDefinitionExportDto() {}
 
   public static ReportDefinitionExportDto mapReportDefinitionToExportDto(
       final ReportDefinitionDto<?> reportDef) {
@@ -51,6 +48,42 @@ public abstract class ReportDefinitionExportDto extends OptimizeEntityExportDto 
     }
   }
 
+  public String getCollectionId() {
+    return collectionId;
+  }
+
+  public void setCollectionId(final String collectionId) {
+    this.collectionId = collectionId;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ReportDefinitionExportDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ReportDefinitionExportDto that = (ReportDefinitionExportDto) o;
+    return Objects.equals(collectionId, that.collectionId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), collectionId);
+  }
+
+  @Override
+  public String toString() {
+    return "ReportDefinitionExportDto(collectionId=" + getCollectionId() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String collectionId = "collectionId";

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/SingleDecisionReportDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/SingleDecisionReportDefinitionExportDto.java
@@ -14,16 +14,10 @@ import io.camunda.optimize.dto.optimize.query.report.single.decision.SingleDecis
 import io.camunda.optimize.dto.optimize.rest.export.ExportEntityType;
 import io.camunda.optimize.service.db.schema.index.report.SingleDecisionReportIndex;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-@Data
 public class SingleDecisionReportDefinitionExportDto extends ReportDefinitionExportDto {
+
   @NotNull private DecisionReportDataDto data;
 
   public SingleDecisionReportDefinitionExportDto(
@@ -35,11 +29,53 @@ public class SingleDecisionReportDefinitionExportDto extends ReportDefinitionExp
         reportDefinition.getName(),
         reportDefinition.getDescription(),
         reportDefinition.getCollectionId());
-    this.data = reportDefinition.getData();
+    data = reportDefinition.getData();
   }
+
+  public SingleDecisionReportDefinitionExportDto(@NotNull final DecisionReportDataDto data) {
+    this.data = data;
+  }
+
+  public SingleDecisionReportDefinitionExportDto() {}
 
   @Override
   public ExportEntityType getExportEntityType() {
     return SINGLE_DECISION_REPORT;
+  }
+
+  public @NotNull DecisionReportDataDto getData() {
+    return data;
+  }
+
+  public void setData(@NotNull final DecisionReportDataDto data) {
+    this.data = data;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof SingleDecisionReportDefinitionExportDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final SingleDecisionReportDefinitionExportDto that =
+        (SingleDecisionReportDefinitionExportDto) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), data);
+  }
+
+  @Override
+  public String toString() {
+    return "SingleDecisionReportDefinitionExportDto(data=" + getData() + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/SingleProcessReportDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/SingleProcessReportDefinitionExportDto.java
@@ -14,16 +14,10 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProces
 import io.camunda.optimize.dto.optimize.rest.export.ExportEntityType;
 import io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-@Data
 public class SingleProcessReportDefinitionExportDto extends ReportDefinitionExportDto {
+
   @NotNull private ProcessReportDataDto data;
 
   public SingleProcessReportDefinitionExportDto(
@@ -35,11 +29,52 @@ public class SingleProcessReportDefinitionExportDto extends ReportDefinitionExpo
         reportDefinition.getName(),
         reportDefinition.getDescription(),
         reportDefinition.getCollectionId());
-    this.data = reportDefinition.getData();
+    data = reportDefinition.getData();
   }
+
+  public SingleProcessReportDefinitionExportDto(@NotNull final ProcessReportDataDto data) {
+    this.data = data;
+  }
+
+  public SingleProcessReportDefinitionExportDto() {}
 
   @Override
   public ExportEntityType getExportEntityType() {
     return SINGLE_PROCESS_REPORT;
+  }
+
+  public @NotNull ProcessReportDataDto getData() {
+    return data;
+  }
+
+  public void setData(@NotNull final ProcessReportDataDto data) {
+    this.data = data;
+  }
+
+  @Override
+  public String toString() {
+    return "SingleProcessReportDefinitionExportDto(data=" + getData() + ")";
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof SingleProcessReportDefinitionExportDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final SingleProcessReportDefinitionExportDto that = (SingleProcessReportDefinitionExportDto) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), data);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedCombinedReportEvaluationResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedCombinedReportEvaluationResponseDto.java
@@ -9,14 +9,8 @@ package io.camunda.optimize.dto.optimize.rest.report;
 
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.report.combined.CombinedReportDefinitionRequestDto;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthorizedCombinedReportEvaluationResponseDto<T>
     extends AuthorizedReportEvaluationResponseDto<CombinedReportDefinitionRequestDto> {
 
@@ -28,5 +22,46 @@ public class AuthorizedCombinedReportEvaluationResponseDto<T>
       final CombinedProcessReportResultDataDto<T> result) {
     super(currentUserRole, reportDefinition);
     this.result = result;
+  }
+
+  protected AuthorizedCombinedReportEvaluationResponseDto() {}
+
+  public CombinedProcessReportResultDataDto<T> getResult() {
+    return result;
+  }
+
+  public void setResult(final CombinedProcessReportResultDataDto<T> result) {
+    this.result = result;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof AuthorizedCombinedReportEvaluationResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), result);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedCombinedReportEvaluationResponseDto<?> that =
+        (AuthorizedCombinedReportEvaluationResponseDto<?>) o;
+    return Objects.equals(result, that.result);
+  }
+
+  @Override
+  public String toString() {
+    return "AuthorizedCombinedReportEvaluationResponseDto(result=" + getResult() + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedReportEvaluationResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedReportEvaluationResponseDto.java
@@ -11,21 +11,58 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.camunda.optimize.dto.optimize.AuthorizedEntityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class AuthorizedReportEvaluationResponseDto<D extends ReportDefinitionDto<?>>
     extends AuthorizedEntityDto {
+
   @JsonUnwrapped protected D reportDefinition;
 
   public AuthorizedReportEvaluationResponseDto(
       final RoleType currentUserRole, final D reportDefinition) {
     super(currentUserRole);
     this.reportDefinition = reportDefinition;
+  }
+
+  protected AuthorizedReportEvaluationResponseDto() {}
+
+  public D getReportDefinition() {
+    return reportDefinition;
+  }
+
+  @JsonUnwrapped
+  public void setReportDefinition(final D reportDefinition) {
+    this.reportDefinition = reportDefinition;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof AuthorizedReportEvaluationResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), reportDefinition);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedReportEvaluationResponseDto<?> that =
+        (AuthorizedReportEvaluationResponseDto<?>) o;
+    return Objects.equals(reportDefinition, that.reportDefinition);
+  }
+
+  @Override
+  public String toString() {
+    return "AuthorizedReportEvaluationResponseDto(reportDefinition=" + getReportDefinition() + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedSingleReportEvaluationResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedSingleReportEvaluationResponseDto.java
@@ -9,14 +9,8 @@ package io.camunda.optimize.dto.optimize.rest.report;
 
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthorizedSingleReportEvaluationResponseDto<T, D extends ReportDefinitionDto<?>>
     extends AuthorizedReportEvaluationResponseDto<D> {
 
@@ -28,6 +22,47 @@ public class AuthorizedSingleReportEvaluationResponseDto<T, D extends ReportDefi
       final D reportDefinition) {
     super(currentUserRole, reportDefinition);
     this.result = result;
+  }
+
+  protected AuthorizedSingleReportEvaluationResponseDto() {}
+
+  public ReportResultResponseDto<T> getResult() {
+    return result;
+  }
+
+  public void setResult(final ReportResultResponseDto<T> result) {
+    this.result = result;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof AuthorizedSingleReportEvaluationResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), result);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedSingleReportEvaluationResponseDto<?, ?> that =
+        (AuthorizedSingleReportEvaluationResponseDto<?, ?>) o;
+    return Objects.equals(result, that.result);
+  }
+
+  @Override
+  public String toString() {
+    return "AuthorizedSingleReportEvaluationResponseDto(result=" + getResult() + ")";
   }
 
   public enum Fields {

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/CombinedProcessReportResultDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/CombinedProcessReportResultDataDto.java
@@ -8,15 +8,65 @@
 package io.camunda.optimize.dto.optimize.rest.report;
 
 import java.util.Map;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CombinedProcessReportResultDataDto<T> {
+
   protected Map<String, AuthorizedProcessReportEvaluationResponseDto<T>> data;
   private long instanceCount;
+
+  public CombinedProcessReportResultDataDto(
+      final Map<String, AuthorizedProcessReportEvaluationResponseDto<T>> data,
+      final long instanceCount) {
+    this.data = data;
+    this.instanceCount = instanceCount;
+  }
+
+  protected CombinedProcessReportResultDataDto() {}
+
+  public Map<String, AuthorizedProcessReportEvaluationResponseDto<T>> getData() {
+    return data;
+  }
+
+  public void setData(final Map<String, AuthorizedProcessReportEvaluationResponseDto<T>> data) {
+    this.data = data;
+  }
+
+  public long getInstanceCount() {
+    return instanceCount;
+  }
+
+  public void setInstanceCount(final long instanceCount) {
+    this.instanceCount = instanceCount;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CombinedProcessReportResultDataDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data, instanceCount);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CombinedProcessReportResultDataDto<?> that = (CombinedProcessReportResultDataDto<?>) o;
+    return instanceCount == that.instanceCount && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public String toString() {
+    return "CombinedProcessReportResultDataDto(data="
+        + getData()
+        + ", instanceCount="
+        + getInstanceCount()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/ReportResultResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/ReportResultResponseDto.java
@@ -13,21 +13,30 @@ import io.camunda.optimize.dto.optimize.rest.pagination.PaginationDto;
 import io.camunda.optimize.dto.optimize.rest.report.measure.MeasureResponseDto;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class ReportResultResponseDto<T> {
+
   private long instanceCount;
   private long instanceCountWithoutFilters;
   private List<MeasureResponseDto<T>> measures = new ArrayList<>();
   private PaginationDto pagination;
 
-  public void addMeasure(MeasureResponseDto<T> measure) {
-    this.measures.add(measure);
+  public ReportResultResponseDto(
+      final long instanceCount,
+      final long instanceCountWithoutFilters,
+      final List<MeasureResponseDto<T>> measures,
+      final PaginationDto pagination) {
+    this.instanceCount = instanceCount;
+    this.instanceCountWithoutFilters = instanceCountWithoutFilters;
+    this.measures = measures;
+    this.pagination = pagination;
+  }
+
+  public ReportResultResponseDto() {}
+
+  public void addMeasure(final MeasureResponseDto<T> measure) {
+    measures.add(measure);
   }
 
   @JsonIgnore
@@ -43,5 +52,71 @@ public class ReportResultResponseDto<T> {
   // here for API compatibility as the frontend currently makes use of this property
   public ResultType getType() {
     return getMeasures().stream().findFirst().map(MeasureResponseDto::getType).orElse(null);
+  }
+
+  public long getInstanceCount() {
+    return instanceCount;
+  }
+
+  public void setInstanceCount(final long instanceCount) {
+    this.instanceCount = instanceCount;
+  }
+
+  public long getInstanceCountWithoutFilters() {
+    return instanceCountWithoutFilters;
+  }
+
+  public void setInstanceCountWithoutFilters(final long instanceCountWithoutFilters) {
+    this.instanceCountWithoutFilters = instanceCountWithoutFilters;
+  }
+
+  public List<MeasureResponseDto<T>> getMeasures() {
+    return measures;
+  }
+
+  public void setMeasures(final List<MeasureResponseDto<T>> measures) {
+    this.measures = measures;
+  }
+
+  public PaginationDto getPagination() {
+    return pagination;
+  }
+
+  public void setPagination(final PaginationDto pagination) {
+    this.pagination = pagination;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ReportResultResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportResultResponseDto<?> that = (ReportResultResponseDto<?>) o;
+    return instanceCount == that.instanceCount
+        && instanceCountWithoutFilters == that.instanceCountWithoutFilters
+        && Objects.equals(measures, that.measures)
+        && Objects.equals(pagination, that.pagination);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(instanceCount, instanceCountWithoutFilters, measures, pagination);
+  }
+
+  @Override
+  public String toString() {
+    return "ReportResultResponseDto(instanceCount="
+        + getInstanceCount()
+        + ", instanceCountWithoutFilters="
+        + getInstanceCountWithoutFilters()
+        + ", measures="
+        + getMeasures()
+        + ", pagination="
+        + getPagination()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/measure/MeasureResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/measure/MeasureResponseDto.java
@@ -18,14 +18,8 @@ import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.UserTaskDurationTime;
 import io.camunda.optimize.dto.optimize.query.report.single.result.ResultType;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
@@ -37,9 +31,101 @@ import lombok.NoArgsConstructor;
   @JsonSubTypes.Type(value = RawDataMeasureResponseDto.class, name = RAW_RESULT_TYPE),
 })
 public class MeasureResponseDto<T> {
+
   private ViewProperty property;
   private AggregationDto aggregationType;
   private UserTaskDurationTime userTaskDurationTime;
   private T data;
   private ResultType type;
+
+  public MeasureResponseDto(
+      final ViewProperty property,
+      final AggregationDto aggregationType,
+      final UserTaskDurationTime userTaskDurationTime,
+      final T data,
+      final ResultType type) {
+    this.property = property;
+    this.aggregationType = aggregationType;
+    this.userTaskDurationTime = userTaskDurationTime;
+    this.data = data;
+    this.type = type;
+  }
+
+  protected MeasureResponseDto() {}
+
+  public ViewProperty getProperty() {
+    return this.property;
+  }
+
+  public AggregationDto getAggregationType() {
+    return this.aggregationType;
+  }
+
+  public UserTaskDurationTime getUserTaskDurationTime() {
+    return this.userTaskDurationTime;
+  }
+
+  public T getData() {
+    return this.data;
+  }
+
+  public ResultType getType() {
+    return this.type;
+  }
+
+  public void setProperty(final ViewProperty property) {
+    this.property = property;
+  }
+
+  public void setAggregationType(final AggregationDto aggregationType) {
+    this.aggregationType = aggregationType;
+  }
+
+  public void setUserTaskDurationTime(final UserTaskDurationTime userTaskDurationTime) {
+    this.userTaskDurationTime = userTaskDurationTime;
+  }
+
+  public void setData(final T data) {
+    this.data = data;
+  }
+
+  public void setType(final ResultType type) {
+    this.type = type;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MeasureResponseDto<?> that = (MeasureResponseDto<?>) o;
+    return Objects.equals(property, that.property)
+        && Objects.equals(aggregationType, that.aggregationType)
+        && userTaskDurationTime == that.userTaskDurationTime
+        && Objects.equals(data, that.data)
+        && type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(property, aggregationType, userTaskDurationTime, data, type);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MeasureResponseDto;
+  }
+
+  public String toString() {
+    return "MeasureResponseDto(property="
+        + this.getProperty()
+        + ", aggregationType="
+        + this.getAggregationType()
+        + ", userTaskDurationTime="
+        + this.getUserTaskDurationTime()
+        + ", data="
+        + this.getData()
+        + ", type="
+        + this.getType()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
@@ -17,17 +17,8 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Map;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import java.util.Objects;
 
-@EqualsAndHashCode
-@Getter
-@Setter
-@NoArgsConstructor
-@ToString(callSuper = true)
 public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends Intent>
     implements Record<VALUE> {
 
@@ -48,9 +39,70 @@ public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends I
   private Map<String, Object> authorizations;
   private long operationReference;
 
+  public ZeebeRecordDto() {}
+
   @Override
   public String toJson() {
     throw new UnsupportedOperationException("Operation not supported");
+  }
+
+  public OffsetDateTime getDateForTimestamp() {
+    return OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.systemDefault());
+  }
+
+  @Override
+  public long getPosition() {
+    return position;
+  }
+
+  @Override
+  public long getSourceRecordPosition() {
+    return sourceRecordPosition;
+  }
+
+  @Override
+  public long getKey() {
+    return key;
+  }
+
+  @Override
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public INTENT getIntent() {
+    return intent;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public RecordType getRecordType() {
+    return recordType;
+  }
+
+  @Override
+  public RejectionType getRejectionType() {
+    return rejectionType;
+  }
+
+  @Override
+  public String getRejectionReason() {
+    return rejectionReason;
+  }
+
+  @Override
+  public String getBrokerVersion() {
+    return brokerVersion;
+  }
+
+  @Override
+  public Map<String, Object> getAuthorizations() {
+    return authorizations;
   }
 
   @Override
@@ -59,14 +111,177 @@ public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends I
   }
 
   @Override
+  public ValueType getValueType() {
+    return valueType;
+  }
+
+  @Override
+  public VALUE getValue() {
+    return value;
+  }
+
+  @Override
+  public long getOperationReference() {
+    return operationReference;
+  }
+
+  @Override
   public Record<VALUE> copyOf() {
     throw new UnsupportedOperationException("Operation not supported");
   }
 
-  public OffsetDateTime getDateForTimestamp() {
-    return OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.systemDefault());
+  public void setOperationReference(final long operationReference) {
+    this.operationReference = operationReference;
   }
 
+  public void setValue(final VALUE value) {
+    this.value = value;
+  }
+
+  public void setValueType(final ValueType valueType) {
+    this.valueType = valueType;
+  }
+
+  public void setAuthorizations(final Map<String, Object> authorizations) {
+    this.authorizations = authorizations;
+  }
+
+  public void setBrokerVersion(final String brokerVersion) {
+    this.brokerVersion = brokerVersion;
+  }
+
+  public void setRejectionReason(final String rejectionReason) {
+    this.rejectionReason = rejectionReason;
+  }
+
+  public void setRejectionType(final RejectionType rejectionType) {
+    this.rejectionType = rejectionType;
+  }
+
+  public void setRecordType(final RecordType recordType) {
+    this.recordType = recordType;
+  }
+
+  public void setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+  }
+
+  public void setIntent(final INTENT intent) {
+    this.intent = intent;
+  }
+
+  public void setTimestamp(final long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public void setKey(final long key) {
+    this.key = key;
+  }
+
+  public void setSourceRecordPosition(final long sourceRecordPosition) {
+    this.sourceRecordPosition = sourceRecordPosition;
+  }
+
+  public void setPosition(final long position) {
+    this.position = position;
+  }
+
+  public Long getSequence() {
+    return sequence;
+  }
+
+  public void setSequence(final Long sequence) {
+    this.sequence = sequence;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeRecordDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        position,
+        sequence,
+        sourceRecordPosition,
+        key,
+        timestamp,
+        partitionId,
+        recordType,
+        rejectionType,
+        rejectionReason,
+        brokerVersion,
+        valueType,
+        value,
+        intent,
+        authorizations,
+        operationReference);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeRecordDto<?, ?> that = (ZeebeRecordDto<?, ?>) o;
+    return position == that.position
+        && sourceRecordPosition == that.sourceRecordPosition
+        && key == that.key
+        && timestamp == that.timestamp
+        && partitionId == that.partitionId
+        && operationReference == that.operationReference
+        && Objects.equals(sequence, that.sequence)
+        && Objects.equals(recordType, that.recordType)
+        && Objects.equals(rejectionType, that.rejectionType)
+        && Objects.equals(rejectionReason, that.rejectionReason)
+        && Objects.equals(brokerVersion, that.brokerVersion)
+        && Objects.equals(valueType, that.valueType)
+        && Objects.equals(value, that.value)
+        && Objects.equals(intent, that.intent)
+        && Objects.equals(authorizations, that.authorizations);
+  }
+
+  @Override
+  public String toString() {
+    return "ZeebeRecordDto(super="
+        + super.toString()
+        + ", position="
+        + getPosition()
+        + ", sequence="
+        + getSequence()
+        + ", sourceRecordPosition="
+        + getSourceRecordPosition()
+        + ", key="
+        + getKey()
+        + ", timestamp="
+        + getTimestamp()
+        + ", partitionId="
+        + getPartitionId()
+        + ", recordType="
+        + getRecordType()
+        + ", rejectionType="
+        + getRejectionType()
+        + ", rejectionReason="
+        + getRejectionReason()
+        + ", brokerVersion="
+        + getBrokerVersion()
+        + ", valueType="
+        + getValueType()
+        + ", value="
+        + getValue()
+        + ", intent="
+        + getIntent()
+        + ", authorizations="
+        + getAuthorizations()
+        + ", operationReference="
+        + getOperationReference()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String position = "position";

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionDataDto.java
@@ -10,12 +10,10 @@ package io.camunda.optimize.dto.zeebe.definition;
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Arrays;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
-@EqualsAndHashCode
-@Data
 public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
 
   private byte[] resource;
@@ -26,6 +24,8 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
   private String bpmnProcessId;
   private String tenantId;
   private String versionTag;
+
+  public ZeebeProcessDefinitionDataDto() {}
 
   @Override
   public String toJson() {
@@ -46,5 +46,118 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
   @Override
   public String getTenantId() {
     return StringUtils.isEmpty(tenantId) ? ZEEBE_DEFAULT_TENANT_ID : tenantId;
+  }
+
+  public byte[] getResource() {
+    return this.resource;
+  }
+
+  public long getProcessDefinitionKey() {
+    return this.processDefinitionKey;
+  }
+
+  public int getVersion() {
+    return this.version;
+  }
+
+  public byte[] getChecksum() {
+    return this.checksum;
+  }
+
+  public String getResourceName() {
+    return this.resourceName;
+  }
+
+  public String getBpmnProcessId() {
+    return this.bpmnProcessId;
+  }
+
+  public String getVersionTag() {
+    return this.versionTag;
+  }
+
+  public void setResource(final byte[] resource) {
+    this.resource = resource;
+  }
+
+  public void setProcessDefinitionKey(final long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public void setVersion(final int version) {
+    this.version = version;
+  }
+
+  public void setChecksum(final byte[] checksum) {
+    this.checksum = checksum;
+  }
+
+  public void setResourceName(final String resourceName) {
+    this.resourceName = resourceName;
+  }
+
+  public void setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public void setVersionTag(final String versionTag) {
+    this.versionTag = versionTag;
+  }
+
+  public String toString() {
+    return "ZeebeProcessDefinitionDataDto(resource="
+        + java.util.Arrays.toString(this.getResource())
+        + ", processDefinitionKey="
+        + this.getProcessDefinitionKey()
+        + ", version="
+        + this.getVersion()
+        + ", checksum="
+        + java.util.Arrays.toString(this.getChecksum())
+        + ", resourceName="
+        + this.getResourceName()
+        + ", bpmnProcessId="
+        + this.getBpmnProcessId()
+        + ", tenantId="
+        + this.getTenantId()
+        + ", versionTag="
+        + this.getVersionTag()
+        + ")";
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeProcessDefinitionDataDto that = (ZeebeProcessDefinitionDataDto) o;
+    return processDefinitionKey == that.processDefinitionKey
+        && version == that.version
+        && Objects.deepEquals(resource, that.resource)
+        && Objects.deepEquals(checksum, that.checksum)
+        && Objects.equals(resourceName, that.resourceName)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(versionTag, that.versionTag);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        Arrays.hashCode(resource),
+        processDefinitionKey,
+        version,
+        Arrays.hashCode(checksum),
+        resourceName,
+        bpmnProcessId,
+        tenantId,
+        versionTag);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeProcessDefinitionDataDto;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionRecordDto.java
@@ -9,8 +9,29 @@ package io.camunda.optimize.dto.zeebe.definition;
 
 import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class ZeebeProcessDefinitionRecordDto
-    extends ZeebeRecordDto<ZeebeProcessDefinitionDataDto, ProcessIntent> {}
+    extends ZeebeRecordDto<ZeebeProcessDefinitionDataDto, ProcessIntent> {
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeProcessDefinitionRecordDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentDataDto.java
@@ -13,12 +13,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import java.util.List;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
-@EqualsAndHashCode
-@Data
 public class ZeebeIncidentDataDto implements IncidentRecordValue {
 
   private String errorMessage;
@@ -31,6 +28,8 @@ public class ZeebeIncidentDataDto implements IncidentRecordValue {
   private ErrorType errorType;
   private long variableScopeKey;
   private String tenantId;
+
+  public ZeebeIncidentDataDto() {}
 
   @Override
   public String toJson() {
@@ -60,6 +59,143 @@ public class ZeebeIncidentDataDto implements IncidentRecordValue {
     throw new UnsupportedOperationException("Operation not supported");
   }
 
+  public String getErrorMessage() {
+    return this.errorMessage;
+  }
+
+  public String getBpmnProcessId() {
+    return this.bpmnProcessId;
+  }
+
+  public String getElementId() {
+    return this.elementId;
+  }
+
+  public long getElementInstanceKey() {
+    return this.elementInstanceKey;
+  }
+
+  public long getProcessInstanceKey() {
+    return this.processInstanceKey;
+  }
+
+  public long getProcessDefinitionKey() {
+    return this.processDefinitionKey;
+  }
+
+  public long getJobKey() {
+    return this.jobKey;
+  }
+
+  public ErrorType getErrorType() {
+    return this.errorType;
+  }
+
+  public long getVariableScopeKey() {
+    return this.variableScopeKey;
+  }
+
+  public void setErrorMessage(final String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+
+  public void setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+  }
+
+  public void setElementId(final String elementId) {
+    this.elementId = elementId;
+  }
+
+  public void setElementInstanceKey(final long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
+  }
+
+  public void setProcessInstanceKey(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+  }
+
+  public void setProcessDefinitionKey(final long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public void setJobKey(final long jobKey) {
+    this.jobKey = jobKey;
+  }
+
+  public void setErrorType(final ErrorType errorType) {
+    this.errorType = errorType;
+  }
+
+  public void setVariableScopeKey(final long variableScopeKey) {
+    this.variableScopeKey = variableScopeKey;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public String toString() {
+    return "ZeebeIncidentDataDto(errorMessage="
+        + this.getErrorMessage()
+        + ", bpmnProcessId="
+        + this.getBpmnProcessId()
+        + ", elementId="
+        + this.getElementId()
+        + ", elementInstanceKey="
+        + this.getElementInstanceKey()
+        + ", processInstanceKey="
+        + this.getProcessInstanceKey()
+        + ", processDefinitionKey="
+        + this.getProcessDefinitionKey()
+        + ", jobKey="
+        + this.getJobKey()
+        + ", errorType="
+        + this.getErrorType()
+        + ", variableScopeKey="
+        + this.getVariableScopeKey()
+        + ", tenantId="
+        + this.getTenantId()
+        + ")";
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeIncidentDataDto that = (ZeebeIncidentDataDto) o;
+    return elementInstanceKey == that.elementInstanceKey
+        && processInstanceKey == that.processInstanceKey
+        && processDefinitionKey == that.processDefinitionKey
+        && jobKey == that.jobKey
+        && variableScopeKey == that.variableScopeKey
+        && Objects.equals(errorMessage, that.errorMessage)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(elementId, that.elementId)
+        && Objects.equals(errorType, that.errorType)
+        && Objects.equals(tenantId, that.tenantId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        errorMessage,
+        bpmnProcessId,
+        elementId,
+        elementInstanceKey,
+        processInstanceKey,
+        processDefinitionKey,
+        jobKey,
+        errorType,
+        variableScopeKey,
+        tenantId);
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String errorMessage = "errorMessage";

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentRecordDto.java
@@ -9,7 +9,28 @@ package io.camunda.optimize.dto.zeebe.incident;
 
 import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
-public class ZeebeIncidentRecordDto extends ZeebeRecordDto<ZeebeIncidentDataDto, IncidentIntent> {}
+public class ZeebeIncidentRecordDto extends ZeebeRecordDto<ZeebeIncidentDataDto, IncidentIntent> {
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeIncidentRecordDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
@@ -12,12 +12,12 @@ import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DE
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
-@EqualsAndHashCode
-@Data
 public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
 
   private int version;
@@ -31,14 +31,16 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
   private long processInstanceKey;
   private String tenantId;
 
-  @Override
-  public String toJson() {
-    throw new UnsupportedOperationException("Operation not supported");
-  }
+  private final BpmnEventType bpmnEventType;
+  private final List<List<Long>> elementInstancePath;
+  private final List<Long> processDefinitionPath;
+  private final List<Integer> callingElementPath;
 
-  @Override
-  public BpmnEventType getBpmnEventType() {
-    throw new UnsupportedOperationException("Operation not supported");
+  public ZeebeProcessInstanceDataDto() {
+    bpmnEventType = BpmnEventType.UNSPECIFIED;
+    elementInstancePath = new ArrayList<>();
+    processDefinitionPath = new ArrayList<>();
+    callingElementPath = new ArrayList<>();
   }
 
   @Override
@@ -46,6 +48,182 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
     return StringUtils.isEmpty(tenantId) ? ZEEBE_DEFAULT_TENANT_ID : tenantId;
   }
 
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  @Override
+  public int getVersion() {
+    return version;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  @Override
+  public String getElementId() {
+    return elementId;
+  }
+
+  @Override
+  public long getFlowScopeKey() {
+    return flowScopeKey;
+  }
+
+  @Override
+  public BpmnElementType getBpmnElementType() {
+    return bpmnElementType;
+  }
+
+  @Override
+  public long getParentProcessInstanceKey() {
+    return parentProcessInstanceKey;
+  }
+
+  @Override
+  public long getParentElementInstanceKey() {
+    return parentElementInstanceKey;
+  }
+
+  @Override
+  public BpmnEventType getBpmnEventType() {
+    return bpmnEventType;
+  }
+
+  @Override
+  public List<List<Long>> getElementInstancePath() {
+    return elementInstancePath;
+  }
+
+  @Override
+  public List<Long> getProcessDefinitionPath() {
+    return processDefinitionPath;
+  }
+
+  @Override
+  public List<Integer> getCallingElementPath() {
+    return callingElementPath;
+  }
+
+  @Override
+  public Set<String> getTags() {
+    return Set.of();
+  }
+
+  public void setParentElementInstanceKey(final long parentElementInstanceKey) {
+    this.parentElementInstanceKey = parentElementInstanceKey;
+  }
+
+  public void setParentProcessInstanceKey(final long parentProcessInstanceKey) {
+    this.parentProcessInstanceKey = parentProcessInstanceKey;
+  }
+
+  public void setBpmnElementType(final BpmnElementType bpmnElementType) {
+    this.bpmnElementType = bpmnElementType;
+  }
+
+  public void setFlowScopeKey(final long flowScopeKey) {
+    this.flowScopeKey = flowScopeKey;
+  }
+
+  public void setElementId(final String elementId) {
+    this.elementId = elementId;
+  }
+
+  public void setProcessInstanceKey(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+  }
+
+  public void setProcessDefinitionKey(final long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public void setVersion(final int version) {
+    this.version = version;
+  }
+
+  public void setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeProcessInstanceDataDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        version,
+        bpmnProcessId,
+        processDefinitionKey,
+        flowScopeKey,
+        bpmnElementType,
+        parentProcessInstanceKey,
+        parentElementInstanceKey,
+        elementId,
+        processInstanceKey,
+        tenantId);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeProcessInstanceDataDto that = (ZeebeProcessInstanceDataDto) o;
+    return version == that.version
+        && processDefinitionKey == that.processDefinitionKey
+        && flowScopeKey == that.flowScopeKey
+        && parentProcessInstanceKey == that.parentProcessInstanceKey
+        && parentElementInstanceKey == that.parentElementInstanceKey
+        && processInstanceKey == that.processInstanceKey
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(bpmnElementType, that.bpmnElementType)
+        && Objects.equals(elementId, that.elementId)
+        && Objects.equals(tenantId, that.tenantId);
+  }
+
+  @Override
+  public String toString() {
+    return "ZeebeProcessInstanceDataDto(version="
+        + getVersion()
+        + ", bpmnProcessId="
+        + getBpmnProcessId()
+        + ", processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", flowScopeKey="
+        + getFlowScopeKey()
+        + ", bpmnElementType="
+        + getBpmnElementType()
+        + ", parentProcessInstanceKey="
+        + getParentProcessInstanceKey()
+        + ", parentElementInstanceKey="
+        + getParentElementInstanceKey()
+        + ", elementId="
+        + getElementId()
+        + ", processInstanceKey="
+        + getProcessInstanceKey()
+        + ", tenantId="
+        + getTenantId()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String version = "version";

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceRecordDto.java
@@ -9,8 +9,29 @@ package io.camunda.optimize.dto.zeebe.process;
 
 import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class ZeebeProcessInstanceRecordDto
-    extends ZeebeRecordDto<ZeebeProcessInstanceDataDto, ProcessInstanceIntent> {}
+    extends ZeebeRecordDto<ZeebeProcessInstanceDataDto, ProcessInstanceIntent> {
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeProcessInstanceRecordDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
@@ -7,19 +7,18 @@
  */
 package io.camunda.optimize.dto.zeebe.usertask;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.service.util.DateFormatterUtil;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
-import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
-import net.minidev.json.annotate.JsonIgnore;
+import java.util.Objects;
+import org.slf4j.Logger;
 
-@Data
-@Slf4j
 public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
 
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(ZeebeUserTaskDataDto.class);
   private long userTaskKey;
   private String assignee;
   private List<String> candidateGroupsList;
@@ -41,12 +40,14 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
   private Map<String, String> customHeaders;
   private long creationTimestamp;
 
+  public ZeebeUserTaskDataDto() {}
+
   @JsonIgnore
   public OffsetDateTime getDateForDueDate() {
     return DateFormatterUtil.getOffsetDateTimeFromIsoZoneDateTimeString(dueDate)
         .orElseGet(
             () -> {
-              log.info(
+              LOG.info(
                   "Unable to parse due date of userTask record: {}. UserTask will be imported without dueDate data.",
                   dueDate);
               return null;
@@ -54,10 +55,293 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
   }
 
   @Override
+  public long getUserTaskKey() {
+    return userTaskKey;
+  }
+
+  @Override
+  public String getAssignee() {
+    return assignee;
+  }
+
+  @Override
+  public List<String> getCandidateGroupsList() {
+    return candidateGroupsList;
+  }
+
+  @Override
+  public List<String> getCandidateUsersList() {
+    return candidateUsersList;
+  }
+
+  @Override
+  public String getDueDate() {
+    return dueDate;
+  }
+
+  @Override
+  public String getFollowUpDate() {
+    return followUpDate;
+  }
+
+  @Override
+  public long getFormKey() {
+    return formKey;
+  }
+
+  @Override
+  public List<String> getChangedAttributes() {
+    return changedAttributes;
+  }
+
+  @Override
+  public String getAction() {
+    return action;
+  }
+
+  @Override
+  public String getExternalFormReference() {
+    return externalFormReference;
+  }
+
+  @Override
+  public Map<String, String> getCustomHeaders() {
+    return customHeaders;
+  }
+
+  @Override
+  public long getCreationTimestamp() {
+    return creationTimestamp;
+  }
+
+  @Override
+  public String getElementId() {
+    return elementId;
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKey;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  @Override
+  public int getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  @Override
   public int getPriority() {
     throw new UnsupportedOperationException("Operation not supported");
   }
 
+  public void setProcessDefinitionKey(final long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public void setProcessDefinitionVersion(final int processDefinitionVersion) {
+    this.processDefinitionVersion = processDefinitionVersion;
+  }
+
+  public void setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+  }
+
+  public void setElementInstanceKey(final long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
+  }
+
+  public void setElementId(final String elementId) {
+    this.elementId = elementId;
+  }
+
+  public void setCreationTimestamp(final long creationTimestamp) {
+    this.creationTimestamp = creationTimestamp;
+  }
+
+  public void setCustomHeaders(final Map<String, String> customHeaders) {
+    this.customHeaders = customHeaders;
+  }
+
+  public void setExternalFormReference(final String externalFormReference) {
+    this.externalFormReference = externalFormReference;
+  }
+
+  public void setAction(final String action) {
+    this.action = action;
+  }
+
+  public void setChangedAttributes(final List<String> changedAttributes) {
+    this.changedAttributes = changedAttributes;
+  }
+
+  public void setFormKey(final long formKey) {
+    this.formKey = formKey;
+  }
+
+  public void setFollowUpDate(final String followUpDate) {
+    this.followUpDate = followUpDate;
+  }
+
+  public void setDueDate(final String dueDate) {
+    this.dueDate = dueDate;
+  }
+
+  public void setCandidateUsersList(final List<String> candidateUsersList) {
+    this.candidateUsersList = candidateUsersList;
+  }
+
+  public void setCandidateGroupsList(final List<String> candidateGroupsList) {
+    this.candidateGroupsList = candidateGroupsList;
+  }
+
+  public void setAssignee(final String assignee) {
+    this.assignee = assignee;
+  }
+
+  public void setUserTaskKey(final long userTaskKey) {
+    this.userTaskKey = userTaskKey;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public void setProcessInstanceKey(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return variables;
+  }
+
+  public void setVariables(final Map<String, Object> variables) {
+    this.variables = variables;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeUserTaskDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeUserTaskDataDto that = (ZeebeUserTaskDataDto) o;
+    return userTaskKey == that.userTaskKey
+        && elementInstanceKey == that.elementInstanceKey
+        && processDefinitionVersion == that.processDefinitionVersion
+        && processDefinitionKey == that.processDefinitionKey
+        && processInstanceKey == that.processInstanceKey
+        && formKey == that.formKey
+        && creationTimestamp == that.creationTimestamp
+        && Objects.equals(assignee, that.assignee)
+        && Objects.equals(candidateGroupsList, that.candidateGroupsList)
+        && Objects.equals(candidateUsersList, that.candidateUsersList)
+        && Objects.equals(dueDate, that.dueDate)
+        && Objects.equals(elementId, that.elementId)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(changedAttributes, that.changedAttributes)
+        && Objects.equals(variables, that.variables)
+        && Objects.equals(followUpDate, that.followUpDate)
+        && Objects.equals(action, that.action)
+        && Objects.equals(externalFormReference, that.externalFormReference)
+        && Objects.equals(customHeaders, that.customHeaders);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        userTaskKey,
+        assignee,
+        candidateGroupsList,
+        candidateUsersList,
+        dueDate,
+        elementId,
+        elementInstanceKey,
+        bpmnProcessId,
+        processDefinitionVersion,
+        processDefinitionKey,
+        processInstanceKey,
+        tenantId,
+        changedAttributes,
+        variables,
+        followUpDate,
+        formKey,
+        action,
+        externalFormReference,
+        customHeaders,
+        creationTimestamp);
+  }
+
+  @Override
+  public String toString() {
+    return "ZeebeUserTaskDataDto(userTaskKey="
+        + getUserTaskKey()
+        + ", assignee="
+        + getAssignee()
+        + ", candidateGroupsList="
+        + getCandidateGroupsList()
+        + ", candidateUsersList="
+        + getCandidateUsersList()
+        + ", dueDate="
+        + getDueDate()
+        + ", elementId="
+        + getElementId()
+        + ", elementInstanceKey="
+        + getElementInstanceKey()
+        + ", bpmnProcessId="
+        + getBpmnProcessId()
+        + ", processDefinitionVersion="
+        + getProcessDefinitionVersion()
+        + ", processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", processInstanceKey="
+        + getProcessInstanceKey()
+        + ", tenantId="
+        + getTenantId()
+        + ", changedAttributes="
+        + getChangedAttributes()
+        + ", variables="
+        + getVariables()
+        + ", followUpDate="
+        + getFollowUpDate()
+        + ", formKey="
+        + getFormKey()
+        + ", action="
+        + getAction()
+        + ", externalFormReference="
+        + getExternalFormReference()
+        + ", customHeaders="
+        + getCustomHeaders()
+        + ", creationTimestamp="
+        + getCreationTimestamp()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String userTaskKey = "userTaskKey";

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
@@ -10,10 +10,9 @@ package io.camunda.optimize.dto.zeebe.variable;
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
-import lombok.Data;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
-@Data
 public class ZeebeVariableDataDto implements VariableRecordValue {
 
   private String name;
@@ -24,6 +23,8 @@ public class ZeebeVariableDataDto implements VariableRecordValue {
   private String bpmnProcessId;
   private String tenantId;
 
+  public ZeebeVariableDataDto() {}
+
   @Override
   public String toJson() {
     throw new UnsupportedOperationException("Operation not supported");
@@ -32,5 +33,107 @@ public class ZeebeVariableDataDto implements VariableRecordValue {
   @Override
   public String getTenantId() {
     return StringUtils.isEmpty(tenantId) ? ZEEBE_DEFAULT_TENANT_ID : tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public long getScopeKey() {
+    return scopeKey;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public void setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+  }
+
+  public void setProcessDefinitionKey(final long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public void setProcessInstanceKey(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+  }
+
+  public void setScopeKey(final long scopeKey) {
+    this.scopeKey = scopeKey;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeVariableDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeVariableDataDto that = (ZeebeVariableDataDto) o;
+    return scopeKey == that.scopeKey
+        && processInstanceKey == that.processInstanceKey
+        && processDefinitionKey == that.processDefinitionKey
+        && Objects.equals(name, that.name)
+        && Objects.equals(value, that.value)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(tenantId, that.tenantId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        name, value, scopeKey, processInstanceKey, processDefinitionKey, bpmnProcessId, tenantId);
+  }
+
+  @Override
+  public String toString() {
+    return "ZeebeVariableDataDto(name="
+        + getName()
+        + ", value="
+        + getValue()
+        + ", scopeKey="
+        + getScopeKey()
+        + ", processInstanceKey="
+        + getProcessInstanceKey()
+        + ", processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", bpmnProcessId="
+        + getBpmnProcessId()
+        + ", tenantId="
+        + getTenantId()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableRecordDto.java
@@ -9,7 +9,28 @@ package io.camunda.optimize.dto.zeebe.variable;
 
 import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
-public class ZeebeVariableRecordDto extends ZeebeRecordDto<ZeebeVariableDataDto, VariableIntent> {}
+public class ZeebeVariableRecordDto extends ZeebeRecordDto<ZeebeVariableDataDto, VariableIntent> {
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeVariableRecordDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/cloud/CCSaaSOrganizationsClient.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/cloud/CCSaaSOrganizationsClient.java
@@ -11,23 +11,22 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.CCSaaSCondition;
-import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
 @Conditional(CCSaaSCondition.class)
 public class CCSaaSOrganizationsClient extends AbstractCCSaaSClient {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(CCSaaSOrganizationsClient.class);
 
   public CCSaaSOrganizationsClient(
       final ConfigurationService configurationService, final ObjectMapper objectMapper) {
@@ -36,7 +35,7 @@ public class CCSaaSOrganizationsClient extends AbstractCCSaaSClient {
 
   public Optional<String> getSalesPlanType(final String accessToken) {
     try {
-      log.info("Fetching cloud organisation.");
+      LOG.info("Fetching cloud organisation.");
       final HttpGet request =
           new HttpGet(
               String.format(
@@ -44,7 +43,7 @@ public class CCSaaSOrganizationsClient extends AbstractCCSaaSClient {
                   getCloudUsersConfiguration().getAccountsUrl(),
                   getCloudAuthConfiguration().getOrganizationId()));
       try (final CloseableHttpResponse response = performRequest(request, accessToken)) {
-        if (response.getStatusLine().getStatusCode() != Response.Status.OK.getStatusCode()) {
+        if (response.getStatusLine().getStatusCode() != HttpStatus.OK.value()) {
           throw new OptimizeRuntimeException(
               String.format(
                   "Unexpected response when fetching cloud organisation: %s",
@@ -57,22 +56,94 @@ public class CCSaaSOrganizationsClient extends AbstractCCSaaSClient {
             .flatMap(AccountsOrganisationResponse::getSalesPlan)
             .flatMap(AccountsSalesPlanDto::getType);
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new OptimizeRuntimeException("There was a problem fetching the cloud organisation.", e);
     }
   }
 
-  @Data
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
-  @AllArgsConstructor
   public static class AccountsOrganisationResponse {
+
     private Optional<AccountsSalesPlanDto> salesPlan;
+
+    public AccountsOrganisationResponse(final Optional<AccountsSalesPlanDto> salesPlan) {
+      this.salesPlan = salesPlan;
+    }
+
+    protected AccountsOrganisationResponse() {}
+
+    public Optional<AccountsSalesPlanDto> getSalesPlan() {
+      return salesPlan;
+    }
+
+    public void setSalesPlan(final Optional<AccountsSalesPlanDto> salesPlan) {
+      this.salesPlan = salesPlan;
+    }
+
+    protected boolean canEqual(final Object other) {
+      return other instanceof AccountsOrganisationResponse;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AccountsOrganisationResponse that = (AccountsOrganisationResponse) o;
+      return Objects.equals(salesPlan, that.salesPlan);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(salesPlan);
+    }
+
+    @Override
+    public String toString() {
+      return "CCSaaSOrganizationsClient.AccountsOrganisationResponse(salesPlan="
+          + getSalesPlan()
+          + ")";
+    }
   }
 
-  @Data
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
-  @AllArgsConstructor
   public static class AccountsSalesPlanDto {
+
     private Optional<String> type;
+
+    public AccountsSalesPlanDto(final Optional<String> type) {
+      this.type = type;
+    }
+
+    protected AccountsSalesPlanDto() {}
+
+    public Optional<String> getType() {
+      return type;
+    }
+
+    public void setType(final Optional<String> type) {
+      this.type = type;
+    }
+
+    protected boolean canEqual(final Object other) {
+      return other instanceof AccountsSalesPlanDto;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AccountsSalesPlanDto that = (AccountsSalesPlanDto) o;
+      return Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(type);
+    }
+
+    @Override
+    public String toString() {
+      return "CCSaaSOrganizationsClient.AccountsSalesPlanDto(type=" + getType() + ")";
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/cloud/CCSaasClusterClient.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/cloud/CCSaasClusterClient.java
@@ -21,30 +21,30 @@ import io.camunda.optimize.dto.optimize.query.ui_configuration.AppName;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.CCSaaSCondition;
-import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
-import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
 @Conditional(CCSaaSCondition.class)
 public class CCSaasClusterClient extends AbstractCCSaaSClient {
 
   private static final String GET_CLUSTERS_TEMPLATE = GET_ORGS_TEMPLATE + "/clusters";
-  private Map<AppName, String> webappsLinks;
   private static final Set<AppName> REQUIRED_WEBAPPS_LINKS =
       Set.of(CONSOLE, OPERATE, OPTIMIZE, MODELER, TASKLIST);
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(CCSaasClusterClient.class);
+  private Map<AppName, String> webappsLinks;
 
   public CCSaasClusterClient(
       final ConfigurationService configurationService, final ObjectMapper objectMapper) {
@@ -62,7 +62,7 @@ public class CCSaasClusterClient extends AbstractCCSaaSClient {
 
   private Map<AppName, String> retrieveWebappsLinks(final String accessToken) {
     try {
-      log.info("Fetching cluster metadata.");
+      LOG.info("Fetching cluster metadata.");
       final HttpGet request =
           new HttpGet(
               String.format(
@@ -71,13 +71,13 @@ public class CCSaasClusterClient extends AbstractCCSaaSClient {
                   getCloudAuthConfiguration().getOrganizationId()));
       final ClusterMetadata[] metadataForAllClusters;
       try (final CloseableHttpResponse response = performRequest(request, accessToken)) {
-        if (response.getStatusLine().getStatusCode() != Response.Status.OK.getStatusCode()) {
+        if (response.getStatusLine().getStatusCode() != HttpStatus.OK.value()) {
           throw new OptimizeRuntimeException(
               String.format(
                   "Unexpected response when fetching cluster metadata: %s",
                   response.getStatusLine().getStatusCode()));
         }
-        log.info("Processing response from Cluster metadata");
+        LOG.info("Processing response from Cluster metadata");
         metadataForAllClusters =
             objectMapper.readValue(response.getEntity().getContent(), ClusterMetadata[].class);
       }
@@ -115,11 +115,51 @@ public class CCSaasClusterClient extends AbstractCCSaaSClient {
         .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  @Data
   @JsonIgnoreProperties(ignoreUnknown = true)
   private static class ClusterMetadata implements Serializable {
 
     private String uuid;
     private Map<AppName, String> urls = new EnumMap<>(AppName.class);
+
+    public ClusterMetadata() {}
+
+    public String getUuid() {
+      return uuid;
+    }
+
+    public void setUuid(final String uuid) {
+      this.uuid = uuid;
+    }
+
+    public Map<AppName, String> getUrls() {
+      return urls;
+    }
+
+    public void setUrls(final Map<AppName, String> urls) {
+      this.urls = urls;
+    }
+
+    protected boolean canEqual(final Object other) {
+      return other instanceof ClusterMetadata;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final ClusterMetadata that = (ClusterMetadata) o;
+      return Objects.equals(uuid, that.uuid) && Objects.equals(urls, that.urls);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(uuid, urls);
+    }
+
+    @Override
+    public String toString() {
+      return "CCSaasClusterClient.ClusterMetadata(uuid=" + getUuid() + ", urls=" + getUrls() + ")";
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/KpiService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/KpiService.java
@@ -48,21 +48,28 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
-@AllArgsConstructor
 public class KpiService {
 
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(KpiService.class);
   private final ReportService reportService;
   private final LocalizationService localizationService;
   private final PlainReportEvaluationHandler reportEvaluationHandler;
+
+  public KpiService(
+      final ReportService reportService,
+      final LocalizationService localizationService,
+      final PlainReportEvaluationHandler reportEvaluationHandler) {
+    this.reportService = reportService;
+    this.localizationService = localizationService;
+    this.reportEvaluationHandler = reportEvaluationHandler;
+  }
 
   public List<KpiResultDto> evaluateKpiReports(final String processDefinitionKey) {
     final List<SingleProcessReportDefinitionRequestDto> kpiReports =
@@ -235,10 +242,57 @@ public class KpiService {
     return validKpis;
   }
 
-  @Data
-  @AllArgsConstructor
   private static class TargetAndUnit {
+
     private String target;
     private TargetValueUnit targetValueUnit;
+
+    public TargetAndUnit(final String target, final TargetValueUnit targetValueUnit) {
+      this.target = target;
+      this.targetValueUnit = targetValueUnit;
+    }
+
+    public String getTarget() {
+      return target;
+    }
+
+    public void setTarget(final String target) {
+      this.target = target;
+    }
+
+    public TargetValueUnit getTargetValueUnit() {
+      return targetValueUnit;
+    }
+
+    public void setTargetValueUnit(final TargetValueUnit targetValueUnit) {
+      this.targetValueUnit = targetValueUnit;
+    }
+
+    protected boolean canEqual(final Object other) {
+      return other instanceof TargetAndUnit;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final TargetAndUnit that = (TargetAndUnit) o;
+      return Objects.equals(target, that.target) && targetValueUnit == that.targetValueUnit;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(target, targetValueUnit);
+    }
+
+    @Override
+    public String toString() {
+      return "KpiService.TargetAndUnit(target="
+          + getTarget()
+          + ", targetValueUnit="
+          + getTargetValueUnit()
+          + ")";
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/context/VariableAggregationContextES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/context/VariableAggregationContextES.java
@@ -8,15 +8,110 @@
 package io.camunda.optimize.service.db.es.report.context;
 
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation.Builder.ContainerBuilder;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import io.camunda.optimize.service.db.report.context.VariableAggregationContext;
 import java.util.Map;
-import lombok.Data;
-import lombok.experimental.SuperBuilder;
+import java.util.Objects;
 
-@SuperBuilder
-@Data
 public class VariableAggregationContextES extends VariableAggregationContext {
+
   private final BoolQuery baseQueryForMinMaxStats;
   private final Map<String, Aggregation.Builder.ContainerBuilder> subAggregations;
+
+  protected VariableAggregationContextES(final VariableAggregationContextESBuilder<?, ?> b) {
+    super(b);
+    this.baseQueryForMinMaxStats = b.baseQueryForMinMaxStats;
+    this.subAggregations = b.subAggregations;
+  }
+
+  public BoolQuery getBaseQueryForMinMaxStats() {
+    return this.baseQueryForMinMaxStats;
+  }
+
+  public Map<String, ContainerBuilder> getSubAggregations() {
+    return this.subAggregations;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final VariableAggregationContextES that = (VariableAggregationContextES) o;
+    return Objects.equals(baseQueryForMinMaxStats, that.baseQueryForMinMaxStats)
+        && Objects.equals(subAggregations, that.subAggregations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), baseQueryForMinMaxStats, subAggregations);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof VariableAggregationContextES;
+  }
+
+  public String toString() {
+    return "VariableAggregationContextES(baseQueryForMinMaxStats="
+        + this.getBaseQueryForMinMaxStats()
+        + ", subAggregations="
+        + this.getSubAggregations()
+        + ")";
+  }
+
+  public static VariableAggregationContextESBuilder<?, ?> builder() {
+    return new VariableAggregationContextESBuilderImpl();
+  }
+
+  public abstract static class VariableAggregationContextESBuilder<
+          C extends VariableAggregationContextES,
+          B extends VariableAggregationContextESBuilder<C, B>>
+      extends VariableAggregationContextBuilder<C, B> {
+
+    private BoolQuery baseQueryForMinMaxStats;
+    private Map<String, ContainerBuilder> subAggregations;
+
+    public B baseQueryForMinMaxStats(final BoolQuery baseQueryForMinMaxStats) {
+      this.baseQueryForMinMaxStats = baseQueryForMinMaxStats;
+      return self();
+    }
+
+    public B subAggregations(final Map<String, ContainerBuilder> subAggregations) {
+      this.subAggregations = subAggregations;
+      return self();
+    }
+
+    protected abstract B self();
+
+    public abstract C build();
+
+    public String toString() {
+      return "VariableAggregationContextES.VariableAggregationContextESBuilder(super="
+          + super.toString()
+          + ", baseQueryForMinMaxStats="
+          + this.baseQueryForMinMaxStats
+          + ", subAggregations="
+          + this.subAggregations
+          + ")";
+    }
+  }
+
+  private static final class VariableAggregationContextESBuilderImpl
+      extends VariableAggregationContextESBuilder<
+          VariableAggregationContextES, VariableAggregationContextESBuilderImpl> {
+
+    private VariableAggregationContextESBuilderImpl() {}
+
+    protected VariableAggregationContextESBuilderImpl self() {
+      return this;
+    }
+
+    public VariableAggregationContextES build() {
+      return new VariableAggregationContextES(this);
+    }
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/filter/FilterContext.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/filter/FilterContext.java
@@ -8,12 +8,81 @@
 package io.camunda.optimize.service.db.filter;
 
 import java.time.ZoneId;
-import lombok.Builder;
-import lombok.Value;
+import java.util.Objects;
 
-@Builder
-@Value
-public class FilterContext {
-  ZoneId timezone;
-  boolean userTaskReport;
+public final class FilterContext {
+
+  private final ZoneId timezone;
+  private final boolean userTaskReport;
+
+  FilterContext(final ZoneId timezone, final boolean userTaskReport) {
+    this.timezone = timezone;
+    this.userTaskReport = userTaskReport;
+  }
+
+  public ZoneId getTimezone() {
+    return timezone;
+  }
+
+  public boolean isUserTaskReport() {
+    return userTaskReport;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FilterContext that = (FilterContext) o;
+    return userTaskReport == that.userTaskReport && Objects.equals(timezone, that.timezone);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(timezone, userTaskReport);
+  }
+
+  @Override
+  public String toString() {
+    return "FilterContext(timezone="
+        + getTimezone()
+        + ", userTaskReport="
+        + isUserTaskReport()
+        + ")";
+  }
+
+  public static FilterContextBuilder builder() {
+    return new FilterContextBuilder();
+  }
+
+  public static class FilterContextBuilder {
+
+    private ZoneId timezone;
+    private boolean userTaskReport;
+
+    FilterContextBuilder() {}
+
+    public FilterContextBuilder timezone(final ZoneId timezone) {
+      this.timezone = timezone;
+      return this;
+    }
+
+    public FilterContextBuilder userTaskReport(final boolean userTaskReport) {
+      this.userTaskReport = userTaskReport;
+      return this;
+    }
+
+    public FilterContext build() {
+      return new FilterContext(timezone, userTaskReport);
+    }
+
+    @Override
+    public String toString() {
+      return "FilterContext.FilterContextBuilder(timezone="
+          + timezone
+          + ", userTaskReport="
+          + userTaskReport
+          + ")";
+    }
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/context/VariableAggregationContextOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/context/VariableAggregationContextOS.java
@@ -9,14 +9,108 @@ package io.camunda.optimize.service.db.os.report.context;
 
 import io.camunda.optimize.service.db.report.context.VariableAggregationContext;
 import java.util.Map;
-import lombok.Data;
-import lombok.experimental.SuperBuilder;
+import java.util.Objects;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 
-@SuperBuilder
-@Data
 public class VariableAggregationContextOS extends VariableAggregationContext {
+
   private final Query baseQueryForMinMaxStats;
   private final Map<String, Aggregation> subAggregations;
+
+  protected VariableAggregationContextOS(final VariableAggregationContextOSBuilder<?, ?> b) {
+    super(b);
+    this.baseQueryForMinMaxStats = b.baseQueryForMinMaxStats;
+    this.subAggregations = b.subAggregations;
+  }
+
+  public Query getBaseQueryForMinMaxStats() {
+    return this.baseQueryForMinMaxStats;
+  }
+
+  public Map<String, Aggregation> getSubAggregations() {
+    return this.subAggregations;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final VariableAggregationContextOS that = (VariableAggregationContextOS) o;
+    return Objects.equals(baseQueryForMinMaxStats, that.baseQueryForMinMaxStats)
+        && Objects.equals(subAggregations, that.subAggregations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), baseQueryForMinMaxStats, subAggregations);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof VariableAggregationContextOS;
+  }
+
+  public String toString() {
+    return "VariableAggregationContextOS(baseQueryForMinMaxStats="
+        + this.getBaseQueryForMinMaxStats()
+        + ", subAggregations="
+        + this.getSubAggregations()
+        + ")";
+  }
+
+  public static VariableAggregationContextOSBuilder<?, ?> builder() {
+    return new VariableAggregationContextOSBuilderImpl();
+  }
+
+  public abstract static class VariableAggregationContextOSBuilder<
+          C extends VariableAggregationContextOS,
+          B extends VariableAggregationContextOSBuilder<C, B>>
+      extends VariableAggregationContextBuilder<C, B> {
+
+    private Query baseQueryForMinMaxStats;
+    private Map<String, Aggregation> subAggregations;
+
+    public B baseQueryForMinMaxStats(final Query baseQueryForMinMaxStats) {
+      this.baseQueryForMinMaxStats = baseQueryForMinMaxStats;
+      return self();
+    }
+
+    public B subAggregations(final Map<String, Aggregation> subAggregations) {
+      this.subAggregations = subAggregations;
+      return self();
+    }
+
+    protected abstract B self();
+
+    public abstract C build();
+
+    public String toString() {
+      return "VariableAggregationContextOS.VariableAggregationContextOSBuilder(super="
+          + super.toString()
+          + ", baseQueryForMinMaxStats="
+          + this.baseQueryForMinMaxStats
+          + ", subAggregations="
+          + this.subAggregations
+          + ")";
+    }
+  }
+
+  private static final class VariableAggregationContextOSBuilderImpl
+      extends VariableAggregationContextOSBuilder<
+          VariableAggregationContextOS, VariableAggregationContextOSBuilderImpl> {
+
+    private VariableAggregationContextOSBuilderImpl() {}
+
+    protected VariableAggregationContextOSBuilderImpl self() {
+      return this;
+    }
+
+    public VariableAggregationContextOS build() {
+      return new VariableAggregationContextOS(this);
+    }
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ExecutionContext.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ExecutionContext.java
@@ -20,13 +20,13 @@ import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import lombok.Data;
 
-@Data
 public class ExecutionContext<D extends SingleReportDataDto, P extends ExecutionPlan> {
+
   private P plan;
   private D reportData;
   private ZoneId timezone;
@@ -103,5 +103,179 @@ public class ExecutionContext<D extends SingleReportDataDto, P extends Execution
       builder.userTaskReport(((ProcessReportDataDto) definitionReportData).isUserTaskReport());
     }
     return builder.build();
+  }
+
+  public P getPlan() {
+    return this.plan;
+  }
+
+  public D getReportData() {
+    return this.reportData;
+  }
+
+  public ZoneId getTimezone() {
+    return this.timezone;
+  }
+
+  public long getUnfilteredTotalInstanceCount() {
+    return this.unfilteredTotalInstanceCount;
+  }
+
+  public Optional<PaginationDto> getPagination() {
+    return this.pagination;
+  }
+
+  public boolean isCsvExport() {
+    return this.isCsvExport;
+  }
+
+  public boolean isJsonExport() {
+    return this.isJsonExport;
+  }
+
+  public Map<String, String> getAllDistributedByKeysAndLabels() {
+    return this.allDistributedByKeysAndLabels;
+  }
+
+  public Set<String> getAllVariablesNames() {
+    return this.allVariablesNames;
+  }
+
+  public Set<String> getHiddenFlowNodeIds() {
+    return this.hiddenFlowNodeIds;
+  }
+
+  public FilterContext getFilterContext() {
+    return this.filterContext;
+  }
+
+  public boolean isMultiIndexAlias() {
+    return this.multiIndexAlias;
+  }
+
+  public void setPlan(final P plan) {
+    this.plan = plan;
+  }
+
+  public void setReportData(final D reportData) {
+    this.reportData = reportData;
+  }
+
+  public void setTimezone(final ZoneId timezone) {
+    this.timezone = timezone;
+  }
+
+  public void setUnfilteredTotalInstanceCount(final long unfilteredTotalInstanceCount) {
+    this.unfilteredTotalInstanceCount = unfilteredTotalInstanceCount;
+  }
+
+  public void setPagination(final Optional<PaginationDto> pagination) {
+    this.pagination = pagination;
+  }
+
+  public void setCsvExport(final boolean isCsvExport) {
+    this.isCsvExport = isCsvExport;
+  }
+
+  public void setJsonExport(final boolean isJsonExport) {
+    this.isJsonExport = isJsonExport;
+  }
+
+  public void setCombinedRangeMinMaxStats(final MinMaxStatDto combinedRangeMinMaxStats) {
+    this.combinedRangeMinMaxStats = combinedRangeMinMaxStats;
+  }
+
+  public void setAllDistributedByKeysAndLabels(
+      final Map<String, String> allDistributedByKeysAndLabels) {
+    this.allDistributedByKeysAndLabels = allDistributedByKeysAndLabels;
+  }
+
+  public void setAllVariablesNames(final Set<String> allVariablesNames) {
+    this.allVariablesNames = allVariablesNames;
+  }
+
+  public void setHiddenFlowNodeIds(final Set<String> hiddenFlowNodeIds) {
+    this.hiddenFlowNodeIds = hiddenFlowNodeIds;
+  }
+
+  public void setFilterContext(final FilterContext filterContext) {
+    this.filterContext = filterContext;
+  }
+
+  public void setMultiIndexAlias(final boolean multiIndexAlias) {
+    this.multiIndexAlias = multiIndexAlias;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExecutionContext<?, ?> that = (ExecutionContext<?, ?>) o;
+    return unfilteredTotalInstanceCount == that.unfilteredTotalInstanceCount
+        && isCsvExport == that.isCsvExport
+        && isJsonExport == that.isJsonExport
+        && multiIndexAlias == that.multiIndexAlias
+        && Objects.equals(plan, that.plan)
+        && Objects.equals(reportData, that.reportData)
+        && Objects.equals(timezone, that.timezone)
+        && Objects.equals(pagination, that.pagination)
+        && Objects.equals(combinedRangeMinMaxStats, that.combinedRangeMinMaxStats)
+        && Objects.equals(allDistributedByKeysAndLabels, that.allDistributedByKeysAndLabels)
+        && Objects.equals(allVariablesNames, that.allVariablesNames)
+        && Objects.equals(hiddenFlowNodeIds, that.hiddenFlowNodeIds)
+        && Objects.equals(filterContext, that.filterContext);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        plan,
+        reportData,
+        timezone,
+        unfilteredTotalInstanceCount,
+        pagination,
+        isCsvExport,
+        isJsonExport,
+        combinedRangeMinMaxStats,
+        allDistributedByKeysAndLabels,
+        allVariablesNames,
+        hiddenFlowNodeIds,
+        filterContext,
+        multiIndexAlias);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ExecutionContext;
+  }
+
+  public String toString() {
+    return "ExecutionContext(plan="
+        + this.getPlan()
+        + ", reportData="
+        + this.getReportData()
+        + ", timezone="
+        + this.getTimezone()
+        + ", unfilteredTotalInstanceCount="
+        + this.getUnfilteredTotalInstanceCount()
+        + ", pagination="
+        + this.getPagination()
+        + ", isCsvExport="
+        + this.isCsvExport()
+        + ", isJsonExport="
+        + this.isJsonExport()
+        + ", combinedRangeMinMaxStats="
+        + this.getCombinedRangeMinMaxStats()
+        + ", allDistributedByKeysAndLabels="
+        + this.getAllDistributedByKeysAndLabels()
+        + ", allVariablesNames="
+        + this.getAllVariablesNames()
+        + ", hiddenFlowNodeIds="
+        + this.getHiddenFlowNodeIds()
+        + ", filterContext="
+        + this.getFilterContext()
+        + ", multiIndexAlias="
+        + this.isMultiIndexAlias()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationContext.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationContext.java
@@ -12,11 +12,10 @@ import static io.camunda.optimize.util.SuppressionConstants.UNCHECKED_CAST;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
 import io.camunda.optimize.dto.optimize.rest.pagination.PaginationDto;
 import java.time.ZoneId;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import lombok.Data;
 
-@Data
 public class ReportEvaluationContext<R extends ReportDefinitionDto<?>> {
 
   private R reportDefinition;
@@ -31,6 +30,8 @@ public class ReportEvaluationContext<R extends ReportDefinitionDto<?>> {
 
   // users can define which timezone the date data should be based on
   private ZoneId timezone = ZoneId.systemDefault();
+
+  public ReportEvaluationContext() {}
 
   public Optional<PaginationDto> getPagination() {
     return Optional.ofNullable(pagination);
@@ -47,5 +48,106 @@ public class ReportEvaluationContext<R extends ReportDefinitionDto<?>> {
     context.setJsonExport(evaluationInfo.isJsonExport());
     context.setHiddenFlowNodeIds(evaluationInfo.getHiddenFlowNodeIds());
     return context;
+  }
+
+  public R getReportDefinition() {
+    return this.reportDefinition;
+  }
+
+  public boolean isCsvExport() {
+    return this.isCsvExport;
+  }
+
+  public boolean isJsonExport() {
+    return this.isJsonExport;
+  }
+
+  public Set<String> getHiddenFlowNodeIds() {
+    return this.hiddenFlowNodeIds;
+  }
+
+  public MinMaxStatDto getCombinedRangeMinMaxStats() {
+    return this.combinedRangeMinMaxStats;
+  }
+
+  public ZoneId getTimezone() {
+    return this.timezone;
+  }
+
+  public void setReportDefinition(final R reportDefinition) {
+    this.reportDefinition = reportDefinition;
+  }
+
+  public void setPagination(final PaginationDto pagination) {
+    this.pagination = pagination;
+  }
+
+  public void setCsvExport(final boolean isCsvExport) {
+    this.isCsvExport = isCsvExport;
+  }
+
+  public void setJsonExport(final boolean isJsonExport) {
+    this.isJsonExport = isJsonExport;
+  }
+
+  public void setHiddenFlowNodeIds(final Set<String> hiddenFlowNodeIds) {
+    this.hiddenFlowNodeIds = hiddenFlowNodeIds;
+  }
+
+  public void setCombinedRangeMinMaxStats(final MinMaxStatDto combinedRangeMinMaxStats) {
+    this.combinedRangeMinMaxStats = combinedRangeMinMaxStats;
+  }
+
+  public void setTimezone(final ZoneId timezone) {
+    this.timezone = timezone;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportEvaluationContext<?> that = (ReportEvaluationContext<?>) o;
+    return isCsvExport == that.isCsvExport
+        && isJsonExport == that.isJsonExport
+        && Objects.equals(reportDefinition, that.reportDefinition)
+        && Objects.equals(pagination, that.pagination)
+        && Objects.equals(hiddenFlowNodeIds, that.hiddenFlowNodeIds)
+        && Objects.equals(combinedRangeMinMaxStats, that.combinedRangeMinMaxStats)
+        && Objects.equals(timezone, that.timezone);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        reportDefinition,
+        pagination,
+        isCsvExport,
+        isJsonExport,
+        hiddenFlowNodeIds,
+        combinedRangeMinMaxStats,
+        timezone);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ReportEvaluationContext;
+  }
+
+  public String toString() {
+    return "ReportEvaluationContext(reportDefinition="
+        + this.getReportDefinition()
+        + ", pagination="
+        + this.getPagination()
+        + ", isCsvExport="
+        + this.isCsvExport()
+        + ", isJsonExport="
+        + this.isJsonExport()
+        + ", hiddenFlowNodeIds="
+        + this.getHiddenFlowNodeIds()
+        + ", combinedRangeMinMaxStats="
+        + this.getCombinedRangeMinMaxStats()
+        + ", timezone="
+        + this.getTimezone()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/context/VariableAggregationContext.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/context/VariableAggregationContext.java
@@ -13,14 +13,12 @@ import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import io.camunda.optimize.service.db.filter.FilterContext;
 import io.camunda.optimize.service.db.report.MinMaxStatDto;
 import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.Data;
-import lombok.NonNull;
-import lombok.experimental.SuperBuilder;
 
-@SuperBuilder
-@Data
 public class VariableAggregationContext {
+
   private final String variableName;
   private final VariableType variableType;
   private final String variablePath;
@@ -32,7 +30,25 @@ public class VariableAggregationContext {
   private final String[] indexNames;
   private MinMaxStatDto variableRangeMinMaxStats;
   private final MinMaxStatDto combinedRangeMinMaxStats;
-  @NonNull private final FilterContext filterContext;
+  private final FilterContext filterContext;
+
+  protected VariableAggregationContext(final VariableAggregationContextBuilder<?, ?> b) {
+    this.variableName = b.variableName;
+    this.variableType = b.variableType;
+    this.variablePath = b.variablePath;
+    this.nestedVariableNameField = b.nestedVariableNameField;
+    this.nestedVariableValueFieldLabel = b.nestedVariableValueFieldLabel;
+    this.timezone = b.timezone;
+    this.customBucketDto = b.customBucketDto;
+    this.dateUnit = b.dateUnit;
+    this.indexNames = b.indexNames;
+    this.variableRangeMinMaxStats = b.variableRangeMinMaxStats;
+    this.combinedRangeMinMaxStats = b.combinedRangeMinMaxStats;
+    this.filterContext = b.filterContext;
+    if (filterContext == null) {
+      throw new IllegalArgumentException("FilterContext cannot be null");
+    }
+  }
 
   public Optional<MinMaxStatDto> getCombinedRangeMinMaxStats() {
     return Optional.ofNullable(combinedRangeMinMaxStats);
@@ -40,5 +56,254 @@ public class VariableAggregationContext {
 
   public double getMaxVariableValue() {
     return getCombinedRangeMinMaxStats().orElse(variableRangeMinMaxStats).getMax();
+  }
+
+  public String getVariableName() {
+    return this.variableName;
+  }
+
+  public VariableType getVariableType() {
+    return this.variableType;
+  }
+
+  public String getVariablePath() {
+    return this.variablePath;
+  }
+
+  public String getNestedVariableNameField() {
+    return this.nestedVariableNameField;
+  }
+
+  public String getNestedVariableValueFieldLabel() {
+    return this.nestedVariableValueFieldLabel;
+  }
+
+  public ZoneId getTimezone() {
+    return this.timezone;
+  }
+
+  public CustomBucketDto getCustomBucketDto() {
+    return this.customBucketDto;
+  }
+
+  public AggregateByDateUnit getDateUnit() {
+    return this.dateUnit;
+  }
+
+  public String[] getIndexNames() {
+    return this.indexNames;
+  }
+
+  public MinMaxStatDto getVariableRangeMinMaxStats() {
+    return this.variableRangeMinMaxStats;
+  }
+
+  public FilterContext getFilterContext() {
+    return this.filterContext;
+  }
+
+  public void setVariableRangeMinMaxStats(final MinMaxStatDto variableRangeMinMaxStats) {
+    this.variableRangeMinMaxStats = variableRangeMinMaxStats;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableAggregationContext that = (VariableAggregationContext) o;
+    return Objects.equals(variableName, that.variableName)
+        && variableType == that.variableType
+        && Objects.equals(variablePath, that.variablePath)
+        && Objects.equals(nestedVariableNameField, that.nestedVariableNameField)
+        && Objects.equals(nestedVariableValueFieldLabel, that.nestedVariableValueFieldLabel)
+        && Objects.equals(timezone, that.timezone)
+        && Objects.equals(customBucketDto, that.customBucketDto)
+        && dateUnit == that.dateUnit
+        && Objects.deepEquals(indexNames, that.indexNames)
+        && Objects.equals(variableRangeMinMaxStats, that.variableRangeMinMaxStats)
+        && Objects.equals(combinedRangeMinMaxStats, that.combinedRangeMinMaxStats)
+        && Objects.equals(filterContext, that.filterContext);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        variableName,
+        variableType,
+        variablePath,
+        nestedVariableNameField,
+        nestedVariableValueFieldLabel,
+        timezone,
+        customBucketDto,
+        dateUnit,
+        Arrays.hashCode(indexNames),
+        variableRangeMinMaxStats,
+        combinedRangeMinMaxStats,
+        filterContext);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof VariableAggregationContext;
+  }
+
+  public String toString() {
+    return "VariableAggregationContext(variableName="
+        + this.getVariableName()
+        + ", variableType="
+        + this.getVariableType()
+        + ", variablePath="
+        + this.getVariablePath()
+        + ", nestedVariableNameField="
+        + this.getNestedVariableNameField()
+        + ", nestedVariableValueFieldLabel="
+        + this.getNestedVariableValueFieldLabel()
+        + ", timezone="
+        + this.getTimezone()
+        + ", customBucketDto="
+        + this.getCustomBucketDto()
+        + ", dateUnit="
+        + this.getDateUnit()
+        + ", indexNames="
+        + java.util.Arrays.deepToString(this.getIndexNames())
+        + ", variableRangeMinMaxStats="
+        + this.getVariableRangeMinMaxStats()
+        + ", combinedRangeMinMaxStats="
+        + this.getCombinedRangeMinMaxStats()
+        + ", filterContext="
+        + this.getFilterContext()
+        + ")";
+  }
+
+  public static VariableAggregationContextBuilder<?, ?> builder() {
+    return new VariableAggregationContextBuilderImpl();
+  }
+
+  public abstract static class VariableAggregationContextBuilder<
+      C extends VariableAggregationContext, B extends VariableAggregationContextBuilder<C, B>> {
+
+    private String variableName;
+    private VariableType variableType;
+    private String variablePath;
+    private String nestedVariableNameField;
+    private String nestedVariableValueFieldLabel;
+    private ZoneId timezone;
+    private CustomBucketDto customBucketDto;
+    private AggregateByDateUnit dateUnit;
+    private String[] indexNames;
+    private MinMaxStatDto variableRangeMinMaxStats;
+    private MinMaxStatDto combinedRangeMinMaxStats;
+    private FilterContext filterContext;
+
+    public B variableName(final String variableName) {
+      this.variableName = variableName;
+      return self();
+    }
+
+    public B variableType(final VariableType variableType) {
+      this.variableType = variableType;
+      return self();
+    }
+
+    public B variablePath(final String variablePath) {
+      this.variablePath = variablePath;
+      return self();
+    }
+
+    public B nestedVariableNameField(final String nestedVariableNameField) {
+      this.nestedVariableNameField = nestedVariableNameField;
+      return self();
+    }
+
+    public B nestedVariableValueFieldLabel(final String nestedVariableValueFieldLabel) {
+      this.nestedVariableValueFieldLabel = nestedVariableValueFieldLabel;
+      return self();
+    }
+
+    public B timezone(final ZoneId timezone) {
+      this.timezone = timezone;
+      return self();
+    }
+
+    public B customBucketDto(final CustomBucketDto customBucketDto) {
+      this.customBucketDto = customBucketDto;
+      return self();
+    }
+
+    public B dateUnit(final AggregateByDateUnit dateUnit) {
+      this.dateUnit = dateUnit;
+      return self();
+    }
+
+    public B indexNames(final String[] indexNames) {
+      this.indexNames = indexNames;
+      return self();
+    }
+
+    public B variableRangeMinMaxStats(final MinMaxStatDto variableRangeMinMaxStats) {
+      this.variableRangeMinMaxStats = variableRangeMinMaxStats;
+      return self();
+    }
+
+    public B combinedRangeMinMaxStats(final MinMaxStatDto combinedRangeMinMaxStats) {
+      this.combinedRangeMinMaxStats = combinedRangeMinMaxStats;
+      return self();
+    }
+
+    public B filterContext(final FilterContext filterContext) {
+      if (filterContext == null) {
+        throw new IllegalArgumentException("filterContext must not be null");
+      }
+
+      this.filterContext = filterContext;
+      return self();
+    }
+
+    protected abstract B self();
+
+    public abstract C build();
+
+    public String toString() {
+      return "VariableAggregationContext.VariableAggregationContextBuilder(variableName="
+          + this.variableName
+          + ", variableType="
+          + this.variableType
+          + ", variablePath="
+          + this.variablePath
+          + ", nestedVariableNameField="
+          + this.nestedVariableNameField
+          + ", nestedVariableValueFieldLabel="
+          + this.nestedVariableValueFieldLabel
+          + ", timezone="
+          + this.timezone
+          + ", customBucketDto="
+          + this.customBucketDto
+          + ", dateUnit="
+          + this.dateUnit
+          + ", indexNames="
+          + java.util.Arrays.deepToString(this.indexNames)
+          + ", variableRangeMinMaxStats="
+          + this.variableRangeMinMaxStats
+          + ", combinedRangeMinMaxStats="
+          + this.combinedRangeMinMaxStats
+          + ", filterContext="
+          + this.filterContext
+          + ")";
+    }
+  }
+
+  private static final class VariableAggregationContextBuilderImpl
+      extends VariableAggregationContextBuilder<
+          VariableAggregationContext, VariableAggregationContextBuilderImpl> {
+
+    private VariableAggregationContextBuilderImpl() {}
+
+    protected VariableAggregationContextBuilderImpl self() {
+      return this;
+    }
+
+    public VariableAggregationContext build() {
+      return new VariableAggregationContext(this);
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/page/PositionBasedImportPage.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/page/PositionBasedImportPage.java
@@ -7,12 +7,68 @@
  */
 package io.camunda.optimize.service.importing.page;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class PositionBasedImportPage implements ImportPage {
 
   private Long position = 0L;
   private Long sequence = 0L;
   private boolean hasSeenSequenceField = false;
+
+  public PositionBasedImportPage() {}
+
+  public Long getPosition() {
+    return position;
+  }
+
+  public void setPosition(final Long position) {
+    this.position = position;
+  }
+
+  public Long getSequence() {
+    return sequence;
+  }
+
+  public void setSequence(final Long sequence) {
+    this.sequence = sequence;
+  }
+
+  public boolean isHasSeenSequenceField() {
+    return hasSeenSequenceField;
+  }
+
+  public void setHasSeenSequenceField(final boolean hasSeenSequenceField) {
+    this.hasSeenSequenceField = hasSeenSequenceField;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PositionBasedImportPage;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PositionBasedImportPage that = (PositionBasedImportPage) o;
+    return hasSeenSequenceField == that.hasSeenSequenceField
+        && Objects.equals(position, that.position)
+        && Objects.equals(sequence, that.sequence);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(position, sequence, hasSeenSequenceField);
+  }
+
+  @Override
+  public String toString() {
+    return "PositionBasedImportPage(position="
+        + getPosition()
+        + ", sequence="
+        + getSequence()
+        + ", hasSeenSequenceField="
+        + isHasSeenSequenceField()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelEntityEventProperties.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelEntityEventProperties.java
@@ -8,12 +8,10 @@
 package io.camunda.optimize.service.mixpanel.client;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class MixpanelEntityEventProperties extends MixpanelEventProperties {
+
   @JsonProperty("entityId")
   private String entityId;
 
@@ -24,5 +22,41 @@ public class MixpanelEntityEventProperties extends MixpanelEventProperties {
       final String clusterId) {
     super(stage, organizationId, clusterId);
     this.entityId = entityId;
+  }
+
+  public String getEntityId() {
+    return entityId;
+  }
+
+  @JsonProperty("entityId")
+  public void setEntityId(final String entityId) {
+    this.entityId = entityId;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof MixpanelEntityEventProperties;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final MixpanelEntityEventProperties that = (MixpanelEntityEventProperties) o;
+    return Objects.equals(entityId, that.entityId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), entityId);
+  }
+
+  @Override
+  public String toString() {
+    return "MixpanelEntityEventProperties(entityId=" + getEntityId() + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelEvent.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelEvent.java
@@ -7,15 +7,10 @@
  */
 package io.camunda.optimize.service.mixpanel.client;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MixpanelEvent {
+
   public static final String EVENT_NAME_PREFIX = "optimize:";
 
   private String event;
@@ -23,7 +18,53 @@ public class MixpanelEvent {
 
   public MixpanelEvent(
       final EventReportingEvent eventName, final MixpanelEventProperties properties) {
-    this.event = EVENT_NAME_PREFIX + eventName;
+    event = EVENT_NAME_PREFIX + eventName;
     this.properties = properties;
+  }
+
+  public MixpanelEvent(final String event, final MixpanelEventProperties properties) {
+    this.event = event;
+    this.properties = properties;
+  }
+
+  protected MixpanelEvent() {}
+
+  public String getEvent() {
+    return event;
+  }
+
+  public void setEvent(final String event) {
+    this.event = event;
+  }
+
+  public MixpanelEventProperties getProperties() {
+    return properties;
+  }
+
+  public void setProperties(final MixpanelEventProperties properties) {
+    this.properties = properties;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MixpanelEvent;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MixpanelEvent that = (MixpanelEvent) o;
+    return Objects.equals(event, that.event) && Objects.equals(properties, that.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(event, properties);
+  }
+
+  @Override
+  public String toString() {
+    return "MixpanelEvent(event=" + getEvent() + ", properties=" + getProperties() + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelEventProperties.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelEventProperties.java
@@ -8,13 +8,11 @@
 package io.camunda.optimize.service.mixpanel.client;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import java.util.UUID;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
 public class MixpanelEventProperties {
+
   // Mixpanel default properties, see
   // https://developer.mixpanel.com/reference/import-events#high-level-requirements
   @JsonProperty("time")
@@ -51,6 +49,8 @@ public class MixpanelEventProperties {
     this.clusterId = clusterId;
   }
 
+  public MixpanelEventProperties() {}
+
   @JsonProperty("org_id")
   public String getOrgGroupKey() {
     return organizationId;
@@ -59,5 +59,124 @@ public class MixpanelEventProperties {
   @JsonProperty("cluster_id")
   public String getOrgClusterId() {
     return clusterId;
+  }
+
+  public long getTime() {
+    return time;
+  }
+
+  @JsonProperty("time")
+  public void setTime(final long time) {
+    this.time = time;
+  }
+
+  public String getDistinctId() {
+    return distinctId;
+  }
+
+  @JsonProperty("distinct_id")
+  public void setDistinctId(final String distinctId) {
+    this.distinctId = distinctId;
+  }
+
+  public String getInsertId() {
+    return insertId;
+  }
+
+  @JsonProperty("$insert_id")
+  public void setInsertId(final String insertId) {
+    this.insertId = insertId;
+  }
+
+  public String getProduct() {
+    return product;
+  }
+
+  @JsonProperty("product")
+  public void setProduct(final String product) {
+    this.product = product;
+  }
+
+  public String getOrganizationId() {
+    return organizationId;
+  }
+
+  @JsonProperty("orgId")
+  public void setOrganizationId(final String organizationId) {
+    this.organizationId = organizationId;
+  }
+
+  public String getStage() {
+    return stage;
+  }
+
+  @JsonProperty("stage")
+  public void setStage(final String stage) {
+    this.stage = stage;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  @JsonProperty("userId")
+  public void setUserId(final String userId) {
+    this.userId = userId;
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  @JsonProperty("clusterId")
+  public void setClusterId(final String clusterId) {
+    this.clusterId = clusterId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MixpanelEventProperties;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MixpanelEventProperties that = (MixpanelEventProperties) o;
+    return time == that.time
+        && Objects.equals(distinctId, that.distinctId)
+        && Objects.equals(insertId, that.insertId)
+        && Objects.equals(product, that.product)
+        && Objects.equals(organizationId, that.organizationId)
+        && Objects.equals(stage, that.stage)
+        && Objects.equals(userId, that.userId)
+        && Objects.equals(clusterId, that.clusterId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        time, distinctId, insertId, product, organizationId, stage, userId, clusterId);
+  }
+
+  @Override
+  public String toString() {
+    return "MixpanelEventProperties(time="
+        + getTime()
+        + ", distinctId="
+        + getDistinctId()
+        + ", insertId="
+        + getInsertId()
+        + ", product="
+        + getProduct()
+        + ", organizationId="
+        + getOrganizationId()
+        + ", stage="
+        + getStage()
+        + ", userId="
+        + getUserId()
+        + ", clusterId="
+        + getClusterId()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelHeartbeatMetrics.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelHeartbeatMetrics.java
@@ -7,11 +7,8 @@
  */
 package io.camunda.optimize.service.mixpanel.client;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
 public class MixpanelHeartbeatMetrics {
 
   private long processReportCount;
@@ -21,4 +18,127 @@ public class MixpanelHeartbeatMetrics {
   private long dashboardShareCount;
   private long alertCount;
   private long taskReportCount;
+
+  public MixpanelHeartbeatMetrics(
+      final long processReportCount,
+      final long decisionReportCount,
+      final long dashboardCount,
+      final long reportShareCount,
+      final long dashboardShareCount,
+      final long alertCount,
+      final long taskReportCount) {
+    this.processReportCount = processReportCount;
+    this.decisionReportCount = decisionReportCount;
+    this.dashboardCount = dashboardCount;
+    this.reportShareCount = reportShareCount;
+    this.dashboardShareCount = dashboardShareCount;
+    this.alertCount = alertCount;
+    this.taskReportCount = taskReportCount;
+  }
+
+  public long getProcessReportCount() {
+    return processReportCount;
+  }
+
+  public void setProcessReportCount(final long processReportCount) {
+    this.processReportCount = processReportCount;
+  }
+
+  public long getDecisionReportCount() {
+    return decisionReportCount;
+  }
+
+  public void setDecisionReportCount(final long decisionReportCount) {
+    this.decisionReportCount = decisionReportCount;
+  }
+
+  public long getDashboardCount() {
+    return dashboardCount;
+  }
+
+  public void setDashboardCount(final long dashboardCount) {
+    this.dashboardCount = dashboardCount;
+  }
+
+  public long getReportShareCount() {
+    return reportShareCount;
+  }
+
+  public void setReportShareCount(final long reportShareCount) {
+    this.reportShareCount = reportShareCount;
+  }
+
+  public long getDashboardShareCount() {
+    return dashboardShareCount;
+  }
+
+  public void setDashboardShareCount(final long dashboardShareCount) {
+    this.dashboardShareCount = dashboardShareCount;
+  }
+
+  public long getAlertCount() {
+    return alertCount;
+  }
+
+  public void setAlertCount(final long alertCount) {
+    this.alertCount = alertCount;
+  }
+
+  public long getTaskReportCount() {
+    return taskReportCount;
+  }
+
+  public void setTaskReportCount(final long taskReportCount) {
+    this.taskReportCount = taskReportCount;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MixpanelHeartbeatMetrics;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MixpanelHeartbeatMetrics that = (MixpanelHeartbeatMetrics) o;
+    return processReportCount == that.processReportCount
+        && decisionReportCount == that.decisionReportCount
+        && dashboardCount == that.dashboardCount
+        && reportShareCount == that.reportShareCount
+        && dashboardShareCount == that.dashboardShareCount
+        && alertCount == that.alertCount
+        && taskReportCount == that.taskReportCount;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        processReportCount,
+        decisionReportCount,
+        dashboardCount,
+        reportShareCount,
+        dashboardShareCount,
+        alertCount,
+        taskReportCount);
+  }
+
+  @Override
+  public String toString() {
+    return "MixpanelHeartbeatMetrics(processReportCount="
+        + getProcessReportCount()
+        + ", decisionReportCount="
+        + getDecisionReportCount()
+        + ", dashboardCount="
+        + getDashboardCount()
+        + ", reportShareCount="
+        + getReportShareCount()
+        + ", dashboardShareCount="
+        + getDashboardShareCount()
+        + ", alertCount="
+        + getAlertCount()
+        + ", taskReportCount="
+        + getTaskReportCount()
+        + ")";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelHeartbeatProperties.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelHeartbeatProperties.java
@@ -8,12 +8,10 @@
 package io.camunda.optimize.service.mixpanel.client;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class MixpanelHeartbeatProperties extends MixpanelEventProperties {
+
   @JsonProperty("processReportCount")
   private long processReportCount;
 
@@ -41,12 +39,130 @@ public class MixpanelHeartbeatProperties extends MixpanelEventProperties {
       final String organizationId,
       final String clusterId) {
     super(stage, organizationId, clusterId);
-    this.processReportCount = mixpanelHeartbeatMetrics.getProcessReportCount();
-    this.decisionReportCount = mixpanelHeartbeatMetrics.getDecisionReportCount();
-    this.dashboardCount = mixpanelHeartbeatMetrics.getDashboardCount();
-    this.reportShareCount = mixpanelHeartbeatMetrics.getReportShareCount();
-    this.dashboardShareCount = mixpanelHeartbeatMetrics.getDashboardShareCount();
-    this.alertCount = mixpanelHeartbeatMetrics.getAlertCount();
-    this.taskReportCount = mixpanelHeartbeatMetrics.getTaskReportCount();
+    processReportCount = mixpanelHeartbeatMetrics.getProcessReportCount();
+    decisionReportCount = mixpanelHeartbeatMetrics.getDecisionReportCount();
+    dashboardCount = mixpanelHeartbeatMetrics.getDashboardCount();
+    reportShareCount = mixpanelHeartbeatMetrics.getReportShareCount();
+    dashboardShareCount = mixpanelHeartbeatMetrics.getDashboardShareCount();
+    alertCount = mixpanelHeartbeatMetrics.getAlertCount();
+    taskReportCount = mixpanelHeartbeatMetrics.getTaskReportCount();
+  }
+
+  public long getProcessReportCount() {
+    return processReportCount;
+  }
+
+  @JsonProperty("processReportCount")
+  public void setProcessReportCount(final long processReportCount) {
+    this.processReportCount = processReportCount;
+  }
+
+  public long getDecisionReportCount() {
+    return decisionReportCount;
+  }
+
+  @JsonProperty("decisionReportCount")
+  public void setDecisionReportCount(final long decisionReportCount) {
+    this.decisionReportCount = decisionReportCount;
+  }
+
+  public long getDashboardCount() {
+    return dashboardCount;
+  }
+
+  @JsonProperty("dashboardCount")
+  public void setDashboardCount(final long dashboardCount) {
+    this.dashboardCount = dashboardCount;
+  }
+
+  public long getReportShareCount() {
+    return reportShareCount;
+  }
+
+  @JsonProperty("reportShareCount")
+  public void setReportShareCount(final long reportShareCount) {
+    this.reportShareCount = reportShareCount;
+  }
+
+  public long getDashboardShareCount() {
+    return dashboardShareCount;
+  }
+
+  @JsonProperty("dashboardShareCount")
+  public void setDashboardShareCount(final long dashboardShareCount) {
+    this.dashboardShareCount = dashboardShareCount;
+  }
+
+  public long getAlertCount() {
+    return alertCount;
+  }
+
+  @JsonProperty("alertCount")
+  public void setAlertCount(final long alertCount) {
+    this.alertCount = alertCount;
+  }
+
+  public long getTaskReportCount() {
+    return taskReportCount;
+  }
+
+  @JsonProperty("taskReportCount")
+  public void setTaskReportCount(final long taskReportCount) {
+    this.taskReportCount = taskReportCount;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof MixpanelHeartbeatProperties;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final MixpanelHeartbeatProperties that = (MixpanelHeartbeatProperties) o;
+    return processReportCount == that.processReportCount
+        && decisionReportCount == that.decisionReportCount
+        && dashboardCount == that.dashboardCount
+        && reportShareCount == that.reportShareCount
+        && dashboardShareCount == that.dashboardShareCount
+        && alertCount == that.alertCount
+        && taskReportCount == that.taskReportCount;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(),
+        processReportCount,
+        decisionReportCount,
+        dashboardCount,
+        reportShareCount,
+        dashboardShareCount,
+        alertCount,
+        taskReportCount);
+  }
+
+  @Override
+  public String toString() {
+    return "MixpanelHeartbeatProperties(processReportCount="
+        + getProcessReportCount()
+        + ", decisionReportCount="
+        + getDecisionReportCount()
+        + ", dashboardCount="
+        + getDashboardCount()
+        + ", reportShareCount="
+        + getReportShareCount()
+        + ", dashboardShareCount="
+        + getDashboardShareCount()
+        + ", alertCount="
+        + getAlertCount()
+        + ", taskReportCount="
+        + getTaskReportCount()
+        + ")";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelImportResponse.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/mixpanel/client/MixpanelImportResponse.java
@@ -9,21 +9,67 @@ package io.camunda.optimize.service.mixpanel.client;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
-@Data
-@NoArgsConstructor
 public class MixpanelImportResponse {
+
   @JsonProperty("error")
   private String error;
 
   @JsonProperty("num_records_imported")
   private int numberOfRecordsImported;
 
+  public MixpanelImportResponse() {}
+
   @JsonIgnore
   public boolean isSuccessful() {
-    return StringUtils.isEmpty(this.error);
+    return StringUtils.isEmpty(error);
+  }
+
+  public String getError() {
+    return error;
+  }
+
+  @JsonProperty("error")
+  public void setError(final String error) {
+    this.error = error;
+  }
+
+  public int getNumberOfRecordsImported() {
+    return numberOfRecordsImported;
+  }
+
+  @JsonProperty("num_records_imported")
+  public void setNumberOfRecordsImported(final int numberOfRecordsImported) {
+    this.numberOfRecordsImported = numberOfRecordsImported;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MixpanelImportResponse;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MixpanelImportResponse that = (MixpanelImportResponse) o;
+    return numberOfRecordsImported == that.numberOfRecordsImported
+        && Objects.equals(error, that.error);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(error, numberOfRecordsImported);
+  }
+
+  @Override
+  public String toString() {
+    return "MixpanelImportResponse(error="
+        + getError()
+        + ", numberOfRecordsImported="
+        + getNumberOfRecordsImported()
+        + ")";
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/EngineUserDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/EngineUserDto.java
@@ -7,15 +7,56 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EngineUserDto {
+
   private UserProfileDto profile;
   private UserCredentialsDto credentials;
+
+  public EngineUserDto(final UserProfileDto profile, final UserCredentialsDto credentials) {
+    this.profile = profile;
+    this.credentials = credentials;
+  }
+
+  protected EngineUserDto() {}
+
+  public UserProfileDto getProfile() {
+    return profile;
+  }
+
+  public void setProfile(final UserProfileDto profile) {
+    this.profile = profile;
+  }
+
+  public UserCredentialsDto getCredentials() {
+    return credentials;
+  }
+
+  public void setCredentials(final UserCredentialsDto credentials) {
+    this.credentials = credentials;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EngineUserDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EngineUserDto that = (EngineUserDto) o;
+    return Objects.equals(profile, that.profile) && Objects.equals(credentials, that.credentials);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(profile, credentials);
+  }
+
+  @Override
+  public String toString() {
+    return "EngineUserDto(profile=" + getProfile() + ", credentials=" + getCredentials() + ")";
+  }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/ExecutionDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/ExecutionDto.java
@@ -7,11 +7,51 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ExecutionDto {
 
   private String id;
   private String processInstanceId;
+
+  public ExecutionDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ExecutionDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExecutionDto that = (ExecutionDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(processInstanceId, that.processInstanceId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, processInstanceId);
+  }
+
+  @Override
+  public String toString() {
+    return "ExecutionDto(id=" + getId() + ", processInstanceId=" + getProcessInstanceId() + ")";
+  }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/ExternalTaskEngineDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/ExternalTaskEngineDto.java
@@ -7,11 +7,55 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ExternalTaskEngineDto {
 
   protected String id;
   protected String processInstanceId;
+
+  public ExternalTaskEngineDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ExternalTaskEngineDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExternalTaskEngineDto that = (ExternalTaskEngineDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(processInstanceId, that.processInstanceId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, processInstanceId);
+  }
+
+  @Override
+  public String toString() {
+    return "ExternalTaskEngineDto(id="
+        + getId()
+        + ", processInstanceId="
+        + getProcessInstanceId()
+        + ")";
+  }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/GroupDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/GroupDto.java
@@ -7,18 +7,105 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class GroupDto {
+
   private String id;
   private String name;
   private String type;
+
+  public GroupDto(final String id, final String name, final String type) {
+    this.id = id;
+    this.name = name;
+    this.type = type;
+  }
+
+  protected GroupDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof GroupDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final GroupDto groupDto = (GroupDto) o;
+    return Objects.equals(id, groupDto.id)
+        && Objects.equals(name, groupDto.name)
+        && Objects.equals(type, groupDto.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, type);
+  }
+
+  @Override
+  public String toString() {
+    return "GroupDto(id=" + getId() + ", name=" + getName() + ", type=" + getType() + ")";
+  }
+
+  public static GroupDtoBuilder builder() {
+    return new GroupDtoBuilder();
+  }
+
+  public static class GroupDtoBuilder {
+
+    private String id;
+    private String name;
+    private String type;
+
+    GroupDtoBuilder() {}
+
+    public GroupDtoBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public GroupDtoBuilder name(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public GroupDtoBuilder type(final String type) {
+      this.type = type;
+      return this;
+    }
+
+    public GroupDto build() {
+      return new GroupDto(id, name, type);
+    }
+
+    @Override
+    public String toString() {
+      return "GroupDto.GroupDtoBuilder(id=" + id + ", name=" + name + ", type=" + type + ")";
+    }
+  }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/JobEngineDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/JobEngineDto.java
@@ -7,10 +7,45 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class JobEngineDto {
 
   protected String id;
+
+  public JobEngineDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof JobEngineDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final JobEngineDto that = (JobEngineDto) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public String toString() {
+    return "JobEngineDto(id=" + getId() + ")";
+  }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/UserProfileDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/engine/dto/UserProfileDto.java
@@ -7,19 +7,142 @@
  */
 package io.camunda.optimize.rest.engine.dto;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class UserProfileDto {
+
   protected String id;
   protected String firstName;
   protected String lastName;
   protected String email;
+
+  public UserProfileDto(
+      final String id, final String firstName, final String lastName, final String email) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.email = email;
+  }
+
+  protected UserProfileDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(final String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(final String lastName) {
+    this.lastName = lastName;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(final String email) {
+    this.email = email;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof UserProfileDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, firstName, lastName, email);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UserProfileDto that = (UserProfileDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(firstName, that.firstName)
+        && Objects.equals(lastName, that.lastName)
+        && Objects.equals(email, that.email);
+  }
+
+  @Override
+  public String toString() {
+    return "UserProfileDto(id="
+        + getId()
+        + ", firstName="
+        + getFirstName()
+        + ", lastName="
+        + getLastName()
+        + ", email="
+        + getEmail()
+        + ")";
+  }
+
+  public static UserProfileDtoBuilder builder() {
+    return new UserProfileDtoBuilder();
+  }
+
+  public static class UserProfileDtoBuilder {
+
+    private String id;
+    private String firstName;
+    private String lastName;
+    private String email;
+
+    UserProfileDtoBuilder() {}
+
+    public UserProfileDtoBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public UserProfileDtoBuilder firstName(final String firstName) {
+      this.firstName = firstName;
+      return this;
+    }
+
+    public UserProfileDtoBuilder lastName(final String lastName) {
+      this.lastName = lastName;
+      return this;
+    }
+
+    public UserProfileDtoBuilder email(final String email) {
+      this.email = email;
+      return this;
+    }
+
+    public UserProfileDto build() {
+      return new UserProfileDto(id, firstName, lastName, email);
+    }
+
+    @Override
+    public String toString() {
+      return "UserProfileDto.UserProfileDtoBuilder(id="
+          + id
+          + ", firstName="
+          + firstName
+          + ", lastName="
+          + lastName
+          + ", email="
+          + email
+          + ")";
+    }
+  }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/EngineIncidentDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/EngineIncidentDto.java
@@ -8,9 +8,8 @@
 package io.camunda.optimize.test.util.client.dto;
 
 import java.util.Date;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class EngineIncidentDto {
 
   protected String id;
@@ -27,4 +26,196 @@ public class EngineIncidentDto {
   protected String incidentMessage;
   protected String tenantId;
   protected String jobDefinitionId;
+
+  public EngineIncidentDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getProcessDefinitionId() {
+    return processDefinitionId;
+  }
+
+  public void setProcessDefinitionId(final String processDefinitionId) {
+    this.processDefinitionId = processDefinitionId;
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public String getExecutionId() {
+    return executionId;
+  }
+
+  public void setExecutionId(final String executionId) {
+    this.executionId = executionId;
+  }
+
+  public Date getIncidentTimestamp() {
+    return incidentTimestamp;
+  }
+
+  public void setIncidentTimestamp(final Date incidentTimestamp) {
+    this.incidentTimestamp = incidentTimestamp;
+  }
+
+  public String getIncidentType() {
+    return incidentType;
+  }
+
+  public void setIncidentType(final String incidentType) {
+    this.incidentType = incidentType;
+  }
+
+  public String getActivityId() {
+    return activityId;
+  }
+
+  public void setActivityId(final String activityId) {
+    this.activityId = activityId;
+  }
+
+  public String getFailedActivityId() {
+    return failedActivityId;
+  }
+
+  public void setFailedActivityId(final String failedActivityId) {
+    this.failedActivityId = failedActivityId;
+  }
+
+  public String getCauseIncidentId() {
+    return causeIncidentId;
+  }
+
+  public void setCauseIncidentId(final String causeIncidentId) {
+    this.causeIncidentId = causeIncidentId;
+  }
+
+  public String getRootCauseIncidentId() {
+    return rootCauseIncidentId;
+  }
+
+  public void setRootCauseIncidentId(final String rootCauseIncidentId) {
+    this.rootCauseIncidentId = rootCauseIncidentId;
+  }
+
+  public String getConfiguration() {
+    return configuration;
+  }
+
+  public void setConfiguration(final String configuration) {
+    this.configuration = configuration;
+  }
+
+  public String getIncidentMessage() {
+    return incidentMessage;
+  }
+
+  public void setIncidentMessage(final String incidentMessage) {
+    this.incidentMessage = incidentMessage;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public String getJobDefinitionId() {
+    return jobDefinitionId;
+  }
+
+  public void setJobDefinitionId(final String jobDefinitionId) {
+    this.jobDefinitionId = jobDefinitionId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EngineIncidentDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EngineIncidentDto that = (EngineIncidentDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(executionId, that.executionId)
+        && Objects.equals(incidentTimestamp, that.incidentTimestamp)
+        && Objects.equals(incidentType, that.incidentType)
+        && Objects.equals(activityId, that.activityId)
+        && Objects.equals(failedActivityId, that.failedActivityId)
+        && Objects.equals(causeIncidentId, that.causeIncidentId)
+        && Objects.equals(rootCauseIncidentId, that.rootCauseIncidentId)
+        && Objects.equals(configuration, that.configuration)
+        && Objects.equals(incidentMessage, that.incidentMessage)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(jobDefinitionId, that.jobDefinitionId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        processDefinitionId,
+        processInstanceId,
+        executionId,
+        incidentTimestamp,
+        incidentType,
+        activityId,
+        failedActivityId,
+        causeIncidentId,
+        rootCauseIncidentId,
+        configuration,
+        incidentMessage,
+        tenantId,
+        jobDefinitionId);
+  }
+
+  @Override
+  public String toString() {
+    return "EngineIncidentDto(id="
+        + getId()
+        + ", processDefinitionId="
+        + getProcessDefinitionId()
+        + ", processInstanceId="
+        + getProcessInstanceId()
+        + ", executionId="
+        + getExecutionId()
+        + ", incidentTimestamp="
+        + getIncidentTimestamp()
+        + ", incidentType="
+        + getIncidentType()
+        + ", activityId="
+        + getActivityId()
+        + ", failedActivityId="
+        + getFailedActivityId()
+        + ", causeIncidentId="
+        + getCauseIncidentId()
+        + ", rootCauseIncidentId="
+        + getRootCauseIncidentId()
+        + ", configuration="
+        + getConfiguration()
+        + ", incidentMessage="
+        + getIncidentMessage()
+        + ", tenantId="
+        + getTenantId()
+        + ", jobDefinitionId="
+        + getJobDefinitionId()
+        + ")";
+  }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/MessageCorrelationDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/MessageCorrelationDto.java
@@ -9,12 +9,68 @@ package io.camunda.optimize.test.util.client.dto;
 
 import java.util.HashMap;
 import java.util.Map;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class MessageCorrelationDto {
 
+  Map<String, VariableValueDto> processVariables = new HashMap<>();
   private String messageName;
   private boolean all;
-  Map<String, VariableValueDto> processVariables = new HashMap<>();
+
+  public MessageCorrelationDto() {}
+
+  public String getMessageName() {
+    return messageName;
+  }
+
+  public void setMessageName(final String messageName) {
+    this.messageName = messageName;
+  }
+
+  public boolean isAll() {
+    return all;
+  }
+
+  public void setAll(final boolean all) {
+    this.all = all;
+  }
+
+  public Map<String, VariableValueDto> getProcessVariables() {
+    return processVariables;
+  }
+
+  public void setProcessVariables(final Map<String, VariableValueDto> processVariables) {
+    this.processVariables = processVariables;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MessageCorrelationDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MessageCorrelationDto that = (MessageCorrelationDto) o;
+    return all == that.all
+        && Objects.equals(processVariables, that.processVariables)
+        && Objects.equals(messageName, that.messageName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processVariables, messageName, all);
+  }
+
+  @Override
+  public String toString() {
+    return "MessageCorrelationDto(messageName="
+        + getMessageName()
+        + ", all="
+        + isAll()
+        + ", processVariables="
+        + getProcessVariables()
+        + ")";
+  }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/TaskDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/TaskDto.java
@@ -9,13 +9,69 @@ package io.camunda.optimize.test.util.client.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.OffsetDateTime;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TaskDto {
 
   private String id;
   private OffsetDateTime created;
   private String processInstanceId;
+
+  public TaskDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public OffsetDateTime getCreated() {
+    return created;
+  }
+
+  public void setCreated(final OffsetDateTime created) {
+    this.created = created;
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof TaskDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TaskDto taskDto = (TaskDto) o;
+    return Objects.equals(id, taskDto.id)
+        && Objects.equals(created, taskDto.created)
+        && Objects.equals(processInstanceId, taskDto.processInstanceId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, created, processInstanceId);
+  }
+
+  @Override
+  public String toString() {
+    return "TaskDto(id="
+        + getId()
+        + ", created="
+        + getCreated()
+        + ", processInstanceId="
+        + getProcessInstanceId()
+        + ")";
+  }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/VariableValueDto.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/test/util/client/dto/VariableValueDto.java
@@ -8,15 +8,56 @@
 package io.camunda.optimize.test.util.client.dto;
 
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Data
 public class VariableValueDto {
 
   private Object value;
   private VariableType type;
+
+  public VariableValueDto(final Object value, final VariableType type) {
+    this.value = value;
+    this.type = type;
+  }
+
+  public VariableValueDto() {}
+
+  public Object getValue() {
+    return value;
+  }
+
+  public void setValue(final Object value) {
+    this.value = value;
+  }
+
+  public VariableType getType() {
+    return type;
+  }
+
+  public void setType(final VariableType type) {
+    this.type = type;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof VariableValueDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableValueDto that = (VariableValueDto) o;
+    return Objects.equals(value, that.value) && type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value, type);
+  }
+
+  @Override
+  public String toString() {
+    return "VariableValueDto(value=" + getValue() + ", type=" + getType() + ")";
+  }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/service/UpgradeStepLogEntryDto.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/service/UpgradeStepLogEntryDto.java
@@ -10,30 +10,150 @@ package io.camunda.optimize.upgrade.service;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
 import java.time.Instant;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
-@Builder
 public class UpgradeStepLogEntryDto {
 
-  @NonNull private String indexName;
-  @NonNull private String optimizeVersion;
-  @NonNull private UpgradeStepType stepType;
-  @NonNull private Integer stepNumber;
+  private String indexName;
+  private String optimizeVersion;
+  private UpgradeStepType stepType;
+  private Integer stepNumber;
   private Instant appliedDate;
+
+  public UpgradeStepLogEntryDto(
+      final String indexName,
+      final String optimizeVersion,
+      final UpgradeStepType stepType,
+      final Integer stepNumber,
+      final Instant appliedDate) {
+    if (indexName == null) {
+      throw new IllegalArgumentException("indexName cannot be null");
+    }
+
+    if (optimizeVersion == null) {
+      throw new IllegalArgumentException("optimizeVersion cannot be null");
+    }
+
+    if (stepType == null) {
+      throw new IllegalArgumentException("stepType cannot be null");
+    }
+
+    if (stepNumber == null) {
+      throw new IllegalArgumentException("stepNumber cannot be null");
+    }
+
+    this.indexName = indexName;
+    this.optimizeVersion = optimizeVersion;
+    this.stepType = stepType;
+    this.stepNumber = stepNumber;
+    this.appliedDate = appliedDate;
+  }
+
+  protected UpgradeStepLogEntryDto() {}
 
   @JsonIgnore
   public String getId() {
     return String.join("_", optimizeVersion, stepType.toString(), indexName);
   }
 
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public void setIndexName(final String indexName) {
+    if (indexName == null) {
+      throw new IllegalArgumentException("indexName cannot be null");
+    }
+
+    this.indexName = indexName;
+  }
+
+  public String getOptimizeVersion() {
+    return optimizeVersion;
+  }
+
+  public void setOptimizeVersion(final String optimizeVersion) {
+    if (optimizeVersion == null) {
+      throw new IllegalArgumentException("optimizeVersion cannot be null");
+    }
+
+    this.optimizeVersion = optimizeVersion;
+  }
+
+  public UpgradeStepType getStepType() {
+    return stepType;
+  }
+
+  public void setStepType(final UpgradeStepType stepType) {
+    if (stepType == null) {
+      throw new IllegalArgumentException("stepType cannot be null");
+    }
+
+    this.stepType = stepType;
+  }
+
+  public Integer getStepNumber() {
+    return stepNumber;
+  }
+
+  public void setStepNumber(final Integer stepNumber) {
+    if (stepNumber == null) {
+      throw new IllegalArgumentException("stepNumber cannot be null");
+    }
+
+    this.stepNumber = stepNumber;
+  }
+
+  public Instant getAppliedDate() {
+    return appliedDate;
+  }
+
+  public void setAppliedDate(final Instant appliedDate) {
+    this.appliedDate = appliedDate;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof UpgradeStepLogEntryDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UpgradeStepLogEntryDto that = (UpgradeStepLogEntryDto) o;
+    return Objects.equals(indexName, that.indexName)
+        && Objects.equals(optimizeVersion, that.optimizeVersion)
+        && stepType == that.stepType
+        && Objects.equals(stepNumber, that.stepNumber)
+        && Objects.equals(appliedDate, that.appliedDate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(indexName, optimizeVersion, stepType, stepNumber, appliedDate);
+  }
+
+  @Override
+  public String toString() {
+    return "UpgradeStepLogEntryDto(indexName="
+        + getIndexName()
+        + ", optimizeVersion="
+        + getOptimizeVersion()
+        + ", stepType="
+        + getStepType()
+        + ", stepNumber="
+        + getStepNumber()
+        + ", appliedDate="
+        + getAppliedDate()
+        + ")";
+  }
+
+  public static UpgradeStepLogEntryDtoBuilder builder() {
+    return new UpgradeStepLogEntryDtoBuilder();
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String indexName = "indexName";
@@ -41,5 +161,77 @@ public class UpgradeStepLogEntryDto {
     public static final String stepType = "stepType";
     public static final String stepNumber = "stepNumber";
     public static final String appliedDate = "appliedDate";
+  }
+
+  public static class UpgradeStepLogEntryDtoBuilder {
+
+    private String indexName;
+    private String optimizeVersion;
+    private UpgradeStepType stepType;
+    private Integer stepNumber;
+    private Instant appliedDate;
+
+    UpgradeStepLogEntryDtoBuilder() {}
+
+    public UpgradeStepLogEntryDtoBuilder indexName(final String indexName) {
+      if (indexName == null) {
+        throw new IllegalArgumentException("indexName cannot be null");
+      }
+
+      this.indexName = indexName;
+      return this;
+    }
+
+    public UpgradeStepLogEntryDtoBuilder optimizeVersion(final String optimizeVersion) {
+      if (optimizeVersion == null) {
+        throw new IllegalArgumentException("optimizeVersion cannot be null");
+      }
+
+      this.optimizeVersion = optimizeVersion;
+      return this;
+    }
+
+    public UpgradeStepLogEntryDtoBuilder stepType(final UpgradeStepType stepType) {
+      if (stepType == null) {
+        throw new IllegalArgumentException("stepType cannot be null");
+      }
+
+      this.stepType = stepType;
+      return this;
+    }
+
+    public UpgradeStepLogEntryDtoBuilder stepNumber(final Integer stepNumber) {
+      if (stepNumber == null) {
+        throw new IllegalArgumentException("stepNumber cannot be null");
+      }
+
+      this.stepNumber = stepNumber;
+      return this;
+    }
+
+    public UpgradeStepLogEntryDtoBuilder appliedDate(final Instant appliedDate) {
+      this.appliedDate = appliedDate;
+      return this;
+    }
+
+    public UpgradeStepLogEntryDto build() {
+      return new UpgradeStepLogEntryDto(
+          indexName, optimizeVersion, stepType, stepNumber, appliedDate);
+    }
+
+    @Override
+    public String toString() {
+      return "UpgradeStepLogEntryDto.UpgradeStepLogEntryDtoBuilder(indexName="
+          + indexName
+          + ", optimizeVersion="
+          + optimizeVersion
+          + ", stepType="
+          + stepType
+          + ", stepNumber="
+          + stepNumber
+          + ", appliedDate="
+          + appliedDate
+          + ")";
+    }
   }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/document/DeleteDataStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/document/DeleteDataStep.java
@@ -12,9 +12,8 @@ import io.camunda.optimize.service.db.schema.IndexMappingCreator;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class DeleteDataStep extends UpgradeStep {
 
   private final DatabaseQueryWrapper queryWrapper;
@@ -30,7 +29,29 @@ public class DeleteDataStep extends UpgradeStep {
   }
 
   @Override
-  public void performUpgradeStep(final SchemaUpgradeClient<?, ?> schemaUpgradeClient) {
+  public void performUpgradeStep(final SchemaUpgradeClient<?, ?, ?> schemaUpgradeClient) {
     schemaUpgradeClient.deleteDataByIndexName(index, queryWrapper);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DeleteDataStep;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DeleteDataStep that = (DeleteDataStep) o;
+    return Objects.equals(queryWrapper, that.queryWrapper);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), queryWrapper);
   }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/document/InsertDataStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/document/InsertDataStep.java
@@ -11,10 +11,10 @@ import io.camunda.optimize.service.db.schema.IndexMappingCreator;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class InsertDataStep extends UpgradeStep {
+
   private final String data;
 
   public InsertDataStep(final IndexMappingCreator index, final String data) {
@@ -28,7 +28,29 @@ public class InsertDataStep extends UpgradeStep {
   }
 
   @Override
-  public void performUpgradeStep(final SchemaUpgradeClient<?, ?> schemaUpgradeClient) {
+  public void performUpgradeStep(final SchemaUpgradeClient<?, ?, ?> schemaUpgradeClient) {
     schemaUpgradeClient.insertDataByIndexName(index, data);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof InsertDataStep;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final InsertDataStep that = (InsertDataStep) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), data);
   }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/CreateIndexStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/CreateIndexStep.java
@@ -12,11 +12,11 @@ import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
-import lombok.EqualsAndHashCode;
 
-@EqualsAndHashCode(callSuper = true)
 public class CreateIndexStep extends UpgradeStep {
+
   private Set<String> readOnlyAliases = new HashSet<>();
 
   public CreateIndexStep(final IndexMappingCreator index) {
@@ -34,7 +34,29 @@ public class CreateIndexStep extends UpgradeStep {
   }
 
   @Override
-  public void performUpgradeStep(final SchemaUpgradeClient<?, ?> schemaUpgradeClient) {
+  public void performUpgradeStep(final SchemaUpgradeClient<?, ?, ?> schemaUpgradeClient) {
     schemaUpgradeClient.createOrUpdateIndex(index, readOnlyAliases);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof CreateIndexStep;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final CreateIndexStep that = (CreateIndexStep) o;
+    return Objects.equals(readOnlyAliases, that.readOnlyAliases);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), readOnlyAliases);
   }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/DeleteIndexIfExistsStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/DeleteIndexIfExistsStep.java
@@ -11,15 +11,13 @@ import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class DeleteIndexIfExistsStep extends UpgradeStep {
 
   // This should be the name of the index without prefix and without version suffix
-  @Getter private final String indexName;
-  @Getter private final int indexVersion;
+  private final String indexName;
+  private final int indexVersion;
 
   public DeleteIndexIfExistsStep(final String indexName, final int indexVersion) {
     super(null);
@@ -29,7 +27,7 @@ public class DeleteIndexIfExistsStep extends UpgradeStep {
   }
 
   @Override
-  public void performUpgradeStep(final SchemaUpgradeClient<?, ?> schemaUpgradeClient) {
+  public void performUpgradeStep(final SchemaUpgradeClient<?, ?, ?> schemaUpgradeClient) {
     final OptimizeIndexNameService indexNameService = schemaUpgradeClient.getIndexNameService();
     final String indexAlias = indexNameService.getOptimizeIndexAliasForIndex(indexName);
     schemaUpgradeClient.getAliases(indexAlias).stream()
@@ -45,5 +43,35 @@ public class DeleteIndexIfExistsStep extends UpgradeStep {
   @Override
   public UpgradeStepType getType() {
     return UpgradeStepType.SCHEMA_DELETE_INDEX;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DeleteIndexIfExistsStep;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DeleteIndexIfExistsStep that = (DeleteIndexIfExistsStep) o;
+    return indexVersion == that.indexVersion && Objects.equals(indexName, that.indexName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), indexName, indexVersion);
+  }
+
+  public String getIndexName() {
+    return this.indexName;
+  }
+
+  public int getIndexVersion() {
+    return this.indexVersion;
   }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/DeleteIndexTemplateIfExistsStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/DeleteIndexTemplateIfExistsStep.java
@@ -15,15 +15,13 @@ import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.exception.UpgradeRuntimeException;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class DeleteIndexTemplateIfExistsStep extends UpgradeStep {
 
   // This should be the name of the template prefix and without version suffix or optimize prefix
-  @Getter private final String templateName;
-  @Getter private final int templateVersion;
+  private final String templateName;
+  private final int templateVersion;
 
   public DeleteIndexTemplateIfExistsStep(final String templateName, final int templateVersion) {
     super(null);
@@ -57,5 +55,36 @@ public class DeleteIndexTemplateIfExistsStep extends UpgradeStep {
         "%s[Template]",
         OptimizeIndexNameService.getOptimizeIndexOrTemplateNameForAliasAndVersion(
             templateName, String.valueOf(templateVersion)));
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DeleteIndexTemplateIfExistsStep;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DeleteIndexTemplateIfExistsStep that = (DeleteIndexTemplateIfExistsStep) o;
+    return templateVersion == that.templateVersion
+        && Objects.equals(templateName, that.templateName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), templateName, templateVersion);
+  }
+
+  public String getTemplateName() {
+    return this.templateName;
+  }
+
+  public int getTemplateVersion() {
+    return this.templateVersion;
   }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/ReindexStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/ReindexStep.java
@@ -12,15 +12,12 @@ import io.camunda.optimize.service.db.schema.IndexMappingCreator;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import java.util.Objects;
 
-@AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
 public class ReindexStep extends UpgradeStep {
-  @Getter private final IndexMappingCreator sourceIndex;
-  @Getter private final IndexMappingCreator targetIndex;
+
+  private final IndexMappingCreator sourceIndex;
+  private final IndexMappingCreator targetIndex;
   private final DatabaseQueryWrapper queryWrapper;
   private final String mappingScript;
 
@@ -31,13 +28,57 @@ public class ReindexStep extends UpgradeStep {
     this(sourceIndex, targetIndex, queryWrapper, null);
   }
 
+  public ReindexStep(
+      final IndexMappingCreator sourceIndex,
+      final IndexMappingCreator targetIndex,
+      final DatabaseQueryWrapper queryWrapper,
+      final String mappingScript) {
+    this.sourceIndex = sourceIndex;
+    this.targetIndex = targetIndex;
+    this.queryWrapper = queryWrapper;
+    this.mappingScript = mappingScript;
+  }
+
   @Override
   public UpgradeStepType getType() {
     return UpgradeStepType.REINDEX;
   }
 
   @Override
-  public void performUpgradeStep(final SchemaUpgradeClient<?, ?> schemaUpgradeClient) {
+  public void performUpgradeStep(final SchemaUpgradeClient<?, ?, ?> schemaUpgradeClient) {
     schemaUpgradeClient.reindex(sourceIndex, targetIndex, queryWrapper, mappingScript);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ReindexStep;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ReindexStep that = (ReindexStep) o;
+    return Objects.equals(sourceIndex, that.sourceIndex)
+        && Objects.equals(targetIndex, that.targetIndex)
+        && Objects.equals(queryWrapper, that.queryWrapper)
+        && Objects.equals(mappingScript, that.mappingScript);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), sourceIndex, targetIndex, queryWrapper, mappingScript);
+  }
+
+  public IndexMappingCreator getSourceIndex() {
+    return sourceIndex;
+  }
+
+  public IndexMappingCreator getTargetIndex() {
+    return targetIndex;
   }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/UpdateMappingIndexStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/UpdateMappingIndexStep.java
@@ -11,9 +11,8 @@ import io.camunda.optimize.service.db.schema.IndexMappingCreator;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.steps.UpgradeStep;
 import io.camunda.optimize.upgrade.steps.UpgradeStepType;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class UpdateMappingIndexStep extends UpgradeStep {
 
   public UpdateMappingIndexStep(final IndexMappingCreator index) {
@@ -26,7 +25,29 @@ public class UpdateMappingIndexStep extends UpgradeStep {
   }
 
   @Override
-  public void performUpgradeStep(final SchemaUpgradeClient<?, ?> schemaUpgradeClient) {
+  public void performUpgradeStep(final SchemaUpgradeClient<?, ?, ?> schemaUpgradeClient) {
     schemaUpgradeClient.updateIndexDynamicSettingsAndMappings(index);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof UpdateMappingIndexStep;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(index);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UpdateMappingIndexStep that = (UpdateMappingIndexStep) o;
+    return Objects.equals(index, that.index);
   }
 }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/db/indices/UserTestDto.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/db/indices/UserTestDto.java
@@ -5,19 +5,24 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.rest.engine.dto;
+package io.camunda.optimize.upgrade.db.indices;
 
 import java.util.Objects;
 
-public class UserCredentialsDto {
+public class UserTestDto {
 
-  private String password;
+  String username;
+  String password;
 
-  public UserCredentialsDto(final String password) {
-    this.password = password;
+  public UserTestDto() {}
+
+  public String getUsername() {
+    return username;
   }
 
-  protected UserCredentialsDto() {}
+  public void setUsername(final String username) {
+    this.username = username;
+  }
 
   public String getPassword() {
     return password;
@@ -28,12 +33,12 @@ public class UserCredentialsDto {
   }
 
   protected boolean canEqual(final Object other) {
-    return other instanceof UserCredentialsDto;
+    return other instanceof UserTestDto;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(password);
+    return Objects.hash(username, password);
   }
 
   @Override
@@ -44,12 +49,12 @@ public class UserCredentialsDto {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final UserCredentialsDto that = (UserCredentialsDto) o;
-    return Objects.equals(password, that.password);
+    final UserTestDto that = (UserTestDto) o;
+    return Objects.equals(username, that.username) && Objects.equals(password, that.password);
   }
 
   @Override
   public String toString() {
-    return "UserCredentialsDto(password=" + getPassword() + ")";
+    return "UserTestDto(username=" + getUsername() + ", password=" + getPassword() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/AuthorizedEntityDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/AuthorizedEntityDto.java
@@ -7,15 +7,47 @@
  */
 package io.camunda.optimize.dto.optimize;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 // supposed to be called from entity specific subclasses only
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthorizedEntityDto {
+
   private RoleType currentUserRole;
+
+  protected AuthorizedEntityDto(final RoleType currentUserRole) {
+    this.currentUserRole = currentUserRole;
+  }
+
+  protected AuthorizedEntityDto() {}
+
+  public RoleType getCurrentUserRole() {
+    return currentUserRole;
+  }
+
+  public void setCurrentUserRole(final RoleType currentUserRole) {
+    this.currentUserRole = currentUserRole;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof AuthorizedEntityDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AuthorizedEntityDto that = (AuthorizedEntityDto) o;
+    return currentUserRole == that.currentUserRole;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(currentUserRole);
+  }
+
+  @Override
+  public String toString() {
+    return "AuthorizedEntityDto(currentUserRole=" + getCurrentUserRole() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DecisionDefinitionOptimizeDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DecisionDefinitionOptimizeDto.java
@@ -12,14 +12,8 @@ import io.camunda.optimize.dto.optimize.datasource.EngineDataSourceDto;
 import io.camunda.optimize.dto.optimize.query.variable.DecisionVariableNameResponseDto;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class DecisionDefinitionOptimizeDto extends DefinitionOptimizeResponseDto {
 
   private String dmn10Xml;
@@ -42,7 +36,6 @@ public class DecisionDefinitionOptimizeDto extends DefinitionOptimizeResponseDto
     this.outputVariableNames = outputVariableNames;
   }
 
-  @Builder
   public DecisionDefinitionOptimizeDto(
       final String id,
       final String key,
@@ -60,6 +53,196 @@ public class DecisionDefinitionOptimizeDto extends DefinitionOptimizeResponseDto
     this.dmn10Xml = dmn10Xml;
     this.inputVariableNames = inputVariableNames;
     this.outputVariableNames = outputVariableNames;
+  }
+
+  public DecisionDefinitionOptimizeDto(
+      final String dmn10Xml,
+      final List<DecisionVariableNameResponseDto> inputVariableNames,
+      final List<DecisionVariableNameResponseDto> outputVariableNames) {
+    this.dmn10Xml = dmn10Xml;
+    this.inputVariableNames = inputVariableNames;
+    this.outputVariableNames = outputVariableNames;
+  }
+
+  public String getDmn10Xml() {
+    return dmn10Xml;
+  }
+
+  public void setDmn10Xml(final String dmn10Xml) {
+    this.dmn10Xml = dmn10Xml;
+  }
+
+  public List<DecisionVariableNameResponseDto> getInputVariableNames() {
+    return inputVariableNames;
+  }
+
+  public void setInputVariableNames(
+      final List<DecisionVariableNameResponseDto> inputVariableNames) {
+    this.inputVariableNames = inputVariableNames;
+  }
+
+  public List<DecisionVariableNameResponseDto> getOutputVariableNames() {
+    return outputVariableNames;
+  }
+
+  public void setOutputVariableNames(
+      final List<DecisionVariableNameResponseDto> outputVariableNames) {
+    this.outputVariableNames = outputVariableNames;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DecisionDefinitionOptimizeDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DecisionDefinitionOptimizeDto that = (DecisionDefinitionOptimizeDto) o;
+    return Objects.equals(dmn10Xml, that.dmn10Xml)
+        && Objects.equals(inputVariableNames, that.inputVariableNames)
+        && Objects.equals(outputVariableNames, that.outputVariableNames);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), dmn10Xml, inputVariableNames, outputVariableNames);
+  }
+
+  @Override
+  public String toString() {
+    return "DecisionDefinitionOptimizeDto(dmn10Xml="
+        + getDmn10Xml()
+        + ", inputVariableNames="
+        + getInputVariableNames()
+        + ", outputVariableNames="
+        + getOutputVariableNames()
+        + ")";
+  }
+
+  public static DecisionDefinitionOptimizeDtoBuilder builder() {
+    return new DecisionDefinitionOptimizeDtoBuilder();
+  }
+
+  public static class DecisionDefinitionOptimizeDtoBuilder {
+
+    private String id;
+    private String key;
+    private String version;
+    private String versionTag;
+    private String name;
+    private DataSourceDto dataSource;
+    private String tenantId;
+    private String dmn10Xml;
+    private boolean deleted;
+    private List<DecisionVariableNameResponseDto> inputVariableNames;
+    private List<DecisionVariableNameResponseDto> outputVariableNames;
+
+    DecisionDefinitionOptimizeDtoBuilder() {}
+
+    public DecisionDefinitionOptimizeDtoBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public DecisionDefinitionOptimizeDtoBuilder key(final String key) {
+      this.key = key;
+      return this;
+    }
+
+    public DecisionDefinitionOptimizeDtoBuilder version(final String version) {
+      this.version = version;
+      return this;
+    }
+
+    public DecisionDefinitionOptimizeDtoBuilder versionTag(final String versionTag) {
+      this.versionTag = versionTag;
+      return this;
+    }
+
+    public DecisionDefinitionOptimizeDtoBuilder name(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public DecisionDefinitionOptimizeDtoBuilder dataSource(final DataSourceDto dataSource) {
+      this.dataSource = dataSource;
+      return this;
+    }
+
+    public DecisionDefinitionOptimizeDtoBuilder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    public DecisionDefinitionOptimizeDtoBuilder dmn10Xml(final String dmn10Xml) {
+      this.dmn10Xml = dmn10Xml;
+      return this;
+    }
+
+    public DecisionDefinitionOptimizeDtoBuilder deleted(final boolean deleted) {
+      this.deleted = deleted;
+      return this;
+    }
+
+    public DecisionDefinitionOptimizeDtoBuilder inputVariableNames(
+        final List<DecisionVariableNameResponseDto> inputVariableNames) {
+      this.inputVariableNames = inputVariableNames;
+      return this;
+    }
+
+    public DecisionDefinitionOptimizeDtoBuilder outputVariableNames(
+        final List<DecisionVariableNameResponseDto> outputVariableNames) {
+      this.outputVariableNames = outputVariableNames;
+      return this;
+    }
+
+    public DecisionDefinitionOptimizeDto build() {
+      return new DecisionDefinitionOptimizeDto(
+          id,
+          key,
+          version,
+          versionTag,
+          name,
+          dataSource,
+          tenantId,
+          dmn10Xml,
+          deleted,
+          inputVariableNames,
+          outputVariableNames);
+    }
+
+    @Override
+    public String toString() {
+      return "DecisionDefinitionOptimizeDto.DecisionDefinitionOptimizeDtoBuilder(id="
+          + id
+          + ", key="
+          + key
+          + ", version="
+          + version
+          + ", versionTag="
+          + versionTag
+          + ", name="
+          + name
+          + ", dataSource="
+          + dataSource
+          + ", tenantId="
+          + tenantId
+          + ", dmn10Xml="
+          + dmn10Xml
+          + ", deleted="
+          + deleted
+          + ", inputVariableNames="
+          + inputVariableNames
+          + ", outputVariableNames="
+          + outputVariableNames
+          + ")";
+    }
   }
 
   public enum Fields {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DefinitionOptimizeResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DefinitionOptimizeResponseDto.java
@@ -10,14 +10,8 @@ package io.camunda.optimize.dto.optimize;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.datasource.DataSourceDto;
 import java.io.Serializable;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
 public abstract class DefinitionOptimizeResponseDto implements Serializable, OptimizeDto {
 
   private String id;
@@ -35,6 +29,152 @@ public abstract class DefinitionOptimizeResponseDto implements Serializable, Opt
     this.dataSource = dataSource;
   }
 
+  public DefinitionOptimizeResponseDto(
+      final String id,
+      final String key,
+      final String version,
+      final String versionTag,
+      final String name,
+      final DataSourceDto dataSource,
+      final String tenantId,
+      final boolean deleted,
+      final DefinitionType type) {
+    this.id = id;
+    this.key = key;
+    this.version = version;
+    this.versionTag = versionTag;
+    this.name = name;
+    this.dataSource = dataSource;
+    this.tenantId = tenantId;
+    this.deleted = deleted;
+    this.type = type;
+  }
+
+  protected DefinitionOptimizeResponseDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(final String key) {
+    this.key = key;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(final String version) {
+    this.version = version;
+  }
+
+  public String getVersionTag() {
+    return versionTag;
+  }
+
+  public void setVersionTag(final String versionTag) {
+    this.versionTag = versionTag;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public DataSourceDto getDataSource() {
+    return dataSource;
+  }
+
+  public void setDataSource(final DataSourceDto dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public boolean isDeleted() {
+    return deleted;
+  }
+
+  public void setDeleted(final boolean deleted) {
+    this.deleted = deleted;
+  }
+
+  public DefinitionType getType() {
+    return type;
+  }
+
+  @JsonIgnore
+  public void setType(final DefinitionType type) {
+    this.type = type;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DefinitionOptimizeResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionOptimizeResponseDto that = (DefinitionOptimizeResponseDto) o;
+    return deleted == that.deleted
+        && Objects.equals(id, that.id)
+        && Objects.equals(key, that.key)
+        && Objects.equals(version, that.version)
+        && Objects.equals(versionTag, that.versionTag)
+        && Objects.equals(name, that.name)
+        && Objects.equals(dataSource, that.dataSource)
+        && Objects.equals(tenantId, that.tenantId)
+        && type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, key, version, versionTag, name, dataSource, tenantId, deleted, type);
+  }
+
+  @Override
+  public String toString() {
+    return "DefinitionOptimizeResponseDto(id="
+        + getId()
+        + ", key="
+        + getKey()
+        + ", version="
+        + getVersion()
+        + ", versionTag="
+        + getVersionTag()
+        + ", name="
+        + getName()
+        + ", dataSource="
+        + getDataSource()
+        + ", tenantId="
+        + getTenantId()
+        + ", deleted="
+        + isDeleted()
+        + ", type="
+        + getType()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/FlowNodeDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/FlowNodeDataDto.java
@@ -8,15 +8,68 @@
 package io.camunda.optimize.dto.optimize;
 
 import java.io.Serializable;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@RequiredArgsConstructor
 public class FlowNodeDataDto implements Serializable {
+
   private String id;
   private String name;
   private String type;
+
+  public FlowNodeDataDto() {}
+
+  public FlowNodeDataDto(final String id, final String name, final String type) {
+    this.id = id;
+    this.name = name;
+    this.type = type;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof FlowNodeDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FlowNodeDataDto that = (FlowNodeDataDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, type);
+  }
+
+  @Override
+  public String toString() {
+    return "FlowNodeDataDto(id=" + getId() + ", name=" + getName() + ", type=" + getType() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/FlowNodeTotalDurationDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/FlowNodeTotalDurationDataDto.java
@@ -7,14 +7,56 @@
  */
 package io.camunda.optimize.dto.optimize;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class FlowNodeTotalDurationDataDto {
+
   String name;
   long value;
+
+  public FlowNodeTotalDurationDataDto(final String name, final long value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  public FlowNodeTotalDurationDataDto() {}
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public long getValue() {
+    return value;
+  }
+
+  public void setValue(final long value) {
+    this.value = value;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof FlowNodeTotalDurationDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FlowNodeTotalDurationDataDto that = (FlowNodeTotalDurationDataDto) o;
+    return value == that.value && Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, value);
+  }
+
+  @Override
+  public String toString() {
+    return "FlowNodeTotalDurationDataDto(name=" + getName() + ", value=" + getValue() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/GroupDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/GroupDto.java
@@ -8,20 +8,12 @@
 package io.camunda.optimize.dto.optimize;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.ToString;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(callSuper = true)
-@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 public class GroupDto extends IdentityWithMetadataResponseDto {
 
   private Long memberCount;
@@ -34,8 +26,22 @@ public class GroupDto extends IdentityWithMetadataResponseDto {
     this(id, name, null);
   }
 
-  public GroupDto(@NonNull final String id, final String name, final Long memberCount) {
+  public GroupDto(final String id, final String name, final Long memberCount) {
     super(id, IdentityType.GROUP, Optional.ofNullable(name).orElse(id));
+    if (id == null) {
+      throw new OptimizeRuntimeException("id is null");
+    }
+
+    this.memberCount = memberCount;
+  }
+
+  protected GroupDto() {}
+
+  public Long getMemberCount() {
+    return memberCount;
+  }
+
+  public void setMemberCount(final Long memberCount) {
     this.memberCount = memberCount;
   }
 
@@ -45,6 +51,37 @@ public class GroupDto extends IdentityWithMetadataResponseDto {
     return List.of(this::getId, this::getName);
   }
 
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof GroupDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), memberCount);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final GroupDto groupDto = (GroupDto) o;
+    return Objects.equals(memberCount, groupDto.memberCount);
+  }
+
+  @Override
+  public String toString() {
+    return "GroupDto(super=" + super.toString() + ", memberCount=" + getMemberCount() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String memberCount = "memberCount";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/IdentityDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/IdentityDto.java
@@ -7,20 +7,71 @@
  */
 package io.camunda.optimize.dto.optimize;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class IdentityDto {
 
-  @NonNull private String id;
+  private String id;
   private IdentityType type;
 
+  public IdentityDto(final String id, final IdentityType type) {
+    if (id == null) {
+      throw new IllegalArgumentException("id cannot be null");
+    }
+
+    this.id = id;
+    this.type = type;
+  }
+
+  protected IdentityDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    if (id == null) {
+      throw new IllegalArgumentException("id cannot be null");
+    }
+
+    this.id = id;
+  }
+
+  public IdentityType getType() {
+    return type;
+  }
+
+  public void setType(final IdentityType type) {
+    this.type = type;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof IdentityDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, type);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IdentityDto that = (IdentityDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(type, that.type);
+  }
+
+  @Override
+  public String toString() {
+    return "IdentityDto(id=" + getId() + ", type=" + getType() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/IdentityWithMetadataResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/IdentityWithMetadataResponseDto.java
@@ -11,12 +11,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 
 @JsonTypeInfo(
@@ -28,10 +24,6 @@ import org.apache.commons.lang3.StringUtils;
   @JsonSubTypes.Type(value = UserDto.class, name = "user"),
   @JsonSubTypes.Type(value = GroupDto.class, name = "group"),
 })
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
 public abstract class IdentityWithMetadataResponseDto extends IdentityDto {
 
   private String name;
@@ -45,6 +37,8 @@ public abstract class IdentityWithMetadataResponseDto extends IdentityDto {
     super(id, type);
     this.name = name;
   }
+
+  protected IdentityWithMetadataResponseDto() {}
 
   @JsonIgnore
   protected abstract List<Supplier<String>> getSearchableDtoFields();
@@ -63,6 +57,49 @@ public abstract class IdentityWithMetadataResponseDto extends IdentityDto {
                         && StringUtils.containsAnyIgnoreCase(searchableField.get(), searchTerm));
   }
 
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof IdentityWithMetadataResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), name);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final IdentityWithMetadataResponseDto that = (IdentityWithMetadataResponseDto) o;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public String toString() {
+    return "IdentityWithMetadataResponseDto(super="
+        + super.toString()
+        + ", name="
+        + getName()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String name = "name";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ImportRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ImportRequestDto.java
@@ -8,11 +8,8 @@
 package io.camunda.optimize.dto.optimize;
 
 import io.camunda.optimize.service.db.schema.ScriptData;
-import lombok.Builder;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
-@Builder
 public class ImportRequestDto {
 
   private String importName;
@@ -22,6 +19,201 @@ public class ImportRequestDto {
   private Object source;
   private RequestType type;
   private int retryNumberOnConflict;
+
+  ImportRequestDto(
+      final String importName,
+      final String indexName,
+      final ScriptData scriptData,
+      final String id,
+      final Object source,
+      final RequestType type,
+      final int retryNumberOnConflict) {
+    this.importName = importName;
+    this.indexName = indexName;
+    this.scriptData = scriptData;
+    this.id = id;
+    this.source = source;
+    this.type = type;
+    this.retryNumberOnConflict = retryNumberOnConflict;
+  }
+
+  public String getImportName() {
+    return importName;
+  }
+
+  public void setImportName(final String importName) {
+    this.importName = importName;
+  }
+
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public void setIndexName(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  public ScriptData getScriptData() {
+    return scriptData;
+  }
+
+  public void setScriptData(final ScriptData scriptData) {
+    this.scriptData = scriptData;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public Object getSource() {
+    return source;
+  }
+
+  public void setSource(final Object source) {
+    this.source = source;
+  }
+
+  public RequestType getType() {
+    return type;
+  }
+
+  public void setType(final RequestType type) {
+    this.type = type;
+  }
+
+  public int getRetryNumberOnConflict() {
+    return retryNumberOnConflict;
+  }
+
+  public void setRetryNumberOnConflict(final int retryNumberOnConflict) {
+    this.retryNumberOnConflict = retryNumberOnConflict;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ImportRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(importName, indexName, scriptData, id, source, type, retryNumberOnConflict);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ImportRequestDto that = (ImportRequestDto) o;
+    return retryNumberOnConflict == that.retryNumberOnConflict
+        && Objects.equals(importName, that.importName)
+        && Objects.equals(indexName, that.indexName)
+        && Objects.equals(scriptData, that.scriptData)
+        && Objects.equals(id, that.id)
+        && Objects.equals(source, that.source)
+        && Objects.equals(type, that.type);
+  }
+
+  @Override
+  public String toString() {
+    return "ImportRequestDto(importName="
+        + getImportName()
+        + ", indexName="
+        + getIndexName()
+        + ", scriptData="
+        + getScriptData()
+        + ", id="
+        + getId()
+        + ", source="
+        + getSource()
+        + ", type="
+        + getType()
+        + ", retryNumberOnConflict="
+        + getRetryNumberOnConflict()
+        + ")";
+  }
+
+  public static ImportRequestDtoBuilder builder() {
+    return new ImportRequestDtoBuilder();
+  }
+
+  public static class ImportRequestDtoBuilder {
+
+    private String importName;
+    private String indexName;
+    private ScriptData scriptData;
+    private String id;
+    private Object source;
+    private RequestType type;
+    private int retryNumberOnConflict;
+
+    ImportRequestDtoBuilder() {}
+
+    public ImportRequestDtoBuilder importName(final String importName) {
+      this.importName = importName;
+      return this;
+    }
+
+    public ImportRequestDtoBuilder indexName(final String indexName) {
+      this.indexName = indexName;
+      return this;
+    }
+
+    public ImportRequestDtoBuilder scriptData(final ScriptData scriptData) {
+      this.scriptData = scriptData;
+      return this;
+    }
+
+    public ImportRequestDtoBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public ImportRequestDtoBuilder source(final Object source) {
+      this.source = source;
+      return this;
+    }
+
+    public ImportRequestDtoBuilder type(final RequestType type) {
+      this.type = type;
+      return this;
+    }
+
+    public ImportRequestDtoBuilder retryNumberOnConflict(final int retryNumberOnConflict) {
+      this.retryNumberOnConflict = retryNumberOnConflict;
+      return this;
+    }
+
+    public ImportRequestDto build() {
+      return new ImportRequestDto(
+          importName, indexName, scriptData, id, source, type, retryNumberOnConflict);
+    }
+
+    @Override
+    public String toString() {
+      return "ImportRequestDto.ImportRequestDtoBuilder(importName="
+          + importName
+          + ", indexName="
+          + indexName
+          + ", scriptData="
+          + scriptData
+          + ", id="
+          + id
+          + ", source="
+          + source
+          + ", type="
+          + type
+          + ", retryNumberOnConflict="
+          + retryNumberOnConflict
+          + ")";
+    }
+  }
 
   public enum Fields {
     importName,

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessDefinitionOptimizeDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessDefinitionOptimizeDto.java
@@ -15,14 +15,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto {
 
   private String bpmn20Xml;
@@ -59,7 +53,6 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
     this.userTaskNames = userTaskNames;
   }
 
-  @Builder
   public ProcessDefinitionOptimizeDto(
       final String id,
       final String key,
@@ -81,8 +74,23 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
     this.onboarded = onboarded;
   }
 
+  public ProcessDefinitionOptimizeDto(
+      final String bpmn20Xml,
+      final List<FlowNodeDataDto> flowNodeData,
+      final Map<String, String> userTaskNames,
+      final boolean onboarded) {
+    this.bpmn20Xml = bpmn20Xml;
+    this.flowNodeData = flowNodeData;
+    this.userTaskNames = userTaskNames;
+    this.onboarded = onboarded;
+  }
+
   public final List<FlowNodeDataDto> getFlowNodeData() {
     return flowNodeData == null ? new ArrayList<>() : flowNodeData;
+  }
+
+  public void setFlowNodeData(final List<FlowNodeDataDto> flowNodeData) {
+    this.flowNodeData = flowNodeData;
   }
 
   @JsonIgnore
@@ -98,6 +106,72 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
     return userTaskNames == null ? new HashMap<>() : new HashMap<>(userTaskNames);
   }
 
+  public void setUserTaskNames(final Map<String, String> userTaskNames) {
+    this.userTaskNames = userTaskNames;
+  }
+
+  public String getBpmn20Xml() {
+    return bpmn20Xml;
+  }
+
+  public void setBpmn20Xml(final String bpmn20Xml) {
+    this.bpmn20Xml = bpmn20Xml;
+  }
+
+  public boolean isOnboarded() {
+    return onboarded;
+  }
+
+  public void setOnboarded(final boolean onboarded) {
+    this.onboarded = onboarded;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessDefinitionOptimizeDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), bpmn20Xml, flowNodeData, userTaskNames, onboarded);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ProcessDefinitionOptimizeDto that = (ProcessDefinitionOptimizeDto) o;
+    return onboarded == that.onboarded
+        && Objects.equals(bpmn20Xml, that.bpmn20Xml)
+        && Objects.equals(flowNodeData, that.flowNodeData)
+        && Objects.equals(userTaskNames, that.userTaskNames);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessDefinitionOptimizeDto(bpmn20Xml="
+        + getBpmn20Xml()
+        + ", flowNodeData="
+        + getFlowNodeData()
+        + ", userTaskNames="
+        + getUserTaskNames()
+        + ", onboarded="
+        + isOnboarded()
+        + ")";
+  }
+
+  public static ProcessDefinitionOptimizeDtoBuilder builder() {
+    return new ProcessDefinitionOptimizeDtoBuilder();
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String bpmn20Xml = "bpmn20Xml";
@@ -105,5 +179,130 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
     public static final String userTaskNames = "userTaskNames";
     public static final String onboarded = "onboarded";
     public static final String eventBased = "eventBased";
+  }
+
+  public static class ProcessDefinitionOptimizeDtoBuilder {
+
+    private String id;
+    private String key;
+    private String version;
+    private String versionTag;
+    private String name;
+    private DataSourceDto dataSource;
+    private String tenantId;
+    private String bpmn20Xml;
+    private boolean deleted;
+    private boolean onboarded;
+    private List<FlowNodeDataDto> flowNodeData;
+    private Map<String, String> userTaskNames;
+
+    ProcessDefinitionOptimizeDtoBuilder() {}
+
+    public ProcessDefinitionOptimizeDtoBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public ProcessDefinitionOptimizeDtoBuilder key(final String key) {
+      this.key = key;
+      return this;
+    }
+
+    public ProcessDefinitionOptimizeDtoBuilder version(final String version) {
+      this.version = version;
+      return this;
+    }
+
+    public ProcessDefinitionOptimizeDtoBuilder versionTag(final String versionTag) {
+      this.versionTag = versionTag;
+      return this;
+    }
+
+    public ProcessDefinitionOptimizeDtoBuilder name(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public ProcessDefinitionOptimizeDtoBuilder dataSource(final DataSourceDto dataSource) {
+      this.dataSource = dataSource;
+      return this;
+    }
+
+    public ProcessDefinitionOptimizeDtoBuilder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    public ProcessDefinitionOptimizeDtoBuilder bpmn20Xml(final String bpmn20Xml) {
+      this.bpmn20Xml = bpmn20Xml;
+      return this;
+    }
+
+    public ProcessDefinitionOptimizeDtoBuilder deleted(final boolean deleted) {
+      this.deleted = deleted;
+      return this;
+    }
+
+    public ProcessDefinitionOptimizeDtoBuilder onboarded(final boolean onboarded) {
+      this.onboarded = onboarded;
+      return this;
+    }
+
+    public ProcessDefinitionOptimizeDtoBuilder flowNodeData(
+        final List<FlowNodeDataDto> flowNodeData) {
+      this.flowNodeData = flowNodeData;
+      return this;
+    }
+
+    public ProcessDefinitionOptimizeDtoBuilder userTaskNames(
+        final Map<String, String> userTaskNames) {
+      this.userTaskNames = userTaskNames;
+      return this;
+    }
+
+    public ProcessDefinitionOptimizeDto build() {
+      return new ProcessDefinitionOptimizeDto(
+          id,
+          key,
+          version,
+          versionTag,
+          name,
+          dataSource,
+          tenantId,
+          bpmn20Xml,
+          deleted,
+          onboarded,
+          flowNodeData,
+          userTaskNames);
+    }
+
+    @Override
+    public String toString() {
+      return "ProcessDefinitionOptimizeDto.ProcessDefinitionOptimizeDtoBuilder(id="
+          + id
+          + ", key="
+          + key
+          + ", version="
+          + version
+          + ", versionTag="
+          + versionTag
+          + ", name="
+          + name
+          + ", dataSource="
+          + dataSource
+          + ", tenantId="
+          + tenantId
+          + ", bpmn20Xml="
+          + bpmn20Xml
+          + ", deleted="
+          + deleted
+          + ", onboarded="
+          + onboarded
+          + ", flowNodeData="
+          + flowNodeData
+          + ", userTaskNames="
+          + userTaskNames
+          + ")";
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessInstanceDto.java
@@ -17,17 +17,8 @@ import io.camunda.optimize.dto.optimize.query.variable.SimpleProcessVariableDto;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
-@SuperBuilder
 public class ProcessInstanceDto implements OptimizeDto {
 
   private String processDefinitionKey;
@@ -39,11 +30,73 @@ public class ProcessInstanceDto implements OptimizeDto {
   private OffsetDateTime endDate;
   private Long duration; // duration in ms
   private String state;
-  @Builder.Default private List<FlowNodeInstanceDto> flowNodeInstances = new ArrayList<>();
-  @Builder.Default private List<SimpleProcessVariableDto> variables = new ArrayList<>();
-  @Builder.Default private List<IncidentDto> incidents = new ArrayList<>();
+  private List<FlowNodeInstanceDto> flowNodeInstances = new ArrayList<>();
+  private List<SimpleProcessVariableDto> variables = new ArrayList<>();
+  private List<IncidentDto> incidents = new ArrayList<>();
   private DataSourceDto dataSource;
   private String tenantId;
+
+  protected ProcessInstanceDto(
+      final String processDefinitionKey,
+      final String processDefinitionVersion,
+      final String processDefinitionId,
+      final String processInstanceId,
+      final String businessKey,
+      final OffsetDateTime startDate,
+      final OffsetDateTime endDate,
+      final Long duration,
+      final String state,
+      final List<FlowNodeInstanceDto> flowNodeInstances,
+      final List<SimpleProcessVariableDto> variables,
+      final List<IncidentDto> incidents,
+      final DataSourceDto dataSource,
+      final String tenantId) {
+    this.processDefinitionKey = processDefinitionKey;
+    this.processDefinitionVersion = processDefinitionVersion;
+    this.processDefinitionId = processDefinitionId;
+    this.processInstanceId = processInstanceId;
+    this.businessKey = businessKey;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.duration = duration;
+    this.state = state;
+    this.flowNodeInstances = flowNodeInstances;
+    this.variables = variables;
+    this.incidents = incidents;
+    this.dataSource = dataSource;
+    this.tenantId = tenantId;
+  }
+
+  public ProcessInstanceDto() {}
+
+  protected ProcessInstanceDto(final ProcessInstanceDtoBuilder<?, ?> b) {
+    processDefinitionKey = b.processDefinitionKey;
+    processDefinitionVersion = b.processDefinitionVersion;
+    processDefinitionId = b.processDefinitionId;
+    processInstanceId = b.processInstanceId;
+    businessKey = b.businessKey;
+    startDate = b.startDate;
+    endDate = b.endDate;
+    duration = b.duration;
+    state = b.state;
+    if (b.flowNodeInstancesSet) {
+      flowNodeInstances = b.flowNodeInstancesValue;
+    } else {
+      flowNodeInstances = defaultFlowNodeInstances();
+    }
+    if (b.variablesSet) {
+      variables = b.variablesValue;
+    } else {
+      variables = defaultVariables();
+    }
+    if (b.incidentsSet) {
+      incidents = b.incidentsValue;
+    } else {
+      incidents = defaultIncidents();
+    }
+    dataSource = b.dataSource;
+    tenantId = b.tenantId;
+  }
 
   @JsonIgnore
   public List<FlowNodeInstanceDto> getUserTasks() {
@@ -52,6 +105,216 @@ public class ProcessInstanceDto implements OptimizeDto {
         .toList();
   }
 
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
+
+  public void setProcessDefinitionVersion(final String processDefinitionVersion) {
+    this.processDefinitionVersion = processDefinitionVersion;
+  }
+
+  public String getProcessDefinitionId() {
+    return processDefinitionId;
+  }
+
+  public void setProcessDefinitionId(final String processDefinitionId) {
+    this.processDefinitionId = processDefinitionId;
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public String getBusinessKey() {
+    return businessKey;
+  }
+
+  public void setBusinessKey(final String businessKey) {
+    this.businessKey = businessKey;
+  }
+
+  public OffsetDateTime getStartDate() {
+    return startDate;
+  }
+
+  public void setStartDate(final OffsetDateTime startDate) {
+    this.startDate = startDate;
+  }
+
+  public OffsetDateTime getEndDate() {
+    return endDate;
+  }
+
+  public void setEndDate(final OffsetDateTime endDate) {
+    this.endDate = endDate;
+  }
+
+  public Long getDuration() {
+    return duration;
+  }
+
+  public void setDuration(final Long duration) {
+    this.duration = duration;
+  }
+
+  public String getState() {
+    return state;
+  }
+
+  public void setState(final String state) {
+    this.state = state;
+  }
+
+  public List<FlowNodeInstanceDto> getFlowNodeInstances() {
+    return flowNodeInstances;
+  }
+
+  public void setFlowNodeInstances(final List<FlowNodeInstanceDto> flowNodeInstances) {
+    this.flowNodeInstances = flowNodeInstances;
+  }
+
+  public List<SimpleProcessVariableDto> getVariables() {
+    return variables;
+  }
+
+  public void setVariables(final List<SimpleProcessVariableDto> variables) {
+    this.variables = variables;
+  }
+
+  public List<IncidentDto> getIncidents() {
+    return incidents;
+  }
+
+  public void setIncidents(final List<IncidentDto> incidents) {
+    this.incidents = incidents;
+  }
+
+  public DataSourceDto getDataSource() {
+    return dataSource;
+  }
+
+  public void setDataSource(final DataSourceDto dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessInstanceDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        processDefinitionKey,
+        processDefinitionVersion,
+        processDefinitionId,
+        processInstanceId,
+        businessKey,
+        startDate,
+        endDate,
+        duration,
+        state,
+        flowNodeInstances,
+        variables,
+        incidents,
+        dataSource,
+        tenantId);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessInstanceDto that = (ProcessInstanceDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersion, that.processDefinitionVersion)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(businessKey, that.businessKey)
+        && Objects.equals(startDate, that.startDate)
+        && Objects.equals(endDate, that.endDate)
+        && Objects.equals(duration, that.duration)
+        && Objects.equals(state, that.state)
+        && Objects.equals(flowNodeInstances, that.flowNodeInstances)
+        && Objects.equals(variables, that.variables)
+        && Objects.equals(incidents, that.incidents)
+        && Objects.equals(dataSource, that.dataSource)
+        && Objects.equals(tenantId, that.tenantId);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessInstanceDto(processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", processDefinitionVersion="
+        + getProcessDefinitionVersion()
+        + ", processDefinitionId="
+        + getProcessDefinitionId()
+        + ", processInstanceId="
+        + getProcessInstanceId()
+        + ", businessKey="
+        + getBusinessKey()
+        + ", startDate="
+        + getStartDate()
+        + ", endDate="
+        + getEndDate()
+        + ", duration="
+        + getDuration()
+        + ", state="
+        + getState()
+        + ", flowNodeInstances="
+        + getFlowNodeInstances()
+        + ", variables="
+        + getVariables()
+        + ", incidents="
+        + getIncidents()
+        + ", dataSource="
+        + getDataSource()
+        + ", tenantId="
+        + getTenantId()
+        + ")";
+  }
+
+  private static List<FlowNodeInstanceDto> defaultFlowNodeInstances() {
+    return new ArrayList<>();
+  }
+
+  private static List<SimpleProcessVariableDto> defaultVariables() {
+    return new ArrayList<>();
+  }
+
+  private static List<IncidentDto> defaultIncidents() {
+    return new ArrayList<>();
+  }
+
+  public static ProcessInstanceDtoBuilder<?, ?> builder() {
+    return new ProcessInstanceDtoBuilderImpl();
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String processDefinitionKey = "processDefinitionKey";
@@ -68,5 +331,153 @@ public class ProcessInstanceDto implements OptimizeDto {
     public static final String incidents = "incidents";
     public static final String dataSource = "dataSource";
     public static final String tenantId = "tenantId";
+  }
+
+  public abstract static class ProcessInstanceDtoBuilder<
+      C extends ProcessInstanceDto, B extends ProcessInstanceDtoBuilder<C, B>> {
+
+    private String processDefinitionKey;
+    private String processDefinitionVersion;
+    private String processDefinitionId;
+    private String processInstanceId;
+    private String businessKey;
+    private OffsetDateTime startDate;
+    private OffsetDateTime endDate;
+    private Long duration;
+    private String state;
+    private List<FlowNodeInstanceDto> flowNodeInstancesValue;
+    private boolean flowNodeInstancesSet;
+    private List<SimpleProcessVariableDto> variablesValue;
+    private boolean variablesSet;
+    private List<IncidentDto> incidentsValue;
+    private boolean incidentsSet;
+    private DataSourceDto dataSource;
+    private String tenantId;
+
+    public B processDefinitionKey(final String processDefinitionKey) {
+      this.processDefinitionKey = processDefinitionKey;
+      return self();
+    }
+
+    public B processDefinitionVersion(final String processDefinitionVersion) {
+      this.processDefinitionVersion = processDefinitionVersion;
+      return self();
+    }
+
+    public B processDefinitionId(final String processDefinitionId) {
+      this.processDefinitionId = processDefinitionId;
+      return self();
+    }
+
+    public B processInstanceId(final String processInstanceId) {
+      this.processInstanceId = processInstanceId;
+      return self();
+    }
+
+    public B businessKey(final String businessKey) {
+      this.businessKey = businessKey;
+      return self();
+    }
+
+    public B startDate(final OffsetDateTime startDate) {
+      this.startDate = startDate;
+      return self();
+    }
+
+    public B endDate(final OffsetDateTime endDate) {
+      this.endDate = endDate;
+      return self();
+    }
+
+    public B duration(final Long duration) {
+      this.duration = duration;
+      return self();
+    }
+
+    public B state(final String state) {
+      this.state = state;
+      return self();
+    }
+
+    public B flowNodeInstances(final List<FlowNodeInstanceDto> flowNodeInstances) {
+      flowNodeInstancesValue = flowNodeInstances;
+      flowNodeInstancesSet = true;
+      return self();
+    }
+
+    public B variables(final List<SimpleProcessVariableDto> variables) {
+      variablesValue = variables;
+      variablesSet = true;
+      return self();
+    }
+
+    public B incidents(final List<IncidentDto> incidents) {
+      incidentsValue = incidents;
+      incidentsSet = true;
+      return self();
+    }
+
+    public B dataSource(final DataSourceDto dataSource) {
+      this.dataSource = dataSource;
+      return self();
+    }
+
+    public B tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return self();
+    }
+
+    protected abstract B self();
+
+    public abstract C build();
+
+    @Override
+    public String toString() {
+      return "ProcessInstanceDto.ProcessInstanceDtoBuilder(processDefinitionKey="
+          + processDefinitionKey
+          + ", processDefinitionVersion="
+          + processDefinitionVersion
+          + ", processDefinitionId="
+          + processDefinitionId
+          + ", processInstanceId="
+          + processInstanceId
+          + ", businessKey="
+          + businessKey
+          + ", startDate="
+          + startDate
+          + ", endDate="
+          + endDate
+          + ", duration="
+          + duration
+          + ", state="
+          + state
+          + ", flowNodeInstancesValue="
+          + flowNodeInstancesValue
+          + ", variablesValue="
+          + variablesValue
+          + ", incidentsValue="
+          + incidentsValue
+          + ", dataSource="
+          + dataSource
+          + ", tenantId="
+          + tenantId
+          + ")";
+    }
+  }
+
+  private static final class ProcessInstanceDtoBuilderImpl
+      extends ProcessInstanceDtoBuilder<ProcessInstanceDto, ProcessInstanceDtoBuilderImpl> {
+
+    private ProcessInstanceDtoBuilderImpl() {}
+
+    @Override
+    protected ProcessInstanceDtoBuilderImpl self() {
+      return this;
+    }
+
+    @Override
+    public ProcessInstanceDto build() {
+      return new ProcessInstanceDto(this);
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/SettingsDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/SettingsDto.java
@@ -8,25 +8,99 @@
 package io.camunda.optimize.dto.optimize;
 
 import java.time.OffsetDateTime;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor
-@Builder
-@Data
 public class SettingsDto {
 
   private Boolean sharingEnabled;
 
   private OffsetDateTime lastModified;
 
+  public SettingsDto(final Boolean sharingEnabled, final OffsetDateTime lastModified) {
+    this.sharingEnabled = sharingEnabled;
+    this.lastModified = lastModified;
+  }
+
+  private SettingsDto() {}
+
   public Optional<Boolean> getSharingEnabled() {
     return Optional.ofNullable(sharingEnabled);
+  }
+
+  public void setSharingEnabled(final Boolean sharingEnabled) {
+    this.sharingEnabled = sharingEnabled;
+  }
+
+  public OffsetDateTime getLastModified() {
+    return lastModified;
+  }
+
+  public void setLastModified(final OffsetDateTime lastModified) {
+    this.lastModified = lastModified;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof SettingsDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SettingsDto that = (SettingsDto) o;
+    return Objects.equals(sharingEnabled, that.sharingEnabled)
+        && Objects.equals(lastModified, that.lastModified);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sharingEnabled, lastModified);
+  }
+
+  @Override
+  public String toString() {
+    return "SettingsDto(sharingEnabled="
+        + getSharingEnabled()
+        + ", lastModified="
+        + getLastModified()
+        + ")";
+  }
+
+  public static SettingsDtoBuilder builder() {
+    return new SettingsDtoBuilder();
+  }
+
+  public static class SettingsDtoBuilder {
+
+    private Boolean sharingEnabled;
+    private OffsetDateTime lastModified;
+
+    SettingsDtoBuilder() {}
+
+    public SettingsDtoBuilder sharingEnabled(final Boolean sharingEnabled) {
+      this.sharingEnabled = sharingEnabled;
+      return this;
+    }
+
+    public SettingsDtoBuilder lastModified(final OffsetDateTime lastModified) {
+      this.lastModified = lastModified;
+      return this;
+    }
+
+    public SettingsDto build() {
+      return new SettingsDto(sharingEnabled, lastModified);
+    }
+
+    @Override
+    public String toString() {
+      return "SettingsDto.SettingsDtoBuilder(sharingEnabled="
+          + sharingEnabled
+          + ", lastModified="
+          + lastModified
+          + ")";
+    }
   }
 
   public enum Fields {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/SimpleDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/SimpleDefinitionDto.java
@@ -9,32 +9,128 @@ package io.camunda.optimize.dto.optimize;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Data
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class SimpleDefinitionDto {
-  @EqualsAndHashCode.Include @NonNull private String key;
+
+  private String key;
   private String name;
-  @EqualsAndHashCode.Include @NonNull private DefinitionType type;
-  @NonNull private Set<String> engines = new HashSet<>();
+  private DefinitionType type;
+  private Set<String> engines = new HashSet<>();
 
   public SimpleDefinitionDto(
-      @NonNull final String key,
-      final String name,
-      @NonNull final DefinitionType type,
-      @NonNull final String engine) {
+      final String key, final String name, final DefinitionType type, final String engine) {
+    if (key == null) {
+      throw new IllegalArgumentException("key cannot be null");
+    }
+    if (type == null) {
+      throw new IllegalArgumentException("type cannot be null");
+    }
+    if (engine == null) {
+      throw new IllegalArgumentException("engine cannot be null");
+    }
+
     this.key = key;
     this.name = name;
     this.type = type;
     engines = Collections.singleton(engine);
+  }
+
+  public SimpleDefinitionDto(
+      final String key, final String name, final DefinitionType type, final Set<String> engines) {
+    if (key == null) {
+      throw new IllegalArgumentException("key cannot be null");
+    }
+    if (type == null) {
+      throw new IllegalArgumentException("type cannot be null");
+    }
+    if (engines == null) {
+      throw new IllegalArgumentException("engines cannot be null");
+    }
+
+    this.key = key;
+    this.name = name;
+    this.type = type;
+    this.engines = engines;
+  }
+
+  protected SimpleDefinitionDto() {}
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(final String key) {
+    if (key == null) {
+      throw new IllegalArgumentException("key cannot be null");
+    }
+
+    this.key = key;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public DefinitionType getType() {
+    return type;
+  }
+
+  public void setType(final DefinitionType type) {
+    if (type == null) {
+      throw new IllegalArgumentException("type cannot be null");
+    }
+
+    this.type = type;
+  }
+
+  public Set<String> getEngines() {
+    return engines;
+  }
+
+  public void setEngines(final Set<String> engines) {
+    if (engines == null) {
+      throw new IllegalArgumentException("engines cannot be null");
+    }
+    this.engines = engines;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof SimpleDefinitionDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SimpleDefinitionDto that = (SimpleDefinitionDto) o;
+    return Objects.equals(key, that.key)
+        && Objects.equals(name, that.name)
+        && type == that.type
+        && Objects.equals(engines, that.engines);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, name, type, engines);
+  }
+
+  @Override
+  public String toString() {
+    return "SimpleDefinitionDto(key="
+        + getKey()
+        + ", name="
+        + getName()
+        + ", type="
+        + getType()
+        + ", engines="
+        + getEngines()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/TenantDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/TenantDto.java
@@ -7,23 +7,110 @@
  */
 package io.camunda.optimize.dto.optimize;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Data
-@Builder
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class TenantDto implements OptimizeDto {
 
-  @EqualsAndHashCode.Include private String id;
-  @EqualsAndHashCode.Include private String name;
+  private String id;
+  private String name;
   private String engine;
+
+  public TenantDto(final String id, final String name, final String engine) {
+    this.id = id;
+    this.name = name;
+    this.engine = engine;
+  }
+
+  protected TenantDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getEngine() {
+    return engine;
+  }
+
+  public void setEngine(final String engine) {
+    this.engine = engine;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof TenantDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, engine);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TenantDto that = (TenantDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(engine, that.engine);
+  }
+
+  @Override
+  public String toString() {
+    return "TenantDto(id=" + getId() + ", name=" + getName() + ", engine=" + getEngine() + ")";
+  }
+
+  public static TenantDtoBuilder builder() {
+    return new TenantDtoBuilder();
+  }
+
+  public static class TenantDtoBuilder {
+
+    private String id;
+    private String name;
+    private String engine;
+
+    TenantDtoBuilder() {}
+
+    public TenantDtoBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public TenantDtoBuilder name(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public TenantDtoBuilder engine(final String engine) {
+      this.engine = engine;
+      return this;
+    }
+
+    public TenantDto build() {
+      return new TenantDto(id, name, engine);
+    }
+
+    @Override
+    public String toString() {
+      return "TenantDto.TenantDtoBuilder(id=" + id + ", name=" + name + ", engine=" + engine + ")";
+    }
+  }
 
   public enum Fields {
     id,

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/UserDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/UserDto.java
@@ -17,18 +17,8 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(callSuper = true)
-@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 public class UserDto extends IdentityWithMetadataResponseDto {
 
   private String firstName;
@@ -58,17 +48,23 @@ public class UserDto extends IdentityWithMetadataResponseDto {
 
   @JsonCreator
   public UserDto(
-      @JsonProperty(required = true, value = "id") @NonNull final String id,
+      @JsonProperty(required = true, value = "id") final String id,
       @JsonProperty(required = false, value = "firstName") final String firstName,
       @JsonProperty(required = false, value = "lastName") final String lastName,
       @JsonProperty(required = false, value = "email") final String email,
       @JsonProperty(required = false, value = "roles") final List<String> roles) {
     super(id, IdentityType.USER, resolveName(id, firstName, lastName));
+    if (id == null) {
+      throw new IllegalArgumentException("id cannot be null");
+    }
+
     this.firstName = firstName;
     this.lastName = lastName;
     this.email = email;
     this.roles = roles;
   }
+
+  protected UserDto() {}
 
   private static String resolveName(
       final String id, final String firstName, final String lastName) {
@@ -79,6 +75,38 @@ public class UserDto extends IdentityWithMetadataResponseDto {
                 Collectors.joining(" "), s -> StringUtils.isNotBlank(s) ? s.trim() : id));
   }
 
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(final String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(final String lastName) {
+    this.lastName = lastName;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(final String email) {
+    this.email = email;
+  }
+
+  public List<String> getRoles() {
+    return roles;
+  }
+
+  public void setRoles(final List<String> roles) {
+    this.roles = roles;
+  }
+
   @Override
   @JsonIgnore
   public List<Supplier<String>> getSearchableDtoFields() {
@@ -86,6 +114,47 @@ public class UserDto extends IdentityWithMetadataResponseDto {
         this::getId, this::getEmail, this::getName, this::getFirstName, this::getLastName);
   }
 
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof UserDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final UserDto userDto = (UserDto) o;
+    return Objects.equals(firstName, userDto.firstName)
+        && Objects.equals(lastName, userDto.lastName)
+        && Objects.equals(email, userDto.email)
+        && Objects.equals(roles, userDto.roles);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), firstName, lastName, email, roles);
+  }
+
+  @Override
+  public String toString() {
+    return "UserDto(super="
+        + super.toString()
+        + ", firstName="
+        + getFirstName()
+        + ", lastName="
+        + getLastName()
+        + ", email="
+        + getEmail()
+        + ", roles="
+        + getRoles()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String firstName = "firstName";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ZeebeConfigDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ZeebeConfigDto.java
@@ -7,13 +7,57 @@
  */
 package io.camunda.optimize.dto.optimize;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
 public class ZeebeConfigDto implements SchedulerConfig {
 
   private String name;
   private int partitionCount;
+
+  public ZeebeConfigDto(final String name, final int partitionCount) {
+    this.name = name;
+    this.partitionCount = partitionCount;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public int getPartitionCount() {
+    return partitionCount;
+  }
+
+  public void setPartitionCount(final int partitionCount) {
+    this.partitionCount = partitionCount;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeConfigDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, partitionCount);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeConfigDto that = (ZeebeConfigDto) o;
+    return partitionCount == that.partitionCount && Objects.equals(name, that.name);
+  }
+
+  @Override
+  public String toString() {
+    return "ZeebeConfigDto(name=" + getName() + ", partitionCount=" + getPartitionCount() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/alert/AlertNotificationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/alert/AlertNotificationDto.java
@@ -8,11 +8,8 @@
 package io.camunda.optimize.dto.optimize.alert;
 
 import io.camunda.optimize.dto.optimize.query.alert.AlertDefinitionDto;
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
 public class AlertNotificationDto {
 
   private final AlertDefinitionDto alert;
@@ -20,4 +17,74 @@ public class AlertNotificationDto {
   private final AlertNotificationType type;
   private final String alertMessage;
   private final String reportLink;
+
+  public AlertNotificationDto(
+      final AlertDefinitionDto alert,
+      final Double currentValue,
+      final AlertNotificationType type,
+      final String alertMessage,
+      final String reportLink) {
+    this.alert = alert;
+    this.currentValue = currentValue;
+    this.type = type;
+    this.alertMessage = alertMessage;
+    this.reportLink = reportLink;
+  }
+
+  public AlertDefinitionDto getAlert() {
+    return alert;
+  }
+
+  public Double getCurrentValue() {
+    return currentValue;
+  }
+
+  public AlertNotificationType getType() {
+    return type;
+  }
+
+  public String getAlertMessage() {
+    return alertMessage;
+  }
+
+  public String getReportLink() {
+    return reportLink;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof AlertNotificationDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AlertNotificationDto that = (AlertNotificationDto) o;
+    return Objects.equals(alert, that.alert)
+        && Objects.equals(currentValue, that.currentValue)
+        && type == that.type
+        && Objects.equals(alertMessage, that.alertMessage)
+        && Objects.equals(reportLink, that.reportLink);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(alert, currentValue, type, alertMessage, reportLink);
+  }
+
+  @Override
+  public String toString() {
+    return "AlertNotificationDto(alert="
+        + getAlert()
+        + ", currentValue="
+        + getCurrentValue()
+        + ", type="
+        + getType()
+        + ", alertMessage="
+        + getAlertMessage()
+        + ", reportLink="
+        + getReportLink()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/CloudUserDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/CloudUserDto.java
@@ -8,12 +8,9 @@
 package io.camunda.optimize.dto.optimize.cloud;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
 public class CloudUserDto {
 
   private String userId;
@@ -21,7 +18,78 @@ public class CloudUserDto {
   private String email;
   private List<String> roles;
 
+  public CloudUserDto() {}
+
   public List<Supplier<String>> getSearchableDtoFields() {
     return List.of(this::getUserId, this::getName, this::getEmail);
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public void setUserId(final String userId) {
+    this.userId = userId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(final String email) {
+    this.email = email;
+  }
+
+  public List<String> getRoles() {
+    return roles;
+  }
+
+  public void setRoles(final List<String> roles) {
+    this.roles = roles;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CloudUserDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(userId, name, email, roles);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CloudUserDto that = (CloudUserDto) o;
+    return Objects.equals(userId, that.userId)
+        && Objects.equals(name, that.name)
+        && Objects.equals(email, that.email)
+        && Objects.equals(roles, that.roles);
+  }
+
+  @Override
+  public String toString() {
+    return "CloudUserDto(userId="
+        + getUserId()
+        + ", name="
+        + getName()
+        + ", email="
+        + getEmail()
+        + ", roles="
+        + getRoles()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/TokenRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/TokenRequestDto.java
@@ -8,15 +8,8 @@
 package io.camunda.optimize.dto.optimize.cloud;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class TokenRequestDto {
 
   @JsonProperty("client_id")
@@ -30,4 +23,145 @@ public class TokenRequestDto {
 
   @JsonProperty("grant_type")
   private String grantType;
+
+  public TokenRequestDto(
+      final String clientId,
+      final String clientSecret,
+      final String audience,
+      final String grantType) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.audience = audience;
+    this.grantType = grantType;
+  }
+
+  public TokenRequestDto() {}
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  @JsonProperty("client_id")
+  public void setClientId(final String clientId) {
+    this.clientId = clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  @JsonProperty("client_secret")
+  public void setClientSecret(final String clientSecret) {
+    this.clientSecret = clientSecret;
+  }
+
+  public String getAudience() {
+    return audience;
+  }
+
+  @JsonProperty("audience")
+  public void setAudience(final String audience) {
+    this.audience = audience;
+  }
+
+  public String getGrantType() {
+    return grantType;
+  }
+
+  @JsonProperty("grant_type")
+  public void setGrantType(final String grantType) {
+    this.grantType = grantType;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof TokenRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(clientId, clientSecret, audience, grantType);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TokenRequestDto that = (TokenRequestDto) o;
+    return Objects.equals(clientId, that.clientId)
+        && Objects.equals(clientSecret, that.clientSecret)
+        && Objects.equals(audience, that.audience)
+        && Objects.equals(grantType, that.grantType);
+  }
+
+  @Override
+  public String toString() {
+    return "TokenRequestDto(clientId="
+        + getClientId()
+        + ", clientSecret="
+        + getClientSecret()
+        + ", audience="
+        + getAudience()
+        + ", grantType="
+        + getGrantType()
+        + ")";
+  }
+
+  public static TokenRequestDtoBuilder builder() {
+    return new TokenRequestDtoBuilder();
+  }
+
+  public static class TokenRequestDtoBuilder {
+
+    private String clientId;
+    private String clientSecret;
+    private String audience;
+    private String grantType;
+
+    TokenRequestDtoBuilder() {}
+
+    @JsonProperty("client_id")
+    public TokenRequestDtoBuilder clientId(final String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    @JsonProperty("client_secret")
+    public TokenRequestDtoBuilder clientSecret(final String clientSecret) {
+      this.clientSecret = clientSecret;
+      return this;
+    }
+
+    @JsonProperty("audience")
+    public TokenRequestDtoBuilder audience(final String audience) {
+      this.audience = audience;
+      return this;
+    }
+
+    @JsonProperty("grant_type")
+    public TokenRequestDtoBuilder grantType(final String grantType) {
+      this.grantType = grantType;
+      return this;
+    }
+
+    public TokenRequestDto build() {
+      return new TokenRequestDto(clientId, clientSecret, audience, grantType);
+    }
+
+    @Override
+    public String toString() {
+      return "TokenRequestDto.TokenRequestDtoBuilder(clientId="
+          + clientId
+          + ", clientSecret="
+          + clientSecret
+          + ", audience="
+          + audience
+          + ", grantType="
+          + grantType
+          + ")";
+    }
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/TokenResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/TokenResponseDto.java
@@ -8,11 +8,8 @@
 package io.camunda.optimize.dto.optimize.cloud;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
 public class TokenResponseDto {
 
   @JsonProperty("access_token")
@@ -26,4 +23,79 @@ public class TokenResponseDto {
 
   @JsonProperty("scope")
   private String scope;
+
+  public TokenResponseDto() {}
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  @JsonProperty("access_token")
+  public void setAccessToken(final String accessToken) {
+    this.accessToken = accessToken;
+  }
+
+  public String getTokenType() {
+    return tokenType;
+  }
+
+  @JsonProperty("token_type")
+  public void setTokenType(final String tokenType) {
+    this.tokenType = tokenType;
+  }
+
+  public long getExpiresIn() {
+    return expiresIn;
+  }
+
+  @JsonProperty("expires_in")
+  public void setExpiresIn(final long expiresIn) {
+    this.expiresIn = expiresIn;
+  }
+
+  public String getScope() {
+    return scope;
+  }
+
+  @JsonProperty("scope")
+  public void setScope(final String scope) {
+    this.scope = scope;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof TokenResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(accessToken, tokenType, expiresIn, scope);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TokenResponseDto that = (TokenResponseDto) o;
+    return expiresIn == that.expiresIn
+        && Objects.equals(accessToken, that.accessToken)
+        && Objects.equals(tokenType, that.tokenType)
+        && Objects.equals(scope, that.scope);
+  }
+
+  @Override
+  public String toString() {
+    return "TokenResponseDto(accessToken="
+        + getAccessToken()
+        + ", tokenType="
+        + getTokenType()
+        + ", expiresIn="
+        + getExpiresIn()
+        + ", scope="
+        + getScope()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/panelnotifications/PanelNotificationDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/panelnotifications/PanelNotificationDataDto.java
@@ -7,17 +7,10 @@
  */
 package io.camunda.optimize.dto.optimize.cloud.panelnotifications;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@EqualsAndHashCode
-@Builder
-@Data
-public class PanelNotificationDataDto {
+public final class PanelNotificationDataDto {
+
   private final String uniqueId;
   private final String source;
   private final String type;
@@ -25,4 +18,170 @@ public class PanelNotificationDataDto {
   private final String title;
   private final String description;
   private final PanelNotificationMetaDataDto meta;
+
+  private PanelNotificationDataDto(
+      final String uniqueId,
+      final String source,
+      final String type,
+      final String orgId,
+      final String title,
+      final String description,
+      final PanelNotificationMetaDataDto meta) {
+    this.uniqueId = uniqueId;
+    this.source = source;
+    this.type = type;
+    this.orgId = orgId;
+    this.title = title;
+    this.description = description;
+    this.meta = meta;
+  }
+
+  public String getUniqueId() {
+    return uniqueId;
+  }
+
+  public String getSource() {
+    return source;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getOrgId() {
+    return orgId;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public PanelNotificationMetaDataDto getMeta() {
+    return meta;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PanelNotificationDataDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(uniqueId, source, type, orgId, title, description, meta);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PanelNotificationDataDto that = (PanelNotificationDataDto) o;
+    return Objects.equals(uniqueId, that.uniqueId)
+        && Objects.equals(source, that.source)
+        && Objects.equals(type, that.type)
+        && Objects.equals(orgId, that.orgId)
+        && Objects.equals(title, that.title)
+        && Objects.equals(description, that.description)
+        && Objects.equals(meta, that.meta);
+  }
+
+  @Override
+  public String toString() {
+    return "PanelNotificationDataDto(uniqueId="
+        + getUniqueId()
+        + ", source="
+        + getSource()
+        + ", type="
+        + getType()
+        + ", orgId="
+        + getOrgId()
+        + ", title="
+        + getTitle()
+        + ", description="
+        + getDescription()
+        + ", meta="
+        + getMeta()
+        + ")";
+  }
+
+  public static PanelNotificationDataDtoBuilder builder() {
+    return new PanelNotificationDataDtoBuilder();
+  }
+
+  public static class PanelNotificationDataDtoBuilder {
+
+    private String uniqueId;
+    private String source;
+    private String type;
+    private String orgId;
+    private String title;
+    private String description;
+    private PanelNotificationMetaDataDto meta;
+
+    PanelNotificationDataDtoBuilder() {}
+
+    public PanelNotificationDataDtoBuilder uniqueId(final String uniqueId) {
+      this.uniqueId = uniqueId;
+      return this;
+    }
+
+    public PanelNotificationDataDtoBuilder source(final String source) {
+      this.source = source;
+      return this;
+    }
+
+    public PanelNotificationDataDtoBuilder type(final String type) {
+      this.type = type;
+      return this;
+    }
+
+    public PanelNotificationDataDtoBuilder orgId(final String orgId) {
+      this.orgId = orgId;
+      return this;
+    }
+
+    public PanelNotificationDataDtoBuilder title(final String title) {
+      this.title = title;
+      return this;
+    }
+
+    public PanelNotificationDataDtoBuilder description(final String description) {
+      this.description = description;
+      return this;
+    }
+
+    public PanelNotificationDataDtoBuilder meta(final PanelNotificationMetaDataDto meta) {
+      this.meta = meta;
+      return this;
+    }
+
+    public PanelNotificationDataDto build() {
+      return new PanelNotificationDataDto(uniqueId, source, type, orgId, title, description, meta);
+    }
+
+    @Override
+    public String toString() {
+      return "PanelNotificationDataDto.PanelNotificationDataDtoBuilder(uniqueId="
+          + uniqueId
+          + ", source="
+          + source
+          + ", type="
+          + type
+          + ", orgId="
+          + orgId
+          + ", title="
+          + title
+          + ", description="
+          + description
+          + ", meta="
+          + meta
+          + ")";
+    }
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/panelnotifications/PanelNotificationMetaDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/panelnotifications/PanelNotificationMetaDataDto.java
@@ -7,19 +7,125 @@
  */
 package io.camunda.optimize.dto.optimize.cloud.panelnotifications;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Arrays;
+import java.util.Objects;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@EqualsAndHashCode
-@Builder
-@Data
-public class PanelNotificationMetaDataDto {
+public final class PanelNotificationMetaDataDto {
+
   private final String identifier;
   private final String[] permissions;
   private final String href;
   private final String label;
+
+  private PanelNotificationMetaDataDto(
+      final String identifier, final String[] permissions, final String href, final String label) {
+    this.identifier = identifier;
+    this.permissions = permissions;
+    this.href = href;
+    this.label = label;
+  }
+
+  public String getIdentifier() {
+    return identifier;
+  }
+
+  public String[] getPermissions() {
+    return permissions;
+  }
+
+  public String getHref() {
+    return href;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PanelNotificationMetaDataDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(identifier, Arrays.hashCode(permissions), href, label);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PanelNotificationMetaDataDto that = (PanelNotificationMetaDataDto) o;
+    return Objects.equals(identifier, that.identifier)
+        && Arrays.equals(permissions, that.permissions)
+        && Objects.equals(href, that.href)
+        && Objects.equals(label, that.label);
+  }
+
+  @Override
+  public String toString() {
+    return "PanelNotificationMetaDataDto(identifier="
+        + getIdentifier()
+        + ", permissions="
+        + java.util.Arrays.deepToString(getPermissions())
+        + ", href="
+        + getHref()
+        + ", label="
+        + getLabel()
+        + ")";
+  }
+
+  public static PanelNotificationMetaDataDtoBuilder builder() {
+    return new PanelNotificationMetaDataDtoBuilder();
+  }
+
+  public static class PanelNotificationMetaDataDtoBuilder {
+
+    private String identifier;
+    private String[] permissions;
+    private String href;
+    private String label;
+
+    PanelNotificationMetaDataDtoBuilder() {}
+
+    public PanelNotificationMetaDataDtoBuilder identifier(final String identifier) {
+      this.identifier = identifier;
+      return this;
+    }
+
+    public PanelNotificationMetaDataDtoBuilder permissions(final String[] permissions) {
+      this.permissions = permissions;
+      return this;
+    }
+
+    public PanelNotificationMetaDataDtoBuilder href(final String href) {
+      this.href = href;
+      return this;
+    }
+
+    public PanelNotificationMetaDataDtoBuilder label(final String label) {
+      this.label = label;
+      return this;
+    }
+
+    public PanelNotificationMetaDataDto build() {
+      return new PanelNotificationMetaDataDto(identifier, permissions, href, label);
+    }
+
+    @Override
+    public String toString() {
+      return "PanelNotificationMetaDataDto.PanelNotificationMetaDataDtoBuilder(identifier="
+          + identifier
+          + ", permissions="
+          + java.util.Arrays.deepToString(permissions)
+          + ", href="
+          + href
+          + ", label="
+          + label
+          + ")";
+    }
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/panelnotifications/PanelNotificationRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/cloud/panelnotifications/PanelNotificationRequestDto.java
@@ -7,16 +7,71 @@
  */
 package io.camunda.optimize.dto.optimize.cloud.panelnotifications;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@EqualsAndHashCode
-@Builder
-@Data
-public class PanelNotificationRequestDto {
+public final class PanelNotificationRequestDto {
+
   private final PanelNotificationDataDto notification;
+
+  private PanelNotificationRequestDto(final PanelNotificationDataDto notification) {
+    this.notification = notification;
+  }
+
+  public PanelNotificationDataDto getNotification() {
+    return notification;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PanelNotificationRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(notification);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PanelNotificationRequestDto that = (PanelNotificationRequestDto) o;
+    return Objects.equals(notification, that.notification);
+  }
+
+  @Override
+  public String toString() {
+    return "PanelNotificationRequestDto(notification=" + getNotification() + ")";
+  }
+
+  public static PanelNotificationRequestDtoBuilder builder() {
+    return new PanelNotificationRequestDtoBuilder();
+  }
+
+  public static class PanelNotificationRequestDtoBuilder {
+
+    private PanelNotificationDataDto notification;
+
+    PanelNotificationRequestDtoBuilder() {}
+
+    public PanelNotificationRequestDtoBuilder notification(
+        final PanelNotificationDataDto notification) {
+      this.notification = notification;
+      return this;
+    }
+
+    public PanelNotificationRequestDto build() {
+      return new PanelNotificationRequestDto(notification);
+    }
+
+    @Override
+    public String toString() {
+      return "PanelNotificationRequestDto.PanelNotificationRequestDtoBuilder(notification="
+          + notification
+          + ")";
+    }
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/DataSourceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/DataSourceDto.java
@@ -12,13 +12,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.DataImportSourceType;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.io.Serializable;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
@@ -33,6 +28,56 @@ public abstract class DataSourceDto implements OptimizeDto, Serializable {
   private DataImportSourceType type;
   private String name;
 
+  public DataSourceDto(final DataImportSourceType type, final String name) {
+    this.type = type;
+    this.name = name;
+  }
+
+  public DataSourceDto() {}
+
+  public DataImportSourceType getType() {
+    return type;
+  }
+
+  public void setType(final DataImportSourceType type) {
+    this.type = type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DataSourceDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, name);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DataSourceDto that = (DataSourceDto) o;
+    return Objects.equals(type, that.type) && Objects.equals(name, that.name);
+  }
+
+  @Override
+  public String toString() {
+    return "DataSourceDto(type=" + getType() + ", name=" + getName() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String type = "type";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/EngineDataSourceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/EngineDataSourceDto.java
@@ -9,13 +9,8 @@ package io.camunda.optimize.dto.optimize.datasource;
 
 import io.camunda.optimize.dto.optimize.DataImportSourceType;
 import io.camunda.optimize.dto.optimize.SchedulerConfig;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import java.util.Objects;
 
-@Getter
-@EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
 public class EngineDataSourceDto extends DataSourceDto implements SchedulerConfig {
 
   public EngineDataSourceDto() {
@@ -24,5 +19,31 @@ public class EngineDataSourceDto extends DataSourceDto implements SchedulerConfi
 
   public EngineDataSourceDto(final String engineAlias) {
     super(DataImportSourceType.ENGINE, engineAlias);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof EngineDataSourceDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
+  }
+
+  @Override
+  public String toString() {
+    return "EngineDataSourceDto(super=" + super.toString() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/IngestedDataSourceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/IngestedDataSourceDto.java
@@ -9,13 +9,8 @@ package io.camunda.optimize.dto.optimize.datasource;
 
 import io.camunda.optimize.dto.optimize.DataImportSourceType;
 import io.camunda.optimize.dto.optimize.SchedulerConfig;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import java.util.Objects;
 
-@Getter
-@EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
 public class IngestedDataSourceDto extends DataSourceDto implements SchedulerConfig {
 
   public IngestedDataSourceDto() {
@@ -24,5 +19,31 @@ public class IngestedDataSourceDto extends DataSourceDto implements SchedulerCon
 
   public IngestedDataSourceDto(final String name) {
     super(DataImportSourceType.INGESTED_DATA, name);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof IngestedDataSourceDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
+  }
+
+  @Override
+  public String toString() {
+    return "IngestedDataSourceDto(super=" + super.toString() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/ZeebeDataSourceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/ZeebeDataSourceDto.java
@@ -8,13 +8,8 @@
 package io.camunda.optimize.dto.optimize.datasource;
 
 import io.camunda.optimize.dto.optimize.DataImportSourceType;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import java.util.Objects;
 
-@Getter
-@EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
 public class ZeebeDataSourceDto extends DataSourceDto {
 
   private int partitionId;
@@ -26,5 +21,43 @@ public class ZeebeDataSourceDto extends DataSourceDto {
   public ZeebeDataSourceDto(final String name, final int partitionId) {
     super(DataImportSourceType.ZEEBE, name);
     this.partitionId = partitionId;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeDataSourceDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), partitionId);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ZeebeDataSourceDto that = (ZeebeDataSourceDto) o;
+    return partitionId == that.partitionId;
+  }
+
+  @Override
+  public String toString() {
+    return "ZeebeDataSourceDto(super="
+        + super.toString()
+        + ", partitionId="
+        + getPartitionId()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/ImportIndexDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/ImportIndexDto.java
@@ -7,18 +7,14 @@
  */
 package io.camunda.optimize.dto.optimize.index;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import io.camunda.optimize.dto.optimize.datasource.DataSourceDto;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Data
 public abstract class ImportIndexDto<T extends DataSourceDto> implements OptimizeDto {
 
   protected OffsetDateTime lastImportExecutionTimestamp =
@@ -26,7 +22,91 @@ public abstract class ImportIndexDto<T extends DataSourceDto> implements Optimiz
   protected OffsetDateTime timestampOfLastEntity =
       OffsetDateTime.ofInstant(Instant.EPOCH, ZoneId.systemDefault());
   protected T dataSource;
+  protected String dbTypeIndexRefersTo;
 
+  public ImportIndexDto(
+      final OffsetDateTime lastImportExecutionTimestamp,
+      final OffsetDateTime timestampOfLastEntity,
+      final String dbTypeIndexRefersTo,
+      final T dataSource) {
+    this.lastImportExecutionTimestamp = lastImportExecutionTimestamp;
+    this.timestampOfLastEntity = timestampOfLastEntity;
+    this.dbTypeIndexRefersTo = dbTypeIndexRefersTo;
+    this.dataSource = dataSource;
+  }
+
+  public ImportIndexDto() {}
+
+  public OffsetDateTime getLastImportExecutionTimestamp() {
+    return lastImportExecutionTimestamp;
+  }
+
+  public void setLastImportExecutionTimestamp(final OffsetDateTime lastImportExecutionTimestamp) {
+    this.lastImportExecutionTimestamp = lastImportExecutionTimestamp;
+  }
+
+  public OffsetDateTime getTimestampOfLastEntity() {
+    return timestampOfLastEntity;
+  }
+
+  public void setTimestampOfLastEntity(final OffsetDateTime timestampOfLastEntity) {
+    this.timestampOfLastEntity = timestampOfLastEntity;
+  }
+
+  @JsonProperty("esTypeIndexRefersTo")
+  public String getDbTypeIndexRefersTo() {
+    return dbTypeIndexRefersTo;
+  }
+
+  public void setDbTypeIndexRefersTo(final String dbTypeIndexRefersTo) {
+    this.dbTypeIndexRefersTo = dbTypeIndexRefersTo;
+  }
+
+  public T getDataSource() {
+    return dataSource;
+  }
+
+  public void setDataSource(final T dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ImportIndexDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        lastImportExecutionTimestamp, timestampOfLastEntity, dbTypeIndexRefersTo, dataSource);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ImportIndexDto<?> that = (ImportIndexDto<?>) o;
+    return Objects.equals(lastImportExecutionTimestamp, that.lastImportExecutionTimestamp)
+        && Objects.equals(timestampOfLastEntity, that.timestampOfLastEntity)
+        && Objects.equals(dbTypeIndexRefersTo, that.dbTypeIndexRefersTo)
+        && Objects.equals(dataSource, that.dataSource);
+  }
+
+  @Override
+  public String toString() {
+    return "ImportIndexDto(lastImportExecutionTimestamp="
+        + getLastImportExecutionTimestamp()
+        + ", timestampOfLastEntity="
+        + getTimestampOfLastEntity()
+        + ", dataSource="
+        + getDataSource()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String lastImportExecutionTimestamp = "lastImportExecutionTimestamp";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/PositionBasedImportIndexDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/PositionBasedImportIndexDto.java
@@ -8,26 +8,90 @@
 package io.camunda.optimize.dto.optimize.index;
 
 import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class PositionBasedImportIndexDto extends ImportIndexDto<ZeebeDataSourceDto> {
 
   protected long positionOfLastEntity = 0;
   protected long sequenceOfLastEntity = 0;
-  protected String esTypeIndexRefersTo;
   // flag to indicate whether at least one record with a sequence field has been imported
   protected boolean hasSeenSequenceField = false;
 
+  public PositionBasedImportIndexDto() {}
+
+  public long getPositionOfLastEntity() {
+    return positionOfLastEntity;
+  }
+
+  public void setPositionOfLastEntity(final long positionOfLastEntity) {
+    this.positionOfLastEntity = positionOfLastEntity;
+  }
+
+  public long getSequenceOfLastEntity() {
+    return sequenceOfLastEntity;
+  }
+
+  public void setSequenceOfLastEntity(final long sequenceOfLastEntity) {
+    this.sequenceOfLastEntity = sequenceOfLastEntity;
+  }
+
+  public boolean isHasSeenSequenceField() {
+    return hasSeenSequenceField;
+  }
+
+  public void setHasSeenSequenceField(final boolean hasSeenSequenceField) {
+    this.hasSeenSequenceField = hasSeenSequenceField;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof PositionBasedImportIndexDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(), positionOfLastEntity, sequenceOfLastEntity, hasSeenSequenceField);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final PositionBasedImportIndexDto that = (PositionBasedImportIndexDto) o;
+    return positionOfLastEntity == that.positionOfLastEntity
+        && sequenceOfLastEntity == that.sequenceOfLastEntity
+        && hasSeenSequenceField == that.hasSeenSequenceField;
+  }
+
+  @Override
+  public String toString() {
+    return "PositionBasedImportIndexDto(positionOfLastEntity="
+        + getPositionOfLastEntity()
+        + ", sequenceOfLastEntity="
+        + getSequenceOfLastEntity()
+        + ", dbTypeIndexRefersTo="
+        + getDbTypeIndexRefersTo()
+        + ", hasSeenSequenceField="
+        + isHasSeenSequenceField()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String positionOfLastEntity = "positionOfLastEntity";
     public static final String sequenceOfLastEntity = "sequenceOfLastEntity";
-    public static final String esTypeIndexRefersTo = "esTypeIndexRefersTo";
+    // With the support of Opensearch it was decided to get rid of ES prefixes in variable names.
+    // However, to avoid reindexing it was decided to keep original field names in indices
+    public static final String dbTypeIndexRefersTo = "esTypeIndexRefersTo";
     public static final String hasSeenSequenceField = "hasSeenSequenceField";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/TimestampBasedImportIndexDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/TimestampBasedImportIndexDto.java
@@ -11,34 +11,55 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import io.camunda.optimize.dto.optimize.datasource.IngestedDataSourceDto;
 import java.time.OffsetDateTime;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class TimestampBasedImportIndexDto extends ImportIndexDto<IngestedDataSourceDto>
     implements OptimizeDto {
-
-  protected String esTypeIndexRefersTo;
-
   public TimestampBasedImportIndexDto(
       final OffsetDateTime lastImportExecutionTimestamp,
       final OffsetDateTime timestampOfLastEntity,
-      final String esTypeIndexRefersTo,
+      final String dbTypeIndexRefersTo,
       final IngestedDataSourceDto dataSourceDto) {
-    super(lastImportExecutionTimestamp, timestampOfLastEntity, dataSourceDto);
-    this.esTypeIndexRefersTo = esTypeIndexRefersTo;
+    super(lastImportExecutionTimestamp, timestampOfLastEntity, dbTypeIndexRefersTo, dataSourceDto);
   }
+
+  public TimestampBasedImportIndexDto() {}
 
   @JsonIgnore
   public String getDataSourceName() {
     return dataSource.getName();
   }
 
-  public static final class Fields {
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof TimestampBasedImportIndexDto;
+  }
 
-    public static final String esTypeIndexRefersTo = "esTypeIndexRefersTo";
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
+  }
+
+  @Override
+  public String toString() {
+    return "TimestampBasedImportIndexDto(dbTypeIndexRefersTo=" + getDbTypeIndexRefersTo() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
+  public static final class Fields {
+    // With the support of Opensearch it was decided to get rid of ES prefixes in variable names.
+    // However, to avoid reindexing it was decided to keep original field names in indices
+    public static final String dbTypeIndexRefersTo = "esTypeIndexRefersTo";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/AssigneeOperationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/AssigneeOperationDto.java
@@ -10,23 +10,94 @@ package io.camunda.optimize.dto.optimize.persistence;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class AssigneeOperationDto implements OptimizeDto, Serializable {
 
-  @EqualsAndHashCode.Include private String id;
+  private String id;
 
   private String userId;
   private String operationType;
   private OffsetDateTime timestamp;
 
+  public AssigneeOperationDto(
+      final String id,
+      final String userId,
+      final String operationType,
+      final OffsetDateTime timestamp) {
+    this.id = id;
+    this.userId = userId;
+    this.operationType = operationType;
+    this.timestamp = timestamp;
+  }
+
+  public AssigneeOperationDto() {}
+
+  public String getId() {
+    return this.id;
+  }
+
+  public String getUserId() {
+    return this.userId;
+  }
+
+  public String getOperationType() {
+    return this.operationType;
+  }
+
+  public OffsetDateTime getTimestamp() {
+    return this.timestamp;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public void setUserId(final String userId) {
+    this.userId = userId;
+  }
+
+  public void setOperationType(final String operationType) {
+    this.operationType = operationType;
+  }
+
+  public void setTimestamp(final OffsetDateTime timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public String toString() {
+    return "AssigneeOperationDto(id="
+        + this.getId()
+        + ", userId="
+        + this.getUserId()
+        + ", operationType="
+        + this.getOperationType()
+        + ", timestamp="
+        + this.getTimestamp()
+        + ")";
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AssigneeOperationDto that = (AssigneeOperationDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(userId, that.userId)
+        && Objects.equals(operationType, that.operationType)
+        && Objects.equals(timestamp, that.timestamp);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, userId, operationType, timestamp);
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/BusinessKeyDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/BusinessKeyDto.java
@@ -8,22 +8,60 @@
 package io.camunda.optimize.dto.optimize.persistence;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import java.util.Objects;
 
-@Getter
-@ToString
-@AllArgsConstructor
-@NoArgsConstructor
-@EqualsAndHashCode
 public class BusinessKeyDto implements OptimizeDto {
 
   private String processInstanceId;
   private String businessKey;
 
+  public BusinessKeyDto(final String processInstanceId, final String businessKey) {
+    this.processInstanceId = processInstanceId;
+    this.businessKey = businessKey;
+  }
+
+  public BusinessKeyDto() {}
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public String getBusinessKey() {
+    return businessKey;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof BusinessKeyDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processInstanceId, businessKey);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BusinessKeyDto that = (BusinessKeyDto) o;
+    return Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(businessKey, that.businessKey);
+  }
+
+  @Override
+  public String toString() {
+    return "BusinessKeyDto(processInstanceId="
+        + getProcessInstanceId()
+        + ", businessKey="
+        + getBusinessKey()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String processInstanceId = "processInstanceId";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/CandidateGroupOperationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/CandidateGroupOperationDto.java
@@ -10,23 +10,98 @@ package io.camunda.optimize.dto.optimize.persistence;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class CandidateGroupOperationDto implements OptimizeDto, Serializable {
 
-  @EqualsAndHashCode.Include private String id;
-
+  private String id;
   private String groupId;
   private String operationType;
   private OffsetDateTime timestamp;
 
+  public CandidateGroupOperationDto(
+      final String id,
+      final String groupId,
+      final String operationType,
+      final OffsetDateTime timestamp) {
+    this.id = id;
+    this.groupId = groupId;
+    this.operationType = operationType;
+    this.timestamp = timestamp;
+  }
+
+  public CandidateGroupOperationDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public void setGroupId(final String groupId) {
+    this.groupId = groupId;
+  }
+
+  public String getOperationType() {
+    return operationType;
+  }
+
+  public void setOperationType(final String operationType) {
+    this.operationType = operationType;
+  }
+
+  public OffsetDateTime getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(final OffsetDateTime timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CandidateGroupOperationDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, groupId, operationType, timestamp);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CandidateGroupOperationDto that = (CandidateGroupOperationDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(groupId, that.groupId)
+        && Objects.equals(operationType, that.operationType)
+        && Objects.equals(timestamp, that.timestamp);
+  }
+
+  @Override
+  public String toString() {
+    return "CandidateGroupOperationDto(id="
+        + getId()
+        + ", groupId="
+        + getGroupId()
+        + ", operationType="
+        + getOperationType()
+        + ", timestamp="
+        + getTimestamp()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/incident/IncidentDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/incident/IncidentDto.java
@@ -11,15 +11,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
-@Builder
 public class IncidentDto implements Serializable, OptimizeDto {
 
   protected String id;
@@ -37,6 +30,238 @@ public class IncidentDto implements Serializable, OptimizeDto {
   private String tenantId;
   @JsonIgnore private String engineAlias;
 
+  public IncidentDto(
+      final String id,
+      final OffsetDateTime createTime,
+      final OffsetDateTime endTime,
+      final Long durationInMs,
+      final IncidentType incidentType,
+      final String activityId,
+      final String failedActivityId,
+      final String incidentMessage,
+      final IncidentStatus incidentStatus,
+      final String processInstanceId,
+      final String definitionKey,
+      final String definitionVersion,
+      final String tenantId,
+      final String engineAlias) {
+    this.id = id;
+    this.createTime = createTime;
+    this.endTime = endTime;
+    this.durationInMs = durationInMs;
+    this.incidentType = incidentType;
+    this.activityId = activityId;
+    this.failedActivityId = failedActivityId;
+    this.incidentMessage = incidentMessage;
+    this.incidentStatus = incidentStatus;
+    this.processInstanceId = processInstanceId;
+    this.definitionKey = definitionKey;
+    this.definitionVersion = definitionVersion;
+    this.tenantId = tenantId;
+    this.engineAlias = engineAlias;
+  }
+
+  public IncidentDto() {}
+
+  public String getId() {
+    return this.id;
+  }
+
+  public OffsetDateTime getCreateTime() {
+    return this.createTime;
+  }
+
+  public OffsetDateTime getEndTime() {
+    return this.endTime;
+  }
+
+  public Long getDurationInMs() {
+    return this.durationInMs;
+  }
+
+  public IncidentType getIncidentType() {
+    return this.incidentType;
+  }
+
+  public String getActivityId() {
+    return this.activityId;
+  }
+
+  public String getFailedActivityId() {
+    return this.failedActivityId;
+  }
+
+  public String getIncidentMessage() {
+    return this.incidentMessage;
+  }
+
+  public IncidentStatus getIncidentStatus() {
+    return this.incidentStatus;
+  }
+
+  public String getProcessInstanceId() {
+    return this.processInstanceId;
+  }
+
+  public String getDefinitionKey() {
+    return this.definitionKey;
+  }
+
+  public String getDefinitionVersion() {
+    return this.definitionVersion;
+  }
+
+  public String getTenantId() {
+    return this.tenantId;
+  }
+
+  public String getEngineAlias() {
+    return this.engineAlias;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public void setCreateTime(final OffsetDateTime createTime) {
+    this.createTime = createTime;
+  }
+
+  public void setEndTime(final OffsetDateTime endTime) {
+    this.endTime = endTime;
+  }
+
+  public void setDurationInMs(final Long durationInMs) {
+    this.durationInMs = durationInMs;
+  }
+
+  public void setIncidentType(final IncidentType incidentType) {
+    this.incidentType = incidentType;
+  }
+
+  public void setActivityId(final String activityId) {
+    this.activityId = activityId;
+  }
+
+  public void setFailedActivityId(final String failedActivityId) {
+    this.failedActivityId = failedActivityId;
+  }
+
+  public void setIncidentMessage(final String incidentMessage) {
+    this.incidentMessage = incidentMessage;
+  }
+
+  public void setIncidentStatus(final IncidentStatus incidentStatus) {
+    this.incidentStatus = incidentStatus;
+  }
+
+  @JsonIgnore
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public void setDefinitionKey(final String definitionKey) {
+    this.definitionKey = definitionKey;
+  }
+
+  public void setDefinitionVersion(final String definitionVersion) {
+    this.definitionVersion = definitionVersion;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  @JsonIgnore
+  public void setEngineAlias(final String engineAlias) {
+    this.engineAlias = engineAlias;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IncidentDto that = (IncidentDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(createTime, that.createTime)
+        && Objects.equals(endTime, that.endTime)
+        && Objects.equals(durationInMs, that.durationInMs)
+        && Objects.equals(incidentType, that.incidentType)
+        && Objects.equals(activityId, that.activityId)
+        && Objects.equals(failedActivityId, that.failedActivityId)
+        && Objects.equals(incidentMessage, that.incidentMessage)
+        && Objects.equals(incidentStatus, that.incidentStatus)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(definitionKey, that.definitionKey)
+        && Objects.equals(definitionVersion, that.definitionVersion)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(engineAlias, that.engineAlias);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof IncidentDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        createTime,
+        endTime,
+        durationInMs,
+        incidentType,
+        activityId,
+        failedActivityId,
+        incidentMessage,
+        incidentStatus,
+        processInstanceId,
+        definitionKey,
+        definitionVersion,
+        tenantId,
+        engineAlias);
+  }
+
+  public String toString() {
+    return "IncidentDto(id="
+        + this.getId()
+        + ", createTime="
+        + this.getCreateTime()
+        + ", endTime="
+        + this.getEndTime()
+        + ", durationInMs="
+        + this.getDurationInMs()
+        + ", incidentType="
+        + this.getIncidentType()
+        + ", activityId="
+        + this.getActivityId()
+        + ", failedActivityId="
+        + this.getFailedActivityId()
+        + ", incidentMessage="
+        + this.getIncidentMessage()
+        + ", incidentStatus="
+        + this.getIncidentStatus()
+        + ", processInstanceId="
+        + this.getProcessInstanceId()
+        + ", definitionKey="
+        + this.getDefinitionKey()
+        + ", definitionVersion="
+        + this.getDefinitionVersion()
+        + ", tenantId="
+        + this.getTenantId()
+        + ", engineAlias="
+        + this.getEngineAlias()
+        + ")";
+  }
+
+  public static IncidentDtoBuilder builder() {
+    return new IncidentDtoBuilder();
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String processInstanceId = "processInstanceId";
@@ -53,5 +278,147 @@ public class IncidentDto implements Serializable, OptimizeDto {
     public static final String failedActivityId = "failedActivityId";
     public static final String incidentMessage = "incidentMessage";
     public static final String incidentStatus = "incidentStatus";
+  }
+
+  public static class IncidentDtoBuilder {
+
+    private String id;
+    private OffsetDateTime createTime;
+    private OffsetDateTime endTime;
+    private Long durationInMs;
+    private IncidentType incidentType;
+    private String activityId;
+    private String failedActivityId;
+    private String incidentMessage;
+    private IncidentStatus incidentStatus;
+    private String processInstanceId;
+    private String definitionKey;
+    private String definitionVersion;
+    private String tenantId;
+    private String engineAlias;
+
+    IncidentDtoBuilder() {}
+
+    public IncidentDtoBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public IncidentDtoBuilder createTime(final OffsetDateTime createTime) {
+      this.createTime = createTime;
+      return this;
+    }
+
+    public IncidentDtoBuilder endTime(final OffsetDateTime endTime) {
+      this.endTime = endTime;
+      return this;
+    }
+
+    public IncidentDtoBuilder durationInMs(final Long durationInMs) {
+      this.durationInMs = durationInMs;
+      return this;
+    }
+
+    public IncidentDtoBuilder incidentType(final IncidentType incidentType) {
+      this.incidentType = incidentType;
+      return this;
+    }
+
+    public IncidentDtoBuilder activityId(final String activityId) {
+      this.activityId = activityId;
+      return this;
+    }
+
+    public IncidentDtoBuilder failedActivityId(final String failedActivityId) {
+      this.failedActivityId = failedActivityId;
+      return this;
+    }
+
+    public IncidentDtoBuilder incidentMessage(final String incidentMessage) {
+      this.incidentMessage = incidentMessage;
+      return this;
+    }
+
+    public IncidentDtoBuilder incidentStatus(final IncidentStatus incidentStatus) {
+      this.incidentStatus = incidentStatus;
+      return this;
+    }
+
+    @JsonIgnore
+    public IncidentDtoBuilder processInstanceId(final String processInstanceId) {
+      this.processInstanceId = processInstanceId;
+      return this;
+    }
+
+    public IncidentDtoBuilder definitionKey(final String definitionKey) {
+      this.definitionKey = definitionKey;
+      return this;
+    }
+
+    public IncidentDtoBuilder definitionVersion(final String definitionVersion) {
+      this.definitionVersion = definitionVersion;
+      return this;
+    }
+
+    public IncidentDtoBuilder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    @JsonIgnore
+    public IncidentDtoBuilder engineAlias(final String engineAlias) {
+      this.engineAlias = engineAlias;
+      return this;
+    }
+
+    public IncidentDto build() {
+      return new IncidentDto(
+          this.id,
+          this.createTime,
+          this.endTime,
+          this.durationInMs,
+          this.incidentType,
+          this.activityId,
+          this.failedActivityId,
+          this.incidentMessage,
+          this.incidentStatus,
+          this.processInstanceId,
+          this.definitionKey,
+          this.definitionVersion,
+          this.tenantId,
+          this.engineAlias);
+    }
+
+    public String toString() {
+      return "IncidentDto.IncidentDtoBuilder(id="
+          + this.id
+          + ", createTime="
+          + this.createTime
+          + ", endTime="
+          + this.endTime
+          + ", durationInMs="
+          + this.durationInMs
+          + ", incidentType="
+          + this.incidentType
+          + ", activityId="
+          + this.activityId
+          + ", failedActivityId="
+          + this.failedActivityId
+          + ", incidentMessage="
+          + this.incidentMessage
+          + ", incidentStatus="
+          + this.incidentStatus
+          + ", processInstanceId="
+          + this.processInstanceId
+          + ", definitionKey="
+          + this.definitionKey
+          + ", definitionVersion="
+          + this.definitionVersion
+          + ", tenantId="
+          + this.tenantId
+          + ", engineAlias="
+          + this.engineAlias
+          + ")";
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/incident/IncidentType.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/incident/IncidentType.java
@@ -12,14 +12,9 @@ import static io.camunda.optimize.service.util.importing.ZeebeConstants.FAILED_J
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Objects;
+import org.slf4j.Logger;
 
-@Slf4j
-@EqualsAndHashCode
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class IncidentType {
 
   public static final IncidentType FAILED_EXTERNAL_TASK =
@@ -31,16 +26,16 @@ public class IncidentType {
    https://docs.camunda.org/manual/latest/user-guide/process-engine/incidents/#incident-types
   */
   private static final IncidentType FAILED_JOB = new IncidentType(FAILED_JOB_INCIDENT_TYPE);
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(IncidentType.class);
   private final String id;
+
+  protected IncidentType(final String id) {
+    this.id = id;
+  }
 
   @JsonValue
   public String getId() {
     return id;
-  }
-
-  @Override
-  public String toString() {
-    return getId();
   }
 
   public static IncidentType valueOfId(final String incidentTypeId) {
@@ -49,8 +44,34 @@ public class IncidentType {
     }
     if (!FAILED_JOB.getId().equals(incidentTypeId)
         && !FAILED_EXTERNAL_TASK.getId().equals(incidentTypeId)) {
-      log.debug("Importing custom incident type [{}]", incidentTypeId);
+      LOG.debug("Importing custom incident type [{}]", incidentTypeId);
     }
     return new IncidentType(incidentTypeId);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof IncidentType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IncidentType that = (IncidentType) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public String toString() {
+    return getId();
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/MetadataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/MetadataDto.java
@@ -9,18 +9,63 @@ package io.camunda.optimize.dto.optimize.query;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.io.Serializable;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Data
 public class MetadataDto implements OptimizeDto, Serializable {
 
   private String schemaVersion;
   private String installationId;
+
+  public MetadataDto(final String schemaVersion, final String installationId) {
+    this.schemaVersion = schemaVersion;
+    this.installationId = installationId;
+  }
+
+  protected MetadataDto() {}
+
+  public String getSchemaVersion() {
+    return schemaVersion;
+  }
+
+  public void setSchemaVersion(final String schemaVersion) {
+    this.schemaVersion = schemaVersion;
+  }
+
+  public String getInstallationId() {
+    return installationId;
+  }
+
+  public void setInstallationId(final String installationId) {
+    this.installationId = installationId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MetadataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MetadataDto that = (MetadataDto) o;
+    return Objects.equals(schemaVersion, that.schemaVersion)
+        && Objects.equals(installationId, that.installationId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(schemaVersion, installationId);
+  }
+
+  @Override
+  public String toString() {
+    return "MetadataDto(schemaVersion="
+        + getSchemaVersion()
+        + ", installationId="
+        + getInstallationId()
+        + ")";
+  }
 
   public enum Fields {
     schemaVersion,

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertCreationRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertCreationRequestDto.java
@@ -9,11 +9,8 @@ package io.camunda.optimize.dto.optimize.query.alert;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
 public class AlertCreationRequestDto {
 
   private String name;
@@ -24,10 +21,129 @@ public class AlertCreationRequestDto {
   private boolean fixNotification;
   private AlertInterval reminder;
   private List<String> emails = new ArrayList<>();
-  private String webhook;
+
+  public AlertCreationRequestDto() {}
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public AlertInterval getCheckInterval() {
+    return checkInterval;
+  }
+
+  public void setCheckInterval(final AlertInterval checkInterval) {
+    this.checkInterval = checkInterval;
+  }
+
+  public String getReportId() {
+    return reportId;
+  }
+
+  public void setReportId(final String reportId) {
+    this.reportId = reportId;
+  }
+
+  public Double getThreshold() {
+    return threshold;
+  }
+
+  public void setThreshold(final Double threshold) {
+    this.threshold = threshold;
+  }
+
+  public AlertThresholdOperator getThresholdOperator() {
+    return thresholdOperator;
+  }
+
+  public void setThresholdOperator(final AlertThresholdOperator thresholdOperator) {
+    this.thresholdOperator = thresholdOperator;
+  }
+
+  public boolean isFixNotification() {
+    return fixNotification;
+  }
+
+  public void setFixNotification(final boolean fixNotification) {
+    this.fixNotification = fixNotification;
+  }
+
+  public AlertInterval getReminder() {
+    return reminder;
+  }
+
+  public void setReminder(final AlertInterval reminder) {
+    this.reminder = reminder;
+  }
+
+  public List<String> getEmails() {
+    return emails;
+  }
+
+  public void setEmails(final List<String> emails) {
+    this.emails = emails;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof AlertCreationRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AlertCreationRequestDto that = (AlertCreationRequestDto) o;
+    return fixNotification == that.fixNotification
+        && Objects.equals(name, that.name)
+        && Objects.equals(checkInterval, that.checkInterval)
+        && Objects.equals(reportId, that.reportId)
+        && Objects.equals(threshold, that.threshold)
+        && thresholdOperator == that.thresholdOperator
+        && Objects.equals(reminder, that.reminder)
+        && Objects.equals(emails, that.emails);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        name,
+        checkInterval,
+        reportId,
+        threshold,
+        thresholdOperator,
+        fixNotification,
+        reminder,
+        emails);
+  }
+
+  @Override
+  public String toString() {
+    return "AlertCreationRequestDto(name="
+        + getName()
+        + ", checkInterval="
+        + getCheckInterval()
+        + ", reportId="
+        + getReportId()
+        + ", threshold="
+        + getThreshold()
+        + ", thresholdOperator="
+        + getThresholdOperator()
+        + ", fixNotification="
+        + isFixNotification()
+        + ", reminder="
+        + getReminder()
+        + ", emails="
+        + getEmails()
+        + ")";
+  }
 
   // needed to allow inheritance of field name constants
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @SuppressWarnings("checkstyle:ConstantName")
   public static class Fields {
 
     public static final String name = "name";
@@ -38,6 +154,7 @@ public class AlertCreationRequestDto {
     public static final String fixNotification = "fixNotification";
     public static final String reminder = "reminder";
     public static final String emails = "emails";
-    public static final String webhook = "webhook";
+
+    protected Fields() {}
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertDefinitionDto.java
@@ -8,11 +8,8 @@
 package io.camunda.optimize.dto.optimize.query.alert;
 
 import java.time.OffsetDateTime;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class AlertDefinitionDto extends AlertCreationRequestDto {
 
   protected String id;
@@ -22,7 +19,103 @@ public class AlertDefinitionDto extends AlertCreationRequestDto {
   protected String lastModifier;
   protected boolean triggered;
 
+  public AlertDefinitionDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public OffsetDateTime getLastModified() {
+    return lastModified;
+  }
+
+  public void setLastModified(final OffsetDateTime lastModified) {
+    this.lastModified = lastModified;
+  }
+
+  public OffsetDateTime getCreated() {
+    return created;
+  }
+
+  public void setCreated(final OffsetDateTime created) {
+    this.created = created;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(final String owner) {
+    this.owner = owner;
+  }
+
+  public String getLastModifier() {
+    return lastModifier;
+  }
+
+  public void setLastModifier(final String lastModifier) {
+    this.lastModifier = lastModifier;
+  }
+
+  public boolean isTriggered() {
+    return triggered;
+  }
+
+  public void setTriggered(final boolean triggered) {
+    this.triggered = triggered;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof AlertDefinitionDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AlertDefinitionDto that = (AlertDefinitionDto) o;
+    return triggered == that.triggered
+        && Objects.equals(id, that.id)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(created, that.created)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(), id, lastModified, created, owner, lastModifier, triggered);
+  }
+
+  @Override
+  public String toString() {
+    return "AlertDefinitionDto(id="
+        + getId()
+        + ", lastModified="
+        + getLastModified()
+        + ", created="
+        + getCreated()
+        + ", owner="
+        + getOwner()
+        + ", lastModifier="
+        + getLastModifier()
+        + ", triggered="
+        + isTriggered()
+        + ")";
+  }
+
   /** Needed to inherit field name constants from {@link AlertCreationRequestDto} */
+  @SuppressWarnings("checkstyle:ConstantName")
   public static class Fields extends AlertCreationRequestDto.Fields {
 
     public static final String id = "id";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertInterval.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertInterval.java
@@ -7,18 +7,60 @@
  */
 package io.camunda.optimize.dto.optimize.query.alert;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class AlertInterval {
 
   private int value;
   private AlertIntervalUnit unit;
 
+  public AlertInterval(final int value, final AlertIntervalUnit unit) {
+    this.value = value;
+    this.unit = unit;
+  }
+
+  public AlertInterval() {}
+
+  public int getValue() {
+    return value;
+  }
+
+  public void setValue(final int value) {
+    this.value = value;
+  }
+
+  public AlertIntervalUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final AlertIntervalUnit unit) {
+    this.unit = unit;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof AlertInterval;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AlertInterval that = (AlertInterval) o;
+    return value == that.value && unit == that.unit;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value, unit);
+  }
+
+  @Override
+  public String toString() {
+    return "AlertInterval(value=" + getValue() + ", unit=" + getUnit() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String value = "value";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/BaseCollectionDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/BaseCollectionDefinitionDto.java
@@ -8,9 +8,8 @@
 package io.camunda.optimize.dto.optimize.query.collection;
 
 import java.time.OffsetDateTime;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class BaseCollectionDefinitionDto<DATA_TYPE> {
 
   protected String id;
@@ -21,6 +20,122 @@ public class BaseCollectionDefinitionDto<DATA_TYPE> {
   protected String lastModifier;
   protected DATA_TYPE data;
   protected boolean automaticallyCreated = false;
+
+  public BaseCollectionDefinitionDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public OffsetDateTime getLastModified() {
+    return lastModified;
+  }
+
+  public void setLastModified(final OffsetDateTime lastModified) {
+    this.lastModified = lastModified;
+  }
+
+  public OffsetDateTime getCreated() {
+    return created;
+  }
+
+  public void setCreated(final OffsetDateTime created) {
+    this.created = created;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(final String owner) {
+    this.owner = owner;
+  }
+
+  public String getLastModifier() {
+    return lastModifier;
+  }
+
+  public void setLastModifier(final String lastModifier) {
+    this.lastModifier = lastModifier;
+  }
+
+  public DATA_TYPE getData() {
+    return data;
+  }
+
+  public void setData(final DATA_TYPE data) {
+    this.data = data;
+  }
+
+  public boolean isAutomaticallyCreated() {
+    return automaticallyCreated;
+  }
+
+  public void setAutomaticallyCreated(final boolean automaticallyCreated) {
+    this.automaticallyCreated = automaticallyCreated;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof BaseCollectionDefinitionDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id, name, lastModified, created, owner, lastModifier, data, automaticallyCreated);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BaseCollectionDefinitionDto<?> that = (BaseCollectionDefinitionDto<?>) o;
+    return automaticallyCreated == that.automaticallyCreated
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(created, that.created)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public String toString() {
+    return "BaseCollectionDefinitionDto(id="
+        + getId()
+        + ", name="
+        + getName()
+        + ", lastModified="
+        + getLastModified()
+        + ", created="
+        + getCreated()
+        + ", owner="
+        + getOwner()
+        + ", lastModifier="
+        + getLastModifier()
+        + ", data="
+        + getData()
+        + ", automaticallyCreated="
+        + isAutomaticallyCreated()
+        + ")";
+  }
 
   public enum Fields {
     id,

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionDataDto.java
@@ -11,15 +11,74 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Data
 public class CollectionDataDto {
 
   protected Object configuration = new HashMap<>();
   private List<CollectionRoleRequestDto> roles = new ArrayList<>();
   private List<CollectionScopeEntryDto> scope = new ArrayList<>();
+
+  public CollectionDataDto() {}
+
+  public Object getConfiguration() {
+    return configuration;
+  }
+
+  public void setConfiguration(final Object configuration) {
+    this.configuration = configuration;
+  }
+
+  public List<CollectionRoleRequestDto> getRoles() {
+    return roles;
+  }
+
+  public void setRoles(final List<CollectionRoleRequestDto> roles) {
+    this.roles = roles;
+  }
+
+  public List<CollectionScopeEntryDto> getScope() {
+    return scope;
+  }
+
+  public void setScope(final List<CollectionScopeEntryDto> scope) {
+    this.scope = scope;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CollectionDataDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(configuration, roles, scope);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionDataDto that = (CollectionDataDto) o;
+    return Objects.equals(configuration, that.configuration)
+        && Objects.equals(roles, that.roles)
+        && Objects.equals(scope, that.scope);
+  }
+
+  @Override
+  public String toString() {
+    return "CollectionDataDto(configuration="
+        + getConfiguration()
+        + ", roles="
+        + getRoles()
+        + ", scope="
+        + getScope()
+        + ")";
+  }
 
   public enum Fields {
     configuration,

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleRequestDto.java
@@ -9,21 +9,13 @@ package io.camunda.optimize.dto.optimize.query.collection;
 
 import io.camunda.optimize.dto.optimize.IdentityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CollectionRoleRequestDto {
 
   private static final String ID_SEGMENT_SEPARATOR = ":";
-
-  @Setter(value = AccessLevel.PROTECTED)
   private String id;
-
   private IdentityDto identity;
   private RoleType role;
 
@@ -32,8 +24,24 @@ public class CollectionRoleRequestDto {
     this.role = role;
   }
 
+  protected CollectionRoleRequestDto() {}
+
   public String getId() {
     return Optional.ofNullable(id).orElse(convertIdentityToRoleId(identity));
+  }
+
+  protected void setId(final String id) {
+    this.id = id;
+  }
+
+  private String convertIdentityToRoleId(final IdentityDto identity) {
+    return identity.getType() == null
+        ? "UNKNOWN" + ID_SEGMENT_SEPARATOR + identity.getId()
+        : identity.getType().name() + ID_SEGMENT_SEPARATOR + identity.getId();
+  }
+
+  public IdentityDto getIdentity() {
+    return identity;
   }
 
   public void setIdentity(final IdentityDto identity) {
@@ -41,10 +49,46 @@ public class CollectionRoleRequestDto {
     this.identity = identity;
   }
 
-  private String convertIdentityToRoleId(final IdentityDto identity) {
-    return identity.getType() == null
-        ? "UNKNOWN" + ID_SEGMENT_SEPARATOR + identity.getId()
-        : identity.getType().name() + ID_SEGMENT_SEPARATOR + identity.getId();
+  public RoleType getRole() {
+    return role;
+  }
+
+  public void setRole(final RoleType role) {
+    this.role = role;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CollectionRoleRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, identity, role);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionRoleRequestDto that = (CollectionRoleRequestDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(identity, that.identity)
+        && Objects.equals(role, that.role);
+  }
+
+  @Override
+  public String toString() {
+    return "CollectionRoleRequestDto(id="
+        + getId()
+        + ", identity="
+        + getIdentity()
+        + ", role="
+        + getRole()
+        + ")";
   }
 
   public enum Fields {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleResponseDto.java
@@ -12,21 +12,13 @@ import io.camunda.optimize.dto.optimize.IdentityType;
 import io.camunda.optimize.dto.optimize.IdentityWithMetadataResponseDto;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.UserDto;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CollectionRoleResponseDto implements Comparable<CollectionRoleResponseDto> {
 
   private static final String ID_SEGMENT_SEPARATOR = ":";
-
-  @Setter(value = AccessLevel.PROTECTED)
   private String id;
-
   private IdentityWithMetadataResponseDto identity;
   private RoleType role;
 
@@ -56,6 +48,8 @@ public class CollectionRoleResponseDto implements Comparable<CollectionRoleRespo
     this.role = role;
   }
 
+  protected CollectionRoleResponseDto() {}
+
   @Override
   public int compareTo(final CollectionRoleResponseDto other) {
     if (identity instanceof UserDto && other.getIdentity() instanceof GroupDto) {
@@ -74,6 +68,64 @@ public class CollectionRoleResponseDto implements Comparable<CollectionRoleRespo
   public static <T extends IdentityWithMetadataResponseDto> CollectionRoleResponseDto from(
       final CollectionRoleRequestDto roleDto, final T identityWithMetaData) {
     return new CollectionRoleResponseDto(identityWithMetaData, roleDto.getRole());
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  protected void setId(final String id) {
+    this.id = id;
+  }
+
+  public IdentityWithMetadataResponseDto getIdentity() {
+    return identity;
+  }
+
+  public void setIdentity(final IdentityWithMetadataResponseDto identity) {
+    this.identity = identity;
+  }
+
+  public RoleType getRole() {
+    return role;
+  }
+
+  public void setRole(final RoleType role) {
+    this.role = role;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CollectionRoleResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, identity, role);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionRoleResponseDto that = (CollectionRoleResponseDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(identity, that.identity)
+        && Objects.equals(role, that.role);
+  }
+
+  @Override
+  public String toString() {
+    return "CollectionRoleResponseDto(id="
+        + getId()
+        + ", identity="
+        + getIdentity()
+        + ", role="
+        + getRole()
+        + ")";
   }
 
   public enum Fields {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleUpdateRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleUpdateRequestDto.java
@@ -8,17 +8,51 @@
 package io.camunda.optimize.dto.optimize.query.collection;
 
 import io.camunda.optimize.dto.optimize.RoleType;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class CollectionRoleUpdateRequestDto {
 
   private RoleType role;
+
+  public CollectionRoleUpdateRequestDto(final RoleType role) {
+    this.role = role;
+  }
+
+  protected CollectionRoleUpdateRequestDto() {}
+
+  public RoleType getRole() {
+    return role;
+  }
+
+  public void setRole(final RoleType role) {
+    this.role = role;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CollectionRoleUpdateRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(role);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionRoleUpdateRequestDto that = (CollectionRoleUpdateRequestDto) o;
+    return Objects.equals(role, that.role);
+  }
+
+  @Override
+  public String toString() {
+    return "CollectionRoleUpdateRequestDto(role=" + getRole() + ")";
+  }
 
   public enum Fields {
     role

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionScopeEntryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionScopeEntryDto.java
@@ -14,24 +14,14 @@ import static io.camunda.optimize.dto.optimize.query.collection.ScopeComplianceT
 import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.ReportConstants;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class CollectionScopeEntryDto {
 
   private static final String ID_SEGMENT_SEPARATOR = ":";
 
-  @EqualsAndHashCode.Include
-  @Setter(value = AccessLevel.PROTECTED)
   private String id;
-
   private DefinitionType definitionType;
   private String definitionKey;
   private List<String> tenants = ReportConstants.DEFAULT_TENANT_IDS;
@@ -61,9 +51,15 @@ public class CollectionScopeEntryDto {
     this.tenants = tenants;
   }
 
+  protected CollectionScopeEntryDto() {}
+
   public String getId() {
     return Optional.ofNullable(id)
         .orElse(convertTypeAndKeyToScopeEntryId(definitionType, definitionKey));
+  }
+
+  protected void setId(final String id) {
+    this.id = id;
   }
 
   public ScopeComplianceType getComplianceType(
@@ -88,6 +84,67 @@ public class CollectionScopeEntryDto {
   public static String convertTypeAndKeyToScopeEntryId(
       final DefinitionType definitionType, final String definitionKey) {
     return definitionType.getId() + ID_SEGMENT_SEPARATOR + definitionKey;
+  }
+
+  public DefinitionType getDefinitionType() {
+    return definitionType;
+  }
+
+  public void setDefinitionType(final DefinitionType definitionType) {
+    this.definitionType = definitionType;
+  }
+
+  public String getDefinitionKey() {
+    return definitionKey;
+  }
+
+  public void setDefinitionKey(final String definitionKey) {
+    this.definitionKey = definitionKey;
+  }
+
+  public List<String> getTenants() {
+    return tenants;
+  }
+
+  public void setTenants(final List<String> tenants) {
+    this.tenants = tenants;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CollectionScopeEntryDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, definitionType, definitionKey, tenants);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionScopeEntryDto that = (CollectionScopeEntryDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(definitionType, that.definitionType)
+        && Objects.equals(definitionKey, that.definitionKey)
+        && Objects.equals(tenants, that.tenants);
+  }
+
+  @Override
+  public String toString() {
+    return "CollectionScopeEntryDto(id="
+        + getId()
+        + ", definitionType="
+        + getDefinitionType()
+        + ", definitionKey="
+        + getDefinitionKey()
+        + ", tenants="
+        + getTenants()
+        + ")";
   }
 
   public enum Fields {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionScopeEntryUpdateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionScopeEntryUpdateDto.java
@@ -9,18 +9,53 @@ package io.camunda.optimize.dto.optimize.query.collection;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class CollectionScopeEntryUpdateDto {
+
   private List<String> tenants = new ArrayList<>();
 
-  public CollectionScopeEntryUpdateDto(CollectionScopeEntryDto scopeEntryDto) {
-    this.tenants = scopeEntryDto.getTenants();
+  public CollectionScopeEntryUpdateDto(final CollectionScopeEntryDto scopeEntryDto) {
+    tenants = scopeEntryDto.getTenants();
+  }
+
+  public CollectionScopeEntryUpdateDto(final List<String> tenants) {
+    this.tenants = tenants;
+  }
+
+  protected CollectionScopeEntryUpdateDto() {}
+
+  public List<String> getTenants() {
+    return tenants;
+  }
+
+  public void setTenants(final List<String> tenants) {
+    this.tenants = tenants;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CollectionScopeEntryUpdateDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tenants);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CollectionScopeEntryUpdateDto that = (CollectionScopeEntryUpdateDto) o;
+    return Objects.equals(tenants, that.tenants);
+  }
+
+  @Override
+  public String toString() {
+    return "CollectionScopeEntryUpdateDto(tenants=" + getTenants() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/BaseDashboardDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/BaseDashboardDefinitionDto.java
@@ -11,9 +11,8 @@ import io.camunda.optimize.dto.optimize.query.dashboard.filter.DashboardFilterDt
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class BaseDashboardDefinitionDto {
 
   protected String id;
@@ -29,6 +28,175 @@ public class BaseDashboardDefinitionDto {
   protected List<DashboardFilterDto<?>> availableFilters = new ArrayList<>();
   protected Long refreshRateSeconds;
 
+  public BaseDashboardDefinitionDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
+  }
+
+  public OffsetDateTime getLastModified() {
+    return lastModified;
+  }
+
+  public void setLastModified(final OffsetDateTime lastModified) {
+    this.lastModified = lastModified;
+  }
+
+  public OffsetDateTime getCreated() {
+    return created;
+  }
+
+  public void setCreated(final OffsetDateTime created) {
+    this.created = created;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(final String owner) {
+    this.owner = owner;
+  }
+
+  public String getLastModifier() {
+    return lastModifier;
+  }
+
+  public void setLastModifier(final String lastModifier) {
+    this.lastModifier = lastModifier;
+  }
+
+  public String getCollectionId() {
+    return collectionId;
+  }
+
+  public void setCollectionId(final String collectionId) {
+    this.collectionId = collectionId;
+  }
+
+  public boolean isManagementDashboard() {
+    return managementDashboard;
+  }
+
+  public void setManagementDashboard(final boolean managementDashboard) {
+    this.managementDashboard = managementDashboard;
+  }
+
+  public boolean isInstantPreviewDashboard() {
+    return instantPreviewDashboard;
+  }
+
+  public void setInstantPreviewDashboard(final boolean instantPreviewDashboard) {
+    this.instantPreviewDashboard = instantPreviewDashboard;
+  }
+
+  public List<DashboardFilterDto<?>> getAvailableFilters() {
+    return availableFilters;
+  }
+
+  public void setAvailableFilters(final List<DashboardFilterDto<?>> availableFilters) {
+    this.availableFilters = availableFilters;
+  }
+
+  public Long getRefreshRateSeconds() {
+    return refreshRateSeconds;
+  }
+
+  public void setRefreshRateSeconds(final Long refreshRateSeconds) {
+    this.refreshRateSeconds = refreshRateSeconds;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof BaseDashboardDefinitionDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BaseDashboardDefinitionDto that = (BaseDashboardDefinitionDto) o;
+    return managementDashboard == that.managementDashboard
+        && instantPreviewDashboard == that.instantPreviewDashboard
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(created, that.created)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && Objects.equals(collectionId, that.collectionId)
+        && Objects.equals(availableFilters, that.availableFilters)
+        && Objects.equals(refreshRateSeconds, that.refreshRateSeconds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        name,
+        description,
+        lastModified,
+        created,
+        owner,
+        lastModifier,
+        collectionId,
+        managementDashboard,
+        instantPreviewDashboard,
+        availableFilters,
+        refreshRateSeconds);
+  }
+
+  @Override
+  public String toString() {
+    return "BaseDashboardDefinitionDto(id="
+        + getId()
+        + ", name="
+        + getName()
+        + ", description="
+        + getDescription()
+        + ", lastModified="
+        + getLastModified()
+        + ", created="
+        + getCreated()
+        + ", owner="
+        + getOwner()
+        + ", lastModifier="
+        + getLastModifier()
+        + ", collectionId="
+        + getCollectionId()
+        + ", managementDashboard="
+        + isManagementDashboard()
+        + ", instantPreviewDashboard="
+        + isInstantPreviewDashboard()
+        + ", availableFilters="
+        + getAvailableFilters()
+        + ", refreshRateSeconds="
+        + getRefreshRateSeconds()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/DashboardDefinitionRestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/DashboardDefinitionRestDto.java
@@ -21,20 +21,19 @@ import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
-@NoArgsConstructor
-@AllArgsConstructor
 public class DashboardDefinitionRestDto extends BaseDashboardDefinitionDto
     implements CollectionEntity {
 
   @Valid protected List<DashboardReportTileDto> tiles = new ArrayList<>();
+
+  public DashboardDefinitionRestDto(@Valid final List<DashboardReportTileDto> tiles) {
+    this.tiles = tiles;
+  }
+
+  public DashboardDefinitionRestDto() {}
 
   @JsonIgnore
   public Set<String> getTileIds() {
@@ -59,6 +58,42 @@ public class DashboardDefinitionRestDto extends BaseDashboardDefinitionDto
         roleType);
   }
 
+  public @Valid List<DashboardReportTileDto> getTiles() {
+    return tiles;
+  }
+
+  public void setTiles(@Valid final List<DashboardReportTileDto> tiles) {
+    this.tiles = tiles;
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardDefinitionRestDto(tiles=" + getTiles() + ")";
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardDefinitionRestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardDefinitionRestDto that = (DashboardDefinitionRestDto) o;
+    return Objects.equals(tiles, that.tiles);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), tiles);
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String tiles = "tiles";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/InstantDashboardDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/InstantDashboardDataDto.java
@@ -8,11 +8,10 @@
 package io.camunda.optimize.dto.optimize.query.dashboard;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.Data;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Data
 public class InstantDashboardDataDto {
 
   public static final String INSTANT_DASHBOARD_DEFAULT_TEMPLATE = "template1.json";
@@ -22,8 +21,26 @@ public class InstantDashboardDataDto {
   private long templateHash;
   private String dashboardId;
 
+  public InstantDashboardDataDto() {}
+
   public String getInstantDashboardId() {
     return processDefinitionKey + "_" + templateName.replace(".", "");
+  }
+
+  public void setInstantDashboardId(final String instantDashboardId) {
+    this.instantDashboardId = instantDashboardId;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String getTemplateName() {
+    return templateName;
   }
 
   public void setTemplateName(final String templateName) {
@@ -31,6 +48,61 @@ public class InstantDashboardDataDto {
         StringUtils.isEmpty(templateName) ? INSTANT_DASHBOARD_DEFAULT_TEMPLATE : templateName;
   }
 
+  public long getTemplateHash() {
+    return templateHash;
+  }
+
+  public void setTemplateHash(final long templateHash) {
+    this.templateHash = templateHash;
+  }
+
+  public String getDashboardId() {
+    return dashboardId;
+  }
+
+  public void setDashboardId(final String dashboardId) {
+    this.dashboardId = dashboardId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof InstantDashboardDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final InstantDashboardDataDto that = (InstantDashboardDataDto) o;
+    return templateHash == that.templateHash
+        && Objects.equals(instantDashboardId, that.instantDashboardId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(templateName, that.templateName)
+        && Objects.equals(dashboardId, that.dashboardId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        instantDashboardId, processDefinitionKey, templateName, templateHash, dashboardId);
+  }
+
+  @Override
+  public String toString() {
+    return "InstantDashboardDataDto(instantDashboardId="
+        + getInstantDashboardId()
+        + ", processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", templateName="
+        + getTemplateName()
+        + ", templateHash="
+        + getTemplateHash()
+        + ", dashboardId="
+        + getDashboardId()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String instantDashboardId = "instantDashboardId";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/DashboardFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/DashboardFilterDto.java
@@ -10,11 +10,8 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = DashboardInstanceStartDateFilterDto.class, name = "instanceStartDate"),
@@ -32,6 +29,40 @@ public abstract class DashboardFilterDto<DATA extends FilterDataDto> {
     this.data = data;
   }
 
+  public DashboardFilterDto() {}
+
+  public DATA getData() {
+    return data;
+  }
+
+  public void setData(final DATA data) {
+    this.data = data;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardFilterDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardFilterDto<?> that = (DashboardFilterDto<?>) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(data);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardFilterDto(data=" + getData() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String data = "data";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardBooleanVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardBooleanVariableFilterDataDto.java
@@ -10,12 +10,10 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.List;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
-@Data
 public class DashboardBooleanVariableFilterDataDto extends DashboardVariableFilterDataDto {
+
   protected List<Boolean> defaultValues;
 
   protected DashboardBooleanVariableFilterDataDto() {
@@ -32,5 +30,40 @@ public class DashboardBooleanVariableFilterDataDto extends DashboardVariableFilt
       final List<Boolean> defaultValues) {
     super(VariableType.BOOLEAN, name, data);
     this.defaultValues = defaultValues;
+  }
+
+  public List<Boolean> getDefaultValues() {
+    return defaultValues;
+  }
+
+  public void setDefaultValues(final List<Boolean> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardBooleanVariableFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardBooleanVariableFilterDataDto that = (DashboardBooleanVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardBooleanVariableFilterDataDto(defaultValues=" + getDefaultValues() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDateFilterDataDto.java
@@ -9,18 +9,50 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterDataDto;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DashboardDateFilterDataDto implements FilterDataDto {
 
   private DateFilterDataDto<?> defaultValues;
 
+  public DashboardDateFilterDataDto(final DateFilterDataDto<?> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  protected DashboardDateFilterDataDto() {}
+
+  public DateFilterDataDto<?> getDefaultValues() {
+    return defaultValues;
+  }
+
+  public void setDefaultValues(final DateFilterDataDto<?> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardDateFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardDateFilterDataDto that = (DashboardDateFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(defaultValues);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardDateFilterDataDto(defaultValues=" + getDefaultValues() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String defaultValues = "defaultValues";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDateVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDateVariableFilterDataDto.java
@@ -10,12 +10,10 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
-@Data
 public class DashboardDateVariableFilterDataDto extends DashboardVariableFilterDataDto {
+
   protected DateFilterDataDto<?> defaultValues;
 
   protected DashboardDateVariableFilterDataDto() {
@@ -32,5 +30,40 @@ public class DashboardDateVariableFilterDataDto extends DashboardVariableFilterD
       final DateFilterDataDto<?> defaultValues) {
     super(VariableType.DATE, name, data);
     this.defaultValues = defaultValues;
+  }
+
+  public DateFilterDataDto<?> getDefaultValues() {
+    return defaultValues;
+  }
+
+  public void setDefaultValues(final DateFilterDataDto<?> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardDateVariableFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardDateVariableFilterDataDto that = (DashboardDateVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardDateVariableFilterDataDto(defaultValues=" + getDefaultValues() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDoubleVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDoubleVariableFilterDataDto.java
@@ -10,12 +10,10 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.List;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
-@Data
 public class DashboardDoubleVariableFilterDataDto extends DashboardVariableFilterDataDto {
+
   protected List<String> defaultValues;
 
   protected DashboardDoubleVariableFilterDataDto() {
@@ -33,5 +31,40 @@ public class DashboardDoubleVariableFilterDataDto extends DashboardVariableFilte
       final List<String> defaultValues) {
     super(VariableType.DOUBLE, name, data);
     this.defaultValues = defaultValues;
+  }
+
+  public List<String> getDefaultValues() {
+    return defaultValues;
+  }
+
+  public void setDefaultValues(final List<String> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardDoubleVariableFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardDoubleVariableFilterDataDto that = (DashboardDoubleVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardDoubleVariableFilterDataDto(defaultValues=" + getDefaultValues() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardIdentityFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardIdentityFilterDataDto.java
@@ -10,14 +10,8 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.operator.MembershipFilterOperator;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.data.IdentityLinkFilterDataDto;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class DashboardIdentityFilterDataDto extends IdentityLinkFilterDataDto {
 
   protected boolean allowCustomValues;
@@ -41,6 +35,57 @@ public class DashboardIdentityFilterDataDto extends IdentityLinkFilterDataDto {
     this.defaultValues = defaultValues;
   }
 
+  protected DashboardIdentityFilterDataDto() {}
+
+  public boolean isAllowCustomValues() {
+    return allowCustomValues;
+  }
+
+  public void setAllowCustomValues(final boolean allowCustomValues) {
+    this.allowCustomValues = allowCustomValues;
+  }
+
+  public List<String> getDefaultValues() {
+    return defaultValues;
+  }
+
+  public void setDefaultValues(final List<String> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardIdentityFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardIdentityFilterDataDto that = (DashboardIdentityFilterDataDto) o;
+    return allowCustomValues == that.allowCustomValues
+        && Objects.equals(defaultValues, that.defaultValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), allowCustomValues, defaultValues);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardIdentityFilterDataDto(allowCustomValues="
+        + isAllowCustomValues()
+        + ", defaultValues="
+        + getDefaultValues()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String allowCustomValues = "allowCustomValues";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardIntegerVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardIntegerVariableFilterDataDto.java
@@ -10,12 +10,10 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.List;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
-@Data
 public class DashboardIntegerVariableFilterDataDto extends DashboardVariableFilterDataDto {
+
   protected List<String> defaultValues;
 
   protected DashboardIntegerVariableFilterDataDto() {
@@ -33,5 +31,43 @@ public class DashboardIntegerVariableFilterDataDto extends DashboardVariableFilt
       final List<String> defaultValues) {
     super(VariableType.INTEGER, name, data);
     this.defaultValues = defaultValues;
+  }
+
+  public List<String> getDefaultValues() {
+    return defaultValues;
+  }
+
+  public void setDefaultValues(final List<String> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardIntegerVariableFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardIntegerVariableFilterDataDto that = (DashboardIntegerVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardIntegerVariableFilterDataDto(defaultValues=" + getDefaultValues() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardLongVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardLongVariableFilterDataDto.java
@@ -10,12 +10,10 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.List;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
-@Data
 public class DashboardLongVariableFilterDataDto extends DashboardVariableFilterDataDto {
+
   protected List<String> defaultValues;
 
   protected DashboardLongVariableFilterDataDto() {
@@ -33,5 +31,40 @@ public class DashboardLongVariableFilterDataDto extends DashboardVariableFilterD
       final List<String> defaultValues) {
     super(VariableType.LONG, name, data);
     this.defaultValues = defaultValues;
+  }
+
+  public List<String> getDefaultValues() {
+    return defaultValues;
+  }
+
+  public void setDefaultValues(final List<String> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardLongVariableFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardLongVariableFilterDataDto that = (DashboardLongVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardLongVariableFilterDataDto(defaultValues=" + getDefaultValues() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardShortVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardShortVariableFilterDataDto.java
@@ -10,12 +10,10 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.List;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
-@Data
 public class DashboardShortVariableFilterDataDto extends DashboardVariableFilterDataDto {
+
   protected List<String> defaultValues;
 
   protected DashboardShortVariableFilterDataDto() {
@@ -33,5 +31,40 @@ public class DashboardShortVariableFilterDataDto extends DashboardVariableFilter
       final List<String> defaultValues) {
     super(VariableType.SHORT, name, data);
     this.defaultValues = defaultValues;
+  }
+
+  public List<String> getDefaultValues() {
+    return defaultValues;
+  }
+
+  public void setDefaultValues(final List<String> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardShortVariableFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardShortVariableFilterDataDto that = (DashboardShortVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardShortVariableFilterDataDto(defaultValues=" + getDefaultValues() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardStateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardStateFilterDataDto.java
@@ -9,18 +9,50 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DashboardStateFilterDataDto implements FilterDataDto {
 
   private List<String> defaultValues;
 
+  public DashboardStateFilterDataDto(final List<String> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  protected DashboardStateFilterDataDto() {}
+
+  public List<String> getDefaultValues() {
+    return defaultValues;
+  }
+
+  public void setDefaultValues(final List<String> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardStateFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardStateFilterDataDto that = (DashboardStateFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(defaultValues);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardStateFilterDataDto(defaultValues=" + getDefaultValues() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String defaultValues = "defaultValues";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardStringVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardStringVariableFilterDataDto.java
@@ -10,12 +10,10 @@ package io.camunda.optimize.dto.optimize.query.dashboard.filter.data;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.List;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
-@Data
 public class DashboardStringVariableFilterDataDto extends DashboardVariableFilterDataDto {
+
   protected List<String> defaultValues;
 
   protected DashboardStringVariableFilterDataDto() {
@@ -33,5 +31,49 @@ public class DashboardStringVariableFilterDataDto extends DashboardVariableFilte
       final List<String> defaultValues) {
     super(VariableType.STRING, name, data);
     this.defaultValues = defaultValues;
+  }
+
+  public List<String> getDefaultValues() {
+    return defaultValues;
+  }
+
+  public void setDefaultValues(final List<String> defaultValues) {
+    this.defaultValues = defaultValues;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardStringVariableFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardStringVariableFilterDataDto that = (DashboardStringVariableFilterDataDto) o;
+    return Objects.equals(defaultValues, that.defaultValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), defaultValues);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardStringVariableFilterDataDto("
+        + "defaultValues="
+        + getDefaultValues()
+        + ", type="
+        + getType()
+        + ", name="
+        + getName()
+        + ", data="
+        + getData()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardVariableFilterDataDto.java
@@ -27,9 +27,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data.DashboardVariableFilterSubDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -61,8 +59,6 @@ import lombok.NoArgsConstructor;
   @JsonSubTypes.Type(value = DashboardDateVariableFilterDataDto.class, name = DATE_TYPE),
   @JsonSubTypes.Type(value = DashboardDateVariableFilterDataDto.class, name = DATE_TYPE_LOWERCASE)
 })
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class DashboardVariableFilterDataDto implements FilterDataDto {
 
   protected VariableType type;
@@ -74,5 +70,60 @@ public abstract class DashboardVariableFilterDataDto implements FilterDataDto {
     this.name = name;
     this.type = type;
     this.data = data;
+  }
+
+  protected DashboardVariableFilterDataDto() {}
+
+  public VariableType getType() {
+    return type;
+  }
+
+  public void setType(final VariableType type) {
+    this.type = type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public DashboardVariableFilterSubDataDto getData() {
+    return data;
+  }
+
+  public void setData(final DashboardVariableFilterSubDataDto data) {
+    this.data = data;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardVariableFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardVariableFilterDataDto that = (DashboardVariableFilterDataDto) o;
+    return type == that.type && Objects.equals(name, that.name) && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, name, data);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardVariableFilterDataDto(type="
+        + getType()
+        + ", name="
+        + getName()
+        + ", data="
+        + getData()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/DashboardReportTileDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/DashboardReportTileDto.java
@@ -8,15 +8,8 @@
 package io.camunda.optimize.dto.optimize.query.dashboard.tile;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@Builder(toBuilder = true)
-@NoArgsConstructor
-@AllArgsConstructor
 public class DashboardReportTileDto {
 
   protected String id;
@@ -25,6 +18,112 @@ public class DashboardReportTileDto {
   @NotNull protected DashboardTileType type;
   protected Object configuration;
 
+  public DashboardReportTileDto(
+      final String id,
+      final PositionDto position,
+      final DimensionDto dimensions,
+      @NotNull final DashboardTileType type,
+      final Object configuration) {
+    this.id = id;
+    this.position = position;
+    this.dimensions = dimensions;
+    this.type = type;
+    this.configuration = configuration;
+  }
+
+  public DashboardReportTileDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public PositionDto getPosition() {
+    return position;
+  }
+
+  public void setPosition(final PositionDto position) {
+    this.position = position;
+  }
+
+  public DimensionDto getDimensions() {
+    return dimensions;
+  }
+
+  public void setDimensions(final DimensionDto dimensions) {
+    this.dimensions = dimensions;
+  }
+
+  public @NotNull DashboardTileType getType() {
+    return type;
+  }
+
+  public void setType(@NotNull final DashboardTileType type) {
+    this.type = type;
+  }
+
+  public Object getConfiguration() {
+    return configuration;
+  }
+
+  public void setConfiguration(final Object configuration) {
+    this.configuration = configuration;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardReportTileDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DashboardReportTileDto that = (DashboardReportTileDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(position, that.position)
+        && Objects.equals(dimensions, that.dimensions)
+        && type == that.type
+        && Objects.equals(configuration, that.configuration);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, position, dimensions, type, configuration);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardReportTileDto(id="
+        + getId()
+        + ", position="
+        + getPosition()
+        + ", dimensions="
+        + getDimensions()
+        + ", type="
+        + getType()
+        + ", configuration="
+        + getConfiguration()
+        + ")";
+  }
+
+  public static DashboardReportTileDtoBuilder builder() {
+    return new DashboardReportTileDtoBuilder();
+  }
+
+  public DashboardReportTileDtoBuilder toBuilder() {
+    return new DashboardReportTileDtoBuilder()
+        .id(id)
+        .position(position)
+        .dimensions(dimensions)
+        .type(type)
+        .configuration(configuration);
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";
@@ -32,5 +131,60 @@ public class DashboardReportTileDto {
     public static final String dimensions = "dimensions";
     public static final String type = "type";
     public static final String configuration = "configuration";
+  }
+
+  public static class DashboardReportTileDtoBuilder {
+
+    private String id;
+    private PositionDto position;
+    private DimensionDto dimensions;
+    private @NotNull DashboardTileType type;
+    private Object configuration;
+
+    DashboardReportTileDtoBuilder() {}
+
+    public DashboardReportTileDtoBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public DashboardReportTileDtoBuilder position(final PositionDto position) {
+      this.position = position;
+      return this;
+    }
+
+    public DashboardReportTileDtoBuilder dimensions(final DimensionDto dimensions) {
+      this.dimensions = dimensions;
+      return this;
+    }
+
+    public DashboardReportTileDtoBuilder type(@NotNull final DashboardTileType type) {
+      this.type = type;
+      return this;
+    }
+
+    public DashboardReportTileDtoBuilder configuration(final Object configuration) {
+      this.configuration = configuration;
+      return this;
+    }
+
+    public DashboardReportTileDto build() {
+      return new DashboardReportTileDto(id, position, dimensions, type, configuration);
+    }
+
+    @Override
+    public String toString() {
+      return "DashboardReportTileDto.DashboardReportTileDtoBuilder(id="
+          + id
+          + ", position="
+          + position
+          + ", dimensions="
+          + dimensions
+          + ", type="
+          + type
+          + ", configuration="
+          + configuration
+          + ")";
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/DimensionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/DimensionDto.java
@@ -7,18 +7,60 @@
  */
 package io.camunda.optimize.dto.optimize.query.dashboard.tile;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class DimensionDto {
 
   protected int width;
   protected int height;
 
+  public DimensionDto(final int width, final int height) {
+    this.width = width;
+    this.height = height;
+  }
+
+  public DimensionDto() {}
+
+  public int getWidth() {
+    return width;
+  }
+
+  public void setWidth(final int width) {
+    this.width = width;
+  }
+
+  public int getHeight() {
+    return height;
+  }
+
+  public void setHeight(final int height) {
+    this.height = height;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DimensionDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DimensionDto that = (DimensionDto) o;
+    return width == that.width && height == that.height;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(width, height);
+  }
+
+  @Override
+  public String toString() {
+    return "DimensionDto(width=" + getWidth() + ", height=" + getHeight() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String width = "width";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/PositionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/PositionDto.java
@@ -7,18 +7,60 @@
  */
 package io.camunda.optimize.dto.optimize.query.dashboard.tile;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class PositionDto {
 
   protected int x;
   protected int y;
 
+  public PositionDto(final int x, final int y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  public PositionDto() {}
+
+  public int getX() {
+    return x;
+  }
+
+  public void setX(final int x) {
+    this.x = x;
+  }
+
+  public int getY() {
+    return y;
+  }
+
+  public void setY(final int y) {
+    this.y = y;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PositionDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PositionDto that = (PositionDto) o;
+    return x == that.x && y == that.y;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(x, y);
+  }
+
+  @Override
+  public String toString() {
+    return "PositionDto(x=" + getX() + ", y=" + getY() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String x = "x";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntitiesDeleteRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntitiesDeleteRequestDto.java
@@ -9,16 +9,77 @@ package io.camunda.optimize.dto.optimize.query.entity;
 
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class EntitiesDeleteRequestDto {
 
   @NotNull List<String> reports;
   @NotNull List<String> collections;
   @NotNull List<String> dashboards;
+
+  public EntitiesDeleteRequestDto(
+      @NotNull final List<String> reports,
+      @NotNull final List<String> collections,
+      @NotNull final List<String> dashboards) {
+    this.reports = reports;
+    this.collections = collections;
+    this.dashboards = dashboards;
+  }
+
+  public EntitiesDeleteRequestDto() {}
+
+  public @NotNull List<String> getReports() {
+    return reports;
+  }
+
+  public void setReports(@NotNull final List<String> reports) {
+    this.reports = reports;
+  }
+
+  public @NotNull List<String> getCollections() {
+    return collections;
+  }
+
+  public void setCollections(@NotNull final List<String> collections) {
+    this.collections = collections;
+  }
+
+  public @NotNull List<String> getDashboards() {
+    return dashboards;
+  }
+
+  public void setDashboards(@NotNull final List<String> dashboards) {
+    this.dashboards = dashboards;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EntitiesDeleteRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntitiesDeleteRequestDto that = (EntitiesDeleteRequestDto) o;
+    return Objects.equals(reports, that.reports)
+        && Objects.equals(collections, that.collections)
+        && Objects.equals(dashboards, that.dashboards);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(reports, collections, dashboards);
+  }
+
+  @Override
+  public String toString() {
+    return "EntitiesDeleteRequestDto(reports="
+        + getReports()
+        + ", collections="
+        + getCollections()
+        + ", dashboards="
+        + getDashboards()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityData.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityData.java
@@ -10,13 +10,8 @@ package io.camunda.optimize.dto.optimize.query.entity;
 import io.camunda.optimize.dto.optimize.IdentityType;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class EntityData {
 
   private Map<EntityType, Long> subEntityCounts = new HashMap<>();
@@ -24,5 +19,57 @@ public class EntityData {
 
   public EntityData(final Map<EntityType, Long> subEntityCounts) {
     this.subEntityCounts = subEntityCounts;
+  }
+
+  public EntityData(
+      final Map<EntityType, Long> subEntityCounts, final Map<IdentityType, Long> roleCounts) {
+    this.subEntityCounts = subEntityCounts;
+    this.roleCounts = roleCounts;
+  }
+
+  public EntityData() {}
+
+  public Map<EntityType, Long> getSubEntityCounts() {
+    return subEntityCounts;
+  }
+
+  public void setSubEntityCounts(final Map<EntityType, Long> subEntityCounts) {
+    this.subEntityCounts = subEntityCounts;
+  }
+
+  public Map<IdentityType, Long> getRoleCounts() {
+    return roleCounts;
+  }
+
+  public void setRoleCounts(final Map<IdentityType, Long> roleCounts) {
+    this.roleCounts = roleCounts;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EntityData;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntityData that = (EntityData) o;
+    return Objects.equals(subEntityCounts, that.subEntityCounts)
+        && Objects.equals(roleCounts, that.roleCounts);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(subEntityCounts, roleCounts);
+  }
+
+  @Override
+  public String toString() {
+    return "EntityData(subEntityCounts="
+        + getSubEntityCounts()
+        + ", roleCounts="
+        + getRoleCounts()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityNameRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityNameRequestDto.java
@@ -7,24 +7,79 @@
  */
 package io.camunda.optimize.dto.optimize.query.entity;
 
-import jakarta.ws.rs.QueryParam;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class EntityNameRequestDto {
 
-  @QueryParam("collectionId")
   private String collectionId;
 
-  @QueryParam("dashboardId")
   private String dashboardId;
 
-  @QueryParam("reportId")
   private String reportId;
+
+  public EntityNameRequestDto(
+      final String collectionId, final String dashboardId, final String reportId) {
+    this.collectionId = collectionId;
+    this.dashboardId = dashboardId;
+    this.reportId = reportId;
+  }
+
+  public EntityNameRequestDto() {}
+
+  public String getCollectionId() {
+    return collectionId;
+  }
+
+  public void setCollectionId(final String collectionId) {
+    this.collectionId = collectionId;
+  }
+
+  public String getDashboardId() {
+    return dashboardId;
+  }
+
+  public void setDashboardId(final String dashboardId) {
+    this.dashboardId = dashboardId;
+  }
+
+  public String getReportId() {
+    return reportId;
+  }
+
+  public void setReportId(final String reportId) {
+    this.reportId = reportId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EntityNameRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntityNameRequestDto that = (EntityNameRequestDto) o;
+    return Objects.equals(collectionId, that.collectionId)
+        && Objects.equals(dashboardId, that.dashboardId)
+        && Objects.equals(reportId, that.reportId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(collectionId, dashboardId, reportId);
+  }
+
+  @Override
+  public String toString() {
+    return "EntityNameRequestDto(collectionId="
+        + getCollectionId()
+        + ", dashboardId="
+        + getDashboardId()
+        + ", reportId="
+        + getReportId()
+        + ")";
+  }
 
   public enum Fields {
     collectionId,

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityNameResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityNameResponseDto.java
@@ -7,16 +7,75 @@
  */
 package io.camunda.optimize.dto.optimize.query.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class EntityNameResponseDto {
 
   private String collectionName;
   private String dashboardName;
   private String reportName;
+
+  public EntityNameResponseDto(
+      final String collectionName, final String dashboardName, final String reportName) {
+    this.collectionName = collectionName;
+    this.dashboardName = dashboardName;
+    this.reportName = reportName;
+  }
+
+  public EntityNameResponseDto() {}
+
+  public String getCollectionName() {
+    return collectionName;
+  }
+
+  public void setCollectionName(final String collectionName) {
+    this.collectionName = collectionName;
+  }
+
+  public String getDashboardName() {
+    return dashboardName;
+  }
+
+  public void setDashboardName(final String dashboardName) {
+    this.dashboardName = dashboardName;
+  }
+
+  public String getReportName() {
+    return reportName;
+  }
+
+  public void setReportName(final String reportName) {
+    this.reportName = reportName;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EntityNameResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntityNameResponseDto that = (EntityNameResponseDto) o;
+    return Objects.equals(collectionName, that.collectionName)
+        && Objects.equals(dashboardName, that.dashboardName)
+        && Objects.equals(reportName, that.reportName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(collectionName, dashboardName, reportName);
+  }
+
+  @Override
+  public String toString() {
+    return "EntityNameResponseDto(collectionName="
+        + getCollectionName()
+        + ", dashboardName="
+        + getDashboardName()
+        + ", reportName="
+        + getReportName()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityResponseDto.java
@@ -10,14 +10,8 @@ package io.camunda.optimize.dto.optimize.query.entity;
 import io.camunda.optimize.dto.optimize.ReportType;
 import io.camunda.optimize.dto.optimize.RoleType;
 import java.time.OffsetDateTime;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Data
 public class EntityResponseDto {
 
   private String id;
@@ -86,6 +80,202 @@ public class EntityResponseDto {
         currentUserRole);
   }
 
+  public EntityResponseDto(
+      final String id,
+      final String name,
+      final String description,
+      final OffsetDateTime lastModified,
+      final OffsetDateTime created,
+      final String owner,
+      final String lastModifier,
+      final EntityType entityType,
+      final EntityData data,
+      final Boolean combined,
+      final ReportType reportType,
+      final RoleType currentUserRole) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+    this.lastModified = lastModified;
+    this.created = created;
+    this.owner = owner;
+    this.lastModifier = lastModifier;
+    this.entityType = entityType;
+    this.data = data;
+    this.combined = combined;
+    this.reportType = reportType;
+    this.currentUserRole = currentUserRole;
+  }
+
+  protected EntityResponseDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
+  }
+
+  public OffsetDateTime getLastModified() {
+    return lastModified;
+  }
+
+  public void setLastModified(final OffsetDateTime lastModified) {
+    this.lastModified = lastModified;
+  }
+
+  public OffsetDateTime getCreated() {
+    return created;
+  }
+
+  public void setCreated(final OffsetDateTime created) {
+    this.created = created;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(final String owner) {
+    this.owner = owner;
+  }
+
+  public String getLastModifier() {
+    return lastModifier;
+  }
+
+  public void setLastModifier(final String lastModifier) {
+    this.lastModifier = lastModifier;
+  }
+
+  public EntityType getEntityType() {
+    return entityType;
+  }
+
+  public void setEntityType(final EntityType entityType) {
+    this.entityType = entityType;
+  }
+
+  public EntityData getData() {
+    return data;
+  }
+
+  public void setData(final EntityData data) {
+    this.data = data;
+  }
+
+  public Boolean getCombined() {
+    return combined;
+  }
+
+  public void setCombined(final Boolean combined) {
+    this.combined = combined;
+  }
+
+  public ReportType getReportType() {
+    return reportType;
+  }
+
+  public void setReportType(final ReportType reportType) {
+    this.reportType = reportType;
+  }
+
+  public RoleType getCurrentUserRole() {
+    return currentUserRole;
+  }
+
+  public void setCurrentUserRole(final RoleType currentUserRole) {
+    this.currentUserRole = currentUserRole;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EntityResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntityResponseDto that = (EntityResponseDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(created, that.created)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && entityType == that.entityType
+        && Objects.equals(data, that.data)
+        && Objects.equals(combined, that.combined)
+        && reportType == that.reportType
+        && currentUserRole == that.currentUserRole;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        name,
+        description,
+        lastModified,
+        created,
+        owner,
+        lastModifier,
+        entityType,
+        data,
+        combined,
+        reportType,
+        currentUserRole);
+  }
+
+  @Override
+  public String toString() {
+    return "EntityResponseDto(id="
+        + getId()
+        + ", name="
+        + getName()
+        + ", description="
+        + getDescription()
+        + ", lastModified="
+        + getLastModified()
+        + ", created="
+        + getCreated()
+        + ", owner="
+        + getOwner()
+        + ", lastModifier="
+        + getLastModifier()
+        + ", entityType="
+        + getEntityType()
+        + ", data="
+        + getData()
+        + ", combined="
+        + getCombined()
+        + ", reportType="
+        + getReportType()
+        + ", currentUserRole="
+        + getCurrentUserRole()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/process/FlowNodeInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/process/FlowNodeInstanceDto.java
@@ -17,14 +17,8 @@ import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class FlowNodeInstanceDto implements Serializable, OptimizeDto {
 
   private String flowNodeInstanceId;
@@ -60,15 +54,37 @@ public class FlowNodeInstanceDto implements Serializable, OptimizeDto {
 
   // engine activity instance specific ctor with mandatory and default but nullable fields
   public FlowNodeInstanceDto(
-      @NonNull final String definitionKey,
-      @NonNull final String definitionVersion,
+      final String definitionKey,
+      final String definitionVersion,
       final String tenantId,
-      @NonNull final String engine,
-      @NonNull final String processInstanceId,
-      @NonNull final String flowNodeId,
-      @NonNull final String flowNodeType,
-      @NonNull final String flowNodeInstanceId,
+      final String engine,
+      final String processInstanceId,
+      final String flowNodeId,
+      final String flowNodeType,
+      final String flowNodeInstanceId,
       final String userTaskInstanceId) {
+    if (definitionKey == null) {
+      throw new IllegalArgumentException("Definition key cannot be null");
+    }
+    if (definitionVersion == null) {
+      throw new IllegalArgumentException("Definition version cannot be null");
+    }
+    if (engine == null) {
+      throw new IllegalArgumentException("Engine cannot be null");
+    }
+    if (processInstanceId == null) {
+      throw new IllegalArgumentException("ProcessInstanceId cannot be null");
+    }
+    if (flowNodeId == null) {
+      throw new IllegalArgumentException("FlowNodeId cannot be null");
+    }
+    if (flowNodeType == null) {
+      throw new IllegalArgumentException("FlowNodeType cannot be null");
+    }
+    if (flowNodeInstanceId == null) {
+      throw new IllegalArgumentException("FlowNodeInstanceId cannot be null");
+    }
+
     this.flowNodeInstanceId = flowNodeInstanceId;
     this.flowNodeId = flowNodeId;
     this.flowNodeType = flowNodeType;
@@ -82,13 +98,32 @@ public class FlowNodeInstanceDto implements Serializable, OptimizeDto {
 
   // zeebe process activity instance specific ctor with mandatory fields
   public FlowNodeInstanceDto(
-      @NonNull final String definitionKey,
-      @NonNull final String definitionVersion,
+      final String definitionKey,
+      final String definitionVersion,
       final String tenantId,
-      @NonNull final String processInstanceId,
-      @NonNull final String flowNodeId,
-      @NonNull final String flowNodeType,
-      @NonNull final String flowNodeInstanceId) {
+      final String processInstanceId,
+      final String flowNodeId,
+      final String flowNodeType,
+      final String flowNodeInstanceId) {
+    if (definitionKey == null) {
+      throw new IllegalArgumentException("Definition key cannot be null");
+    }
+    if (definitionVersion == null) {
+      throw new IllegalArgumentException("Definition version cannot be null");
+    }
+    if (processInstanceId == null) {
+      throw new IllegalArgumentException("ProcessInstanceId cannot be null");
+    }
+    if (flowNodeId == null) {
+      throw new IllegalArgumentException("FlowNodeId cannot be null");
+    }
+    if (flowNodeType == null) {
+      throw new IllegalArgumentException("FlowNodeType cannot be null");
+    }
+    if (flowNodeInstanceId == null) {
+      throw new IllegalArgumentException("FlowNodeInstanceId cannot be null");
+    }
+
     this.flowNodeInstanceId = flowNodeInstanceId;
     this.flowNodeId = flowNodeId;
     this.flowNodeType = flowNodeType;
@@ -100,12 +135,31 @@ public class FlowNodeInstanceDto implements Serializable, OptimizeDto {
 
   // engine user task specific ctor with mandatory fields
   public FlowNodeInstanceDto(
-      @NonNull final String definitionKey,
-      @NonNull final String engine,
-      @NonNull final String processInstanceId,
-      @NonNull final String flowNodeId,
-      @NonNull final String flowNodeInstanceId,
-      @NonNull final String userTaskInstanceId) {
+      final String definitionKey,
+      final String engine,
+      final String processInstanceId,
+      final String flowNodeId,
+      final String flowNodeInstanceId,
+      final String userTaskInstanceId) {
+    if (definitionKey == null) {
+      throw new IllegalArgumentException("Definition key cannot be null");
+    }
+    if (engine == null) {
+      throw new IllegalArgumentException("Engine cannot be null");
+    }
+    if (processInstanceId == null) {
+      throw new IllegalArgumentException("ProcessInstanceId cannot be null");
+    }
+    if (flowNodeId == null) {
+      throw new IllegalArgumentException("FlowNodeId cannot be null");
+    }
+    if (flowNodeInstanceId == null) {
+      throw new IllegalArgumentException("FlowNodeInstanceId cannot be null");
+    }
+    if (userTaskInstanceId == null) {
+      throw new IllegalArgumentException("UserTaskInstanceId cannot be null");
+    }
+
     this.processInstanceId = processInstanceId;
     this.definitionKey = definitionKey;
     this.engine = engine;
@@ -117,10 +171,23 @@ public class FlowNodeInstanceDto implements Serializable, OptimizeDto {
 
   // engine identity link log specific ctor with mandatory fields
   public FlowNodeInstanceDto(
-      @NonNull final String definitionKey,
-      @NonNull final String engine,
-      @NonNull final String processInstanceId,
-      @NonNull final String userTaskInstanceId) {
+      final String definitionKey,
+      final String engine,
+      final String processInstanceId,
+      final String userTaskInstanceId) {
+    if (definitionKey == null) {
+      throw new IllegalArgumentException("Definition key cannot be null");
+    }
+    if (engine == null) {
+      throw new IllegalArgumentException("Engine cannot be null");
+    }
+    if (processInstanceId == null) {
+      throw new IllegalArgumentException("ProcessInstanceId cannot be null");
+    }
+    if (userTaskInstanceId == null) {
+      throw new IllegalArgumentException("UserTaskInstanceId cannot be null");
+    }
+
     this.processInstanceId = processInstanceId;
     this.definitionKey = definitionKey;
     this.engine = engine;
@@ -128,6 +195,330 @@ public class FlowNodeInstanceDto implements Serializable, OptimizeDto {
     this.userTaskInstanceId = userTaskInstanceId;
   }
 
+  public FlowNodeInstanceDto(
+      final String flowNodeInstanceId,
+      final String flowNodeId,
+      final String flowNodeType,
+      final String processInstanceId,
+      final Long totalDurationInMs,
+      final OffsetDateTime startDate,
+      final OffsetDateTime endDate,
+      final Boolean canceled,
+      final String definitionKey,
+      final String definitionVersion,
+      final String tenantId,
+      final String engine,
+      final String userTaskInstanceId,
+      final OffsetDateTime dueDate,
+      final String deleteReason,
+      final String assignee,
+      final List<String> candidateGroups,
+      final List<AssigneeOperationDto> assigneeOperations,
+      final List<CandidateGroupOperationDto> candidateGroupOperations,
+      final Long idleDurationInMs,
+      final Long workDurationInMs) {
+    this.flowNodeInstanceId = flowNodeInstanceId;
+    this.flowNodeId = flowNodeId;
+    this.flowNodeType = flowNodeType;
+    this.processInstanceId = processInstanceId;
+    this.totalDurationInMs = totalDurationInMs;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.canceled = canceled;
+    this.definitionKey = definitionKey;
+    this.definitionVersion = definitionVersion;
+    this.tenantId = tenantId;
+    this.engine = engine;
+    this.userTaskInstanceId = userTaskInstanceId;
+    this.dueDate = dueDate;
+    this.deleteReason = deleteReason;
+    this.assignee = assignee;
+    this.candidateGroups = candidateGroups;
+    this.assigneeOperations = assigneeOperations;
+    this.candidateGroupOperations = candidateGroupOperations;
+    this.idleDurationInMs = idleDurationInMs;
+    this.workDurationInMs = workDurationInMs;
+  }
+
+  public FlowNodeInstanceDto() {}
+
+  public String getFlowNodeInstanceId() {
+    return flowNodeInstanceId;
+  }
+
+  public void setFlowNodeInstanceId(final String flowNodeInstanceId) {
+    this.flowNodeInstanceId = flowNodeInstanceId;
+  }
+
+  public String getFlowNodeId() {
+    return flowNodeId;
+  }
+
+  public void setFlowNodeId(final String flowNodeId) {
+    this.flowNodeId = flowNodeId;
+  }
+
+  public String getFlowNodeType() {
+    return flowNodeType;
+  }
+
+  public void setFlowNodeType(final String flowNodeType) {
+    this.flowNodeType = flowNodeType;
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public Long getTotalDurationInMs() {
+    return totalDurationInMs;
+  }
+
+  public void setTotalDurationInMs(final Long totalDurationInMs) {
+    this.totalDurationInMs = totalDurationInMs;
+  }
+
+  public OffsetDateTime getStartDate() {
+    return startDate;
+  }
+
+  public void setStartDate(final OffsetDateTime startDate) {
+    this.startDate = startDate;
+  }
+
+  public OffsetDateTime getEndDate() {
+    return endDate;
+  }
+
+  public void setEndDate(final OffsetDateTime endDate) {
+    this.endDate = endDate;
+  }
+
+  public Boolean getCanceled() {
+    return canceled;
+  }
+
+  public void setCanceled(final Boolean canceled) {
+    this.canceled = canceled;
+  }
+
+  public String getDefinitionKey() {
+    return definitionKey;
+  }
+
+  public void setDefinitionKey(final String definitionKey) {
+    this.definitionKey = definitionKey;
+  }
+
+  public String getDefinitionVersion() {
+    return definitionVersion;
+  }
+
+  public void setDefinitionVersion(final String definitionVersion) {
+    this.definitionVersion = definitionVersion;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public String getEngine() {
+    return engine;
+  }
+
+  @JsonIgnore
+  public void setEngine(final String engine) {
+    this.engine = engine;
+  }
+
+  public String getUserTaskInstanceId() {
+    return userTaskInstanceId;
+  }
+
+  public void setUserTaskInstanceId(final String userTaskInstanceId) {
+    this.userTaskInstanceId = userTaskInstanceId;
+  }
+
+  public OffsetDateTime getDueDate() {
+    return dueDate;
+  }
+
+  public void setDueDate(final OffsetDateTime dueDate) {
+    this.dueDate = dueDate;
+  }
+
+  public String getDeleteReason() {
+    return deleteReason;
+  }
+
+  public void setDeleteReason(final String deleteReason) {
+    this.deleteReason = deleteReason;
+  }
+
+  public String getAssignee() {
+    return assignee;
+  }
+
+  public void setAssignee(final String assignee) {
+    this.assignee = assignee;
+  }
+
+  public List<String> getCandidateGroups() {
+    return candidateGroups;
+  }
+
+  public void setCandidateGroups(final List<String> candidateGroups) {
+    this.candidateGroups = candidateGroups;
+  }
+
+  public List<AssigneeOperationDto> getAssigneeOperations() {
+    return assigneeOperations;
+  }
+
+  public void setAssigneeOperations(final List<AssigneeOperationDto> assigneeOperations) {
+    this.assigneeOperations = assigneeOperations;
+  }
+
+  public List<CandidateGroupOperationDto> getCandidateGroupOperations() {
+    return candidateGroupOperations;
+  }
+
+  public void setCandidateGroupOperations(
+      final List<CandidateGroupOperationDto> candidateGroupOperations) {
+    this.candidateGroupOperations = candidateGroupOperations;
+  }
+
+  public Long getIdleDurationInMs() {
+    return idleDurationInMs;
+  }
+
+  public void setIdleDurationInMs(final Long idleDurationInMs) {
+    this.idleDurationInMs = idleDurationInMs;
+  }
+
+  public Long getWorkDurationInMs() {
+    return workDurationInMs;
+  }
+
+  public void setWorkDurationInMs(final Long workDurationInMs) {
+    this.workDurationInMs = workDurationInMs;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof FlowNodeInstanceDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FlowNodeInstanceDto that = (FlowNodeInstanceDto) o;
+    return Objects.equals(flowNodeInstanceId, that.flowNodeInstanceId)
+        && Objects.equals(flowNodeId, that.flowNodeId)
+        && Objects.equals(flowNodeType, that.flowNodeType)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(totalDurationInMs, that.totalDurationInMs)
+        && Objects.equals(startDate, that.startDate)
+        && Objects.equals(endDate, that.endDate)
+        && Objects.equals(canceled, that.canceled)
+        && Objects.equals(definitionKey, that.definitionKey)
+        && Objects.equals(definitionVersion, that.definitionVersion)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(engine, that.engine)
+        && Objects.equals(userTaskInstanceId, that.userTaskInstanceId)
+        && Objects.equals(dueDate, that.dueDate)
+        && Objects.equals(deleteReason, that.deleteReason)
+        && Objects.equals(assignee, that.assignee)
+        && Objects.equals(candidateGroups, that.candidateGroups)
+        && Objects.equals(assigneeOperations, that.assigneeOperations)
+        && Objects.equals(candidateGroupOperations, that.candidateGroupOperations)
+        && Objects.equals(idleDurationInMs, that.idleDurationInMs)
+        && Objects.equals(workDurationInMs, that.workDurationInMs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        flowNodeInstanceId,
+        flowNodeId,
+        flowNodeType,
+        processInstanceId,
+        totalDurationInMs,
+        startDate,
+        endDate,
+        canceled,
+        definitionKey,
+        definitionVersion,
+        tenantId,
+        engine,
+        userTaskInstanceId,
+        dueDate,
+        deleteReason,
+        assignee,
+        candidateGroups,
+        assigneeOperations,
+        candidateGroupOperations,
+        idleDurationInMs,
+        workDurationInMs);
+  }
+
+  @Override
+  public String toString() {
+    return "FlowNodeInstanceDto(flowNodeInstanceId="
+        + getFlowNodeInstanceId()
+        + ", flowNodeId="
+        + getFlowNodeId()
+        + ", flowNodeType="
+        + getFlowNodeType()
+        + ", processInstanceId="
+        + getProcessInstanceId()
+        + ", totalDurationInMs="
+        + getTotalDurationInMs()
+        + ", startDate="
+        + getStartDate()
+        + ", endDate="
+        + getEndDate()
+        + ", canceled="
+        + getCanceled()
+        + ", definitionKey="
+        + getDefinitionKey()
+        + ", definitionVersion="
+        + getDefinitionVersion()
+        + ", tenantId="
+        + getTenantId()
+        + ", engine="
+        + getEngine()
+        + ", userTaskInstanceId="
+        + getUserTaskInstanceId()
+        + ", dueDate="
+        + getDueDate()
+        + ", deleteReason="
+        + getDeleteReason()
+        + ", assignee="
+        + getAssignee()
+        + ", candidateGroups="
+        + getCandidateGroups()
+        + ", assigneeOperations="
+        + getAssigneeOperations()
+        + ", candidateGroupOperations="
+        + getCandidateGroupOperations()
+        + ", idleDurationInMs="
+        + getIdleDurationInMs()
+        + ", workDurationInMs="
+        + getWorkDurationInMs()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String flowNodeInstanceId = "flowNodeInstanceId";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/InitialProcessOwnerDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/InitialProcessOwnerDto.java
@@ -7,14 +7,61 @@
  */
 package io.camunda.optimize.dto.optimize.query.processoverview;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class InitialProcessOwnerDto {
+
   private String processDefinitionKey;
   private String owner;
+
+  public InitialProcessOwnerDto(final String processDefinitionKey, final String owner) {
+    this.processDefinitionKey = processDefinitionKey;
+    this.owner = owner;
+  }
+
+  public InitialProcessOwnerDto() {}
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(final String owner) {
+    this.owner = owner;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof InitialProcessOwnerDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final InitialProcessOwnerDto that = (InitialProcessOwnerDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(owner, that.owner);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processDefinitionKey, owner);
+  }
+
+  @Override
+  public String toString() {
+    return "InitialProcessOwnerDto(processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", owner="
+        + getOwner()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/KpiResultDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/KpiResultDto.java
@@ -16,12 +16,9 @@ import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.time.Duration;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
-@Data
-@NoArgsConstructor
 public class KpiResultDto {
 
   private String reportId;
@@ -36,6 +33,8 @@ public class KpiResultDto {
   private KpiType type;
   private ViewProperty measure;
   private TargetValueUnit unit;
+
+  public KpiResultDto() {}
 
   @JsonIgnore
   public boolean isTargetMet() {
@@ -66,6 +65,130 @@ public class KpiResultDto {
     }
   }
 
+  public String getReportId() {
+    return reportId;
+  }
+
+  public void setReportId(final String reportId) {
+    this.reportId = reportId;
+  }
+
+  public String getCollectionId() {
+    return collectionId;
+  }
+
+  public void setCollectionId(final String collectionId) {
+    this.collectionId = collectionId;
+  }
+
+  public String getReportName() {
+    return reportName;
+  }
+
+  public void setReportName(final String reportName) {
+    this.reportName = reportName;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
+  }
+
+  public String getTarget() {
+    return target;
+  }
+
+  public void setTarget(final String target) {
+    this.target = target;
+  }
+
+  public boolean isBelow() {
+    return isBelow;
+  }
+
+  @JsonProperty("isBelow")
+  public void setBelow(final boolean isBelow) {
+    this.isBelow = isBelow;
+  }
+
+  public KpiType getType() {
+    return type;
+  }
+
+  public void setType(final KpiType type) {
+    this.type = type;
+  }
+
+  public ViewProperty getMeasure() {
+    return measure;
+  }
+
+  public void setMeasure(final ViewProperty measure) {
+    this.measure = measure;
+  }
+
+  public TargetValueUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final TargetValueUnit unit) {
+    this.unit = unit;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof KpiResultDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final KpiResultDto that = (KpiResultDto) o;
+    return isBelow == that.isBelow
+        && Objects.equals(reportId, that.reportId)
+        && Objects.equals(collectionId, that.collectionId)
+        && Objects.equals(reportName, that.reportName)
+        && Objects.equals(value, that.value)
+        && Objects.equals(target, that.target)
+        && type == that.type
+        && Objects.equals(measure, that.measure)
+        && unit == that.unit;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        reportId, collectionId, reportName, value, target, isBelow, type, measure, unit);
+  }
+
+  @Override
+  public String toString() {
+    return "KpiResultDto(reportId="
+        + getReportId()
+        + ", collectionId="
+        + getCollectionId()
+        + ", reportName="
+        + getReportName()
+        + ", value="
+        + getValue()
+        + ", target="
+        + getTarget()
+        + ", isBelow="
+        + isBelow()
+        + ", type="
+        + getType()
+        + ", measure="
+        + getMeasure()
+        + ", unit="
+        + getUnit()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String reportId = "reportId";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestDto.java
@@ -8,15 +8,8 @@
 package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
-@AllArgsConstructor
-@NoArgsConstructor
 public class ProcessDigestDto extends ProcessDigestResponseDto {
 
   // This is the baseline results, or in other words the results that were included in the
@@ -28,7 +21,49 @@ public class ProcessDigestDto extends ProcessDigestResponseDto {
     this.kpiReportResults = kpiReportResults;
   }
 
+  public ProcessDigestDto(final Map<String, String> kpiReportResults) {
+    this.kpiReportResults = kpiReportResults;
+  }
+
+  public ProcessDigestDto() {}
+
+  public Map<String, String> getKpiReportResults() {
+    return kpiReportResults;
+  }
+
+  public void setKpiReportResults(final Map<String, String> kpiReportResults) {
+    this.kpiReportResults = kpiReportResults;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessDigestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final ProcessDigestDto that = (ProcessDigestDto) o;
+    return Objects.equals(kpiReportResults, that.kpiReportResults);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), kpiReportResults);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessDigestDto(kpiReportResults=" + getKpiReportResults() + ")";
+  }
+
   /** Needed to inherit field name constants from {@link ProcessDigestResponseDto} */
+  @SuppressWarnings("checkstyle:ConstantName")
   public static class Fields extends ProcessDigestResponseDto.Fields {
 
     public static final String kpiReportResults = "kpiReportResults";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestRequestDto.java
@@ -8,15 +8,48 @@
 package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class ProcessDigestRequestDto {
 
   @JsonProperty("enabled")
   private boolean enabled;
+
+  public ProcessDigestRequestDto(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public ProcessDigestRequestDto() {}
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  @JsonProperty("enabled")
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessDigestRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessDigestRequestDto that = (ProcessDigestRequestDto) o;
+    return enabled == that.enabled;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(enabled);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessDigestRequestDto(enabled=" + isEnabled() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestResponseDto.java
@@ -9,23 +9,57 @@ package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class ProcessDigestResponseDto implements OptimizeDto {
 
   @JsonProperty("enabled")
   protected boolean enabled;
 
+  public ProcessDigestResponseDto(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public ProcessDigestResponseDto() {}
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  @JsonProperty("enabled")
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessDigestResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessDigestResponseDto that = (ProcessDigestResponseDto) o;
+    return enabled == that.enabled;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(enabled);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessDigestResponseDto(enabled=" + isEnabled() + ")";
+  }
+
   // needed to allow inheritance of field name constants
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @SuppressWarnings("checkstyle:ConstantName")
   public static class Fields {
 
     public static final String enabled = "enabled";
+
+    protected Fields() {}
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOverviewDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOverviewDto.java
@@ -9,13 +9,8 @@ package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class ProcessOverviewDto implements OptimizeDto {
 
   private String owner;
@@ -23,6 +18,86 @@ public class ProcessOverviewDto implements OptimizeDto {
   private ProcessDigestDto digest;
   private Map<String, String> lastKpiEvaluationResults;
 
+  public ProcessOverviewDto(
+      final String owner,
+      final String processDefinitionKey,
+      final ProcessDigestDto digest,
+      final Map<String, String> lastKpiEvaluationResults) {
+    this.owner = owner;
+    this.processDefinitionKey = processDefinitionKey;
+    this.digest = digest;
+    this.lastKpiEvaluationResults = lastKpiEvaluationResults;
+  }
+
+  public ProcessOverviewDto() {}
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(final String owner) {
+    this.owner = owner;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public ProcessDigestDto getDigest() {
+    return digest;
+  }
+
+  public void setDigest(final ProcessDigestDto digest) {
+    this.digest = digest;
+  }
+
+  public Map<String, String> getLastKpiEvaluationResults() {
+    return lastKpiEvaluationResults;
+  }
+
+  public void setLastKpiEvaluationResults(final Map<String, String> lastKpiEvaluationResults) {
+    this.lastKpiEvaluationResults = lastKpiEvaluationResults;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessOverviewDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessOverviewDto that = (ProcessOverviewDto) o;
+    return Objects.equals(owner, that.owner)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(digest, that.digest)
+        && Objects.equals(lastKpiEvaluationResults, that.lastKpiEvaluationResults);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(owner, processDefinitionKey, digest, lastKpiEvaluationResults);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessOverviewDto(owner="
+        + getOwner()
+        + ", processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", digest="
+        + getDigest()
+        + ", lastKpiEvaluationResults="
+        + getLastKpiEvaluationResults()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String owner = "owner";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOverviewResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOverviewResponseDto.java
@@ -8,13 +8,8 @@
 package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class ProcessOverviewResponseDto {
 
   private String processDefinitionName;
@@ -23,6 +18,99 @@ public class ProcessOverviewResponseDto {
   private ProcessDigestResponseDto digest;
   private List<KpiResultDto> kpis;
 
+  public ProcessOverviewResponseDto(
+      final String processDefinitionName,
+      final String processDefinitionKey,
+      final ProcessOwnerResponseDto owner,
+      final ProcessDigestResponseDto digest,
+      final List<KpiResultDto> kpis) {
+    this.processDefinitionName = processDefinitionName;
+    this.processDefinitionKey = processDefinitionKey;
+    this.owner = owner;
+    this.digest = digest;
+    this.kpis = kpis;
+  }
+
+  public ProcessOverviewResponseDto() {}
+
+  public String getProcessDefinitionName() {
+    return processDefinitionName;
+  }
+
+  public void setProcessDefinitionName(final String processDefinitionName) {
+    this.processDefinitionName = processDefinitionName;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public ProcessOwnerResponseDto getOwner() {
+    return owner;
+  }
+
+  public void setOwner(final ProcessOwnerResponseDto owner) {
+    this.owner = owner;
+  }
+
+  public ProcessDigestResponseDto getDigest() {
+    return digest;
+  }
+
+  public void setDigest(final ProcessDigestResponseDto digest) {
+    this.digest = digest;
+  }
+
+  public List<KpiResultDto> getKpis() {
+    return kpis;
+  }
+
+  public void setKpis(final List<KpiResultDto> kpis) {
+    this.kpis = kpis;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessOverviewResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessOverviewResponseDto that = (ProcessOverviewResponseDto) o;
+    return Objects.equals(processDefinitionName, that.processDefinitionName)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(digest, that.digest)
+        && Objects.equals(kpis, that.kpis);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processDefinitionName, processDefinitionKey, owner, digest, kpis);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessOverviewResponseDto(processDefinitionName="
+        + getProcessDefinitionName()
+        + ", processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", owner="
+        + getOwner()
+        + ", digest="
+        + getDigest()
+        + ", kpis="
+        + getKpis()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String processDefinitionName = "processDefinitionName";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOwnerResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOwnerResponseDto.java
@@ -8,15 +8,56 @@
 package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class ProcessOwnerResponseDto implements OptimizeDto {
 
   private String id;
   private String name;
+
+  public ProcessOwnerResponseDto(final String id, final String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public ProcessOwnerResponseDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessOwnerResponseDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessOwnerResponseDto that = (ProcessOwnerResponseDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessOwnerResponseDto(id=" + getId() + ", name=" + getName() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessUpdateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessUpdateDto.java
@@ -9,15 +9,62 @@ package io.camunda.optimize.dto.optimize.query.processoverview;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class ProcessUpdateDto implements OptimizeDto {
 
   private String ownerId;
   @NotNull private ProcessDigestRequestDto processDigest;
+
+  public ProcessUpdateDto(
+      final String ownerId, @NotNull final ProcessDigestRequestDto processDigest) {
+    this.ownerId = ownerId;
+    this.processDigest = processDigest;
+  }
+
+  public ProcessUpdateDto() {}
+
+  public String getOwnerId() {
+    return ownerId;
+  }
+
+  public void setOwnerId(final String ownerId) {
+    this.ownerId = ownerId;
+  }
+
+  public @NotNull ProcessDigestRequestDto getProcessDigest() {
+    return processDigest;
+  }
+
+  public void setProcessDigest(@NotNull final ProcessDigestRequestDto processDigest) {
+    this.processDigest = processDigest;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessUpdateDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessUpdateDto that = (ProcessUpdateDto) o;
+    return Objects.equals(ownerId, that.ownerId)
+        && Objects.equals(processDigest, that.processDigest);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(ownerId, processDigest);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessUpdateDto(ownerId="
+        + getOwnerId()
+        + ", processDigest="
+        + getProcessDigest()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/AdditionalProcessReportEvaluationFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/AdditionalProcessReportEvaluationFilterDto.java
@@ -10,13 +10,47 @@ package io.camunda.optimize.dto.optimize.query.report;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class AdditionalProcessReportEvaluationFilterDto {
+
   protected List<ProcessFilterDto<?>> filter = new ArrayList<>();
+
+  public AdditionalProcessReportEvaluationFilterDto(final List<ProcessFilterDto<?>> filter) {
+    this.filter = filter;
+  }
+
+  public AdditionalProcessReportEvaluationFilterDto() {}
+
+  public List<ProcessFilterDto<?>> getFilter() {
+    return filter;
+  }
+
+  public void setFilter(final List<ProcessFilterDto<?>> filter) {
+    this.filter = filter;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof AdditionalProcessReportEvaluationFilterDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AdditionalProcessReportEvaluationFilterDto that =
+        (AdditionalProcessReportEvaluationFilterDto) o;
+    return Objects.equals(filter, that.filter);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(filter);
+  }
+
+  @Override
+  public String toString() {
+    return "AdditionalProcessReportEvaluationFilterDto(filter=" + getFilter() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/AuthorizedReportEvaluationResult.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/AuthorizedReportEvaluationResult.java
@@ -9,17 +9,50 @@ package io.camunda.optimize.dto.optimize.query.report;
 
 import io.camunda.optimize.dto.optimize.AuthorizedEntityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class AuthorizedReportEvaluationResult extends AuthorizedEntityDto {
+
   private ReportEvaluationResult evaluationResult;
 
   public AuthorizedReportEvaluationResult(
       final ReportEvaluationResult evaluationResult, final RoleType currentUserRole) {
     super(currentUserRole);
     this.evaluationResult = evaluationResult;
+  }
+
+  public ReportEvaluationResult getEvaluationResult() {
+    return evaluationResult;
+  }
+
+  public void setEvaluationResult(final ReportEvaluationResult evaluationResult) {
+    this.evaluationResult = evaluationResult;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof AuthorizedReportEvaluationResult;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedReportEvaluationResult that = (AuthorizedReportEvaluationResult) o;
+    return Objects.equals(evaluationResult, that.evaluationResult);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), evaluationResult);
+  }
+
+  @Override
+  public String toString() {
+    return "AuthorizedReportEvaluationResult(evaluationResult=" + getEvaluationResult() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportDefinitionDto.java
@@ -16,13 +16,8 @@ import io.camunda.optimize.dto.optimize.query.entity.EntityResponseDto;
 import io.camunda.optimize.dto.optimize.query.entity.EntityType;
 import jakarta.validation.Valid;
 import java.time.OffsetDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.experimental.SuperBuilder;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@SuperBuilder(toBuilder = true)
 public class ReportDefinitionDto<D extends ReportDataDto> implements CollectionEntity {
 
   protected String id;
@@ -46,6 +41,75 @@ public class ReportDefinitionDto<D extends ReportDataDto> implements CollectionE
     this.reportType = reportType;
   }
 
+  public ReportDefinitionDto(
+      final String id,
+      final String name,
+      final String description,
+      final OffsetDateTime lastModified,
+      final OffsetDateTime created,
+      final String owner,
+      final String lastModifier,
+      final String collectionId,
+      @Valid final D data,
+      final boolean combined,
+      final ReportType reportType) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+    this.lastModified = lastModified;
+    this.created = created;
+    this.owner = owner;
+    this.lastModifier = lastModifier;
+    this.collectionId = collectionId;
+    this.data = data;
+    this.combined = combined;
+    this.reportType = reportType;
+  }
+
+  protected ReportDefinitionDto(final ReportDefinitionDtoBuilder<D, ?, ?> b) {
+    id = b.id;
+    name = b.name;
+    description = b.description;
+    lastModified = b.lastModified;
+    created = b.created;
+    owner = b.owner;
+    lastModifier = b.lastModifier;
+    collectionId = b.collectionId;
+    data = b.data;
+    combined = b.combined;
+    reportType = b.reportType;
+  }
+
+  @JsonIgnore
+  public DefinitionType getDefinitionType() {
+    return reportType.toDefinitionType();
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String getCollectionId() {
+    return collectionId;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getOwner() {
+    return owner;
+  }
+
+  @Override
+  public OffsetDateTime getLastModified() {
+    return lastModified;
+  }
+
   @Override
   public EntityResponseDto toEntityDto(final RoleType roleType) {
     return new EntityResponseDto(
@@ -62,11 +126,141 @@ public class ReportDefinitionDto<D extends ReportDataDto> implements CollectionE
         roleType);
   }
 
-  @JsonIgnore
-  public DefinitionType getDefinitionType() {
-    return reportType.toDefinitionType();
+  public void setLastModified(final OffsetDateTime lastModified) {
+    this.lastModified = lastModified;
   }
 
+  public void setOwner(final String owner) {
+    this.owner = owner;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public void setCollectionId(final String collectionId) {
+    this.collectionId = collectionId;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
+  }
+
+  public OffsetDateTime getCreated() {
+    return created;
+  }
+
+  public void setCreated(final OffsetDateTime created) {
+    this.created = created;
+  }
+
+  public String getLastModifier() {
+    return lastModifier;
+  }
+
+  public void setLastModifier(final String lastModifier) {
+    this.lastModifier = lastModifier;
+  }
+
+  public @Valid D getData() {
+    return data;
+  }
+
+  public void setData(@Valid final D data) {
+    this.data = data;
+  }
+
+  public boolean isCombined() {
+    return combined;
+  }
+
+  public ReportType getReportType() {
+    return reportType;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ReportDefinitionDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportDefinitionDto<?> that = (ReportDefinitionDto<?>) o;
+    return combined == that.combined
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(created, that.created)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && Objects.equals(collectionId, that.collectionId)
+        && Objects.equals(data, that.data)
+        && reportType == that.reportType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        name,
+        description,
+        lastModified,
+        created,
+        owner,
+        lastModifier,
+        collectionId,
+        data,
+        combined,
+        reportType);
+  }
+
+  @Override
+  public String toString() {
+    return "ReportDefinitionDto(id="
+        + getId()
+        + ", name="
+        + getName()
+        + ", description="
+        + getDescription()
+        + ", lastModified="
+        + getLastModified()
+        + ", created="
+        + getCreated()
+        + ", owner="
+        + getOwner()
+        + ", lastModifier="
+        + getLastModifier()
+        + ", collectionId="
+        + getCollectionId()
+        + ", data="
+        + getData()
+        + ", combined="
+        + isCombined()
+        + ", reportType="
+        + getReportType()
+        + ")";
+  }
+
+  public static <D extends ReportDataDto> ReportDefinitionDtoBuilder<D, ?, ?> builder() {
+    return new ReportDefinitionDtoBuilderImpl<D>();
+  }
+
+  public ReportDefinitionDtoBuilder<D, ?, ?> toBuilder() {
+    return new ReportDefinitionDtoBuilderImpl<D>().fillValuesFrom(this);
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";
@@ -80,5 +274,150 @@ public class ReportDefinitionDto<D extends ReportDataDto> implements CollectionE
     public static final String data = "data";
     public static final String combined = "combined";
     public static final String reportType = "reportType";
+  }
+
+  public abstract static class ReportDefinitionDtoBuilder<
+      D extends ReportDataDto,
+      C extends ReportDefinitionDto<D>,
+      B extends ReportDefinitionDtoBuilder<D, C, B>> {
+
+    private String id;
+    private String name;
+    private String description;
+    private OffsetDateTime lastModified;
+    private OffsetDateTime created;
+    private String owner;
+    private String lastModifier;
+    private String collectionId;
+    private @Valid D data;
+    private boolean combined;
+    private ReportType reportType;
+
+    public @Valid D getData() {
+      return data;
+    }
+
+    public B id(final String id) {
+      this.id = id;
+      return self();
+    }
+
+    public B name(final String name) {
+      this.name = name;
+      return self();
+    }
+
+    public B description(final String description) {
+      this.description = description;
+      return self();
+    }
+
+    public B lastModified(final OffsetDateTime lastModified) {
+      this.lastModified = lastModified;
+      return self();
+    }
+
+    public B created(final OffsetDateTime created) {
+      this.created = created;
+      return self();
+    }
+
+    public B owner(final String owner) {
+      this.owner = owner;
+      return self();
+    }
+
+    public B lastModifier(final String lastModifier) {
+      this.lastModifier = lastModifier;
+      return self();
+    }
+
+    public B collectionId(final String collectionId) {
+      this.collectionId = collectionId;
+      return self();
+    }
+
+    public B data(@Valid final D data) {
+      this.data = data;
+      return self();
+    }
+
+    public B combined(final boolean combined) {
+      this.combined = combined;
+      return self();
+    }
+
+    public B reportType(final ReportType reportType) {
+      this.reportType = reportType;
+      return self();
+    }
+
+    private static <D extends ReportDataDto> void fillValuesFromInstanceIntoBuilder(
+        final ReportDefinitionDto<D> instance, final ReportDefinitionDtoBuilder<D, ?, ?> b) {
+      b.id(instance.id);
+      b.name(instance.name);
+      b.description(instance.description);
+      b.lastModified(instance.lastModified);
+      b.created(instance.created);
+      b.owner(instance.owner);
+      b.lastModifier(instance.lastModifier);
+      b.collectionId(instance.collectionId);
+      b.data(instance.data);
+      b.combined(instance.combined);
+      b.reportType(instance.reportType);
+    }
+
+    protected B fillValuesFrom(final C instance) {
+      ReportDefinitionDtoBuilder.fillValuesFromInstanceIntoBuilder(instance, this);
+      return self();
+    }
+
+    protected abstract B self();
+
+    public abstract C build();
+
+    @Override
+    public String toString() {
+      return "ReportDefinitionDto.ReportDefinitionDtoBuilder(id="
+          + id
+          + ", name="
+          + name
+          + ", description="
+          + description
+          + ", lastModified="
+          + lastModified
+          + ", created="
+          + created
+          + ", owner="
+          + owner
+          + ", lastModifier="
+          + lastModifier
+          + ", collectionId="
+          + collectionId
+          + ", data="
+          + data
+          + ", combined="
+          + combined
+          + ", reportType="
+          + reportType
+          + ")";
+    }
+  }
+
+  private static final class ReportDefinitionDtoBuilderImpl<D extends ReportDataDto>
+      extends ReportDefinitionDtoBuilder<
+          D, ReportDefinitionDto<D>, ReportDefinitionDtoBuilderImpl<D>> {
+
+    private ReportDefinitionDtoBuilderImpl() {}
+
+    @Override
+    protected ReportDefinitionDtoBuilderImpl<D> self() {
+      return this;
+    }
+
+    @Override
+    public ReportDefinitionDto<D> build() {
+      return new ReportDefinitionDto<D>(this);
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportDefinitionUpdateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportDefinitionUpdateDto.java
@@ -9,10 +9,9 @@ package io.camunda.optimize.dto.optimize.query.report;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.OffsetDateTime;
-import lombok.Data;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Data
 public class ReportDefinitionUpdateDto {
 
   protected String id;
@@ -23,4 +22,117 @@ public class ReportDefinitionUpdateDto {
   protected String owner;
   protected String lastModifier;
   protected String collectionId;
+
+  public ReportDefinitionUpdateDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
+  }
+
+  public OffsetDateTime getLastModified() {
+    return lastModified;
+  }
+
+  public void setLastModified(final OffsetDateTime lastModified) {
+    this.lastModified = lastModified;
+  }
+
+  public OffsetDateTime getCreated() {
+    return created;
+  }
+
+  public void setCreated(final OffsetDateTime created) {
+    this.created = created;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(final String owner) {
+    this.owner = owner;
+  }
+
+  public String getLastModifier() {
+    return lastModifier;
+  }
+
+  public void setLastModifier(final String lastModifier) {
+    this.lastModifier = lastModifier;
+  }
+
+  public String getCollectionId() {
+    return collectionId;
+  }
+
+  public void setCollectionId(final String collectionId) {
+    this.collectionId = collectionId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ReportDefinitionUpdateDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportDefinitionUpdateDto that = (ReportDefinitionUpdateDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(lastModified, that.lastModified)
+        && Objects.equals(created, that.created)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastModifier, that.lastModifier)
+        && Objects.equals(collectionId, that.collectionId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id, name, description, lastModified, created, owner, lastModifier, collectionId);
+  }
+
+  @Override
+  public String toString() {
+    return "ReportDefinitionUpdateDto(id="
+        + getId()
+        + ", name="
+        + getName()
+        + ", description="
+        + getDescription()
+        + ", lastModified="
+        + getLastModified()
+        + ", created="
+        + getCreated()
+        + ", owner="
+        + getOwner()
+        + ", lastModifier="
+        + getLastModifier()
+        + ", collectionId="
+        + getCollectionId()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportEvaluationResult.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportEvaluationResult.java
@@ -10,17 +10,21 @@ package io.camunda.optimize.dto.optimize.query.report;
 import io.camunda.optimize.dto.optimize.rest.pagination.PaginatedDataExportDto;
 import java.time.ZoneId;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Data
 public abstract class ReportEvaluationResult {
 
-  @NonNull protected ReportDefinitionDto<?> reportDefinition;
+  protected ReportDefinitionDto<?> reportDefinition;
+
+  public ReportEvaluationResult(final ReportDefinitionDto<?> reportDefinition) {
+    if (reportDefinition == null) {
+      throw new IllegalArgumentException("reportDefinition cannot be null");
+    }
+
+    this.reportDefinition = reportDefinition;
+  }
+
+  public ReportEvaluationResult() {}
 
   public String getId() {
     return reportDefinition.getId();
@@ -30,4 +34,39 @@ public abstract class ReportEvaluationResult {
       final Integer limit, final Integer offset, final ZoneId timezone);
 
   public abstract PaginatedDataExportDto getResult();
+
+  public ReportDefinitionDto<?> getReportDefinition() {
+    return reportDefinition;
+  }
+
+  public void setReportDefinition(final ReportDefinitionDto<?> reportDefinition) {
+    if (reportDefinition == null) {
+      throw new IllegalArgumentException("reportDefinition cannot be null");
+    }
+
+    this.reportDefinition = reportDefinition;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ReportEvaluationResult;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportEvaluationResult that = (ReportEvaluationResult) o;
+    return Objects.equals(reportDefinition, that.reportDefinition);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(reportDefinition);
+  }
+
+  @Override
+  public String toString() {
+    return "ReportEvaluationResult(reportDefinition=" + getReportDefinition() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedProcessReportDefinitionUpdateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedProcessReportDefinitionUpdateDto.java
@@ -9,13 +9,48 @@ package io.camunda.optimize.dto.optimize.query.report.combined;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionUpdateDto;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class CombinedProcessReportDefinitionUpdateDto extends ReportDefinitionUpdateDto {
 
   protected CombinedReportDataDto data;
+
+  public CombinedProcessReportDefinitionUpdateDto() {}
+
+  public CombinedReportDataDto getData() {
+    return data;
+  }
+
+  public void setData(final CombinedReportDataDto data) {
+    this.data = data;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof CombinedProcessReportDefinitionUpdateDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final CombinedProcessReportDefinitionUpdateDto that =
+        (CombinedProcessReportDefinitionUpdateDto) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), data);
+  }
+
+  @Override
+  public String toString() {
+    return "CombinedProcessReportDefinitionUpdateDto(data=" + getData() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedReportDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedReportDataDto.java
@@ -15,20 +15,26 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class CombinedReportDataDto implements ReportDataDto {
 
   protected CombinedReportConfigurationDto configuration = new CombinedReportConfigurationDto();
   protected ProcessVisualization visualization;
   protected List<CombinedReportItemDto> reports = new ArrayList<>();
+
+  public CombinedReportDataDto(
+      final CombinedReportConfigurationDto configuration,
+      final ProcessVisualization visualization,
+      final List<CombinedReportItemDto> reports) {
+    this.configuration = configuration;
+    this.visualization = visualization;
+    this.reports = reports;
+  }
+
+  public CombinedReportDataDto() {}
 
   @JsonIgnore
   public List<String> getReportIds() {
@@ -50,6 +56,62 @@ public class CombinedReportDataDto implements ReportDataDto {
     return Collections.singletonList(createCommandKey());
   }
 
+  public CombinedReportConfigurationDto getConfiguration() {
+    return configuration;
+  }
+
+  public void setConfiguration(final CombinedReportConfigurationDto configuration) {
+    this.configuration = configuration;
+  }
+
+  public ProcessVisualization getVisualization() {
+    return visualization;
+  }
+
+  public void setVisualization(final ProcessVisualization visualization) {
+    this.visualization = visualization;
+  }
+
+  public List<CombinedReportItemDto> getReports() {
+    return reports;
+  }
+
+  public void setReports(final List<CombinedReportItemDto> reports) {
+    this.reports = reports;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CombinedReportDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CombinedReportDataDto that = (CombinedReportDataDto) o;
+    return Objects.equals(configuration, that.configuration)
+        && visualization == that.visualization
+        && Objects.equals(reports, that.reports);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(configuration, visualization, reports);
+  }
+
+  @Override
+  public String toString() {
+    return "CombinedReportDataDto(configuration="
+        + getConfiguration()
+        + ", visualization="
+        + getVisualization()
+        + ", reports="
+        + getReports()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String configuration = "configuration";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedReportItemDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedReportItemDto.java
@@ -9,28 +9,116 @@ package io.camunda.optimize.dto.optimize.query.report.combined;
 
 import static io.camunda.optimize.dto.optimize.ReportConstants.DEFAULT_CONFIGURATION_COLOR;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@Builder(toBuilder = true)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class CombinedReportItemDto {
 
   private String id;
-  @Builder.Default private String color = DEFAULT_CONFIGURATION_COLOR;
+  private String color = DEFAULT_CONFIGURATION_COLOR;
 
   public CombinedReportItemDto(final String id) {
     this.id = id;
   }
 
+  public CombinedReportItemDto(final String id, final String color) {
+    this.id = id;
+    this.color = color;
+  }
+
+  protected CombinedReportItemDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getColor() {
+    return color;
+  }
+
+  public void setColor(final String color) {
+    this.color = color;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CombinedReportItemDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CombinedReportItemDto that = (CombinedReportItemDto) o;
+    return Objects.equals(id, that.id) && Objects.equals(color, that.color);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, color);
+  }
+
+  @Override
+  public String toString() {
+    return "CombinedReportItemDto(id=" + getId() + ", color=" + getColor() + ")";
+  }
+
+  private static String defaultColor() {
+    return DEFAULT_CONFIGURATION_COLOR;
+  }
+
+  public static CombinedReportItemDtoBuilder builder() {
+    return new CombinedReportItemDtoBuilder();
+  }
+
+  public CombinedReportItemDtoBuilder toBuilder() {
+    return new CombinedReportItemDtoBuilder().id(id).color(color);
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";
     public static final String color = "color";
+  }
+
+  public static class CombinedReportItemDtoBuilder {
+
+    private String id;
+    private String colorValue;
+    private boolean colorSet;
+
+    CombinedReportItemDtoBuilder() {}
+
+    public CombinedReportItemDtoBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public CombinedReportItemDtoBuilder color(final String color) {
+      colorValue = color;
+      colorSet = true;
+      return this;
+    }
+
+    public CombinedReportItemDto build() {
+      String colorValue = this.colorValue;
+      if (!colorSet) {
+        colorValue = CombinedReportItemDto.defaultColor();
+      }
+      return new CombinedReportItemDto(id, colorValue);
+    }
+
+    @Override
+    public String toString() {
+      return "CombinedReportItemDto.CombinedReportItemDtoBuilder(id="
+          + id
+          + ", colorValue="
+          + colorValue
+          + ")";
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/CombinedReportConfigurationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/CombinedReportConfigurationDto.java
@@ -10,13 +10,7 @@ package io.camunda.optimize.dto.optimize.query.report.combined.configuration;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.dto.optimize.query.report.combined.configuration.target_value.CombinedReportTargetValueDto;
 import java.util.Objects;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 
-@Getter
-@Setter
-@ToString
 public class CombinedReportConfigurationDto {
 
   private Boolean pointMarkers = true;
@@ -37,12 +31,10 @@ public class CombinedReportConfigurationDto {
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof final CombinedReportConfigurationDto that)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
+    final CombinedReportConfigurationDto that = (CombinedReportConfigurationDto) o;
     return Objects.equals(pointMarkers, that.pointMarkers)
         && Objects.equals(hideRelativeValue, that.hideRelativeValue)
         && Objects.equals(hideAbsoluteValue, that.hideAbsoluteValue)
@@ -64,5 +56,92 @@ public class CombinedReportConfigurationDto {
         alwaysShowRelative,
         alwaysShowAbsolute,
         targetValue);
+  }
+
+  @Override
+  public String toString() {
+    return "CombinedReportConfigurationDto(pointMarkers="
+        + getPointMarkers()
+        + ", hideRelativeValue="
+        + getHideRelativeValue()
+        + ", hideAbsoluteValue="
+        + getHideAbsoluteValue()
+        + ", yLabel="
+        + getYLabel()
+        + ", xLabel="
+        + getXLabel()
+        + ", alwaysShowRelative="
+        + getAlwaysShowRelative()
+        + ", alwaysShowAbsolute="
+        + getAlwaysShowAbsolute()
+        + ", targetValue="
+        + getTargetValue()
+        + ")";
+  }
+
+  public Boolean getPointMarkers() {
+    return pointMarkers;
+  }
+
+  public void setPointMarkers(final Boolean pointMarkers) {
+    this.pointMarkers = pointMarkers;
+  }
+
+  public Boolean getHideRelativeValue() {
+    return hideRelativeValue;
+  }
+
+  public void setHideRelativeValue(final Boolean hideRelativeValue) {
+    this.hideRelativeValue = hideRelativeValue;
+  }
+
+  public Boolean getHideAbsoluteValue() {
+    return hideAbsoluteValue;
+  }
+
+  public void setHideAbsoluteValue(final Boolean hideAbsoluteValue) {
+    this.hideAbsoluteValue = hideAbsoluteValue;
+  }
+
+  public String getYLabel() {
+    return yLabel;
+  }
+
+  @JsonProperty("yLabel")
+  public void setYLabel(final String yLabel) {
+    this.yLabel = yLabel;
+  }
+
+  public String getXLabel() {
+    return xLabel;
+  }
+
+  @JsonProperty("xLabel")
+  public void setXLabel(final String xLabel) {
+    this.xLabel = xLabel;
+  }
+
+  public Boolean getAlwaysShowRelative() {
+    return alwaysShowRelative;
+  }
+
+  public void setAlwaysShowRelative(final Boolean alwaysShowRelative) {
+    this.alwaysShowRelative = alwaysShowRelative;
+  }
+
+  public Boolean getAlwaysShowAbsolute() {
+    return alwaysShowAbsolute;
+  }
+
+  public void setAlwaysShowAbsolute(final Boolean alwaysShowAbsolute) {
+    this.alwaysShowAbsolute = alwaysShowAbsolute;
+  }
+
+  public CombinedReportTargetValueDto getTargetValue() {
+    return targetValue;
+  }
+
+  public void setTargetValue(final CombinedReportTargetValueDto targetValue) {
+    this.targetValue = targetValue;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/target_value/CombinedReportCountChartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/target_value/CombinedReportCountChartDto.java
@@ -8,35 +8,51 @@
 package io.camunda.optimize.dto.optimize.query.report.combined.configuration.target_value;
 
 import java.util.Objects;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@ToString
 public class CombinedReportCountChartDto {
 
   private Boolean isBelow = false;
   private String value = "100";
 
+  public CombinedReportCountChartDto(final Boolean isBelow, final String value) {
+    this.isBelow = isBelow;
+    this.value = value;
+  }
+
+  public CombinedReportCountChartDto() {}
+
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof final CombinedReportCountChartDto that)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
+    final CombinedReportCountChartDto that = (CombinedReportCountChartDto) o;
     return Objects.equals(isBelow, that.isBelow) && Objects.equals(value, that.value);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(isBelow, value);
+  }
+
+  @Override
+  public String toString() {
+    return "CombinedReportCountChartDto(isBelow=" + getIsBelow() + ", value=" + getValue() + ")";
+  }
+
+  public Boolean getIsBelow() {
+    return isBelow;
+  }
+
+  public void setIsBelow(final Boolean isBelow) {
+    this.isBelow = isBelow;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/target_value/CombinedReportDurationChartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/target_value/CombinedReportDurationChartDto.java
@@ -9,31 +9,28 @@ package io.camunda.optimize.dto.optimize.query.report.combined.configuration.tar
 
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import java.util.Objects;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@ToString
 public class CombinedReportDurationChartDto {
 
   private TargetValueUnit unit = TargetValueUnit.HOURS;
   private Boolean isBelow = false;
   private String value = "2";
 
+  public CombinedReportDurationChartDto(
+      final TargetValueUnit unit, final Boolean isBelow, final String value) {
+    this.unit = unit;
+    this.isBelow = isBelow;
+    this.value = value;
+  }
+
+  public CombinedReportDurationChartDto() {}
+
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof final CombinedReportDurationChartDto that)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
+    final CombinedReportDurationChartDto that = (CombinedReportDurationChartDto) o;
     return unit == that.unit
         && Objects.equals(isBelow, that.isBelow)
         && Objects.equals(value, that.value);
@@ -42,5 +39,40 @@ public class CombinedReportDurationChartDto {
   @Override
   public int hashCode() {
     return Objects.hash(unit, isBelow, value);
+  }
+
+  @Override
+  public String toString() {
+    return "CombinedReportDurationChartDto(unit="
+        + getUnit()
+        + ", isBelow="
+        + getIsBelow()
+        + ", value="
+        + getValue()
+        + ")";
+  }
+
+  public TargetValueUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final TargetValueUnit unit) {
+    this.unit = unit;
+  }
+
+  public Boolean getIsBelow() {
+    return isBelow;
+  }
+
+  public void setIsBelow(final Boolean isBelow) {
+    this.isBelow = isBelow;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/target_value/CombinedReportTargetValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/configuration/target_value/CombinedReportTargetValueDto.java
@@ -8,31 +8,30 @@
 package io.camunda.optimize.dto.optimize.query.report.combined.configuration.target_value;
 
 import java.util.Objects;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
-@Setter
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
-@ToString
 public class CombinedReportTargetValueDto {
 
   private CombinedReportCountChartDto countChart = new CombinedReportCountChartDto();
   private Boolean active = false;
   private CombinedReportDurationChartDto durationChart = new CombinedReportDurationChartDto();
 
+  public CombinedReportTargetValueDto(
+      final CombinedReportCountChartDto countChart,
+      final Boolean active,
+      final CombinedReportDurationChartDto durationChart) {
+    this.countChart = countChart;
+    this.active = active;
+    this.durationChart = durationChart;
+  }
+
+  public CombinedReportTargetValueDto() {}
+
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof final CombinedReportTargetValueDto that)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
+    final CombinedReportTargetValueDto that = (CombinedReportTargetValueDto) o;
     return Objects.equals(countChart, that.countChart)
         && Objects.equals(active, that.active)
         && Objects.equals(durationChart, that.durationChart);
@@ -41,5 +40,40 @@ public class CombinedReportTargetValueDto {
   @Override
   public int hashCode() {
     return Objects.hash(countChart, active, durationChart);
+  }
+
+  @Override
+  public String toString() {
+    return "CombinedReportTargetValueDto(countChart="
+        + getCountChart()
+        + ", active="
+        + getActive()
+        + ", durationChart="
+        + getDurationChart()
+        + ")";
+  }
+
+  public CombinedReportCountChartDto getCountChart() {
+    return countChart;
+  }
+
+  public void setCountChart(final CombinedReportCountChartDto countChart) {
+    this.countChart = countChart;
+  }
+
+  public Boolean getActive() {
+    return active;
+  }
+
+  public void setActive(final Boolean active) {
+    this.active = active;
+  }
+
+  public CombinedReportDurationChartDto getDurationChart() {
+    return durationChart;
+  }
+
+  public void setDurationChart(final CombinedReportDurationChartDto durationChart) {
+    this.durationChart = durationChart;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ReportDataDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ReportDataDefinitionDto.java
@@ -13,14 +13,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.ReportConstants;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
-@Data
-@NoArgsConstructor
 public class ReportDataDefinitionDto {
 
   @NotEmpty private String identifier = UUID.randomUUID().toString();
@@ -89,11 +84,117 @@ public class ReportDataDefinitionDto {
     this.versions = versions;
   }
 
+  public ReportDataDefinitionDto(
+      @NotEmpty final String identifier,
+      final String key,
+      final String name,
+      final String displayName,
+      final List<String> versions,
+      final List<String> tenantIds) {
+    this.identifier = identifier;
+    this.key = key;
+    this.name = name;
+    this.displayName = displayName;
+    this.versions = versions;
+    this.tenantIds = tenantIds;
+  }
+
+  public ReportDataDefinitionDto() {}
+
   @JsonIgnore
   public void setVersion(final String version) {
     versions = List.of(version);
   }
 
+  public @NotEmpty String getIdentifier() {
+    return identifier;
+  }
+
+  public void setIdentifier(@NotEmpty final String identifier) {
+    this.identifier = identifier;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(final String key) {
+    this.key = key;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public void setDisplayName(final String displayName) {
+    this.displayName = displayName;
+  }
+
+  public List<String> getVersions() {
+    return versions;
+  }
+
+  public void setVersions(final List<String> versions) {
+    this.versions = versions;
+  }
+
+  public List<String> getTenantIds() {
+    return tenantIds;
+  }
+
+  public void setTenantIds(final List<String> tenantIds) {
+    this.tenantIds = tenantIds;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ReportDataDefinitionDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportDataDefinitionDto that = (ReportDataDefinitionDto) o;
+    return Objects.equals(identifier, that.identifier)
+        && Objects.equals(key, that.key)
+        && Objects.equals(name, that.name)
+        && Objects.equals(displayName, that.displayName)
+        && Objects.equals(versions, that.versions)
+        && Objects.equals(tenantIds, that.tenantIds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(identifier, key, name, displayName, versions, tenantIds);
+  }
+
+  @Override
+  public String toString() {
+    return "ReportDataDefinitionDto(identifier="
+        + getIdentifier()
+        + ", key="
+        + getKey()
+        + ", name="
+        + getName()
+        + ", displayName="
+        + getDisplayName()
+        + ", versions="
+        + getVersions()
+        + ", tenantIds="
+        + getTenantIds()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String identifier = "identifier";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ViewProperty.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ViewProperty.java
@@ -21,33 +21,32 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.view.StringV
 import io.camunda.optimize.dto.optimize.query.report.single.process.view.TypedViewPropertyDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.view.VariableViewPropertyDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.EqualsAndHashCode;
 
-@EqualsAndHashCode
 public class ViewProperty implements Combinable {
+
   public static final ViewProperty FREQUENCY = new ViewProperty(VIEW_FREQUENCY_PROPERTY);
   public static final ViewProperty DURATION = new ViewProperty(VIEW_DURATION_PROPERTY);
   public static final ViewProperty PERCENTAGE = new ViewProperty(VIEW_PERCENTAGE_PROPERTY);
   public static final ViewProperty RAW_DATA = new ViewProperty(VIEW_RAW_DATA_PROPERTY);
-
-  // uppercase is intended here to align it with other static fields
-  @SuppressWarnings("java:S100")
-  public static ViewProperty VARIABLE(final String variableName, final VariableType variableType) {
-    return new ViewProperty(variableName, variableType);
-  }
-
   private final TypedViewPropertyDto viewPropertyDto;
 
   @JsonCreator
   public ViewProperty(final String singleStringProperty) {
-    this.viewPropertyDto = new StringViewPropertyDto(singleStringProperty);
+    viewPropertyDto = new StringViewPropertyDto(singleStringProperty);
   }
 
   @JsonCreator
   private ViewProperty(
       @JsonProperty("name") final String name, @JsonProperty("type") final VariableType type) {
-    this.viewPropertyDto = new VariableViewPropertyDto(name, type);
+    viewPropertyDto = new VariableViewPropertyDto(name, type);
+  }
+
+  // uppercase is intended here to align it with other static fields
+  @SuppressWarnings("java:S100")
+  public static ViewProperty variable(final String variableName, final VariableType variableType) {
+    return new ViewProperty(variableName, variableType);
   }
 
   @Override
@@ -58,7 +57,7 @@ public class ViewProperty implements Combinable {
     if (!(o instanceof ViewProperty)) {
       return false;
     }
-    ViewProperty other = (ViewProperty) o;
+    final ViewProperty other = (ViewProperty) o;
     return Combinable.isCombinable(viewPropertyDto, other.viewPropertyDto);
   }
 
@@ -70,7 +69,25 @@ public class ViewProperty implements Combinable {
   @JsonIgnore
   public <T extends TypedViewPropertyDto> Optional<T> getViewPropertyDtoIfOfType(
       final Class<T> clazz) {
-    return Optional.of(this.viewPropertyDto).filter(clazz::isInstance).map(clazz::cast);
+    return Optional.of(viewPropertyDto).filter(clazz::isInstance).map(clazz::cast);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ViewProperty;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ViewProperty that = (ViewProperty) o;
+    return Objects.equals(viewPropertyDto, that.viewPropertyDto);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(viewPropertyDto);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/AggregationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/AggregationDto.java
@@ -8,19 +8,60 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class AggregationDto implements OptimizeDto {
-
-  public AggregationDto(final AggregationType aggregationType) {
-    this.type = aggregationType;
-  }
 
   AggregationType type;
   Double value;
+
+  public AggregationDto(final AggregationType aggregationType) {
+    type = aggregationType;
+  }
+
+  public AggregationDto(final AggregationType type, final Double value) {
+    this.type = type;
+    this.value = value;
+  }
+
+  public AggregationDto() {}
+
+  public AggregationType getType() {
+    return type;
+  }
+
+  public void setType(final AggregationType type) {
+    this.type = type;
+  }
+
+  public Double getValue() {
+    return value;
+  }
+
+  public void setValue(final Double value) {
+    this.value = value;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof AggregationDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AggregationDto that = (AggregationDto) o;
+    return type == that.type && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, value);
+  }
+
+  @Override
+  public String toString() {
+    return "AggregationDto(type=" + getType() + ", value=" + getValue() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/MeasureVisualizationsDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/MeasureVisualizationsDto.java
@@ -8,14 +8,59 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration;
 
 import io.camunda.optimize.dto.optimize.ReportConstants;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class MeasureVisualizationsDto {
 
   private String frequency = ReportConstants.BAR_VISUALIZATION;
   private String duration = ReportConstants.LINE_VISUALIZATION;
 
+  public MeasureVisualizationsDto() {}
+
+  public String getFrequency() {
+    return frequency;
+  }
+
+  public void setFrequency(final String frequency) {
+    this.frequency = frequency;
+  }
+
+  public String getDuration() {
+    return duration;
+  }
+
+  public void setDuration(final String duration) {
+    this.duration = duration;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MeasureVisualizationsDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MeasureVisualizationsDto that = (MeasureVisualizationsDto) o;
+    return Objects.equals(frequency, that.frequency) && Objects.equals(duration, that.duration);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(frequency, duration);
+  }
+
+  @Override
+  public String toString() {
+    return "MeasureVisualizationsDto(frequency="
+        + getFrequency()
+        + ", duration="
+        + getDuration()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String frequency = "frequency";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/SingleReportConfigurationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/SingleReportConfigurationDto.java
@@ -20,77 +20,118 @@ import io.camunda.optimize.dto.optimize.query.sorting.ReportSortingDto;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
 
-@AllArgsConstructor
-@Builder
-@Data
-@NoArgsConstructor
 public class SingleReportConfigurationDto implements Combinable {
 
-  @Builder.Default private String color = ReportConstants.DEFAULT_CONFIGURATION_COLOR;
+  private String color = ReportConstants.DEFAULT_CONFIGURATION_COLOR;
 
-  @Builder.Default
   private Set<AggregationDto> aggregationTypes =
       new LinkedHashSet<>(Collections.singletonList(new AggregationDto(AggregationType.AVERAGE)));
 
-  @Builder.Default
   private Set<UserTaskDurationTime> userTaskDurationTimes =
       new LinkedHashSet<>(Collections.singletonList(UserTaskDurationTime.TOTAL));
 
-  @Builder.Default private Boolean showInstanceCount = false;
-  @Builder.Default private Boolean pointMarkers = true;
-  @Builder.Default private Integer precision = null;
-  @Builder.Default private Boolean hideRelativeValue = false;
-  @Builder.Default private Boolean hideAbsoluteValue = false;
+  private Boolean showInstanceCount = false;
+  private Boolean pointMarkers = true;
+  private Integer precision = null;
+  private Boolean hideRelativeValue = false;
+  private Boolean hideAbsoluteValue = false;
 
-  @Builder.Default
   // needed to ensure the name is serialized properly, see https://stackoverflow.com/a/30207335
   @JsonProperty("yLabel")
   private String yLabel = "";
 
-  @Builder.Default
   // needed to ensure the name is serialized properly, see https://stackoverflow.com/a/30207335
   @JsonProperty("xLabel")
   private String xLabel = "";
 
-  @Builder.Default private Boolean alwaysShowRelative = false;
-  @Builder.Default private Boolean alwaysShowAbsolute = false;
-  @Builder.Default private Boolean showGradientBars = true;
-  @Builder.Default private String xml = null;
-  @Builder.Default private TableColumnDto tableColumns = new TableColumnDto();
-
-  @Builder.Default
+  private Boolean alwaysShowRelative = false;
+  private Boolean alwaysShowAbsolute = false;
+  private Boolean showGradientBars = true;
+  private String xml = null;
+  private TableColumnDto tableColumns = new TableColumnDto();
   private SingleReportTargetValueDto targetValue = new SingleReportTargetValueDto();
-
-  @Builder.Default private HeatmapTargetValueDto heatmapTargetValue = new HeatmapTargetValueDto();
-
-  @Builder.Default @NonNull
+  private HeatmapTargetValueDto heatmapTargetValue = new HeatmapTargetValueDto();
   private AggregateByDateUnit groupByDateVariableUnit = AggregateByDateUnit.AUTOMATIC;
-
-  @Builder.Default @NonNull
   private AggregateByDateUnit distributeByDateVariableUnit = AggregateByDateUnit.AUTOMATIC;
-
-  @Builder.Default private CustomBucketDto customBucket = CustomBucketDto.builder().build();
-
-  @Builder.Default
+  private CustomBucketDto customBucket = CustomBucketDto.builder().build();
   private CustomBucketDto distributeByCustomBucket = CustomBucketDto.builder().build();
-
-  @Builder.Default private ReportSortingDto sorting = null;
-  @Builder.Default private ProcessPartDto processPart = null;
-
-  @Builder.Default
+  private ReportSortingDto sorting = null;
+  private ProcessPartDto processPart = null;
   private MeasureVisualizationsDto measureVisualizations = new MeasureVisualizationsDto();
+  private Boolean stackedBar = false;
+  private Boolean horizontalBar = false;
+  private Boolean logScale = false;
 
-  @Builder.Default private Boolean stackedBar = false;
-  @Builder.Default private Boolean horizontalBar = false;
-  @Builder.Default private Boolean logScale = false;
+  public SingleReportConfigurationDto(
+      final String color,
+      final Set<AggregationDto> aggregationTypes,
+      final Set<UserTaskDurationTime> userTaskDurationTimes,
+      final Boolean showInstanceCount,
+      final Boolean pointMarkers,
+      final Integer precision,
+      final Boolean hideRelativeValue,
+      final Boolean hideAbsoluteValue,
+      final String yLabel,
+      final String xLabel,
+      final Boolean alwaysShowRelative,
+      final Boolean alwaysShowAbsolute,
+      final Boolean showGradientBars,
+      final String xml,
+      final TableColumnDto tableColumns,
+      final SingleReportTargetValueDto targetValue,
+      final HeatmapTargetValueDto heatmapTargetValue,
+      final AggregateByDateUnit groupByDateVariableUnit,
+      final AggregateByDateUnit distributeByDateVariableUnit,
+      final CustomBucketDto customBucket,
+      final CustomBucketDto distributeByCustomBucket,
+      final ReportSortingDto sorting,
+      final ProcessPartDto processPart,
+      final MeasureVisualizationsDto measureVisualizations,
+      final Boolean stackedBar,
+      final Boolean horizontalBar,
+      final Boolean logScale) {
+    if (groupByDateVariableUnit == null) {
+      throw new IllegalArgumentException("groupByDateVariableUnit must not be null");
+    }
+
+    if (distributeByDateVariableUnit == null) {
+      throw new IllegalArgumentException("distributeByDateVariableUnit must not be null");
+    }
+
+    this.color = color;
+    this.aggregationTypes = aggregationTypes;
+    this.userTaskDurationTimes = userTaskDurationTimes;
+    this.showInstanceCount = showInstanceCount;
+    this.pointMarkers = pointMarkers;
+    this.precision = precision;
+    this.hideRelativeValue = hideRelativeValue;
+    this.hideAbsoluteValue = hideAbsoluteValue;
+    this.yLabel = yLabel;
+    this.xLabel = xLabel;
+    this.alwaysShowRelative = alwaysShowRelative;
+    this.alwaysShowAbsolute = alwaysShowAbsolute;
+    this.showGradientBars = showGradientBars;
+    this.xml = xml;
+    this.tableColumns = tableColumns;
+    this.targetValue = targetValue;
+    this.heatmapTargetValue = heatmapTargetValue;
+    this.groupByDateVariableUnit = groupByDateVariableUnit;
+    this.distributeByDateVariableUnit = distributeByDateVariableUnit;
+    this.customBucket = customBucket;
+    this.distributeByCustomBucket = distributeByCustomBucket;
+    this.sorting = sorting;
+    this.processPart = processPart;
+    this.measureVisualizations = measureVisualizations;
+    this.stackedBar = stackedBar;
+    this.horizontalBar = horizontalBar;
+    this.logScale = logScale;
+  }
+
+  public SingleReportConfigurationDto() {}
 
   @JsonIgnore
   public String createCommandKey() {
@@ -111,9 +152,41 @@ public class SingleReportConfigurationDto implements Combinable {
         && userTaskDurationTimesAmount == that.getUserTaskDurationTimes().size();
   }
 
+  public Optional<ReportSortingDto> getSorting() {
+    return Optional.ofNullable(sorting);
+  }
+
+  public void setSorting(final ReportSortingDto sorting) {
+    this.sorting = sorting;
+  }
+
+  public Optional<ProcessPartDto> getProcessPart() {
+    return Optional.ofNullable(processPart);
+  }
+
+  public void setProcessPart(final ProcessPartDto processPart) {
+    this.processPart = processPart;
+  }
+
+  public String getColor() {
+    return color;
+  }
+
+  public void setColor(final String color) {
+    this.color = color;
+  }
+
+  public Set<AggregationDto> getAggregationTypes() {
+    return aggregationTypes;
+  }
+
   public void setAggregationTypes(final AggregationDto... aggregationTypes) {
     // deduplication using an intermediate set
     this.aggregationTypes = new LinkedHashSet<>(Arrays.asList(aggregationTypes));
+  }
+
+  public Set<UserTaskDurationTime> getUserTaskDurationTimes() {
+    return userTaskDurationTimes;
   }
 
   public void setUserTaskDurationTimes(final UserTaskDurationTime... userTaskDurationTimes) {
@@ -121,14 +194,437 @@ public class SingleReportConfigurationDto implements Combinable {
     this.userTaskDurationTimes = new LinkedHashSet<>(Arrays.asList(userTaskDurationTimes));
   }
 
-  public Optional<ReportSortingDto> getSorting() {
-    return Optional.ofNullable(sorting);
+  public Boolean getShowInstanceCount() {
+    return showInstanceCount;
   }
 
-  public Optional<ProcessPartDto> getProcessPart() {
-    return Optional.ofNullable(processPart);
+  public void setShowInstanceCount(final Boolean showInstanceCount) {
+    this.showInstanceCount = showInstanceCount;
   }
 
+  public Boolean getPointMarkers() {
+    return pointMarkers;
+  }
+
+  public void setPointMarkers(final Boolean pointMarkers) {
+    this.pointMarkers = pointMarkers;
+  }
+
+  public Integer getPrecision() {
+    return precision;
+  }
+
+  public void setPrecision(final Integer precision) {
+    this.precision = precision;
+  }
+
+  public Boolean getHideRelativeValue() {
+    return hideRelativeValue;
+  }
+
+  public void setHideRelativeValue(final Boolean hideRelativeValue) {
+    this.hideRelativeValue = hideRelativeValue;
+  }
+
+  public Boolean getHideAbsoluteValue() {
+    return hideAbsoluteValue;
+  }
+
+  public void setHideAbsoluteValue(final Boolean hideAbsoluteValue) {
+    this.hideAbsoluteValue = hideAbsoluteValue;
+  }
+
+  public String getYLabel() {
+    return yLabel;
+  }
+
+  @JsonProperty("yLabel")
+  public void setYLabel(final String yLabel) {
+    this.yLabel = yLabel;
+  }
+
+  public String getXLabel() {
+    return xLabel;
+  }
+
+  @JsonProperty("xLabel")
+  public void setXLabel(final String xLabel) {
+    this.xLabel = xLabel;
+  }
+
+  public Boolean getAlwaysShowRelative() {
+    return alwaysShowRelative;
+  }
+
+  public void setAlwaysShowRelative(final Boolean alwaysShowRelative) {
+    this.alwaysShowRelative = alwaysShowRelative;
+  }
+
+  public Boolean getAlwaysShowAbsolute() {
+    return alwaysShowAbsolute;
+  }
+
+  public void setAlwaysShowAbsolute(final Boolean alwaysShowAbsolute) {
+    this.alwaysShowAbsolute = alwaysShowAbsolute;
+  }
+
+  public Boolean getShowGradientBars() {
+    return showGradientBars;
+  }
+
+  public void setShowGradientBars(final Boolean showGradientBars) {
+    this.showGradientBars = showGradientBars;
+  }
+
+  public String getXml() {
+    return xml;
+  }
+
+  public void setXml(final String xml) {
+    this.xml = xml;
+  }
+
+  public TableColumnDto getTableColumns() {
+    return tableColumns;
+  }
+
+  public void setTableColumns(final TableColumnDto tableColumns) {
+    this.tableColumns = tableColumns;
+  }
+
+  public SingleReportTargetValueDto getTargetValue() {
+    return targetValue;
+  }
+
+  public void setTargetValue(final SingleReportTargetValueDto targetValue) {
+    this.targetValue = targetValue;
+  }
+
+  public HeatmapTargetValueDto getHeatmapTargetValue() {
+    return heatmapTargetValue;
+  }
+
+  public void setHeatmapTargetValue(final HeatmapTargetValueDto heatmapTargetValue) {
+    this.heatmapTargetValue = heatmapTargetValue;
+  }
+
+  public AggregateByDateUnit getGroupByDateVariableUnit() {
+    return groupByDateVariableUnit;
+  }
+
+  public void setGroupByDateVariableUnit(final AggregateByDateUnit groupByDateVariableUnit) {
+    if (groupByDateVariableUnit == null) {
+      throw new IllegalArgumentException("groupByDateVariableUnit must not be null");
+    }
+
+    this.groupByDateVariableUnit = groupByDateVariableUnit;
+  }
+
+  public AggregateByDateUnit getDistributeByDateVariableUnit() {
+    return distributeByDateVariableUnit;
+  }
+
+  public void setDistributeByDateVariableUnit(
+      final AggregateByDateUnit distributeByDateVariableUnit) {
+    if (distributeByDateVariableUnit == null) {
+      throw new IllegalArgumentException("distributeByDateVariableUnit must not be null");
+    }
+
+    this.distributeByDateVariableUnit = distributeByDateVariableUnit;
+  }
+
+  public CustomBucketDto getCustomBucket() {
+    return customBucket;
+  }
+
+  public void setCustomBucket(final CustomBucketDto customBucket) {
+    this.customBucket = customBucket;
+  }
+
+  public CustomBucketDto getDistributeByCustomBucket() {
+    return distributeByCustomBucket;
+  }
+
+  public void setDistributeByCustomBucket(final CustomBucketDto distributeByCustomBucket) {
+    this.distributeByCustomBucket = distributeByCustomBucket;
+  }
+
+  public MeasureVisualizationsDto getMeasureVisualizations() {
+    return measureVisualizations;
+  }
+
+  public void setMeasureVisualizations(final MeasureVisualizationsDto measureVisualizations) {
+    this.measureVisualizations = measureVisualizations;
+  }
+
+  public Boolean getStackedBar() {
+    return stackedBar;
+  }
+
+  public void setStackedBar(final Boolean stackedBar) {
+    this.stackedBar = stackedBar;
+  }
+
+  public Boolean getHorizontalBar() {
+    return horizontalBar;
+  }
+
+  public void setHorizontalBar(final Boolean horizontalBar) {
+    this.horizontalBar = horizontalBar;
+  }
+
+  public Boolean getLogScale() {
+    return logScale;
+  }
+
+  public void setLogScale(final Boolean logScale) {
+    this.logScale = logScale;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof SingleReportConfigurationDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SingleReportConfigurationDto that = (SingleReportConfigurationDto) o;
+    return Objects.equals(color, that.color)
+        && Objects.equals(aggregationTypes, that.aggregationTypes)
+        && Objects.equals(userTaskDurationTimes, that.userTaskDurationTimes)
+        && Objects.equals(showInstanceCount, that.showInstanceCount)
+        && Objects.equals(pointMarkers, that.pointMarkers)
+        && Objects.equals(precision, that.precision)
+        && Objects.equals(hideRelativeValue, that.hideRelativeValue)
+        && Objects.equals(hideAbsoluteValue, that.hideAbsoluteValue)
+        && Objects.equals(yLabel, that.yLabel)
+        && Objects.equals(xLabel, that.xLabel)
+        && Objects.equals(alwaysShowRelative, that.alwaysShowRelative)
+        && Objects.equals(alwaysShowAbsolute, that.alwaysShowAbsolute)
+        && Objects.equals(showGradientBars, that.showGradientBars)
+        && Objects.equals(xml, that.xml)
+        && Objects.equals(tableColumns, that.tableColumns)
+        && Objects.equals(targetValue, that.targetValue)
+        && Objects.equals(heatmapTargetValue, that.heatmapTargetValue)
+        && groupByDateVariableUnit == that.groupByDateVariableUnit
+        && distributeByDateVariableUnit == that.distributeByDateVariableUnit
+        && Objects.equals(customBucket, that.customBucket)
+        && Objects.equals(distributeByCustomBucket, that.distributeByCustomBucket)
+        && Objects.equals(sorting, that.sorting)
+        && Objects.equals(processPart, that.processPart)
+        && Objects.equals(measureVisualizations, that.measureVisualizations)
+        && Objects.equals(stackedBar, that.stackedBar)
+        && Objects.equals(horizontalBar, that.horizontalBar)
+        && Objects.equals(logScale, that.logScale);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        color,
+        aggregationTypes,
+        userTaskDurationTimes,
+        showInstanceCount,
+        pointMarkers,
+        precision,
+        hideRelativeValue,
+        hideAbsoluteValue,
+        yLabel,
+        xLabel,
+        alwaysShowRelative,
+        alwaysShowAbsolute,
+        showGradientBars,
+        xml,
+        tableColumns,
+        targetValue,
+        heatmapTargetValue,
+        groupByDateVariableUnit,
+        distributeByDateVariableUnit,
+        customBucket,
+        distributeByCustomBucket,
+        sorting,
+        processPart,
+        measureVisualizations,
+        stackedBar,
+        horizontalBar,
+        logScale);
+  }
+
+  @Override
+  public String toString() {
+    return "SingleReportConfigurationDto(color="
+        + getColor()
+        + ", aggregationTypes="
+        + getAggregationTypes()
+        + ", userTaskDurationTimes="
+        + getUserTaskDurationTimes()
+        + ", showInstanceCount="
+        + getShowInstanceCount()
+        + ", pointMarkers="
+        + getPointMarkers()
+        + ", precision="
+        + getPrecision()
+        + ", hideRelativeValue="
+        + getHideRelativeValue()
+        + ", hideAbsoluteValue="
+        + getHideAbsoluteValue()
+        + ", yLabel="
+        + getYLabel()
+        + ", xLabel="
+        + getXLabel()
+        + ", alwaysShowRelative="
+        + getAlwaysShowRelative()
+        + ", alwaysShowAbsolute="
+        + getAlwaysShowAbsolute()
+        + ", showGradientBars="
+        + getShowGradientBars()
+        + ", xml="
+        + getXml()
+        + ", tableColumns="
+        + getTableColumns()
+        + ", targetValue="
+        + getTargetValue()
+        + ", heatmapTargetValue="
+        + getHeatmapTargetValue()
+        + ", groupByDateVariableUnit="
+        + getGroupByDateVariableUnit()
+        + ", distributeByDateVariableUnit="
+        + getDistributeByDateVariableUnit()
+        + ", customBucket="
+        + getCustomBucket()
+        + ", distributeByCustomBucket="
+        + getDistributeByCustomBucket()
+        + ", sorting="
+        + getSorting()
+        + ", processPart="
+        + getProcessPart()
+        + ", measureVisualizations="
+        + getMeasureVisualizations()
+        + ", stackedBar="
+        + getStackedBar()
+        + ", horizontalBar="
+        + getHorizontalBar()
+        + ", logScale="
+        + getLogScale()
+        + ")";
+  }
+
+  private static String defaultColor() {
+    return ReportConstants.DEFAULT_CONFIGURATION_COLOR;
+  }
+
+  private static Set<AggregationDto> defaultAggregationTypes() {
+    return new LinkedHashSet<>(
+        Collections.singletonList(new AggregationDto(AggregationType.AVERAGE)));
+  }
+
+  private static Set<UserTaskDurationTime> defaultUserTaskDurationTimes() {
+    return new LinkedHashSet<>(Collections.singletonList(UserTaskDurationTime.TOTAL));
+  }
+
+  private static Boolean defaultShowInstanceCount() {
+    return false;
+  }
+
+  private static Boolean defaultPointMarkers() {
+    return true;
+  }
+
+  private static Integer defaultPrecision() {
+    return null;
+  }
+
+  private static Boolean defaultHideRelativeValue() {
+    return false;
+  }
+
+  private static Boolean defaultHideAbsoluteValue() {
+    return false;
+  }
+
+  private static String defaultYLabel() {
+    return "";
+  }
+
+  private static String defaultXLabel() {
+    return "";
+  }
+
+  private static Boolean defaultAlwaysShowRelative() {
+    return false;
+  }
+
+  private static Boolean defaultAlwaysShowAbsolute() {
+    return false;
+  }
+
+  private static Boolean defaultShowGradientBars() {
+    return true;
+  }
+
+  private static String defaultXml() {
+    return null;
+  }
+
+  private static TableColumnDto defaultTableColumns() {
+    return new TableColumnDto();
+  }
+
+  private static SingleReportTargetValueDto defaultTargetValue() {
+    return new SingleReportTargetValueDto();
+  }
+
+  private static HeatmapTargetValueDto defaultHeatmapTargetValue() {
+    return new HeatmapTargetValueDto();
+  }
+
+  private static AggregateByDateUnit defaultGroupByDateVariableUnit() {
+    return AggregateByDateUnit.AUTOMATIC;
+  }
+
+  private static AggregateByDateUnit defaultDistributeByDateVariableUnit() {
+    return AggregateByDateUnit.AUTOMATIC;
+  }
+
+  private static CustomBucketDto defaultCustomBucket() {
+    return CustomBucketDto.builder().build();
+  }
+
+  private static CustomBucketDto defaultDistributeByCustomBucket() {
+    return CustomBucketDto.builder().build();
+  }
+
+  private static ReportSortingDto defaultSorting() {
+    return null;
+  }
+
+  private static ProcessPartDto defaultProcessPart() {
+    return null;
+  }
+
+  private static MeasureVisualizationsDto defaultMeasureVisualizations() {
+    return new MeasureVisualizationsDto();
+  }
+
+  private static Boolean defaultStackedBar() {
+    return false;
+  }
+
+  private static Boolean defaultHorizontalBar() {
+    return false;
+  }
+
+  private static Boolean defaultLogScale() {
+    return false;
+  }
+
+  public static SingleReportConfigurationDtoBuilder builder() {
+    return new SingleReportConfigurationDtoBuilder();
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String color = "color";
@@ -158,5 +654,449 @@ public class SingleReportConfigurationDto implements Combinable {
     public static final String stackedBar = "stackedBar";
     public static final String horizontalBar = "horizontalBar";
     public static final String logScale = "logScale";
+  }
+
+  public static class SingleReportConfigurationDtoBuilder {
+
+    private String colorValue;
+    private boolean colorSet;
+    private Set<AggregationDto> aggregationTypesValue;
+    private boolean aggregationTypesSet;
+    private Set<UserTaskDurationTime> userTaskDurationTimesValue;
+    private boolean userTaskDurationTimesSet;
+    private Boolean showInstanceCountValue;
+    private boolean showInstanceCountSet;
+    private Boolean pointMarkersValue;
+    private boolean pointMarkersSet;
+    private Integer precisionValue;
+    private boolean precisionSet;
+    private Boolean hideRelativeValueValue;
+    private boolean hideRelativeValueSet;
+    private Boolean hideAbsoluteValueValue;
+    private boolean hideAbsoluteValueSet;
+    private String yLabelValue;
+    private boolean yLabelSet;
+    private String xLabelValue;
+    private boolean xLabelSet;
+    private Boolean alwaysShowRelativeValue;
+    private boolean alwaysShowRelativeSet;
+    private Boolean alwaysShowAbsoluteValue;
+    private boolean alwaysShowAbsoluteSet;
+    private Boolean showGradientBarsValue;
+    private boolean showGradientBarsSet;
+    private String xmlValue;
+    private boolean xmlSet;
+    private TableColumnDto tableColumnsValue;
+    private boolean tableColumnsSet;
+    private SingleReportTargetValueDto targetValueValue;
+    private boolean targetValueSet;
+    private HeatmapTargetValueDto heatmapTargetValueValue;
+    private boolean heatmapTargetValueSet;
+    private AggregateByDateUnit groupByDateVariableUnitValue;
+    private boolean groupByDateVariableUnitSet;
+    private AggregateByDateUnit distributeByDateVariableUnitValue;
+    private boolean distributeByDateVariableUnitSet;
+    private CustomBucketDto customBucketValue;
+    private boolean customBucketSet;
+    private CustomBucketDto distributeByCustomBucketValue;
+    private boolean distributeByCustomBucketSet;
+    private ReportSortingDto sortingValue;
+    private boolean sortingSet;
+    private ProcessPartDto processPartValue;
+    private boolean processPartSet;
+    private MeasureVisualizationsDto measureVisualizationsValue;
+    private boolean measureVisualizationsSet;
+    private Boolean stackedBarValue;
+    private boolean stackedBarSet;
+    private Boolean horizontalBarValue;
+    private boolean horizontalBarSet;
+    private Boolean logScaleValue;
+    private boolean logScaleSet;
+
+    SingleReportConfigurationDtoBuilder() {}
+
+    public SingleReportConfigurationDtoBuilder color(final String color) {
+      colorValue = color;
+      colorSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder aggregationTypes(
+        final Set<AggregationDto> aggregationTypes) {
+      aggregationTypesValue = aggregationTypes;
+      aggregationTypesSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder userTaskDurationTimes(
+        final Set<UserTaskDurationTime> userTaskDurationTimes) {
+      userTaskDurationTimesValue = userTaskDurationTimes;
+      userTaskDurationTimesSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder showInstanceCount(final Boolean showInstanceCount) {
+      showInstanceCountValue = showInstanceCount;
+      showInstanceCountSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder pointMarkers(final Boolean pointMarkers) {
+      pointMarkersValue = pointMarkers;
+      pointMarkersSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder precision(final Integer precision) {
+      precisionValue = precision;
+      precisionSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder hideRelativeValue(final Boolean hideRelativeValue) {
+      hideRelativeValueValue = hideRelativeValue;
+      hideRelativeValueSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder hideAbsoluteValue(final Boolean hideAbsoluteValue) {
+      hideAbsoluteValueValue = hideAbsoluteValue;
+      hideAbsoluteValueSet = true;
+      return this;
+    }
+
+    @JsonProperty("yLabel")
+    public SingleReportConfigurationDtoBuilder yLabel(final String yLabel) {
+      yLabelValue = yLabel;
+      yLabelSet = true;
+      return this;
+    }
+
+    @JsonProperty("xLabel")
+    public SingleReportConfigurationDtoBuilder xLabel(final String xLabel) {
+      xLabelValue = xLabel;
+      xLabelSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder alwaysShowRelative(
+        final Boolean alwaysShowRelative) {
+      alwaysShowRelativeValue = alwaysShowRelative;
+      alwaysShowRelativeSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder alwaysShowAbsolute(
+        final Boolean alwaysShowAbsolute) {
+      alwaysShowAbsoluteValue = alwaysShowAbsolute;
+      alwaysShowAbsoluteSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder showGradientBars(final Boolean showGradientBars) {
+      showGradientBarsValue = showGradientBars;
+      showGradientBarsSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder xml(final String xml) {
+      xmlValue = xml;
+      xmlSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder tableColumns(final TableColumnDto tableColumns) {
+      tableColumnsValue = tableColumns;
+      tableColumnsSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder targetValue(
+        final SingleReportTargetValueDto targetValue) {
+      targetValueValue = targetValue;
+      targetValueSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder heatmapTargetValue(
+        final HeatmapTargetValueDto heatmapTargetValue) {
+      heatmapTargetValueValue = heatmapTargetValue;
+      heatmapTargetValueSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder groupByDateVariableUnit(
+        final AggregateByDateUnit groupByDateVariableUnit) {
+      if (groupByDateVariableUnit == null) {
+        throw new IllegalArgumentException("groupByDateVariableUnit must not be null");
+      }
+
+      groupByDateVariableUnitValue = groupByDateVariableUnit;
+      groupByDateVariableUnitSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder distributeByDateVariableUnit(
+        final AggregateByDateUnit distributeByDateVariableUnit) {
+      if (distributeByDateVariableUnit == null) {
+        throw new IllegalArgumentException("distributeByDateVariableUnit must not be null");
+      }
+
+      distributeByDateVariableUnitValue = distributeByDateVariableUnit;
+      distributeByDateVariableUnitSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder customBucket(final CustomBucketDto customBucket) {
+      customBucketValue = customBucket;
+      customBucketSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder distributeByCustomBucket(
+        final CustomBucketDto distributeByCustomBucket) {
+      distributeByCustomBucketValue = distributeByCustomBucket;
+      distributeByCustomBucketSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder sorting(final ReportSortingDto sorting) {
+      sortingValue = sorting;
+      sortingSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder processPart(final ProcessPartDto processPart) {
+      processPartValue = processPart;
+      processPartSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder measureVisualizations(
+        final MeasureVisualizationsDto measureVisualizations) {
+      measureVisualizationsValue = measureVisualizations;
+      measureVisualizationsSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder stackedBar(final Boolean stackedBar) {
+      stackedBarValue = stackedBar;
+      stackedBarSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder horizontalBar(final Boolean horizontalBar) {
+      horizontalBarValue = horizontalBar;
+      horizontalBarSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDtoBuilder logScale(final Boolean logScale) {
+      logScaleValue = logScale;
+      logScaleSet = true;
+      return this;
+    }
+
+    public SingleReportConfigurationDto build() {
+      String colorValue = this.colorValue;
+      if (!colorSet) {
+        colorValue = SingleReportConfigurationDto.defaultColor();
+      }
+      Set<AggregationDto> aggregationTypesValue = this.aggregationTypesValue;
+      if (!aggregationTypesSet) {
+        aggregationTypesValue = SingleReportConfigurationDto.defaultAggregationTypes();
+      }
+      Set<UserTaskDurationTime> userTaskDurationTimesValue = this.userTaskDurationTimesValue;
+      if (!userTaskDurationTimesSet) {
+        userTaskDurationTimesValue = SingleReportConfigurationDto.defaultUserTaskDurationTimes();
+      }
+      Boolean showInstanceCountValue = this.showInstanceCountValue;
+      if (!showInstanceCountSet) {
+        showInstanceCountValue = SingleReportConfigurationDto.defaultShowInstanceCount();
+      }
+      Boolean pointMarkersValue = this.pointMarkersValue;
+      if (!pointMarkersSet) {
+        pointMarkersValue = SingleReportConfigurationDto.defaultPointMarkers();
+      }
+      Integer precisionValue = this.precisionValue;
+      if (!precisionSet) {
+        precisionValue = SingleReportConfigurationDto.defaultPrecision();
+      }
+      Boolean hideRelativeValueValue = this.hideRelativeValueValue;
+      if (!hideRelativeValueSet) {
+        hideRelativeValueValue = SingleReportConfigurationDto.defaultHideRelativeValue();
+      }
+      Boolean hideAbsoluteValueValue = this.hideAbsoluteValueValue;
+      if (!hideAbsoluteValueSet) {
+        hideAbsoluteValueValue = SingleReportConfigurationDto.defaultHideAbsoluteValue();
+      }
+      String yLabelValue = this.yLabelValue;
+      if (!yLabelSet) {
+        yLabelValue = SingleReportConfigurationDto.defaultYLabel();
+      }
+      String xLabelValue = this.xLabelValue;
+      if (!xLabelSet) {
+        xLabelValue = SingleReportConfigurationDto.defaultXLabel();
+      }
+      Boolean alwaysShowRelativeValue = this.alwaysShowRelativeValue;
+      if (!alwaysShowRelativeSet) {
+        alwaysShowRelativeValue = SingleReportConfigurationDto.defaultAlwaysShowRelative();
+      }
+      Boolean alwaysShowAbsoluteValue = this.alwaysShowAbsoluteValue;
+      if (!alwaysShowAbsoluteSet) {
+        alwaysShowAbsoluteValue = SingleReportConfigurationDto.defaultAlwaysShowAbsolute();
+      }
+      Boolean showGradientBarsValue = this.showGradientBarsValue;
+      if (!showGradientBarsSet) {
+        showGradientBarsValue = SingleReportConfigurationDto.defaultShowGradientBars();
+      }
+      String xmlValue = this.xmlValue;
+      if (!xmlSet) {
+        xmlValue = SingleReportConfigurationDto.defaultXml();
+      }
+      TableColumnDto tableColumnsValue = this.tableColumnsValue;
+      if (!tableColumnsSet) {
+        tableColumnsValue = SingleReportConfigurationDto.defaultTableColumns();
+      }
+      SingleReportTargetValueDto targetValueValue = this.targetValueValue;
+      if (!targetValueSet) {
+        targetValueValue = SingleReportConfigurationDto.defaultTargetValue();
+      }
+      HeatmapTargetValueDto heatmapTargetValueValue = this.heatmapTargetValueValue;
+      if (!heatmapTargetValueSet) {
+        heatmapTargetValueValue = SingleReportConfigurationDto.defaultHeatmapTargetValue();
+      }
+      AggregateByDateUnit groupByDateVariableUnitValue = this.groupByDateVariableUnitValue;
+      if (!groupByDateVariableUnitSet) {
+        groupByDateVariableUnitValue =
+            SingleReportConfigurationDto.defaultGroupByDateVariableUnit();
+      }
+      AggregateByDateUnit distributeByDateVariableUnitValue =
+          this.distributeByDateVariableUnitValue;
+      if (!distributeByDateVariableUnitSet) {
+        distributeByDateVariableUnitValue =
+            SingleReportConfigurationDto.defaultDistributeByDateVariableUnit();
+      }
+      CustomBucketDto customBucketValue = this.customBucketValue;
+      if (!customBucketSet) {
+        customBucketValue = SingleReportConfigurationDto.defaultCustomBucket();
+      }
+      CustomBucketDto distributeByCustomBucketValue = this.distributeByCustomBucketValue;
+      if (!distributeByCustomBucketSet) {
+        distributeByCustomBucketValue =
+            SingleReportConfigurationDto.defaultDistributeByCustomBucket();
+      }
+      ReportSortingDto sortingValue = this.sortingValue;
+      if (!sortingSet) {
+        sortingValue = SingleReportConfigurationDto.defaultSorting();
+      }
+      ProcessPartDto processPartValue = this.processPartValue;
+      if (!processPartSet) {
+        processPartValue = SingleReportConfigurationDto.defaultProcessPart();
+      }
+      MeasureVisualizationsDto measureVisualizationsValue = this.measureVisualizationsValue;
+      if (!measureVisualizationsSet) {
+        measureVisualizationsValue = SingleReportConfigurationDto.defaultMeasureVisualizations();
+      }
+      Boolean stackedBarValue = this.stackedBarValue;
+      if (!stackedBarSet) {
+        stackedBarValue = SingleReportConfigurationDto.defaultStackedBar();
+      }
+      Boolean horizontalBarValue = this.horizontalBarValue;
+      if (!horizontalBarSet) {
+        horizontalBarValue = SingleReportConfigurationDto.defaultHorizontalBar();
+      }
+      Boolean logScaleValue = this.logScaleValue;
+      if (!logScaleSet) {
+        logScaleValue = SingleReportConfigurationDto.defaultLogScale();
+      }
+      return new SingleReportConfigurationDto(
+          colorValue,
+          aggregationTypesValue,
+          userTaskDurationTimesValue,
+          showInstanceCountValue,
+          pointMarkersValue,
+          precisionValue,
+          hideRelativeValueValue,
+          hideAbsoluteValueValue,
+          yLabelValue,
+          xLabelValue,
+          alwaysShowRelativeValue,
+          alwaysShowAbsoluteValue,
+          showGradientBarsValue,
+          xmlValue,
+          tableColumnsValue,
+          targetValueValue,
+          heatmapTargetValueValue,
+          groupByDateVariableUnitValue,
+          distributeByDateVariableUnitValue,
+          customBucketValue,
+          distributeByCustomBucketValue,
+          sortingValue,
+          processPartValue,
+          measureVisualizationsValue,
+          stackedBarValue,
+          horizontalBarValue,
+          logScaleValue);
+    }
+
+    @Override
+    public String toString() {
+      return "SingleReportConfigurationDto.SingleReportConfigurationDtoBuilder(colorValue="
+          + colorValue
+          + ", aggregationTypesValue="
+          + aggregationTypesValue
+          + ", userTaskDurationTimesValue="
+          + userTaskDurationTimesValue
+          + ", showInstanceCountValue="
+          + showInstanceCountValue
+          + ", pointMarkersValue="
+          + pointMarkersValue
+          + ", precisionValue="
+          + precisionValue
+          + ", hideRelativeValueValue="
+          + hideRelativeValueValue
+          + ", hideAbsoluteValueValue="
+          + hideAbsoluteValueValue
+          + ", yLabelValue="
+          + yLabelValue
+          + ", xLabelValue="
+          + xLabelValue
+          + ", alwaysShowRelativeValue="
+          + alwaysShowRelativeValue
+          + ", alwaysShowAbsoluteValue="
+          + alwaysShowAbsoluteValue
+          + ", showGradientBarsValue="
+          + showGradientBarsValue
+          + ", xmlValue="
+          + xmlValue
+          + ", tableColumnsValue="
+          + tableColumnsValue
+          + ", targetValueValue="
+          + targetValueValue
+          + ", heatmapTargetValueValue="
+          + heatmapTargetValueValue
+          + ", groupByDateVariableUnitValue="
+          + groupByDateVariableUnitValue
+          + ", distributeByDateVariableUnitValue="
+          + distributeByDateVariableUnitValue
+          + ", customBucketValue="
+          + customBucketValue
+          + ", distributeByCustomBucketValue="
+          + distributeByCustomBucketValue
+          + ", sortingValue="
+          + sortingValue
+          + ", processPartValue="
+          + processPartValue
+          + ", measureVisualizationsValue="
+          + measureVisualizationsValue
+          + ", stackedBarValue="
+          + stackedBarValue
+          + ", horizontalBarValue="
+          + horizontalBarValue
+          + ", logScaleValue="
+          + logScaleValue
+          + ")";
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/TableColumnDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/TableColumnDto.java
@@ -13,18 +13,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-@Data
-@Slf4j
 public class TableColumnDto {
 
   public static final String VARIABLE_PREFIX = "variable:";
@@ -32,11 +24,25 @@ public class TableColumnDto {
   public static final String OUTPUT_PREFIX = "output:";
   public static final String FLOWNODE_DURATION_PREFIX = "dur:";
   public static final String COUNT_PREFIX = "count:";
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(TableColumnDto.class);
 
-  @Builder.Default private boolean includeNewVariables = false;
-  @Builder.Default private List<String> excludedColumns = new ArrayList<>();
-  @Builder.Default private List<String> includedColumns = new ArrayList<>();
-  @Builder.Default private List<String> columnOrder = new ArrayList<>();
+  private boolean includeNewVariables = false;
+  private List<String> excludedColumns = new ArrayList<>();
+  private List<String> includedColumns = new ArrayList<>();
+  private List<String> columnOrder = new ArrayList<>();
+
+  public TableColumnDto(
+      final boolean includeNewVariables,
+      final List<String> excludedColumns,
+      final List<String> includedColumns,
+      final List<String> columnOrder) {
+    this.includeNewVariables = includeNewVariables;
+    this.excludedColumns = excludedColumns;
+    this.includedColumns = includedColumns;
+    this.columnOrder = columnOrder;
+  }
+
+  public TableColumnDto() {}
 
   public void addNewAndRemoveUnexpectedVariableColumns(final List<String> allVariableColumns) {
     final List<String> newColumns = determineNewColumns(allVariableColumns);
@@ -77,6 +83,10 @@ public class TableColumnDto {
     includedColumns.removeAll(excludedColumns);
     sortIncludedColumns();
     return includedColumns;
+  }
+
+  public void setIncludedColumns(final List<String> includedColumns) {
+    this.includedColumns = includedColumns;
   }
 
   private List<String> determineNewColumns(final List<String> allColumns) {
@@ -152,18 +162,169 @@ public class TableColumnDto {
     try {
       return digitsInString.isEmpty() ? 0 : Double.parseDouble(digitsInString);
     } catch (final NumberFormatException e) {
-      log.debug(
+      LOG.debug(
           "Cannot parse numbers in variable column names to double, ignoring and sorting by string.",
           e);
       return Double.MAX_VALUE;
     }
   }
 
+  public boolean isIncludeNewVariables() {
+    return includeNewVariables;
+  }
+
+  public void setIncludeNewVariables(final boolean includeNewVariables) {
+    this.includeNewVariables = includeNewVariables;
+  }
+
+  public List<String> getExcludedColumns() {
+    return excludedColumns;
+  }
+
+  public void setExcludedColumns(final List<String> excludedColumns) {
+    this.excludedColumns = excludedColumns;
+  }
+
+  public List<String> getColumnOrder() {
+    return columnOrder;
+  }
+
+  public void setColumnOrder(final List<String> columnOrder) {
+    this.columnOrder = columnOrder;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof TableColumnDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TableColumnDto that = (TableColumnDto) o;
+    return includeNewVariables == that.includeNewVariables
+        && Objects.equals(excludedColumns, that.excludedColumns)
+        && Objects.equals(includedColumns, that.includedColumns)
+        && Objects.equals(columnOrder, that.columnOrder);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(includeNewVariables, excludedColumns, includedColumns, columnOrder);
+  }
+
+  @Override
+  public String toString() {
+    return "TableColumnDto(includeNewVariables="
+        + isIncludeNewVariables()
+        + ", excludedColumns="
+        + getExcludedColumns()
+        + ", includedColumns="
+        + getIncludedColumns()
+        + ", columnOrder="
+        + getColumnOrder()
+        + ")";
+  }
+
+  private static boolean defaultIncludeNewVariables() {
+    return false;
+  }
+
+  private static List<String> defaultExcludedColumns() {
+    return new ArrayList<>();
+  }
+
+  private static List<String> defaultIncludedColumns() {
+    return new ArrayList<>();
+  }
+
+  private static List<String> defaultColumnOrder() {
+    return new ArrayList<>();
+  }
+
+  public static TableColumnDtoBuilder builder() {
+    return new TableColumnDtoBuilder();
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String includeNewVariables = "includeNewVariables";
     public static final String excludedColumns = "excludedColumns";
     public static final String includedColumns = "includedColumns";
     public static final String columnOrder = "columnOrder";
+  }
+
+  public static class TableColumnDtoBuilder {
+
+    private boolean includeNewVariablesValue;
+    private boolean includeNewVariablesSet;
+    private List<String> excludedColumnsValue;
+    private boolean excludedColumnsSet;
+    private List<String> includedColumnsValue;
+    private boolean includedColumnsSet;
+    private List<String> columnOrderValue;
+    private boolean columnOrderSet;
+
+    TableColumnDtoBuilder() {}
+
+    public TableColumnDtoBuilder includeNewVariables(final boolean includeNewVariables) {
+      includeNewVariablesValue = includeNewVariables;
+      includeNewVariablesSet = true;
+      return this;
+    }
+
+    public TableColumnDtoBuilder excludedColumns(final List<String> excludedColumns) {
+      excludedColumnsValue = excludedColumns;
+      excludedColumnsSet = true;
+      return this;
+    }
+
+    public TableColumnDtoBuilder includedColumns(final List<String> includedColumns) {
+      includedColumnsValue = includedColumns;
+      includedColumnsSet = true;
+      return this;
+    }
+
+    public TableColumnDtoBuilder columnOrder(final List<String> columnOrder) {
+      columnOrderValue = columnOrder;
+      columnOrderSet = true;
+      return this;
+    }
+
+    public TableColumnDto build() {
+      boolean includeNewVariablesValue = this.includeNewVariablesValue;
+      if (!includeNewVariablesSet) {
+        includeNewVariablesValue = TableColumnDto.defaultIncludeNewVariables();
+      }
+      List<String> excludedColumnsValue = this.excludedColumnsValue;
+      if (!excludedColumnsSet) {
+        excludedColumnsValue = TableColumnDto.defaultExcludedColumns();
+      }
+      List<String> includedColumnsValue = this.includedColumnsValue;
+      if (!includedColumnsSet) {
+        includedColumnsValue = TableColumnDto.defaultIncludedColumns();
+      }
+      List<String> columnOrderValue = this.columnOrderValue;
+      if (!columnOrderSet) {
+        columnOrderValue = TableColumnDto.defaultColumnOrder();
+      }
+      return new TableColumnDto(
+          includeNewVariablesValue, excludedColumnsValue, includedColumnsValue, columnOrderValue);
+    }
+
+    @Override
+    public String toString() {
+      return "TableColumnDto.TableColumnDtoBuilder(includeNewVariablesValue="
+          + includeNewVariablesValue
+          + ", excludedColumnsValue="
+          + excludedColumnsValue
+          + ", includedColumnsValue="
+          + includedColumnsValue
+          + ", columnOrderValue="
+          + columnOrderValue
+          + ")";
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/custom_buckets/CustomBucketDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/custom_buckets/CustomBucketDto.java
@@ -10,34 +10,39 @@ package io.camunda.optimize.dto.optimize.query.report.single.configuration.custo
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class CustomBucketDto {
 
-  @Builder.Default private boolean active = false;
+  private boolean active = false;
 
-  @Builder.Default
   @JsonFormat(shape = JsonFormat.Shape.STRING)
   private Double bucketSize = 10.0;
 
-  @Builder.Default private BucketUnit bucketSizeUnit = null;
+  private BucketUnit bucketSizeUnit = null;
 
   // baseline = start of first bucket, if left null or customBuckets are inactive,
   // the bucket range will start at the min value
-  @Builder.Default
   @JsonFormat(shape = JsonFormat.Shape.STRING)
   private Double baseline = 0.0;
 
-  @Builder.Default private BucketUnit baselineUnit = null;
+  private BucketUnit baselineUnit = null;
+
+  public CustomBucketDto(
+      final boolean active,
+      final Double bucketSize,
+      final BucketUnit bucketSizeUnit,
+      final Double baseline,
+      final BucketUnit baselineUnit) {
+    this.active = active;
+    this.bucketSize = bucketSize;
+    this.bucketSizeUnit = bucketSizeUnit;
+    this.baseline = baseline;
+    this.baselineUnit = baselineUnit;
+  }
+
+  protected CustomBucketDto() {}
 
   public Optional<Double> getBucketSizeInUnit(final BucketUnit requestedBucketUnit) {
     return convertValueToRequestedUnit(requestedBucketUnit, bucketSize, bucketSizeUnit);
@@ -91,6 +96,197 @@ public class CustomBucketDto {
         throw new OptimizeRuntimeException("Unsupported bucket unit: " + bucketUnit);
     }
     return chronoUnit.getDuration().toMillis();
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(final boolean active) {
+    this.active = active;
+  }
+
+  public Double getBucketSize() {
+    return bucketSize;
+  }
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
+  public void setBucketSize(final Double bucketSize) {
+    this.bucketSize = bucketSize;
+  }
+
+  public BucketUnit getBucketSizeUnit() {
+    return bucketSizeUnit;
+  }
+
+  public void setBucketSizeUnit(final BucketUnit bucketSizeUnit) {
+    this.bucketSizeUnit = bucketSizeUnit;
+  }
+
+  public Double getBaseline() {
+    return baseline;
+  }
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
+  public void setBaseline(final Double baseline) {
+    this.baseline = baseline;
+  }
+
+  public BucketUnit getBaselineUnit() {
+    return baselineUnit;
+  }
+
+  public void setBaselineUnit(final BucketUnit baselineUnit) {
+    this.baselineUnit = baselineUnit;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CustomBucketDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CustomBucketDto that = (CustomBucketDto) o;
+    return active == that.active
+        && Objects.equals(bucketSize, that.bucketSize)
+        && bucketSizeUnit == that.bucketSizeUnit
+        && Objects.equals(baseline, that.baseline)
+        && baselineUnit == that.baselineUnit;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(active, bucketSize, bucketSizeUnit, baseline, baselineUnit);
+  }
+
+  @Override
+  public String toString() {
+    return "CustomBucketDto(active="
+        + isActive()
+        + ", bucketSize="
+        + getBucketSize()
+        + ", bucketSizeUnit="
+        + getBucketSizeUnit()
+        + ", baseline="
+        + getBaseline()
+        + ", baselineUnit="
+        + getBaselineUnit()
+        + ")";
+  }
+
+  private static boolean defaultActive() {
+    return false;
+  }
+
+  private static Double defaultBucketSize() {
+    return 10.0;
+  }
+
+  private static BucketUnit defaultBucketSizeUnit() {
+    return null;
+  }
+
+  private static Double defaultBaseline() {
+    return 0.0;
+  }
+
+  private static BucketUnit defaultBaselineUnit() {
+    return null;
+  }
+
+  public static CustomBucketDtoBuilder builder() {
+    return new CustomBucketDtoBuilder();
+  }
+
+  public static class CustomBucketDtoBuilder {
+
+    private boolean activeValue;
+    private boolean activeSet;
+    private Double bucketSizeValue;
+    private boolean bucketSizeSet;
+    private BucketUnit bucketSizeUnitValue;
+    private boolean bucketSizeUnitSet;
+    private Double baselineValue;
+    private boolean baselineSet;
+    private BucketUnit baselineUnitValue;
+    private boolean baselineUnitSet;
+
+    CustomBucketDtoBuilder() {}
+
+    public CustomBucketDtoBuilder active(final boolean active) {
+      activeValue = active;
+      activeSet = true;
+      return this;
+    }
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    public CustomBucketDtoBuilder bucketSize(final Double bucketSize) {
+      bucketSizeValue = bucketSize;
+      bucketSizeSet = true;
+      return this;
+    }
+
+    public CustomBucketDtoBuilder bucketSizeUnit(final BucketUnit bucketSizeUnit) {
+      bucketSizeUnitValue = bucketSizeUnit;
+      bucketSizeUnitSet = true;
+      return this;
+    }
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    public CustomBucketDtoBuilder baseline(final Double baseline) {
+      baselineValue = baseline;
+      baselineSet = true;
+      return this;
+    }
+
+    public CustomBucketDtoBuilder baselineUnit(final BucketUnit baselineUnit) {
+      baselineUnitValue = baselineUnit;
+      baselineUnitSet = true;
+      return this;
+    }
+
+    public CustomBucketDto build() {
+      boolean activeValue = this.activeValue;
+      if (!activeSet) {
+        activeValue = CustomBucketDto.defaultActive();
+      }
+      Double bucketSizeValue = this.bucketSizeValue;
+      if (!bucketSizeSet) {
+        bucketSizeValue = CustomBucketDto.defaultBucketSize();
+      }
+      BucketUnit bucketSizeUnitValue = this.bucketSizeUnitValue;
+      if (!bucketSizeUnitSet) {
+        bucketSizeUnitValue = CustomBucketDto.defaultBucketSizeUnit();
+      }
+      Double baselineValue = this.baselineValue;
+      if (!baselineSet) {
+        baselineValue = CustomBucketDto.defaultBaseline();
+      }
+      BucketUnit baselineUnitValue = this.baselineUnitValue;
+      if (!baselineUnitSet) {
+        baselineUnitValue = CustomBucketDto.defaultBaselineUnit();
+      }
+      return new CustomBucketDto(
+          activeValue, bucketSizeValue, bucketSizeUnitValue, baselineValue, baselineUnitValue);
+    }
+
+    @Override
+    public String toString() {
+      return "CustomBucketDto.CustomBucketDtoBuilder(active$value="
+          + activeValue
+          + ", bucketSizeValue="
+          + bucketSizeValue
+          + ", bucketSizeUnitValue="
+          + bucketSizeUnitValue
+          + ", baselineValue="
+          + baselineValue
+          + ", baselineUnitValue="
+          + baselineUnitValue
+          + ")";
+    }
   }
 
   public enum Fields {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/heatmap_target_value/HeatmapTargetValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/heatmap_target_value/HeatmapTargetValueDto.java
@@ -9,11 +9,51 @@ package io.camunda.optimize.dto.optimize.query.report.single.configuration.heatm
 
 import java.util.HashMap;
 import java.util.Map;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class HeatmapTargetValueDto {
 
   private Boolean active = false;
   private Map<String, HeatmapTargetValueEntryDto> values = new HashMap<>();
+
+  public HeatmapTargetValueDto() {}
+
+  public Boolean getActive() {
+    return active;
+  }
+
+  public void setActive(final Boolean active) {
+    this.active = active;
+  }
+
+  public Map<String, HeatmapTargetValueEntryDto> getValues() {
+    return values;
+  }
+
+  public void setValues(final Map<String, HeatmapTargetValueEntryDto> values) {
+    this.values = values;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof HeatmapTargetValueDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final HeatmapTargetValueDto that = (HeatmapTargetValueDto) o;
+    return Objects.equals(active, that.active) && Objects.equals(values, that.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(active, values);
+  }
+
+  @Override
+  public String toString() {
+    return "HeatmapTargetValueDto(active=" + getActive() + ", values=" + getValues() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/heatmap_target_value/HeatmapTargetValueEntryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/heatmap_target_value/HeatmapTargetValueEntryDto.java
@@ -8,9 +8,8 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.heatmap_target_value;
 
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class HeatmapTargetValueEntryDto {
 
   private TargetValueUnit unit = TargetValueUnit.HOURS;
@@ -21,5 +20,44 @@ public class HeatmapTargetValueEntryDto {
   public HeatmapTargetValueEntryDto(final TargetValueUnit unit, final String value) {
     this.unit = unit;
     this.value = value;
+  }
+
+  public TargetValueUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final TargetValueUnit unit) {
+    this.unit = unit;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof HeatmapTargetValueEntryDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final HeatmapTargetValueEntryDto that = (HeatmapTargetValueEntryDto) o;
+    return unit == that.unit && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(unit, value);
+  }
+
+  @Override
+  public String toString() {
+    return "HeatmapTargetValueEntryDto(unit=" + getUnit() + ", value=" + getValue() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/BaseLineDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/BaseLineDto.java
@@ -8,13 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
 import java.util.Objects;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 
-@Getter
-@Setter
-@ToString
 public class BaseLineDto {
 
   private TargetValueUnit unit = TargetValueUnit.HOURS;
@@ -22,17 +16,36 @@ public class BaseLineDto {
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof final BaseLineDto that)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
+    final BaseLineDto that = (BaseLineDto) o;
     return unit == that.unit && Objects.equals(value, that.value);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(unit, value);
+  }
+
+  @Override
+  public String toString() {
+    return "BaseLineDto(unit=" + getUnit() + ", value=" + getValue() + ")";
+  }
+
+  public TargetValueUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final TargetValueUnit unit) {
+    this.unit = unit;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/CountProgressDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/CountProgressDto.java
@@ -8,13 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
 import java.util.Objects;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 
-@Getter
-@Setter
-@ToString
 public class CountProgressDto {
 
   private String baseline = "0";
@@ -22,23 +16,57 @@ public class CountProgressDto {
   private Boolean isBelow = false;
 
   @Override
-  public int hashCode() {
-    return Objects.hash(baseline, target);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CountProgressDto that = (CountProgressDto) o;
+    return Objects.equals(baseline, that.baseline)
+        && Objects.equals(target, that.target)
+        && Objects.equals(isBelow, that.isBelow);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof final CountProgressDto that)) {
-      return false;
-    }
-    return Objects.equals(baseline, that.baseline)
-        && Objects.equals(isBelow, that.isBelow)
-        && Objects.equals(target, that.target);
+  public int hashCode() {
+    return Objects.hash(baseline, target, isBelow);
   }
 
+  @Override
+  public String toString() {
+    return "CountProgressDto(baseline="
+        + getBaseline()
+        + ", target="
+        + getTarget()
+        + ", isBelow="
+        + getIsBelow()
+        + ")";
+  }
+
+  public String getBaseline() {
+    return baseline;
+  }
+
+  public void setBaseline(final String baseline) {
+    this.baseline = baseline;
+  }
+
+  public String getTarget() {
+    return target;
+  }
+
+  public void setTarget(final String target) {
+    this.target = target;
+  }
+
+  public Boolean getIsBelow() {
+    return isBelow;
+  }
+
+  public void setIsBelow(final Boolean isBelow) {
+    this.isBelow = isBelow;
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String baseline = "baseline";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/DurationProgressDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/DurationProgressDto.java
@@ -8,17 +8,20 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
 import java.util.Objects;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 
-@Getter
-@Setter
-@ToString
 public class DurationProgressDto {
 
   private BaseLineDto baseline = new BaseLineDto();
   private TargetDto target = new TargetDto();
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DurationProgressDto that = (DurationProgressDto) o;
+    return Objects.equals(baseline, that.baseline) && Objects.equals(target, that.target);
+  }
 
   @Override
   public int hashCode() {
@@ -26,16 +29,27 @@ public class DurationProgressDto {
   }
 
   @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof final DurationProgressDto that)) {
-      return false;
-    }
-    return Objects.equals(baseline, that.baseline) && Objects.equals(target, that.target);
+  public String toString() {
+    return "DurationProgressDto(baseline=" + getBaseline() + ", target=" + getTarget() + ")";
   }
 
+  public BaseLineDto getBaseline() {
+    return baseline;
+  }
+
+  public void setBaseline(final BaseLineDto baseline) {
+    this.baseline = baseline;
+  }
+
+  public TargetDto getTarget() {
+    return target;
+  }
+
+  public void setTarget(final TargetDto target) {
+    this.target = target;
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String baseline = "baseline";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportCountChartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportCountChartDto.java
@@ -8,13 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
 import java.util.Objects;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 
-@Getter
-@Setter
-@ToString
 public class SingleReportCountChartDto {
 
   private Boolean isBelow = false;
@@ -22,17 +16,36 @@ public class SingleReportCountChartDto {
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof final SingleReportCountChartDto that)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
+    final SingleReportCountChartDto that = (SingleReportCountChartDto) o;
     return Objects.equals(isBelow, that.isBelow) && Objects.equals(value, that.value);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(isBelow, value);
+  }
+
+  @Override
+  public String toString() {
+    return "SingleReportCountChartDto(isBelow=" + getIsBelow() + ", value=" + getValue() + ")";
+  }
+
+  public Boolean getIsBelow() {
+    return isBelow;
+  }
+
+  public void setIsBelow(final Boolean isBelow) {
+    this.isBelow = isBelow;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportDurationChartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportDurationChartDto.java
@@ -8,13 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
 import java.util.Objects;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 
-@Getter
-@Setter
-@ToString
 public class SingleReportDurationChartDto {
 
   private TargetValueUnit unit = TargetValueUnit.HOURS;
@@ -23,12 +17,10 @@ public class SingleReportDurationChartDto {
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof final SingleReportDurationChartDto that)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
+    final SingleReportDurationChartDto that = (SingleReportDurationChartDto) o;
     return unit == that.unit
         && Objects.equals(isBelow, that.isBelow)
         && Objects.equals(value, that.value);
@@ -37,5 +29,40 @@ public class SingleReportDurationChartDto {
   @Override
   public int hashCode() {
     return Objects.hash(unit, isBelow, value);
+  }
+
+  @Override
+  public String toString() {
+    return "SingleReportDurationChartDto(unit="
+        + getUnit()
+        + ", isBelow="
+        + getIsBelow()
+        + ", value="
+        + getValue()
+        + ")";
+  }
+
+  public TargetValueUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final TargetValueUnit unit) {
+    this.unit = unit;
+  }
+
+  public Boolean getIsBelow() {
+    return isBelow;
+  }
+
+  public void setIsBelow(final Boolean isBelow) {
+    this.isBelow = isBelow;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportTargetValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportTargetValueDto.java
@@ -7,9 +7,8 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class SingleReportTargetValueDto {
 
   private SingleReportCountChartDto countChart = new SingleReportCountChartDto();
@@ -19,6 +18,97 @@ public class SingleReportTargetValueDto {
   private SingleReportDurationChartDto durationChart = new SingleReportDurationChartDto();
   private Boolean isKpi;
 
+  public SingleReportTargetValueDto() {}
+
+  public SingleReportCountChartDto getCountChart() {
+    return countChart;
+  }
+
+  public void setCountChart(final SingleReportCountChartDto countChart) {
+    this.countChart = countChart;
+  }
+
+  public DurationProgressDto getDurationProgress() {
+    return durationProgress;
+  }
+
+  public void setDurationProgress(final DurationProgressDto durationProgress) {
+    this.durationProgress = durationProgress;
+  }
+
+  public Boolean getActive() {
+    return active;
+  }
+
+  public void setActive(final Boolean active) {
+    this.active = active;
+  }
+
+  public CountProgressDto getCountProgress() {
+    return countProgress;
+  }
+
+  public void setCountProgress(final CountProgressDto countProgress) {
+    this.countProgress = countProgress;
+  }
+
+  public SingleReportDurationChartDto getDurationChart() {
+    return durationChart;
+  }
+
+  public void setDurationChart(final SingleReportDurationChartDto durationChart) {
+    this.durationChart = durationChart;
+  }
+
+  public Boolean getIsKpi() {
+    return isKpi;
+  }
+
+  public void setIsKpi(final Boolean isKpi) {
+    this.isKpi = isKpi;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof SingleReportTargetValueDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SingleReportTargetValueDto that = (SingleReportTargetValueDto) o;
+    return Objects.equals(countChart, that.countChart)
+        && Objects.equals(durationProgress, that.durationProgress)
+        && Objects.equals(active, that.active)
+        && Objects.equals(countProgress, that.countProgress)
+        && Objects.equals(durationChart, that.durationChart)
+        && Objects.equals(isKpi, that.isKpi);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(countChart, durationProgress, active, countProgress, durationChart, isKpi);
+  }
+
+  @Override
+  public String toString() {
+    return "SingleReportTargetValueDto(countChart="
+        + getCountChart()
+        + ", durationProgress="
+        + getDurationProgress()
+        + ", active="
+        + getActive()
+        + ", countProgress="
+        + getCountProgress()
+        + ", durationChart="
+        + getDurationChart()
+        + ", isKpi="
+        + getIsKpi()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String countChart = "countChart";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/TargetDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/TargetDto.java
@@ -8,13 +8,7 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
 import java.util.Objects;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 
-@Getter
-@Setter
-@ToString
 public class TargetDto {
 
   private TargetValueUnit unit = TargetValueUnit.HOURS;
@@ -22,23 +16,57 @@ public class TargetDto {
   private Boolean isBelow = false;
 
   @Override
-  public int hashCode() {
-    return Objects.hash(unit, value);
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TargetDto targetDto = (TargetDto) o;
+    return unit == targetDto.unit
+        && Objects.equals(value, targetDto.value)
+        && Objects.equals(isBelow, targetDto.isBelow);
   }
 
   @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof final TargetDto targetDto)) {
-      return false;
-    }
-    return unit == targetDto.unit
-        && Objects.equals(isBelow, targetDto.isBelow)
-        && Objects.equals(value, targetDto.value);
+  public int hashCode() {
+    return Objects.hash(unit, value, isBelow);
   }
 
+  @Override
+  public String toString() {
+    return "TargetDto(unit="
+        + getUnit()
+        + ", value="
+        + getValue()
+        + ", isBelow="
+        + getIsBelow()
+        + ")";
+  }
+
+  public TargetValueUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final TargetValueUnit unit) {
+    this.unit = unit;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
+  }
+
+  public Boolean getIsBelow() {
+    return isBelow;
+  }
+
+  public void setIsBelow(final Boolean isBelow) {
+    this.isBelow = isBelow;
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String unit = "unit";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/DecisionReportDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/DecisionReportDataDto.java
@@ -21,29 +21,50 @@ import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
-@EqualsAndHashCode(callSuper = false)
-@NoArgsConstructor
-@SuperBuilder
 @DecisionFiltersMustReferenceExistingDefinitionsConstraint
 public class DecisionReportDataDto extends SingleReportDataDto {
 
-  @Builder.Default @Valid protected List<DecisionFilterDto<?>> filter = new ArrayList<>();
+  @Valid protected List<DecisionFilterDto<?>> filter = new ArrayList<>();
   protected DecisionViewDto view;
   protected DecisionGroupByDto<?> groupBy;
 
-  @Builder.Default
   protected ProcessReportDistributedByDto<?> distributedBy = new NoneDistributedByDto();
 
   protected DecisionVisualization visualization;
+
+  public DecisionReportDataDto(
+      @Valid final List<DecisionFilterDto<?>> filter,
+      final DecisionViewDto view,
+      final DecisionGroupByDto<?> groupBy,
+      final ProcessReportDistributedByDto<?> distributedBy,
+      final DecisionVisualization visualization) {
+    this.filter = filter;
+    this.view = view;
+    this.groupBy = groupBy;
+    this.distributedBy = distributedBy;
+    this.visualization = visualization;
+  }
+
+  public DecisionReportDataDto() {}
+
+  protected DecisionReportDataDto(final DecisionReportDataDtoBuilder<?, ?> b) {
+    super(b);
+    if (b.filterSet) {
+      filter = b.filterValue;
+    } else {
+      filter = defaultFilter();
+    }
+    view = b.view;
+    groupBy = b.groupBy;
+    if (b.distributedBySet) {
+      distributedBy = b.distributedByValue;
+    } else {
+      distributedBy = defaultDistributedBy();
+    }
+    visualization = b.visualization;
+  }
 
   public String getDecisionDefinitionKey() {
     return getDefinitionKey();
@@ -107,6 +128,97 @@ public class DecisionReportDataDto extends SingleReportDataDto {
     return Collections.singletonList(createCommandKey());
   }
 
+  public @Valid List<DecisionFilterDto<?>> getFilter() {
+    return filter;
+  }
+
+  public void setFilter(@Valid final List<DecisionFilterDto<?>> filter) {
+    this.filter = filter;
+  }
+
+  public DecisionViewDto getView() {
+    return view;
+  }
+
+  public void setView(final DecisionViewDto view) {
+    this.view = view;
+  }
+
+  public DecisionGroupByDto<?> getGroupBy() {
+    return groupBy;
+  }
+
+  public void setGroupBy(final DecisionGroupByDto<?> groupBy) {
+    this.groupBy = groupBy;
+  }
+
+  public ProcessReportDistributedByDto<?> getDistributedBy() {
+    return distributedBy;
+  }
+
+  public void setDistributedBy(final ProcessReportDistributedByDto<?> distributedBy) {
+    this.distributedBy = distributedBy;
+  }
+
+  public DecisionVisualization getVisualization() {
+    return visualization;
+  }
+
+  public void setVisualization(final DecisionVisualization visualization) {
+    this.visualization = visualization;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DecisionReportDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionReportDataDto that = (DecisionReportDataDto) o;
+    return Objects.equals(filter, that.filter)
+        && Objects.equals(view, that.view)
+        && Objects.equals(groupBy, that.groupBy)
+        && Objects.equals(distributedBy, that.distributedBy)
+        && visualization == that.visualization;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(filter, view, groupBy, distributedBy, visualization);
+  }
+
+  @Override
+  public String toString() {
+    return "DecisionReportDataDto(filter="
+        + getFilter()
+        + ", view="
+        + getView()
+        + ", groupBy="
+        + getGroupBy()
+        + ", distributedBy="
+        + getDistributedBy()
+        + ", visualization="
+        + getVisualization()
+        + ")";
+  }
+
+  @Valid
+  private static List<DecisionFilterDto<?>> defaultFilter() {
+    return new ArrayList<>();
+  }
+
+  private static ProcessReportDistributedByDto<?> defaultDistributedBy() {
+    return new NoneDistributedByDto();
+  }
+
+  public static DecisionReportDataDtoBuilder<?, ?> builder() {
+    return new DecisionReportDataDtoBuilderImpl();
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String filter = "filter";
@@ -114,5 +226,85 @@ public class DecisionReportDataDto extends SingleReportDataDto {
     public static final String groupBy = "groupBy";
     public static final String distributedBy = "distributedBy";
     public static final String visualization = "visualization";
+  }
+
+  public abstract static class DecisionReportDataDtoBuilder<
+          C extends DecisionReportDataDto, B extends DecisionReportDataDtoBuilder<C, B>>
+      extends SingleReportDataDtoBuilder<C, B> {
+
+    private @Valid List<DecisionFilterDto<?>> filterValue;
+    private boolean filterSet;
+    private DecisionViewDto view;
+    private DecisionGroupByDto<?> groupBy;
+    private ProcessReportDistributedByDto<?> distributedByValue;
+    private boolean distributedBySet;
+    private DecisionVisualization visualization;
+
+    public B filter(@Valid final List<DecisionFilterDto<?>> filter) {
+      filterValue = filter;
+      filterSet = true;
+      return self();
+    }
+
+    public B view(final DecisionViewDto view) {
+      this.view = view;
+      return self();
+    }
+
+    public B groupBy(final DecisionGroupByDto<?> groupBy) {
+      this.groupBy = groupBy;
+      return self();
+    }
+
+    public B distributedBy(final ProcessReportDistributedByDto<?> distributedBy) {
+      distributedByValue = distributedBy;
+      distributedBySet = true;
+      return self();
+    }
+
+    public B visualization(final DecisionVisualization visualization) {
+      this.visualization = visualization;
+      return self();
+    }
+
+    @Override
+    protected abstract B self();
+
+    @Override
+    public abstract C build();
+
+    @Override
+    public String toString() {
+      return "DecisionReportDataDto.DecisionReportDataDtoBuilder(super="
+          + super.toString()
+          + ", filterValue="
+          + filterValue
+          + ", view="
+          + view
+          + ", groupBy="
+          + groupBy
+          + ", distributedByValue="
+          + distributedByValue
+          + ", visualization="
+          + visualization
+          + ")";
+    }
+  }
+
+  private static final class DecisionReportDataDtoBuilderImpl
+      extends DecisionReportDataDtoBuilder<
+          DecisionReportDataDto, DecisionReportDataDtoBuilderImpl> {
+
+    private DecisionReportDataDtoBuilderImpl() {}
+
+    @Override
+    protected DecisionReportDataDtoBuilderImpl self() {
+      return this;
+    }
+
+    @Override
+    public DecisionReportDataDto build() {
+      return new DecisionReportDataDto(this);
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/filter/DecisionFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/filter/DecisionFilterDto.java
@@ -13,9 +13,7 @@ import io.camunda.optimize.dto.optimize.ReportConstants;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
@@ -23,16 +21,55 @@ import lombok.NoArgsConstructor;
   @JsonSubTypes.Type(value = InputVariableFilterDto.class, name = "inputVariable"),
   @JsonSubTypes.Type(value = OutputVariableFilterDto.class, name = "outputVariable"),
 })
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public abstract class DecisionFilterDto<DATA extends FilterDataDto> {
+
   protected DATA data;
 
   @NotEmpty protected List<String> appliedTo = List.of(ReportConstants.APPLIED_TO_ALL_DEFINITIONS);
 
   protected DecisionFilterDto(final DATA data) {
     this.data = data;
+  }
+
+  public DecisionFilterDto(final DATA data, @NotEmpty final List<String> appliedTo) {
+    this.data = data;
+    this.appliedTo = appliedTo;
+  }
+
+  public DecisionFilterDto() {}
+
+  public DATA getData() {
+    return data;
+  }
+
+  public void setData(final DATA data) {
+    this.data = data;
+  }
+
+  public @NotEmpty List<String> getAppliedTo() {
+    return appliedTo;
+  }
+
+  public void setAppliedTo(@NotEmpty final List<String> appliedTo) {
+    this.appliedTo = appliedTo;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DecisionFilterDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionFilterDto<?> that = (DecisionFilterDto<?>) o;
+    return Objects.equals(data, that.data) && Objects.equals(appliedTo, that.appliedTo);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data, appliedTo);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/group/DecisionGroupByDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/group/DecisionGroupByDto.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.query.report.Combinable;
 import io.camunda.optimize.dto.optimize.query.report.single.decision.group.value.DecisionGroupByValueDto;
 import java.util.Objects;
-import lombok.Data;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -39,32 +38,68 @@ import lombok.Data;
       name = GROUP_BY_OUTPUT_VARIABLE_TYPE),
   @JsonSubTypes.Type(value = DecisionGroupByMatchedRuleDto.class, name = GROUP_BY_MATCHED_RULE_TYPE)
 })
-@Data
 public abstract class DecisionGroupByDto<VALUE extends DecisionGroupByValueDto>
     implements Combinable {
 
   @JsonProperty protected DecisionGroupByType type;
   protected VALUE value;
 
-  @Override
-  public String toString() {
-    return type.getId();
-  }
+  public DecisionGroupByDto() {}
 
   @Override
-  public boolean isCombinable(Object o) {
+  public boolean isCombinable(final Object o) {
     if (this == o) {
       return true;
     }
     if (!(o instanceof DecisionGroupByDto)) {
       return false;
     }
-    DecisionGroupByDto<?> that = (DecisionGroupByDto<?>) o;
+    final DecisionGroupByDto<?> that = (DecisionGroupByDto<?>) o;
     return Objects.equals(type, that.type) && Combinable.isCombinable(value, that.value);
   }
 
   @JsonIgnore
   public String createCommandKey() {
+    return type.getId();
+  }
+
+  public DecisionGroupByType getType() {
+    return type;
+  }
+
+  @JsonProperty
+  public void setType(final DecisionGroupByType type) {
+    this.type = type;
+  }
+
+  public VALUE getValue() {
+    return value;
+  }
+
+  public void setValue(final VALUE value) {
+    this.value = value;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DecisionGroupByDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionGroupByDto<?> that = (DecisionGroupByDto<?>) o;
+    return type == that.type && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, value);
+  }
+
+  @Override
+  public String toString() {
     return type.getId();
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/group/value/DecisionGroupByEvaluationDateTimeValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/group/value/DecisionGroupByEvaluationDateTimeValueDto.java
@@ -9,22 +9,55 @@ package io.camunda.optimize.dto.optimize.query.report.single.decision.group.valu
 
 import io.camunda.optimize.dto.optimize.query.report.single.group.AggregateByDateUnit;
 import java.util.Objects;
-import lombok.Data;
 
-@Data
 public class DecisionGroupByEvaluationDateTimeValueDto implements DecisionGroupByValueDto {
 
   protected AggregateByDateUnit unit;
 
+  public DecisionGroupByEvaluationDateTimeValueDto() {}
+
   @Override
-  public boolean isCombinable(Object o) {
+  public boolean isCombinable(final Object o) {
     if (this == o) {
       return true;
     }
     if (!(o instanceof DecisionGroupByEvaluationDateTimeValueDto)) {
       return false;
     }
-    DecisionGroupByEvaluationDateTimeValueDto that = (DecisionGroupByEvaluationDateTimeValueDto) o;
+    final DecisionGroupByEvaluationDateTimeValueDto that =
+        (DecisionGroupByEvaluationDateTimeValueDto) o;
     return Objects.equals(unit, that.unit);
+  }
+
+  public AggregateByDateUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final AggregateByDateUnit unit) {
+    this.unit = unit;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DecisionGroupByEvaluationDateTimeValueDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionGroupByEvaluationDateTimeValueDto that =
+        (DecisionGroupByEvaluationDateTimeValueDto) o;
+    return unit == that.unit;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(unit);
+  }
+
+  @Override
+  public String toString() {
+    return "DecisionGroupByEvaluationDateTimeValueDto(unit=" + getUnit() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/InputVariableEntry.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/InputVariableEntry.java
@@ -9,11 +9,10 @@ package io.camunda.optimize.dto.optimize.query.report.single.decision.result.raw
 
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.Objects;
-import lombok.Getter;
-import lombok.Setter;
 
 public class InputVariableEntry extends VariableEntry {
-  @Getter @Setter private Object value;
+
+  private Object value;
 
   protected InputVariableEntry() {}
 
@@ -25,10 +24,7 @@ public class InputVariableEntry extends VariableEntry {
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof InputVariableEntry)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
     if (!super.equals(o)) {
@@ -41,5 +37,13 @@ public class InputVariableEntry extends VariableEntry {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), value);
+  }
+
+  public Object getValue() {
+    return value;
+  }
+
+  public void setValue(final Object value) {
+    this.value = value;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/OutputVariableEntry.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/OutputVariableEntry.java
@@ -13,18 +13,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import lombok.Getter;
-import lombok.Setter;
 
 public class OutputVariableEntry extends VariableEntry {
-  @Getter @Setter private List<Object> values = new ArrayList<>();
+
+  private List<Object> values = new ArrayList<>();
 
   protected OutputVariableEntry() {}
 
   public OutputVariableEntry(
       final String id, final String name, final VariableType type, final Object value) {
     super(id, name, type);
-    this.values.add(value);
+    values.add(value);
   }
 
   public OutputVariableEntry(
@@ -41,15 +40,12 @@ public class OutputVariableEntry extends VariableEntry {
 
   @JsonIgnore
   public Object getFirstValue() {
-    return this.values.stream().findFirst().orElse(null);
+    return values.stream().findFirst().orElse(null);
   }
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof OutputVariableEntry)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
     if (!super.equals(o)) {
@@ -62,5 +58,13 @@ public class OutputVariableEntry extends VariableEntry {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), values);
+  }
+
+  public List<Object> getValues() {
+    return values;
+  }
+
+  public void setValues(final List<Object> values) {
+    this.values = values;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/RawDataDecisionInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/RawDataDecisionInstanceDto.java
@@ -10,13 +10,8 @@ package io.camunda.optimize.dto.optimize.query.report.single.decision.result.raw
 import io.camunda.optimize.dto.optimize.query.report.single.RawDataInstanceDto;
 import java.time.OffsetDateTime;
 import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Data
 public class RawDataDecisionInstanceDto implements RawDataInstanceDto {
 
   protected String decisionDefinitionKey;
@@ -28,6 +23,159 @@ public class RawDataDecisionInstanceDto implements RawDataInstanceDto {
   protected String tenantId;
   protected Map<String, InputVariableEntry> inputVariables;
   protected Map<String, OutputVariableEntry> outputVariables;
+
+  public RawDataDecisionInstanceDto(
+      final String decisionDefinitionKey,
+      final String decisionDefinitionId,
+      final String decisionInstanceId,
+      final String processInstanceId,
+      final OffsetDateTime evaluationDateTime,
+      final String engineName,
+      final String tenantId,
+      final Map<String, InputVariableEntry> inputVariables,
+      final Map<String, OutputVariableEntry> outputVariables) {
+    this.decisionDefinitionKey = decisionDefinitionKey;
+    this.decisionDefinitionId = decisionDefinitionId;
+    this.decisionInstanceId = decisionInstanceId;
+    this.processInstanceId = processInstanceId;
+    this.evaluationDateTime = evaluationDateTime;
+    this.engineName = engineName;
+    this.tenantId = tenantId;
+    this.inputVariables = inputVariables;
+    this.outputVariables = outputVariables;
+  }
+
+  public RawDataDecisionInstanceDto() {}
+
+  public String getDecisionDefinitionKey() {
+    return decisionDefinitionKey;
+  }
+
+  public void setDecisionDefinitionKey(final String decisionDefinitionKey) {
+    this.decisionDefinitionKey = decisionDefinitionKey;
+  }
+
+  public String getDecisionDefinitionId() {
+    return decisionDefinitionId;
+  }
+
+  public void setDecisionDefinitionId(final String decisionDefinitionId) {
+    this.decisionDefinitionId = decisionDefinitionId;
+  }
+
+  public String getDecisionInstanceId() {
+    return decisionInstanceId;
+  }
+
+  public void setDecisionInstanceId(final String decisionInstanceId) {
+    this.decisionInstanceId = decisionInstanceId;
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public OffsetDateTime getEvaluationDateTime() {
+    return evaluationDateTime;
+  }
+
+  public void setEvaluationDateTime(final OffsetDateTime evaluationDateTime) {
+    this.evaluationDateTime = evaluationDateTime;
+  }
+
+  public String getEngineName() {
+    return engineName;
+  }
+
+  public void setEngineName(final String engineName) {
+    this.engineName = engineName;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public Map<String, InputVariableEntry> getInputVariables() {
+    return inputVariables;
+  }
+
+  public void setInputVariables(final Map<String, InputVariableEntry> inputVariables) {
+    this.inputVariables = inputVariables;
+  }
+
+  public Map<String, OutputVariableEntry> getOutputVariables() {
+    return outputVariables;
+  }
+
+  public void setOutputVariables(final Map<String, OutputVariableEntry> outputVariables) {
+    this.outputVariables = outputVariables;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof RawDataDecisionInstanceDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RawDataDecisionInstanceDto that = (RawDataDecisionInstanceDto) o;
+    return Objects.equals(decisionDefinitionKey, that.decisionDefinitionKey)
+        && Objects.equals(decisionDefinitionId, that.decisionDefinitionId)
+        && Objects.equals(decisionInstanceId, that.decisionInstanceId)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(evaluationDateTime, that.evaluationDateTime)
+        && Objects.equals(engineName, that.engineName)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(inputVariables, that.inputVariables)
+        && Objects.equals(outputVariables, that.outputVariables);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        decisionDefinitionKey,
+        decisionDefinitionId,
+        decisionInstanceId,
+        processInstanceId,
+        evaluationDateTime,
+        engineName,
+        tenantId,
+        inputVariables,
+        outputVariables);
+  }
+
+  @Override
+  public String toString() {
+    return "RawDataDecisionInstanceDto(decisionDefinitionKey="
+        + getDecisionDefinitionKey()
+        + ", decisionDefinitionId="
+        + getDecisionDefinitionId()
+        + ", decisionInstanceId="
+        + getDecisionInstanceId()
+        + ", processInstanceId="
+        + getProcessInstanceId()
+        + ", evaluationDateTime="
+        + getEvaluationDateTime()
+        + ", engineName="
+        + getEngineName()
+        + ", tenantId="
+        + getTenantId()
+        + ", inputVariables="
+        + getInputVariables()
+        + ", outputVariables="
+        + getOutputVariables()
+        + ")";
+  }
 
   public enum Fields {
     decisionDefinitionKey,

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/VariableEntry.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/VariableEntry.java
@@ -9,12 +9,9 @@ package io.camunda.optimize.dto.optimize.query.report.single.decision.result.raw
 
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.Objects;
-import lombok.Getter;
-import lombok.Setter;
 
-@Getter
-@Setter
 public class VariableEntry {
+
   private String id;
   private String name;
   private VariableType type;
@@ -29,20 +26,39 @@ public class VariableEntry {
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof VariableEntry)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
     final VariableEntry that = (VariableEntry) o;
-    return Objects.equals(id, that.id)
-        && Objects.equals(name, that.name)
-        && Objects.equals(type, that.type);
+    return Objects.equals(id, that.id) && Objects.equals(name, that.name) && type == that.type;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(id, name, type);
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public VariableType getType() {
+    return type;
+  }
+
+  public void setType(final VariableType type) {
+    this.type = type;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/view/DecisionViewDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/view/DecisionViewDto.java
@@ -13,13 +13,8 @@ import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class DecisionViewDto {
 
   protected List<ViewProperty> properties = new ArrayList<>();
@@ -28,9 +23,19 @@ public class DecisionViewDto {
     getProperties().add(property);
   }
 
+  public DecisionViewDto(final List<ViewProperty> properties) {
+    this.properties = properties;
+  }
+
+  public DecisionViewDto() {}
+
   @JsonIgnore
   public String createCommandKey() {
     return getProperties().stream().findFirst().map(ViewProperty::toString).orElse(null);
+  }
+
+  public List<ViewProperty> getProperties() {
+    return properties;
   }
 
   @JsonSetter
@@ -42,6 +47,30 @@ public class DecisionViewDto {
     this.properties = Arrays.asList(properties);
   }
 
+  protected boolean canEqual(final Object other) {
+    return other instanceof DecisionViewDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionViewDto that = (DecisionViewDto) o;
+    return Objects.equals(properties, that.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(properties);
+  }
+
+  @Override
+  public String toString() {
+    return "DecisionViewDto(properties=" + getProperties() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String properties = "properties";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/OperatorMultipleValuesFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/OperatorMultipleValuesFilterDataDto.java
@@ -9,14 +9,11 @@ package io.camunda.optimize.dto.optimize.query.report.single.filter.data;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
 public class OperatorMultipleValuesFilterDataDto {
+
   protected FilterOperator operator;
   protected List<String> values;
 
@@ -24,5 +21,50 @@ public class OperatorMultipleValuesFilterDataDto {
       final FilterOperator operator, final List<String> values) {
     this.operator = operator;
     this.values = Optional.ofNullable(values).orElseGet(ArrayList::new);
+  }
+
+  protected OperatorMultipleValuesFilterDataDto() {}
+
+  public FilterOperator getOperator() {
+    return operator;
+  }
+
+  public void setOperator(final FilterOperator operator) {
+    this.operator = operator;
+  }
+
+  public List<String> getValues() {
+    return values;
+  }
+
+  public void setValues(final List<String> values) {
+    this.values = values;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof OperatorMultipleValuesFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OperatorMultipleValuesFilterDataDto that = (OperatorMultipleValuesFilterDataDto) o;
+    return operator == that.operator && Objects.equals(values, that.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(operator, values);
+  }
+
+  @Override
+  public String toString() {
+    return "OperatorMultipleValuesFilterDataDto(operator="
+        + getOperator()
+        + ", values="
+        + getValues()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/DateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/DateFilterDataDto.java
@@ -18,9 +18,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.ins
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.instance.RelativeDateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.instance.RollingDateFilterDataDto;
 import java.time.OffsetDateTime;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
+import java.util.Objects;
 
 /**
  * Abstract class that contains a hidden "type" field to distinguish which filter type the jackson
@@ -35,9 +33,6 @@ import lombok.Setter;
   @JsonSubTypes.Type(value = RollingDateFilterDataDto.class, name = ROLLING_DATE_FILTER),
   @JsonSubTypes.Type(value = RelativeDateFilterDataDto.class, name = RELATIVE_DATE_FILTER),
 })
-@Getter
-@Setter
-@EqualsAndHashCode
 public abstract class DateFilterDataDto<START> implements FilterDataDto {
 
   protected DateFilterType type;
@@ -55,6 +50,69 @@ public abstract class DateFilterDataDto<START> implements FilterDataDto {
     this.end = end;
   }
 
+  public DateFilterType getType() {
+    return this.type;
+  }
+
+  public START getStart() {
+    return this.start;
+  }
+
+  public OffsetDateTime getEnd() {
+    return this.end;
+  }
+
+  public boolean isIncludeUndefined() {
+    return this.includeUndefined;
+  }
+
+  public boolean isExcludeUndefined() {
+    return this.excludeUndefined;
+  }
+
+  public void setType(final DateFilterType type) {
+    this.type = type;
+  }
+
+  public void setStart(final START start) {
+    this.start = start;
+  }
+
+  public void setEnd(final OffsetDateTime end) {
+    this.end = end;
+  }
+
+  public void setIncludeUndefined(final boolean includeUndefined) {
+    this.includeUndefined = includeUndefined;
+  }
+
+  public void setExcludeUndefined(final boolean excludeUndefined) {
+    this.excludeUndefined = excludeUndefined;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DateFilterDataDto<?> that = (DateFilterDataDto<?>) o;
+    return includeUndefined == that.includeUndefined
+        && excludeUndefined == that.excludeUndefined
+        && type == that.type
+        && Objects.equals(start, that.start)
+        && Objects.equals(end, that.end);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, start, end, includeUndefined, excludeUndefined);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DateFilterDataDto;
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String type = "type";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/RelativeDateFilterStartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/RelativeDateFilterStartDto.java
@@ -7,22 +7,55 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.filter.data.date;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import java.util.Objects;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode
 public class RelativeDateFilterStartDto {
 
   protected Long value;
   protected DateUnit unit;
 
+  public RelativeDateFilterStartDto(final Long value, final DateUnit unit) {
+    this.value = value;
+    this.unit = unit;
+  }
+
+  public RelativeDateFilterStartDto() {}
+
+  public Long getValue() {
+    return value;
+  }
+
+  public void setValue(final Long value) {
+    this.value = value;
+  }
+
+  public DateUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final DateUnit unit) {
+    this.unit = unit;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof RelativeDateFilterStartDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RelativeDateFilterStartDto that = (RelativeDateFilterStartDto) o;
+    return Objects.equals(value, that.value) && unit == that.unit;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value, unit);
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String value = "value";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/RollingDateFilterStartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/RollingDateFilterStartDto.java
@@ -7,22 +7,55 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.filter.data.date;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import java.util.Objects;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@EqualsAndHashCode
 public class RollingDateFilterStartDto {
 
   protected Long value;
   protected DateUnit unit;
 
+  public RollingDateFilterStartDto(final Long value, final DateUnit unit) {
+    this.value = value;
+    this.unit = unit;
+  }
+
+  public RollingDateFilterStartDto() {}
+
+  public Long getValue() {
+    return value;
+  }
+
+  public void setValue(final Long value) {
+    this.value = value;
+  }
+
+  public DateUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final DateUnit unit) {
+    this.unit = unit;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof RollingDateFilterStartDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RollingDateFilterStartDto that = (RollingDateFilterStartDto) o;
+    return Objects.equals(value, that.value) && unit == that.unit;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value, unit);
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String value = "value";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/FixedFlowNodeDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/FixedFlowNodeDateFilterDataDto.java
@@ -12,9 +12,8 @@ import static io.camunda.optimize.util.SuppressionConstants.UNUSED;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import java.time.OffsetDateTime;
 import java.util.List;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class FixedFlowNodeDateFilterDataDto extends FlowNodeDateFilterDataDto<OffsetDateTime> {
 
   @SuppressWarnings(UNUSED)
@@ -25,5 +24,26 @@ public class FixedFlowNodeDateFilterDataDto extends FlowNodeDateFilterDataDto<Of
   public FixedFlowNodeDateFilterDataDto(
       final List<String> flowNodeIds, final OffsetDateTime start, final OffsetDateTime end) {
     super(flowNodeIds, DateFilterType.FIXED, start, end);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof FixedFlowNodeDateFilterDataDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/FlowNodeDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/FlowNodeDateFilterDataDto.java
@@ -17,9 +17,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.Dat
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import java.time.OffsetDateTime;
 import java.util.List;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
+import java.util.Objects;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -30,9 +28,6 @@ import lombok.Setter;
   @JsonSubTypes.Type(value = RollingFlowNodeDateFilterDataDto.class, name = ROLLING_DATE_FILTER),
   @JsonSubTypes.Type(value = RelativeFlowNodeDateFilterDataDto.class, name = RELATIVE_DATE_FILTER),
 })
-@Getter
-@Setter
-@EqualsAndHashCode(callSuper = true)
 public abstract class FlowNodeDateFilterDataDto<START> extends DateFilterDataDto<START> {
 
   protected List<String> flowNodeIds;
@@ -46,6 +41,37 @@ public abstract class FlowNodeDateFilterDataDto<START> extends DateFilterDataDto
     this.flowNodeIds = flowNodeIds;
   }
 
+  public List<String> getFlowNodeIds() {
+    return flowNodeIds;
+  }
+
+  public void setFlowNodeIds(final List<String> flowNodeIds) {
+    this.flowNodeIds = flowNodeIds;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof FlowNodeDateFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final FlowNodeDateFilterDataDto<?> that = (FlowNodeDateFilterDataDto<?>) o;
+    return Objects.equals(flowNodeIds, that.flowNodeIds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), flowNodeIds);
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String flowNodeIds = "flowNodeIds";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/RelativeFlowNodeDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/RelativeFlowNodeDateFilterDataDto.java
@@ -12,9 +12,8 @@ import static io.camunda.optimize.util.SuppressionConstants.UNUSED;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RelativeDateFilterStartDto;
 import java.util.List;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class RelativeFlowNodeDateFilterDataDto
     extends FlowNodeDateFilterDataDto<RelativeDateFilterStartDto> {
 
@@ -26,5 +25,26 @@ public class RelativeFlowNodeDateFilterDataDto
   public RelativeFlowNodeDateFilterDataDto(
       final List<String> flowNodeIds, final RelativeDateFilterStartDto relativeDateFilterStartDto) {
     super(flowNodeIds, DateFilterType.RELATIVE, relativeDateFilterStartDto, null);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof RelativeFlowNodeDateFilterDataDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/RollingFlowNodeDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/RollingFlowNodeDateFilterDataDto.java
@@ -12,9 +12,8 @@ import static io.camunda.optimize.util.SuppressionConstants.UNUSED;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
 import java.util.List;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class RollingFlowNodeDateFilterDataDto
     extends FlowNodeDateFilterDataDto<RollingDateFilterStartDto> {
 
@@ -26,5 +25,26 @@ public class RollingFlowNodeDateFilterDataDto
   public RollingFlowNodeDateFilterDataDto(
       final List<String> flowNodeIds, final RollingDateFilterStartDto rollingDateFilterStartDto) {
     super(flowNodeIds, DateFilterType.ROLLING, rollingDateFilterStartDto, null);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof RollingFlowNodeDateFilterDataDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/instance/FixedDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/instance/FixedDateFilterDataDto.java
@@ -10,15 +10,36 @@ package io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.in
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import java.time.OffsetDateTime;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class FixedDateFilterDataDto extends DateFilterDataDto<OffsetDateTime> {
+
   public FixedDateFilterDataDto() {
     this(null, null);
   }
 
   public FixedDateFilterDataDto(final OffsetDateTime dateTime, final OffsetDateTime end) {
     super(DateFilterType.FIXED, dateTime, end);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof FixedDateFilterDataDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/instance/RelativeDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/instance/RelativeDateFilterDataDto.java
@@ -10,15 +10,36 @@ package io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.in
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RelativeDateFilterStartDto;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class RelativeDateFilterDataDto extends DateFilterDataDto<RelativeDateFilterStartDto> {
+
   public RelativeDateFilterDataDto() {
     this(null);
   }
 
   public RelativeDateFilterDataDto(final RelativeDateFilterStartDto relativeDateFilterStartDto) {
     super(DateFilterType.RELATIVE, relativeDateFilterStartDto, null);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof RelativeDateFilterDataDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/instance/RollingDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/instance/RollingDateFilterDataDto.java
@@ -10,15 +10,36 @@ package io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.in
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateFilterType;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.RollingDateFilterStartDto;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
 public class RollingDateFilterDataDto extends DateFilterDataDto<RollingDateFilterStartDto> {
+
   public RollingDateFilterDataDto() {
     this(null);
   }
 
   public RollingDateFilterDataDto(final RollingDateFilterStartDto rollingDateFilterStartDto) {
     super(DateFilterType.ROLLING, rollingDateFilterStartDto, null);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof RollingDateFilterDataDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/MultipleVariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/MultipleVariableFilterDataDto.java
@@ -9,13 +9,46 @@ package io.camunda.optimize.dto.optimize.query.report.single.filter.data.variabl
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class MultipleVariableFilterDataDto implements FilterDataDto {
+
   protected List<VariableFilterDataDto<?>> data;
+
+  public MultipleVariableFilterDataDto(final List<VariableFilterDataDto<?>> data) {
+    this.data = data;
+  }
+
+  public MultipleVariableFilterDataDto() {}
+
+  public List<VariableFilterDataDto<?>> getData() {
+    return data;
+  }
+
+  public void setData(final List<VariableFilterDataDto<?>> data) {
+    this.data = data;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MultipleVariableFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MultipleVariableFilterDataDto that = (MultipleVariableFilterDataDto) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(data);
+  }
+
+  @Override
+  public String toString() {
+    return "MultipleVariableFilterDataDto(data=" + getData() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/VariableFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/VariableFilterDataDto.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
-import lombok.Data;
+import java.util.Objects;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -48,10 +48,9 @@ import lombok.Data;
   @JsonSubTypes.Type(value = DateVariableFilterDataDto.class, name = DATE_TYPE),
   @JsonSubTypes.Type(value = DateVariableFilterDataDto.class, name = DATE_TYPE_LOWERCASE)
 })
-@Data
 public abstract class VariableFilterDataDto<DATA> implements FilterDataDto {
-  protected VariableType type;
 
+  protected VariableType type;
   protected String name;
   protected DATA data;
 
@@ -59,5 +58,58 @@ public abstract class VariableFilterDataDto<DATA> implements FilterDataDto {
     this.name = name;
     this.type = type;
     this.data = data;
+  }
+
+  public VariableType getType() {
+    return type;
+  }
+
+  public void setType(final VariableType type) {
+    this.type = type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public DATA getData() {
+    return data;
+  }
+
+  public void setData(final DATA data) {
+    this.data = data;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof VariableFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableFilterDataDto<?> that = (VariableFilterDataDto<?>) o;
+    return type == that.type && Objects.equals(name, that.name) && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, name, data);
+  }
+
+  @Override
+  public String toString() {
+    return "VariableFilterDataDto(type="
+        + getType()
+        + ", name="
+        + getName()
+        + ", data="
+        + getData()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/data/BooleanVariableFilterSubDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/data/BooleanVariableFilterSubDataDto.java
@@ -8,16 +8,46 @@
 package io.camunda.optimize.dto.optimize.query.report.single.filter.data.variable.data;
 
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
 public class BooleanVariableFilterSubDataDto {
+
   protected List<Boolean> values;
 
   public BooleanVariableFilterSubDataDto(final List<Boolean> values) {
     this.values = values;
+  }
+
+  protected BooleanVariableFilterSubDataDto() {}
+
+  public List<Boolean> getValues() {
+    return values;
+  }
+
+  public void setValues(final List<Boolean> values) {
+    this.values = values;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof BooleanVariableFilterSubDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BooleanVariableFilterSubDataDto that = (BooleanVariableFilterSubDataDto) o;
+    return Objects.equals(values, that.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(values);
+  }
+
+  @Override
+  public String toString() {
+    return "BooleanVariableFilterSubDataDto(values=" + getValues() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/data/DashboardVariableFilterSubDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/data/DashboardVariableFilterSubDataDto.java
@@ -10,16 +10,8 @@ package io.camunda.optimize.dto.optimize.query.report.single.filter.data.variabl
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterOperator;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.OperatorMultipleValuesFilterDataDto;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
-@EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
 public class DashboardVariableFilterSubDataDto extends OperatorMultipleValuesFilterDataDto {
 
   protected boolean allowCustomValues;
@@ -30,6 +22,48 @@ public class DashboardVariableFilterSubDataDto extends OperatorMultipleValuesFil
     this.allowCustomValues = allowCustomValues;
   }
 
+  protected DashboardVariableFilterSubDataDto() {}
+
+  public boolean isAllowCustomValues() {
+    return allowCustomValues;
+  }
+
+  public void setAllowCustomValues(final boolean allowCustomValues) {
+    this.allowCustomValues = allowCustomValues;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof DashboardVariableFilterSubDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final DashboardVariableFilterSubDataDto that = (DashboardVariableFilterSubDataDto) o;
+    return allowCustomValues == that.allowCustomValues;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), allowCustomValues);
+  }
+
+  @Override
+  public String toString() {
+    return "DashboardVariableFilterSubDataDto(super="
+        + super.toString()
+        + ", allowCustomValues="
+        + isAllowCustomValues()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String allowCustomValues = "allowCustomValues";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessReportDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessReportDataDto.java
@@ -34,34 +34,68 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
-@AllArgsConstructor
-@Data
-@EqualsAndHashCode(callSuper = false)
-@NoArgsConstructor
-@SuperBuilder
 @ProcessFiltersMustReferenceExistingDefinitionsConstraint
 public class ProcessReportDataDto extends SingleReportDataDto implements Combinable {
 
   private static final String COMMAND_KEY_SEPARATOR = "_";
   private static final String MISSING_COMMAND_PART_PLACEHOLDER = "null";
 
-  @Builder.Default @Valid protected List<ProcessFilterDto<?>> filter = new ArrayList<>();
+  @Valid protected List<ProcessFilterDto<?>> filter = new ArrayList<>();
   protected ProcessViewDto view;
   protected ProcessGroupByDto<?> groupBy;
 
-  @Builder.Default
   protected ProcessReportDistributedByDto<?> distributedBy = new ProcessReportDistributedByDto<>();
 
   protected ProcessVisualization visualization;
-  @Builder.Default protected boolean managementReport = false;
-  @Builder.Default protected boolean instantPreviewReport = false;
+  protected boolean managementReport = false;
+  protected boolean instantPreviewReport = false;
+
+  public ProcessReportDataDto(
+      @Valid final List<ProcessFilterDto<?>> filter,
+      final ProcessViewDto view,
+      final ProcessGroupByDto<?> groupBy,
+      final ProcessReportDistributedByDto<?> distributedBy,
+      final ProcessVisualization visualization,
+      final boolean managementReport,
+      final boolean instantPreviewReport) {
+    this.filter = filter;
+    this.view = view;
+    this.groupBy = groupBy;
+    this.distributedBy = distributedBy;
+    this.visualization = visualization;
+    this.managementReport = managementReport;
+    this.instantPreviewReport = instantPreviewReport;
+  }
+
+  public ProcessReportDataDto() {}
+
+  protected ProcessReportDataDto(final ProcessReportDataDtoBuilder<?, ?> b) {
+    super(b);
+    if (b.filterSet) {
+      filter = b.filterValue;
+    } else {
+      filter = defaultFilter();
+    }
+    view = b.view;
+    groupBy = b.groupBy;
+    if (b.distributedBySet) {
+      distributedBy = b.distributedByValue;
+    } else {
+      distributedBy = defaultDistributedBy();
+    }
+    visualization = b.visualization;
+    if (b.managementReportSet) {
+      managementReport = b.managementReportValue;
+    } else {
+      managementReport = defaultManagementReport();
+    }
+    if (b.instantPreviewReportSet) {
+      instantPreviewReport = b.instantPreviewReportValue;
+    } else {
+      instantPreviewReport = defaultInstantPreviewReport();
+    }
+  }
 
   public String getProcessDefinitionKey() {
     return getDefinitionKey();
@@ -260,6 +294,134 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
         && ProcessViewEntity.PROCESS_INSTANCE.equals(view.getEntity());
   }
 
+  public @Valid List<ProcessFilterDto<?>> getFilter() {
+    return filter;
+  }
+
+  public void setFilter(@Valid final List<ProcessFilterDto<?>> filter) {
+    this.filter = filter;
+  }
+
+  public ProcessViewDto getView() {
+    return view;
+  }
+
+  public void setView(final ProcessViewDto view) {
+    this.view = view;
+  }
+
+  public ProcessGroupByDto<?> getGroupBy() {
+    return groupBy;
+  }
+
+  public void setGroupBy(final ProcessGroupByDto<?> groupBy) {
+    this.groupBy = groupBy;
+  }
+
+  public ProcessReportDistributedByDto<?> getDistributedBy() {
+    return distributedBy;
+  }
+
+  public void setDistributedBy(final ProcessReportDistributedByDto<?> distributedBy) {
+    this.distributedBy = distributedBy;
+  }
+
+  public ProcessVisualization getVisualization() {
+    return visualization;
+  }
+
+  public void setVisualization(final ProcessVisualization visualization) {
+    this.visualization = visualization;
+  }
+
+  public boolean isManagementReport() {
+    return managementReport;
+  }
+
+  public void setManagementReport(final boolean managementReport) {
+    this.managementReport = managementReport;
+  }
+
+  public boolean isInstantPreviewReport() {
+    return instantPreviewReport;
+  }
+
+  public void setInstantPreviewReport(final boolean instantPreviewReport) {
+    this.instantPreviewReport = instantPreviewReport;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessReportDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessReportDataDto that = (ProcessReportDataDto) o;
+    return managementReport == that.managementReport
+        && instantPreviewReport == that.instantPreviewReport
+        && Objects.equals(filter, that.filter)
+        && Objects.equals(view, that.view)
+        && Objects.equals(groupBy, that.groupBy)
+        && Objects.equals(distributedBy, that.distributedBy)
+        && visualization == that.visualization;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        filter,
+        view,
+        groupBy,
+        distributedBy,
+        visualization,
+        managementReport,
+        instantPreviewReport);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessReportDataDto(filter="
+        + getFilter()
+        + ", view="
+        + getView()
+        + ", groupBy="
+        + getGroupBy()
+        + ", distributedBy="
+        + getDistributedBy()
+        + ", visualization="
+        + getVisualization()
+        + ", managementReport="
+        + isManagementReport()
+        + ", instantPreviewReport="
+        + isInstantPreviewReport()
+        + ")";
+  }
+
+  @Valid
+  private static List<ProcessFilterDto<?>> defaultFilter() {
+    return new ArrayList<>();
+  }
+
+  private static ProcessReportDistributedByDto<?> defaultDistributedBy() {
+    return new ProcessReportDistributedByDto<>();
+  }
+
+  private static boolean defaultManagementReport() {
+    return false;
+  }
+
+  private static boolean defaultInstantPreviewReport() {
+    return false;
+  }
+
+  public static ProcessReportDataDtoBuilder<?, ?> builder() {
+    return new ProcessReportDataDtoBuilderImpl();
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String filter = "filter";
@@ -269,5 +431,104 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
     public static final String visualization = "visualization";
     public static final String managementReport = "managementReport";
     public static final String instantPreviewReport = "instantPreviewReport";
+  }
+
+  public abstract static class ProcessReportDataDtoBuilder<
+          C extends ProcessReportDataDto, B extends ProcessReportDataDtoBuilder<C, B>>
+      extends SingleReportDataDtoBuilder<C, B> {
+
+    private @Valid List<ProcessFilterDto<?>> filterValue;
+    private boolean filterSet;
+    private ProcessViewDto view;
+    private ProcessGroupByDto<?> groupBy;
+    private ProcessReportDistributedByDto<?> distributedByValue;
+    private boolean distributedBySet;
+    private ProcessVisualization visualization;
+    private boolean managementReportValue;
+    private boolean managementReportSet;
+    private boolean instantPreviewReportValue;
+    private boolean instantPreviewReportSet;
+
+    public B filter(@Valid final List<ProcessFilterDto<?>> filter) {
+      filterValue = filter;
+      filterSet = true;
+      return self();
+    }
+
+    public B view(final ProcessViewDto view) {
+      this.view = view;
+      return self();
+    }
+
+    public B groupBy(final ProcessGroupByDto<?> groupBy) {
+      this.groupBy = groupBy;
+      return self();
+    }
+
+    public B distributedBy(final ProcessReportDistributedByDto<?> distributedBy) {
+      distributedByValue = distributedBy;
+      distributedBySet = true;
+      return self();
+    }
+
+    public B visualization(final ProcessVisualization visualization) {
+      this.visualization = visualization;
+      return self();
+    }
+
+    public B managementReport(final boolean managementReport) {
+      managementReportValue = managementReport;
+      managementReportSet = true;
+      return self();
+    }
+
+    public B instantPreviewReport(final boolean instantPreviewReport) {
+      instantPreviewReportValue = instantPreviewReport;
+      instantPreviewReportSet = true;
+      return self();
+    }
+
+    @Override
+    protected abstract B self();
+
+    @Override
+    public abstract C build();
+
+    @Override
+    public String toString() {
+      return "ProcessReportDataDto.ProcessReportDataDtoBuilder(super="
+          + super.toString()
+          + ", filterValue="
+          + filterValue
+          + ", view="
+          + view
+          + ", groupBy="
+          + groupBy
+          + ", distributedByValue="
+          + distributedByValue
+          + ", visualization="
+          + visualization
+          + ", managementReportValue="
+          + managementReportValue
+          + ", instantPreviewReportValue="
+          + instantPreviewReportValue
+          + ")";
+    }
+  }
+
+  private static final class ProcessReportDataDtoBuilderImpl
+      extends ProcessReportDataDtoBuilder<ProcessReportDataDto, ProcessReportDataDtoBuilderImpl> {
+
+    private ProcessReportDataDtoBuilderImpl() {}
+
+    @Override
+    protected ProcessReportDataDtoBuilderImpl self() {
+      return this;
+    }
+
+    @Override
+    public ProcessReportDataDto build() {
+      return new ProcessReportDataDto(this);
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/SingleProcessReportDefinitionUpdateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/SingleProcessReportDefinitionUpdateDto.java
@@ -9,13 +9,47 @@ package io.camunda.optimize.dto.optimize.query.report.single.process;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionUpdateDto;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class SingleProcessReportDefinitionUpdateDto extends ReportDefinitionUpdateDto {
 
   protected ProcessReportDataDto data;
+
+  public SingleProcessReportDefinitionUpdateDto() {}
+
+  public ProcessReportDataDto getData() {
+    return data;
+  }
+
+  public void setData(final ProcessReportDataDto data) {
+    this.data = data;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof SingleProcessReportDefinitionUpdateDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final SingleProcessReportDefinitionUpdateDto that = (SingleProcessReportDefinitionUpdateDto) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), data);
+  }
+
+  @Override
+  public String toString() {
+    return "SingleProcessReportDefinitionUpdateDto(data=" + getData() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/ProcessReportDistributedByDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/ProcessReportDistributedByDto.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.query.report.Combinable;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.DistributedByType;
 import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.value.ProcessReportDistributedByValueDto;
-import lombok.Data;
+import java.util.Objects;
 
 /**
  * Abstract class that contains a hidden "type" field to distinguish which distributed by type the
@@ -47,17 +47,13 @@ import lombok.Data;
   @JsonSubTypes.Type(value = EndDateDistributedByDto.class, name = DISTRIBUTED_BY_END_DATE),
   @JsonSubTypes.Type(value = ProcessDistributedByDto.class, name = DISTRIBUTED_BY_PROCESS)
 })
-@Data
 public class ProcessReportDistributedByDto<VALUE extends ProcessReportDistributedByValueDto>
     implements Combinable {
 
   @JsonProperty protected DistributedByType type = DistributedByType.NONE;
   protected VALUE value;
 
-  @Override
-  public String toString() {
-    return type.getId();
-  }
+  public ProcessReportDistributedByDto() {}
 
   @JsonIgnore
   public String createCommandKey() {
@@ -70,6 +66,47 @@ public class ProcessReportDistributedByDto<VALUE extends ProcessReportDistribute
         && DistributedByType.NONE.equals(((ProcessReportDistributedByDto<?>) o).getType());
   }
 
+  public DistributedByType getType() {
+    return type;
+  }
+
+  @JsonProperty
+  public void setType(final DistributedByType type) {
+    this.type = type;
+  }
+
+  public VALUE getValue() {
+    return value;
+  }
+
+  public void setValue(final VALUE value) {
+    this.value = value;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessReportDistributedByDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessReportDistributedByDto<?> that = (ProcessReportDistributedByDto<?>) o;
+    return type == that.type && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, value);
+  }
+
+  @Override
+  public String toString() {
+    return type.getId();
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String type = "type";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/value/DateDistributedByValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/value/DateDistributedByValueDto.java
@@ -8,10 +8,42 @@
 package io.camunda.optimize.dto.optimize.query.report.single.process.distributed.value;
 
 import io.camunda.optimize.dto.optimize.query.report.single.group.AggregateByDateUnit;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class DateDistributedByValueDto implements ProcessReportDistributedByValueDto {
 
   protected AggregateByDateUnit unit;
+
+  public DateDistributedByValueDto() {}
+
+  public AggregateByDateUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final AggregateByDateUnit unit) {
+    this.unit = unit;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DateDistributedByValueDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DateDistributedByValueDto that = (DateDistributedByValueDto) o;
+    return unit == that.unit;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(unit);
+  }
+
+  @Override
+  public String toString() {
+    return "DateDistributedByValueDto(unit=" + getUnit() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/value/VariableDistributedByValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/value/VariableDistributedByValueDto.java
@@ -8,10 +8,51 @@
 package io.camunda.optimize.dto.optimize.query.report.single.process.distributed.value;
 
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class VariableDistributedByValueDto implements ProcessReportDistributedByValueDto {
+
   protected String name;
   protected VariableType type;
+
+  public VariableDistributedByValueDto() {}
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public VariableType getType() {
+    return type;
+  }
+
+  public void setType(final VariableType type) {
+    this.type = type;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof VariableDistributedByValueDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableDistributedByValueDto that = (VariableDistributedByValueDto) o;
+    return Objects.equals(name, that.name) && type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type);
+  }
+
+  @Override
+  public String toString() {
+    return "VariableDistributedByValueDto(name=" + getName() + ", type=" + getType() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/FlowNodeStartDateFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/FlowNodeStartDateFilterDto.java
@@ -9,14 +9,35 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter;
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.flownode.FlowNodeDateFilterDataDto;
 import java.util.List;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@EqualsAndHashCode(callSuper = true)
-@NoArgsConstructor
 public class FlowNodeStartDateFilterDto extends ProcessFilterDto<FlowNodeDateFilterDataDto<?>> {
+
+  public FlowNodeStartDateFilterDto() {}
+
   @Override
   public List<FilterApplicationLevel> validApplicationLevels() {
     return List.of(FilterApplicationLevel.VIEW, FilterApplicationLevel.INSTANCE);
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof FlowNodeStartDateFilterDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/ProcessFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/ProcessFilterDto.java
@@ -14,8 +14,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDa
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
 /**
  * Abstract class that contains a hidden "type" field to distinguish, which filter type the jackson
@@ -63,8 +62,6 @@ import lombok.NoArgsConstructor;
       value = CompletedOrCanceledFlowNodesOnlyFilterDto.class,
       name = "completedOrCanceledFlowNodesOnly")
 })
-@Data
-@NoArgsConstructor
 public abstract class ProcessFilterDto<DATA extends FilterDataDto> {
 
   protected DATA data;
@@ -77,13 +74,60 @@ public abstract class ProcessFilterDto<DATA extends FilterDataDto> {
     setFilterLevel(filterLevel);
   }
 
+  public ProcessFilterDto() {}
+
   public abstract List<FilterApplicationLevel> validApplicationLevels();
+
+  public DATA getData() {
+    return data;
+  }
+
+  public void setData(final DATA data) {
+    this.data = data;
+  }
+
+  public @NotNull FilterApplicationLevel getFilterLevel() {
+    return filterLevel;
+  }
+
+  public void setFilterLevel(@NotNull final FilterApplicationLevel filterLevel) {
+    this.filterLevel = filterLevel;
+  }
+
+  public @NotEmpty List<String> getAppliedTo() {
+    return appliedTo;
+  }
+
+  public void setAppliedTo(@NotEmpty final List<String> appliedTo) {
+    this.appliedTo = appliedTo;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessFilterDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessFilterDto<?> that = (ProcessFilterDto<?>) o;
+    return Objects.equals(data, that.data)
+        && filterLevel == that.filterLevel
+        && Objects.equals(appliedTo, that.appliedTo);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data, filterLevel, appliedTo);
+  }
 
   @Override
   public String toString() {
     return "ProcessFilter=" + getClass().getSimpleName();
   }
 
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String data = "data";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/CanceledFlowNodeFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/CanceledFlowNodeFilterDataDto.java
@@ -9,10 +9,42 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class CanceledFlowNodeFilterDataDto implements FilterDataDto {
 
   protected List<String> values;
+
+  public CanceledFlowNodeFilterDataDto() {}
+
+  public List<String> getValues() {
+    return values;
+  }
+
+  public void setValues(final List<String> values) {
+    this.values = values;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CanceledFlowNodeFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CanceledFlowNodeFilterDataDto that = (CanceledFlowNodeFilterDataDto) o;
+    return Objects.equals(values, that.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(values);
+  }
+
+  @Override
+  public String toString() {
+    return "CanceledFlowNodeFilterDataDto(values=" + getValues() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/DurationFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/DurationFilterDataDto.java
@@ -10,19 +10,142 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DurationUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.operator.ComparisonOperator;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class DurationFilterDataDto implements FilterDataDto {
 
   protected Long value;
   protected DurationUnit unit;
   protected ComparisonOperator operator;
   protected boolean includeNull;
+
+  public DurationFilterDataDto(
+      final Long value,
+      final DurationUnit unit,
+      final ComparisonOperator operator,
+      final boolean includeNull) {
+    this.value = value;
+    this.unit = unit;
+    this.operator = operator;
+    this.includeNull = includeNull;
+  }
+
+  public DurationFilterDataDto() {}
+
+  public Long getValue() {
+    return value;
+  }
+
+  public void setValue(final Long value) {
+    this.value = value;
+  }
+
+  public DurationUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final DurationUnit unit) {
+    this.unit = unit;
+  }
+
+  public ComparisonOperator getOperator() {
+    return operator;
+  }
+
+  public void setOperator(final ComparisonOperator operator) {
+    this.operator = operator;
+  }
+
+  public boolean isIncludeNull() {
+    return includeNull;
+  }
+
+  public void setIncludeNull(final boolean includeNull) {
+    this.includeNull = includeNull;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DurationFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DurationFilterDataDto that = (DurationFilterDataDto) o;
+    return includeNull == that.includeNull
+        && Objects.equals(value, that.value)
+        && unit == that.unit
+        && operator == that.operator;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value, unit, operator, includeNull);
+  }
+
+  @Override
+  public String toString() {
+    return "DurationFilterDataDto(value="
+        + getValue()
+        + ", unit="
+        + getUnit()
+        + ", operator="
+        + getOperator()
+        + ", includeNull="
+        + isIncludeNull()
+        + ")";
+  }
+
+  public static DurationFilterDataDtoBuilder builder() {
+    return new DurationFilterDataDtoBuilder();
+  }
+
+  public static class DurationFilterDataDtoBuilder {
+
+    private Long value;
+    private DurationUnit unit;
+    private ComparisonOperator operator;
+    private boolean includeNull;
+
+    DurationFilterDataDtoBuilder() {}
+
+    public DurationFilterDataDtoBuilder value(final Long value) {
+      this.value = value;
+      return this;
+    }
+
+    public DurationFilterDataDtoBuilder unit(final DurationUnit unit) {
+      this.unit = unit;
+      return this;
+    }
+
+    public DurationFilterDataDtoBuilder operator(final ComparisonOperator operator) {
+      this.operator = operator;
+      return this;
+    }
+
+    public DurationFilterDataDtoBuilder includeNull(final boolean includeNull) {
+      this.includeNull = includeNull;
+      return this;
+    }
+
+    public DurationFilterDataDto build() {
+      return new DurationFilterDataDto(value, unit, operator, includeNull);
+    }
+
+    @Override
+    public String toString() {
+      return "DurationFilterDataDto.DurationFilterDataDtoBuilder(value="
+          + value
+          + ", unit="
+          + unit
+          + ", operator="
+          + operator
+          + ", includeNull="
+          + includeNull
+          + ")";
+    }
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/ExecutedFlowNodeFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/ExecutedFlowNodeFilterDataDto.java
@@ -10,11 +10,55 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.operator.MembershipFilterOperator;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ExecutedFlowNodeFilterDataDto implements FilterDataDto {
 
   protected MembershipFilterOperator operator;
   protected List<String> values;
+
+  public ExecutedFlowNodeFilterDataDto() {}
+
+  public MembershipFilterOperator getOperator() {
+    return operator;
+  }
+
+  public void setOperator(final MembershipFilterOperator operator) {
+    this.operator = operator;
+  }
+
+  public List<String> getValues() {
+    return values;
+  }
+
+  public void setValues(final List<String> values) {
+    this.values = values;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ExecutedFlowNodeFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExecutedFlowNodeFilterDataDto that = (ExecutedFlowNodeFilterDataDto) o;
+    return operator == that.operator && Objects.equals(values, that.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(operator, values);
+  }
+
+  @Override
+  public String toString() {
+    return "ExecutedFlowNodeFilterDataDto(operator="
+        + getOperator()
+        + ", values="
+        + getValues()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/ExecutingFlowNodeFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/ExecutingFlowNodeFilterDataDto.java
@@ -9,10 +9,42 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data
 
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ExecutingFlowNodeFilterDataDto implements FilterDataDto {
 
   protected List<String> values;
+
+  public ExecutingFlowNodeFilterDataDto() {}
+
+  public List<String> getValues() {
+    return values;
+  }
+
+  public void setValues(final List<String> values) {
+    this.values = values;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ExecutingFlowNodeFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExecutingFlowNodeFilterDataDto that = (ExecutingFlowNodeFilterDataDto) o;
+    return Objects.equals(values, that.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(values);
+  }
+
+  @Override
+  public String toString() {
+    return "ExecutingFlowNodeFilterDataDto(values=" + getValues() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/FlowNodeDurationFiltersDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/FlowNodeDurationFiltersDataDto.java
@@ -10,18 +10,41 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class FlowNodeDurationFiltersDataDto extends HashMap<String, DurationFilterDataDto>
     implements FilterDataDto {
+
   public FlowNodeDurationFiltersDataDto() {
     super();
   }
 
   public FlowNodeDurationFiltersDataDto(final Map<String, DurationFilterDataDto> map) {
     super(map);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
+  }
+
+  @Override
+  public String toString() {
+    return "FlowNodeDurationFiltersDataDto()";
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof FlowNodeDurationFiltersDataDto;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/IdentityLinkFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/data/IdentityLinkFilterDataDto.java
@@ -10,16 +10,57 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.filter.data
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.operator.MembershipFilterOperator;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IdentityLinkFilterDataDto implements FilterDataDto {
 
   protected MembershipFilterOperator operator;
   protected List<String> values;
+
+  public IdentityLinkFilterDataDto(
+      final MembershipFilterOperator operator, final List<String> values) {
+    this.operator = operator;
+    this.values = values;
+  }
+
+  protected IdentityLinkFilterDataDto() {}
+
+  public MembershipFilterOperator getOperator() {
+    return operator;
+  }
+
+  public void setOperator(final MembershipFilterOperator operator) {
+    this.operator = operator;
+  }
+
+  public List<String> getValues() {
+    return values;
+  }
+
+  public void setValues(final List<String> values) {
+    this.values = values;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof IdentityLinkFilterDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IdentityLinkFilterDataDto that = (IdentityLinkFilterDataDto) o;
+    return operator == that.operator && Objects.equals(values, that.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(operator, values);
+  }
+
+  @Override
+  public String toString() {
+    return "IdentityLinkFilterDataDto(operator=" + getOperator() + ", values=" + getValues() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessGroupByDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessGroupByDto.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.query.report.Combinable;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.value.ProcessGroupByValueDto;
 import java.util.Objects;
-import lombok.Data;
 
 /**
  * Abstract class that contains a hidden "type" field to distinguish which group by type the jackson
@@ -47,27 +46,23 @@ import lombok.Data;
   @JsonSubTypes.Type(value = CandidateGroupGroupByDto.class, name = GROUP_BY_CANDIDATE_GROUP),
   @JsonSubTypes.Type(value = DurationGroupByDto.class, name = GROUP_BY_DURATION),
 })
-@Data
 public abstract class ProcessGroupByDto<VALUE extends ProcessGroupByValueDto>
     implements Combinable {
 
   @JsonProperty protected ProcessGroupByType type;
   protected VALUE value;
 
-  @Override
-  public String toString() {
-    return type.getId();
-  }
+  public ProcessGroupByDto() {}
 
   @Override
-  public boolean isCombinable(Object o) {
+  public boolean isCombinable(final Object o) {
     if (this == o) {
       return true;
     }
     if (!(o instanceof ProcessGroupByDto)) {
       return false;
     }
-    ProcessGroupByDto<?> that = (ProcessGroupByDto<?>) o;
+    final ProcessGroupByDto<?> that = (ProcessGroupByDto<?>) o;
     return isTypeCombinable(that) && Combinable.isCombinable(value, that.value);
   }
 
@@ -77,6 +72,46 @@ public abstract class ProcessGroupByDto<VALUE extends ProcessGroupByValueDto>
 
   @JsonIgnore
   public String createCommandKey() {
+    return type.getId();
+  }
+
+  public ProcessGroupByType getType() {
+    return type;
+  }
+
+  @JsonProperty
+  public void setType(final ProcessGroupByType type) {
+    this.type = type;
+  }
+
+  public VALUE getValue() {
+    return value;
+  }
+
+  public void setValue(final VALUE value) {
+    this.value = value;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessGroupByDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessGroupByDto<?> that = (ProcessGroupByDto<?>) o;
+    return type == that.type && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, value);
+  }
+
+  @Override
+  public String toString() {
     return type.getId();
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/value/DateGroupByValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/value/DateGroupByValueDto.java
@@ -9,26 +9,57 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.group.value
 
 import io.camunda.optimize.dto.optimize.query.report.single.group.AggregateByDateUnit;
 import java.util.Objects;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class DateGroupByValueDto implements ProcessGroupByValueDto {
 
   protected AggregateByDateUnit unit;
 
+  public DateGroupByValueDto(final AggregateByDateUnit unit) {
+    this.unit = unit;
+  }
+
+  public DateGroupByValueDto() {}
+
   @Override
-  public boolean isCombinable(Object o) {
+  public boolean isCombinable(final Object o) {
     if (this == o) {
       return true;
     }
     if (!(o instanceof DateGroupByValueDto)) {
       return false;
     }
-    DateGroupByValueDto that = (DateGroupByValueDto) o;
+    final DateGroupByValueDto that = (DateGroupByValueDto) o;
     return Objects.equals(unit, that.unit);
+  }
+
+  public AggregateByDateUnit getUnit() {
+    return unit;
+  }
+
+  public void setUnit(final AggregateByDateUnit unit) {
+    this.unit = unit;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DateGroupByValueDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DateGroupByValueDto that = (DateGroupByValueDto) o;
+    return unit == that.unit;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(unit);
+  }
+
+  @Override
+  public String toString() {
+    return "DateGroupByValueDto(unit=" + getUnit() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/value/VariableGroupByValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/value/VariableGroupByValueDto.java
@@ -9,23 +9,62 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.group.value
 
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
 import java.util.Objects;
-import lombok.Data;
 
-@Data
 public class VariableGroupByValueDto implements ProcessGroupByValueDto {
 
   protected String name;
   protected VariableType type;
 
+  public VariableGroupByValueDto() {}
+
   @Override
-  public boolean isCombinable(Object o) {
+  public boolean isCombinable(final Object o) {
     if (this == o) {
       return true;
     }
     if (!(o instanceof VariableGroupByValueDto)) {
       return false;
     }
-    VariableGroupByValueDto that = (VariableGroupByValueDto) o;
+    final VariableGroupByValueDto that = (VariableGroupByValueDto) o;
     return Objects.equals(name, that.name) && Objects.equals(type, that.type);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public VariableType getType() {
+    return type;
+  }
+
+  public void setType(final VariableType type) {
+    this.type = type;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof VariableGroupByValueDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableGroupByValueDto that = (VariableGroupByValueDto) o;
+    return Objects.equals(name, that.name) && type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type);
+  }
+
+  @Override
+  public String toString() {
+    return "VariableGroupByValueDto(name=" + getName() + ", type=" + getType() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataCountDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataCountDto.java
@@ -8,18 +8,76 @@
 package io.camunda.optimize.dto.optimize.query.report.single.process.result.raw;
 
 import io.camunda.optimize.dto.optimize.query.report.single.RawDataInstanceDto;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class RawDataCountDto implements RawDataInstanceDto {
 
   protected long incidents;
   protected long openIncidents;
   protected long userTasks;
+
+  public RawDataCountDto(final long incidents, final long openIncidents, final long userTasks) {
+    this.incidents = incidents;
+    this.openIncidents = openIncidents;
+    this.userTasks = userTasks;
+  }
+
+  public RawDataCountDto() {}
+
+  public long getIncidents() {
+    return incidents;
+  }
+
+  public void setIncidents(final long incidents) {
+    this.incidents = incidents;
+  }
+
+  public long getOpenIncidents() {
+    return openIncidents;
+  }
+
+  public void setOpenIncidents(final long openIncidents) {
+    this.openIncidents = openIncidents;
+  }
+
+  public long getUserTasks() {
+    return userTasks;
+  }
+
+  public void setUserTasks(final long userTasks) {
+    this.userTasks = userTasks;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof RawDataCountDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RawDataCountDto that = (RawDataCountDto) o;
+    return incidents == that.incidents
+        && openIncidents == that.openIncidents
+        && userTasks == that.userTasks;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(incidents, openIncidents, userTasks);
+  }
+
+  @Override
+  public String toString() {
+    return "RawDataCountDto(incidents="
+        + getIncidents()
+        + ", openIncidents="
+        + getOpenIncidents()
+        + ", userTasks="
+        + getUserTasks()
+        + ")";
+  }
 
   public enum Fields {
     incidents,

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataFlowNodeDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataFlowNodeDataDto.java
@@ -9,16 +9,91 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.result.raw;
 
 import io.camunda.optimize.dto.optimize.query.report.single.RawDataInstanceDto;
 import java.time.OffsetDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class RawDataFlowNodeDataDto implements RawDataInstanceDto {
+
   private String id;
   private String name;
   private OffsetDateTime startDate;
   private OffsetDateTime endDate;
+
+  public RawDataFlowNodeDataDto(
+      final String id,
+      final String name,
+      final OffsetDateTime startDate,
+      final OffsetDateTime endDate) {
+    this.id = id;
+    this.name = name;
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
+
+  public RawDataFlowNodeDataDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public OffsetDateTime getStartDate() {
+    return startDate;
+  }
+
+  public void setStartDate(final OffsetDateTime startDate) {
+    this.startDate = startDate;
+  }
+
+  public OffsetDateTime getEndDate() {
+    return endDate;
+  }
+
+  public void setEndDate(final OffsetDateTime endDate) {
+    this.endDate = endDate;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof RawDataFlowNodeDataDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RawDataFlowNodeDataDto that = (RawDataFlowNodeDataDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(startDate, that.startDate)
+        && Objects.equals(endDate, that.endDate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, startDate, endDate);
+  }
+
+  @Override
+  public String toString() {
+    return "RawDataFlowNodeDataDto(id="
+        + getId()
+        + ", name="
+        + getName()
+        + ", startDate="
+        + getStartDate()
+        + ", endDate="
+        + getEndDate()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataProcessInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataProcessInstanceDto.java
@@ -12,13 +12,8 @@ import io.camunda.optimize.dto.optimize.query.report.single.RawDataInstanceDto;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Data
 public class RawDataProcessInstanceDto implements RawDataInstanceDto {
 
   protected String processDefinitionKey;
@@ -41,6 +36,216 @@ public class RawDataProcessInstanceDto implements RawDataInstanceDto {
 
   // Note that the flow node data field can only be included on the Json export response
   protected List<RawDataFlowNodeDataDto> flowNodeInstances;
+
+  public RawDataProcessInstanceDto(
+      final String processDefinitionKey,
+      final String processDefinitionId,
+      final String processInstanceId,
+      final RawDataCountDto counts,
+      final Map<String, FlowNodeTotalDurationDataDto> flowNodeDurations,
+      final String businessKey,
+      final OffsetDateTime startDate,
+      final OffsetDateTime endDate,
+      final Long duration,
+      final String engineName,
+      final String tenantId,
+      final Map<String, Object> variables,
+      final List<RawDataFlowNodeDataDto> flowNodeInstances) {
+    this.processDefinitionKey = processDefinitionKey;
+    this.processDefinitionId = processDefinitionId;
+    this.processInstanceId = processInstanceId;
+    this.counts = counts;
+    this.flowNodeDurations = flowNodeDurations;
+    this.businessKey = businessKey;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.duration = duration;
+    this.engineName = engineName;
+    this.tenantId = tenantId;
+    this.variables = variables;
+    this.flowNodeInstances = flowNodeInstances;
+  }
+
+  public RawDataProcessInstanceDto() {}
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String getProcessDefinitionId() {
+    return processDefinitionId;
+  }
+
+  public void setProcessDefinitionId(final String processDefinitionId) {
+    this.processDefinitionId = processDefinitionId;
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public RawDataCountDto getCounts() {
+    return counts;
+  }
+
+  public void setCounts(final RawDataCountDto counts) {
+    this.counts = counts;
+  }
+
+  public Map<String, FlowNodeTotalDurationDataDto> getFlowNodeDurations() {
+    return flowNodeDurations;
+  }
+
+  public void setFlowNodeDurations(
+      final Map<String, FlowNodeTotalDurationDataDto> flowNodeDurations) {
+    this.flowNodeDurations = flowNodeDurations;
+  }
+
+  public String getBusinessKey() {
+    return businessKey;
+  }
+
+  public void setBusinessKey(final String businessKey) {
+    this.businessKey = businessKey;
+  }
+
+  public OffsetDateTime getStartDate() {
+    return startDate;
+  }
+
+  public void setStartDate(final OffsetDateTime startDate) {
+    this.startDate = startDate;
+  }
+
+  public OffsetDateTime getEndDate() {
+    return endDate;
+  }
+
+  public void setEndDate(final OffsetDateTime endDate) {
+    this.endDate = endDate;
+  }
+
+  public Long getDuration() {
+    return duration;
+  }
+
+  public void setDuration(final Long duration) {
+    this.duration = duration;
+  }
+
+  public String getEngineName() {
+    return engineName;
+  }
+
+  public void setEngineName(final String engineName) {
+    this.engineName = engineName;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public Map<String, Object> getVariables() {
+    return variables;
+  }
+
+  public void setVariables(final Map<String, Object> variables) {
+    this.variables = variables;
+  }
+
+  public List<RawDataFlowNodeDataDto> getFlowNodeInstances() {
+    return flowNodeInstances;
+  }
+
+  public void setFlowNodeInstances(final List<RawDataFlowNodeDataDto> flowNodeInstances) {
+    this.flowNodeInstances = flowNodeInstances;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof RawDataProcessInstanceDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RawDataProcessInstanceDto that = (RawDataProcessInstanceDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(counts, that.counts)
+        && Objects.equals(flowNodeDurations, that.flowNodeDurations)
+        && Objects.equals(businessKey, that.businessKey)
+        && Objects.equals(startDate, that.startDate)
+        && Objects.equals(endDate, that.endDate)
+        && Objects.equals(duration, that.duration)
+        && Objects.equals(engineName, that.engineName)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(variables, that.variables)
+        && Objects.equals(flowNodeInstances, that.flowNodeInstances);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        processDefinitionKey,
+        processDefinitionId,
+        processInstanceId,
+        counts,
+        flowNodeDurations,
+        businessKey,
+        startDate,
+        endDate,
+        duration,
+        engineName,
+        tenantId,
+        variables,
+        flowNodeInstances);
+  }
+
+  @Override
+  public String toString() {
+    return "RawDataProcessInstanceDto(processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", processDefinitionId="
+        + getProcessDefinitionId()
+        + ", processInstanceId="
+        + getProcessInstanceId()
+        + ", counts="
+        + getCounts()
+        + ", flowNodeDurations="
+        + getFlowNodeDurations()
+        + ", businessKey="
+        + getBusinessKey()
+        + ", startDate="
+        + getStartDate()
+        + ", endDate="
+        + getEndDate()
+        + ", duration="
+        + getDuration()
+        + ", engineName="
+        + getEngineName()
+        + ", tenantId="
+        + getTenantId()
+        + ", variables="
+        + getVariables()
+        + ", flowNodeInstances="
+        + getFlowNodeInstances()
+        + ")";
+  }
 
   public enum Fields {
     processDefinitionKey,

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/ProcessViewDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/ProcessViewDto.java
@@ -18,11 +18,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@Data
 public class ProcessViewDto implements Combinable {
 
   private static final Set<ProcessViewEntity> FLOW_NODE_ENTITIES =
@@ -45,6 +41,8 @@ public class ProcessViewDto implements Combinable {
     this.entity = entity;
     this.properties = properties;
   }
+
+  public ProcessViewDto() {}
 
   @Override
   public boolean isCombinable(final Object o) {
@@ -79,15 +77,6 @@ public class ProcessViewDto implements Combinable {
     return properties != null && !properties.isEmpty() ? properties.get(0) : null;
   }
 
-  @JsonSetter
-  public void setProperties(final List<ViewProperty> properties) {
-    this.properties = new ArrayList<>(properties);
-  }
-
-  public void setProperties(final ViewProperty... properties) {
-    this.properties = Arrays.asList(properties);
-  }
-
   private boolean isEntityCombinable(final ProcessViewDto viewDto) {
     // note: user tasks are combinable with flow nodes as they are a subset of flow nodes
     return Objects.equals(entity, viewDto.entity)
@@ -98,6 +87,51 @@ public class ProcessViewDto implements Combinable {
     return Combinable.isCombinable(getFirstProperty(), viewDto.getFirstProperty());
   }
 
+  public ProcessViewEntity getEntity() {
+    return entity;
+  }
+
+  public void setEntity(final ProcessViewEntity entity) {
+    this.entity = entity;
+  }
+
+  public List<ViewProperty> getProperties() {
+    return properties;
+  }
+
+  @JsonSetter
+  public void setProperties(final List<ViewProperty> properties) {
+    this.properties = new ArrayList<>(properties);
+  }
+
+  public void setProperties(final ViewProperty... properties) {
+    this.properties = Arrays.asList(properties);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessViewDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessViewDto that = (ProcessViewDto) o;
+    return entity == that.entity && Objects.equals(properties, that.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(entity, properties);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessViewDto(entity=" + getEntity() + ", properties=" + getProperties() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String entity = "entity";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/StringViewPropertyDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/StringViewPropertyDto.java
@@ -9,14 +9,14 @@ package io.camunda.optimize.dto.optimize.query.report.single.process.view;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Objects;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
-@Data
-@AllArgsConstructor
 public class StringViewPropertyDto implements TypedViewPropertyDto {
 
   private final String id;
+
+  public StringViewPropertyDto(final String id) {
+    this.id = id;
+  }
 
   @JsonValue
   public String getId() {
@@ -31,8 +31,26 @@ public class StringViewPropertyDto implements TypedViewPropertyDto {
     if (!(o instanceof StringViewPropertyDto)) {
       return false;
     }
-    StringViewPropertyDto stringViewPropertyDto = (StringViewPropertyDto) o;
+    final StringViewPropertyDto stringViewPropertyDto = (StringViewPropertyDto) o;
     return Objects.equals(getId(), stringViewPropertyDto.getId());
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof StringViewPropertyDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final StringViewPropertyDto that = (StringViewPropertyDto) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/VariableViewPropertyDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/VariableViewPropertyDto.java
@@ -8,23 +8,51 @@
 package io.camunda.optimize.dto.optimize.query.report.single.process.view;
 
 import io.camunda.optimize.dto.optimize.query.variable.VariableType;
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
 public class VariableViewPropertyDto implements TypedViewPropertyDto {
 
   private final String name;
   private final VariableType type;
 
-  @Override
-  public String toString() {
-    return "aggregation";
+  public VariableViewPropertyDto(final String name, final VariableType type) {
+    this.name = name;
+    this.type = type;
   }
 
   @Override
   public boolean isCombinable(final Object o) {
     return o instanceof VariableViewPropertyDto;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public VariableType getType() {
+    return type;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof VariableViewPropertyDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VariableViewPropertyDto that = (VariableViewPropertyDto) o;
+    return Objects.equals(name, that.name) && type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type);
+  }
+
+  @Override
+  public String toString() {
+    return "aggregation";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/result/MeasureDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/result/MeasureDto.java
@@ -10,33 +10,107 @@ package io.camunda.optimize.dto.optimize.query.report.single.result;
 import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.UserTaskDurationTime;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MeasureDto<T> {
+
   private ViewProperty property;
   private AggregationDto aggregationType;
   private UserTaskDurationTime userTaskDurationTime;
   private T data;
 
+  public MeasureDto(
+      final ViewProperty property,
+      final AggregationDto aggregationType,
+      final UserTaskDurationTime userTaskDurationTime,
+      final T data) {
+    this.property = property;
+    this.aggregationType = aggregationType;
+    this.userTaskDurationTime = userTaskDurationTime;
+    this.data = data;
+  }
+
+  protected MeasureDto() {}
+
   public static <T> MeasureDto<T> of(
-      ViewProperty property,
-      AggregationDto aggregationType,
-      UserTaskDurationTime userTaskDurationTime,
-      T data) {
+      final ViewProperty property,
+      final AggregationDto aggregationType,
+      final UserTaskDurationTime userTaskDurationTime,
+      final T data) {
     return new MeasureDto<>(property, aggregationType, userTaskDurationTime, data);
   }
 
-  public static <T> MeasureDto<T> of(ViewProperty property, T data) {
+  public static <T> MeasureDto<T> of(final ViewProperty property, final T data) {
     return new MeasureDto<>(property, null, null, data);
   }
 
-  public static <T> MeasureDto<T> of(T data) {
+  public static <T> MeasureDto<T> of(final T data) {
     return new MeasureDto<>(null, null, null, data);
+  }
+
+  public ViewProperty getProperty() {
+    return property;
+  }
+
+  public void setProperty(final ViewProperty property) {
+    this.property = property;
+  }
+
+  public AggregationDto getAggregationType() {
+    return aggregationType;
+  }
+
+  public void setAggregationType(final AggregationDto aggregationType) {
+    this.aggregationType = aggregationType;
+  }
+
+  public UserTaskDurationTime getUserTaskDurationTime() {
+    return userTaskDurationTime;
+  }
+
+  public void setUserTaskDurationTime(final UserTaskDurationTime userTaskDurationTime) {
+    this.userTaskDurationTime = userTaskDurationTime;
+  }
+
+  public T getData() {
+    return data;
+  }
+
+  public void setData(final T data) {
+    this.data = data;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MeasureDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MeasureDto<?> that = (MeasureDto<?>) o;
+    return Objects.equals(property, that.property)
+        && Objects.equals(aggregationType, that.aggregationType)
+        && userTaskDurationTime == that.userTaskDurationTime
+        && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(property, aggregationType, userTaskDurationTime, data);
+  }
+
+  @Override
+  public String toString() {
+    return "MeasureDto(property="
+        + getProperty()
+        + ", aggregationType="
+        + getAggregationType()
+        + ", userTaskDurationTime="
+        + getUserTaskDurationTime()
+        + ", data="
+        + getData()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/result/hyper/HyperMapResultEntryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/result/hyper/HyperMapResultEntryDto.java
@@ -8,39 +8,89 @@
 package io.camunda.optimize.dto.optimize.query.report.single.result.hyper;
 
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import java.util.Objects;
 
-@EqualsAndHashCode
-@ToString
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HyperMapResultEntryDto {
 
   // @formatter:off
-  @NonNull @Getter @Setter private String key;
-  @Getter @Setter private List<MapResultEntryDto> value;
-  @Setter private String label;
+  private String key;
+  private List<MapResultEntryDto> value;
+  private String label;
 
   // @formatter:on
 
-  public HyperMapResultEntryDto(@NonNull final String key, final List<MapResultEntryDto> value) {
+  public HyperMapResultEntryDto(final String key, final List<MapResultEntryDto> value) {
+    if (key == null) {
+      throw new IllegalArgumentException("key cannot be null");
+    }
+
     this.key = key;
     this.value = value;
   }
 
   public HyperMapResultEntryDto(
-      @NonNull final String key, final List<MapResultEntryDto> value, String label) {
+      final String key, final List<MapResultEntryDto> value, final String label) {
+    if (key == null) {
+      throw new IllegalArgumentException("key cannot be null");
+    }
+
     this.key = key;
     setValue(value);
     this.label = label;
   }
 
+  protected HyperMapResultEntryDto() {}
+
   public String getLabel() {
     return label != null && !label.isEmpty() ? label : key;
+  }
+
+  public void setLabel(final String label) {
+    this.label = label;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof HyperMapResultEntryDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final HyperMapResultEntryDto that = (HyperMapResultEntryDto) o;
+    return Objects.equals(key, that.key)
+        && Objects.equals(value, that.value)
+        && Objects.equals(label, that.label);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, value, label);
+  }
+
+  @Override
+  public String toString() {
+    return "HyperMapResultEntryDto(key=" + key + ", value=" + value + ", label=" + getLabel() + ")";
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(final String key) {
+    if (key == null) {
+      throw new IllegalArgumentException("key cannot be null");
+    }
+
+    this.key = key;
+  }
+
+  public List<MapResultEntryDto> getValue() {
+    return value;
+  }
+
+  public void setValue(final List<MapResultEntryDto> value) {
+    this.value = value;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/result/hyper/MapResultEntryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/result/hyper/MapResultEntryDto.java
@@ -7,38 +7,88 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.result.hyper;
 
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.ToString;
+import java.util.Objects;
 
-@EqualsAndHashCode
-@ToString
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MapResultEntryDto {
 
   // @formatter:off
-  @NonNull @Getter @Setter private String key;
-  @Getter @Setter private Double value;
-  @Setter private String label;
+  private String key;
+  private Double value;
+  private String label;
 
   // @formatter:on
 
-  public MapResultEntryDto(@NonNull final String key, final Double value) {
+  public MapResultEntryDto(final String key, final Double value) {
+    if (key == null) {
+      throw new IllegalArgumentException("key cannot be null");
+    }
+
     this.key = key;
     this.value = value;
   }
 
-  public MapResultEntryDto(@NonNull final String key, final Double value, String label) {
+  public MapResultEntryDto(final String key, final Double value, final String label) {
+    if (key == null) {
+      throw new IllegalArgumentException("key cannot be null");
+    }
+
     this.key = key;
     this.value = value;
     this.label = label;
   }
 
+  protected MapResultEntryDto() {}
+
   public String getLabel() {
     return label != null && !label.isEmpty() ? label : key;
+  }
+
+  public void setLabel(final String label) {
+    this.label = label;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MapResultEntryDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MapResultEntryDto that = (MapResultEntryDto) o;
+    return Objects.equals(key, that.key)
+        && Objects.equals(value, that.value)
+        && Objects.equals(label, that.label);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, value, label);
+  }
+
+  @Override
+  public String toString() {
+    return "MapResultEntryDto(key=" + key + ", value=" + value + ", label=" + getLabel() + ")";
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(final String key) {
+    if (key == null) {
+      throw new IllegalArgumentException("key cannot be null");
+    }
+
+    this.key = key;
+  }
+
+  public Double getValue() {
+    return value;
+  }
+
+  public void setValue(final Double value) {
+    this.value = value;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/sorting/ReportSortingDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/sorting/ReportSortingDto.java
@@ -7,16 +7,11 @@
  */
 package io.camunda.optimize.dto.optimize.query.sorting;
 
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@AllArgsConstructor(access = AccessLevel.PUBLIC)
-@NoArgsConstructor(access = AccessLevel.PUBLIC)
-@Data
 public class ReportSortingDto {
+
   public static final String SORT_BY_KEY = "key";
   public static final String SORT_BY_VALUE = "value";
   public static final String SORT_BY_LABEL = "label";
@@ -24,11 +19,52 @@ public class ReportSortingDto {
   private String by;
   private SortOrder order;
 
+  public ReportSortingDto(final String by, final SortOrder order) {
+    this.by = by;
+    this.order = order;
+  }
+
+  public ReportSortingDto() {}
+
   public Optional<String> getBy() {
     return Optional.ofNullable(by);
   }
 
+  public void setBy(final String by) {
+    this.by = by;
+  }
+
   public Optional<SortOrder> getOrder() {
     return Optional.ofNullable(order);
+  }
+
+  public void setOrder(final SortOrder order) {
+    this.order = order;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ReportSortingDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(by, order);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportSortingDto that = (ReportSortingDto) o;
+    return Objects.equals(by, that.by) && Objects.equals(order, that.order);
+  }
+
+  @Override
+  public String toString() {
+    return "ReportSortingDto(by=" + getBy() + ", order=" + getOrder() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/MixpanelConfigResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/MixpanelConfigResponseDto.java
@@ -7,14 +7,10 @@
  */
 package io.camunda.optimize.dto.optimize.query.ui_configuration;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class MixpanelConfigResponseDto {
+
   private boolean enabled;
   private String apiHost;
   private String token;
@@ -22,4 +18,125 @@ public class MixpanelConfigResponseDto {
   private String osanoScriptUrl;
   private String stage;
   private String clusterId;
+
+  public MixpanelConfigResponseDto(
+      final boolean enabled,
+      final String apiHost,
+      final String token,
+      final String organizationId,
+      final String osanoScriptUrl,
+      final String stage,
+      final String clusterId) {
+    this.enabled = enabled;
+    this.apiHost = apiHost;
+    this.token = token;
+    this.organizationId = organizationId;
+    this.osanoScriptUrl = osanoScriptUrl;
+    this.stage = stage;
+    this.clusterId = clusterId;
+  }
+
+  public MixpanelConfigResponseDto() {}
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getApiHost() {
+    return apiHost;
+  }
+
+  public void setApiHost(final String apiHost) {
+    this.apiHost = apiHost;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public void setToken(final String token) {
+    this.token = token;
+  }
+
+  public String getOrganizationId() {
+    return organizationId;
+  }
+
+  public void setOrganizationId(final String organizationId) {
+    this.organizationId = organizationId;
+  }
+
+  public String getOsanoScriptUrl() {
+    return osanoScriptUrl;
+  }
+
+  public void setOsanoScriptUrl(final String osanoScriptUrl) {
+    this.osanoScriptUrl = osanoScriptUrl;
+  }
+
+  public String getStage() {
+    return stage;
+  }
+
+  public void setStage(final String stage) {
+    this.stage = stage;
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  public void setClusterId(final String clusterId) {
+    this.clusterId = clusterId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MixpanelConfigResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, token, apiHost, organizationId, clusterId, stage, osanoScriptUrl);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MixpanelConfigResponseDto that = (MixpanelConfigResponseDto) o;
+    return enabled == that.enabled
+        && Objects.equals(token, that.token)
+        && Objects.equals(apiHost, that.apiHost)
+        && Objects.equals(organizationId, that.organizationId)
+        && Objects.equals(clusterId, that.clusterId)
+        && Objects.equals(stage, that.stage)
+        && Objects.equals(osanoScriptUrl, that.osanoScriptUrl);
+  }
+
+  @Override
+  public String toString() {
+    return "MixpanelConfigResponseDto(enabled="
+        + isEnabled()
+        + ", apiHost="
+        + getApiHost()
+        + ", token="
+        + getToken()
+        + ", organizationId="
+        + getOrganizationId()
+        + ", osanoScriptUrl="
+        + getOsanoScriptUrl()
+        + ", stage="
+        + getStage()
+        + ", clusterId="
+        + getClusterId()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/OnboardingResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/OnboardingResponseDto.java
@@ -7,17 +7,108 @@
  */
 package io.camunda.optimize.dto.optimize.query.ui_configuration;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class OnboardingResponseDto {
+
   private boolean enabled;
   private String appCuesScriptUrl;
   private String orgId;
   private String clusterId;
   private String salesPlanType;
+
+  public OnboardingResponseDto(
+      final boolean enabled,
+      final String appCuesScriptUrl,
+      final String orgId,
+      final String clusterId,
+      final String salesPlanType) {
+    this.enabled = enabled;
+    this.appCuesScriptUrl = appCuesScriptUrl;
+    this.orgId = orgId;
+    this.clusterId = clusterId;
+    this.salesPlanType = salesPlanType;
+  }
+
+  public OnboardingResponseDto() {}
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getAppCuesScriptUrl() {
+    return appCuesScriptUrl;
+  }
+
+  public void setAppCuesScriptUrl(final String appCuesScriptUrl) {
+    this.appCuesScriptUrl = appCuesScriptUrl;
+  }
+
+  public String getOrgId() {
+    return orgId;
+  }
+
+  public void setOrgId(final String orgId) {
+    this.orgId = orgId;
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  public void setClusterId(final String clusterId) {
+    this.clusterId = clusterId;
+  }
+
+  public String getSalesPlanType() {
+    return salesPlanType;
+  }
+
+  public void setSalesPlanType(final String salesPlanType) {
+    this.salesPlanType = salesPlanType;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof OnboardingResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, appCuesScriptUrl, orgId, clusterId, salesPlanType);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OnboardingResponseDto that = (OnboardingResponseDto) o;
+    return enabled == that.enabled
+        && Objects.equals(appCuesScriptUrl, that.appCuesScriptUrl)
+        && Objects.equals(orgId, that.orgId)
+        && Objects.equals(clusterId, that.clusterId)
+        && Objects.equals(salesPlanType, that.salesPlanType);
+  }
+
+  @Override
+  public String toString() {
+    return "OnboardingResponseDto(enabled="
+        + isEnabled()
+        + ", appCuesScriptUrl="
+        + getAppCuesScriptUrl()
+        + ", orgId="
+        + getOrgId()
+        + ", clusterId="
+        + getClusterId()
+        + ", salesPlanType="
+        + getSalesPlanType()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/UIConfigurationResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/UIConfigurationResponseDto.java
@@ -9,15 +9,9 @@ package io.camunda.optimize.dto.optimize.query.ui_configuration;
 
 import io.camunda.optimize.service.util.configuration.DatabaseType;
 import io.camunda.optimize.service.util.configuration.OptimizeProfile;
-import java.util.List;
 import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class UIConfigurationResponseDto {
 
   private boolean emailEnabled;
@@ -31,15 +25,318 @@ public class UIConfigurationResponseDto {
   private OptimizeProfile optimizeProfile;
   private Map<AppName, String> webappsLinks; // links for the app switcher
   private String notificationsUrl;
-  private List<String> webhooks;
   private boolean logoutHidden;
   private int maxNumDataSourcesForReport;
   private Integer exportCsvLimit;
   private DatabaseType optimizeDatabase;
   private boolean validLicense;
   private String licenseType;
+  private boolean isCommercial;
+  private String expiresAt;
 
   private MixpanelConfigResponseDto mixpanel = new MixpanelConfigResponseDto();
 
   private OnboardingResponseDto onboarding = new OnboardingResponseDto();
+
+  public UIConfigurationResponseDto(
+      final boolean emailEnabled,
+      final boolean sharingEnabled,
+      final boolean tenantsAvailable,
+      final boolean userSearchAvailable,
+      final boolean userTaskAssigneeAnalyticsEnabled,
+      final String optimizeVersion,
+      final String optimizeDocsVersion,
+      final boolean isEnterpriseMode,
+      final OptimizeProfile optimizeProfile,
+      final Map<AppName, String> webappsLinks,
+      final String notificationsUrl,
+      final boolean logoutHidden,
+      final int maxNumDataSourcesForReport,
+      final Integer exportCsvLimit,
+      final DatabaseType optimizeDatabase,
+      final boolean validLicense,
+      final String licenseType,
+      final MixpanelConfigResponseDto mixpanel,
+      final OnboardingResponseDto onboarding) {
+    this.emailEnabled = emailEnabled;
+    this.sharingEnabled = sharingEnabled;
+    this.tenantsAvailable = tenantsAvailable;
+    this.userSearchAvailable = userSearchAvailable;
+    this.userTaskAssigneeAnalyticsEnabled = userTaskAssigneeAnalyticsEnabled;
+    this.optimizeVersion = optimizeVersion;
+    this.optimizeDocsVersion = optimizeDocsVersion;
+    this.isEnterpriseMode = isEnterpriseMode;
+    this.optimizeProfile = optimizeProfile;
+    this.webappsLinks = webappsLinks;
+    this.notificationsUrl = notificationsUrl;
+    this.logoutHidden = logoutHidden;
+    this.maxNumDataSourcesForReport = maxNumDataSourcesForReport;
+    this.exportCsvLimit = exportCsvLimit;
+    this.optimizeDatabase = optimizeDatabase;
+    this.validLicense = validLicense;
+    this.licenseType = licenseType;
+    this.mixpanel = mixpanel;
+    this.onboarding = onboarding;
+  }
+
+  public UIConfigurationResponseDto() {}
+
+  public boolean isEmailEnabled() {
+    return emailEnabled;
+  }
+
+  public void setEmailEnabled(final boolean emailEnabled) {
+    this.emailEnabled = emailEnabled;
+  }
+
+  public boolean isSharingEnabled() {
+    return sharingEnabled;
+  }
+
+  public void setSharingEnabled(final boolean sharingEnabled) {
+    this.sharingEnabled = sharingEnabled;
+  }
+
+  public boolean isTenantsAvailable() {
+    return tenantsAvailable;
+  }
+
+  public void setTenantsAvailable(final boolean tenantsAvailable) {
+    this.tenantsAvailable = tenantsAvailable;
+  }
+
+  public boolean isUserSearchAvailable() {
+    return userSearchAvailable;
+  }
+
+  public void setUserSearchAvailable(final boolean userSearchAvailable) {
+    this.userSearchAvailable = userSearchAvailable;
+  }
+
+  public boolean isUserTaskAssigneeAnalyticsEnabled() {
+    return userTaskAssigneeAnalyticsEnabled;
+  }
+
+  public void setUserTaskAssigneeAnalyticsEnabled(final boolean userTaskAssigneeAnalyticsEnabled) {
+    this.userTaskAssigneeAnalyticsEnabled = userTaskAssigneeAnalyticsEnabled;
+  }
+
+  public String getOptimizeVersion() {
+    return optimizeVersion;
+  }
+
+  public void setOptimizeVersion(final String optimizeVersion) {
+    this.optimizeVersion = optimizeVersion;
+  }
+
+  public String getOptimizeDocsVersion() {
+    return optimizeDocsVersion;
+  }
+
+  public void setOptimizeDocsVersion(final String optimizeDocsVersion) {
+    this.optimizeDocsVersion = optimizeDocsVersion;
+  }
+
+  public boolean isEnterpriseMode() {
+    return isEnterpriseMode;
+  }
+
+  public void setEnterpriseMode(final boolean isEnterpriseMode) {
+    this.isEnterpriseMode = isEnterpriseMode;
+  }
+
+  public OptimizeProfile getOptimizeProfile() {
+    return optimizeProfile;
+  }
+
+  public void setOptimizeProfile(final OptimizeProfile optimizeProfile) {
+    this.optimizeProfile = optimizeProfile;
+  }
+
+  public Map<AppName, String> getWebappsLinks() {
+    return webappsLinks;
+  }
+
+  public void setWebappsLinks(final Map<AppName, String> webappsLinks) {
+    this.webappsLinks = webappsLinks;
+  }
+
+  public String getNotificationsUrl() {
+    return notificationsUrl;
+  }
+
+  public void setNotificationsUrl(final String notificationsUrl) {
+    this.notificationsUrl = notificationsUrl;
+  }
+
+  public boolean isLogoutHidden() {
+    return logoutHidden;
+  }
+
+  public void setLogoutHidden(final boolean logoutHidden) {
+    this.logoutHidden = logoutHidden;
+  }
+
+  public int getMaxNumDataSourcesForReport() {
+    return maxNumDataSourcesForReport;
+  }
+
+  public void setMaxNumDataSourcesForReport(final int maxNumDataSourcesForReport) {
+    this.maxNumDataSourcesForReport = maxNumDataSourcesForReport;
+  }
+
+  public Integer getExportCsvLimit() {
+    return exportCsvLimit;
+  }
+
+  public void setExportCsvLimit(final Integer exportCsvLimit) {
+    this.exportCsvLimit = exportCsvLimit;
+  }
+
+  public DatabaseType getOptimizeDatabase() {
+    return optimizeDatabase;
+  }
+
+  public void setOptimizeDatabase(final DatabaseType optimizeDatabase) {
+    this.optimizeDatabase = optimizeDatabase;
+  }
+
+  public boolean isValidLicense() {
+    return validLicense;
+  }
+
+  public void setValidLicense(final boolean validLicense) {
+    this.validLicense = validLicense;
+  }
+
+  public String getLicenseType() {
+    return licenseType;
+  }
+
+  public void setLicenseType(final String licenseType) {
+    this.licenseType = licenseType;
+  }
+
+  public boolean isCommercial() {
+    return isCommercial;
+  }
+
+  public void setCommercial(final boolean isCommercial) {
+    this.isCommercial = isCommercial;
+  }
+
+  public String getExpiresAt() {
+    return expiresAt;
+  }
+
+  public void setExpiresAt(final String expiresAt) {
+    this.expiresAt = expiresAt;
+  }
+
+  public MixpanelConfigResponseDto getMixpanel() {
+    return mixpanel;
+  }
+
+  public void setMixpanel(final MixpanelConfigResponseDto mixpanel) {
+    this.mixpanel = mixpanel;
+  }
+
+  public OnboardingResponseDto getOnboarding() {
+    return onboarding;
+  }
+
+  public void setOnboarding(final OnboardingResponseDto onboarding) {
+    this.onboarding = onboarding;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof UIConfigurationResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        logoutHidden,
+        maxNumDataSourcesForReport,
+        userTaskAssigneeAnalyticsEnabled,
+        emailEnabled,
+        sharingEnabled,
+        mixpanel,
+        onboarding,
+        optimizeVersion,
+        optimizeProfile,
+        validLicense,
+        licenseType,
+        isCommercial,
+        expiresAt,
+        notificationsUrl,
+        webappsLinks);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UIConfigurationResponseDto that = (UIConfigurationResponseDto) o;
+    return logoutHidden == that.logoutHidden
+        && maxNumDataSourcesForReport == that.maxNumDataSourcesForReport
+        && userTaskAssigneeAnalyticsEnabled == that.userTaskAssigneeAnalyticsEnabled
+        && emailEnabled == that.emailEnabled
+        && sharingEnabled == that.sharingEnabled
+        && validLicense == that.validLicense
+        && isCommercial == that.isCommercial
+        && Objects.equals(mixpanel, that.mixpanel)
+        && Objects.equals(onboarding, that.onboarding)
+        && Objects.equals(optimizeVersion, that.optimizeVersion)
+        && Objects.equals(optimizeProfile, that.optimizeProfile)
+        && Objects.equals(notificationsUrl, that.notificationsUrl)
+        && Objects.equals(webappsLinks, that.webappsLinks);
+  }
+
+  @Override
+  public String toString() {
+    return "UIConfigurationResponseDto(emailEnabled="
+        + isEmailEnabled()
+        + ", sharingEnabled="
+        + isSharingEnabled()
+        + ", tenantsAvailable="
+        + isTenantsAvailable()
+        + ", userSearchAvailable="
+        + isUserSearchAvailable()
+        + ", userTaskAssigneeAnalyticsEnabled="
+        + isUserTaskAssigneeAnalyticsEnabled()
+        + ", optimizeVersion="
+        + getOptimizeVersion()
+        + ", optimizeDocsVersion="
+        + getOptimizeDocsVersion()
+        + ", isEnterpriseMode="
+        + isEnterpriseMode()
+        + ", optimizeProfile="
+        + getOptimizeProfile()
+        + ", webappsLinks="
+        + getWebappsLinks()
+        + ", notificationsUrl="
+        + getNotificationsUrl()
+        + ", logoutHidden="
+        + isLogoutHidden()
+        + ", maxNumDataSourcesForReport="
+        + getMaxNumDataSourcesForReport()
+        + ", exportCsvLimit="
+        + getExportCsvLimit()
+        + ", optimizeDatabase="
+        + getOptimizeDatabase()
+        + ", validLicense="
+        + isValidLicense()
+        + ", licenseType="
+        + getLicenseType()
+        + ", mixpanel="
+        + getMixpanel()
+        + ", onboarding="
+        + getOnboarding()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DecisionVariableNameRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DecisionVariableNameRequestDto.java
@@ -16,36 +16,97 @@ import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
-@NoArgsConstructor
 public class DecisionVariableNameRequestDto {
+
   @NotNull private String decisionDefinitionKey;
   private List<String> decisionDefinitionVersions = new ArrayList<>();
   private List<String> tenantIds = new ArrayList<>(DEFAULT_TENANT_IDS);
 
   public DecisionVariableNameRequestDto(
       @NotNull final String key, final String version, final String tenantId) {
-    this.decisionDefinitionKey = key;
-    this.decisionDefinitionVersions = Collections.singletonList(version);
-    this.tenantIds = Collections.singletonList(tenantId);
+    decisionDefinitionKey = key;
+    decisionDefinitionVersions = Collections.singletonList(version);
+    tenantIds = Collections.singletonList(tenantId);
   }
 
   public DecisionVariableNameRequestDto(@NotNull final String key, final List<String> versions) {
-    this.decisionDefinitionKey = key;
-    this.decisionDefinitionVersions = versions;
+    decisionDefinitionKey = key;
+    decisionDefinitionVersions = versions;
   }
 
+  public DecisionVariableNameRequestDto(
+      @NotNull final String decisionDefinitionKey,
+      final List<String> decisionDefinitionVersions,
+      final List<String> tenantIds) {
+    this.decisionDefinitionKey = decisionDefinitionKey;
+    this.decisionDefinitionVersions = decisionDefinitionVersions;
+    this.tenantIds = tenantIds;
+  }
+
+  public DecisionVariableNameRequestDto() {}
+
   @JsonIgnore
-  public void setDecisionDefinitionVersion(String decisionDefinitionVersion) {
-    this.decisionDefinitionVersions = Lists.newArrayList(decisionDefinitionVersion);
+  public void setDecisionDefinitionVersion(final String decisionDefinitionVersion) {
+    decisionDefinitionVersions = Lists.newArrayList(decisionDefinitionVersion);
   }
 
   public List<String> getTenantIds() {
     return TenantListHandlingUtil.sortAndReturnTenantIdList(tenantIds);
+  }
+
+  public void setTenantIds(final List<String> tenantIds) {
+    this.tenantIds = tenantIds;
+  }
+
+  public @NotNull String getDecisionDefinitionKey() {
+    return decisionDefinitionKey;
+  }
+
+  public void setDecisionDefinitionKey(@NotNull final String decisionDefinitionKey) {
+    this.decisionDefinitionKey = decisionDefinitionKey;
+  }
+
+  public List<String> getDecisionDefinitionVersions() {
+    return decisionDefinitionVersions;
+  }
+
+  public void setDecisionDefinitionVersions(final List<String> decisionDefinitionVersions) {
+    this.decisionDefinitionVersions = decisionDefinitionVersions;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DecisionVariableNameRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(decisionDefinitionKey, decisionDefinitionVersions, tenantIds);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionVariableNameRequestDto that = (DecisionVariableNameRequestDto) o;
+    return Objects.equals(decisionDefinitionKey, that.decisionDefinitionKey)
+        && Objects.equals(decisionDefinitionVersions, that.decisionDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds);
+  }
+
+  @Override
+  public String toString() {
+    return "DecisionVariableNameRequestDto(decisionDefinitionKey="
+        + getDecisionDefinitionKey()
+        + ", decisionDefinitionVersions="
+        + getDecisionDefinitionVersions()
+        + ", tenantIds="
+        + getTenantIds()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DecisionVariableNameResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DecisionVariableNameResponseDto.java
@@ -7,16 +7,78 @@
  */
 package io.camunda.optimize.dto.optimize.query.variable;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class DecisionVariableNameResponseDto {
 
   protected String id;
   protected String name;
   protected VariableType type;
+
+  public DecisionVariableNameResponseDto(
+      final String id, final String name, final VariableType type) {
+    this.id = id;
+    this.name = name;
+    this.type = type;
+  }
+
+  public DecisionVariableNameResponseDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public VariableType getType() {
+    return type;
+  }
+
+  public void setType(final VariableType type) {
+    this.type = type;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DecisionVariableNameResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, type);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionVariableNameResponseDto that = (DecisionVariableNameResponseDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type);
+  }
+
+  @Override
+  public String toString() {
+    return "DecisionVariableNameResponseDto(id="
+        + getId()
+        + ", name="
+        + getName()
+        + ", type="
+        + getType()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DecisionVariableValueRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DecisionVariableValueRequestDto.java
@@ -15,9 +15,8 @@ import io.camunda.optimize.service.util.TenantListHandlingUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class DecisionVariableValueRequestDto {
 
   private String decisionDefinitionKey;
@@ -29,12 +28,131 @@ public class DecisionVariableValueRequestDto {
   private Integer resultOffset = 0;
   private Integer numResults = MAX_RESPONSE_SIZE_LIMIT;
 
+  public DecisionVariableValueRequestDto() {}
+
   @JsonIgnore
-  public void setDecisionDefinitionVersion(String decisionDefinitionVersion) {
-    this.decisionDefinitionVersions = Lists.newArrayList(decisionDefinitionVersion);
+  public void setDecisionDefinitionVersion(final String decisionDefinitionVersion) {
+    decisionDefinitionVersions = Lists.newArrayList(decisionDefinitionVersion);
   }
 
   public List<String> getTenantIds() {
     return TenantListHandlingUtil.sortAndReturnTenantIdList(tenantIds);
+  }
+
+  public void setTenantIds(final List<String> tenantIds) {
+    this.tenantIds = tenantIds;
+  }
+
+  public String getDecisionDefinitionKey() {
+    return decisionDefinitionKey;
+  }
+
+  public void setDecisionDefinitionKey(final String decisionDefinitionKey) {
+    this.decisionDefinitionKey = decisionDefinitionKey;
+  }
+
+  public List<String> getDecisionDefinitionVersions() {
+    return decisionDefinitionVersions;
+  }
+
+  public void setDecisionDefinitionVersions(final List<String> decisionDefinitionVersions) {
+    this.decisionDefinitionVersions = decisionDefinitionVersions;
+  }
+
+  public String getVariableId() {
+    return variableId;
+  }
+
+  public void setVariableId(final String variableId) {
+    this.variableId = variableId;
+  }
+
+  public VariableType getVariableType() {
+    return variableType;
+  }
+
+  public void setVariableType(final VariableType variableType) {
+    this.variableType = variableType;
+  }
+
+  public String getValueFilter() {
+    return valueFilter;
+  }
+
+  public void setValueFilter(final String valueFilter) {
+    this.valueFilter = valueFilter;
+  }
+
+  public Integer getResultOffset() {
+    return resultOffset;
+  }
+
+  public void setResultOffset(final Integer resultOffset) {
+    this.resultOffset = resultOffset;
+  }
+
+  public Integer getNumResults() {
+    return numResults;
+  }
+
+  public void setNumResults(final Integer numResults) {
+    this.numResults = numResults;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DecisionVariableValueRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        decisionDefinitionKey,
+        decisionDefinitionVersions,
+        tenantIds,
+        variableId,
+        variableType,
+        valueFilter,
+        resultOffset,
+        numResults);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DecisionVariableValueRequestDto that = (DecisionVariableValueRequestDto) o;
+    return Objects.equals(decisionDefinitionKey, that.decisionDefinitionKey)
+        && Objects.equals(decisionDefinitionVersions, that.decisionDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds)
+        && Objects.equals(variableId, that.variableId)
+        && Objects.equals(variableType, that.variableType)
+        && Objects.equals(valueFilter, that.valueFilter)
+        && Objects.equals(resultOffset, that.resultOffset)
+        && Objects.equals(numResults, that.numResults);
+  }
+
+  @Override
+  public String toString() {
+    return "DecisionVariableValueRequestDto(decisionDefinitionKey="
+        + getDecisionDefinitionKey()
+        + ", decisionDefinitionVersions="
+        + getDecisionDefinitionVersions()
+        + ", tenantIds="
+        + getTenantIds()
+        + ", variableId="
+        + getVariableId()
+        + ", variableType="
+        + getVariableType()
+        + ", valueFilter="
+        + getValueFilter()
+        + ", resultOffset="
+        + getResultOffset()
+        + ", numResults="
+        + getNumResults()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DefinitionVariableLabelsDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DefinitionVariableLabelsDto.java
@@ -11,19 +11,69 @@ import io.camunda.optimize.dto.optimize.OptimizeDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class DefinitionVariableLabelsDto implements OptimizeDto {
 
   @NotBlank private String definitionKey;
 
   @Valid private List<LabelDto> labels;
 
+  public DefinitionVariableLabelsDto(
+      @NotBlank final String definitionKey, @Valid final List<LabelDto> labels) {
+    this.definitionKey = definitionKey;
+    this.labels = labels;
+  }
+
+  public DefinitionVariableLabelsDto() {}
+
+  public @NotBlank String getDefinitionKey() {
+    return definitionKey;
+  }
+
+  public void setDefinitionKey(@NotBlank final String definitionKey) {
+    this.definitionKey = definitionKey;
+  }
+
+  public @Valid List<LabelDto> getLabels() {
+    return labels;
+  }
+
+  public void setLabels(@Valid final List<LabelDto> labels) {
+    this.labels = labels;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DefinitionVariableLabelsDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(definitionKey, labels);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DefinitionVariableLabelsDto that = (DefinitionVariableLabelsDto) o;
+    return Objects.equals(definitionKey, that.definitionKey) && Objects.equals(labels, that.labels);
+  }
+
+  @Override
+  public String toString() {
+    return "DefinitionVariableLabelsDto(definitionKey="
+        + getDefinitionKey()
+        + ", labels="
+        + getLabels()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String definitionKey = "definitionKey";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ExternalProcessVariableDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ExternalProcessVariableDto.java
@@ -8,9 +8,8 @@
 package io.camunda.optimize.dto.optimize.query.variable;
 
 import io.camunda.optimize.dto.optimize.OptimizeDto;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ExternalProcessVariableDto implements OptimizeDto {
 
   private String variableId;
@@ -22,6 +21,125 @@ public class ExternalProcessVariableDto implements OptimizeDto {
   private String processDefinitionKey;
   private String serializationDataFormat; // optional, used for object variables
 
+  public ExternalProcessVariableDto() {}
+
+  public String getVariableId() {
+    return this.variableId;
+  }
+
+  public String getVariableName() {
+    return this.variableName;
+  }
+
+  public String getVariableValue() {
+    return this.variableValue;
+  }
+
+  public VariableType getVariableType() {
+    return this.variableType;
+  }
+
+  public Long getIngestionTimestamp() {
+    return this.ingestionTimestamp;
+  }
+
+  public String getProcessInstanceId() {
+    return this.processInstanceId;
+  }
+
+  public String getProcessDefinitionKey() {
+    return this.processDefinitionKey;
+  }
+
+  public String getSerializationDataFormat() {
+    return this.serializationDataFormat;
+  }
+
+  public void setVariableId(final String variableId) {
+    this.variableId = variableId;
+  }
+
+  public void setVariableName(final String variableName) {
+    this.variableName = variableName;
+  }
+
+  public void setVariableValue(final String variableValue) {
+    this.variableValue = variableValue;
+  }
+
+  public void setVariableType(final VariableType variableType) {
+    this.variableType = variableType;
+  }
+
+  public void setIngestionTimestamp(final Long ingestionTimestamp) {
+    this.ingestionTimestamp = ingestionTimestamp;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public void setSerializationDataFormat(final String serializationDataFormat) {
+    this.serializationDataFormat = serializationDataFormat;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        variableId,
+        variableName,
+        variableValue,
+        variableType,
+        ingestionTimestamp,
+        processInstanceId,
+        processDefinitionKey,
+        serializationDataFormat);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExternalProcessVariableDto that = (ExternalProcessVariableDto) o;
+    return Objects.equals(variableId, that.variableId)
+        && Objects.equals(variableName, that.variableName)
+        && Objects.equals(variableValue, that.variableValue)
+        && Objects.equals(variableType, that.variableType)
+        && Objects.equals(ingestionTimestamp, that.ingestionTimestamp)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(serializationDataFormat, that.serializationDataFormat);
+  }
+
+  public String toString() {
+    return "ExternalProcessVariableDto(variableId="
+        + this.getVariableId()
+        + ", variableName="
+        + this.getVariableName()
+        + ", variableValue="
+        + this.getVariableValue()
+        + ", variableType="
+        + this.getVariableType()
+        + ", ingestionTimestamp="
+        + this.getIngestionTimestamp()
+        + ", processInstanceId="
+        + this.getProcessInstanceId()
+        + ", processDefinitionKey="
+        + this.getProcessDefinitionKey()
+        + ", serializationDataFormat="
+        + this.getSerializationDataFormat()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String variableId = "variableId";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ExternalProcessVariableRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ExternalProcessVariableRequestDto.java
@@ -11,11 +11,8 @@ import io.camunda.optimize.dto.optimize.OptimizeDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@Data
 public class ExternalProcessVariableRequestDto implements OptimizeDto {
 
   @NotBlank private String id;
@@ -25,6 +22,8 @@ public class ExternalProcessVariableRequestDto implements OptimizeDto {
   @NotBlank private String processInstanceId;
   @NotBlank private String processDefinitionKey;
   private String serializationDataFormat; // optional, used for object variables
+
+  public ExternalProcessVariableRequestDto() {}
 
   public static List<ExternalProcessVariableDto> toExternalProcessVariableDtos(
       final Long ingestionTimestamp, final List<ExternalProcessVariableRequestDto> variableDtos) {
@@ -47,6 +46,105 @@ public class ExternalProcessVariableRequestDto implements OptimizeDto {
         .toList();
   }
 
+  public @NotBlank String getId() {
+    return this.id;
+  }
+
+  public @NotBlank String getName() {
+    return this.name;
+  }
+
+  public String getValue() {
+    return this.value;
+  }
+
+  public @NotNull VariableType getType() {
+    return this.type;
+  }
+
+  public @NotBlank String getProcessInstanceId() {
+    return this.processInstanceId;
+  }
+
+  public @NotBlank String getProcessDefinitionKey() {
+    return this.processDefinitionKey;
+  }
+
+  public String getSerializationDataFormat() {
+    return this.serializationDataFormat;
+  }
+
+  public void setId(@NotBlank final String id) {
+    this.id = id;
+  }
+
+  public void setName(@NotBlank final String name) {
+    this.name = name;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
+  }
+
+  public void setType(@NotNull final VariableType type) {
+    this.type = type;
+  }
+
+  public void setProcessInstanceId(@NotBlank final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public void setProcessDefinitionKey(@NotBlank final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public void setSerializationDataFormat(final String serializationDataFormat) {
+    this.serializationDataFormat = serializationDataFormat;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id, name, value, type, processInstanceId, processDefinitionKey, serializationDataFormat);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExternalProcessVariableRequestDto that = (ExternalProcessVariableRequestDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(value, that.value)
+        && Objects.equals(type, that.type)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(serializationDataFormat, that.serializationDataFormat);
+  }
+
+  public String toString() {
+    return "ExternalProcessVariableRequestDto(id="
+        + this.getId()
+        + ", name="
+        + this.getName()
+        + ", value="
+        + this.getValue()
+        + ", type="
+        + this.getType()
+        + ", processInstanceId="
+        + this.getProcessInstanceId()
+        + ", processDefinitionKey="
+        + this.getProcessDefinitionKey()
+        + ", serializationDataFormat="
+        + this.getSerializationDataFormat()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/LabelDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/LabelDto.java
@@ -10,19 +10,84 @@ package io.camunda.optimize.dto.optimize.query.variable;
 import io.camunda.optimize.dto.optimize.OptimizeDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class LabelDto implements OptimizeDto {
 
   private String variableLabel;
   @NotBlank private String variableName;
   @NotNull private VariableType variableType;
 
+  public LabelDto(
+      final String variableLabel,
+      @NotBlank final String variableName,
+      @NotNull final VariableType variableType) {
+    this.variableLabel = variableLabel;
+    this.variableName = variableName;
+    this.variableType = variableType;
+  }
+
+  public LabelDto() {}
+
+  public String getVariableLabel() {
+    return variableLabel;
+  }
+
+  public void setVariableLabel(final String variableLabel) {
+    this.variableLabel = variableLabel;
+  }
+
+  public @NotBlank String getVariableName() {
+    return variableName;
+  }
+
+  public void setVariableName(@NotBlank final String variableName) {
+    this.variableName = variableName;
+  }
+
+  public @NotNull VariableType getVariableType() {
+    return variableType;
+  }
+
+  public void setVariableType(@NotNull final VariableType variableType) {
+    this.variableType = variableType;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof LabelDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(variableLabel, variableName, variableType);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final LabelDto that = (LabelDto) o;
+    return Objects.equals(variableLabel, that.variableLabel)
+        && Objects.equals(variableName, that.variableName)
+        && Objects.equals(variableType, that.variableType);
+  }
+
+  @Override
+  public String toString() {
+    return "LabelDto(variableLabel="
+        + getVariableLabel()
+        + ", variableName="
+        + getVariableName()
+        + ", variableType="
+        + getVariableType()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String variableLabel = "variableLabel";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessToQueryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessToQueryDto.java
@@ -15,17 +15,24 @@ import io.camunda.optimize.service.util.TenantListHandlingUtil;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class ProcessToQueryDto {
+
   @NotNull private String processDefinitionKey;
   private List<String> processDefinitionVersions = new ArrayList<>();
   private List<String> tenantIds = new ArrayList<>(DEFAULT_TENANT_IDS);
+
+  public ProcessToQueryDto(
+      @NotNull final String processDefinitionKey,
+      final List<String> processDefinitionVersions,
+      final List<String> tenantIds) {
+    this.processDefinitionKey = processDefinitionKey;
+    this.processDefinitionVersions = processDefinitionVersions;
+    this.tenantIds = tenantIds;
+  }
+
+  public ProcessToQueryDto() {}
 
   @JsonIgnore
   public void setProcessDefinitionVersion(final String processDefinitionVersion) {
@@ -34,5 +41,59 @@ public class ProcessToQueryDto {
 
   public List<String> getTenantIds() {
     return TenantListHandlingUtil.sortAndReturnTenantIdList(tenantIds);
+  }
+
+  public void setTenantIds(final List<String> tenantIds) {
+    this.tenantIds = tenantIds;
+  }
+
+  public @NotNull String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(@NotNull final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public List<String> getProcessDefinitionVersions() {
+    return processDefinitionVersions;
+  }
+
+  public void setProcessDefinitionVersions(final List<String> processDefinitionVersions) {
+    this.processDefinitionVersions = processDefinitionVersions;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessToQueryDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processDefinitionKey, processDefinitionVersions, tenantIds);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessToQueryDto that = (ProcessToQueryDto) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersions, that.processDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessToQueryDto(processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", processDefinitionVersions="
+        + getProcessDefinitionVersions()
+        + ", tenantIds="
+        + getTenantIds()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableDto.java
@@ -11,13 +11,8 @@ import io.camunda.optimize.dto.optimize.OptimizeDto;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class ProcessVariableDto implements OptimizeDto {
 
   private String id;
@@ -32,4 +27,197 @@ public class ProcessVariableDto implements OptimizeDto {
   private Long version;
   private String engineAlias;
   private String tenantId;
+
+  public ProcessVariableDto(
+      final String id,
+      final String name,
+      final String type,
+      final List<String> value,
+      final OffsetDateTime timestamp,
+      final Map<String, Object> valueInfo,
+      final String processDefinitionKey,
+      final String processDefinitionId,
+      final String processInstanceId,
+      final Long version,
+      final String engineAlias,
+      final String tenantId) {
+    this.id = id;
+    this.name = name;
+    this.type = type;
+    this.value = value;
+    this.timestamp = timestamp;
+    this.valueInfo = valueInfo;
+    this.processDefinitionKey = processDefinitionKey;
+    this.processDefinitionId = processDefinitionId;
+    this.processInstanceId = processInstanceId;
+    this.version = version;
+    this.engineAlias = engineAlias;
+    this.tenantId = tenantId;
+  }
+
+  public ProcessVariableDto() {}
+
+  public String getId() {
+    return this.id;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public String getType() {
+    return this.type;
+  }
+
+  public List<String> getValue() {
+    return this.value;
+  }
+
+  public OffsetDateTime getTimestamp() {
+    return this.timestamp;
+  }
+
+  public Map<String, Object> getValueInfo() {
+    return this.valueInfo;
+  }
+
+  public String getProcessDefinitionKey() {
+    return this.processDefinitionKey;
+  }
+
+  public String getProcessDefinitionId() {
+    return this.processDefinitionId;
+  }
+
+  public String getProcessInstanceId() {
+    return this.processInstanceId;
+  }
+
+  public Long getVersion() {
+    return this.version;
+  }
+
+  public String getEngineAlias() {
+    return this.engineAlias;
+  }
+
+  public String getTenantId() {
+    return this.tenantId;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
+  }
+
+  public void setValue(final List<String> value) {
+    this.value = value;
+  }
+
+  public void setTimestamp(final OffsetDateTime timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public void setValueInfo(final Map<String, Object> valueInfo) {
+    this.valueInfo = valueInfo;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public void setProcessDefinitionId(final String processDefinitionId) {
+    this.processDefinitionId = processDefinitionId;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public void setVersion(final Long version) {
+    this.version = version;
+  }
+
+  public void setEngineAlias(final String engineAlias) {
+    this.engineAlias = engineAlias;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        name,
+        type,
+        value,
+        timestamp,
+        valueInfo,
+        processDefinitionKey,
+        processDefinitionId,
+        processInstanceId,
+        version,
+        engineAlias,
+        tenantId);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableDto that = (ProcessVariableDto) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(value, that.value)
+        && Objects.equals(timestamp, that.timestamp)
+        && Objects.equals(valueInfo, that.valueInfo)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(version, that.version)
+        && Objects.equals(engineAlias, that.engineAlias)
+        && Objects.equals(tenantId, that.tenantId);
+  }
+
+  public String toString() {
+    return "ProcessVariableDto(id="
+        + this.getId()
+        + ", name="
+        + this.getName()
+        + ", type="
+        + this.getType()
+        + ", value="
+        + this.getValue()
+        + ", timestamp="
+        + this.getTimestamp()
+        + ", valueInfo="
+        + this.getValueInfo()
+        + ", processDefinitionKey="
+        + this.getProcessDefinitionKey()
+        + ", processDefinitionId="
+        + this.getProcessDefinitionId()
+        + ", processInstanceId="
+        + this.getProcessInstanceId()
+        + ", version="
+        + this.getVersion()
+        + ", engineAlias="
+        + this.getEngineAlias()
+        + ", tenantId="
+        + this.getTenantId()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableNameRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableNameRequestDto.java
@@ -13,25 +13,84 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@Data
 public class ProcessVariableNameRequestDto {
+
   private List<ProcessToQueryDto> processesToQuery = new ArrayList<>();
   private List<ProcessFilterDto<?>> filter = new ArrayList<>();
 
   @JsonIgnore private ZoneId timezone = ZoneId.systemDefault();
 
   public ProcessVariableNameRequestDto(
-      List<ProcessToQueryDto> processesToQuery, List<ProcessFilterDto<?>> filter) {
+      final List<ProcessToQueryDto> processesToQuery, final List<ProcessFilterDto<?>> filter) {
     this.processesToQuery = processesToQuery;
     this.filter = filter;
     timezone = ZoneId.systemDefault();
   }
 
-  public ProcessVariableNameRequestDto(List<ProcessToQueryDto> processesToQuery) {
+  public ProcessVariableNameRequestDto(final List<ProcessToQueryDto> processesToQuery) {
     this(processesToQuery, Collections.emptyList());
+  }
+
+  public ProcessVariableNameRequestDto() {}
+
+  public List<ProcessToQueryDto> getProcessesToQuery() {
+    return processesToQuery;
+  }
+
+  public void setProcessesToQuery(final List<ProcessToQueryDto> processesToQuery) {
+    this.processesToQuery = processesToQuery;
+  }
+
+  public List<ProcessFilterDto<?>> getFilter() {
+    return filter;
+  }
+
+  public void setFilter(final List<ProcessFilterDto<?>> filter) {
+    this.filter = filter;
+  }
+
+  public ZoneId getTimezone() {
+    return timezone;
+  }
+
+  @JsonIgnore
+  public void setTimezone(final ZoneId timezone) {
+    this.timezone = timezone;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessVariableNameRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processesToQuery, filter, timezone);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableNameRequestDto that = (ProcessVariableNameRequestDto) o;
+    return Objects.equals(processesToQuery, that.processesToQuery)
+        && Objects.equals(filter, that.filter)
+        && Objects.equals(timezone, that.timezone);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessVariableNameRequestDto(processesToQuery="
+        + getProcessesToQuery()
+        + ", filter="
+        + getFilter()
+        + ", timezone="
+        + getTimezone()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableNameResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableNameResponseDto.java
@@ -7,15 +7,78 @@
  */
 package io.camunda.optimize.dto.optimize.query.variable;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class ProcessVariableNameResponseDto {
+
   protected String name;
   protected VariableType type;
   protected String label;
+
+  public ProcessVariableNameResponseDto(
+      final String name, final VariableType type, final String label) {
+    this.name = name;
+    this.type = type;
+    this.label = label;
+  }
+
+  public ProcessVariableNameResponseDto() {}
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public VariableType getType() {
+    return type;
+  }
+
+  public void setType(final VariableType type) {
+    this.type = type;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public void setLabel(final String label) {
+    this.label = label;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessVariableNameResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type, label);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableNameResponseDto that = (ProcessVariableNameResponseDto) o;
+    return Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(label, that.label);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessVariableNameResponseDto(name="
+        + getName()
+        + ", type="
+        + getType()
+        + ", label="
+        + getLabel()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableReportValuesRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableReportValuesRequestDto.java
@@ -10,9 +10,8 @@ package io.camunda.optimize.dto.optimize.query.variable;
 import static io.camunda.optimize.service.db.DatabaseConstants.MAX_RESPONSE_SIZE_LIMIT;
 
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ProcessVariableReportValuesRequestDto {
 
   private List<String> reportIds;
@@ -21,4 +20,97 @@ public class ProcessVariableReportValuesRequestDto {
   private String valueFilter;
   private Integer resultOffset = 0;
   private Integer numResults = MAX_RESPONSE_SIZE_LIMIT;
+
+  public ProcessVariableReportValuesRequestDto() {}
+
+  public List<String> getReportIds() {
+    return reportIds;
+  }
+
+  public void setReportIds(final List<String> reportIds) {
+    this.reportIds = reportIds;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public VariableType getType() {
+    return type;
+  }
+
+  public void setType(final VariableType type) {
+    this.type = type;
+  }
+
+  public String getValueFilter() {
+    return valueFilter;
+  }
+
+  public void setValueFilter(final String valueFilter) {
+    this.valueFilter = valueFilter;
+  }
+
+  public Integer getResultOffset() {
+    return resultOffset;
+  }
+
+  public void setResultOffset(final Integer resultOffset) {
+    this.resultOffset = resultOffset;
+  }
+
+  public Integer getNumResults() {
+    return numResults;
+  }
+
+  public void setNumResults(final Integer numResults) {
+    this.numResults = numResults;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessVariableReportValuesRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(reportIds, name, type, valueFilter, resultOffset, numResults);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableReportValuesRequestDto that = (ProcessVariableReportValuesRequestDto) o;
+    return Objects.equals(reportIds, that.reportIds)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(valueFilter, that.valueFilter)
+        && Objects.equals(resultOffset, that.resultOffset)
+        && Objects.equals(numResults, that.numResults);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessVariableReportValuesRequestDto(reportIds="
+        + getReportIds()
+        + ", name="
+        + getName()
+        + ", type="
+        + getType()
+        + ", valueFilter="
+        + getValueFilter()
+        + ", resultOffset="
+        + getResultOffset()
+        + ", numResults="
+        + getNumResults()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableSourceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableSourceDto.java
@@ -10,17 +10,168 @@ package io.camunda.optimize.dto.optimize.query.variable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.Builder;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
-@Builder
 public class ProcessVariableSourceDto {
 
   private String processInstanceId;
   private String processDefinitionKey;
-  @Builder.Default private List<String> processDefinitionVersions = new ArrayList<>();
+  private List<String> processDefinitionVersions = new ArrayList<>();
 
-  @Builder.Default
   private List<String> tenantIds = new ArrayList<>(Collections.singletonList(null));
+
+  ProcessVariableSourceDto(
+      final String processInstanceId,
+      final String processDefinitionKey,
+      final List<String> processDefinitionVersions,
+      final List<String> tenantIds) {
+    this.processInstanceId = processInstanceId;
+    this.processDefinitionKey = processDefinitionKey;
+    this.processDefinitionVersions = processDefinitionVersions;
+    this.tenantIds = tenantIds;
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public List<String> getProcessDefinitionVersions() {
+    return processDefinitionVersions;
+  }
+
+  public void setProcessDefinitionVersions(final List<String> processDefinitionVersions) {
+    this.processDefinitionVersions = processDefinitionVersions;
+  }
+
+  public List<String> getTenantIds() {
+    return tenantIds;
+  }
+
+  public void setTenantIds(final List<String> tenantIds) {
+    this.tenantIds = tenantIds;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessVariableSourceDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        processInstanceId, processDefinitionKey, processDefinitionVersions, tenantIds);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableSourceDto that = (ProcessVariableSourceDto) o;
+    return Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersions, that.processDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessVariableSourceDto(processInstanceId="
+        + getProcessInstanceId()
+        + ", processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", processDefinitionVersions="
+        + getProcessDefinitionVersions()
+        + ", tenantIds="
+        + getTenantIds()
+        + ")";
+  }
+
+  private static List<String> defaultProcessDefinitionVersions() {
+    return new ArrayList<>();
+  }
+
+  private static List<String> defaultTenantIds() {
+    return new ArrayList<>(Collections.singletonList(null));
+  }
+
+  public static ProcessVariableSourceDtoBuilder builder() {
+    return new ProcessVariableSourceDtoBuilder();
+  }
+
+  public static class ProcessVariableSourceDtoBuilder {
+
+    private String processInstanceId;
+    private String processDefinitionKey;
+    private List<String> processDefinitionVersionsValue;
+    private boolean processDefinitionVersionsSet;
+    private List<String> tenantIdsValue;
+    private boolean tenantIdsSet;
+
+    ProcessVariableSourceDtoBuilder() {}
+
+    public ProcessVariableSourceDtoBuilder processInstanceId(final String processInstanceId) {
+      this.processInstanceId = processInstanceId;
+      return this;
+    }
+
+    public ProcessVariableSourceDtoBuilder processDefinitionKey(final String processDefinitionKey) {
+      this.processDefinitionKey = processDefinitionKey;
+      return this;
+    }
+
+    public ProcessVariableSourceDtoBuilder processDefinitionVersions(
+        final List<String> processDefinitionVersions) {
+      processDefinitionVersionsValue = processDefinitionVersions;
+      processDefinitionVersionsSet = true;
+      return this;
+    }
+
+    public ProcessVariableSourceDtoBuilder tenantIds(final List<String> tenantIds) {
+      tenantIdsValue = tenantIds;
+      tenantIdsSet = true;
+      return this;
+    }
+
+    public ProcessVariableSourceDto build() {
+      List<String> processDefinitionVersionsValue = this.processDefinitionVersionsValue;
+      if (!processDefinitionVersionsSet) {
+        processDefinitionVersionsValue =
+            ProcessVariableSourceDto.defaultProcessDefinitionVersions();
+      }
+      List<String> tenantIdsValue = this.tenantIdsValue;
+      if (!tenantIdsSet) {
+        tenantIdsValue = ProcessVariableSourceDto.defaultTenantIds();
+      }
+      return new ProcessVariableSourceDto(
+          processInstanceId, processDefinitionKey, processDefinitionVersionsValue, tenantIdsValue);
+    }
+
+    @Override
+    public String toString() {
+      return "ProcessVariableSourceDto.ProcessVariableSourceDtoBuilder(processInstanceId="
+          + processInstanceId
+          + ", processDefinitionKey="
+          + processDefinitionKey
+          + ", processDefinitionVersionsValue="
+          + processDefinitionVersionsValue
+          + ", tenantIdsValue="
+          + tenantIdsValue
+          + ")";
+    }
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableValueRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableValueRequestDto.java
@@ -15,9 +15,8 @@ import io.camunda.optimize.service.util.TenantListHandlingUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ProcessVariableValueRequestDto {
 
   private String processInstanceId;
@@ -30,12 +29,143 @@ public class ProcessVariableValueRequestDto {
   private Integer resultOffset = 0;
   private Integer numResults = MAX_RESPONSE_SIZE_LIMIT;
 
+  public ProcessVariableValueRequestDto() {}
+
   @JsonIgnore
-  public void setProcessDefinitionVersion(String processDefinitionVersion) {
-    this.processDefinitionVersions = Lists.newArrayList(processDefinitionVersion);
+  public void setProcessDefinitionVersion(final String processDefinitionVersion) {
+    processDefinitionVersions = Lists.newArrayList(processDefinitionVersion);
   }
 
   public List<String> getTenantIds() {
     return TenantListHandlingUtil.sortAndReturnTenantIdList(tenantIds);
+  }
+
+  public void setTenantIds(final List<String> tenantIds) {
+    this.tenantIds = tenantIds;
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(final String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public List<String> getProcessDefinitionVersions() {
+    return processDefinitionVersions;
+  }
+
+  public void setProcessDefinitionVersions(final List<String> processDefinitionVersions) {
+    this.processDefinitionVersions = processDefinitionVersions;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public VariableType getType() {
+    return type;
+  }
+
+  public void setType(final VariableType type) {
+    this.type = type;
+  }
+
+  public String getValueFilter() {
+    return valueFilter;
+  }
+
+  public void setValueFilter(final String valueFilter) {
+    this.valueFilter = valueFilter;
+  }
+
+  public Integer getResultOffset() {
+    return resultOffset;
+  }
+
+  public void setResultOffset(final Integer resultOffset) {
+    this.resultOffset = resultOffset;
+  }
+
+  public Integer getNumResults() {
+    return numResults;
+  }
+
+  public void setNumResults(final Integer numResults) {
+    this.numResults = numResults;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessVariableValueRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        processInstanceId,
+        processDefinitionKey,
+        processDefinitionVersions,
+        tenantIds,
+        name,
+        type,
+        valueFilter,
+        resultOffset,
+        numResults);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableValueRequestDto that = (ProcessVariableValueRequestDto) o;
+    return Objects.equals(processInstanceId, that.processInstanceId)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionVersions, that.processDefinitionVersions)
+        && Objects.equals(tenantIds, that.tenantIds)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(valueFilter, that.valueFilter)
+        && Objects.equals(resultOffset, that.resultOffset)
+        && Objects.equals(numResults, that.numResults);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessVariableValueRequestDto(processInstanceId="
+        + getProcessInstanceId()
+        + ", processDefinitionKey="
+        + getProcessDefinitionKey()
+        + ", processDefinitionVersions="
+        + getProcessDefinitionVersions()
+        + ", tenantIds="
+        + getTenantIds()
+        + ", name="
+        + getName()
+        + ", type="
+        + getType()
+        + ", valueFilter="
+        + getValueFilter()
+        + ", resultOffset="
+        + getResultOffset()
+        + ", numResults="
+        + getNumResults()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableValuesQueryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ProcessVariableValuesQueryDto.java
@@ -13,12 +13,9 @@ import io.camunda.optimize.dto.optimize.query.report.single.SingleReportDataDto;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
-import lombok.Builder;
-import lombok.Data;
 
-@Data
-@Builder
 public class ProcessVariableValuesQueryDto {
 
   private List<ProcessVariableSourceDto> processVariableSources;
@@ -27,6 +24,21 @@ public class ProcessVariableValuesQueryDto {
   private String valueFilter;
   private Integer resultOffset;
   private Integer numResults;
+
+  ProcessVariableValuesQueryDto(
+      final List<ProcessVariableSourceDto> processVariableSources,
+      final String name,
+      final VariableType type,
+      final String valueFilter,
+      final Integer resultOffset,
+      final Integer numResults) {
+    this.processVariableSources = processVariableSources;
+    this.name = name;
+    this.type = type;
+    this.valueFilter = valueFilter;
+    this.resultOffset = resultOffset;
+    this.numResults = numResults;
+  }
 
   public static ProcessVariableValuesQueryDto fromProcessVariableValueRequestDto(
       final ProcessVariableValueRequestDto requestDto) {
@@ -73,5 +85,166 @@ public class ProcessVariableValuesQueryDto {
         .numResults(requestDto.getNumResults())
         .processVariableSources(reportSources)
         .build();
+  }
+
+  public List<ProcessVariableSourceDto> getProcessVariableSources() {
+    return processVariableSources;
+  }
+
+  public void setProcessVariableSources(
+      final List<ProcessVariableSourceDto> processVariableSources) {
+    this.processVariableSources = processVariableSources;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public VariableType getType() {
+    return type;
+  }
+
+  public void setType(final VariableType type) {
+    this.type = type;
+  }
+
+  public String getValueFilter() {
+    return valueFilter;
+  }
+
+  public void setValueFilter(final String valueFilter) {
+    this.valueFilter = valueFilter;
+  }
+
+  public Integer getResultOffset() {
+    return resultOffset;
+  }
+
+  public void setResultOffset(final Integer resultOffset) {
+    this.resultOffset = resultOffset;
+  }
+
+  public Integer getNumResults() {
+    return numResults;
+  }
+
+  public void setNumResults(final Integer numResults) {
+    this.numResults = numResults;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessVariableValuesQueryDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processVariableSources, name, type, valueFilter, resultOffset, numResults);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessVariableValuesQueryDto that = (ProcessVariableValuesQueryDto) o;
+    return Objects.equals(processVariableSources, that.processVariableSources)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(valueFilter, that.valueFilter)
+        && Objects.equals(resultOffset, that.resultOffset)
+        && Objects.equals(numResults, that.numResults);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessVariableValuesQueryDto(processVariableSources="
+        + getProcessVariableSources()
+        + ", name="
+        + getName()
+        + ", type="
+        + getType()
+        + ", valueFilter="
+        + getValueFilter()
+        + ", resultOffset="
+        + getResultOffset()
+        + ", numResults="
+        + getNumResults()
+        + ")";
+  }
+
+  public static ProcessVariableValuesQueryDtoBuilder builder() {
+    return new ProcessVariableValuesQueryDtoBuilder();
+  }
+
+  public static class ProcessVariableValuesQueryDtoBuilder {
+
+    private List<ProcessVariableSourceDto> processVariableSources;
+    private String name;
+    private VariableType type;
+    private String valueFilter;
+    private Integer resultOffset;
+    private Integer numResults;
+
+    ProcessVariableValuesQueryDtoBuilder() {}
+
+    public ProcessVariableValuesQueryDtoBuilder processVariableSources(
+        final List<ProcessVariableSourceDto> processVariableSources) {
+      this.processVariableSources = processVariableSources;
+      return this;
+    }
+
+    public ProcessVariableValuesQueryDtoBuilder name(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public ProcessVariableValuesQueryDtoBuilder type(final VariableType type) {
+      this.type = type;
+      return this;
+    }
+
+    public ProcessVariableValuesQueryDtoBuilder valueFilter(final String valueFilter) {
+      this.valueFilter = valueFilter;
+      return this;
+    }
+
+    public ProcessVariableValuesQueryDtoBuilder resultOffset(final Integer resultOffset) {
+      this.resultOffset = resultOffset;
+      return this;
+    }
+
+    public ProcessVariableValuesQueryDtoBuilder numResults(final Integer numResults) {
+      this.numResults = numResults;
+      return this;
+    }
+
+    public ProcessVariableValuesQueryDto build() {
+      return new ProcessVariableValuesQueryDto(
+          processVariableSources, name, type, valueFilter, resultOffset, numResults);
+    }
+
+    @Override
+    public String toString() {
+      return "ProcessVariableValuesQueryDto.ProcessVariableValuesQueryDtoBuilder(processVariableSources="
+          + processVariableSources
+          + ", name="
+          + name
+          + ", type="
+          + type
+          + ", valueFilter="
+          + valueFilter
+          + ", resultOffset="
+          + resultOffset
+          + ", numResults="
+          + numResults
+          + ")";
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/SimpleProcessVariableDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/SimpleProcessVariableDto.java
@@ -8,25 +8,116 @@
 package io.camunda.optimize.dto.optimize.query.variable;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class SimpleProcessVariableDto {
 
-  @EqualsAndHashCode.Include private String id;
+  private String id;
   private String name;
   private String type;
   private List<String> value;
-  @EqualsAndHashCode.Include private long version;
+  private long version;
 
+  public SimpleProcessVariableDto(
+      final String id,
+      final String name,
+      final String type,
+      final List<String> value,
+      final long version) {
+    this.id = id;
+    this.name = name;
+    this.type = type;
+    this.value = value;
+    this.version = version;
+  }
+
+  public SimpleProcessVariableDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
+  }
+
+  public List<String> getValue() {
+    return value;
+  }
+
+  public void setValue(final List<String> value) {
+    this.value = value;
+  }
+
+  public long getVersion() {
+    return version;
+  }
+
+  public void setVersion(final long version) {
+    this.version = version;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof SimpleProcessVariableDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, type, value, version);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SimpleProcessVariableDto that = (SimpleProcessVariableDto) o;
+    return version == that.version
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public String toString() {
+    return "SimpleProcessVariableDto(id="
+        + getId()
+        + ", name="
+        + getName()
+        + ", type="
+        + getType()
+        + ", value="
+        + getValue()
+        + ", version="
+        + getVersion()
+        + ")";
+  }
+
+  public static SimpleProcessVariableDtoBuilder builder() {
+    return new SimpleProcessVariableDtoBuilder();
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String id = "id";
@@ -34,5 +125,60 @@ public class SimpleProcessVariableDto {
     public static final String type = "type";
     public static final String value = "value";
     public static final String version = "version";
+  }
+
+  public static class SimpleProcessVariableDtoBuilder {
+
+    private String id;
+    private String name;
+    private String type;
+    private List<String> value;
+    private long version;
+
+    SimpleProcessVariableDtoBuilder() {}
+
+    public SimpleProcessVariableDtoBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public SimpleProcessVariableDtoBuilder name(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public SimpleProcessVariableDtoBuilder type(final String type) {
+      this.type = type;
+      return this;
+    }
+
+    public SimpleProcessVariableDtoBuilder value(final List<String> value) {
+      this.value = value;
+      return this;
+    }
+
+    public SimpleProcessVariableDtoBuilder version(final long version) {
+      this.version = version;
+      return this;
+    }
+
+    public SimpleProcessVariableDto build() {
+      return new SimpleProcessVariableDto(id, name, type, value, version);
+    }
+
+    @Override
+    public String toString() {
+      return "SimpleProcessVariableDto.SimpleProcessVariableDtoBuilder(id="
+          + id
+          + ", name="
+          + name
+          + ", type="
+          + type
+          + ", value="
+          + value
+          + ", version="
+          + version
+          + ")";
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedCollectionDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedCollectionDefinitionDto.java
@@ -13,16 +13,8 @@ import io.camunda.optimize.dto.optimize.AuthorizedEntityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.collection.CollectionDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.entity.EntityResponseDto;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class AuthorizedCollectionDefinitionDto extends AuthorizedEntityDto {
 
   @JsonUnwrapped private CollectionDefinitionDto definitionDto;
@@ -32,6 +24,12 @@ public class AuthorizedCollectionDefinitionDto extends AuthorizedEntityDto {
     super(currentUserRole);
     this.definitionDto = definitionDto;
   }
+
+  public AuthorizedCollectionDefinitionDto(final CollectionDefinitionDto definitionDto) {
+    this.definitionDto = definitionDto;
+  }
+
+  protected AuthorizedCollectionDefinitionDto() {}
 
   public EntityResponseDto toEntityDto() {
     return definitionDto.toEntityDto(getCurrentUserRole());
@@ -47,5 +45,44 @@ public class AuthorizedCollectionDefinitionDto extends AuthorizedEntityDto {
       default:
         return RoleType.VIEWER;
     }
+  }
+
+  public CollectionDefinitionDto getDefinitionDto() {
+    return definitionDto;
+  }
+
+  @JsonUnwrapped
+  public void setDefinitionDto(final CollectionDefinitionDto definitionDto) {
+    this.definitionDto = definitionDto;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof AuthorizedCollectionDefinitionDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), definitionDto);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedCollectionDefinitionDto that = (AuthorizedCollectionDefinitionDto) o;
+    return Objects.equals(definitionDto, that.definitionDto);
+  }
+
+  @Override
+  public String toString() {
+    return "AuthorizedCollectionDefinitionDto(definitionDto=" + getDefinitionDto() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedCollectionDefinitionRestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedCollectionDefinitionRestDto.java
@@ -12,14 +12,8 @@ import io.camunda.optimize.dto.optimize.AuthorizedEntityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.collection.CollectionDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.collection.CollectionDefinitionRestDto;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class AuthorizedCollectionDefinitionRestDto extends AuthorizedEntityDto {
 
   @JsonUnwrapped private CollectionDefinitionRestDto definitionDto;
@@ -29,6 +23,8 @@ public class AuthorizedCollectionDefinitionRestDto extends AuthorizedEntityDto {
     super(currentUserRole);
     this.definitionDto = definitionDto;
   }
+
+  protected AuthorizedCollectionDefinitionRestDto() {}
 
   public static AuthorizedCollectionDefinitionRestDto from(
       final AuthorizedCollectionDefinitionDto authorizedCollectionDto) {
@@ -47,5 +43,44 @@ public class AuthorizedCollectionDefinitionRestDto extends AuthorizedEntityDto {
     resolvedCollection.setData(collectionDefinitionDto.getData());
     return new AuthorizedCollectionDefinitionRestDto(
         authorizedCollectionDto.getCurrentUserRole(), resolvedCollection);
+  }
+
+  public CollectionDefinitionRestDto getDefinitionDto() {
+    return definitionDto;
+  }
+
+  @JsonUnwrapped
+  public void setDefinitionDto(final CollectionDefinitionRestDto definitionDto) {
+    this.definitionDto = definitionDto;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof AuthorizedCollectionDefinitionRestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), definitionDto);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedCollectionDefinitionRestDto that = (AuthorizedCollectionDefinitionRestDto) o;
+    return Objects.equals(definitionDto, that.definitionDto);
+  }
+
+  @Override
+  public String toString() {
+    return "AuthorizedCollectionDefinitionRestDto(definitionDto=" + getDefinitionDto() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedDashboardDefinitionResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedDashboardDefinitionResponseDto.java
@@ -11,14 +11,8 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.camunda.optimize.dto.optimize.AuthorizedEntityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.dashboard.DashboardDefinitionRestDto;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class AuthorizedDashboardDefinitionResponseDto extends AuthorizedEntityDto {
 
   @JsonUnwrapped private DashboardDefinitionRestDto definitionDto;
@@ -27,5 +21,47 @@ public class AuthorizedDashboardDefinitionResponseDto extends AuthorizedEntityDt
       final RoleType currentUserRole, final DashboardDefinitionRestDto definitionDto) {
     super(currentUserRole);
     this.definitionDto = definitionDto;
+  }
+
+  protected AuthorizedDashboardDefinitionResponseDto() {}
+
+  public DashboardDefinitionRestDto getDefinitionDto() {
+    return definitionDto;
+  }
+
+  @JsonUnwrapped
+  public void setDefinitionDto(final DashboardDefinitionRestDto definitionDto) {
+    this.definitionDto = definitionDto;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof AuthorizedDashboardDefinitionResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), definitionDto);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedDashboardDefinitionResponseDto that =
+        (AuthorizedDashboardDefinitionResponseDto) o;
+    return Objects.equals(definitionDto, that.definitionDto);
+  }
+
+  @Override
+  public String toString() {
+    return "AuthorizedDashboardDefinitionResponseDto(definitionDto=" + getDefinitionDto() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedReportDefinitionResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedReportDefinitionResponseDto.java
@@ -11,14 +11,8 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.camunda.optimize.dto.optimize.AuthorizedEntityDto;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class AuthorizedReportDefinitionResponseDto extends AuthorizedEntityDto {
 
   @JsonUnwrapped private ReportDefinitionDto definitionDto;
@@ -29,6 +23,48 @@ public class AuthorizedReportDefinitionResponseDto extends AuthorizedEntityDto {
     this.definitionDto = definitionDto;
   }
 
+  protected AuthorizedReportDefinitionResponseDto() {}
+
+  public ReportDefinitionDto getDefinitionDto() {
+    return definitionDto;
+  }
+
+  @JsonUnwrapped
+  public void setDefinitionDto(final ReportDefinitionDto definitionDto) {
+    this.definitionDto = definitionDto;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof AuthorizedReportDefinitionResponseDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), definitionDto);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AuthorizedReportDefinitionResponseDto that = (AuthorizedReportDefinitionResponseDto) o;
+    return Objects.equals(definitionDto, that.definitionDto);
+  }
+
+  @Override
+  public String toString() {
+    return "AuthorizedReportDefinitionResponseDto(definitionDto=" + getDefinitionDto() + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String definitionDto = "definitionDto";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/BackupInfoDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/BackupInfoDto.java
@@ -9,17 +9,94 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import io.camunda.optimize.dto.optimize.BackupState;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class BackupInfoDto {
 
   private long backupId;
   private String failureReason;
   private BackupState state;
   private List<SnapshotInfoDto> details;
+
+  public BackupInfoDto(
+      final long backupId,
+      final String failureReason,
+      final BackupState state,
+      final List<SnapshotInfoDto> details) {
+    this.backupId = backupId;
+    this.failureReason = failureReason;
+    this.state = state;
+    this.details = details;
+  }
+
+  public BackupInfoDto() {}
+
+  public long getBackupId() {
+    return backupId;
+  }
+
+  public void setBackupId(final long backupId) {
+    this.backupId = backupId;
+  }
+
+  public String getFailureReason() {
+    return failureReason;
+  }
+
+  public void setFailureReason(final String failureReason) {
+    this.failureReason = failureReason;
+  }
+
+  public BackupState getState() {
+    return state;
+  }
+
+  public void setState(final BackupState state) {
+    this.state = state;
+  }
+
+  public List<SnapshotInfoDto> getDetails() {
+    return details;
+  }
+
+  public void setDetails(final List<SnapshotInfoDto> details) {
+    this.details = details;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof BackupInfoDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(backupId, failureReason, state, details);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BackupInfoDto that = (BackupInfoDto) o;
+    return backupId == that.backupId
+        && Objects.equals(failureReason, that.failureReason)
+        && Objects.equals(state, that.state)
+        && Objects.equals(details, that.details);
+  }
+
+  @Override
+  public String toString() {
+    return "BackupInfoDto(backupId="
+        + getBackupId()
+        + ", failureReason="
+        + getFailureReason()
+        + ", state="
+        + getState()
+        + ", details="
+        + getDetails()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/BackupRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/BackupRequestDto.java
@@ -9,17 +9,51 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Data
 public class BackupRequestDto {
 
   @NotNull
   @Min(0)
   private Long backupId;
+
+  public BackupRequestDto(@NotNull @Min(0) final Long backupId) {
+    this.backupId = backupId;
+  }
+
+  protected BackupRequestDto() {}
+
+  public @NotNull @Min(0) Long getBackupId() {
+    return backupId;
+  }
+
+  public void setBackupId(@NotNull @Min(0) final Long backupId) {
+    this.backupId = backupId;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof BackupRequestDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(backupId);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BackupRequestDto that = (BackupRequestDto) o;
+    return Objects.equals(backupId, that.backupId);
+  }
+
+  @Override
+  public String toString() {
+    return "BackupRequestDto(backupId=" + getBackupId() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/Page.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/Page.java
@@ -9,13 +9,8 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import io.camunda.optimize.dto.optimize.query.sorting.SortOrder;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class Page<T> {
 
   private Integer offset;
@@ -24,4 +19,112 @@ public class Page<T> {
   private String sortBy;
   private SortOrder sortOrder;
   private List<T> results;
+
+  public Page(
+      final Integer offset,
+      final Integer limit,
+      final Long total,
+      final String sortBy,
+      final SortOrder sortOrder,
+      final List<T> results) {
+    this.offset = offset;
+    this.limit = limit;
+    this.total = total;
+    this.sortBy = sortBy;
+    this.sortOrder = sortOrder;
+    this.results = results;
+  }
+
+  public Page() {}
+
+  public Integer getOffset() {
+    return offset;
+  }
+
+  public void setOffset(final Integer offset) {
+    this.offset = offset;
+  }
+
+  public Integer getLimit() {
+    return limit;
+  }
+
+  public void setLimit(final Integer limit) {
+    this.limit = limit;
+  }
+
+  public Long getTotal() {
+    return total;
+  }
+
+  public void setTotal(final Long total) {
+    this.total = total;
+  }
+
+  public String getSortBy() {
+    return sortBy;
+  }
+
+  public void setSortBy(final String sortBy) {
+    this.sortBy = sortBy;
+  }
+
+  public SortOrder getSortOrder() {
+    return sortOrder;
+  }
+
+  public void setSortOrder(final SortOrder sortOrder) {
+    this.sortOrder = sortOrder;
+  }
+
+  public List<T> getResults() {
+    return results;
+  }
+
+  public void setResults(final List<T> results) {
+    this.results = results;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof Page;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(offset, limit, total, sortBy, sortOrder, results);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final Page<?> page = (Page<?>) o;
+    return Objects.equals(offset, page.offset)
+        && Objects.equals(limit, page.limit)
+        && Objects.equals(total, page.total)
+        && Objects.equals(sortBy, page.sortBy)
+        && Objects.equals(sortOrder, page.sortOrder)
+        && Objects.equals(results, page.results);
+  }
+
+  @Override
+  public String toString() {
+    return "Page(offset="
+        + getOffset()
+        + ", limit="
+        + getLimit()
+        + ", total="
+        + getTotal()
+        + ", sortBy="
+        + getSortBy()
+        + ", sortOrder="
+        + getSortOrder()
+        + ", results="
+        + getResults()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/SnapshotInfoDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/SnapshotInfoDto.java
@@ -9,17 +9,88 @@ package io.camunda.optimize.dto.optimize.rest;
 
 import java.time.OffsetDateTime;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 public class SnapshotInfoDto {
 
   private String snapshotName;
   private SnapshotState state;
   private OffsetDateTime startTime;
   private List<String> failures;
+
+  public SnapshotInfoDto(
+      final String snapshotName,
+      final SnapshotState state,
+      final OffsetDateTime startTime,
+      final List<String> failures) {
+    this.snapshotName = snapshotName;
+    this.state = state;
+    this.startTime = startTime;
+    this.failures = failures;
+  }
+
+  public SnapshotInfoDto() {}
+
+  public String getSnapshotName() {
+    return this.snapshotName;
+  }
+
+  public SnapshotState getState() {
+    return this.state;
+  }
+
+  public OffsetDateTime getStartTime() {
+    return this.startTime;
+  }
+
+  public List<String> getFailures() {
+    return this.failures;
+  }
+
+  public void setSnapshotName(final String snapshotName) {
+    this.snapshotName = snapshotName;
+  }
+
+  public void setState(final SnapshotState state) {
+    this.state = state;
+  }
+
+  public void setStartTime(final OffsetDateTime startTime) {
+    this.startTime = startTime;
+  }
+
+  public void setFailures(final List<String> failures) {
+    this.failures = failures;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(snapshotName, state, failures);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SnapshotInfoDto that = (SnapshotInfoDto) o;
+    return Objects.equals(snapshotName, that.snapshotName)
+        && Objects.equals(state, that.state)
+        && Objects.equals(failures, that.failures);
+  }
+
+  public String toString() {
+    return "SnapshotInfoDto(snapshotName="
+        + this.getSnapshotName()
+        + ", state="
+        + this.getState()
+        + ", startTime="
+        + this.getStartTime()
+        + ", failures="
+        + this.getFailures()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginatedDataExportDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginatedDataExportDto.java
@@ -9,13 +9,8 @@ package io.camunda.optimize.dto.optimize.rest.pagination;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Collection;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PaginatedDataExportDto {
 
@@ -26,6 +21,67 @@ public class PaginatedDataExportDto {
   private String reportId;
   private Object data;
 
+  public PaginatedDataExportDto(
+      final String searchRequestId,
+      final String message,
+      final Integer numberOfRecordsInResponse,
+      final long totalNumberOfRecords,
+      final String reportId,
+      final Object data) {
+    this.searchRequestId = searchRequestId;
+    this.message = message;
+    this.numberOfRecordsInResponse = numberOfRecordsInResponse;
+    this.totalNumberOfRecords = totalNumberOfRecords;
+    this.reportId = reportId;
+    this.data = data;
+  }
+
+  public PaginatedDataExportDto() {}
+
+  public String getSearchRequestId() {
+    return searchRequestId;
+  }
+
+  public void setSearchRequestId(final String searchRequestId) {
+    this.searchRequestId = searchRequestId;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(final String message) {
+    this.message = message;
+  }
+
+  public Integer getNumberOfRecordsInResponse() {
+    return numberOfRecordsInResponse;
+  }
+
+  public void setNumberOfRecordsInResponse(final Integer numberOfRecordsInResponse) {
+    this.numberOfRecordsInResponse = numberOfRecordsInResponse;
+  }
+
+  public long getTotalNumberOfRecords() {
+    return totalNumberOfRecords;
+  }
+
+  public void setTotalNumberOfRecords(final long totalNumberOfRecords) {
+    this.totalNumberOfRecords = totalNumberOfRecords;
+  }
+
+  public String getReportId() {
+    return reportId;
+  }
+
+  public void setReportId(final String reportId) {
+    this.reportId = reportId;
+  }
+
+  public Object getData() {
+    return data;
+  }
+
   public void setData(final Object data) {
     this.data = data;
     if (data == null) {
@@ -35,5 +91,46 @@ public class PaginatedDataExportDto {
     } else {
       numberOfRecordsInResponse = 1;
     }
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PaginatedDataExportDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PaginatedDataExportDto that = (PaginatedDataExportDto) o;
+    return totalNumberOfRecords == that.totalNumberOfRecords
+        && Objects.equals(searchRequestId, that.searchRequestId)
+        && Objects.equals(message, that.message)
+        && Objects.equals(numberOfRecordsInResponse, that.numberOfRecordsInResponse)
+        && Objects.equals(reportId, that.reportId)
+        && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        searchRequestId, message, numberOfRecordsInResponse, totalNumberOfRecords, reportId, data);
+  }
+
+  @Override
+  public String toString() {
+    return "PaginatedDataExportDto(searchRequestId="
+        + getSearchRequestId()
+        + ", message="
+        + getMessage()
+        + ", numberOfRecordsInResponse="
+        + getNumberOfRecordsInResponse()
+        + ", totalNumberOfRecords="
+        + getTotalNumberOfRecords()
+        + ", reportId="
+        + getReportId()
+        + ", data="
+        + getData()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationDto.java
@@ -8,17 +8,19 @@
 package io.camunda.optimize.dto.optimize.rest.pagination;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class PaginationDto {
 
   protected Integer limit;
   protected Integer offset;
+
+  public PaginationDto(final Integer limit, final Integer offset) {
+    this.limit = limit;
+    this.offset = offset;
+  }
+
+  public PaginationDto() {}
 
   public static PaginationDto fromPaginationRequest(
       final PaginationRequestDto paginationRequestDto) {
@@ -31,5 +33,44 @@ public class PaginationDto {
   @JsonIgnore
   public boolean isValid() {
     return limit != null;
+  }
+
+  public Integer getLimit() {
+    return limit;
+  }
+
+  public void setLimit(final Integer limit) {
+    this.limit = limit;
+  }
+
+  public Integer getOffset() {
+    return offset;
+  }
+
+  public void setOffset(final Integer offset) {
+    this.offset = offset;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PaginationDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PaginationDto that = (PaginationDto) o;
+    return Objects.equals(limit, that.limit) && Objects.equals(offset, that.offset);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(limit, offset);
+  }
+
+  @Override
+  public String toString() {
+    return "PaginationDto(limit=" + getLimit() + ", offset=" + getOffset() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationRequestDto.java
@@ -11,25 +11,64 @@ import static io.camunda.optimize.service.db.DatabaseConstants.MAX_RESPONSE_SIZE
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.ws.rs.QueryParam;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class PaginationRequestDto {
 
   public static final String LIMIT_PARAM = "limit";
   public static final String OFFSET_PARAM = "offset";
 
-  @QueryParam(LIMIT_PARAM)
   @Min(0)
   @Max(MAX_RESPONSE_SIZE_LIMIT)
   protected Integer limit;
 
-  @QueryParam(OFFSET_PARAM)
   @Min(0)
   protected Integer offset;
+
+  public PaginationRequestDto(
+      @Min(0) @Max(MAX_RESPONSE_SIZE_LIMIT) final Integer limit, @Min(0) final Integer offset) {
+    this.limit = limit;
+    this.offset = offset;
+  }
+
+  public PaginationRequestDto() {}
+
+  public @Min(0) @Max(MAX_RESPONSE_SIZE_LIMIT) Integer getLimit() {
+    return limit;
+  }
+
+  public void setLimit(@Min(0) @Max(MAX_RESPONSE_SIZE_LIMIT) final Integer limit) {
+    this.limit = limit;
+  }
+
+  public @Min(0) Integer getOffset() {
+    return offset;
+  }
+
+  public void setOffset(@Min(0) final Integer offset) {
+    this.offset = offset;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PaginationRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PaginationRequestDto that = (PaginationRequestDto) o;
+    return Objects.equals(limit, that.limit) && Objects.equals(offset, that.offset);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(limit, offset);
+  }
+
+  @Override
+  public String toString() {
+    return "PaginationRequestDto(limit=" + getLimit() + ", offset=" + getOffset() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationScrollableDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationScrollableDto.java
@@ -8,22 +8,22 @@
 package io.camunda.optimize.dto.optimize.rest.pagination;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
-@NoArgsConstructor
-@AllArgsConstructor
 public class PaginationScrollableDto extends PaginationDto {
 
   protected String scrollId;
   protected Integer scrollTimeout;
 
+  public PaginationScrollableDto(final String scrollId, final Integer scrollTimeout) {
+    this.scrollId = scrollId;
+    this.scrollTimeout = scrollTimeout;
+  }
+
+  public PaginationScrollableDto() {}
+
   public static PaginationScrollableDto fromPaginationDto(final PaginationDto pagination) {
-    PaginationScrollableDto paginationObject = new PaginationScrollableDto();
+    final PaginationScrollableDto paginationObject = new PaginationScrollableDto();
     paginationObject.limit = pagination.getLimit();
     paginationObject.offset = pagination.getOffset();
     if (pagination instanceof PaginationScrollableDto) {
@@ -38,9 +38,25 @@ public class PaginationScrollableDto extends PaginationDto {
     final PaginationScrollableDto paginationDto = new PaginationScrollableDto();
     paginationDto.setLimit(paginationRequestDto.getLimit());
     paginationDto.setOffset(null);
-    paginationDto.setScrollId(paginationRequestDto.getScrollId());
-    paginationDto.setScrollTimeout(paginationRequestDto.getScrollTimeout());
+    paginationDto.setScrollId(paginationRequestDto.getSearchRequestId());
+    paginationDto.setScrollTimeout(paginationRequestDto.getPaginationTimeout());
     return paginationDto;
+  }
+
+  public String getScrollId() {
+    return scrollId;
+  }
+
+  public void setScrollId(final String scrollId) {
+    this.scrollId = scrollId;
+  }
+
+  public Integer getScrollTimeout() {
+    return scrollTimeout;
+  }
+
+  public void setScrollTimeout(final Integer scrollTimeout) {
+    this.scrollTimeout = scrollTimeout;
   }
 
   @JsonIgnore
@@ -49,5 +65,37 @@ public class PaginationScrollableDto extends PaginationDto {
     return limit != null
         && ((offset != null && scrollTimeout == null && scrollId == null)
             || (offset == null && scrollTimeout != null));
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof PaginationScrollableDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final PaginationScrollableDto that = (PaginationScrollableDto) o;
+    return Objects.equals(scrollId, that.scrollId)
+        && Objects.equals(scrollTimeout, that.scrollTimeout);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), scrollId, scrollTimeout);
+  }
+
+  @Override
+  public String toString() {
+    return "PaginationScrollableDto(scrollId="
+        + getScrollId()
+        + ", scrollTimeout="
+        + getScrollTimeout()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationScrollableRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationScrollableRequestDto.java
@@ -11,32 +11,81 @@ import static io.camunda.optimize.service.db.DatabaseConstants.MAX_RESPONSE_SIZE
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.QueryParam;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class PaginationScrollableRequestDto {
-
-  public static final String QUERY_LIMIT_PARAM = "limit";
-  public static final String QUERY_SCROLL_ID_PARAM = "searchRequestId";
-  public static final String QUERY_SCROLL_TIMEOUT_PARAM = "paginationTimeout";
-
-  @QueryParam(QUERY_LIMIT_PARAM)
   @Min(0)
-  @DefaultValue("1000")
   @Max(MAX_RESPONSE_SIZE_LIMIT)
-  protected Integer limit;
+  protected Integer limit = 1000;
 
-  @QueryParam(QUERY_SCROLL_ID_PARAM)
-  protected String scrollId;
+  protected String searchRequestId;
 
-  @QueryParam(QUERY_SCROLL_TIMEOUT_PARAM)
   @Min(60)
-  @DefaultValue("120")
-  protected Integer scrollTimeout;
+  protected Integer paginationTimeout = 120;
+
+  public PaginationScrollableRequestDto(
+      @Min(0) @Max(MAX_RESPONSE_SIZE_LIMIT) final Integer limit,
+      final String scrollId,
+      @Min(60) final Integer scrollTimeout) {
+    this.limit = limit;
+    searchRequestId = scrollId;
+    paginationTimeout = scrollTimeout;
+  }
+
+  public PaginationScrollableRequestDto() {}
+
+  public @Min(0) @Max(MAX_RESPONSE_SIZE_LIMIT) Integer getLimit() {
+    return limit;
+  }
+
+  public void setLimit(@Min(0) @Max(MAX_RESPONSE_SIZE_LIMIT) final Integer limit) {
+    this.limit = limit;
+  }
+
+  public String getSearchRequestId() {
+    return searchRequestId;
+  }
+
+  public void setSearchRequestId(final String searchRequestId) {
+    this.searchRequestId = searchRequestId;
+  }
+
+  public @Min(60) Integer getPaginationTimeout() {
+    return paginationTimeout;
+  }
+
+  public void setPaginationTimeout(@Min(60) final Integer paginationTimeout) {
+    this.paginationTimeout = paginationTimeout;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PaginationScrollableRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PaginationScrollableRequestDto that = (PaginationScrollableRequestDto) o;
+    return Objects.equals(limit, that.limit)
+        && Objects.equals(searchRequestId, that.searchRequestId)
+        && Objects.equals(paginationTimeout, that.paginationTimeout);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(limit, searchRequestId, paginationTimeout);
+  }
+
+  @Override
+  public String toString() {
+    return "PaginationScrollableRequestDto(limit="
+        + getLimit()
+        + ", searchRequestId="
+        + getSearchRequestId()
+        + ", paginationTimeout="
+        + getPaginationTimeout()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/sorting/SortRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/sorting/SortRequestDto.java
@@ -8,31 +8,61 @@
 package io.camunda.optimize.dto.optimize.rest.sorting;
 
 import io.camunda.optimize.dto.optimize.query.sorting.SortOrder;
-import jakarta.ws.rs.QueryParam;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SortRequestDto {
 
   public static final String SORT_BY = "sortBy";
   public static final String SORT_ORDER = "sortOrder";
 
-  @QueryParam(SORT_BY)
   private String sortBy;
 
-  @QueryParam(SORT_ORDER)
   private SortOrder sortOrder;
+
+  public SortRequestDto(final String sortBy, final SortOrder sortOrder) {
+    this.sortBy = sortBy;
+    this.sortOrder = sortOrder;
+  }
+
+  public SortRequestDto() {}
 
   public Optional<String> getSortBy() {
     return Optional.ofNullable(sortBy);
   }
 
+  public void setSortBy(final String sortBy) {
+    this.sortBy = sortBy;
+  }
+
   public Optional<SortOrder> getSortOrder() {
     return Optional.ofNullable(sortOrder);
+  }
+
+  public void setSortOrder(final SortOrder sortOrder) {
+    this.sortOrder = sortOrder;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof SortRequestDto;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SortRequestDto that = (SortRequestDto) o;
+    return Objects.equals(sortBy, that.sortBy) && sortOrder == that.sortOrder;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sortBy, sortOrder);
+  }
+
+  @Override
+  public String toString() {
+    return "SortRequestDto(sortBy=" + getSortBy() + ", sortOrder=" + getSortOrder() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/CacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/CacheConfiguration.java
@@ -7,10 +7,59 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class CacheConfiguration {
+
   private int maxSize;
   private int defaultTtlMillis;
+
+  public CacheConfiguration() {}
+
+  public int getMaxSize() {
+    return maxSize;
+  }
+
+  public void setMaxSize(final int maxSize) {
+    this.maxSize = maxSize;
+  }
+
+  public int getDefaultTtlMillis() {
+    return defaultTtlMillis;
+  }
+
+  public void setDefaultTtlMillis(final int defaultTtlMillis) {
+    this.defaultTtlMillis = defaultTtlMillis;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CacheConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(defaultTtlMillis, maxSize);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CacheConfiguration that = (CacheConfiguration) o;
+    return Objects.equals(defaultTtlMillis, that.defaultTtlMillis)
+        && Objects.equals(maxSize, that.maxSize);
+  }
+
+  @Override
+  public String toString() {
+    return "CacheConfiguration(maxSize="
+        + getMaxSize()
+        + ", defaultTtlMillis="
+        + getDefaultTtlMillis()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/CloudUserCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/CloudUserCacheConfiguration.java
@@ -7,10 +7,59 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class CloudUserCacheConfiguration {
+
   private int maxSize;
   private long minFetchIntervalSeconds;
+
+  public CloudUserCacheConfiguration() {}
+
+  public int getMaxSize() {
+    return maxSize;
+  }
+
+  public void setMaxSize(final int maxSize) {
+    this.maxSize = maxSize;
+  }
+
+  public long getMinFetchIntervalSeconds() {
+    return minFetchIntervalSeconds;
+  }
+
+  public void setMinFetchIntervalSeconds(final long minFetchIntervalSeconds) {
+    this.minFetchIntervalSeconds = minFetchIntervalSeconds;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CloudUserCacheConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(minFetchIntervalSeconds, maxSize);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CloudUserCacheConfiguration that = (CloudUserCacheConfiguration) o;
+    return Objects.equals(minFetchIntervalSeconds, that.minFetchIntervalSeconds)
+        && Objects.equals(maxSize, that.maxSize);
+  }
+
+  @Override
+  public String toString() {
+    return "CloudUserCacheConfiguration(maxSize="
+        + getMaxSize()
+        + ", minFetchIntervalSeconds="
+        + getMinFetchIntervalSeconds()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/CsvConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/CsvConfiguration.java
@@ -9,9 +9,8 @@ package io.camunda.optimize.service.util.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.util.configuration.users.AuthorizedUserType;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class CsvConfiguration {
 
   @JsonProperty("limit")
@@ -22,4 +21,67 @@ public class CsvConfiguration {
 
   @JsonProperty("authorizedUsers")
   private AuthorizedUserType authorizedUserType;
+
+  public CsvConfiguration() {}
+
+  public Integer getExportCsvLimit() {
+    return exportCsvLimit;
+  }
+
+  @JsonProperty("limit")
+  public void setExportCsvLimit(final Integer exportCsvLimit) {
+    this.exportCsvLimit = exportCsvLimit;
+  }
+
+  public Character getExportCsvDelimiter() {
+    return exportCsvDelimiter;
+  }
+
+  @JsonProperty("delimiter")
+  public void setExportCsvDelimiter(final Character exportCsvDelimiter) {
+    this.exportCsvDelimiter = exportCsvDelimiter;
+  }
+
+  public AuthorizedUserType getAuthorizedUserType() {
+    return authorizedUserType;
+  }
+
+  @JsonProperty("authorizedUsers")
+  public void setAuthorizedUserType(final AuthorizedUserType authorizedUserType) {
+    this.authorizedUserType = authorizedUserType;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CsvConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(exportCsvDelimiter, exportCsvLimit, authorizedUserType);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CsvConfiguration that = (CsvConfiguration) o;
+    return Objects.equals(exportCsvDelimiter, that.exportCsvDelimiter)
+        && Objects.equals(exportCsvLimit, that.exportCsvLimit)
+        && Objects.equals(authorizedUserType, that.authorizedUserType);
+  }
+
+  @Override
+  public String toString() {
+    return "CsvConfiguration(exportCsvLimit="
+        + getExportCsvLimit()
+        + ", exportCsvDelimiter="
+        + getExportCsvDelimiter()
+        + ", authorizedUserType="
+        + getAuthorizedUserType()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ElasticSearchConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ElasticSearchConfiguration.java
@@ -20,10 +20,9 @@ import io.camunda.search.connect.plugin.PluginConfiguration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.Data;
 
-@Data
 public class ElasticSearchConfiguration {
 
   private DatabaseConnection connection;
@@ -37,6 +36,8 @@ public class ElasticSearchConfiguration {
   private DatabaseSettings settings;
 
   private Map<String, PluginConfiguration> interceptorPlugins;
+
+  public ElasticSearchConfiguration() {}
 
   @JsonIgnore
   public Integer getConnectionTimeout() {
@@ -175,5 +176,92 @@ public class ElasticSearchConfiguration {
   @JsonIgnore
   public void setIndexPrefix(final String prefix) {
     settings.getIndex().setPrefix(prefix);
+  }
+
+  public DatabaseConnection getConnection() {
+    return this.connection;
+  }
+
+  public DatabaseBackup getBackup() {
+    return this.backup;
+  }
+
+  public DatabaseSecurity getSecurity() {
+    return this.security;
+  }
+
+  public int getScrollTimeoutInSeconds() {
+    return this.scrollTimeoutInSeconds;
+  }
+
+  public DatabaseSettings getSettings() {
+    return this.settings;
+  }
+
+  public Map<String, PluginConfiguration> getInterceptorPlugins() {
+    return this.interceptorPlugins;
+  }
+
+  public void setConnection(final DatabaseConnection connection) {
+    this.connection = connection;
+  }
+
+  public void setBackup(final DatabaseBackup backup) {
+    this.backup = backup;
+  }
+
+  public void setSecurity(final DatabaseSecurity security) {
+    this.security = security;
+  }
+
+  public void setScrollTimeoutInSeconds(final int scrollTimeoutInSeconds) {
+    this.scrollTimeoutInSeconds = scrollTimeoutInSeconds;
+  }
+
+  public void setSettings(final DatabaseSettings settings) {
+    this.settings = settings;
+  }
+
+  public void setInterceptorPlugins(final Map<String, PluginConfiguration> interceptorPlugins) {
+    this.interceptorPlugins = interceptorPlugins;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        connection, backup, security, scrollTimeoutInSeconds, settings, interceptorPlugins);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ElasticSearchConfiguration that = (ElasticSearchConfiguration) o;
+    return scrollTimeoutInSeconds == that.scrollTimeoutInSeconds
+        && Objects.equals(connection, that.connection)
+        && Objects.equals(backup, that.backup)
+        && Objects.equals(security, that.security)
+        && Objects.equals(settings, that.settings)
+        && Objects.equals(interceptorPlugins, that.interceptorPlugins);
+  }
+
+  public String toString() {
+    return "ElasticSearchConfiguration(connection="
+        + this.getConnection()
+        + ", backup="
+        + this.getBackup()
+        + ", security="
+        + this.getSecurity()
+        + ", scrollTimeoutInSeconds="
+        + this.getScrollTimeoutInSeconds()
+        + ", settings="
+        + this.getSettings()
+        + ", interceptorPlugins="
+        + this.getInterceptorPlugins()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/EmailAuthenticationConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/EmailAuthenticationConfiguration.java
@@ -11,10 +11,10 @@ import static io.camunda.optimize.service.util.configuration.ConfigurationServic
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class EmailAuthenticationConfiguration {
+
   @JsonProperty("enabled")
   private Boolean enabled;
 
@@ -27,10 +27,85 @@ public class EmailAuthenticationConfiguration {
   @JsonProperty("securityProtocol")
   private EmailSecurityProtocol securityProtocol;
 
+  public EmailAuthenticationConfiguration() {}
+
   public void validate() {
     if (enabled && securityProtocol == null) {
       throw new OptimizeConfigurationException(
           EMAIL_AUTHENTICATION + ".securityProtocol must be set if authentication enabled");
     }
+  }
+
+  public Boolean getEnabled() {
+    return enabled;
+  }
+
+  @JsonProperty("enabled")
+  public void setEnabled(final Boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  @JsonProperty("username")
+  public void setUsername(final String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  @JsonProperty("password")
+  public void setPassword(final String password) {
+    this.password = password;
+  }
+
+  public EmailSecurityProtocol getSecurityProtocol() {
+    return securityProtocol;
+  }
+
+  @JsonProperty("securityProtocol")
+  public void setSecurityProtocol(final EmailSecurityProtocol securityProtocol) {
+    this.securityProtocol = securityProtocol;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EmailAuthenticationConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, username, password, securityProtocol);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EmailAuthenticationConfiguration that = (EmailAuthenticationConfiguration) o;
+    return Objects.equals(enabled, that.enabled)
+        && Objects.equals(username, that.username)
+        && Objects.equals(password, that.password)
+        && Objects.equals(securityProtocol, that.securityProtocol);
+  }
+
+  @Override
+  public String toString() {
+    return "EmailAuthenticationConfiguration(enabled="
+        + getEnabled()
+        + ", username="
+        + getUsername()
+        + ", password="
+        + getPassword()
+        + ", securityProtocol="
+        + getSecurityProtocol()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/EntityConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/EntityConfiguration.java
@@ -9,9 +9,8 @@ package io.camunda.optimize.service.util.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.util.configuration.users.AuthorizedUserType;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class EntityConfiguration {
 
   @JsonProperty("authorizedEditors")
@@ -20,4 +19,65 @@ public class EntityConfiguration {
   private Long kpiRefreshInterval;
 
   private Boolean createOnStartup;
+
+  public EntityConfiguration() {}
+
+  public AuthorizedUserType getAuthorizedUserType() {
+    return authorizedUserType;
+  }
+
+  @JsonProperty("authorizedEditors")
+  public void setAuthorizedUserType(final AuthorizedUserType authorizedUserType) {
+    this.authorizedUserType = authorizedUserType;
+  }
+
+  public Long getKpiRefreshInterval() {
+    return kpiRefreshInterval;
+  }
+
+  public void setKpiRefreshInterval(final Long kpiRefreshInterval) {
+    this.kpiRefreshInterval = kpiRefreshInterval;
+  }
+
+  public Boolean getCreateOnStartup() {
+    return createOnStartup;
+  }
+
+  public void setCreateOnStartup(final Boolean createOnStartup) {
+    this.createOnStartup = createOnStartup;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EntityConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(authorizedUserType, kpiRefreshInterval, createOnStartup);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EntityConfiguration that = (EntityConfiguration) o;
+    return Objects.equals(authorizedUserType, that.authorizedUserType)
+        && Objects.equals(kpiRefreshInterval, that.kpiRefreshInterval)
+        && Objects.equals(createOnStartup, that.createOnStartup);
+  }
+
+  @Override
+  public String toString() {
+    return "EntityConfiguration(authorizedUserType="
+        + getAuthorizedUserType()
+        + ", kpiRefreshInterval="
+        + getKpiRefreshInterval()
+        + ", createOnStartup="
+        + getCreateOnStartup()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ExternalVariableConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ExternalVariableConfiguration.java
@@ -8,13 +8,48 @@
 package io.camunda.optimize.service.util.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ExternalVariableConfiguration {
-  private VariableIngestionConfiguration variableIngestion;
-  private IndexRolloverConfiguration variableIndexRollover;
 
   @JsonProperty("import")
   private ExternalVariableImportConfiguration importConfiguration;
+
+  public ExternalVariableConfiguration() {}
+
+  public ExternalVariableImportConfiguration getImportConfiguration() {
+    return importConfiguration;
+  }
+
+  @JsonProperty("import")
+  public void setImportConfiguration(
+      final ExternalVariableImportConfiguration importConfiguration) {
+    this.importConfiguration = importConfiguration;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ExternalVariableConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(importConfiguration);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExternalVariableConfiguration that = (ExternalVariableConfiguration) o;
+    return Objects.equals(importConfiguration, that.importConfiguration);
+  }
+
+  @Override
+  public String toString() {
+    return "ExternalVariableConfiguration(importConfiguration=" + getImportConfiguration() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ExternalVariableImportConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ExternalVariableImportConfiguration.java
@@ -7,13 +7,58 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExternalVariableImportConfiguration {
+
   private boolean enabled;
   private int maxPageSize;
+
+  protected ExternalVariableImportConfiguration() {}
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public int getMaxPageSize() {
+    return maxPageSize;
+  }
+
+  public void setMaxPageSize(final int maxPageSize) {
+    this.maxPageSize = maxPageSize;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ExternalVariableImportConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, maxPageSize);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExternalVariableImportConfiguration that = (ExternalVariableImportConfiguration) o;
+    return enabled == that.enabled && maxPageSize == that.maxPageSize;
+  }
+
+  @Override
+  public String toString() {
+    return "ExternalVariableImportConfiguration(enabled="
+        + isEnabled()
+        + ", maxPageSize="
+        + getMaxPageSize()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/GlobalCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/GlobalCacheConfiguration.java
@@ -7,13 +7,93 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class GlobalCacheConfiguration {
+
   private CacheConfiguration definitions;
   private CacheConfiguration definitionEngines;
   private CloudUserCacheConfiguration cloudUsers;
   private CacheConfiguration cloudTenantAuthorizations;
   private CacheConfiguration users;
+
+  public GlobalCacheConfiguration() {}
+
+  public CacheConfiguration getDefinitions() {
+    return definitions;
+  }
+
+  public void setDefinitions(final CacheConfiguration definitions) {
+    this.definitions = definitions;
+  }
+
+  public CacheConfiguration getDefinitionEngines() {
+    return definitionEngines;
+  }
+
+  public void setDefinitionEngines(final CacheConfiguration definitionEngines) {
+    this.definitionEngines = definitionEngines;
+  }
+
+  public CloudUserCacheConfiguration getCloudUsers() {
+    return cloudUsers;
+  }
+
+  public void setCloudUsers(final CloudUserCacheConfiguration cloudUsers) {
+    this.cloudUsers = cloudUsers;
+  }
+
+  public CacheConfiguration getCloudTenantAuthorizations() {
+    return cloudTenantAuthorizations;
+  }
+
+  public void setCloudTenantAuthorizations(final CacheConfiguration cloudTenantAuthorizations) {
+    this.cloudTenantAuthorizations = cloudTenantAuthorizations;
+  }
+
+  public CacheConfiguration getUsers() {
+    return users;
+  }
+
+  public void setUsers(final CacheConfiguration users) {
+    this.users = users;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof GlobalCacheConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final GlobalCacheConfiguration that = (GlobalCacheConfiguration) o;
+    return Objects.equals(definitions, that.definitions)
+        && Objects.equals(definitionEngines, that.definitionEngines)
+        && Objects.equals(cloudUsers, that.cloudUsers)
+        && Objects.equals(cloudTenantAuthorizations, that.cloudTenantAuthorizations)
+        && Objects.equals(users, that.users);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        definitions, definitionEngines, cloudUsers, cloudTenantAuthorizations, users);
+  }
+
+  @Override
+  public String toString() {
+    return "GlobalCacheConfiguration(definitions="
+        + getDefinitions()
+        + ", definitionEngines="
+        + getDefinitionEngines()
+        + ", cloudUsers="
+        + getCloudUsers()
+        + ", cloudTenantAuthorizations="
+        + getCloudTenantAuthorizations()
+        + ", users="
+        + getUsers()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/M2mAuth0ClientConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/M2mAuth0ClientConfiguration.java
@@ -7,10 +7,56 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class M2mAuth0ClientConfiguration {
+
   private String m2mClientId;
   private String m2mClientSecret;
+
+  public M2mAuth0ClientConfiguration() {}
+
+  public String getM2mClientId() {
+    return m2mClientId;
+  }
+
+  public void setM2mClientId(final String m2mClientId) {
+    this.m2mClientId = m2mClientId;
+  }
+
+  public String getM2mClientSecret() {
+    return m2mClientSecret;
+  }
+
+  public void setM2mClientSecret(final String m2mClientSecret) {
+    this.m2mClientSecret = m2mClientSecret;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof M2mAuth0ClientConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final M2mAuth0ClientConfiguration that = (M2mAuth0ClientConfiguration) o;
+    return Objects.equals(m2mClientId, that.m2mClientId)
+        && Objects.equals(m2mClientSecret, that.m2mClientSecret);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(m2mClientId, m2mClientSecret);
+  }
+
+  @Override
+  public String toString() {
+    return "M2mAuth0ClientConfiguration(m2mClientId="
+        + getM2mClientId()
+        + ", m2mClientSecret="
+        + getM2mClientSecret()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OnboardingConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OnboardingConfiguration.java
@@ -9,13 +9,10 @@ package io.camunda.optimize.service.util.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.j2objc.annotations.Property;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
 public class OnboardingConfiguration {
+
   @Property("enabled")
   private boolean enabled;
 
@@ -34,14 +31,165 @@ public class OnboardingConfiguration {
   @JsonProperty("properties")
   private Properties properties;
 
-  @AllArgsConstructor
-  @Data
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public OnboardingConfiguration() {}
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getAppCuesScriptUrl() {
+    return appCuesScriptUrl;
+  }
+
+  public void setAppCuesScriptUrl(final String appCuesScriptUrl) {
+    this.appCuesScriptUrl = appCuesScriptUrl;
+  }
+
+  public boolean isScheduleProcessOnboardingChecks() {
+    return scheduleProcessOnboardingChecks;
+  }
+
+  public void setScheduleProcessOnboardingChecks(final boolean scheduleProcessOnboardingChecks) {
+    this.scheduleProcessOnboardingChecks = scheduleProcessOnboardingChecks;
+  }
+
+  public boolean isEnableOnboardingEmails() {
+    return enableOnboardingEmails;
+  }
+
+  public void setEnableOnboardingEmails(final boolean enableOnboardingEmails) {
+    this.enableOnboardingEmails = enableOnboardingEmails;
+  }
+
+  public int getIntervalForCheckingTriggerForOnboardingEmails() {
+    return intervalForCheckingTriggerForOnboardingEmails;
+  }
+
+  public void setIntervalForCheckingTriggerForOnboardingEmails(
+      final int intervalForCheckingTriggerForOnboardingEmails) {
+    this.intervalForCheckingTriggerForOnboardingEmails =
+        intervalForCheckingTriggerForOnboardingEmails;
+  }
+
+  public Properties getProperties() {
+    return properties;
+  }
+
+  @JsonProperty("properties")
+  public void setProperties(final Properties properties) {
+    this.properties = properties;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof OnboardingConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OnboardingConfiguration that = (OnboardingConfiguration) o;
+    return enabled == that.enabled
+        && scheduleProcessOnboardingChecks == that.scheduleProcessOnboardingChecks
+        && enableOnboardingEmails == that.enableOnboardingEmails
+        && intervalForCheckingTriggerForOnboardingEmails
+            == that.intervalForCheckingTriggerForOnboardingEmails
+        && Objects.equals(appCuesScriptUrl, that.appCuesScriptUrl)
+        && Objects.equals(properties, that.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        enabled,
+        appCuesScriptUrl,
+        scheduleProcessOnboardingChecks,
+        enableOnboardingEmails,
+        intervalForCheckingTriggerForOnboardingEmails,
+        properties);
+  }
+
+  @Override
+  public String toString() {
+    return "OnboardingConfiguration(enabled="
+        + isEnabled()
+        + ", appCuesScriptUrl="
+        + getAppCuesScriptUrl()
+        + ", scheduleProcessOnboardingChecks="
+        + isScheduleProcessOnboardingChecks()
+        + ", enableOnboardingEmails="
+        + isEnableOnboardingEmails()
+        + ", intervalForCheckingTriggerForOnboardingEmails="
+        + getIntervalForCheckingTriggerForOnboardingEmails()
+        + ", properties="
+        + getProperties()
+        + ")";
+  }
+
   public static class Properties {
+
     @JsonProperty("organizationId")
     private String organizationId;
 
     @JsonProperty("clusterId")
     private String clusterId;
+
+    public Properties(final String organizationId, final String clusterId) {
+      this.organizationId = organizationId;
+      this.clusterId = clusterId;
+    }
+
+    protected Properties() {}
+
+    public String getOrganizationId() {
+      return organizationId;
+    }
+
+    @JsonProperty("organizationId")
+    public void setOrganizationId(final String organizationId) {
+      this.organizationId = organizationId;
+    }
+
+    public String getClusterId() {
+      return clusterId;
+    }
+
+    @JsonProperty("clusterId")
+    public void setClusterId(final String clusterId) {
+      this.clusterId = clusterId;
+    }
+
+    protected boolean canEqual(final Object other) {
+      return other instanceof Properties;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Properties that = (Properties) o;
+      return Objects.equals(organizationId, that.organizationId)
+          && Objects.equals(clusterId, that.clusterId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(organizationId, clusterId);
+    }
+
+    @Override
+    public String toString() {
+      return "OnboardingConfiguration.Properties(organizationId="
+          + getOrganizationId()
+          + ", clusterId="
+          + getClusterId()
+          + ")";
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OpenSearchConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OpenSearchConfiguration.java
@@ -20,11 +20,10 @@ import io.camunda.search.connect.plugin.PluginConfiguration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.Data;
 
-@Data
 public class OpenSearchConfiguration {
 
   private DatabaseConnection connection;
@@ -38,6 +37,8 @@ public class OpenSearchConfiguration {
   private DatabaseSettings settings;
 
   private Map<String, PluginConfiguration> interceptorPlugins;
+
+  public OpenSearchConfiguration() {}
 
   @JsonIgnore
   public Integer getConnectionTimeout() {
@@ -167,5 +168,93 @@ public class OpenSearchConfiguration {
   @JsonIgnore
   public void setIndexPrefix(final String prefix) {
     settings.getIndex().setPrefix(prefix);
+  }
+
+  public DatabaseConnection getConnection() {
+    return this.connection;
+  }
+
+  public DatabaseBackup getBackup() {
+    return this.backup;
+  }
+
+  public DatabaseSecurity getSecurity() {
+    return this.security;
+  }
+
+  public int getScrollTimeoutInSeconds() {
+    return this.scrollTimeoutInSeconds;
+  }
+
+  public DatabaseSettings getSettings() {
+    return this.settings;
+  }
+
+  public Map<String, PluginConfiguration> getInterceptorPlugins() {
+    return this.interceptorPlugins;
+  }
+
+  public void setConnection(final DatabaseConnection connection) {
+    this.connection = connection;
+  }
+
+  public void setBackup(final DatabaseBackup backup) {
+    this.backup = backup;
+  }
+
+  public void setSecurity(final DatabaseSecurity security) {
+    this.security = security;
+  }
+
+  public void setScrollTimeoutInSeconds(final int scrollTimeoutInSeconds) {
+    this.scrollTimeoutInSeconds = scrollTimeoutInSeconds;
+  }
+
+  public void setSettings(final DatabaseSettings settings) {
+    this.settings = settings;
+  }
+
+  public void setInterceptorPlugins(final Map<String, PluginConfiguration> interceptorPlugins) {
+    this.interceptorPlugins = interceptorPlugins;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OpenSearchConfiguration that = (OpenSearchConfiguration) o;
+    return scrollTimeoutInSeconds == that.scrollTimeoutInSeconds
+        && Objects.equals(connection, that.connection)
+        && Objects.equals(backup, that.backup)
+        && Objects.equals(security, that.security)
+        && Objects.equals(settings, that.settings)
+        && Objects.equals(interceptorPlugins, that.interceptorPlugins);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        connection, backup, security, scrollTimeoutInSeconds, settings, interceptorPlugins);
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof OpenSearchConfiguration;
+  }
+
+  public String toString() {
+    return "OpenSearchConfiguration(connection="
+        + this.getConnection()
+        + ", backup="
+        + this.getBackup()
+        + ", security="
+        + this.getSecurity()
+        + ", scrollTimeoutInSeconds="
+        + this.getScrollTimeoutInSeconds()
+        + ", settings="
+        + this.getSettings()
+        + ", interceptorPlugins="
+        + this.getInterceptorPlugins()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OptimizeApiConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OptimizeApiConfiguration.java
@@ -8,10 +8,10 @@
 package io.camunda.optimize.service.util.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class OptimizeApiConfiguration {
+
   @JsonProperty("accessToken")
   private String accessToken;
 
@@ -20,4 +20,64 @@ public class OptimizeApiConfiguration {
 
   @JsonProperty("audience")
   private String audience;
+
+  public OptimizeApiConfiguration() {}
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  @JsonProperty("accessToken")
+  public void setAccessToken(final String accessToken) {
+    this.accessToken = accessToken;
+  }
+
+  public String getJwtSetUri() {
+    return jwtSetUri;
+  }
+
+  @JsonProperty("jwtSetUri")
+  public void setJwtSetUri(final String jwtSetUri) {
+    this.jwtSetUri = jwtSetUri;
+  }
+
+  public String getAudience() {
+    return audience;
+  }
+
+  @JsonProperty("audience")
+  public void setAudience(final String audience) {
+    this.audience = audience;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof OptimizeApiConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OptimizeApiConfiguration that = (OptimizeApiConfiguration) o;
+    return Objects.equals(accessToken, that.accessToken)
+        && Objects.equals(jwtSetUri, that.jwtSetUri)
+        && Objects.equals(audience, that.audience);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(accessToken, jwtSetUri, audience);
+  }
+
+  @Override
+  public String toString() {
+    return "OptimizeApiConfiguration(accessToken="
+        + getAccessToken()
+        + ", jwtSetUri="
+        + getJwtSetUri()
+        + ", audience="
+        + getAudience()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/PanelNotificationConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/PanelNotificationConfiguration.java
@@ -7,11 +7,68 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class PanelNotificationConfiguration {
+
   private String url;
   private boolean enabled;
   private String m2mTokenAudience;
+
+  public PanelNotificationConfiguration() {}
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(final String url) {
+    this.url = url;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getM2mTokenAudience() {
+    return m2mTokenAudience;
+  }
+
+  public void setM2mTokenAudience(final String m2mTokenAudience) {
+    this.m2mTokenAudience = m2mTokenAudience;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof PanelNotificationConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PanelNotificationConfiguration that = (PanelNotificationConfiguration) o;
+    return enabled == that.enabled
+        && Objects.equals(url, that.url)
+        && Objects.equals(m2mTokenAudience, that.m2mTokenAudience);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(url, enabled, m2mTokenAudience);
+  }
+
+  @Override
+  public String toString() {
+    return "PanelNotificationConfiguration(url="
+        + getUrl()
+        + ", enabled="
+        + isEnabled()
+        + ", m2mTokenAudience="
+        + getM2mTokenAudience()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ProxyConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ProxyConfiguration.java
@@ -12,15 +12,11 @@ import static io.camunda.optimize.service.util.configuration.ConfigurationServic
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @JsonIgnoreProperties
-@Data
 public class ProxyConfiguration {
+
   @JsonProperty("enabled")
   private boolean enabled;
 
@@ -33,8 +29,18 @@ public class ProxyConfiguration {
   @JsonProperty("sslEnabled")
   private boolean sslEnabled;
 
+  public ProxyConfiguration(
+      final boolean enabled, final String host, final Integer port, final boolean sslEnabled) {
+    this.enabled = enabled;
+    this.host = host;
+    this.port = port;
+    this.sslEnabled = sslEnabled;
+  }
+
+  public ProxyConfiguration() {}
+
   public void validate() {
-    if (this.enabled) {
+    if (enabled) {
       if (host == null || host.isEmpty()) {
         throw new OptimizeConfigurationException(
             ELASTICSEARCH_PROXY + ".host must be set and not empty if proxy is enabled");
@@ -44,5 +50,75 @@ public class ProxyConfiguration {
             ELASTICSEARCH_PROXY + ".port must be set and not empty if proxy is enabled");
       }
     }
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  @JsonProperty("enabled")
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  @JsonProperty("host")
+  public void setHost(final String host) {
+    this.host = host;
+  }
+
+  public Integer getPort() {
+    return port;
+  }
+
+  @JsonProperty("port")
+  public void setPort(final Integer port) {
+    this.port = port;
+  }
+
+  public boolean isSslEnabled() {
+    return sslEnabled;
+  }
+
+  @JsonProperty("sslEnabled")
+  public void setSslEnabled(final boolean sslEnabled) {
+    this.sslEnabled = sslEnabled;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProxyConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProxyConfiguration that = (ProxyConfiguration) o;
+    return enabled == that.enabled
+        && sslEnabled == that.sslEnabled
+        && Objects.equals(host, that.host)
+        && Objects.equals(port, that.port);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, host, port, sslEnabled);
+  }
+
+  @Override
+  public String toString() {
+    return "ProxyConfiguration(enabled="
+        + isEnabled()
+        + ", host="
+        + getHost()
+        + ", port="
+        + getPort()
+        + ", sslEnabled="
+        + isSslEnabled()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/TelemetryConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/TelemetryConfiguration.java
@@ -10,18 +10,20 @@ package io.camunda.optimize.service.util.configuration;
 import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.TELEMETRY_CONFIGURATION;
 
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Data
 public class TelemetryConfiguration {
 
   private boolean initializeTelemetry;
   private long reportingIntervalInHours;
+
+  public TelemetryConfiguration(
+      final boolean initializeTelemetry, final long reportingIntervalInHours) {
+    this.initializeTelemetry = initializeTelemetry;
+    this.reportingIntervalInHours = reportingIntervalInHours;
+  }
+
+  protected TelemetryConfiguration() {}
 
   public void validate() {
     if (reportingIntervalInHours <= 0) {
@@ -30,6 +32,50 @@ public class TelemetryConfiguration {
               "%s.%s must be set to a positive number",
               TELEMETRY_CONFIGURATION, Fields.reportingIntervalInHours.name()));
     }
+  }
+
+  public boolean isInitializeTelemetry() {
+    return initializeTelemetry;
+  }
+
+  public void setInitializeTelemetry(final boolean initializeTelemetry) {
+    this.initializeTelemetry = initializeTelemetry;
+  }
+
+  public long getReportingIntervalInHours() {
+    return reportingIntervalInHours;
+  }
+
+  public void setReportingIntervalInHours(final long reportingIntervalInHours) {
+    this.reportingIntervalInHours = reportingIntervalInHours;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof TelemetryConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TelemetryConfiguration that = (TelemetryConfiguration) o;
+    return initializeTelemetry == that.initializeTelemetry
+        && reportingIntervalInHours == that.reportingIntervalInHours;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(initializeTelemetry, reportingIntervalInHours);
+  }
+
+  @Override
+  public String toString() {
+    return "TelemetryConfiguration(initializeTelemetry="
+        + isInitializeTelemetry()
+        + ", reportingIntervalInHours="
+        + getReportingIntervalInHours()
+        + ")";
   }
 
   public enum Fields {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ZeebeConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ZeebeConfiguration.java
@@ -7,14 +7,8 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ZeebeConfiguration {
 
   private boolean enabled;
@@ -24,4 +18,129 @@ public class ZeebeConfiguration {
   private boolean includeObjectVariableValue;
   private boolean variableImportEnabled;
   private ZeebeImportConfiguration importConfig;
+
+  public ZeebeConfiguration(
+      final boolean enabled,
+      final String name,
+      final int partitionCount,
+      final int maxImportPageSize,
+      final boolean includeObjectVariableValue,
+      final boolean variableImportEnabled,
+      final ZeebeImportConfiguration importConfig) {
+    this.enabled = enabled;
+    this.name = name;
+    this.partitionCount = partitionCount;
+    this.maxImportPageSize = maxImportPageSize;
+    this.includeObjectVariableValue = includeObjectVariableValue;
+    this.variableImportEnabled = variableImportEnabled;
+    this.importConfig = importConfig;
+  }
+
+  protected ZeebeConfiguration() {}
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public int getPartitionCount() {
+    return partitionCount;
+  }
+
+  public void setPartitionCount(final int partitionCount) {
+    this.partitionCount = partitionCount;
+  }
+
+  public int getMaxImportPageSize() {
+    return maxImportPageSize;
+  }
+
+  public void setMaxImportPageSize(final int maxImportPageSize) {
+    this.maxImportPageSize = maxImportPageSize;
+  }
+
+  public boolean isIncludeObjectVariableValue() {
+    return includeObjectVariableValue;
+  }
+
+  public void setIncludeObjectVariableValue(final boolean includeObjectVariableValue) {
+    this.includeObjectVariableValue = includeObjectVariableValue;
+  }
+
+  public boolean isVariableImportEnabled() {
+    return variableImportEnabled;
+  }
+
+  public void setVariableImportEnabled(final boolean variableImportEnabled) {
+    this.variableImportEnabled = variableImportEnabled;
+  }
+
+  public ZeebeImportConfiguration getImportConfig() {
+    return importConfig;
+  }
+
+  public void setImportConfig(final ZeebeImportConfiguration importConfig) {
+    this.importConfig = importConfig;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeConfiguration that = (ZeebeConfiguration) o;
+    return enabled == that.enabled
+        && partitionCount == that.partitionCount
+        && maxImportPageSize == that.maxImportPageSize
+        && includeObjectVariableValue == that.includeObjectVariableValue
+        && variableImportEnabled == that.variableImportEnabled
+        && Objects.equals(name, that.name)
+        && Objects.equals(importConfig, that.importConfig);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        enabled,
+        name,
+        partitionCount,
+        maxImportPageSize,
+        includeObjectVariableValue,
+        variableImportEnabled,
+        importConfig);
+  }
+
+  @Override
+  public String toString() {
+    return "ZeebeConfiguration(enabled="
+        + isEnabled()
+        + ", name="
+        + getName()
+        + ", partitionCount="
+        + getPartitionCount()
+        + ", maxImportPageSize="
+        + getMaxImportPageSize()
+        + ", includeObjectVariableValue="
+        + isIncludeObjectVariableValue()
+        + ", variableImportEnabled="
+        + isVariableImportEnabled()
+        + ", importConfig="
+        + getImportConfig()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ZeebeImportConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ZeebeImportConfiguration.java
@@ -7,16 +7,62 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ZeebeImportConfiguration {
 
   private int dynamicBatchSuccessAttempts;
   private int maxEmptyPagesToImport;
+
+  public ZeebeImportConfiguration(
+      final int dynamicBatchSuccessAttempts, final int maxEmptyPagesToImport) {
+    this.dynamicBatchSuccessAttempts = dynamicBatchSuccessAttempts;
+    this.maxEmptyPagesToImport = maxEmptyPagesToImport;
+  }
+
+  protected ZeebeImportConfiguration() {}
+
+  public int getDynamicBatchSuccessAttempts() {
+    return dynamicBatchSuccessAttempts;
+  }
+
+  public void setDynamicBatchSuccessAttempts(final int dynamicBatchSuccessAttempts) {
+    this.dynamicBatchSuccessAttempts = dynamicBatchSuccessAttempts;
+  }
+
+  public int getMaxEmptyPagesToImport() {
+    return maxEmptyPagesToImport;
+  }
+
+  public void setMaxEmptyPagesToImport(final int maxEmptyPagesToImport) {
+    this.maxEmptyPagesToImport = maxEmptyPagesToImport;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeImportConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeImportConfiguration that = (ZeebeImportConfiguration) o;
+    return dynamicBatchSuccessAttempts == that.dynamicBatchSuccessAttempts
+        && maxEmptyPagesToImport == that.maxEmptyPagesToImport;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(dynamicBatchSuccessAttempts, maxEmptyPagesToImport);
+  }
+
+  @Override
+  public String toString() {
+    return "ZeebeImportConfiguration(dynamicBatchSuccessAttempts="
+        + getDynamicBatchSuccessAttempts()
+        + ", maxEmptyPagesToImport="
+        + getMaxEmptyPagesToImport()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/analytics/AnalyticsConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/analytics/AnalyticsConfiguration.java
@@ -8,15 +8,10 @@
 package io.camunda.optimize.service.util.configuration.analytics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AnalyticsConfiguration {
+
   @JsonProperty("enabled")
   private boolean enabled;
 
@@ -25,4 +20,72 @@ public class AnalyticsConfiguration {
 
   @JsonProperty("osano")
   private OsanoConfiguration osano;
+
+  public AnalyticsConfiguration(
+      final boolean enabled, final MixpanelConfiguration mixpanel, final OsanoConfiguration osano) {
+    this.enabled = enabled;
+    this.mixpanel = mixpanel;
+    this.osano = osano;
+  }
+
+  protected AnalyticsConfiguration() {}
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  @JsonProperty("enabled")
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public MixpanelConfiguration getMixpanel() {
+    return mixpanel;
+  }
+
+  @JsonProperty("mixpanel")
+  public void setMixpanel(final MixpanelConfiguration mixpanel) {
+    this.mixpanel = mixpanel;
+  }
+
+  public OsanoConfiguration getOsano() {
+    return osano;
+  }
+
+  @JsonProperty("osano")
+  public void setOsano(final OsanoConfiguration osano) {
+    this.osano = osano;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof AnalyticsConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mixpanel, osano);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AnalyticsConfiguration that = (AnalyticsConfiguration) o;
+    return Objects.equals(mixpanel, that.mixpanel) && Objects.equals(osano, that.osano);
+  }
+
+  @Override
+  public String toString() {
+    return "AnalyticsConfiguration(enabled="
+        + isEnabled()
+        + ", mixpanel="
+        + getMixpanel()
+        + ", osano="
+        + getOsano()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/analytics/MixpanelConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/analytics/MixpanelConfiguration.java
@@ -9,15 +9,10 @@ package io.camunda.optimize.service.util.configuration.analytics;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@AllArgsConstructor
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MixpanelConfiguration {
+
   @JsonProperty("apiHost")
   private String apiHost;
 
@@ -36,15 +31,127 @@ public class MixpanelConfiguration {
   @JsonProperty("serviceAccount")
   private ServiceAccount serviceAccount;
 
-  @JsonIgnore
-  public String getImportUrl() {
-    return this.apiHost + this.importPath;
+  public MixpanelConfiguration(
+      final String apiHost,
+      final String importPath,
+      final String token,
+      final String projectId,
+      final TrackingProperties properties,
+      final ServiceAccount serviceAccount) {
+    this.apiHost = apiHost;
+    this.importPath = importPath;
+    this.token = token;
+    this.projectId = projectId;
+    this.properties = properties;
+    this.serviceAccount = serviceAccount;
   }
 
-  @AllArgsConstructor
-  @Data
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  protected MixpanelConfiguration() {}
+
+  @JsonIgnore
+  public String getImportUrl() {
+    return apiHost + importPath;
+  }
+
+  public String getApiHost() {
+    return apiHost;
+  }
+
+  @JsonProperty("apiHost")
+  public void setApiHost(final String apiHost) {
+    this.apiHost = apiHost;
+  }
+
+  public String getImportPath() {
+    return importPath;
+  }
+
+  @JsonProperty("importPath")
+  public void setImportPath(final String importPath) {
+    this.importPath = importPath;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  @JsonProperty("token")
+  public void setToken(final String token) {
+    this.token = token;
+  }
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  @JsonProperty("projectId")
+  public void setProjectId(final String projectId) {
+    this.projectId = projectId;
+  }
+
+  public TrackingProperties getProperties() {
+    return properties;
+  }
+
+  @JsonProperty("properties")
+  public void setProperties(final TrackingProperties properties) {
+    this.properties = properties;
+  }
+
+  public ServiceAccount getServiceAccount() {
+    return serviceAccount;
+  }
+
+  @JsonProperty("serviceAccount")
+  public void setServiceAccount(final ServiceAccount serviceAccount) {
+    this.serviceAccount = serviceAccount;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof MixpanelConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(apiHost, importPath, token, projectId, properties, serviceAccount);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MixpanelConfiguration that = (MixpanelConfiguration) o;
+    return Objects.equals(apiHost, that.apiHost)
+        && Objects.equals(importPath, that.importPath)
+        && Objects.equals(token, that.token)
+        && Objects.equals(projectId, that.projectId)
+        && Objects.equals(properties, that.properties)
+        && Objects.equals(serviceAccount, that.serviceAccount);
+  }
+
+  @Override
+  public String toString() {
+    return "MixpanelConfiguration(apiHost="
+        + getApiHost()
+        + ", importPath="
+        + getImportPath()
+        + ", token="
+        + getToken()
+        + ", projectId="
+        + getProjectId()
+        + ", properties="
+        + getProperties()
+        + ", serviceAccount="
+        + getServiceAccount()
+        + ")";
+  }
+
   public static class TrackingProperties {
+
     @JsonProperty("stage")
     private String stage;
 
@@ -53,16 +160,139 @@ public class MixpanelConfiguration {
 
     @JsonProperty("clusterId")
     private String clusterId;
+
+    public TrackingProperties(
+        final String stage, final String organizationId, final String clusterId) {
+      this.stage = stage;
+      this.organizationId = organizationId;
+      this.clusterId = clusterId;
+    }
+
+    protected TrackingProperties() {}
+
+    public String getStage() {
+      return stage;
+    }
+
+    @JsonProperty("stage")
+    public void setStage(final String stage) {
+      this.stage = stage;
+    }
+
+    public String getOrganizationId() {
+      return organizationId;
+    }
+
+    @JsonProperty("organizationId")
+    public void setOrganizationId(final String organizationId) {
+      this.organizationId = organizationId;
+    }
+
+    public String getClusterId() {
+      return clusterId;
+    }
+
+    @JsonProperty("clusterId")
+    public void setClusterId(final String clusterId) {
+      this.clusterId = clusterId;
+    }
+
+    protected boolean canEqual(final Object other) {
+      return other instanceof TrackingProperties;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(stage, organizationId, clusterId);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final TrackingProperties that = (TrackingProperties) o;
+      return Objects.equals(stage, that.stage)
+          && Objects.equals(organizationId, that.organizationId)
+          && Objects.equals(clusterId, that.clusterId);
+    }
+
+    @Override
+    public String toString() {
+      return "MixpanelConfiguration.TrackingProperties(stage="
+          + getStage()
+          + ", organizationId="
+          + getOrganizationId()
+          + ", clusterId="
+          + getClusterId()
+          + ")";
+    }
   }
 
-  @AllArgsConstructor
-  @Data
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
   public static class ServiceAccount {
+
     @JsonProperty("username")
     private String username;
 
     @JsonProperty("secret")
     private String secret;
+
+    public ServiceAccount(final String username, final String secret) {
+      this.username = username;
+      this.secret = secret;
+    }
+
+    protected ServiceAccount() {}
+
+    public String getUsername() {
+      return username;
+    }
+
+    @JsonProperty("username")
+    public void setUsername(final String username) {
+      this.username = username;
+    }
+
+    public String getSecret() {
+      return secret;
+    }
+
+    @JsonProperty("secret")
+    public void setSecret(final String secret) {
+      this.secret = secret;
+    }
+
+    protected boolean canEqual(final Object other) {
+      return other instanceof ServiceAccount;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(username, secret);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final ServiceAccount that = (ServiceAccount) o;
+      return Objects.equals(username, that.username) && Objects.equals(secret, that.secret);
+    }
+
+    @Override
+    public String toString() {
+      return "MixpanelConfiguration.ServiceAccount(username="
+          + getUsername()
+          + ", secret="
+          + getSecret()
+          + ")";
+    }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/analytics/OsanoConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/analytics/OsanoConfiguration.java
@@ -8,20 +8,52 @@
 package io.camunda.optimize.service.util.configuration.analytics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OsanoConfiguration {
+
   @JsonProperty("scriptUrl")
   private String scriptUrl;
 
+  public OsanoConfiguration(final String scriptUrl) {
+    this.scriptUrl = scriptUrl;
+  }
+
+  protected OsanoConfiguration() {}
+
   public Optional<String> getScriptUrl() {
     return Optional.ofNullable(scriptUrl);
+  }
+
+  @JsonProperty("scriptUrl")
+  public void setScriptUrl(final String scriptUrl) {
+    this.scriptUrl = scriptUrl;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof OsanoConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(scriptUrl);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final OsanoConfiguration that = (OsanoConfiguration) o;
+    return Objects.equals(scriptUrl, that.scriptUrl);
+  }
+
+  @Override
+  public String toString() {
+    return "OsanoConfiguration(scriptUrl=" + getScriptUrl() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/cleanup/CleanupConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/cleanup/CleanupConfiguration.java
@@ -15,15 +15,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
 import io.camunda.optimize.service.util.CronNormalizerUtil;
 import java.time.Period;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CleanupConfiguration {
+
   @JsonProperty("cronTrigger")
   private String cronTrigger;
 
@@ -49,6 +46,8 @@ public class CleanupConfiguration {
     this.processDataCleanupConfiguration = processDataCleanupConfiguration;
   }
 
+  protected CleanupConfiguration() {}
+
   public void validate() {
     if (ttl == null) {
       throw new OptimizeConfigurationException(HISTORY_CLEANUP + ".ttl must be set");
@@ -66,11 +65,6 @@ public class CleanupConfiguration {
     return processDataCleanupConfiguration.isEnabled();
   }
 
-  public final void setCronTrigger(String cronTrigger) {
-    this.cronTrigger =
-        Optional.ofNullable(cronTrigger).map(CronNormalizerUtil::normalizeToSixParts).orElse(null);
-  }
-
   public ProcessDefinitionCleanupConfiguration getProcessDefinitionCleanupConfigurationForKey(
       final String processDefinitionKey) {
     final Optional<ProcessDefinitionCleanupConfiguration> keySpecificConfig =
@@ -83,5 +77,82 @@ public class CleanupConfiguration {
         keySpecificConfig
             .flatMap(config -> Optional.ofNullable(config.getCleanupMode()))
             .orElse(processDataCleanupConfiguration.getCleanupMode()));
+  }
+
+  public String getCronTrigger() {
+    return cronTrigger;
+  }
+
+  public final void setCronTrigger(final String cronTrigger) {
+    this.cronTrigger =
+        Optional.ofNullable(cronTrigger).map(CronNormalizerUtil::normalizeToSixParts).orElse(null);
+  }
+
+  public Period getTtl() {
+    return ttl;
+  }
+
+  @JsonProperty("ttl")
+  public void setTtl(final Period ttl) {
+    this.ttl = ttl;
+  }
+
+  public ProcessCleanupConfiguration getProcessDataCleanupConfiguration() {
+    return processDataCleanupConfiguration;
+  }
+
+  @JsonProperty("processDataCleanup")
+  public void setProcessDataCleanupConfiguration(
+      final ProcessCleanupConfiguration processDataCleanupConfiguration) {
+    this.processDataCleanupConfiguration = processDataCleanupConfiguration;
+  }
+
+  public ExternalVariableCleanupConfiguration getExternalVariableCleanupConfiguration() {
+    return externalVariableCleanupConfiguration;
+  }
+
+  @JsonProperty("externalVariableCleanup")
+  public void setExternalVariableCleanupConfiguration(
+      final ExternalVariableCleanupConfiguration externalVariableCleanupConfiguration) {
+    this.externalVariableCleanupConfiguration = externalVariableCleanupConfiguration;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CleanupConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        cronTrigger, ttl, processDataCleanupConfiguration, externalVariableCleanupConfiguration);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CleanupConfiguration that = (CleanupConfiguration) o;
+    return Objects.equals(cronTrigger, that.cronTrigger)
+        && Objects.equals(ttl, that.ttl)
+        && Objects.equals(processDataCleanupConfiguration, that.processDataCleanupConfiguration)
+        && Objects.equals(
+            externalVariableCleanupConfiguration, that.externalVariableCleanupConfiguration);
+  }
+
+  @Override
+  public String toString() {
+    return "CleanupConfiguration(cronTrigger="
+        + getCronTrigger()
+        + ", ttl="
+        + getTtl()
+        + ", processDataCleanupConfiguration="
+        + getProcessDataCleanupConfiguration()
+        + ", externalVariableCleanupConfiguration="
+        + getExternalVariableCleanupConfiguration()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/cleanup/ExternalVariableCleanupConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/cleanup/ExternalVariableCleanupConfiguration.java
@@ -8,15 +8,51 @@
 package io.camunda.optimize.service.util.configuration.cleanup;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExternalVariableCleanupConfiguration {
+
   @JsonProperty("enabled")
   private boolean enabled;
+
+  public ExternalVariableCleanupConfiguration(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  protected ExternalVariableCleanupConfiguration() {}
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  @JsonProperty("enabled")
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ExternalVariableCleanupConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExternalVariableCleanupConfiguration that = (ExternalVariableCleanupConfiguration) o;
+    return enabled == that.enabled;
+  }
+
+  @Override
+  public String toString() {
+    return "ExternalVariableCleanupConfiguration(enabled=" + isEnabled() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/cleanup/ProcessCleanupConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/cleanup/ProcessCleanupConfiguration.java
@@ -16,15 +16,13 @@ import io.camunda.optimize.util.SuppressionConstants;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = false)
 public class ProcessCleanupConfiguration {
+
   @JsonProperty("enabled")
   private boolean enabled;
 
@@ -47,6 +45,8 @@ public class ProcessCleanupConfiguration {
     this.cleanupMode = cleanupMode;
   }
 
+  public ProcessCleanupConfiguration() {}
+
   public void validate() {
     if (cleanupMode == null) {
       throw new OptimizeConfigurationException(
@@ -58,10 +58,81 @@ public class ProcessCleanupConfiguration {
     return new HashSet<>(processDefinitionSpecificConfiguration.keySet());
   }
 
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  @JsonProperty("enabled")
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public CleanupMode getCleanupMode() {
+    return cleanupMode;
+  }
+
+  @JsonProperty("cleanupMode")
+  public void setCleanupMode(final CleanupMode cleanupMode) {
+    this.cleanupMode = cleanupMode;
+  }
+
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  @JsonProperty("batchSize")
+  public void setBatchSize(final int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  public Map<String, ProcessDefinitionCleanupConfiguration>
+      getProcessDefinitionSpecificConfiguration() {
+    return processDefinitionSpecificConfiguration;
+  }
+
   @SuppressWarnings(SuppressionConstants.UNUSED)
   public void setProcessDefinitionSpecificConfiguration(
-      Map<String, ProcessDefinitionCleanupConfiguration> processDefinitionSpecificConfiguration) {
+      final Map<String, ProcessDefinitionCleanupConfiguration>
+          processDefinitionSpecificConfiguration) {
     this.processDefinitionSpecificConfiguration =
         Optional.ofNullable(processDefinitionSpecificConfiguration).orElse(new HashMap<>());
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ProcessCleanupConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, cleanupMode, batchSize, processDefinitionSpecificConfiguration);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessCleanupConfiguration that = (ProcessCleanupConfiguration) o;
+    return enabled == that.enabled
+        && Objects.equals(cleanupMode, that.cleanupMode)
+        && Objects.equals(batchSize, that.batchSize)
+        && Objects.equals(
+            processDefinitionSpecificConfiguration, that.processDefinitionSpecificConfiguration);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessCleanupConfiguration(enabled="
+        + isEnabled()
+        + ", cleanupMode="
+        + getCleanupMode()
+        + ", batchSize="
+        + getBatchSize()
+        + ", processDefinitionSpecificConfiguration="
+        + getProcessDefinitionSpecificConfiguration()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseBackup.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseBackup.java
@@ -8,11 +8,47 @@
 package io.camunda.optimize.service.util.configuration.db;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class DatabaseBackup {
 
   @JsonProperty("repositoryName")
   private String snapshotRepositoryName;
+
+  public DatabaseBackup() {}
+
+  public String getSnapshotRepositoryName() {
+    return snapshotRepositoryName;
+  }
+
+  @JsonProperty("repositoryName")
+  public void setSnapshotRepositoryName(final String snapshotRepositoryName) {
+    this.snapshotRepositoryName = snapshotRepositoryName;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DatabaseBackup;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(snapshotRepositoryName);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseBackup that = (DatabaseBackup) o;
+    return Objects.equals(snapshotRepositoryName, that.snapshotRepositoryName);
+  }
+
+  @Override
+  public String toString() {
+    return "DatabaseBackup(snapshotRepositoryName=" + getSnapshotRepositoryName() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseConnection.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseConnection.java
@@ -11,9 +11,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.util.configuration.ProxyConfiguration;
 import io.camunda.optimize.service.util.configuration.elasticsearch.DatabaseConnectionNodeConfiguration;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class DatabaseConnection {
 
   protected Integer timeout;
@@ -31,4 +30,125 @@ public class DatabaseConnection {
   private Boolean clusterTaskCheckingEnabled;
 
   private Boolean initSchemaEnabled;
+
+  public DatabaseConnection() {}
+
+  public Integer getTimeout() {
+    return this.timeout;
+  }
+
+  public Integer getResponseConsumerBufferLimitInMb() {
+    return this.responseConsumerBufferLimitInMb;
+  }
+
+  public String getPathPrefix() {
+    return this.pathPrefix;
+  }
+
+  public Boolean getSkipHostnameVerification() {
+    return this.skipHostnameVerification;
+  }
+
+  public List<DatabaseConnectionNodeConfiguration> getConnectionNodes() {
+    return this.connectionNodes;
+  }
+
+  public ProxyConfiguration getProxy() {
+    return this.proxy;
+  }
+
+  public Boolean getAwsEnabled() {
+    return this.awsEnabled;
+  }
+
+  public void setTimeout(final Integer timeout) {
+    this.timeout = timeout;
+  }
+
+  public void setResponseConsumerBufferLimitInMb(final Integer responseConsumerBufferLimitInMb) {
+    this.responseConsumerBufferLimitInMb = responseConsumerBufferLimitInMb;
+  }
+
+  public void setPathPrefix(final String pathPrefix) {
+    this.pathPrefix = pathPrefix;
+  }
+
+  public void setSkipHostnameVerification(final Boolean skipHostnameVerification) {
+    this.skipHostnameVerification = skipHostnameVerification;
+  }
+
+  @JsonProperty("nodes")
+  public void setConnectionNodes(final List<DatabaseConnectionNodeConfiguration> connectionNodes) {
+    this.connectionNodes = connectionNodes;
+  }
+
+  public void setProxy(final ProxyConfiguration proxy) {
+    this.proxy = proxy;
+  }
+
+  public void setAwsEnabled(final Boolean awsEnabled) {
+    this.awsEnabled = awsEnabled;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        connectionNodes,
+        timeout,
+        responseConsumerBufferLimitInMb,
+        skipHostnameVerification,
+        pathPrefix,
+        proxy);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseConnection that = (DatabaseConnection) o;
+    return Objects.equals(timeout, that.timeout)
+        && Objects.equals(responseConsumerBufferLimitInMb, that.responseConsumerBufferLimitInMb)
+        && Objects.equals(skipHostnameVerification, that.skipHostnameVerification)
+        && Objects.equals(connectionNodes, that.connectionNodes)
+        && Objects.equals(pathPrefix, that.pathPrefix)
+        && Objects.equals(proxy, that.proxy);
+  }
+
+  public Boolean isClusterTaskCheckingEnabled() {
+    return clusterTaskCheckingEnabled;
+  }
+
+  public void setClusterTaskCheckingEnabled(final Boolean clusterTaskCheckingEnabled) {
+    this.clusterTaskCheckingEnabled = clusterTaskCheckingEnabled;
+  }
+
+  public Boolean isInitSchemaEnabled() {
+    return initSchemaEnabled;
+  }
+
+  public void setInitSchemaEnabled(final Boolean initSchemaEnabled) {
+    this.initSchemaEnabled = initSchemaEnabled;
+  }
+
+  public String toString() {
+    return "DatabaseConnection(timeout="
+        + this.getTimeout()
+        + ", responseConsumerBufferLimitInMb="
+        + this.getResponseConsumerBufferLimitInMb()
+        + ", pathPrefix="
+        + this.getPathPrefix()
+        + ", skipHostnameVerification="
+        + this.getSkipHostnameVerification()
+        + ", connectionNodes="
+        + this.getConnectionNodes()
+        + ", proxy="
+        + this.getProxy()
+        + ", awsEnabled="
+        + this.getAwsEnabled()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseIndex.java
@@ -8,9 +8,8 @@
 package io.camunda.optimize.service.util.configuration.db;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class DatabaseIndex {
 
   @JsonProperty("number_of_replicas")
@@ -26,4 +25,91 @@ public class DatabaseIndex {
   private Integer nestedDocumentsLimit;
 
   private String prefix;
+
+  public DatabaseIndex() {}
+
+  public Integer getNumberOfReplicas() {
+    return numberOfReplicas;
+  }
+
+  @JsonProperty("number_of_replicas")
+  public void setNumberOfReplicas(final Integer numberOfReplicas) {
+    this.numberOfReplicas = numberOfReplicas;
+  }
+
+  public Integer getNumberOfShards() {
+    return numberOfShards;
+  }
+
+  @JsonProperty("number_of_shards")
+  public void setNumberOfShards(final Integer numberOfShards) {
+    this.numberOfShards = numberOfShards;
+  }
+
+  public String getRefreshInterval() {
+    return refreshInterval;
+  }
+
+  @JsonProperty("refresh_interval")
+  public void setRefreshInterval(final String refreshInterval) {
+    this.refreshInterval = refreshInterval;
+  }
+
+  public Integer getNestedDocumentsLimit() {
+    return nestedDocumentsLimit;
+  }
+
+  @JsonProperty("nested_documents_limit")
+  public void setNestedDocumentsLimit(final Integer nestedDocumentsLimit) {
+    this.nestedDocumentsLimit = nestedDocumentsLimit;
+  }
+
+  public String getPrefix() {
+    return prefix;
+  }
+
+  public void setPrefix(final String prefix) {
+    this.prefix = prefix;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DatabaseIndex;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        prefix, numberOfShards, numberOfReplicas, refreshInterval, nestedDocumentsLimit);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseIndex that = (DatabaseIndex) o;
+    return Objects.equals(numberOfShards, that.numberOfShards)
+        && Objects.equals(numberOfReplicas, that.numberOfReplicas)
+        && Objects.equals(nestedDocumentsLimit, that.nestedDocumentsLimit)
+        && Objects.equals(prefix, that.prefix)
+        && Objects.equals(refreshInterval, that.refreshInterval);
+  }
+
+  @Override
+  public String toString() {
+    return "DatabaseIndex(numberOfReplicas="
+        + getNumberOfReplicas()
+        + ", numberOfShards="
+        + getNumberOfShards()
+        + ", refreshInterval="
+        + getRefreshInterval()
+        + ", nestedDocumentsLimit="
+        + getNestedDocumentsLimit()
+        + ", prefix="
+        + getPrefix()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseSSLConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseSSLConfiguration.java
@@ -9,17 +9,83 @@ package io.camunda.optimize.service.util.configuration.db;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class DatabaseSSLConfiguration {
 
   private Boolean enabled;
-
   private Boolean selfSigned;
-
   private String certificate;
 
   @JsonProperty("certificate_authorities")
   private List<String> certificateAuthorities;
+
+  public DatabaseSSLConfiguration() {}
+
+  public Boolean getEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final Boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Boolean getSelfSigned() {
+    return selfSigned;
+  }
+
+  public void setSelfSigned(final Boolean selfSigned) {
+    this.selfSigned = selfSigned;
+  }
+
+  public String getCertificate() {
+    return certificate;
+  }
+
+  public void setCertificate(final String certificate) {
+    this.certificate = certificate;
+  }
+
+  public List<String> getCertificateAuthorities() {
+    return certificateAuthorities;
+  }
+
+  @JsonProperty("certificate_authorities")
+  public void setCertificateAuthorities(final List<String> certificateAuthorities) {
+    this.certificateAuthorities = certificateAuthorities;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DatabaseSSLConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseSSLConfiguration that = (DatabaseSSLConfiguration) o;
+    return Objects.equals(enabled, that.enabled)
+        && Objects.equals(selfSigned, that.selfSigned)
+        && Objects.equals(certificate, that.certificate)
+        && Objects.equals(certificateAuthorities, that.certificateAuthorities);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, selfSigned, certificate, certificateAuthorities);
+  }
+
+  @Override
+  public String toString() {
+    return "DatabaseSSLConfiguration(enabled="
+        + getEnabled()
+        + ", selfSigned="
+        + getSelfSigned()
+        + ", certificate="
+        + getCertificate()
+        + ", certificateAuthorities="
+        + getCertificateAuthorities()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseSecurity.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseSecurity.java
@@ -7,14 +7,71 @@
  */
 package io.camunda.optimize.service.util.configuration.db;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class DatabaseSecurity {
 
   private String username;
-
   private String password;
-
   private DatabaseSSLConfiguration ssl;
+
+  public DatabaseSecurity() {}
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(final String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(final String password) {
+    this.password = password;
+  }
+
+  public DatabaseSSLConfiguration getSsl() {
+    return ssl;
+  }
+
+  public void setSsl(final DatabaseSSLConfiguration ssl) {
+    this.ssl = ssl;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DatabaseSecurity;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(username, password, ssl);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseSecurity that = (DatabaseSecurity) o;
+    return Objects.equals(username, that.username)
+        && Objects.equals(password, that.password)
+        && Objects.equals(ssl, that.ssl);
+  }
+
+  @Override
+  public String toString() {
+    return "DatabaseSecurity(username="
+        + getUsername()
+        + ", password="
+        + getPassword()
+        + ", ssl="
+        + getSsl()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseSettings.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseSettings.java
@@ -7,12 +7,56 @@
  */
 package io.camunda.optimize.service.util.configuration.db;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class DatabaseSettings {
 
   private DatabaseIndex index;
-
   private Integer aggregationBucketLimit;
+
+  public DatabaseSettings() {}
+
+  public DatabaseIndex getIndex() {
+    return index;
+  }
+
+  public void setIndex(final DatabaseIndex index) {
+    this.index = index;
+  }
+
+  public Integer getAggregationBucketLimit() {
+    return aggregationBucketLimit;
+  }
+
+  public void setAggregationBucketLimit(final Integer aggregationBucketLimit) {
+    this.aggregationBucketLimit = aggregationBucketLimit;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DatabaseSettings;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseSettings that = (DatabaseSettings) o;
+    return Objects.equals(index, that.index)
+        && Objects.equals(aggregationBucketLimit, that.aggregationBucketLimit);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(index, aggregationBucketLimit);
+  }
+
+  @Override
+  public String toString() {
+    return "DatabaseSettings(index="
+        + getIndex()
+        + ", aggregationBucketLimit="
+        + getAggregationBucketLimit()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/elasticsearch/DatabaseConnectionNodeConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/elasticsearch/DatabaseConnectionNodeConfiguration.java
@@ -7,11 +7,55 @@
  */
 package io.camunda.optimize.service.util.configuration.elasticsearch;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class DatabaseConnectionNodeConfiguration {
 
   private String host;
   private Integer httpPort;
+
+  public DatabaseConnectionNodeConfiguration() {}
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(final String host) {
+    this.host = host;
+  }
+
+  public Integer getHttpPort() {
+    return httpPort;
+  }
+
+  public void setHttpPort(final Integer httpPort) {
+    this.httpPort = httpPort;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DatabaseConnectionNodeConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DatabaseConnectionNodeConfiguration that = (DatabaseConnectionNodeConfiguration) o;
+    return Objects.equals(host, that.host) && Objects.equals(httpPort, that.httpPort);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(host, httpPort);
+  }
+
+  @Override
+  public String toString() {
+    return "DatabaseConnectionNodeConfiguration(host="
+        + getHost()
+        + ", httpPort="
+        + getHttpPort()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/EventIngestionConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/EventIngestionConfiguration.java
@@ -8,13 +8,60 @@
 package io.camunda.optimize.service.util.configuration.engine;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class EventIngestionConfiguration {
+
   @JsonProperty("maxBatchRequestBytes")
   private long maxBatchRequestBytes;
 
   @JsonProperty("maxRequests")
   private int maxRequests;
+
+  public EventIngestionConfiguration() {}
+
+  public long getMaxBatchRequestBytes() {
+    return maxBatchRequestBytes;
+  }
+
+  @JsonProperty("maxBatchRequestBytes")
+  public void setMaxBatchRequestBytes(final long maxBatchRequestBytes) {
+    this.maxBatchRequestBytes = maxBatchRequestBytes;
+  }
+
+  public int getMaxRequests() {
+    return maxRequests;
+  }
+
+  @JsonProperty("maxRequests")
+  public void setMaxRequests(final int maxRequests) {
+    this.maxRequests = maxRequests;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof EventIngestionConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final EventIngestionConfiguration that = (EventIngestionConfiguration) o;
+    return maxBatchRequestBytes == that.maxBatchRequestBytes && maxRequests == that.maxRequests;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(maxBatchRequestBytes, maxRequests);
+  }
+
+  @Override
+  public String toString() {
+    return "EventIngestionConfiguration(maxBatchRequestBytes="
+        + getMaxBatchRequestBytes()
+        + ", maxRequests="
+        + getMaxRequests()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/IdentityCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/IdentityCacheConfiguration.java
@@ -10,10 +10,9 @@ package io.camunda.optimize.service.util.configuration.engine;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
 import io.camunda.optimize.service.util.CronNormalizerUtil;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.Data;
 
-@Data
 public abstract class IdentityCacheConfiguration {
 
   private boolean includeUserMetaData;
@@ -22,6 +21,8 @@ public abstract class IdentityCacheConfiguration {
   private int maxPageSize;
   private long maxEntryLimit;
 
+  public IdentityCacheConfiguration() {}
+
   public void validate() {
     if (cronTrigger == null || cronTrigger.isEmpty()) {
       throw new OptimizeConfigurationException(
@@ -29,14 +30,89 @@ public abstract class IdentityCacheConfiguration {
     }
   }
 
+  @JsonIgnore
+  public abstract String getConfigName();
+
+  public boolean isIncludeUserMetaData() {
+    return includeUserMetaData;
+  }
+
+  public void setIncludeUserMetaData(final boolean includeUserMetaData) {
+    this.includeUserMetaData = includeUserMetaData;
+  }
+
+  public boolean isCollectionRoleCleanupEnabled() {
+    return collectionRoleCleanupEnabled;
+  }
+
+  public void setCollectionRoleCleanupEnabled(final boolean collectionRoleCleanupEnabled) {
+    this.collectionRoleCleanupEnabled = collectionRoleCleanupEnabled;
+  }
+
+  public String getCronTrigger() {
+    return cronTrigger;
+  }
+
   public final void setCronTrigger(final String cronTrigger) {
     this.cronTrigger =
         Optional.ofNullable(cronTrigger).map(CronNormalizerUtil::normalizeToSixParts).orElse(null);
   }
 
-  @JsonIgnore
-  public abstract String getConfigName();
+  public int getMaxPageSize() {
+    return maxPageSize;
+  }
 
+  public void setMaxPageSize(final int maxPageSize) {
+    this.maxPageSize = maxPageSize;
+  }
+
+  public long getMaxEntryLimit() {
+    return maxEntryLimit;
+  }
+
+  public void setMaxEntryLimit(final long maxEntryLimit) {
+    this.maxEntryLimit = maxEntryLimit;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof IdentityCacheConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IdentityCacheConfiguration that = (IdentityCacheConfiguration) o;
+    return includeUserMetaData == that.includeUserMetaData
+        && collectionRoleCleanupEnabled == that.collectionRoleCleanupEnabled
+        && maxPageSize == that.maxPageSize
+        && maxEntryLimit == that.maxEntryLimit
+        && Objects.equals(cronTrigger, that.cronTrigger);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        includeUserMetaData, collectionRoleCleanupEnabled, cronTrigger, maxPageSize, maxEntryLimit);
+  }
+
+  @Override
+  public String toString() {
+    return "IdentityCacheConfiguration(includeUserMetaData="
+        + isIncludeUserMetaData()
+        + ", collectionRoleCleanupEnabled="
+        + isCollectionRoleCleanupEnabled()
+        + ", cronTrigger="
+        + getCronTrigger()
+        + ", maxPageSize="
+        + getMaxPageSize()
+        + ", maxEntryLimit="
+        + getMaxEntryLimit()
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
   public static final class Fields {
 
     public static final String includeUserMetaData = "includeUserMetaData";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/UserIdentityCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/UserIdentityCacheConfiguration.java
@@ -9,12 +9,38 @@ package io.camunda.optimize.service.util.configuration.engine;
 
 import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.IDENTITY_SYNC_CONFIGURATION;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class UserIdentityCacheConfiguration extends IdentityCacheConfiguration {
+
+  public UserIdentityCacheConfiguration() {}
+
+  @Override
+  public String toString() {
+    return "UserIdentityCacheConfiguration()";
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof UserIdentityCacheConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
+  }
+
   @Override
   public String getConfigName() {
     return IDENTITY_SYNC_CONFIGURATION;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/UserTaskIdentityCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/UserTaskIdentityCacheConfiguration.java
@@ -9,14 +9,40 @@ package io.camunda.optimize.service.util.configuration.engine;
 
 import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.IMPORT_USER_TASK_IDENTITY_META_DATA;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
 public class UserTaskIdentityCacheConfiguration extends IdentityCacheConfiguration {
+
+  public UserTaskIdentityCacheConfiguration() {}
+
   @Override
   public String getConfigName() {
     return IMPORT_USER_TASK_IDENTITY_META_DATA;
+  }
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof UserTaskIdentityCacheConfiguration;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
+  }
+
+  @Override
+  public String toString() {
+    return "UserTaskIdentityCacheConfiguration()";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/AuthConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/AuthConfiguration.java
@@ -11,11 +11,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.util.SuppressionConstants;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.Data;
 
-@Data
 public class AuthConfiguration {
+
   @JsonProperty("cloud")
   private CloudAuthConfiguration cloudAuthConfiguration;
 
@@ -31,6 +31,8 @@ public class AuthConfiguration {
   @JsonProperty("cookie")
   private CookieConfiguration cookieConfiguration;
 
+  public AuthConfiguration() {}
+
   @JsonIgnore
   public int getTokenLifeTimeMinutes() {
     return tokenLifeTime;
@@ -40,10 +42,93 @@ public class AuthConfiguration {
     return Optional.ofNullable(tokenSecret);
   }
 
+  @JsonProperty("token.secret")
+  public void setTokenSecret(final String tokenSecret) {
+    this.tokenSecret = tokenSecret;
+  }
+
   @SuppressWarnings(SuppressionConstants.UNUSED)
   @JsonProperty("token")
   private void unpackToken(final Map<String, String> token) {
     tokenLifeTime = Integer.valueOf(token.get("lifeMin"));
     tokenSecret = token.get("secret");
+  }
+
+  public CloudAuthConfiguration getCloudAuthConfiguration() {
+    return cloudAuthConfiguration;
+  }
+
+  @JsonProperty("cloud")
+  public void setCloudAuthConfiguration(final CloudAuthConfiguration cloudAuthConfiguration) {
+    this.cloudAuthConfiguration = cloudAuthConfiguration;
+  }
+
+  public CCSMAuthConfiguration getCcsmAuthConfiguration() {
+    return ccsmAuthConfiguration;
+  }
+
+  @JsonProperty("ccsm")
+  public void setCcsmAuthConfiguration(final CCSMAuthConfiguration ccsmAuthConfiguration) {
+    this.ccsmAuthConfiguration = ccsmAuthConfiguration;
+  }
+
+  public Integer getTokenLifeTime() {
+    return tokenLifeTime;
+  }
+
+  @JsonProperty("token.lifeMin")
+  public void setTokenLifeTime(final Integer tokenLifeTime) {
+    this.tokenLifeTime = tokenLifeTime;
+  }
+
+  public CookieConfiguration getCookieConfiguration() {
+    return cookieConfiguration;
+  }
+
+  @JsonProperty("cookie")
+  public void setCookieConfiguration(final CookieConfiguration cookieConfiguration) {
+    this.cookieConfiguration = cookieConfiguration;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof AuthConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AuthConfiguration that = (AuthConfiguration) o;
+    return Objects.equals(cloudAuthConfiguration, that.cloudAuthConfiguration)
+        && Objects.equals(ccsmAuthConfiguration, that.ccsmAuthConfiguration)
+        && Objects.equals(tokenLifeTime, that.tokenLifeTime)
+        && Objects.equals(tokenSecret, that.tokenSecret)
+        && Objects.equals(cookieConfiguration, that.cookieConfiguration);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        cloudAuthConfiguration,
+        ccsmAuthConfiguration,
+        tokenLifeTime,
+        tokenSecret,
+        cookieConfiguration);
+  }
+
+  @Override
+  public String toString() {
+    return "AuthConfiguration(cloudAuthConfiguration="
+        + getCloudAuthConfiguration()
+        + ", ccsmAuthConfiguration="
+        + getCcsmAuthConfiguration()
+        + ", tokenLifeTime="
+        + getTokenLifeTime()
+        + ", tokenSecret="
+        + getTokenSecret()
+        + ", cookieConfiguration="
+        + getCookieConfiguration()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/CCSMAuthConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/CCSMAuthConfiguration.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.optimize.service.util.configuration.security;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class CCSMAuthConfiguration {
+
   // the url to Identity
   private String issuerUrl;
   // the url to Identity (back channel for container to container communication)
@@ -24,4 +24,106 @@ public class CCSMAuthConfiguration {
   // Identity audience
   private String audience;
   private String baseUrl;
+
+  public CCSMAuthConfiguration() {}
+
+  public String getIssuerUrl() {
+    return issuerUrl;
+  }
+
+  public void setIssuerUrl(final String issuerUrl) {
+    this.issuerUrl = issuerUrl;
+  }
+
+  public String getIssuerBackendUrl() {
+    return issuerBackendUrl;
+  }
+
+  public void setIssuerBackendUrl(final String issuerBackendUrl) {
+    this.issuerBackendUrl = issuerBackendUrl;
+  }
+
+  public String getRedirectRootUrl() {
+    return redirectRootUrl;
+  }
+
+  public void setRedirectRootUrl(final String redirectRootUrl) {
+    this.redirectRootUrl = redirectRootUrl;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public void setClientId(final String clientId) {
+    this.clientId = clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  public void setClientSecret(final String clientSecret) {
+    this.clientSecret = clientSecret;
+  }
+
+  public String getAudience() {
+    return audience;
+  }
+
+  public void setAudience(final String audience) {
+    this.audience = audience;
+  }
+
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+
+  public void setBaseUrl(final String baseUrl) {
+    this.baseUrl = baseUrl;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CCSMAuthConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CCSMAuthConfiguration that = (CCSMAuthConfiguration) o;
+    return Objects.equals(issuerUrl, that.issuerUrl)
+        && Objects.equals(issuerBackendUrl, that.issuerBackendUrl)
+        && Objects.equals(redirectRootUrl, that.redirectRootUrl)
+        && Objects.equals(clientId, that.clientId)
+        && Objects.equals(clientSecret, that.clientSecret)
+        && Objects.equals(audience, that.audience)
+        && Objects.equals(baseUrl, that.baseUrl);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        issuerUrl, issuerBackendUrl, redirectRootUrl, clientId, clientSecret, audience, baseUrl);
+  }
+
+  @Override
+  public String toString() {
+    return "CCSMAuthConfiguration(issuerUrl="
+        + getIssuerUrl()
+        + ", issuerBackendUrl="
+        + getIssuerBackendUrl()
+        + ", redirectRootUrl="
+        + getRedirectRootUrl()
+        + ", clientId="
+        + getClientId()
+        + ", clientSecret="
+        + getClientSecret()
+        + ", audience="
+        + getAudience()
+        + ", baseUrl="
+        + getBaseUrl()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/CloudAuthConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/CloudAuthConfiguration.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.optimize.service.util.configuration.security;
 
+import java.util.Objects;
 import java.util.Optional;
-import lombok.Data;
 
-@Data
 public class CloudAuthConfiguration {
+
   // oauth client id to use by Optimize
   private String clientId;
   // oauth client secret to use by Optimize
@@ -35,7 +35,159 @@ public class CloudAuthConfiguration {
   // URL to request access tokens
   private String tokenUrl;
 
+  public CloudAuthConfiguration() {}
+
   public Optional<String> getUserAccessTokenAudience() {
     return Optional.ofNullable(userAccessTokenAudience);
+  }
+
+  public void setUserAccessTokenAudience(final String userAccessTokenAudience) {
+    this.userAccessTokenAudience = userAccessTokenAudience;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public void setClientId(final String clientId) {
+    this.clientId = clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  public void setClientSecret(final String clientSecret) {
+    this.clientSecret = clientSecret;
+  }
+
+  public String getDomain() {
+    return domain;
+  }
+
+  public void setDomain(final String domain) {
+    this.domain = domain;
+  }
+
+  public String getCustomDomain() {
+    return customDomain;
+  }
+
+  public void setCustomDomain(final String customDomain) {
+    this.customDomain = customDomain;
+  }
+
+  public String getUserIdAttributeName() {
+    return userIdAttributeName;
+  }
+
+  public void setUserIdAttributeName(final String userIdAttributeName) {
+    this.userIdAttributeName = userIdAttributeName;
+  }
+
+  public String getOrganizationClaimName() {
+    return organizationClaimName;
+  }
+
+  public void setOrganizationClaimName(final String organizationClaimName) {
+    this.organizationClaimName = organizationClaimName;
+  }
+
+  public String getOrganizationId() {
+    return organizationId;
+  }
+
+  public void setOrganizationId(final String organizationId) {
+    this.organizationId = organizationId;
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  public void setClusterId(final String clusterId) {
+    this.clusterId = clusterId;
+  }
+
+  public String getAudience() {
+    return audience;
+  }
+
+  public void setAudience(final String audience) {
+    this.audience = audience;
+  }
+
+  public String getTokenUrl() {
+    return tokenUrl;
+  }
+
+  public void setTokenUrl(final String tokenUrl) {
+    this.tokenUrl = tokenUrl;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CloudAuthConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CloudAuthConfiguration that = (CloudAuthConfiguration) o;
+    return Objects.equals(clientId, that.clientId)
+        && Objects.equals(clientSecret, that.clientSecret)
+        && Objects.equals(domain, that.domain)
+        && Objects.equals(customDomain, that.customDomain)
+        && Objects.equals(userIdAttributeName, that.userIdAttributeName)
+        && Objects.equals(organizationClaimName, that.organizationClaimName)
+        && Objects.equals(organizationId, that.organizationId)
+        && Objects.equals(clusterId, that.clusterId)
+        && Objects.equals(audience, that.audience)
+        && Objects.equals(userAccessTokenAudience, that.userAccessTokenAudience)
+        && Objects.equals(tokenUrl, that.tokenUrl);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        clientId,
+        clientSecret,
+        domain,
+        customDomain,
+        userIdAttributeName,
+        organizationClaimName,
+        organizationId,
+        clusterId,
+        audience,
+        userAccessTokenAudience,
+        tokenUrl);
+  }
+
+  @Override
+  public String toString() {
+    return "CloudAuthConfiguration(clientId="
+        + getClientId()
+        + ", clientSecret="
+        + getClientSecret()
+        + ", domain="
+        + getDomain()
+        + ", customDomain="
+        + getCustomDomain()
+        + ", userIdAttributeName="
+        + getUserIdAttributeName()
+        + ", organizationClaimName="
+        + getOrganizationClaimName()
+        + ", organizationId="
+        + getOrganizationId()
+        + ", clusterId="
+        + getClusterId()
+        + ", audience="
+        + getAudience()
+        + ", userAccessTokenAudience="
+        + getUserAccessTokenAudience()
+        + ", tokenUrl="
+        + getTokenUrl()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/CookieConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/CookieConfiguration.java
@@ -13,10 +13,9 @@ import io.camunda.optimize.rest.constants.RestConstants;
 import io.camunda.optimize.util.SuppressionConstants;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
-import lombok.Data;
 
-@Data
 public class CookieConfiguration {
 
   @JsonProperty("same-site.enabled")
@@ -28,8 +27,10 @@ public class CookieConfiguration {
   @JsonProperty("maxSize")
   private Integer maxSize;
 
+  public CookieConfiguration() {}
+
   public boolean resolveSecureFlagValue(final String requestScheme) {
-    return Optional.ofNullable(this.cookieSecureMode)
+    return Optional.ofNullable(cookieSecureMode)
         .map(mode -> mode.resolveSecureValue(requestScheme))
         .orElse(false);
   }
@@ -37,24 +38,81 @@ public class CookieConfiguration {
   @SuppressWarnings(SuppressionConstants.UNUSED)
   @JsonProperty("same-site")
   private void unpackSameSite(final Map<String, Boolean> sameSite) {
-    this.sameSiteFlagEnabled = sameSite.get("enabled");
+    sameSiteFlagEnabled = sameSite.get("enabled");
+  }
+
+  public boolean isSameSiteFlagEnabled() {
+    return sameSiteFlagEnabled;
+  }
+
+  @JsonProperty("same-site.enabled")
+  public void setSameSiteFlagEnabled(final boolean sameSiteFlagEnabled) {
+    this.sameSiteFlagEnabled = sameSiteFlagEnabled;
+  }
+
+  public CookieSecureMode getCookieSecureMode() {
+    return cookieSecureMode;
+  }
+
+  @JsonProperty("secure")
+  public void setCookieSecureMode(final CookieSecureMode cookieSecureMode) {
+    this.cookieSecureMode = cookieSecureMode;
+  }
+
+  public Integer getMaxSize() {
+    return maxSize;
+  }
+
+  @JsonProperty("maxSize")
+  public void setMaxSize(final Integer maxSize) {
+    this.maxSize = maxSize;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CookieConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CookieConfiguration that = (CookieConfiguration) o;
+    return sameSiteFlagEnabled == that.sameSiteFlagEnabled
+        && cookieSecureMode == that.cookieSecureMode
+        && Objects.equals(maxSize, that.maxSize);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sameSiteFlagEnabled, cookieSecureMode, maxSize);
+  }
+
+  @Override
+  public String toString() {
+    return "CookieConfiguration(sameSiteFlagEnabled="
+        + isSameSiteFlagEnabled()
+        + ", cookieSecureMode="
+        + getCookieSecureMode()
+        + ", maxSize="
+        + getMaxSize()
+        + ")";
   }
 
   public enum CookieSecureMode {
     AUTO,
     TRUE,
-    FALSE,
-    ;
+    FALSE;
 
     public boolean resolveSecureValue(final String requestScheme) {
       switch (this) {
-        default:
-        case AUTO:
-          return RestConstants.HTTPS_SCHEME.equalsIgnoreCase(requestScheme);
         case TRUE:
           return true;
         case FALSE:
           return false;
+        case AUTO:
+        default:
+          return RestConstants.HTTPS_SCHEME.equalsIgnoreCase(requestScheme);
       }
     }
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/LicenseConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/LicenseConfiguration.java
@@ -8,10 +8,44 @@
 package io.camunda.optimize.service.util.configuration.security;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class LicenseConfiguration {
+
   @JsonProperty("enterprise")
   private boolean enterprise;
+
+  public LicenseConfiguration() {}
+
+  public boolean isEnterprise() {
+    return enterprise;
+  }
+
+  @JsonProperty("enterprise")
+  public void setEnterprise(final boolean enterprise) {
+    this.enterprise = enterprise;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof LicenseConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final LicenseConfiguration that = (LicenseConfiguration) o;
+    return enterprise == that.enterprise;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(enterprise);
+  }
+
+  @Override
+  public String toString() {
+    return "LicenseConfiguration(enterprise=" + isEnterprise() + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/ResponseHeadersConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/ResponseHeadersConfiguration.java
@@ -8,31 +8,171 @@
 package io.camunda.optimize.service.util.configuration.security;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.net.HttpHeaders;
 import io.camunda.optimize.util.SuppressionConstants;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class ResponseHeadersConfiguration {
+
+  private static final String HEADER_DELIMITER = "; ";
+
   @JsonProperty("HSTS.max-age")
   private Long httpStrictTransportSecurityMaxAge;
 
   @JsonProperty("HSTS.includeSubDomains")
   private Boolean httpStrictTransportSecurityIncludeSubdomains;
 
-  @JsonProperty("X-XSS-Protection")
+  @JsonProperty(HttpHeaders.X_XSS_PROTECTION)
   private String xsssProtection;
 
-  @JsonProperty("X-Content-Type-Options")
+  @JsonProperty(HttpHeaders.X_CONTENT_TYPE_OPTIONS)
   private Boolean xContentTypeOptions;
 
-  @JsonProperty("Content-Security-Policy")
+  @JsonProperty(HttpHeaders.CONTENT_SECURITY_POLICY)
   private String contentSecurityPolicy;
+
+  public ResponseHeadersConfiguration() {}
 
   @SuppressWarnings(SuppressionConstants.UNUSED)
   @JsonProperty("HSTS")
   private void unpackHsts(final Map<String, Object> hsts) {
-    this.httpStrictTransportSecurityMaxAge = Long.valueOf((String) hsts.get("max-age"));
-    this.httpStrictTransportSecurityIncludeSubdomains = (Boolean) hsts.get("includeSubDomains");
+    httpStrictTransportSecurityMaxAge = Long.valueOf((String) hsts.get("max-age"));
+    httpStrictTransportSecurityIncludeSubdomains = (Boolean) hsts.get("includeSubDomains");
+  }
+
+  public Long getHttpStrictTransportSecurityMaxAge() {
+    return httpStrictTransportSecurityMaxAge;
+  }
+
+  @JsonProperty("HSTS.max-age")
+  public void setHttpStrictTransportSecurityMaxAge(final Long httpStrictTransportSecurityMaxAge) {
+    this.httpStrictTransportSecurityMaxAge = httpStrictTransportSecurityMaxAge;
+  }
+
+  public boolean getHttpStrictTransportSecurityIncludeSubdomains() {
+    if (httpStrictTransportSecurityIncludeSubdomains == null) {
+      return false;
+    }
+
+    return httpStrictTransportSecurityIncludeSubdomains;
+  }
+
+  @JsonProperty("HSTS.includeSubDomains")
+  public void setHttpStrictTransportSecurityIncludeSubdomains(
+      final Boolean httpStrictTransportSecurityIncludeSubdomains) {
+    this.httpStrictTransportSecurityIncludeSubdomains =
+        httpStrictTransportSecurityIncludeSubdomains;
+  }
+
+  public String getXsssProtection() {
+    return xsssProtection;
+  }
+
+  @JsonProperty(HttpHeaders.X_XSS_PROTECTION)
+  public void setXsssProtection(final String xsssProtection) {
+    this.xsssProtection = xsssProtection;
+  }
+
+  public boolean getXContentTypeOptions() {
+    if (xContentTypeOptions == null) {
+      return false;
+    }
+
+    return xContentTypeOptions;
+  }
+
+  @JsonProperty(HttpHeaders.X_CONTENT_TYPE_OPTIONS)
+  public void setXContentTypeOptions(final Boolean xContentTypeOptions) {
+    this.xContentTypeOptions = xContentTypeOptions;
+  }
+
+  public String getContentSecurityPolicy() {
+    return contentSecurityPolicy;
+  }
+
+  @JsonProperty(HttpHeaders.CONTENT_SECURITY_POLICY)
+  public void setContentSecurityPolicy(final String contentSecurityPolicy) {
+    this.contentSecurityPolicy = contentSecurityPolicy;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof ResponseHeadersConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ResponseHeadersConfiguration that = (ResponseHeadersConfiguration) o;
+    return Objects.equals(httpStrictTransportSecurityMaxAge, that.httpStrictTransportSecurityMaxAge)
+        && Objects.equals(
+            httpStrictTransportSecurityIncludeSubdomains,
+            that.httpStrictTransportSecurityIncludeSubdomains)
+        && Objects.equals(xsssProtection, that.xsssProtection)
+        && Objects.equals(xContentTypeOptions, that.xContentTypeOptions)
+        && Objects.equals(contentSecurityPolicy, that.contentSecurityPolicy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        httpStrictTransportSecurityMaxAge,
+        httpStrictTransportSecurityIncludeSubdomains,
+        xsssProtection,
+        xContentTypeOptions,
+        contentSecurityPolicy);
+  }
+
+  @Override
+  public String toString() {
+    return "ResponseHeadersConfiguration(httpStrictTransportSecurityMaxAge="
+        + getHttpStrictTransportSecurityMaxAge()
+        + ", httpStrictTransportSecurityIncludeSubdomains="
+        + getHttpStrictTransportSecurityIncludeSubdomains()
+        + ", xsssProtection="
+        + getXsssProtection()
+        + ", xContentTypeOptions="
+        + getXContentTypeOptions()
+        + ", contentSecurityPolicy="
+        + getContentSecurityPolicy()
+        + ")";
+  }
+
+  public Map<String, String> getHeadersWithValues() {
+    final Map<String, String> headers = new HashMap<>();
+
+    final List<String> strictTransportSecurityHeaderValues = new ArrayList<>();
+    if (getHttpStrictTransportSecurityMaxAge() != null) {
+      strictTransportSecurityHeaderValues.add("max-age=" + getHttpStrictTransportSecurityMaxAge());
+    }
+
+    if (getHttpStrictTransportSecurityIncludeSubdomains()) {
+      strictTransportSecurityHeaderValues.add("includeSubDomains");
+    }
+
+    if (!strictTransportSecurityHeaderValues.isEmpty()) {
+      headers.put(
+          "Strict-Transport-Security",
+          String.join(HEADER_DELIMITER, strictTransportSecurityHeaderValues));
+    }
+
+    if (getXsssProtection() != null && getXsssProtection().length() > 0) {
+      headers.put(HttpHeaders.X_XSS_PROTECTION, getXsssProtection());
+    }
+
+    if (getXContentTypeOptions()) {
+      headers.put(HttpHeaders.X_CONTENT_TYPE_OPTIONS, "nosniff");
+    }
+
+    if (getContentSecurityPolicy() != null && getContentSecurityPolicy().length() > 0) {
+      headers.put(HttpHeaders.CONTENT_SECURITY_POLICY, getContentSecurityPolicy());
+    }
+
+    return headers;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/SecurityConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/security/SecurityConfiguration.java
@@ -7,12 +7,68 @@
  */
 package io.camunda.optimize.service.util.configuration.security;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class SecurityConfiguration {
 
   private AuthConfiguration auth;
   private LicenseConfiguration license;
   private ResponseHeadersConfiguration responseHeaders;
+
+  public SecurityConfiguration() {}
+
+  public AuthConfiguration getAuth() {
+    return auth;
+  }
+
+  public void setAuth(final AuthConfiguration auth) {
+    this.auth = auth;
+  }
+
+  public LicenseConfiguration getLicense() {
+    return license;
+  }
+
+  public void setLicense(final LicenseConfiguration license) {
+    this.license = license;
+  }
+
+  public ResponseHeadersConfiguration getResponseHeaders() {
+    return responseHeaders;
+  }
+
+  public void setResponseHeaders(final ResponseHeadersConfiguration responseHeaders) {
+    this.responseHeaders = responseHeaders;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof SecurityConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SecurityConfiguration that = (SecurityConfiguration) o;
+    return Objects.equals(auth, that.auth)
+        && Objects.equals(license, that.license)
+        && Objects.equals(responseHeaders, that.responseHeaders);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(auth, license, responseHeaders);
+  }
+
+  @Override
+  public String toString() {
+    return "SecurityConfiguration(auth="
+        + getAuth()
+        + ", license="
+        + getLicense()
+        + ", responseHeaders="
+        + getResponseHeaders()
+        + ")";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ui/UIConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ui/UIConfiguration.java
@@ -8,9 +8,8 @@
 package io.camunda.optimize.service.util.configuration.ui;
 
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class UIConfiguration {
 
   private static final int DATA_SOURCES_LIMIT_FOR_REPORT_MINIMUM_VAL = 1;
@@ -22,6 +21,8 @@ public class UIConfiguration {
   private boolean userTaskAssigneeAnalyticsEnabled;
   private String consoleUrl;
   private String modelerUrl;
+
+  public UIConfiguration() {}
 
   public void validate() {
     if (maxNumDataSourcesForReport < DATA_SOURCES_LIMIT_FOR_REPORT_MINIMUM_VAL) {
@@ -38,5 +39,99 @@ public class UIConfiguration {
               + " number of max data sources for report. The configured limit is "
               + maxNumDataSourcesForReport);
     }
+  }
+
+  public boolean isLogoutHidden() {
+    return logoutHidden;
+  }
+
+  public void setLogoutHidden(final boolean logoutHidden) {
+    this.logoutHidden = logoutHidden;
+  }
+
+  public String getMixpanelToken() {
+    return mixpanelToken;
+  }
+
+  public void setMixpanelToken(final String mixpanelToken) {
+    this.mixpanelToken = mixpanelToken;
+  }
+
+  public int getMaxNumDataSourcesForReport() {
+    return maxNumDataSourcesForReport;
+  }
+
+  public void setMaxNumDataSourcesForReport(final int maxNumDataSourcesForReport) {
+    this.maxNumDataSourcesForReport = maxNumDataSourcesForReport;
+  }
+
+  public boolean isUserTaskAssigneeAnalyticsEnabled() {
+    return userTaskAssigneeAnalyticsEnabled;
+  }
+
+  public void setUserTaskAssigneeAnalyticsEnabled(final boolean userTaskAssigneeAnalyticsEnabled) {
+    this.userTaskAssigneeAnalyticsEnabled = userTaskAssigneeAnalyticsEnabled;
+  }
+
+  public String getConsoleUrl() {
+    return consoleUrl;
+  }
+
+  public void setConsoleUrl(final String consoleUrl) {
+    this.consoleUrl = consoleUrl;
+  }
+
+  public String getModelerUrl() {
+    return modelerUrl;
+  }
+
+  public void setModelerUrl(final String modelerUrl) {
+    this.modelerUrl = modelerUrl;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof UIConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UIConfiguration that = (UIConfiguration) o;
+    return logoutHidden == that.logoutHidden
+        && maxNumDataSourcesForReport == that.maxNumDataSourcesForReport
+        && userTaskAssigneeAnalyticsEnabled == that.userTaskAssigneeAnalyticsEnabled
+        && Objects.equals(mixpanelToken, that.mixpanelToken)
+        && Objects.equals(consoleUrl, that.consoleUrl)
+        && Objects.equals(modelerUrl, that.modelerUrl);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        logoutHidden,
+        mixpanelToken,
+        maxNumDataSourcesForReport,
+        userTaskAssigneeAnalyticsEnabled,
+        consoleUrl,
+        modelerUrl);
+  }
+
+  @Override
+  public String toString() {
+    return "UIConfiguration(logoutHidden="
+        + isLogoutHidden()
+        + ", mixpanelToken="
+        + getMixpanelToken()
+        + ", maxNumDataSourcesForReport="
+        + getMaxNumDataSourcesForReport()
+        + ", userTaskAssigneeAnalyticsEnabled="
+        + isUserTaskAssigneeAnalyticsEnabled()
+        + ", consoleUrl="
+        + getConsoleUrl()
+        + ", modelerUrl="
+        + getModelerUrl()
+        + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/users/CloudUsersConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/users/CloudUsersConfiguration.java
@@ -8,17 +8,49 @@
 package io.camunda.optimize.service.util.configuration.users;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudUsersConfiguration {
 
   private String accountsUrl;
 
+  public CloudUsersConfiguration() {}
+
   // Only here for backwards compatibility as the param got renamed to accountsUrl
   @Deprecated
   public void setUsersUrl(final String usersUrl) {
-    this.accountsUrl = usersUrl;
+    accountsUrl = usersUrl;
+  }
+
+  public String getAccountsUrl() {
+    return accountsUrl;
+  }
+
+  public void setAccountsUrl(final String accountsUrl) {
+    this.accountsUrl = accountsUrl;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof CloudUsersConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final CloudUsersConfiguration that = (CloudUsersConfiguration) o;
+    return Objects.equals(accountsUrl, that.accountsUrl);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(accountsUrl);
+  }
+
+  @Override
+  public String toString() {
+    return "CloudUsersConfiguration(accountsUrl=" + getAccountsUrl() + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/users/UsersConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/users/UsersConfiguration.java
@@ -7,9 +7,42 @@
  */
 package io.camunda.optimize.service.util.configuration.users;
 
-import lombok.Data;
+import java.util.Objects;
 
-@Data
 public class UsersConfiguration {
+
   private CloudUsersConfiguration cloud;
+
+  public UsersConfiguration() {}
+
+  public CloudUsersConfiguration getCloud() {
+    return cloud;
+  }
+
+  public void setCloud(final CloudUsersConfiguration cloud) {
+    this.cloud = cloud;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof UsersConfiguration;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UsersConfiguration that = (UsersConfiguration) o;
+    return Objects.equals(cloud, that.cloud);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(cloud);
+  }
+
+  @Override
+  public String toString() {
+    return "UsersConfiguration(cloud=" + getCloud() + ")";
+  }
 }


### PR DESCRIPTION
# Description
Backport of #38950 to `stable/optimize-8.6`.

relates to #38860