### PR TITLE
fix: reduce failed awaiting archive count logging level

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceToBeArchivedCountJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceToBeArchivedCountJob.java
@@ -38,7 +38,7 @@ public class ProcessInstanceToBeArchivedCountJob implements BackgroundTask {
               if (err == null) {
                 metrics.setProcessInstancesAwaitingArchival(res);
               } else {
-                logger.error("Failed to count number of process instances awaiting archival", err);
+                logger.warn("Failed to count number of process instances awaiting archival", err);
               }
             });
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We log an error when the fetching of process instance awaiting archival request fails. Generally, this is something that recovers itself and does not require user intervention. Therefore, this PR changes the log level to a warn.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #39203
