### PR TITLE
Increase Timeouts for Flaky OC Tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
@@ -170,7 +170,7 @@ test.describe('variables page', () => {
     await taskPanelPage.openTask('usertask_with_variables');
 
     await expect(taskDetailsPage.addVariableButton).toBeHidden();
-    await expect(taskDetailsPage.assignToMeButton).toBeVisible({timeout: 30000});
+    await expect(taskDetailsPage.assignToMeButton).toBeVisible({timeout: 60000});
     await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
     await taskDetailsPage.clickAssignToMeButton();
 
@@ -192,7 +192,7 @@ test.describe('variables page', () => {
     await taskPanelPage.filterBy('Completed');
     await taskPanelPage.openTask('usertask_with_variables');
 
-    await expect(page.getByText('newVariableName')).toBeVisible({timeout: 30000});
+    await expect(page.getByText('newVariableName')).toBeVisible({timeout: 60000});
     await expect(page.getByText('newVariableValue')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Timeouts need to be increased to mitigate flaky test behaviour. 

Successful test run [here](https://github.com/camunda/camunda/actions/runs/18305334885).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
