### PR TITLE
fix: Correct Metadata Display & Positioning for Ad‑Hoc Sub‑Process Inner Instances in Operate History Tree

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
@@ -31,7 +31,10 @@ import {
   getVisibleChildPlaceholders,
   hasChildPlaceholders,
 } from 'modules/utils/instanceHistoryModification';
-import {selectAdHocSubProcessInnerInstance, selectFlowNode} from 'modules/utils/flowNodeSelection';
+import {
+  selectAdHocSubProcessInnerInstance,
+  selectFlowNode,
+} from 'modules/utils/flowNodeSelection';
 import {type BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 
 const TREE_NODE_HEIGHT = 32;

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
@@ -31,6 +31,7 @@ import {
   getVisibleChildPlaceholders,
   hasChildPlaceholders,
 } from 'modules/utils/instanceHistoryModification';
+import {selectAdHocSubProcessInnerInstance, selectFlowNode} from 'modules/utils/flowNodeSelection';
 import {type BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 
 const TREE_NODE_HEIGHT = 32;
@@ -142,11 +143,14 @@ const FlowNodeInstancesTree: React.FC<Props> = observer(
       : processInstanceXmlData?.businessObjects[flowNodeInstance.flowNodeId];
 
     const isMultiInstanceBody = flowNodeInstance.type === 'MULTI_INSTANCE_BODY';
+    const isAdHocSubProcessInnerInstance =
+      flowNodeInstance.type === 'AD_HOC_SUB_PROCESS_INNER_INSTANCE';
 
     const isFoldable =
       isMultiInstanceBody ||
       isSubProcess(businessObject) ||
       isAdHocSubProcess(businessObject) ||
+      isAdHocSubProcessInnerInstance ||
       isRoot;
 
     const hasChildren = flowNodeInstance.isPlaceholder
@@ -222,6 +226,10 @@ const FlowNodeInstancesTree: React.FC<Props> = observer(
       ? hasVisibleChildPlaceholders
       : hasVisibleChildNodes;
     let {rowRef: _, ...carbonTreeNodeProps} = rest;
+    const rootNode = {
+      flowNodeInstanceId: processInstanceDetailsStore.state.processInstance?.id,
+      isMultiInstance: false,
+    };
     return (
       <TreeNode
         {...carbonTreeNodeProps}
@@ -253,14 +261,21 @@ const FlowNodeInstancesTree: React.FC<Props> = observer(
             );
           } else {
             tracking.track({eventName: 'instance-history-item-clicked'});
-            flowNodeSelectionStore.selectFlowNode({
-              flowNodeId: isProcessInstance
-                ? undefined
-                : flowNodeInstance.flowNodeId,
-              flowNodeInstanceId: flowNodeInstance.id,
-              isMultiInstance: isMultiInstanceBody,
-              isPlaceholder: flowNodeInstance.isPlaceholder,
-            });
+            if (isAdHocSubProcessInnerInstance) {
+              if (!isExpanded) {
+                expandSubtree(flowNodeInstance);
+              }
+              selectAdHocSubProcessInnerInstance(rootNode, flowNodeInstance);
+            } else {
+              selectFlowNode(rootNode, {
+                flowNodeId: isProcessInstance
+                  ? undefined
+                  : flowNodeInstance.flowNodeId,
+                flowNodeInstanceId: flowNodeInstance.id,
+                isMultiInstance: isMultiInstanceBody,
+                isPlaceholder: flowNodeInstance.isPlaceholder,
+              });
+            }
           }
         }}
         onToggle={

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -342,9 +342,11 @@ const TopPanel: React.FC = observer(() => {
                     : selectableFlowNodes
                 }
                 selectedFlowNodeIds={
-                  flowNodeSelection?.flowNodeId
-                    ? [flowNodeSelection.flowNodeId]
-                    : undefined
+                  flowNodeSelection?.anchorFlowNodeId
+                    ? [flowNodeSelection.anchorFlowNodeId]
+                    : flowNodeSelection?.flowNodeId
+                      ? [flowNodeSelection.flowNodeId]
+                      : undefined
                 }
                 onFlowNodeSelection={(flowNodeId, isMultiInstance) => {
                   if (modificationsStore.state.status === 'moving-token') {

--- a/operate/client/src/modules/stores/flowNodeSelection.ts
+++ b/operate/client/src/modules/stores/flowNodeSelection.ts
@@ -19,6 +19,7 @@ type Selection = {
   isMultiInstance?: boolean;
   isPlaceholder?: boolean;
   processInstanceId?: string;
+  anchorFlowNodeId?: string;
 };
 
 type State = {

--- a/operate/client/src/modules/utils/flowNodeSelection.test.ts
+++ b/operate/client/src/modules/utils/flowNodeSelection.test.ts
@@ -130,7 +130,6 @@ describe('flowNodeSelection', () => {
       sortValues: ['1606300828415', 'inner-1'] as [string, string],
     };
 
-    // pre-existing different selection
     flowNodeSelectionStore.setSelection({
       flowNodeId: 'existing',
       flowNodeInstanceId: 'existing-1',
@@ -138,7 +137,6 @@ describe('flowNodeSelection', () => {
 
     selectAdHocSubProcessInnerInstance(rootNode, innerInstance);
 
-    // selection should immediately switch to inner instance without anchor
     expect(flowNodeSelectionStore.state.selection).toEqual({
       flowNodeId: 'adhoc-subprocess',
       flowNodeInstanceId: 'inner-1',
@@ -146,7 +144,6 @@ describe('flowNodeSelection', () => {
       anchorFlowNodeId: undefined,
     });
 
-    // now load children (first child becomes anchor)
     flowNodeInstanceStore.handleFetchSuccess({
       'some-tree-path': {
         children: [
@@ -164,9 +161,6 @@ describe('flowNodeSelection', () => {
         running: false,
       },
     });
-
-    // wait microtask queue for when() to resolve
-    await Promise.resolve();
 
     expect(flowNodeSelectionStore.state.selection).toEqual({
       flowNodeId: 'adhoc-subprocess',


### PR DESCRIPTION
# Summary

Ad‑hoc sub‑process *inner instances* don’t exist in the BPMN diagram, so we used the first child to place the popover. Problem: the popover also showed the **child’s** data instead of the inner instance’s execution scope.

## What changed
- Added `anchorFlowNodeId` to selection state so we can **anchor the popover to a child** while **showing metadata for the inner instance itself**.
- Updated both history tree implementations (v1 + v2) to use new selection logic.
- If children aren’t loaded yet, we still select the inner instance and later attach the anchor when the first child arrives (no flicker / no toggle).
- Diagram highlight now prefers `anchorFlowNodeId` when present.
- Tests added/updated to cover: immediate child, delayed child, and anchor update.

## Why it’s safe
- `anchorFlowNodeId` is optional; old code ignoring it keeps working.
- No API surface changes, no new deps.
- Full unit test suite passes (only existing warnings remain).

## Test

https://github.com/user-attachments/assets/b77da340-4268-4728-afe9-da48011165ce

## TL;DR
We separated *what* you’re looking at (inner scope) from *where* we place the popover (first child). Now the data is accurate and the UX feels consistent.
