### PR TITLE
pg/fix-retry-condition

### DIFF
--- a/migration/usage-metric-migration/src/main/java/io/camunda/migration/usagemetric/client/es/ElasticsearchUsageMetricMigrationClient.java
+++ b/migration/usage-metric-migration/src/main/java/io/camunda/migration/usagemetric/client/es/ElasticsearchUsageMetricMigrationClient.java
@@ -274,7 +274,7 @@ public final class ElasticsearchUsageMetricMigrationClient implements UsageMetri
           retryDecorator.decorate(
               operationName,
               () -> client.reindex(request),
-              res -> res.task() == null || res.failures() != null);
+              res -> res.task() == null || (res.failures() != null && !res.failures().isEmpty()));
       return response.task();
     } catch (final Exception e) {
       throw new MigrationException(e);

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
@@ -200,11 +200,10 @@ public class MigrationITExtension
         final ElasticsearchContainer elasticsearchContainer =
             TestSearchContainers.createDefeaultElasticsearchContainer();
         elasticsearchContainer.setPortBindings(List.of("9200:9200"));
-        // elasticsearchContainer.withEnv("logger.org.elasticsearch.deprecation", "ERROR");
         elasticsearchContainer.start();
         closables.add(elasticsearchContainer);
         databaseUrl = "http://" + elasticsearchContainer.getHttpHostAddress();
-        // suppressEsWarnings();
+        suppressEsWarnings();
         expectedDescriptors = new IndexDescriptors(indexPrefix, true).all();
       }
       case ES -> {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fix `reindex` retry condition as the check for `task.failures` was incorrect and returned always true. This resulted in the reindexing operation being retried until it exceeded the limits. Data were migrated correctly but reindex was submitted 3 times.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
