### PR TITLE
[Backport stable/optimize-8.6] deps: update http5 client and core since spring boot upgrade

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -48,8 +48,8 @@
     <jetty.version>12.0.25</jetty.version>
     <jackson.version>2.18.1</jackson.version>
     <jsonpath.version>2.9.0</jsonpath.version>
-    <apache.http5-client.version>5.4</apache.http5-client.version>
-    <apache.http5-core.version>5.3.1</apache.http5-core.version>
+    <apache.http5-client.version>5.5</apache.http5-client.version>
+    <apache.http5-core.version>5.3.4</apache.http5-core.version>
     <guava.version>33.3.1-jre</guava.version>
     <spring.boot.version>3.5.5</spring.boot.version>
     <spring.version>6.2.10</spring.version>


### PR DESCRIPTION
# Description
Backport of #39320 to `stable/optimize-8.6`.

relates to 
original author: @konstantinos-mylosis