### PR TITLE
[Backport stable/8.8] fix: Pass key filters as string

### DIFF
--- a/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/index.v1.test.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/index.v1.test.tsx
@@ -35,6 +35,19 @@ const createWrapper = (
   return Wrapper;
 };
 
+vi.mock('common/config/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('common/config/getClientConfig')>();
+  return {
+    getClientConfig() {
+      return {
+        ...actual.getClientConfig(),
+        clientMode: 'v1',
+      };
+    },
+  };
+});
+
 describe('<CollapsiblePanel />', () => {
   beforeEach(() => {
     nodeMockServer.use(

--- a/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/index.v2.test.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/index.v2.test.tsx
@@ -26,19 +26,6 @@ const definitionsMock = getQueryProcessDefinitionsResponseMock([
   getProcessDefinitionMock(),
 ]);
 
-vi.mock('common/config/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('common/config/getClientConfig')>();
-  return {
-    getClientConfig() {
-      return {
-        ...actual.getClientConfig(),
-        clientMode: 'v2',
-      };
-    },
-  };
-});
-
 const createWrapper = (
   initialEntries: React.ComponentProps<
     typeof MemoryRouter

--- a/tasklist/client/src/v2/api/getQueryVariables.tsx
+++ b/tasklist/client/src/v2/api/getQueryVariables.tsx
@@ -8,10 +8,7 @@
 
 import {type QueryUserTasksRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
 import {getStateLocally} from 'common/local-storage';
-import {
-  numberFiltersSchema,
-  type TaskFilters,
-} from 'v2/features/tasks/filters/useTaskFilters';
+import {type TaskFilters} from 'v2/features/tasks/filters/useTaskFilters';
 
 const SORT_BY_FIELD: Record<
   TaskFilters['sortBy'],
@@ -118,9 +115,6 @@ function convertFiltersToQueryVariables(
     filter,
     candidateGroup,
     candidateUser,
-    processInstanceKey,
-    processDefinitionKey,
-    userTaskKey,
     dueDateFrom,
     dueDateTo,
     followUpDateFrom,
@@ -128,15 +122,8 @@ function convertFiltersToQueryVariables(
     assigned,
     ...restFilters
   } = filters;
-  const numberFilters =
-    numberFiltersSchema.safeParse({
-      processInstanceKey,
-      processDefinitionKey,
-      userTaskKey,
-    }).data ?? {};
   const updatedFilters: QueryUserTasksRequestBody['filter'] = {
     ...restFilters,
-    ...numberFilters,
   };
   const customFilters = getStateLocally('customFilters')?.[filter];
 

--- a/tasklist/client/src/v2/features/tasks/filters/useTaskFilters.ts
+++ b/tasklist/client/src/v2/features/tasks/filters/useTaskFilters.ts
@@ -52,18 +52,6 @@ const filtersSchema = z.object({
   ...apiFiltersSchema.shape,
 });
 
-const numberFiltersSchema = z
-  .object({
-    processInstanceKey: z.coerce.number().optional(),
-    processDefinitionKey: z.coerce.number().optional(),
-    userTaskKey: z.coerce.number().optional(),
-  })
-  .transform((result) =>
-    Object.fromEntries(
-      Object.entries(result).filter(([_, value]) => typeof value === 'number'),
-    ),
-  );
-
 const DEFAULT_FILTERS = filtersSchema.parse({});
 
 type TaskFilters = z.infer<typeof filtersSchema>;
@@ -83,5 +71,5 @@ function useTaskFilters(): TaskFilters {
   }, [queryString]);
 }
 
-export {useTaskFilters, filtersSchema, numberFiltersSchema};
+export {useTaskFilters, filtersSchema};
 export type {TaskFilters};


### PR DESCRIPTION
# Description
Backport of #39210 to `stable/8.8`.

relates to #39197