### PR TITLE
ci: use proper gh app in inherit-core-fields workflow

### DIFF
--- a/.github/workflows/gh-inherit-core-fields.yml
+++ b/.github/workflows/gh-inherit-core-fields.yml
@@ -15,12 +15,27 @@ on:
 
 jobs:
   inherit-from-parent: # owner: @camunda/core-features
-    permissions:
-      issues: write
-      contents: write
+    permissions: {} # restrict default Github token permissions since we use a GitHub App token
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
+      - name: Import Secrets
+        id: vault-secrets
+        uses: hashicorp/vault-action@v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID}}
+          secrets: |
+            secret/data/github.com/organizations/camunda ISSUE_FIELD_INHERITANCE_GH_APP_ID;
+            secret/data/github.com/organizations/camunda ISSUE_FIELD_INHERITANCE_GH_APP_KEY;
+      - name: Generate a GitHub token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.vault-secrets.outputs.ISSUE_FIELD_INHERITANCE_GH_APP_ID }}
+          private-key: ${{ steps.vault-secrets.outputs.ISSUE_FIELD_INHERITANCE_GH_APP_KEY }}
       - uses: actions/checkout@v5
       - name: Inherit fields from parent sub-issue if parent is in project 173(PVT_kwDOACVKPs4A1Kno)
         uses: actions/github-script@v7
@@ -34,5 +49,5 @@ jobs:
               return;
             }
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GHA_BEST_PRACTICES_LINTER: disabled


### PR DESCRIPTION
## Description

The workflow in question has been modified to use a Github App to access organization-level project issues.

The change is untested as its triggers only work when being on the main branch.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

* [ask-infra question](https://camunda.slack.com/archives/C5AHF1D8T/p1759778985145449)
