### PR TITLE
[Backport release-8.8.0] fix: grant taskuser wildcard permissions even if RBA was enabled

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
@@ -236,7 +236,7 @@ public class StaticEntities {
                         AuthorizationResourceType.DECISION_DEFINITION
                             .getSupportedPermissionTypes()))),
             new AuthEntry(
-                audiences.getTasklist() + ":read:*",
+                createTasklistReadPermissionString(audiences),
                 List.of(
                     new CreateAuthorizationRequest(
                         ownerId,
@@ -253,7 +253,7 @@ public class StaticEntities {
                             PermissionType.READ_PROCESS_DEFINITION,
                             PermissionType.READ_USER_TASK)))),
             new AuthEntry(
-                audiences.getTasklist() + ":write:*",
+                createTasklistWritePermissionString(audiences),
                 List.of(
                     new CreateAuthorizationRequest(
                         ownerId,
@@ -319,5 +319,13 @@ public class StaticEntities {
         .filter(a -> a.key().equals(permission))
         .flatMap(a -> a.value().stream())
         .collect(Collectors.toSet());
+  }
+
+  public static String createTasklistReadPermissionString(final Audiences audiences) {
+    return audiences.getTasklist() + ":read:*";
+  }
+
+  public static String createTasklistWritePermissionString(final Audiences audiences) {
+    return audiences.getTasklist() + ":write:*";
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
@@ -299,7 +299,8 @@ public class KeycloakRoleMigrationHandlerTest {
                 new Permission("read:users", "camunda-identity-resource-server"),
                 new Permission("write", "camunda-identity-resource-server"),
                 new Permission("read:*", "operate-api"),
-                new Permission("write:*", "operate-api")))
+                new Permission("write:*", "operate-api"),
+                new Permission("read:*", "tasklist-api")))
         .thenReturn(
             List.of(
                 new Permission("read:*", "tasklist-api"),
@@ -313,7 +314,7 @@ public class KeycloakRoleMigrationHandlerTest {
 
     // then
     final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, times(9)).createAuthorization(results.capture());
+    verify(authorizationServices, times(12)).createAuthorization(results.capture());
     final var authorizationRequests = results.getAllValues();
     assertThat(authorizationRequests)
         .extracting(
@@ -322,16 +323,17 @@ public class KeycloakRoleMigrationHandlerTest {
             CreateAuthorizationRequest::resourceType,
             CreateAuthorizationRequest::permissionTypes)
         .containsExactlyInAnyOrder(
-            tuple(
-                "role_1",
-                AuthorizationOwnerType.ROLE,
-                AuthorizationResourceType.USER,
-                Set.of(PermissionType.READ)),
+            // Identity read/write
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.COMPONENT,
                 Set.of(PermissionType.ACCESS)),
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.USER,
+                Set.of(PermissionType.READ)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -341,11 +343,6 @@ public class KeycloakRoleMigrationHandlerTest {
                     PermissionType.UPDATE,
                     PermissionType.DELETE,
                     PermissionType.CREATE)),
-            tuple(
-                "role_1",
-                AuthorizationOwnerType.ROLE,
-                AuthorizationResourceType.COMPONENT,
-                Set.of(PermissionType.ACCESS)),
             tuple(
                 "role_1",
                 AuthorizationOwnerType.ROLE,
@@ -373,16 +370,40 @@ public class KeycloakRoleMigrationHandlerTest {
                     PermissionType.CREATE,
                     PermissionType.UPDATE,
                     PermissionType.DELETE)),
+            // Operate read/write
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.COMPONENT,
+                Set.of(PermissionType.ACCESS)),
+            // Tasklist read
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.COMPONENT,
+                Set.of(PermissionType.ACCESS)),
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                Set.of(PermissionType.READ_USER_TASK)),
+            // zeebe write
             tuple(
                 "role@name_with_special_chars",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.SYSTEM,
                 Set.of(PermissionType.READ, PermissionType.UPDATE)),
+            // tasklist read/write
             tuple(
                 "role@name_with_special_chars",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.COMPONENT,
-                Set.of(PermissionType.ACCESS)));
+                Set.of(PermissionType.ACCESS)),
+            tuple(
+                "role@name_with_special_chars",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                Set.of(PermissionType.READ_USER_TASK, PermissionType.UPDATE_USER_TASK)));
   }
 
   @Test

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationWithRBAIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationWithRBAIT.java
@@ -75,6 +75,10 @@ public class KeycloakIdentityMigrationWithRBAIT extends AbstractKeycloakIdentity
             tuple("zeebe", ResourceType.SYSTEM, Set.of(PermissionType.READ, PermissionType.UPDATE)),
             tuple("tasklist", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)),
             tuple(
+                "tasklist",
+                ResourceType.PROCESS_DEFINITION,
+                Set.of(PermissionType.READ_USER_TASK, PermissionType.UPDATE_USER_TASK)),
+            tuple(
                 "identity",
                 ResourceType.GROUP,
                 Set.of(

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationWithRBAIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationWithRBAIT.java
@@ -57,7 +57,7 @@ public class SaaSIdentityMigrationWithRBAIT extends AbstractSaaSIdentityMigratio
                       .map(Authorization::getOwnerId)
                       .filter(ROLE_IDS::contains)
                       .toList();
-              assertThat(migratedAuthorizations.size()).isEqualTo(6);
+              assertThat(migratedAuthorizations.size()).isEqualTo(7);
             });
 
     // then
@@ -98,6 +98,12 @@ public class SaaSIdentityMigrationWithRBAIT extends AbstractSaaSIdentityMigratio
                 "tasklist",
                 ResourceType.COMPONENT,
                 Set.of(PermissionType.ACCESS)),
+            tuple(
+                TASK_USER_ROLE_ID,
+                OwnerType.ROLE,
+                "*",
+                ResourceType.PROCESS_DEFINITION,
+                Set.of(PermissionType.READ_USER_TASK, PermissionType.UPDATE_USER_TASK)),
             tuple(
                 VISITOR_ROLE_ID,
                 OwnerType.ROLE,


### PR DESCRIPTION
# Description
Backport of #39156 to `release-8.8.0`.

relates to #39154