### PR TITLE
fix: refer to username instead of email for roles and rba

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/AuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/AuthorizationMigrationHandler.java
@@ -68,7 +68,7 @@ public class AuthorizationMigrationHandler extends MigrationHandler<Authorizatio
                 authorization -> {
                   final var request =
                       new CreateAuthorizationRequest(
-                          user.getEmail(),
+                          user.getUsername(),
                           AuthorizationOwnerType.USER,
                           authorization.resourceKey(),
                           convertResourceType(authorization.resourceType()),
@@ -80,7 +80,7 @@ public class AuthorizationMigrationHandler extends MigrationHandler<Authorizatio
                         "Failed to create authorization for entity with ID: "
                             + authorization.entityId()
                             + " and owner with ID: "
-                            + user.getEmail());
+                            + user.getUsername());
                     createdAuthorizationsCount.incrementAndGet();
                     logger.debug(
                         "Migrated authorization: {} to an Authorization with ownerId: {}",
@@ -92,14 +92,14 @@ public class AuthorizationMigrationHandler extends MigrationHandler<Authorizatio
                           "Failed to migrate authorization for entity with ID: "
                               + authorization.entityId()
                               + " and owner with ID: "
-                              + user.getEmail(),
+                              + user.getUsername(),
                           e);
                     }
                     skippedAuthorizationsCount.incrementAndGet();
                     logger.debug(
                         "Authorization already exists for entity with ID: {} and owner with ID {}. Skipping creation.",
                         authorization.entityId(),
-                        user.getEmail());
+                        user.getUsername());
                   }
                 });
           });

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/UserRoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/UserRoleMigrationHandler.java
@@ -48,7 +48,7 @@ public class UserRoleMigrationHandler extends MigrationHandler<User> {
   protected void process(final List<User> batch) {
     batch.forEach(
         user -> {
-          final var userId = user.getEmail();
+          final var userId = user.getUsername();
           final var userRoles = managementIdentityClient.fetchUserRoles(user.getId());
           totalRoleCount.addAndGet(userRoles.size());
 

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/AuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/AuthorizationMigrationHandlerTest.java
@@ -124,7 +124,7 @@ final class AuthorizationMigrationHandlerTest {
             .sorted(Comparator.comparing(CreateAuthorizationRequest::ownerId))
             .toList();
     assertThat(requests, Matchers.hasSize(4));
-    assertThat(requests.getFirst().ownerId(), Matchers.is("email1"));
+    assertThat(requests.getFirst().ownerId(), Matchers.is("username1"));
     assertThat(requests.getFirst().ownerType(), Matchers.is(AuthorizationOwnerType.USER));
     assertThat(requests.getFirst().resourceId(), Matchers.is("process"));
     assertThat(
@@ -137,7 +137,7 @@ final class AuthorizationMigrationHandlerTest {
             PermissionType.READ_PROCESS_INSTANCE,
             PermissionType.UPDATE_PROCESS_INSTANCE,
             PermissionType.CREATE_PROCESS_INSTANCE));
-    assertThat(requests.get(1).ownerId(), Matchers.is("email1"));
+    assertThat(requests.get(1).ownerId(), Matchers.is("username1"));
     assertThat(requests.get(1).ownerType(), Matchers.is(AuthorizationOwnerType.USER));
     assertThat(requests.get(1).resourceId(), Matchers.is("*"));
     assertThat(
@@ -148,12 +148,12 @@ final class AuthorizationMigrationHandlerTest {
             PermissionType.READ_DECISION_DEFINITION,
             PermissionType.READ_DECISION_INSTANCE,
             PermissionType.DELETE_DECISION_INSTANCE));
-    assertThat(requests.get(2).ownerId(), Matchers.is("email2"));
+    assertThat(requests.get(2).ownerId(), Matchers.is("username2"));
     assertThat(requests.get(2).ownerType(), Matchers.is(AuthorizationOwnerType.USER));
     assertThat(requests.get(2).resourceId(), Matchers.is("process"));
     assertThat(requests.get(2).resourceType(), Matchers.is(AuthorizationResourceType.UNSPECIFIED));
     assertThat(requests.get(2).permissionTypes(), Matchers.empty());
-    assertThat(requests.get(3).ownerId(), Matchers.is("email2"));
+    assertThat(requests.get(3).ownerId(), Matchers.is("username2"));
     assertThat(requests.get(3).ownerType(), Matchers.is(AuthorizationOwnerType.USER));
     assertThat(requests.get(3).resourceId(), Matchers.is("*"));
     assertThat(

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/UserRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/UserRoleMigrationHandlerTest.java
@@ -91,10 +91,10 @@ public class UserRoleMigrationHandlerTest {
     assertThat(requests)
         .extracting(RoleMemberRequest::roleId, RoleMemberRequest::entityId)
         .containsExactlyInAnyOrder(
-            tuple("role_1", "user1@email.com"),
-            tuple("role@name_with_special_chars", "user1@email.com"),
-            tuple("role_2", "user2@email.com"),
-            tuple("role_3", "user2@email.com"));
+            tuple("role_1", "username1"),
+            tuple("role@name_with_special_chars", "username1"),
+            tuple("role_2", "username2"),
+            tuple("role_3", "username2"));
   }
 
   @Test

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -322,19 +322,13 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
     final var zeebeUsers = client.newUsersByRoleSearchRequest("zeebe").send().join().items();
     assertThat(zeebeUsers)
         .extracting(RoleUser::getUsername)
-        .containsExactlyInAnyOrder("user0@email.com", "user1@email.com");
+        .containsExactlyInAnyOrder("user0", "user1");
     final var operateUsers = client.newUsersByRoleSearchRequest("operate").send().join().items();
-    assertThat(operateUsers)
-        .extracting(RoleUser::getUsername)
-        .containsExactlyInAnyOrder("user0@email.com");
+    assertThat(operateUsers).extracting(RoleUser::getUsername).containsExactlyInAnyOrder("user0");
     final var tasklistUsers = client.newUsersByRoleSearchRequest("tasklist").send().join().items();
-    assertThat(tasklistUsers)
-        .extracting(RoleUser::getUsername)
-        .containsExactlyInAnyOrder("user0@email.com");
+    assertThat(tasklistUsers).extracting(RoleUser::getUsername).containsExactlyInAnyOrder("user0");
     final var identityUsers = client.newUsersByRoleSearchRequest("identity").send().join().items();
-    assertThat(identityUsers)
-        .extracting(RoleUser::getUsername)
-        .containsExactlyInAnyOrder("user0@email.com");
+    assertThat(identityUsers).extracting(RoleUser::getUsername).containsExactlyInAnyOrder("user0");
   }
 
   @Test
@@ -350,7 +344,7 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
               final var authorizations = client.newAuthorizationSearchRequest().send().join();
               assertThat(authorizations.items())
                   .extracting(Authorization::getOwnerId)
-                  .contains("user0@email.com", "user1@email.com");
+                  .contains("user0", "user1");
             });
 
     final var authorizations = client.newAuthorizationSearchRequest().send().join();
@@ -363,7 +357,7 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
             a -> new HashSet<>(a.getPermissionTypes()))
         .contains(
             tuple(
-                "user0@email.com",
+                "user0",
                 OwnerType.USER,
                 "*",
                 ResourceType.PROCESS_DEFINITION,
@@ -372,7 +366,7 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
                     PermissionType.READ_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE)),
             tuple(
-                "user1@email.com",
+                "user1",
                 OwnerType.USER,
                 "*",
                 ResourceType.DECISION_DEFINITION,


### PR DESCRIPTION
## Description

In SM we actually use the username as FK for assignments, like done for tenants as well.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39088
