### PR TITLE
fix: remove normalisation of tenantIds

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/MappingRuleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/handler/sm/MappingRuleMigrationHandler.java
@@ -151,7 +151,7 @@ public class MappingRuleMigrationHandler extends MigrationHandler<MappingRule> {
       final Set<Tenant> appliedTenants, final String mappingRuleId) {
     appliedTenants.forEach(
         tenant -> {
-          final var tenantId = normalizeID(tenant.tenantId());
+          final var tenantId = tenant.tenantId();
           try {
             final var tenantMember =
                 new TenantMemberRequest(tenantId, mappingRuleId, EntityType.MAPPING_RULE);

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakTenantMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/KeycloakTenantMigrationHandlerTest.java
@@ -101,11 +101,11 @@ public class KeycloakTenantMigrationHandlerTest {
     when(managementIdentityClient.fetchTenantGroups("<default>"))
         .thenReturn(List.of(new Group("group3", "Group 3")));
     when(managementIdentityClient.fetchTenantClients("tenant1"))
-        .thenReturn(List.of(new Client("client1", "Client 1"), new Client("client2", "Client 2")));
+        .thenReturn(List.of(new Client("client1", "Client1"), new Client("client2", "Client2")));
     when(managementIdentityClient.fetchTenantClients("tenant2"))
-        .thenReturn(List.of(new Client("client3", "Client 3")));
+        .thenReturn(List.of(new Client("client3", "Client3")));
     when(managementIdentityClient.fetchTenantClients("<default>"))
-        .thenReturn(List.of(new Client("client4", "Client 4")));
+        .thenReturn(List.of(new Client("client4", "Client4")));
 
     // when
     migrationHandler.migrate();
@@ -134,21 +134,21 @@ public class KeycloakTenantMigrationHandlerTest {
             // Groups for tenant1
             tuple("tenant1", "group_1", EntityType.GROUP),
             // Clients for tenant1
-            tuple("tenant1", "client_1", EntityType.CLIENT),
-            tuple("tenant1", "client_2", EntityType.CLIENT),
+            tuple("tenant1", "Client1", EntityType.CLIENT),
+            tuple("tenant1", "Client2", EntityType.CLIENT),
             // Users for tenant2
             tuple("tenant2", "username3", EntityType.USER),
             tuple("tenant2", "username4", EntityType.USER),
             // Groups for tenant2
             tuple("tenant2", "group_2", EntityType.GROUP),
             // Clients for tenant2
-            tuple("tenant2", "client_3", EntityType.CLIENT),
+            tuple("tenant2", "Client3", EntityType.CLIENT),
             // Users for default tenant
             tuple("<default>", "username4", EntityType.USER),
             // Groups for default tenant
             tuple("<default>", "group_3", EntityType.GROUP),
             // Clients for default tenant
-            tuple("<default>", "client_4", EntityType.CLIENT));
+            tuple("<default>", "Client4", EntityType.CLIENT));
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcTenantMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/handler/sm/OidcTenantMigrationHandlerTest.java
@@ -69,7 +69,9 @@ public class OidcTenantMigrationHandlerTest {
         .thenReturn(
             List.of(
                 new Tenant("tenant1", "Tenant 1"),
-                new Tenant("tenant2", "Tenant 2"),
+                // Uppercase letter should be migrated as is, this ensures we have no regression
+                // for https://github.com/camunda/camunda/issues/39260
+                new Tenant("Tenant2", "Tenant 2"),
                 new Tenant("<default>", "Default Tenant")));
     when(tenantServices.createTenant(any(TenantRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
@@ -84,7 +86,7 @@ public class OidcTenantMigrationHandlerTest {
     assertThat(capturedTenants).hasSize(2);
     assertThat(capturedTenants.getFirst().tenantId()).isEqualTo("tenant1");
     assertThat(capturedTenants.getFirst().name()).isEqualTo("Tenant 1");
-    assertThat(capturedTenants.getLast().tenantId()).isEqualTo("tenant2");
+    assertThat(capturedTenants.getLast().tenantId()).isEqualTo("Tenant2");
     assertThat(capturedTenants.getLast().name()).isEqualTo("Tenant 2");
     verify(tenantServices, times(0)).addMember(any(TenantMemberRequest.class));
   }

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/AbstractKeycloakIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/AbstractKeycloakIdentityMigrationIT.java
@@ -127,7 +127,8 @@ public abstract class AbstractKeycloakIdentityMigrationIT {
           .withEnv("IDENTITY_TENANTS_0_MEMBERS_2_TYPE", "APPLICATION")
           .withEnv("IDENTITY_TENANTS_0_MEMBERS_2_APPLICATION-ID", IDENTITY_CLIENT)
           .withEnv("IDENTITY_TENANTS_1_NAME", "tenant 2")
-          .withEnv("IDENTITY_TENANTS_1_TENANT-ID", "tenant2")
+          // ensures we have no regression for https://github.com/camunda/camunda/issues/39260
+          .withEnv("IDENTITY_TENANTS_1_TENANT-ID", "TenanT2")
           .withEnv("IDENTITY_TENANTS_1_MEMBERS_0_TYPE", "GROUP")
           .withEnv("IDENTITY_TENANTS_1_MEMBERS_0_GROUP-NAME", "groupB")
           .withEnv("IDENTITY_TENANTS_1_MEMBERS_1_TYPE", "USER")

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/KeycloakIdentityMigrationIT.java
@@ -513,7 +513,7 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
               final var tenants = client.newTenantsSearchRequest().send().join();
               assertThat(tenants.items())
                   .extracting(Tenant::getTenantId)
-                  .contains("tenant1", "tenant2");
+                  .contains("tenant1", "TenanT2");
             });
 
     // then
@@ -522,13 +522,13 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
     final var tenants = client.newTenantsSearchRequest().send().join().items();
     assertThat(tenants)
         .extracting(Tenant::getTenantId, Tenant::getName)
-        .contains(tuple("tenant1", "tenant 1"), tuple("tenant2", "tenant 2"));
+        .contains(tuple("tenant1", "tenant 1"), tuple("TenanT2", "tenant 2"));
 
     final var tenant1Users = client.newUsersByTenantSearchRequest("tenant1").send().join();
     assertThat(tenant1Users.items())
         .extracting(TenantUser::getUsername)
         .containsExactlyInAnyOrder("user0");
-    final var tenant2Users = client.newUsersByTenantSearchRequest("tenant2").send().join();
+    final var tenant2Users = client.newUsersByTenantSearchRequest("TenanT2").send().join();
     assertThat(tenant2Users.items())
         .extracting(TenantUser::getUsername)
         .containsExactlyInAnyOrder("user1");
@@ -538,7 +538,7 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
     assertThat(tenant1Groups.items())
         .extracting(TenantGroup::groupId)
         .containsExactlyInAnyOrder("groupa");
-    final var tenant2Groups = searchGroupsInTenant(restAddress, "tenant2");
+    final var tenant2Groups = searchGroupsInTenant(restAddress, "TenanT2");
     assertThat(tenant2Groups.items())
         .extracting(TenantGroup::groupId)
         .containsExactlyInAnyOrder("groupb");
@@ -546,7 +546,7 @@ public class KeycloakIdentityMigrationIT extends AbstractKeycloakIdentityMigrati
     assertThat(tenant1Clients.items())
         .extracting(TenantClient::clientId)
         .containsExactlyInAnyOrder(IDENTITY_CLIENT);
-    final var tenant2Clients = searchClientsInTenant(restAddress, "tenant2");
+    final var tenant2Clients = searchClientsInTenant(restAddress, "TenanT2");
     assertThat(tenant2Clients.items())
         .extracting(TenantClient::clientId)
         .containsExactlyInAnyOrder(IDENTITY_CLIENT);


### PR DESCRIPTION
## Description

Tenant ids are referenced from process data and thus cannot be normalized without breaking behavior.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39260 
