### PR TITLE
feat: use openapi spec from packaged resources

### DIFF
--- a/clients/java-deprecated/pom.xml
+++ b/clients/java-deprecated/pom.xml
@@ -25,7 +25,8 @@
   <properties>
     <version.java>8</version.java>
     <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
-    <openapi.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto</openapi.dir>
+    <!-- Replaced direct source reference with artifact-based copy to preserve module encapsulation -->
+    <openapi.spec.file>${project.build.directory}/openapi-spec/rest-api.yaml</openapi.spec.file>
   </properties>
 
   <dependencies>
@@ -67,6 +68,12 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-gateway-protocol-impl</artifactId>
+    </dependency>
+
+    <!-- Add direct dependency on protocol jar to allow unpacking the OpenAPI spec -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway-protocol</artifactId>
     </dependency>
 
     <dependency>
@@ -286,6 +293,26 @@
             <ignoredDependency>javax.annotation:javax.annotation-api</ignoredDependency>
           </ignoredDependencies>
         </configuration>
+        <executions>
+          <execution>
+            <id>copy-rest-openapi</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.camunda</groupId>
+                  <artifactId>zeebe-gateway-protocol</artifactId>
+                  <version>${project.version}</version>
+                  <outputDirectory>${project.build.directory}/openapi-spec</outputDirectory>
+                  <includes>rest-api.yaml</includes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -296,38 +323,39 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <configuration>
-          <!-- https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin -->
-          <!-- https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md -->
-          <generatorName>java</generatorName>
-          <inputSpec>${openapi.dir}/rest-api.yaml</inputSpec>
-          <modelPackage>io.camunda.zeebe.client.protocol.rest</modelPackage>
-          <typeMappings>OffsetDateTime=String</typeMappings>
-          <generateApis>false</generateApis>
-          <generateApiTests>false</generateApiTests>
-          <generateSupportingFiles>false</generateSupportingFiles>
-          <generateModels>true</generateModels>
-          <generateModelDocumentation>false</generateModelDocumentation>
-          <generateModelTests>false</generateModelTests>
-          <!-- validate the spec on every generation -->
-          <skipValidateSpec>false</skipValidateSpec>
-          <configOptions>
-            <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
-            <documentationProvider>none</documentationProvider>
-            <enumUnknownDefaultCase>true</enumUnknownDefaultCase>
-            <library>apache-httpclient</library>
-            <java8>true</java8>
-            <openApiNullable>false</openApiNullable>
-            <serializationLibrary>jackson</serializationLibrary>
-            <useReflectionEqualsHashCode>false</useReflectionEqualsHashCode>
-          </configOptions>
-        </configuration>
         <executions>
           <execution>
             <id>rest</id>
             <goals>
               <goal>generate</goal>
             </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <!-- https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin -->
+              <!-- https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md -->
+              <generatorName>java</generatorName>
+              <inputSpec>${openapi.spec.file}</inputSpec>
+              <modelPackage>io.camunda.zeebe.client.protocol.rest</modelPackage>
+              <typeMappings>OffsetDateTime=String</typeMappings>
+              <generateApis>false</generateApis>
+              <generateApiTests>false</generateApiTests>
+              <generateSupportingFiles>false</generateSupportingFiles>
+              <generateModels>true</generateModels>
+              <generateModelDocumentation>false</generateModelDocumentation>
+              <generateModelTests>false</generateModelTests>
+              <!-- validate the spec on every generation -->
+              <skipValidateSpec>false</skipValidateSpec>
+              <configOptions>
+                <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
+                <documentationProvider>none</documentationProvider>
+                <enumUnknownDefaultCase>true</enumUnknownDefaultCase>
+                <library>apache-httpclient</library>
+                <java8>true</java8>
+                <openApiNullable>false</openApiNullable>
+                <serializationLibrary>jackson</serializationLibrary>
+                <useReflectionEqualsHashCode>false</useReflectionEqualsHashCode>
+              </configOptions>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -25,7 +25,8 @@
   <properties>
     <version.java>8</version.java>
     <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
-    <openapi.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto</openapi.dir>
+    <!-- Replaced direct source reference with artifact-based copy to preserve module encapsulation -->
+    <openapi.spec.file>${project.build.directory}/openapi-spec/rest-api.yaml</openapi.spec.file>
   </properties>
 
   <dependencies>
@@ -62,6 +63,12 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-gateway-protocol-impl</artifactId>
+    </dependency>
+
+    <!-- Add direct dependency on protocol jar to allow unpacking the OpenAPI spec -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway-protocol</artifactId>
     </dependency>
 
     <dependency>
@@ -311,6 +318,26 @@
             <ignoredDependency>javax.annotation:javax.annotation-api</ignoredDependency>
           </ignoredDependencies>
         </configuration>
