### PR TITLE
Fix Flaky 8.8 OC Test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
@@ -166,6 +166,7 @@ test.describe('variables page', () => {
     taskDetailsPage,
     taskPanelPage,
   }) => {
+    test.slow();
     await taskPanelPage.filterBy('Unassigned');
     await taskPanelPage.openTask('usertask_with_variables');
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In order to mitigate a test which is consistently proving to be flaky on the CI due to loading issues, the test is now made to be slow.

Successful test run [here](https://github.com/camunda/camunda/actions/runs/18336514886).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
