### PR TITLE
fix: archiver blocking flag being reapplied

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -319,10 +319,10 @@ public class SchemaManager implements CloseableSilently {
     };
   }
 
-  private boolean blockedArchiverMetaIsMissing(final String operateImportPositionIndex) {
+  private boolean blockedArchiverMetaIsMissing(final String tasklistImportPositionIndex) {
     final var mappings =
-        searchEngineClient.getMappings(operateImportPositionIndex, MappingSource.INDEX);
-    return Optional.ofNullable(mappings.get(operateImportPositionIndex).metaProperties())
+        searchEngineClient.getMappings(tasklistImportPositionIndex, MappingSource.INDEX);
+    return Optional.ofNullable(mappings.get(tasklistImportPositionIndex).metaProperties())
         .map(map -> map.get(PI_ARCHIVING_BLOCKED_META_KEY))
         .isEmpty();
   }

--- a/schema-manager/src/main/java/io/camunda/search/schema/utils/TasklistLegacyTaskTemplate.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/utils/TasklistLegacyTaskTemplate.java
@@ -23,9 +23,4 @@ public class TasklistLegacyTaskTemplate extends TaskTemplate {
   public String getVersion() {
     return "8.5.0";
   }
-
-  @Override
-  public String getSchemaClasspathFilename() {
-    return super.getSchemaClasspathFilename();
-  }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/utils/TasklistLegacyTaskTemplate.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/utils/TasklistLegacyTaskTemplate.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema.utils;
+
+import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
+
+/**
+ * Legacy Tasklist task template with version 8.5.0. Only required to verify whether a cluster is a
+ * brownfield or a greenfield installation.
+ */
+public class TasklistLegacyTaskTemplate extends TaskTemplate {
+
+  public TasklistLegacyTaskTemplate(final String indexPrefix, final boolean isElasticsearch) {
+    super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public String getVersion() {
+    return "8.5.0";
+  }
+
+  @Override
+  public String getSchemaClasspathFilename() {
+    return super.getSchemaClasspathFilename();
+  }
+}

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -36,6 +36,7 @@ import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.search.schema.exceptions.SearchEngineException;
 import io.camunda.search.schema.metrics.SchemaManagerMetrics;
 import io.camunda.search.schema.utils.SchemaManagerITInvocationProvider;
+import io.camunda.search.schema.utils.TasklistLegacyTaskTemplate;
 import io.camunda.search.schema.utils.TestIndexDescriptor;
 import io.camunda.search.schema.utils.TestTemplateDescriptor;
 import io.camunda.search.test.utils.SearchClientAdapter;
@@ -45,7 +46,6 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
-import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.camunda.zeebe.test.util.junit.RegressionTestTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
@@ -1582,10 +1582,14 @@ public class SchemaManagerIT {
     final var tasklistImportPositionIndex =
         new TasklistImportPositionIndex(
             CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
-    final var metricsTemplate =
-        new UsageMetricTemplate(CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
+    final var tasklistLegacyTaskTemplate =
+        new TasklistLegacyTaskTemplate(
+            CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
     searchEngineClient.createIndexTemplate(indexTemplate, new IndexConfiguration(), true);
+    searchEngineClient.createIndexTemplate(
+        tasklistLegacyTaskTemplate, new IndexConfiguration(), true);
     searchEngineClient.createIndex(tasklistImportPositionIndex, new IndexConfiguration());
+    searchEngineClient.createIndex(tasklistLegacyTaskTemplate, new IndexConfiguration());
 
     // when - start schema manager with spy to track index creation
     final SearchEngineClient spySearchEngineClient = spy(searchEngineClientFromConfig(config));
@@ -1593,7 +1597,7 @@ public class SchemaManagerIT {
         new SchemaManager(
             spySearchEngineClient,
             Set.of(tasklistImportPositionIndex),
-            Set.of(indexTemplate, metricsTemplate),
+            Set.of(indexTemplate),
             config,
             objectMapper);
 
@@ -1626,10 +1630,14 @@ public class SchemaManagerIT {
     final var tasklistImportPositionIndex =
         new TasklistImportPositionIndex(
             CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
-    final var metricsTemplate =
-        new UsageMetricTemplate(CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
+    final var tasklistLegacyTaskTemplate =
+        new TasklistLegacyTaskTemplate(
+            CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
     searchEngineClient.createIndexTemplate(indexTemplate, new IndexConfiguration(), true);
+    searchEngineClient.createIndexTemplate(
+        tasklistLegacyTaskTemplate, new IndexConfiguration(), true);
     searchEngineClient.createIndex(tasklistImportPositionIndex, new IndexConfiguration());
+    searchEngineClient.createIndex(tasklistLegacyTaskTemplate, new IndexConfiguration());
 
     // when - start schema manager with spy to track index creation
     final SearchEngineClient spySearchEngineClient = spy(searchEngineClientFromConfig(config));
@@ -1637,7 +1645,7 @@ public class SchemaManagerIT {
         new SchemaManager(
             spySearchEngineClient,
             Set.of(tasklistImportPositionIndex),
-            Set.of(indexTemplate, metricsTemplate),
+            Set.of(indexTemplate),
             config,
             objectMapper);
 

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -45,7 +45,7 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
-import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
+import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.camunda.zeebe.test.util.junit.RegressionTestTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
@@ -1582,8 +1582,8 @@ public class SchemaManagerIT {
     final var tasklistImportPositionIndex =
         new TasklistImportPositionIndex(
             CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
-    final var taskTemplate =
-        new TaskTemplate(CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
+    final var metricsTemplate =
+        new UsageMetricTemplate(CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
     searchEngineClient.createIndexTemplate(indexTemplate, new IndexConfiguration(), true);
     searchEngineClient.createIndex(tasklistImportPositionIndex, new IndexConfiguration());
 
@@ -1593,7 +1593,7 @@ public class SchemaManagerIT {
         new SchemaManager(
             spySearchEngineClient,
             Set.of(tasklistImportPositionIndex),
-            Set.of(indexTemplate, taskTemplate),
+            Set.of(indexTemplate, metricsTemplate),
             config,
             objectMapper);
 
@@ -1626,8 +1626,8 @@ public class SchemaManagerIT {
     final var tasklistImportPositionIndex =
         new TasklistImportPositionIndex(
             CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
-    final var taskTemplate =
-        new TaskTemplate(CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
+    final var metricsTemplate =
+        new UsageMetricTemplate(CONFIG_PREFIX, config.connect().getTypeEnum().isElasticSearch());
     searchEngineClient.createIndexTemplate(indexTemplate, new IndexConfiguration(), true);
     searchEngineClient.createIndex(tasklistImportPositionIndex, new IndexConfiguration());
 
@@ -1637,7 +1637,7 @@ public class SchemaManagerIT {
         new SchemaManager(
             spySearchEngineClient,
             Set.of(tasklistImportPositionIndex),
-            Set.of(indexTemplate, taskTemplate),
+            Set.of(indexTemplate, metricsTemplate),
             config,
             objectMapper);
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Utilize the presence of old `tasklist-task-8.5.0_` indices to determine whether this is a greenfield or a brownfield installation
- Fixed some minor comment issues
- Added tests to rerun the Schema Manager and verify the flag is not being reset

> It's not guaranteed that if the check introduced is true, that it is a Greenfield installation since a previous installation could have Tasklist disabled. It's enough for checking regarding flagging the archiver

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39187
