### PR TITLE
fix: add mapping rule authorizations during SM identity migration

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ResourceBasedAuthorizationConstants.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ResourceBasedAuthorizationConstants.java
@@ -19,6 +19,7 @@ public final class ResourceBasedAuthorizationConstants {
           AuthorizationResourceType.ROLE,
           AuthorizationResourceType.USER,
           AuthorizationResourceType.TENANT,
+          AuthorizationResourceType.MAPPING_RULE,
           AuthorizationResourceType.SYSTEM);
 
   private ResourceBasedAuthorizationConstants() {}

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/OidcProperties.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/OidcProperties.java
@@ -9,14 +9,14 @@ package io.camunda.migration.identity.config.sm;
 
 public class OidcProperties {
 
-  private Audiences audience = new Audiences();
+  private Audiences audiences = new Audiences();
 
-  public Audiences getAudience() {
-    return audience;
+  public Audiences getAudiences() {
+    return audiences;
   }
 
-  public void setAudience(final Audiences audience) {
-    this.audience = audience;
+  public void setAudiences(final Audiences audiences) {
+    this.audiences = audiences;
   }
 
   public static class Audiences {

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/StaticEntities.java
@@ -70,6 +70,12 @@ public class StaticEntities {
                         ownerType,
                         "*",
                         AuthorizationResourceType.ROLE,
+                        Set.of(PermissionType.READ)),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.MAPPING_RULE,
                         Set.of(PermissionType.READ)))),
             new AuthEntry(
                 audiences.getIdentity() + ":read:users",
@@ -130,7 +136,13 @@ public class StaticEntities {
                         ownerType,
                         "*",
                         AuthorizationResourceType.ROLE,
-                        AuthorizationResourceType.ROLE.getSupportedPermissionTypes()))),
+                        AuthorizationResourceType.ROLE.getSupportedPermissionTypes()),
+                    new CreateAuthorizationRequest(
+                        ownerId,
+                        ownerType,
+                        "*",
+                        AuthorizationResourceType.MAPPING_RULE,
+                        AuthorizationResourceType.MAPPING_RULE.getSupportedPermissionTypes()))),
             new AuthEntry(
                 audiences.getOperate() + ":read:*",
                 List.of(

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/ClientMigrationHandler.java
@@ -91,7 +91,7 @@ public class ClientMigrationHandler extends MigrationHandler<Client> {
                       .map(
                           permission ->
                               getAuthorizationsByAudience(
-                                  migrationProperties.getOidc().getAudience(),
+                                  migrationProperties.getOidc().getAudiences(),
                                   permission,
                                   clientId,
                                   AuthorizationOwnerType.CLIENT))

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/RoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/RoleMigrationHandler.java
@@ -67,7 +67,7 @@ public class RoleMigrationHandler extends MigrationHandler<Role> {
 
     logger.debug(
         "Running role migration with this default audiences: {}",
-        migrationProperties.getOidc().getAudience());
+        migrationProperties.getOidc().getAudiences());
 
     roles.forEach(
         role -> {
@@ -87,7 +87,7 @@ public class RoleMigrationHandler extends MigrationHandler<Role> {
             logger.debug("Role with name '{}' already exists, skipping creation.", role.name());
           }
           createAuthorizationsForRole(
-              migrationProperties.getOidc().getAudience(), roleId, roleName);
+              migrationProperties.getOidc().getAudiences(), roleId, roleName);
         });
   }
 

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakRoleMigrationHandlerTest.java
@@ -118,10 +118,10 @@ public class KeycloakRoleMigrationHandlerTest {
         .isEqualTo("Description for Role with special chars");
 
     final var authorizationCaptor = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, Mockito.times(19))
+    verify(authorizationServices, Mockito.times(20))
         .createAuthorization(authorizationCaptor.capture());
     final var authorizationRequests = authorizationCaptor.getAllValues();
-    assertThat(authorizationRequests).hasSize(19);
+    assertThat(authorizationRequests).hasSize(20);
     assertThat(authorizationRequests)
         .extracting(
             CreateAuthorizationRequest::ownerId,
@@ -227,6 +227,15 @@ public class KeycloakRoleMigrationHandlerTest {
                     PermissionType.UPDATE,
                     PermissionType.DELETE)),
             tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.MAPPING_RULE,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.CREATE,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE)),
