### PR TITLE
[Backport stable/8.6] ci: fix command to run Operate importer tests

### DIFF
--- a/.github/workflows/operate-run-tests.yml
+++ b/.github/workflows/operate-run-tests.yml
@@ -1,6 +1,4 @@
 name: Operate Run Tests
-env:
-  JAVA_VERSION: "21"
 on:
   workflow_call:
     inputs:
@@ -8,9 +6,17 @@ on:
         description: "Maven command to trigger the test"
         required: true
         type: string
+      forkCount:
+        description: "The number of VMs to fork in parallel in order to execute the tests"
+        required: false
+        default: 4
+        type: number
+env:
+  JAVA_VERSION: "21"
+  LIMITS_CPU: ${{ inputs.forkCount }}
 jobs:
   run-test:
-    runs-on: ubuntu-22.04
+    runs-on: gcp-perf-core-4-default
     timeout-minutes: 30
     steps:
       - name: Check out repository code
@@ -55,16 +61,14 @@ jobs:
       - name: Build Operate
         run: ./mvnw -B -T1C -DskipChecks -DskipTests -P skipFrontendBuild clean install
       - name: Run Tests
-        run: ${{ inputs.command }}
-      - name: Send Slack notification on failure
+        run: ${{ inputs.command }} -T${{ env.LIMITS_CPU }}
+      - name: Upload failed test results
+        uses: ./.github/actions/collect-test-artifacts
         if: failure()
-        uses: slackapi/slack-github-action@v1.27.1
-        env:
-          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.OPERATE_CI_ALERT_WEBHOOK_URL }}
         with:
-          payload: |
-            {
-              "workflow_name": "${{ github.workflow }}",
-              "github_run_url": "https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}",
-              "branch": "${{ github.head_ref || github.ref_name }}"
-            }
+          name: operate-test-results
+          path: |
+            **/failsafe-reports/
+            **/surefire-reports/
+          retention-days: 1
+

--- a/.github/workflows/operate-test-importer.yml
+++ b/.github/workflows/operate-test-importer.yml
@@ -26,5 +26,5 @@ jobs:
     name: Operate zeebe integration tests
     uses: ./.github/workflows/operate-run-tests.yml
     with:
-      command: ./mvnw -pl operate/qa/integration-tests verify -P skipFrontendBuild,operateItStage2 -B -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw -pl operate/qa/integration-tests verify -P skipFrontendBuild,operateItZeebe -B -Dfailsafe.rerunFailingTestsCount=2
     secrets: inherit

--- a/.github/workflows/operate-test-importer.yml
+++ b/.github/workflows/operate-test-importer.yml
@@ -2,7 +2,6 @@ name: "[Legacy] Operate / [IT] Import"
 on:
   push:
     branches:
-      - "main"
       - "stable/**"
     paths:
       - '.github/workflows/operate-*'
@@ -11,9 +10,21 @@ on:
     paths:
       - '.github/workflows/operate-*'
       - "operate/**"
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 jobs:
   run-importer-tests:
+    name: Operate importer integration tests
     uses: ./.github/workflows/operate-run-tests.yml
     with:
-      command: ./mvnw -pl operate -am verify -T1C -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw -pl operate/qa/integration-tests verify -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2
+    secrets: inherit
+  run-zeebe-integration-tests:
+    name: Operate zeebe integration tests
+    uses: ./.github/workflows/operate-run-tests.yml
+    with:
+      command: ./mvnw -pl operate/qa/integration-tests verify -P skipFrontendBuild,operateItStage2 -B -Dfailsafe.rerunFailingTestsCount=2
     secrets: inherit

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -160,7 +160,7 @@
     <profile>
       <id>operateItImport</id>
       <properties>
-        <includeITNames>**/*ZeebeImportIT.java, **/*ZeebeIT.java</includeITNames>
+        <includeITNames>**/*ZeebeImportIT.java</includeITNames>
         <excludeITNames>none</excludeITNames>
         <skipSurefire>true</skipSurefire>
       </properties>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -149,7 +149,7 @@
     </profile>
 
     <profile>
-      <id>operateItStage2</id>
+      <id>operateItZeebe</id>
       <properties>
         <includeITNames>**/*ZeebeIT.java</includeITNames>
         <excludeITNames>none</excludeITNames>

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -471,7 +471,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.5.4</version>
         <configuration>
           <skipITs>false</skipITs>
           <includes>
