### PR TITLE
ci: fix operate screenshot tool by using the correct path

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -342,8 +342,8 @@ jobs:
         if: always()
         with:
           name: Playwright report
-          path: e2e-playwright/docs-screenshots
-          retention-days: 30
+          path: ./operate/client/e2e-playwright/docs-screenshots
+          retention-days: 3
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The `operate-update-screenshots` job in `ci-operate.yml` was not properly uploading screenshots as an artifact to github. See this test run: https://github.com/camunda/camunda/actions/runs/18222307103/job/51884855479

This PR makes a change so that the `actions/upload-artifact@v4` job uses the correct filepath to upload screenshots

Also reduce the retention of the screenshots to 3 days rather than 30. The screenshots job does not take long to run so there is no real reason to keep them around for so long

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/39143