+            tuple(
                 "role@name_with_special_chars",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.SYSTEM,
@@ -314,7 +323,7 @@ public class KeycloakRoleMigrationHandlerTest {
 
     // then
     final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, times(12)).createAuthorization(results.capture());
+    verify(authorizationServices, times(13)).createAuthorization(results.capture());
     final var authorizationRequests = results.getAllValues();
     assertThat(authorizationRequests)
         .extracting(
@@ -365,6 +374,15 @@ public class KeycloakRoleMigrationHandlerTest {
                 "role_1",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.TENANT,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.CREATE,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE)),
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.MAPPING_RULE,
                 Set.of(
                     PermissionType.READ,
                     PermissionType.CREATE,
@@ -454,7 +472,7 @@ public class KeycloakRoleMigrationHandlerTest {
 
     // then
     verify(managementIdentityClient, times(2)).fetchPermissions(any());
-    verify(authorizationServices, times(19)).createAuthorization(any());
+    verify(authorizationServices, times(20)).createAuthorization(any());
   }
 
   @Test
@@ -517,7 +535,7 @@ public class KeycloakRoleMigrationHandlerTest {
 
     // then
     verify(roleServices, Mockito.times(2)).createRole(any(CreateRoleRequest.class));
-    verify(authorizationServices, Mockito.times(20))
+    verify(authorizationServices, Mockito.times(21))
         .createAuthorization(any(CreateAuthorizationRequest.class));
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
@@ -122,10 +122,10 @@ public class OidcRoleMigrationHandlerTest {
         .isEqualTo("Description for Role with special chars");
 
     final var authorizationCaptor = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, Mockito.times(19))
+    verify(authorizationServices, Mockito.times(20))
         .createAuthorization(authorizationCaptor.capture());
     final var authorizationRequests = authorizationCaptor.getAllValues();
-    assertThat(authorizationRequests).hasSize(19);
+    assertThat(authorizationRequests).hasSize(20);
     assertThat(authorizationRequests)
         .extracting(
             CreateAuthorizationRequest::ownerId,
@@ -225,6 +225,15 @@ public class OidcRoleMigrationHandlerTest {
                 "role_1",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.TENANT,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.CREATE,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE)),
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.MAPPING_RULE,
                 Set.of(
                     PermissionType.READ,
                     PermissionType.CREATE,
@@ -323,7 +332,7 @@ public class OidcRoleMigrationHandlerTest {
 
     // then
     verify(managementIdentityClient, times(2)).fetchPermissions(any());
-    verify(authorizationServices, times(19)).createAuthorization(any());
+    verify(authorizationServices, times(20)).createAuthorization(any());
   }
 
   @Test
@@ -386,7 +395,7 @@ public class OidcRoleMigrationHandlerTest {
 
     // then
     verify(roleServices, Mockito.times(2)).createRole(any(CreateRoleRequest.class));
-    verify(authorizationServices, Mockito.times(20))
+    verify(authorizationServices, Mockito.times(21))
         .createAuthorization(any(CreateAuthorizationRequest.class));
   }
 
@@ -446,10 +455,10 @@ public class OidcRoleMigrationHandlerTest {
         .isEqualTo("Description for Role with special chars");
 
     final var authorizationCaptor = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices, Mockito.times(19))
+    verify(authorizationServices, Mockito.times(20))
         .createAuthorization(authorizationCaptor.capture());
     final var authorizationRequests = authorizationCaptor.getAllValues();
-    assertThat(authorizationRequests).hasSize(19);
+    assertThat(authorizationRequests).hasSize(20);
     assertThat(authorizationRequests)
         .extracting(
             CreateAuthorizationRequest::ownerId,
@@ -549,6 +558,15 @@ public class OidcRoleMigrationHandlerTest {
                 "role_1",
                 AuthorizationOwnerType.ROLE,
                 AuthorizationResourceType.TENANT,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.CREATE,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE)),
+            tuple(
+                "role_1",
+                AuthorizationOwnerType.ROLE,
+                AuthorizationResourceType.MAPPING_RULE,
                 Set.of(
                     PermissionType.READ,
                     PermissionType.CREATE,

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcRoleMigrationHandlerTest.java
@@ -65,7 +65,7 @@ public class OidcRoleMigrationHandlerTest {
     this.authorizationServices = authorizationServices;
     final IdentityMigrationProperties identityMigrationProperties =
         new IdentityMigrationProperties();
-    final var audience = identityMigrationProperties.getOidc().getAudience();
+    final var audience = identityMigrationProperties.getOidc().getAudiences();
     audience.setIdentity("identity");
     audience.setZeebe("zeebe");
     identityMigrationProperties.setBackpressureDelay(100);
@@ -429,7 +429,7 @@ public class OidcRoleMigrationHandlerTest {
     // when
     final IdentityMigrationProperties identityMigrationProperties =
         new IdentityMigrationProperties();
-    final var audience = identityMigrationProperties.getOidc().getAudience();
+    final var audience = identityMigrationProperties.getOidc().getAudiences();
     audience.setIdentity("same-audience");
     audience.setZeebe("same-audience");
     final var updatedMigrationHandler =

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -172,6 +172,14 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
                     PermissionType.UPDATE,
                     PermissionType.DELETE,
                     PermissionType.CREATE)),
+            tuple(
+                "identity",
+                ResourceType.MAPPING_RULE,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE,
+                    PermissionType.CREATE)),
             tuple("identity", ResourceType.USER, Set.of(PermissionType.READ)),
             tuple("identity", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)));
   }
@@ -249,6 +257,14 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
             tuple(
                 "identity",
                 ResourceType.AUTHORIZATION,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE,
+                    PermissionType.CREATE)),
+            tuple(
+                "identity",
+                ResourceType.MAPPING_RULE,
                 Set.of(
                     PermissionType.READ,
                     PermissionType.UPDATE,

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationWithRBAIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationWithRBAIT.java
@@ -110,6 +110,14 @@ public class KeycloakIdentityMigrationWithRBAIT extends AbstractKeycloakIdentity
                     PermissionType.UPDATE,
                     PermissionType.DELETE,
                     PermissionType.CREATE)),
+            tuple(
+                "identity",
+                ResourceType.MAPPING_RULE,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE,
+                    PermissionType.CREATE)),
             tuple("identity", ResourceType.USER, Set.of(PermissionType.READ)),
             tuple("identity", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)));
   }

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
@@ -326,6 +326,14 @@ public class OidcIdentityMigrationIT {
                     PermissionType.UPDATE,
                     PermissionType.DELETE,
                     PermissionType.CREATE)),
