### PR TITLE
feat: allow tenant id control in deployment annotation

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/Deployment.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/Deployment.java
@@ -22,6 +22,7 @@ import java.lang.annotation.*;
 @Documented
 @Inherited // has to be inherited to work on spring aop beans
 public @interface Deployment {
-
   String[] resources() default {};
+
+  String tenantId() default "";
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/value/DeploymentValue.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/value/DeploymentValue.java
@@ -15,72 +15,42 @@
  */
 package io.camunda.client.annotation.value;
 
-import io.camunda.client.bean.BeanInfo;
 import java.util.List;
 import java.util.Objects;
 
 public final class DeploymentValue {
   private final List<String> resources;
-  private final BeanInfo beanInfo;
+  private final String tenantId;
 
-  private DeploymentValue(final List<String> resources, final BeanInfo beanInfo) {
+  public DeploymentValue(final List<String> resources, final String tenantId) {
     this.resources = resources;
-    this.beanInfo = beanInfo;
+    this.tenantId = tenantId;
   }
 
   public List<String> getResources() {
     return resources;
   }
 
-  public BeanInfo getClassInfo() {
-    return beanInfo;
+  public String getTenantId() {
+    return tenantId;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(resources, beanInfo);
+    return Objects.hash(resources, tenantId);
   }
 
   @Override
   public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
     final DeploymentValue that = (DeploymentValue) o;
-    return Objects.equals(resources, that.resources) && Objects.equals(beanInfo, that.beanInfo);
+    return Objects.equals(resources, that.resources) && Objects.equals(tenantId, that.tenantId);
   }
 
   @Override
   public String toString() {
-    return "DeploymentValue{" + "resources=" + resources + ", beanInfo=" + beanInfo + '}';
-  }
-
-  public static DeploymentValueBuilder builder() {
-    return new DeploymentValueBuilder();
-  }
-
-  public static final class DeploymentValueBuilder {
-
-    private List<String> resources;
-    private BeanInfo beanInfo;
-
-    private DeploymentValueBuilder() {}
-
-    public DeploymentValueBuilder resources(final List<String> resources) {
-      this.resources = resources;
-      return this;
-    }
-
-    public DeploymentValueBuilder beanInfo(final BeanInfo beanInfo) {
-      this.beanInfo = beanInfo;
-      return this;
-    }
-
-    public DeploymentValue build() {
-      return new DeploymentValue(resources, beanInfo);
-    }
+    return "DeploymentValue{" + "resources=" + resources + ", tenantId='" + tenantId + '\'' + '}';
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/event/CamundaPostDeploymentEvent.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/event/CamundaPostDeploymentEvent.java
@@ -16,7 +16,8 @@
 package io.camunda.client.event;
 
 import io.camunda.client.api.response.DeploymentEvent;
+import java.util.List;
 
 public interface CamundaPostDeploymentEvent {
-  DeploymentEvent getDeployment();
+  List<DeploymentEvent> getDeployments();
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/CamundaPostDeploymentSpringEvent.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/CamundaPostDeploymentSpringEvent.java
@@ -17,19 +17,21 @@ package io.camunda.client.spring.event;
 
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.event.CamundaPostDeploymentEvent;
+import java.util.List;
 import org.springframework.context.ApplicationEvent;
 
 public class CamundaPostDeploymentSpringEvent extends ApplicationEvent
     implements CamundaPostDeploymentEvent {
-  private final DeploymentEvent deployment;
+  private final List<DeploymentEvent> deployments;
 
-  public CamundaPostDeploymentSpringEvent(final Object source, final DeploymentEvent deployment) {
+  public CamundaPostDeploymentSpringEvent(
+      final Object source, final List<DeploymentEvent> deployments) {
     super(source);
-    this.deployment = deployment;
+    this.deployments = deployments;
   }
 
   @Override
-  public DeploymentEvent getDeployment() {
-    return deployment;
+  public List<DeploymentEvent> getDeployments() {
+    return deployments;
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/zeebe/spring/client/annotation/Deployment.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/zeebe/spring/client/annotation/Deployment.java
@@ -26,6 +26,7 @@ import java.lang.annotation.*;
 @Inherited // has to be inherited to work on spring aop beans
 @Deprecated(forRemoval = true, since = "8.8")
 public @interface Deployment {
-
   String[] resources() default {};
+
+  String tenantId() default "";
 }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
@@ -107,7 +107,7 @@ public class AnnotationUtilTest {
       // given
       final BeanInfo classInfo = beanInfo(new DeployingBean());
       // when
-      final DeploymentValue deploymentValue = AnnotationUtil.getDeploymentValue(classInfo).get();
+      final DeploymentValue deploymentValue = AnnotationUtil.getDeploymentValues(classInfo).get(0);
       // then
       assertThat(deploymentValue.getResources()).hasSize(1);
       assertThat(deploymentValue.getResources().get(0)).isEqualTo("classpath*:*.bpmn");

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/bean/factory/ReadDeploymentValueTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/bean/factory/ReadDeploymentValueTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class ReadZeebeDeploymentValueTest {
+public class ReadDeploymentValueTest {
 
   @Test
   public void shouldReadSingleClassPathResourceTest() {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/bean/factory/ReadZeebeDeploymentValueTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/bean/factory/ReadZeebeDeploymentValueTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.spring.bean.factory;
 
-import static io.camunda.client.annotation.AnnotationUtil.getDeploymentValue;
+import static io.camunda.client.annotation.AnnotationUtil.getDeploymentValues;
 import static io.camunda.client.spring.testsupport.BeanInfoUtil.beanInfo;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,7 +24,7 @@ import io.camunda.client.annotation.value.DeploymentValue;
 import io.camunda.client.bean.BeanInfo;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Optional;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -38,17 +38,14 @@ public class ReadZeebeDeploymentValueTest {
     final BeanInfo classInfo = beanInfo(new WithSingleClassPathResource());
 
     final DeploymentValue expectedDeploymentValue =
-        DeploymentValue.builder()
-            .beanInfo(classInfo)
-            .resources(Collections.singletonList("classpath*:/1.bpmn"))
-            .build();
+        new DeploymentValue(Collections.singletonList("classpath*:/1.bpmn"), null);
 
     // when
-    final Optional<DeploymentValue> valueForClass = getDeploymentValue(classInfo);
+    final List<DeploymentValue> valueForClass = getDeploymentValues(classInfo);
 
     // then
-    assertThat(valueForClass.isPresent()).isTrue();
-    assertThat(valueForClass.get()).isEqualTo(expectedDeploymentValue);
+    assertThat(valueForClass).hasSize(1);
+    assertThat(valueForClass.get(0)).isEqualTo(expectedDeploymentValue);
   }
 
   @Test
@@ -57,17 +54,14 @@ public class ReadZeebeDeploymentValueTest {
     final BeanInfo classInfo = beanInfo(new WithMultipleClassPathResource());
 
     final DeploymentValue expectedDeploymentValue =
-        DeploymentValue.builder()
-            .beanInfo(classInfo)
-            .resources(Arrays.asList("classpath*:/1.bpmn", "classpath*:/2.bpmn"))
-            .build();
+        new DeploymentValue(Arrays.asList("classpath*:/1.bpmn", "classpath*:/2.bpmn"), null);
 
     // when
-    final Optional<DeploymentValue> valueForClass = getDeploymentValue(classInfo);
+    final List<DeploymentValue> valueForClass = getDeploymentValues(classInfo);
 
     // then
-    assertThat(valueForClass.isPresent()).isTrue();
-    assertThat(valueForClass.get()).isEqualTo(expectedDeploymentValue);
+    assertThat(valueForClass).hasSize(1);
+    assertThat(valueForClass.get(0)).isEqualTo(expectedDeploymentValue);
   }
 
   @Test
@@ -76,48 +70,40 @@ public class ReadZeebeDeploymentValueTest {
     final BeanInfo classInfo = beanInfo(new WithoutAnnotation());
 
     // when
-    final Optional<DeploymentValue> valueForClass = getDeploymentValue(classInfo);
+    final List<DeploymentValue> valueForClass = getDeploymentValues(classInfo);
 
     // then
-    assertThat(valueForClass.isPresent()).isFalse();
+    assertThat(valueForClass).isEmpty();
   }
 
   @Test
   public void shouldReadSingleClassPathResourceTestLegacy() {
     // given
     final BeanInfo classInfo = beanInfo(new WithSingleClassPathResourceLegacy());
-
     final DeploymentValue expectedDeploymentValue =
-        DeploymentValue.builder()
-            .beanInfo(classInfo)
-            .resources(Collections.singletonList("classpath*:/1.bpmn"))
-            .build();
+        new DeploymentValue(Collections.singletonList("classpath*:/1.bpmn"), null);
 
     // when
-    final Optional<DeploymentValue> valueForClass = getDeploymentValue(classInfo);
+    final List<DeploymentValue> valueForClass = getDeploymentValues(classInfo);
 
     // then
-    assertThat(valueForClass.isPresent()).isTrue();
-    assertThat(valueForClass.get()).isEqualTo(expectedDeploymentValue);
+    assertThat(valueForClass).hasSize(1);
+    assertThat(valueForClass.get(0)).isEqualTo(expectedDeploymentValue);
   }
 
   @Test
   public void shouldReadMultipleClassPathResourcesTestLegacy() {
     // given
     final BeanInfo classInfo = beanInfo(new WithMultipleClassPathResourceLegacy());
-
     final DeploymentValue expectedDeploymentValue =
-        DeploymentValue.builder()
-            .beanInfo(classInfo)
-            .resources(Arrays.asList("classpath*:/1.bpmn", "classpath*:/2.bpmn"))
-            .build();
+        new DeploymentValue(Arrays.asList("classpath*:/1.bpmn", "classpath*:/2.bpmn"), null);
 
     // when
-    final Optional<DeploymentValue> valueForClass = getDeploymentValue(classInfo);
+    final List<DeploymentValue> valueForClass = getDeploymentValues(classInfo);
 
     // then
-    assertThat(valueForClass.isPresent()).isTrue();
-    assertThat(valueForClass.get()).isEqualTo(expectedDeploymentValue);
+    assertThat(valueForClass).hasSize(1);
+    assertThat(valueForClass.get(0)).isEqualTo(expectedDeploymentValue);
   }
 
   @Deployment(resources = "classpath*:/1.bpmn")

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/DeploymentPostProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/DeploymentPostProcessorTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.*;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.annotation.Deployment;
-import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.DeployResourceCommandStep1;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.response.Process;
@@ -47,8 +46,6 @@ public class DeploymentPostProcessorTest {
   @Mock private DeployResourceCommandStep1 deployStep1;
 
   @Mock private DeployResourceCommandStep1.DeployResourceCommandStep2 deployStep2;
-
-  @Mock private CamundaFuture<DeploymentEvent> camundaFuture;
 
   @Mock private DeploymentEvent deploymentEvent;
 
@@ -76,9 +73,7 @@ public class DeploymentPostProcessorTest {
 
     when(deployStep1.addResourceStream(any(), anyString())).thenReturn(deployStep2);
 
-    when(deployStep2.send()).thenReturn(camundaFuture);
-
-    when(camundaFuture.join()).thenReturn(deploymentEvent);
+    when(deployStep2.execute()).thenReturn(deploymentEvent);
 
     when(deploymentEvent.getProcesses()).thenReturn(Collections.singletonList(getProcess()));
 
@@ -88,8 +83,7 @@ public class DeploymentPostProcessorTest {
 
     // then
     verify(deployStep1).addResourceStream(any(), eq("1.bpmn"));
-    verify(deployStep2).send();
-    verify(camundaFuture).join();
+    verify(deployStep2).execute();
   }
 
   @Test
@@ -113,9 +107,7 @@ public class DeploymentPostProcessorTest {
     when(deployStep1.addResourceStream(any(), anyString())).thenReturn(deployStep2);
     when(deployStep2.addResourceStream(any(), anyString())).thenReturn(deployStep2);
 
-    when(deployStep2.send()).thenReturn(camundaFuture);
-
-    when(camundaFuture.join()).thenReturn(deploymentEvent);
+    when(deployStep2.execute()).thenReturn(deploymentEvent);
 
     when(deploymentEvent.getProcesses()).thenReturn(Collections.singletonList(getProcess()));
 
@@ -127,8 +119,7 @@ public class DeploymentPostProcessorTest {
     verify(deployStep1).addResourceStream(any(), eq("1.bpmn"));
     verify(deployStep2).addResourceStream(any(), eq("2.bpmn"));
 
-    verify(deployStep2).send();
-    verify(camundaFuture).join();
+    verify(deployStep2).execute();
   }
 
   @Test
@@ -151,9 +142,7 @@ public class DeploymentPostProcessorTest {
 
     when(deployStep1.addResourceStream(any(), anyString())).thenReturn(deployStep2);
 
-    when(deployStep2.send()).thenReturn(camundaFuture);
-
-    when(camundaFuture.join()).thenReturn(deploymentEvent);
+    when(deployStep2.execute()).thenReturn(deploymentEvent);
 
     when(deploymentEvent.getProcesses()).thenReturn(Collections.singletonList(getProcess()));
 
@@ -164,8 +153,7 @@ public class DeploymentPostProcessorTest {
     // then
     verify(deployStep1, times(1)).addResourceStream(any(), eq("1.bpmn"));
 
-    verify(deployStep2).send();
-    verify(camundaFuture).join();
+    verify(deployStep2).execute();
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a new field `tenantId` to the existing annotation `@Deployment`.

It is optional and will have no effect if omitted. If not, it will allow the control of deployments to different tenants from the same application.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38949 
