### PR TITLE
fix: return directly the index.html instead forwarding to it

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -143,6 +143,7 @@ public class WebSecurityConfig {
           "/rest-api.yaml",
           // deprecated Tasklist v1 Public Endpoints
           "/new/**",
+          "/tasklist/new/**",
           "/favicon.ico");
   // We explicitly support the "at+jwt" JWT 'typ' header defined in
   // https://datatracker.ietf.org/doc/html/rfc9068#name-header
@@ -819,6 +820,12 @@ public class WebSecurityConfig {
                   (authorizeHttpRequests) ->
                       authorizeHttpRequests
                           .requestMatchers(SPRING_DEFAULT_UI_CSS)
+                          .permitAll()
+                          .requestMatchers(
+                              "/tasklist/assets/**",
+                              "/tasklist/client-config.js",
+                              "/tasklist/custom.css",
+                              "/tasklist/favicon.ico")
                           .permitAll()
                           .anyRequest()
                           .authenticated())

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -196,11 +196,6 @@
 
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-webmvc</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/PublicProcessController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/PublicProcessController.java
@@ -15,13 +15,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Controller
@@ -33,10 +31,8 @@ public class PublicProcessController extends ApiErrorController {
   @Autowired private ProcessStore processStore;
 
   @GetMapping("/{bpmnProcessId}")
-  public ModelAndView index(
+  public String index(
       final Model model, @PathVariable final String bpmnProcessId, final HttpServletRequest req) {
-    final ModelAndView modelAndView = new ModelAndView("forward:/tasklist/index.html");
-    modelAndView.setStatus(HttpStatus.OK);
     try {
       final ProcessEntity processEntity = processStore.getProcessByBpmnProcessId(bpmnProcessId);
       final String title =
@@ -44,15 +40,15 @@ public class PublicProcessController extends ApiErrorController {
               ? processEntity.getName()
               : processEntity.getBpmnProcessId();
 
-      modelAndView.addObject("title", title);
+      model.addAttribute("title", title);
     } catch (final NotFoundException ex) {
       LOGGER.warn("Could not find process with id {}", bpmnProcessId);
       LOGGER.debug("StackTrace:", ex);
     }
-    modelAndView.addObject("ogImage", getAbsolutePathOfImage(req));
-    modelAndView.addObject("ogUrl", req.getRequestURL().toString());
-
-    return modelAndView;
+    model.addAttribute("contextPath", req.getContextPath() + "/tasklist/");
+    model.addAttribute("ogImage", getAbsolutePathOfImage(req));
+    model.addAttribute("ogUrl", req.getRequestURL().toString());
+    return "tasklist/index";
   }
 
   private String getAbsolutePathOfImage(final HttpServletRequest request) {

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/PublicProcessControllerTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/PublicProcessControllerTest.java
@@ -8,7 +8,6 @@
 package io.camunda.tasklist.webapp.api.rest.v1.controllers.internal;
 
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -48,10 +47,10 @@ public class PublicProcessControllerTest {
     mockMvc
         .perform(MockMvcRequestBuilders.get("/tasklist/new/test"))
         .andExpect(status().isOk())
-        .andExpect(model().size(3))
+        .andExpect(model().size(4))
+        .andExpect(model().attribute("contextPath", "/tasklist/"))
         .andExpect(model().attribute("title", "processEntity"))
         .andExpect(model().attribute("ogImage", "http://localhost/public-start-form-og-image.jpg"))
-        .andExpect(model().attribute("ogUrl", "http://localhost/tasklist/new/test"))
-        .andExpect(forwardedUrl("/tasklist/index.html"));
+        .andExpect(model().attribute("ogUrl", "http://localhost/tasklist/new/test"));
   }
 }


### PR DESCRIPTION
## Description

Previously we redirected to `/tasklist/new` when access a public start form, with the new Authentication layer `/tasklist` is a protected resource in OIDC mode, this meant that the page would fail to load and instead show the login page, logging in would render the page as expected.

After pairing with @romansmirnov it was decided that we could instead just return the model directly from the endpoint instead of redirecting. This PR does just that and returns directly.

I've tested this myself locally a couple of times now and it produces the desired result using an incognito window.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39234 