+            tuple(
+                "identity",
+                ResourceType.MAPPING_RULE,
+                Set.of(
+                    PermissionType.READ,
+                    PermissionType.UPDATE,
+                    PermissionType.DELETE,
+                    PermissionType.CREATE)),
             tuple("identity", ResourceType.USER, Set.of(PermissionType.READ)),
             tuple("identity", ResourceType.COMPONENT, Set.of(PermissionType.ACCESS)));
   }

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/OidcIdentityMigrationIT.java
@@ -164,7 +164,7 @@ public class OidcIdentityMigrationIT {
     migrationProperties
         .getCluster()
         .setInitialContactPoints(List.of("localhost:" + BROKER.mappedPort(CLUSTER)));
-    migrationProperties.getOidc().getAudience().setIdentity(CAMUNDA_IDENTITY_RESOURCE_SERVER);
+    migrationProperties.getOidc().getAudiences().setIdentity(CAMUNDA_IDENTITY_RESOURCE_SERVER);
     migration = new TestStandaloneIdentityMigration(migrationProperties);
 
     client = BROKER.newClientBuilder().build();


### PR DESCRIPTION
## Description

The Identity read/write permissions should also result in mapping rule auth records. Otherwise Identity users loose access to mapping rules after the migration.

The second commit fixes an integration issue with the helm chart, where the helm chart uses `audiences` in the config property which is also what was agreed with https://github.com/camunda/camunda-platform-helm/issues/3826 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39250