@@ -480,7 +479,7 @@
           <excludes>
             <exclude>${excludeITNames}</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>${testForkCount}</forkCount>
           <reuseForks>true</reuseForks>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <systemPropertyVariables>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/OperationZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/OperationZeebeIT.java
@@ -31,9 +31,15 @@ import io.camunda.operate.entities.dmn.DecisionInstanceEntity;
 import io.camunda.operate.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.operate.schema.templates.DecisionInstanceTemplate;
 import io.camunda.operate.schema.templates.OperationTemplate;
-import io.camunda.operate.util.*;
+import io.camunda.operate.util.ConversionUtils;
+import io.camunda.operate.util.OperateZeebeAbstractIT;
+import io.camunda.operate.util.ZeebeTestUtil;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
-import io.camunda.operate.webapp.reader.*;
+import io.camunda.operate.webapp.reader.BatchOperationReader;
+import io.camunda.operate.webapp.reader.IncidentReader;
+import io.camunda.operate.webapp.reader.ListViewReader;
+import io.camunda.operate.webapp.reader.OperationReader;
+import io.camunda.operate.webapp.reader.VariableReader;
 import io.camunda.operate.webapp.rest.dto.OperationDto;
 import io.camunda.operate.webapp.rest.dto.VariableDto;
 import io.camunda.operate.webapp.rest.dto.VariableRequestDto;
@@ -47,7 +53,11 @@ import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
 import io.camunda.operate.webapp.rest.dto.operation.BatchOperationRequestDto;
 import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
 import io.camunda.operate.webapp.rest.dto.operation.OperationTypeDto;
