### PR TITLE
[Backport stable/8.8] fix: check permission for correlated messages

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -72,8 +72,8 @@ public final class MessageCorrelateBehavior {
   }
 
   /**
-   * Collects message start event subscriptions without writing state changes.
-   * Used for authorization checks before actual correlation.
+   * Collects message start event subscriptions without writing state changes. Used for
+   * authorization checks before actual correlation.
    */
   public void collectMessageStartEventSubscriptions(
       final MessageData messageData, final Subscriptions correlatingSubscriptions) {
@@ -130,8 +130,8 @@ public final class MessageCorrelateBehavior {
   }
 
   /**
-   * Collects message event subscriptions without writing state changes.
-   * Used for authorization checks before actual correlation.
+   * Collects message event subscriptions without writing state changes. Used for authorization
+   * checks before actual correlation.
    */
   public void collectMessageEventSubscriptions(
       final MessageData messageData, final Subscriptions correlatingSubscriptions) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -104,6 +104,28 @@ public final class MessageCorrelationCorrelateProcessor
         .setRequestId(command.getRequestId())
         .setRequestStreamId(command.getRequestStreamId());
 
+    // Collect correlations first without writing to state
+    final var correlatingSubscriptions = new Subscriptions();
+    final var messageData = createMessageData(messageKey, messageCorrelationRecord);
+
+    // Create a temporary subscriptions collector to check authorization first
+    final var tempCorrelatingSubscriptions = new Subscriptions();
+    correlateBehavior.collectMessageEventSubscriptions(messageData, tempCorrelatingSubscriptions);
+    correlateBehavior.collectMessageStartEventSubscriptions(
+        messageData, tempCorrelatingSubscriptions);
+
+    // Check authorization before writing anything to state
+    final var authorizationRejectionOptional =
+        isAuthorizedForAllSubscriptions(
+            command, tempCorrelatingSubscriptions, messageCorrelationRecord.getTenantId());
+    if (authorizationRejectionOptional.isPresent()) {
+      final var rejection = authorizationRejectionOptional.get();
+      rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      return;
+    }
+
+    // Now that authorization passed, write the message and correlations to state
     final var messageRecord =
         new MessageRecord()
             .setName(command.getValue().getName())
@@ -116,20 +138,9 @@ public final class MessageCorrelationCorrelateProcessor
     stateWriter.appendFollowUpEvent(
         messageKey, MessageCorrelationIntent.CORRELATING, messageCorrelationRecord);
 
-    final var correlatingSubscriptions = new Subscriptions();
-    final var messageData = createMessageData(messageKey, messageCorrelationRecord);
+    // Now actually correlate with state writes
     correlateBehavior.correlateToMessageEvents(messageData, correlatingSubscriptions);
     correlateBehavior.correlateToMessageStartEvents(messageData, correlatingSubscriptions);
-
-    final var authorizationRejectionOptional =
-        isAuthorizedForAllSubscriptions(
-            command, correlatingSubscriptions, messageCorrelationRecord.getTenantId());
-    if (authorizationRejectionOptional.isPresent()) {
-      final var rejection = authorizationRejectionOptional.get();
-      rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
-      return;
-    }
 
     if (correlatingSubscriptions.isEmpty()) {
       final var errorMessage =
@@ -137,23 +148,23 @@ public final class MessageCorrelationCorrelateProcessor
               command.getValue().getName(), command.getValue().getCorrelationKey());
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
-    } else {
-      correlatingSubscriptions
-          .getFirstMessageStartEventSubscription()
-          .ifPresent(
-              subscription -> {
-                messageCorrelationRecord.setProcessInstanceKey(
-                    subscription.getProcessInstanceKey());
-
-                stateWriter.appendFollowUpEvent(
-                    messageKey, MessageCorrelationIntent.CORRELATED, messageCorrelationRecord);
-                responseWriter.writeEventOnCommand(
-                    messageKey,
-                    MessageCorrelationIntent.CORRELATED,
-                    messageCorrelationRecord,
-                    command);
-              });
+      return;
     }
+
+    correlatingSubscriptions
+        .getFirstMessageStartEventSubscription()
+        .ifPresent(
+            subscription -> {
+              messageCorrelationRecord.setProcessInstanceKey(subscription.getProcessInstanceKey());
+
+              stateWriter.appendFollowUpEvent(
+                  messageKey, MessageCorrelationIntent.CORRELATED, messageCorrelationRecord);
+              responseWriter.writeEventOnCommand(
+                  messageKey,
+                  MessageCorrelationIntent.CORRELATED,
+                  messageCorrelationRecord,
+                  command);
+            });
 
     correlateBehavior.sendCorrelateCommands(messageData, correlatingSubscriptions);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
@@ -125,6 +125,7 @@ public class SignalBroadcastAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(PROCESS_ID));
+    assertThatNoSignalIsBroadcasted();
   }
 
   @Test
@@ -176,5 +177,17 @@ public class SignalBroadcastAuthorizationTest {
 
   private long createProcessInstance() {
     return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+  }
+
+  private void assertThatNoSignalIsBroadcasted() {
+    final var limitPosition =
+        engine.signal().withSignalName("limitingRecord").broadcast().getPosition();
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getPosition() < limitPosition)
+                .signalRecords()
+                .withIntent(SignalIntent.BROADCASTED)
+                .withSignalName(SIGNAL_NAME))
+        .isEmpty();
   }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -106,6 +106,16 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
         filter(r -> r.getValueType() == ValueType.INCIDENT).map(Record.class::cast));
   }
 
+  public MessageRecordStream messageRecords() {
+    return new MessageRecordStream(
+        filter(r -> r.getValueType() == ValueType.MESSAGE).map(Record.class::cast));
+  }
+
+  public MessageCorrelationRecordStream messageCorrelationRecords() {
+    return new MessageCorrelationRecordStream(
+        filter(r -> r.getValueType() == ValueType.MESSAGE_CORRELATION).map(Record.class::cast));
+  }
+
   public MessageSubscriptionRecordStream messageSubscriptionRecords() {
     return new MessageSubscriptionRecordStream(
         filter(r -> r.getValueType() == ValueType.MESSAGE_SUBSCRIPTION).map(Record.class::cast));

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -138,6 +138,11 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
         filter(r -> r.getValueType() == ValueType.SIGNAL_SUBSCRIPTION).map(Record.class::cast));
   }
 
+  public SignalRecordStream signalRecords() {
+    return new SignalRecordStream(
+        filter(r -> r.getValueType() == ValueType.SIGNAL).map(Record.class::cast));
+  }
+
   public UserTaskRecordStream userTaskRecords() {
     return new UserTaskRecordStream(
         filter(r -> r.getValueType() == ValueType.USER_TASK).map(Record.class::cast));
@@ -161,6 +166,11 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
   public AuthorizationRecordStream authorizationRecords() {
     return new AuthorizationRecordStream(
         filter(r -> r.getValueType() == ValueType.AUTHORIZATION).map(Record.class::cast));
+  }
+
+  public ResourceDeletionRecordStream resourceDeletionRecords() {
+    return new ResourceDeletionRecordStream(
+        filter(r -> r.getValueType() == ValueType.RESOURCE_DELETION).map(Record.class::cast));
   }
 
   public AsyncRequestRecordStream asyncRequestRecords() {


### PR DESCRIPTION
# Description
Backport of #39299 to `stable/8.8`.

relates to #39301