### PR TITLE
fix: Disable CI job (OS schema integrity test) for Optimize

### DIFF
--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -124,6 +124,7 @@ jobs:
 
   os-schema-integrity-test:
     name: OpenSearch Schema Integrity Test
+    if: false
     runs-on: gcp-core-8-default
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Description

We noticed that the "OpenSearch Schema Integrity" CI job was:
* disabled on `main`
* failing consistently for PRs on `stable/optimize-8.7` and `stable/optimize-8.6`

This check is not blocking PRs but consistent failures add no value and they cause confusion and frustration, so this PR attempts to disable the check

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to https://github.com/camunda/camunda/issues/34369
closes #
