### PR TITLE
[Backport stable/operate-8.5] fix: post import queue metric was not correctly registered

### DIFF
--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java
@@ -26,6 +26,7 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.BackoffIdleStrategy;
 import io.camunda.operate.zeebe.ImportValueType;
 import io.camunda.operate.zeebeimport.ImportPositionHolder;
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -59,6 +60,26 @@ public abstract class AbstractIncidentPostImportAction implements PostImportActi
     errorStrategy = new BackoffIdleStrategy(BACKOFF, 1.2f, 10_000);
   }
 
+<<<<<<< HEAD
+=======
+  @PostConstruct
+  protected void initializeMetrics() {
+    final var metricDoc = PostImporterMetricsDoc.POST_IMPORTER_QUEUE_SIZE.getName();
+    final var description = PostImporterMetricsDoc.POST_IMPORTER_QUEUE_SIZE.getDescription();
+
+    metrics.registerGaugeSupplier(
+        metricDoc,
+        description,
+        () -> lastKnownQueueSize,
+        Metrics.TAG_KEY_PARTITION,
+        String.valueOf(partitionId));
+  }
+
+  protected void updateQueueSizeMetric(final long queueSize) {
+    lastKnownQueueSize.set(queueSize);
+  }
+
+>>>>>>> dc0ef38a (fix: post import queue metric was not correctly registered)
   @Override
   public boolean performOneRound() throws IOException {
     final List<IncidentEntity> pendingIncidents = processPendingIncidents();

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ElasticsearchPostImportActionIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ElasticsearchPostImportActionIT.java
@@ -177,8 +177,7 @@ public class ElasticsearchPostImportActionIT extends AbstractElasticsearchConnec
   }
 
   @Test
-  public void shouldUseCorrectRoutingValueWhenUpdatingFlowNodeInstance()
-      throws IOException, InterruptedException {
+  public void shouldUseCorrectRoutingValueWhenUpdatingFlowNodeInstance() throws IOException {
 
     // given
     schemaManager.createSchema();
@@ -272,6 +271,13 @@ public class ElasticsearchPostImportActionIT extends AbstractElasticsearchConnec
     assertUpdateWasRoutedTo(
         bulkActions, listViewTemplate, calledFlowNodeInstanceKey, calledProcessInstanceKey);
     assertUpdateWasRoutedTo(bulkActions, flowNodeInstanceTemplate, calledFlowNodeInstanceKey, null);
+
+    // then - verify that the post importer queue size metric is registered and has correct value
+    final Gauge queueSizeGauge =
+        metrics.getMeterRegistry().find(Metrics.GAUGE_POST_IMPORTER_QUEUE_SIZE).gauge();
+    assertThat(queueSizeGauge).isNotNull();
+    assertThat(queueSizeGauge.getId().getTag("partition")).isEqualTo(String.valueOf(PARTITION_ID));
+    assertThat(queueSizeGauge.value()).isEqualTo(1.0); // One entry in the queue
   }
 
   private void assertUpdateWasRoutedTo(

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchPostImportActionIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchPostImportActionIT.java
@@ -178,8 +178,7 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
   }
 
   @Test
-  public void shouldUseCorrectRoutingValueWhenUpdatingFlowNodeInstance()
-      throws IOException, InterruptedException {
+  public void shouldUseCorrectRoutingValueWhenUpdatingFlowNodeInstance() throws IOException {
 
     // given
     schemaManager.createSchema();
@@ -273,6 +272,13 @@ public class OpensearchPostImportActionIT extends AbstractOpensearchConnectorPro
     assertUpdateWasRoutedTo(
         bulkActions, listViewTemplate, calledFlowNodeInstanceKey, calledProcessInstanceKey);
     assertUpdateWasRoutedTo(bulkActions, flowNodeInstanceTemplate, calledFlowNodeInstanceKey, null);
+
+    // then - verify that the post importer queue size metric is registered and has correct value
+    final Gauge queueSizeGauge =
+        metrics.getMeterRegistry().find(Metrics.GAUGE_POST_IMPORTER_QUEUE_SIZE).gauge();
+    assertThat(queueSizeGauge).isNotNull();
+    assertThat(queueSizeGauge.getId().getTag("partition")).isEqualTo(String.valueOf(PARTITION_ID));
+    assertThat(queueSizeGauge.value()).isEqualTo(1.0); // One entry in the queue
   }
 
   private void assertUpdateWasRoutedTo(


### PR DESCRIPTION
# Description
Backport of #39230 to `stable/operate-8.5`.

relates to 