### PR TITLE
fix: Add temporary error message for large variables on Tasklist V2

### DIFF
--- a/tasklist/client/src/common/error-handling/SomethingWentWrong/index.tsx
+++ b/tasklist/client/src/common/error-handling/SomethingWentWrong/index.tsx
@@ -12,7 +12,13 @@ import styles from './styles.module.scss';
 import cn from 'classnames';
 import {useTranslation} from 'react-i18next';
 
-const SomethingWentWrong: React.FC<{className?: string}> = ({className}) => {
+type Props = {
+  className?: string;
+  title?: string;
+  message?: string;
+};
+
+const SomethingWentWrong: React.FC<Props> = ({className, title, message}) => {
   const {t} = useTranslation();
 
   return (
@@ -21,8 +27,8 @@ const SomethingWentWrong: React.FC<{className?: string}> = ({className}) => {
         <Stack gap={6} orientation="horizontal">
           <ErrorRobot />
           <Stack gap={4}>
-            <Heading>{t('errorGenericErrorTitle')}</Heading>
-            <p>{t('errorGenericErrorMessage')}</p>
+            <Heading>{title ?? t('errorGenericErrorTitle')}</Heading>
+            <p>{message ?? t('errorGenericErrorMessage')}</p>
             <Button kind="primary" onClick={() => window.location.reload()}>
               {t('errorGenericErrorButtonLabel')}
             </Button>

--- a/tasklist/client/src/common/error-handling/errorBoundaries/index.tsx
+++ b/tasklist/client/src/common/error-handling/errorBoundaries/index.tsx
@@ -10,10 +10,24 @@ import type {FallbackProps} from 'react-error-boundary';
 import {useRouteError} from 'react-router-dom';
 import {SomethingWentWrong} from 'common/error-handling/SomethingWentWrong';
 import styles from './styles.module.scss';
+import {TruncatedVariableError} from 'v2/api/useSelectedVariables.query';
+import {useTranslation} from 'react-i18next';
 
 const ErrorWithinLayout: React.FC = () => {
   const error = useRouteError();
+  const isTruncatedVariableError = error instanceof TruncatedVariableError;
+  const {t} = useTranslation();
+
   console.error(error);
+
+  if (isTruncatedVariableError) {
+    return (
+      <SomethingWentWrong
+        title={t('taskDetailsTruncatedVariablesErrorTitle')}
+        message={t('taskDetailsTruncatedVariablesErrorSubtitle')}
+      />
+    );
+  }
 
   return <SomethingWentWrong />;
 };

--- a/tasklist/client/src/common/i18n/locales/de.json
+++ b/tasklist/client/src/common/i18n/locales/de.json
@@ -55,7 +55,7 @@
     "errorGenericErrorButtonLabel": "Erneut versuchen",
     "taskDetailsFailedToFetchVariablesErrorSubtitle": "Wir konnten die Aufgabenvariablen nicht abrufen. Bitte versuchen Sie es erneut oder kontaktieren Sie Ihren Tasklist-Administrator.",
     "taskDetailsTruncatedVariablesErrorTitle": "Variablen sind zu groß",
-    "taskDetailsTruncatedVariablesErrorSubtitle": "Bitte bitten Sie Ihren Operator, Ihr Prozesstoken zu verschieben oder verwenden Sie Tasklist V1",
+    "taskDetailsTruncatedVariablesErrorSubtitle": "Bitte kontaktieren Sie Ihren Tasklist-Administrator.",
     "taskDetailsFormJSSingleFieldError": "Bitte überprüfen Sie 1 Feld",
     "taskDetailsFormJSMultipleFieldError": "Bitte überprüfen Sie {{count}} Felder",
     "formJSPoweredByLabel": "Bereitgestellt von",

--- a/tasklist/client/src/common/i18n/locales/de.json
+++ b/tasklist/client/src/common/i18n/locales/de.json
@@ -54,6 +54,8 @@
     "errorGenericErrorMessage": "Diese Seite konnte nicht geladen werden. Versuchen Sie es später erneut.",
     "errorGenericErrorButtonLabel": "Erneut versuchen",
     "taskDetailsFailedToFetchVariablesErrorSubtitle": "Wir konnten die Aufgabenvariablen nicht abrufen. Bitte versuchen Sie es erneut oder kontaktieren Sie Ihren Tasklist-Administrator.",
+    "taskDetailsTruncatedVariablesErrorTitle": "Variablen sind zu groß",
+    "taskDetailsTruncatedVariablesErrorSubtitle": "Bitte bitten Sie Ihren Operator, Ihr Prozesstoken zu verschieben oder verwenden Sie Tasklist V1",
     "taskDetailsFormJSSingleFieldError": "Bitte überprüfen Sie 1 Feld",
     "taskDetailsFormJSMultipleFieldError": "Bitte überprüfen Sie {{count}} Felder",
     "formJSPoweredByLabel": "Bereitgestellt von",

--- a/tasklist/client/src/common/i18n/locales/en.json
+++ b/tasklist/client/src/common/i18n/locales/en.json
@@ -55,7 +55,7 @@
     "errorGenericErrorButtonLabel": "Try again",
     "taskDetailsFailedToFetchVariablesErrorSubtitle": "We could not fetch the task variables. Please try again or contact your Tasklist administrator.",
     "taskDetailsTruncatedVariablesErrorTitle": "Variables are too large",
-    "taskDetailsTruncatedVariablesErrorSubtitle": "Please ask your Operator to move your process token or use Tasklist V1",
+    "taskDetailsTruncatedVariablesErrorSubtitle": "Please contact your Tasklist administrator.",
     "taskDetailsFormJSSingleFieldError": "Please review 1 field",
     "taskDetailsFormJSMultipleFieldError": "Please review {{count}} fields",
     "formJSPoweredByLabel": "Powered by",

--- a/tasklist/client/src/common/i18n/locales/en.json
+++ b/tasklist/client/src/common/i18n/locales/en.json
@@ -54,6 +54,8 @@
     "errorGenericErrorMessage": "This page could not be loaded. Try again later.",
     "errorGenericErrorButtonLabel": "Try again",
     "taskDetailsFailedToFetchVariablesErrorSubtitle": "We could not fetch the task variables. Please try again or contact your Tasklist administrator.",
+    "taskDetailsTruncatedVariablesErrorTitle": "Variables are too large",
+    "taskDetailsTruncatedVariablesErrorSubtitle": "Please ask your Operator to move your process token or use Tasklist V1",
     "taskDetailsFormJSSingleFieldError": "Please review 1 field",
     "taskDetailsFormJSMultipleFieldError": "Please review {{count}} fields",
     "formJSPoweredByLabel": "Powered by",

--- a/tasklist/client/src/common/i18n/locales/es.json
+++ b/tasklist/client/src/common/i18n/locales/es.json
@@ -55,7 +55,7 @@
     "errorGenericErrorButtonLabel": "Intentar de nuevo",
     "taskDetailsFailedToFetchVariablesErrorSubtitle": "No pudimos obtener las variables de la tarea. Intente nuevamente o contacte con su administrador de Tasklist.",
     "taskDetailsTruncatedVariablesErrorTitle": "Las variables son demasiado grandes",
-    "taskDetailsTruncatedVariablesErrorSubtitle": "Por favor, pida a su Operador que mueva su token de proceso o use Tasklist V1",
+    "taskDetailsTruncatedVariablesErrorSubtitle": "Por favor, contacte con su administrador de Tasklist.",
     "taskDetailsFormJSSingleFieldError": "Por favor revise 1 campo",
     "taskDetailsFormJSMultipleFieldError": "Por favor revise {{count}} campos",
     "formJSPoweredByLabel": "Desarrollado por",

--- a/tasklist/client/src/common/i18n/locales/es.json
+++ b/tasklist/client/src/common/i18n/locales/es.json
@@ -54,6 +54,8 @@
     "errorGenericErrorMessage": "No se pudo cargar esta página. Inténtalo de nuevo más tarde.",
     "errorGenericErrorButtonLabel": "Intentar de nuevo",
     "taskDetailsFailedToFetchVariablesErrorSubtitle": "No pudimos obtener las variables de la tarea. Intente nuevamente o contacte con su administrador de Tasklist.",
+    "taskDetailsTruncatedVariablesErrorTitle": "Las variables son demasiado grandes",
+    "taskDetailsTruncatedVariablesErrorSubtitle": "Por favor, pida a su Operador que mueva su token de proceso o use Tasklist V1",
     "taskDetailsFormJSSingleFieldError": "Por favor revise 1 campo",
     "taskDetailsFormJSMultipleFieldError": "Por favor revise {{count}} campos",
     "formJSPoweredByLabel": "Desarrollado por",

--- a/tasklist/client/src/common/i18n/locales/fr.json
+++ b/tasklist/client/src/common/i18n/locales/fr.json
@@ -55,7 +55,7 @@
     "errorGenericErrorButtonLabel": "Réessayer",
     "taskDetailsFailedToFetchVariablesErrorSubtitle": "Nous n'avons pas pu récupérer les variables de la tâche. Veuillez réessayer ou contacter votre administrateur de Tasklist.",
     "taskDetailsTruncatedVariablesErrorTitle": "Les variables sont trop grandes",
-    "taskDetailsTruncatedVariablesErrorSubtitle": "Veuillez demander à votre Opérateur de déplacer votre jeton de processus ou utilisez Tasklist V1",
+    "taskDetailsTruncatedVariablesErrorSubtitle": "Veuillez contacter votre administrateur Tasklist.",
     "taskDetailsFormJSSingleFieldError": "Veuillez vérifier 1 champ",
     "taskDetailsFormJSMultipleFieldError": "Veuillez vérifier {{count}} champs",
     "formJSPoweredByLabel": "Propulsé par",

--- a/tasklist/client/src/common/i18n/locales/fr.json
+++ b/tasklist/client/src/common/i18n/locales/fr.json
@@ -54,6 +54,8 @@
     "errorGenericErrorMessage": "Cette page n'a pas pu être chargée. Réessayez plus tard.",
     "errorGenericErrorButtonLabel": "Réessayer",
     "taskDetailsFailedToFetchVariablesErrorSubtitle": "Nous n'avons pas pu récupérer les variables de la tâche. Veuillez réessayer ou contacter votre administrateur de Tasklist.",
+    "taskDetailsTruncatedVariablesErrorTitle": "Les variables sont trop grandes",
+    "taskDetailsTruncatedVariablesErrorSubtitle": "Veuillez demander à votre Opérateur de déplacer votre jeton de processus ou utilisez Tasklist V1",
     "taskDetailsFormJSSingleFieldError": "Veuillez vérifier 1 champ",
     "taskDetailsFormJSMultipleFieldError": "Veuillez vérifier {{count}} champs",
     "formJSPoweredByLabel": "Propulsé par",

--- a/tasklist/client/src/common/i18n/locales/fr.json
+++ b/tasklist/client/src/common/i18n/locales/fr.json
@@ -54,7 +54,7 @@
     "errorGenericErrorMessage": "Cette page n'a pas pu être chargée. Réessayez plus tard.",
     "errorGenericErrorButtonLabel": "Réessayer",
     "taskDetailsFailedToFetchVariablesErrorSubtitle": "Nous n'avons pas pu récupérer les variables de la tâche. Veuillez réessayer ou contacter votre administrateur de Tasklist.",
-    "taskDetailsTruncatedVariablesErrorTitle": "Les variables sont trop grandes",
+    "taskDetailsTruncatedVariablesErrorTitle": "Les variables sont trop volumineuses",
     "taskDetailsTruncatedVariablesErrorSubtitle": "Veuillez contacter votre administrateur Tasklist.",
     "taskDetailsFormJSSingleFieldError": "Veuillez vérifier 1 champ",
     "taskDetailsFormJSMultipleFieldError": "Veuillez vérifier {{count}} champs",

--- a/tasklist/client/src/v2/TaskDetails/FormJS/index.tsx
+++ b/tasklist/client/src/v2/TaskDetails/FormJS/index.tsx
@@ -24,7 +24,10 @@ import {
 import {useMemo, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {match, Pattern} from 'ts-pattern';
-import {useSelectedVariables} from 'v2/api/useSelectedVariables.query';
+import {
+  useSelectedVariables,
+  TruncatedVariableError,
+} from 'v2/api/useSelectedVariables.query';
 import {useRemoveFormReference} from 'v2/api/useTask.query';
 import {useUserTaskForm} from 'v2/api/useUserTaskForm.query';
 import {tryParseJSON} from 'v2/features/tasks/details/tryParseJSON';
@@ -65,7 +68,11 @@ const FormJS: React.FC<Props> = ({
   );
   const {schema} = data ?? {};
   const extractedVariables = extractVariablesFromFormSchema(schema);
-  const {data: variablesData, status} = useSelectedVariables(
+  const {
+    data: variablesData,
+    status,
+    error,
+  } = useSelectedVariables(
     {
       userTaskKey,
       variableNames: extractedVariables,
@@ -86,6 +93,10 @@ const FormJS: React.FC<Props> = ({
 
   const canCompleteTask =
     user.username === assignee && state === 'CREATED' && hasFetchedVariables;
+
+  if (error instanceof TruncatedVariableError) {
+    throw error;
+  }
 
   const {removeFormReference} = useRemoveFormReference(task);
   return (


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a temporary error message Tasklist V2 has a task with a form and truncated variables

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #39189
