### PR TITLE
fix: do not log at error for known ClassCastException related to 8.7 heartbeats

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -91,6 +91,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -1260,7 +1261,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
       if (message instanceof final ProtocolRequest protocolMessage) {
         final var subject = protocolMessage.subject();
         final var level =
-            subject.equals(HeartbeatHandler.HEARTBEAT_SUBJECT) ? Level.WARN : Level.ERROR;
+            Objects.equals(subject, HeartbeatHandler.HEARTBEAT_SUBJECT) ? Level.WARN : Level.ERROR;
         logger
             .atLevel(level)
             .log("Failed to dispatch message with subject {} because {}", subject, e.getMessage());

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -110,6 +110,7 @@ import java.util.stream.Collectors;
 import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /** Netty based MessagingService. */
 public final class NettyMessagingService implements ManagedMessagingService {
@@ -1250,12 +1251,21 @@ public final class NettyMessagingService implements ManagedMessagingService {
       } catch (final RejectedExecutionException e) {
         log.warn("Unable to dispatch message due to {}", e.getMessage());
       } catch (final ClassCastException e) {
-        final var logger = getLogger(message.getClass());
-        String subject = "UNKNOWN";
-        if (message instanceof final ProtocolRequest protocolMessage) {
-          subject = protocolMessage.subject();
-        }
-        logger.error("Failed to dispatch message with subject {}", subject, e);
+        logClassCastException(message, e);
+      }
+    }
+
+    private void logClassCastException(final Object message, final ClassCastException e) {
+      final var logger = getLogger(message.getClass());
+      if (message instanceof final ProtocolRequest protocolMessage) {
+        final var subject = protocolMessage.subject();
+        final var level =
+            subject.equals(HeartbeatHandler.HEARTBEAT_SUBJECT) ? Level.WARN : Level.ERROR;
+        logger
+            .atLevel(level)
+            .log("Failed to dispatch message with subject {} because {}", subject, e.getMessage());
+      } else {
+        logger.error("Failed to dispatch message because {}", e.getMessage());
       }
     }
 


### PR DESCRIPTION
## Description
Unfortunately, the 8.7 heartbeats are not compatible with 8.8 version: as this is a known issue which does not cause any actual problem we don't need to log this particular case at error, but we can just log it infrequently at warn.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #33127
