### PR TITLE
feat: log more details on ambiguous legacy configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -9,6 +9,7 @@ package io.camunda.configuration;
 
 import io.camunda.exporter.config.ExporterConfiguration;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -85,21 +86,22 @@ public class UnifiedConfigurationHelper {
 
   private static <T> T getLegacyValue(
       final Set<String> legacyProperties, final ResolvableType expectedType) {
-    final Set<T> legacyValues = new HashSet<>();
+    final var legacyConfigurationValues = new HashMap<String, T>();
 
     for (final String legacyProperty : legacyProperties) {
       final String strValue = environment.getProperty(legacyProperty);
       final T legacyValue = parseLegacyValue(strValue, expectedType);
 
-      LOGGER.trace("Parsing legacy property '" + legacyProperty + "' -> '" + legacyValue + "'");
+      LOGGER.trace("Parsing legacy property '{}' -> '{}'", legacyProperty, legacyValue);
       if (legacyValue != null) {
-        legacyValues.add(legacyValue);
-        LOGGER.trace("Parsed actual value: '" + legacyValue + "'");
+        legacyConfigurationValues.put(legacyProperty, legacyValue);
+        LOGGER.trace("Parsed actual value: '{}'", legacyValue);
       } else {
         LOGGER.trace("Parsed null object");
       }
     }
 
+    final Set<T> legacyValues = new HashSet<>(legacyConfigurationValues.values());
     if (legacyValues.isEmpty()) {
       return null;
     }
@@ -107,8 +109,7 @@ public class UnifiedConfigurationHelper {
     if (legacyValues.size() > 1) {
       throw new UnifiedConfigurationException(
           String.format(
-              "Ambiguous legacy configuration. Legacy properties: %s; Legacy values: %s",
-              String.join(", ", legacyProperties), legacyValues));
+              "Ambiguous legacy configuration. Legacy properties: %s", legacyConfigurationValues));
     }
 
     return legacyValues.iterator().next();

--- a/configuration/src/test/java/io/camunda/configuration/UnifiedConfigurationHelperTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/UnifiedConfigurationHelperTest.java
@@ -80,7 +80,9 @@ class UnifiedConfigurationHelperTest {
             () ->
                 UnifiedConfigurationHelper.validateLegacyConfiguration(
                     NEW_PROPERTY, newValue, String.class, mode, MULTIPLE_LEGACY_PROPERTIES))
-        .withMessageContaining("Ambiguous legacy configuration");
+        .withMessageContaining("Ambiguous legacy configuration")
+        .withMessageContaining("legacy.prop1=legacyValue1")
+        .withMessageContaining("legacy.prop2=legacyValue2");
   }
 
   @Test


### PR DESCRIPTION
## Description

When the new unified configuration checks for ambiguous legacy configuration, the resulting error message only lists the properties and values separately, not which legacy property had which value. This sometimes leads to a guessing game, which property is different (especially in multi-layered helm charts with many defaults).

This PR adds a bit more information which property had which value.