### PR TITLE
deps: force most recent version of openssl to solve CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/log/apt,sharing=locked \
     apt-get -qq update && \
     apt-get install -yqq --no-install-recommends tini ca-certificates systemd perl && \
-    apt-get upgrade -yqq --no-install-recommends systemd perl
+    apt-get upgrade -yqq --no-install-recommends systemd perl openssl
 
 ### Build custom JRE using the base JDK image
 # hadolint ignore=DL3006

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/log/apt,sharing=locked \
     apt-get -qq update && \
     apt-get install -yqq --no-install-recommends tini ca-certificates systemd perl && \
-    apt-get upgrade -yqq --no-install-recommends systemd perl
+    apt-get upgrade -yqq --no-install-recommends systemd perl openssl
 
 ### Build custom JRE using the base JDK image
 # hadolint ignore=DL3006

--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -60,7 +60,7 @@ LABEL io.k8s.description="Tool for process observability and troubleshooting pro
 EXPOSE 8080
 
 RUN apk update && apk upgrade
-RUN apk add --no-cache bash openjdk21-jre tzdata gcompat libgcc libc6-compat
+RUN apk add --no-cache bash openjdk21-jre tzdata gcompat libgcc libc6-compat openssl
 
 ENV OPE_HOME=/usr/local/operate
 

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -65,7 +65,7 @@ EXPOSE 8090 8091
 
 VOLUME /tmp
 
-RUN apk add --no-cache bash curl tini openjdk21-jre tzdata && \
+RUN apk add --no-cache bash curl tini openjdk21-jre tzdata openssl && \
     apk -U upgrade && \
     curl "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" --output /usr/local/bin/wait-for-it.sh && \
     chmod +x /usr/local/bin/wait-for-it.sh && \

--- a/tasklist.Dockerfile
+++ b/tasklist.Dockerfile
@@ -57,7 +57,7 @@ LABEL io.k8s.description="Tasklist is a ready-to-use application to rapidly impl
 EXPOSE 8080
 
 RUN apk update && apk upgrade && \
-    apk add --no-cache bash openjdk21-jre tzdata gcompat libgcc libc6-compat
+    apk add --no-cache bash openjdk21-jre tzdata gcompat libgcc libc6-compat openssl
 
 ENV TASKLIST_HOME=/usr/local/tasklist
 


### PR DESCRIPTION

## Description

<!-- Describe the goal and purpose of this PR. -->
Force an upgraded version of `openssl` to solve 3 CVEs. The base docker image does not use the updated `openssl` version, so it needs to be forced

- CVE-2025-9230
- CVE-2025-9231
- CVE-2025-9232

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/39158
