### PR TITLE
fix: invalidate ilm policy cache after retention period

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -12,11 +12,13 @@ import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.OpensearchRepository;
+import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
@@ -26,6 +28,7 @@ import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.micrometer.core.instrument.Timer;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -70,8 +73,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   private final CamundaExporterMetrics metrics;
   private final OpenSearchGenericClient genericClient;
   private String lastHistoricalArchiverDate = null;
-  private final Cache<String, String> lifeCyclePolicyApplied =
-      Caffeine.newBuilder().maximumSize(200).build();
+  private final Cache<String, String> lifeCyclePolicyApplied;
 
   public OpenSearchArchiverRepository(
       final int partitionId,
@@ -98,6 +100,29 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class);
     this.metrics = metrics;
     this.genericClient = genericClient;
+    lifeCyclePolicyApplied = buildLifeCycleAppliedCache(config.getRetention(), logger);
+  }
+
+  private static Cache<String, String> buildLifeCycleAppliedCache(
+      final RetentionConfiguration config, final Logger logger) {
+    return Caffeine.newBuilder()
+        .maximumSize(200)
+        .expireAfter(
+            Expiry.creating(
+                (k, v) -> {
+                  if (v == null) {
+                    return Duration.ZERO;
+                  }
+                  return DateOfArchivedDocumentsUtil.getRetentionPolicyMinimumAge(
+                          config, v.toString())
+                      .orElseGet(
+                          () -> {
+                            logger.debug(
+                                "Unknown retention policy '{}', using default cache expiration", v);
+                            return Duration.ofHours(1);
+                          });
+                }))
+        .build();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -734,6 +734,56 @@ final class OpenSearchArchiverRepositoryIT {
   }
 
   @Test
+  void shouldReapplyILMPolicyAfterRetentionPeriodExpiration() throws Exception {
+    // given
+    retention.setEnabled(true);
+    final int minimumAgeSeconds = 2;
+    retention.setMinimumAge("%ds".formatted(minimumAgeSeconds));
+    final var indexName1 = processInstanceIndex + UUID.randomUUID();
+    final var indexName2 = processInstanceIndex + UUID.randomUUID();
+
+    final var asyncClient = createOpenSearchAsyncClient();
+    final var genericClientSpy =
+        Mockito.spy(
+            new OpenSearchGenericClient(asyncClient._transport(), asyncClient._transportOptions()));
+
+    final var repository = createRepository(genericClientSpy);
+
+    // when - first setting policy for indexName1 and indexName2
+    repository
+        .setIndexLifeCycle(indexName1)
+        .thenApply(
+            ignore -> {
+              // wait for the cache of indexName1 to expire
+              Awaitility.await().pollDelay(Duration.ofSeconds(minimumAgeSeconds)).until(() -> true);
+              return repository.setIndexLifeCycle(indexName2);
+            })
+        .get();
+
+    final ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+
+    verify(genericClientSpy, times(2)).executeAsync(captor.capture());
+
+    final var requests = captor.getAllValues();
+    assertThat(requests)
+        .map(Request::getEndpoint)
+        .containsExactly("_plugins/_ism/add/" + indexName1, "_plugins/_ism/add/" + indexName2);
+
+    // we reset the spy to ensure that we only capture the next calls
+    reset(genericClientSpy);
+
+    // setting policy second time for indexName1 and indexName2
+    repository.setIndexLifeCycle(indexName1).get();
+    repository.setIndexLifeCycle(indexName2).get();
+
+    // then - only indexName1 should be included in the request, since the cache for it has expired
+    final var captor2 = ArgumentCaptor.forClass(Request.class);
+    verify(genericClientSpy, times(1)).executeAsync(captor2.capture());
+    final var request2 = captor2.getValue();
+    assertThat(request2.getEndpoint()).isEqualTo("_plugins/_ism/add/" + indexName1);
+  }
+
+  @Test
   void shouldApplyIlmToAllHistoricalIndices() throws Exception {
     // given
     retention.setEnabled(true);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Ensure that the index is removed from the `lifeCyclePolicyApplied` cache after the retention period is expired.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #39134 