+        <executions>
+          <execution>
+            <id>copy-rest-openapi</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.camunda</groupId>
+                  <artifactId>zeebe-gateway-protocol</artifactId>
+                  <version>${project.version}</version>
+                  <outputDirectory>${project.build.directory}/openapi-spec</outputDirectory>
+                  <includes>rest-api.yaml</includes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -321,38 +348,38 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <configuration>
-          <!-- https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin -->
-          <!-- https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md -->
-          <generatorName>java</generatorName>
-          <inputSpec>${openapi.dir}/rest-api.yaml</inputSpec>
-          <modelPackage>io.camunda.client.protocol.rest</modelPackage>
-          <typeMappings>OffsetDateTime=String</typeMappings>
-          <generateApis>false</generateApis>
-          <generateApiTests>false</generateApiTests>
-          <generateSupportingFiles>false</generateSupportingFiles>
-          <generateModels>true</generateModels>
-          <generateModelDocumentation>false</generateModelDocumentation>
-          <generateModelTests>false</generateModelTests>
-          <!-- validate the spec on every generation -->
-          <skipValidateSpec>false</skipValidateSpec>
-          <configOptions>
-            <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
-            <documentationProvider>none</documentationProvider>
-            <enumUnknownDefaultCase>true</enumUnknownDefaultCase>
-            <library>apache-httpclient</library>
-            <java8>true</java8>
-            <openApiNullable>false</openApiNullable>
-            <serializationLibrary>jackson</serializationLibrary>
-            <useReflectionEqualsHashCode>false</useReflectionEqualsHashCode>
-          </configOptions>
-        </configuration>
         <executions>
           <execution>
             <id>rest</id>
             <goals>
               <goal>generate</goal>
             </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <!-- https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin -->
+              <!-- https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md -->
+              <generatorName>java</generatorName>
+              <inputSpec>${openapi.spec.file}</inputSpec>
+              <modelPackage>io.camunda.client.protocol.rest</modelPackage>
+              <typeMappings>OffsetDateTime=String</typeMappings>
+              <generateApis>false</generateApis>
+              <generateApiTests>false</generateApiTests>
+              <generateSupportingFiles>false</generateSupportingFiles>
+              <generateModels>true</generateModels>
+              <generateModelDocumentation>false</generateModelDocumentation>
+              <generateModelTests>false</generateModelTests>
+              <skipValidateSpec>false</skipValidateSpec>
+              <configOptions>
+                <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
+                <documentationProvider>none</documentationProvider>
+                <enumUnknownDefaultCase>true</enumUnknownDefaultCase>
+                <library>apache-httpclient</library>
+                <java8>true</java8>
+                <openApiNullable>false</openApiNullable>
+                <serializationLibrary>jackson</serializationLibrary>
+                <useReflectionEqualsHashCode>false</useReflectionEqualsHashCode>
+              </configOptions>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -20,7 +20,9 @@
   <name>Zeebe Gateway REST API server</name>
 
   <properties>
-    <openapi.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto</openapi.dir>
+    <!-- Previously this module referenced another module's source directory (../../zeebe/gateway-protocol/src/main/proto).
+         That breaks module encapsulation and IDE incremental builds. We now copy the spec from the built dependency jar. -->
+    <openapi.spec.file>${project.build.directory}/openapi-spec/rest-api.yaml</openapi.spec.file>
   </properties>
 
   <dependencies>
@@ -435,6 +437,40 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <!-- dependencies only packaged but not explicitly used -->
+          <usedDependencies>
+            <!-- Needed to run tests -->
+            <dependency>org.springframework.boot:spring-boot-starter-web</dependency>
+            <dependency>org.xmlunit:xmlunit-core</dependency>
+            <!-- Used for OpenAPI generation -->
+            <dependency>jakarta.annotation:jakarta.annotation-api</dependency>
+          </usedDependencies>
+        </configuration>
+        <executions>
+          <execution>
+            <id>copy-rest-openapi</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.camunda</groupId>
+                  <artifactId>zeebe-gateway-protocol</artifactId>
+                  <version>${project.version}</version>
+                  <outputDirectory>${project.build.directory}/openapi-spec</outputDirectory>
+                  <includes>rest-api.yaml</includes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
         <executions>
@@ -443,11 +479,12 @@
             <goals>
               <goal>generate</goal>
             </goals>
+            <phase>generate-sources</phase>
             <configuration>
               <!-- https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin -->
               <!-- https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md -->
               <generatorName>spring</generatorName>
-              <inputSpec>${openapi.dir}/rest-api.yaml</inputSpec>
+              <inputSpec>${openapi.spec.file}</inputSpec>
               <modelPackage>io.camunda.zeebe.gateway.protocol.rest</modelPackage>
               <typeMappings>OffsetDateTime=String,Permission=io.camunda.identity.automation.permissions.PermissionEnum</typeMappings>
               <generateApis>false</generateApis>
@@ -469,20 +506,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <!-- dependencies only packaged but not explicitly used -->
-          <usedDependencies>
-            <!-- Needed to run tests -->
-            <dependency>org.springframework.boot:spring-boot-starter-web</dependency>
-            <dependency>org.xmlunit:xmlunit-core</dependency>
-            <!-- Used for OpenAPI generation -->
-            <dependency>jakarta.annotation:jakarta.annotation-api</dependency>
-          </usedDependencies>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION

## Description
The openapi spec is unpacked from the packaged jar's resources instead of being directly referenced on the filesystem.
The previous approach broke module boundaries, by having some modules referencing the openapi spec file from outside of its module.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