-import io.camunda.operate.webapp.zeebe.operation.*;
+import io.camunda.operate.webapp.zeebe.operation.CancelProcessInstanceHandler;
+import io.camunda.operate.webapp.zeebe.operation.DeleteDecisionDefinitionHandler;
+import io.camunda.operate.webapp.zeebe.operation.DeleteProcessDefinitionHandler;
+import io.camunda.operate.webapp.zeebe.operation.ResolveIncidentHandler;
+import io.camunda.operate.webapp.zeebe.operation.UpdateVariableHandler;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.net.HttpURLConnection;
@@ -59,6 +69,7 @@ import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MvcResult;
@@ -122,6 +133,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testBatchOperationsPersisted() throws Exception {
     // given
     final int instanceCount = 10;
@@ -172,6 +184,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testOperationPersisted() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -216,6 +229,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testSeveralOperationsPersistedForSeveralIncidents() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstanceWithIncidents();
@@ -266,6 +280,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testNoOperationsPersistedForNoIncidents() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -315,6 +330,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testResolveIncidentExecutedOnOneInstance() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -369,6 +385,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testResolveIncidentForExecutionListener() throws Exception {
 
     // given
@@ -401,6 +418,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testUpdateVariableOnProcessInstance() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -467,6 +485,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testAddVariableOnProcessInstance() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -850,6 +869,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testRetryOperationOnZeebeNotAvailable() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -880,6 +900,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testFailResolveIncidentBecauseOfNoIncidents() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -922,6 +943,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testFailCancelOnCanceledInstance() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -955,6 +977,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testFailCancelOnCompletedInstance() throws Exception {
     // given
     final String bpmnProcessId = "startEndProcess";
@@ -993,6 +1016,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testFailAddVariableOperationAsVariableAlreadyExists() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -1012,6 +1036,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testFailAddVariableOperationAsOperationAlreadyExists() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -1102,6 +1127,7 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testDeleteProcessDefinitionFailsWhenRunning() throws Exception {
 
     // given

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/ImporterMetricsMockedZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/ImporterMetricsMockedZeebeImportIT.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -32,6 +33,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(initializers = ManagementPropertyRemoval.class)
+@Ignore("https://github.com/camunda/camunda/issues/39185")
 public class ImporterMetricsMockedZeebeImportIT extends OperateZeebeAbstractIT {
 
   @Autowired private ZeebeImporter zeebeImporter;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/ImporterMetricsZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/ImporterMetricsZeebeImportIT.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.util.HashMap;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContextInitializer;
@@ -34,6 +35,7 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(initializers = ManagementPropertyRemoval.class)
+@Ignore("https://github.com/camunda/camunda/issues/39185")
 public class ImporterMetricsZeebeImportIT extends OperateZeebeAbstractIT {
 
   @Autowired private CancelProcessInstanceHandler cancelProcessInstanceHandler;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/BasicZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/BasicZeebeImportIT.java
@@ -51,11 +51,13 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.function.Predicate;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
+@Ignore("https://github.com/camunda/camunda/issues/39185")
 public class BasicZeebeImportIT extends OperateZeebeAbstractIT {
 
   @Autowired private ProcessInstanceReader processInstanceReader;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/IdempotencyZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/IdempotencyZeebeImportIT.java
@@ -12,6 +12,7 @@ import io.camunda.operate.util.TestApplication;
 import io.camunda.operate.util.apps.idempotency.ZeebeImportIdempotencyTestConfig;
 import io.camunda.operate.zeebe.ImportValueType;
 import java.util.function.Predicate;
+import org.junit.Ignore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -27,6 +28,7 @@ import org.springframework.boot.test.context.SpringBootTest;
       "spring.main.allow-bean-definition-overriding=true",
       "spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER"
     })
+@Ignore("https://github.com/camunda/camunda/issues/39185")
 public class IdempotencyZeebeImportIT extends BasicZeebeImportIT {
 
   @Autowired

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ImportMidnightZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ImportMidnightZeebeImportIT.java
@@ -38,6 +38,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,6 +75,7 @@ public class ImportMidnightZeebeImportIT extends OperateZeebeAbstractIT {
   }
 
   @Test
+  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testProcessInstancesCompletedNextDay() throws IOException {
     // having
     final String processId = "demoProcess";

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/RetryAfterFailureZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/RetryAfterFailureZeebeImportIT.java
@@ -11,6 +11,7 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.TestApplication;
 import io.camunda.operate.util.apps.retry_after_failure.RetryAfterFailureTestConfig;
 import org.junit.After;
+import org.junit.Ignore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -23,6 +24,7 @@ import org.springframework.boot.test.context.SpringBootTest;
       "spring.main.allow-bean-definition-overriding=true",
       "spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER"
     })
+@Ignore("https://github.com/camunda/camunda/issues/39185")
 public class RetryAfterFailureZeebeImportIT extends BasicZeebeImportIT {
 
   @Autowired

--- a/operate/qa/pom.xml
+++ b/operate/qa/pom.xml
@@ -24,9 +24,9 @@
   </modules>
 
   <properties>
-    <version.zeebe.old>8.6-SNAPSHOT</version.zeebe.old>
-    <version.zeebe.docker.current>8.7-SNAPSHOT</version.zeebe.docker.current>
-    <version.identity.docker.current>8.7.0</version.identity.docker.current>
+    <version.zeebe.old>8.5.25</version.zeebe.old>
+    <version.zeebe.docker.current>8.6-SNAPSHOT</version.zeebe.docker.current>
+    <version.identity.docker.current>8.6.0</version.identity.docker.current>
   </properties>
 
 </project>

--- a/operate/qa/pom.xml
+++ b/operate/qa/pom.xml
@@ -24,11 +24,9 @@
   </modules>
 
   <properties>
-    <!-- properties for ImportSeveralVersionsTest and import-old-zeebe-tests module -->
-    <version.zeebe.old>8.1.0</version.zeebe.old>
-    <version.zeebe.docker.current>8.6.17</version.zeebe.docker.current>
-    <version.identity.docker.current>8.5.0</version.identity.docker.current>
-
+    <version.zeebe.old>8.6-SNAPSHOT</version.zeebe.old>
+    <version.zeebe.docker.current>8.7-SNAPSHOT</version.zeebe.docker.current>
+    <version.identity.docker.current>8.7.0</version.identity.docker.current>
   </properties>
 
 </project>

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/ContainerVersionsUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/ContainerVersionsUtil.java
@@ -21,12 +21,13 @@ public class ContainerVersionsUtil {
   public static final String VERSIONS_DELIMITER = ",";
   private static final String VERSIONS_FILE = "/container-versions.properties";
 
-  public static String readProperty(String propertyName) {
-    try (InputStream propsFile = ContainerVersionsUtil.class.getResourceAsStream(VERSIONS_FILE)) {
+  public static String readProperty(final String propertyName) {
+    try (final InputStream propsFile =
+        ContainerVersionsUtil.class.getResourceAsStream(VERSIONS_FILE)) {
       final Properties props = new Properties();
       props.load(propsFile);
       return props.getProperty(propertyName);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new OperateRuntimeException(
           "Unable to read the list of supported Zeebe zeebeVersions.", e);
     }


### PR DESCRIPTION
# Description
Backport of #38896 to `stable/8.6`.

relates to camunda/camunda#39185