### PR TITLE
fix: token handover in gh-inherit-core-fields

### DIFF
--- a/.github/workflows/gh-inherit-core-fields.yml
+++ b/.github/workflows/gh-inherit-core-fields.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Inherit fields from parent sub-issue if parent is in project 173(PVT_kwDOACVKPs4A1Kno)
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             try {
               const myScript = require('./.github/actions/core-features/inheritCoreFields.cjs');
@@ -49,5 +50,4 @@ jobs:
               return;
             }
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GHA_BEST_PRACTICES_LINTER: disabled


### PR DESCRIPTION
## Description

* Fixes a bug when handing a Github App token to `actions/github-script`. (behaves differently from passing a PAT or repo-specific token)

:alembic: Fix validated in this [draft PR](https://github.com/camunda/camunda/pull/39305).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
