### PR TITLE
Revert "[Backport stable/operate-8.5] feat: add operate post importer queue size metric"

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -64,8 +64,6 @@ public class Metrics {
 
   // Gauges:
   public static final String GAUGE_IMPORT_QUEUE_SIZE = OPERATE_NAMESPACE + "import.queue.size";
-  public static final String GAUGE_POST_IMPORTER_QUEUE_SIZE =
-      OPERATE_NAMESPACE + "post.importer.queue.size";
   public static final String GAUGE_BPMN_MODEL_COUNT = OPERATE_NAMESPACE + "model.bpmn.count";
   public static final String GAUGE_DMN_MODEL_COUNT = OPERATE_NAMESPACE + "model.dmn.count";
 
@@ -116,14 +114,6 @@ public class Metrics {
     Gauge.builder(name, gaugeSupplier).tags(tags).register(registry);
   }
 
-  public void registerGaugeSupplier(
-      final String name,
-      final String description,
-      final Supplier<Number> gaugeSupplier,
-      final String... tags) {
-    Gauge.builder(name, gaugeSupplier).tags(tags).description(description).register(registry);
-  }
-
   public <E> void registerGaugeQueueSize(
       final String name, final Queue<E> queue, final String... tags) {
     registerGauge(name, queue, q -> q.size(), tags);
@@ -131,10 +121,6 @@ public class Metrics {
 
   public Timer getTimer(final String name, final String... tags) {
     return registry.timer(name, tags);
-  }
-
-  public MeterRegistry getMeterRegistry() {
-    return registry;
   }
 
   public Timer getHistogram(final String name, final String... tags) {

--- a/operate/importer/pom.xml
+++ b/operate/importer/pom.xml
@@ -38,6 +38,7 @@
       <artifactId>operate-importer-8_5</artifactId>
       <scope>runtime</scope>
     </dependency>
+
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch-core</artifactId>

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java
@@ -18,7 +18,6 @@ package io.camunda.operate.zeebeimport.post;
 
 import static java.time.temporal.ChronoUnit.MILLIS;
 
-import io.camunda.operate.Metrics;
 import io.camunda.operate.entities.IncidentEntity;
 import io.camunda.operate.entities.meta.ImportPositionEntity;
 import io.camunda.operate.exceptions.OperateRuntimeException;
@@ -31,7 +30,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,33 +51,12 @@ public abstract class AbstractIncidentPostImportAction implements PostImportActi
   @Autowired protected OperateProperties operateProperties;
 
   @Autowired protected ImportPositionHolder importPositionHolder;
-
-  @Autowired protected Metrics metrics;
-
   protected ImportPositionEntity lastProcessedPosition;
   private final BackoffIdleStrategy errorStrategy;
-  private final AtomicLong lastKnownQueueSize = new AtomicLong(0);
 
   public AbstractIncidentPostImportAction(final int partitionId) {
     this.partitionId = partitionId;
     errorStrategy = new BackoffIdleStrategy(BACKOFF, 1.2f, 10_000);
-  }
-
-  protected void initializeMetrics() {
-    final var metricDoc = Metrics.GAUGE_POST_IMPORTER_QUEUE_SIZE;
-    final var description =
-        "Current size of the post importer queue for processing pending incidents";
-
-    metrics.registerGaugeSupplier(
-        metricDoc,
-        description,
-        () -> lastKnownQueueSize,
-        Metrics.TAG_KEY_PARTITION,
-        String.valueOf(partitionId));
-  }
-
-  protected void updateQueueSizeMetric(final long queueSize) {
-    lastKnownQueueSize.set(queueSize);
   }
 
   @Override

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
@@ -94,13 +94,6 @@ public class ElasticsearchIncidentPostImportAction extends AbstractIncidentPostI
     super(partitionId);
   }
 
-  @Override
-  public void run() {
-    // Initialize metrics when the component is fully loaded
-    initializeMetrics();
-    super.run();
-  }
-
   /**
    * Returns map incident key -> intent (CRAETED|RESOLVED)
    *
@@ -136,11 +129,6 @@ public class ElasticsearchIncidentPostImportAction extends AbstractIncidentPostI
                     .size(operateProperties.getZeebeElasticsearch().getBatchSize()));
     try {
       final SearchResponse response = esClient.search(listViewRequest, RequestOptions.DEFAULT);
-
-      // Update the queue size metric with the total hits count
-      final long queueSize = response.getHits().getTotalHits().value;
-      updateQueueSizeMetric(queueSize);
-
       incidents2Process =
           Arrays.stream(response.getHits().getHits())
               .map(sh -> sh.getSourceAsMap())

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportAction.java
@@ -91,13 +91,6 @@ public class OpensearchIncidentPostImportAction extends AbstractIncidentPostImpo
     super(partitionId);
   }
 
-  @Override
-  public void run() {
-    // Initialize metrics when the component is fully loaded
-    initializeMetrics();
-    super.run();
-  }
-
   /**
    * Returns map incident key -> intent (CRAETED|RESOLVED)
    *
@@ -130,11 +123,6 @@ public class OpensearchIncidentPostImportAction extends AbstractIncidentPostImpo
             .size(operateProperties.getZeebeOpensearch().getBatchSize());
 
     final var response = richOpenSearchClient.doc().search(postImporterQueueRequest, Result.class);
-
-    // Update the queue size metric with the total hits count
-    final long queueSize = response.hits().total().value();
-    updateQueueSizeMetric(queueSize);
-
     incidents2Process =
         response.hits().hits().stream()
             .map(Hit::source)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchPostImportActionIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchPostImportActionIT.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.operate.JacksonConfig;
-import io.camunda.operate.Metrics;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.OpensearchConnector;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
@@ -58,8 +57,6 @@ import io.camunda.operate.zeebeimport.ImportPositionHolder;
 import io.camunda.operate.zeebeimport.post.PostImportAction;
 import io.camunda.operate.zeebeimport.post.opensearch.OpensearchIncidentPostImportAction;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -100,9 +97,7 @@ import org.springframework.test.context.junit4.SpringRunner;
       DatabaseInfo.class,
       OpenSearchSchemaTestHelper.class,
       OpenSearchClientTestHelper.class,
-      OpensearchIncidentPostImportAction.class,
-      Metrics.class,
-      SimpleMeterRegistry.class
+      OpensearchIncidentPostImportAction.class
     },
     properties = {"spring.profiles.active=", OperateProperties.PREFIX + ".database=opensearch"})
 @EnableConfigurationProperties(OperateProperties.class)
@@ -119,7 +114,6 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
   @Autowired protected FlowNodeInstanceTemplate flowNodeInstanceTemplate;
   @Autowired protected PostImporterQueueTemplate postImporterQueueTemplate;
   @Autowired protected IncidentTemplate incidentTemplate;
-  @Autowired protected Metrics metrics;
 
   // not needed for the test but to satisfy our auto wirings
   @MockBean(name = "postImportThreadPoolScheduler")
@@ -144,8 +138,7 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
     schemaTestHelper.dropSchema();
   }
 
-  private void createProcessInstance(
-      final String key, final Consumer<Map<String, Object>> propertiesCreator) {
+  private void createProcessInstance(String key, Consumer<Map<String, Object>> propertiesCreator) {
 
     final Map<String, Object> processInstance = new HashMap<String, Object>();
     propertiesCreator.accept(processInstance);
@@ -160,10 +153,10 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
   }
 
   private void createFlowNodeInstance(
-      final String key,
-      final String processInstanceKey,
-      final Consumer<Map<String, Object>> listViewPropertiesCreator,
-      final Consumer<Map<String, Object>> flowNodeInstancePropertiesCreator) {
+      String key,
+      String processInstanceKey,
+      Consumer<Map<String, Object>> listViewPropertiesCreator,
+      Consumer<Map<String, Object>> flowNodeInstancePropertiesCreator) {
 
     final Map<String, Object> listViewFlowNodeInstance = new HashMap<String, Object>();
     listViewPropertiesCreator.accept(listViewFlowNodeInstance);
@@ -283,10 +276,10 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
   }
 
   private void assertUpdateWasRoutedTo(
-      final List<JsonNode> bulkActions,
-      final IndexDescriptor index,
-      final String documentId,
-      final String expectedRountingKey) {
+      List<JsonNode> bulkActions,
+      IndexDescriptor index,
+      String documentId,
+      String expectedRountingKey) {
     final List<JsonNode> updatesForDocument =
         filterUpdatesToIndexAndDocument(bulkActions, index, documentId);
 
@@ -304,7 +297,7 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
   }
 
   private List<JsonNode> filterUpdatesToIndexAndDocument(
-      final List<JsonNode> bulkActions, final IndexDescriptor index, final String documentId) {
+      List<JsonNode> bulkActions, IndexDescriptor index, String documentId) {
     return bulkActions.stream()
         .filter(n -> n.has("update")) // only updates
         .map(n -> n.get("update"))
@@ -315,7 +308,7 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
         .collect(Collectors.toList());
   }
 
-  private List<JsonNode> parseActions(final String bulkRequestBody) throws IOException {
+  private List<JsonNode> parseActions(String bulkRequestBody) throws IOException {
     final ObjectMapper objectMapper = new ObjectMapper();
     final ObjectReader reader = objectMapper.readerFor(JsonNode.class);
 
@@ -338,37 +331,5 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
     }
 
     return actions;
-  }
-
-  @Test
-  public void shouldEmitPostImporterQueueSizeMetrics() throws IOException {
-    // given
-    schemaManager.createSchema();
-
-    final String postImporterQueueKey = "1";
-    final Map<String, Object> postImporterQueueEntry = new HashMap<String, Object>();
-    postImporterQueueEntry.put("key", 123L);
-    postImporterQueueEntry.put("position", 1L);
-    postImporterQueueEntry.put("actionType", PostImporterActionType.INCIDENT);
-    postImporterQueueEntry.put("intent", IncidentIntent.CREATED);
-    postImporterQueueEntry.put("partitionId", PARTITION_ID);
-
-    searchClientTestHelper.createDocument(
-        postImporterQueueTemplate.getFullQualifiedName(),
-        postImporterQueueKey,
-        postImporterQueueEntry);
-
-    // refresh so that the post importer sees the queue entry
-    searchClientTestHelper.refreshAllIndexes();
-
-    // when
-    postImportAction.performOneRound();
-
-    // then - verify that the post importer queue size metric is registered and has correct value
-    final Gauge queueSizeGauge =
-        metrics.getMeterRegistry().find(Metrics.GAUGE_POST_IMPORTER_QUEUE_SIZE).gauge();
-    assertThat(queueSizeGauge).isNotNull();
-    assertThat(queueSizeGauge.getId().getTag("partition")).isEqualTo(String.valueOf(PARTITION_ID));
-    assertThat(queueSizeGauge.value()).isEqualTo(1.0); // One entry in the queue
   }
 }


### PR DESCRIPTION
Reverts camunda/camunda#39114

The recent introduction of post importer metrics was not successfully backported to operate 8.5 so [CI was failing](https://github.com/camunda/camunda/actions/runs/18275000597/job/52028847180?pr=39074) and blocked our release process. Since this is the last 8.5 patch, reverting this would mean the metric won't show up namespaces that use the deprecated version. Since deprecated versions will naturally have limited tools and metrics and customers will be encouraged to upgrade, we've decided that this limitation is acceptable. 