### PR TITLE
fix: post import queue metric was not correctly registered

### DIFF
--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java
@@ -18,6 +18,7 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.BackoffIdleStrategy;
 import io.camunda.operate.zeebe.ImportValueType;
 import io.camunda.operate.zeebeimport.ImportPositionHolder;
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -56,6 +57,7 @@ public abstract class AbstractIncidentPostImportAction implements PostImportActi
     errorStrategy = new BackoffIdleStrategy(BACKOFF, 1.2f, 10_000);
   }
 
+  @PostConstruct
   protected void initializeMetrics() {
     final var metricDoc = PostImporterMetricsDoc.POST_IMPORTER_QUEUE_SIZE.getName();
     final var description = PostImporterMetricsDoc.POST_IMPORTER_QUEUE_SIZE.getDescription();

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
@@ -88,13 +88,6 @@ public class ElasticsearchIncidentPostImportAction extends AbstractIncidentPostI
     super(partitionId);
   }
 
-  @Override
-  public void run() {
-    // Initialize metrics when the component is fully loaded
-    initializeMetrics();
-    super.run();
-  }
-
   /**
    * Returns map incident key -> intent (CRAETED|RESOLVED)
    *

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportAction.java
@@ -82,13 +82,6 @@ public class OpensearchIncidentPostImportAction extends AbstractIncidentPostImpo
     super(partitionId);
   }
 
-  @Override
-  public void run() {
-    // Initialize metrics when the component is fully loaded
-    initializeMetrics();
-    super.run();
-  }
-
   /**
    * Returns map incident key -> intent (CRAETED|RESOLVED)
    *

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchPostImportActionIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchPostImportActionIT.java
@@ -173,8 +173,7 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
   }
 
   @Test
-  public void shouldUseCorrectRoutingValueWhenUpdatingFlowNodeInstance()
-      throws IOException, InterruptedException {
+  public void shouldUseCorrectRoutingValueWhenUpdatingFlowNodeInstance() throws IOException {
 
     // given
     schemaManager.createSchema();
@@ -268,6 +267,13 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
     assertUpdateWasRoutedTo(
         bulkActions, listViewTemplate, calledFlowNodeInstanceKey, calledProcessInstanceKey);
     assertUpdateWasRoutedTo(bulkActions, flowNodeInstanceTemplate, calledFlowNodeInstanceKey, null);
+
+    // then - verify that the post importer queue size metric is registered and has correct value
+    final Gauge queueSizeGauge =
+        metrics.getMeterRegistry().find(Metrics.GAUGE_POST_IMPORTER_QUEUE_SIZE).gauge();
+    assertThat(queueSizeGauge).isNotNull();
+    assertThat(queueSizeGauge.getId().getTag("partition")).isEqualTo(String.valueOf(PARTITION_ID));
+    assertThat(queueSizeGauge.value()).isEqualTo(1.0); // One entry in the queue
   }
 
   private void assertUpdateWasRoutedTo(
@@ -326,37 +332,5 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
     }
 
     return actions;
-  }
-
-  @Test
-  public void shouldEmitPostImporterQueueSizeMetrics() throws IOException {
-    // given
-    schemaManager.createSchema();
-
-    final String postImporterQueueKey = "1";
-    final Map<String, Object> postImporterQueueEntry = new HashMap<String, Object>();
-    postImporterQueueEntry.put("key", 123L);
-    postImporterQueueEntry.put("position", 1L);
-    postImporterQueueEntry.put("actionType", PostImporterActionType.INCIDENT);
-    postImporterQueueEntry.put("intent", IncidentIntent.CREATED);
-    postImporterQueueEntry.put("partitionId", PARTITION_ID);
-
-    searchClientTestHelper.createDocument(
-        postImporterQueueTemplate.getFullQualifiedName(),
-        postImporterQueueKey,
-        postImporterQueueEntry);
-
-    // refresh so that the post importer sees the queue entry
-    searchClientTestHelper.refreshAllIndexes();
-
-    // when
-    postImportAction.performOneRound();
-
-    // then - verify that the post importer queue size metric is registered and has correct value
-    final Gauge queueSizeGauge =
-        metrics.getMeterRegistry().find(Metrics.GAUGE_POST_IMPORTER_QUEUE_SIZE).gauge();
-    assertThat(queueSizeGauge).isNotNull();
-    assertThat(queueSizeGauge.getId().getTag("partition")).isEqualTo(String.valueOf(PARTITION_ID));
-    assertThat(queueSizeGauge.value()).isEqualTo(1.0); // One entry in the queue
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Since the merge of https://github.com/camunda/camunda/pull/37097, Operate integration tests are failing in stable/8.7 and 8.6 https://github.com/camunda/camunda/actions/runs/18294029586/job/52088029973

- the new `shouldEmitPostImporterQueueSizeMetrics` test did not have all pre-conditions to run the post-importer (incident is missing in DB...)
- I moved the asserts to the existing test `shouldUseCorrectRoutingValueWhenUpdatingFlowNodeInstance` since it produces this expected metric
- Since the job was rescheduling itself, the metric was registered in every run, in the test `metrics.getMeterRegistry().find(Metrics.GAUGE_POST_IMPORTER_QUEUE_SIZE).gauge()` gave null. I replaced that with a single time registration with `@PostConstruct` and it is working now.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
