### PR TITLE
feat(grafana): make zeebe dashboard container filter support 'orchestation'

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -1667,7 +1667,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\"zeebe.*\"}",
+              "expr": "container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\".*(orchestration|zeebe).*\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -1679,7 +1679,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "max(kube_pod_container_resource_limits_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\"zeebe.*\"})",
+              "expr": "max(kube_pod_container_resource_limits_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\".*(orchestration|zeebe).*\"})",
               "hide": false,
               "interval": "",
               "legendFormat": "limit",
@@ -1690,7 +1690,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "min(kube_pod_container_resource_requests_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\"zeebe.*\"})",
+              "expr": "min(kube_pod_container_resource_requests_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\".*(orchestration|zeebe).*\"})",
               "interval": "",
               "legendFormat": "request",
               "refId": "C"
@@ -5654,7 +5654,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*zeebe.*|core.*\", container=~\"zeebe.*|core.*\"}",
+              "expr": "container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(orchestration|zeebe).*\", container=~\".*(orchestration|zeebe).*\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -5669,7 +5669,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(kube_pod_container_resource_limits_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*zeebe.*|core.*\", container=~\"zeebe.*|core.*\"})",
+              "expr": "max(kube_pod_container_resource_limits_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(orchestration|zeebe).*\", container=~\".*(orchestration|zeebe).*\"})",
               "hide": false,
               "interval": "",
               "legendFormat": "limit",
@@ -5682,7 +5682,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "min(kube_pod_container_resource_requests_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*zeebe.*|core.*\", container=~\"zeebe.*|core.*\"})",
+              "expr": "min(kube_pod_container_resource_requests_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(orchestration|zeebe).*\", container=~\".*(orchestration|zeebe).*\"})",
               "interval": "",
               "legendFormat": "request",
               "range": true,


### PR DESCRIPTION
## Description
Added `orchestration` to the container name regex filter, while keeping compatibility for previous container names.
Added `camunda` as pod name filter where `zeebe|core` was present. 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38141
