### PR TITLE
ci: replace deprecated tibdex/github-app-token action

### DIFF
--- a/.github/workflows/c8run-closed-issue.yaml
+++ b/.github/workflows/c8run-closed-issue.yaml
@@ -42,11 +42,11 @@ jobs:
 
         - name: Generate GitHub token
           if: ${{ steps.vars.outputs.match == 'true' }}
-          uses: tibdex/github-app-token@v2
+          uses: actions/create-github-app-token@v2
           id: generate-github-token
           with:
-            app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
-            private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+            app-id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
+            private-key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
 
         - name: Update Closed At field
           if: ${{ steps.vars.outputs.match == 'true' }}


### PR DESCRIPTION
## Description

See https://github.com/tibdex/github-app-token/blob/main/README.md?plain=1#L2
