### PR TITLE
Fix V2 Stateless API Nightly Execution Workflow Failure

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [37654-api-test-generator] # TODO: Change back to [stable/8.8, main] before merging
+        branch: [stable/8.8, main]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Before the workflow was merged, the branch selection was never updated to stable/8.8 & main, therefore the nightly tests will not execute.. This PR fixes this issue.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
