### PR TITLE
Starter and worker app fixes to run against Saas

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/App.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/App.java
@@ -145,8 +145,9 @@ abstract class App implements Runnable {
               "Failed to retrieve topology due to authentication error; check your config", e);
           System.exit(1);
         }
+        THROTTLED_LOGGER.warn("Failed to retrieve topology due to client exception: ", e);
       } catch (final Exception e) {
-        THROTTLED_LOGGER.warn("Topology request failed", e);
+        THROTTLED_LOGGER.warn("Topology request failed: ", e);
       }
     }
   }

--- a/load-tests/load-tester/src/main/resources/application.conf
+++ b/load-tests/load-tester/src/main/resources/application.conf
@@ -21,6 +21,7 @@ app {
       audience = ${?ZEEBE_TOKEN_AUDIENCE}
       clientId = "client-id"
       clientId = ${?ZEEBE_CLIENT_ID}
+      clientSecret = ""
       clientSecret = ${?ZEEBE_CLIENT_SECRET}
       authzUrl = "http://localhost:8080/auth/realms/demo/protocol/openid-connect/auth"
       authzUrl = ${?ZEEBE_AUTHORIZATION_SERVER_URL}

--- a/load-tests/load-tester/src/main/resources/application.conf
+++ b/load-tests/load-tester/src/main/resources/application.conf
@@ -1,13 +1,16 @@
 app {
   brokerUrl = "http://localhost:26500"
-  brokerUrl = ${?ZEEBE_ADDRESS}
+  brokerUrl = ${?ZEEBE_GRPC_ADDRESS}
   brokerRestUrl = "http://localhost:8080"
+  brokerRestUrl = ${?ZEEBE_REST_ADDRESS}
   tls = false
+  tls = ${?TLS}
   preferRest = false
   monitoringPort = 9600
 
   auth {
     type = "NONE" # NONE, BASIC
+    type = ${?ZEEBE_AUTH_TYPE}
     basic {
       username = "demo"
       password = "demo"
@@ -15,9 +18,12 @@ app {
 
     oauth {
       audience = "${brokerUrl}"
+      audience = ${?ZEEBE_TOKEN_AUDIENCE}
       clientId = "client-id"
-      clientSecret = ""
+      clientId = ${?ZEEBE_CLIENT_ID}
+      clientSecret = ${?ZEEBE_CLIENT_SECRET}
       authzUrl = "http://localhost:8080/auth/realms/demo/protocol/openid-connect/auth"
+      authzUrl = ${?ZEEBE_AUTHORIZATION_SERVER_URL}
     }
   }
 


### PR DESCRIPTION
## Description

The goal of this PR is firstly to fix the starter and worker configuration to allow it again to run against saas when configuring the helm benchmark to do so. This requires that we override the credentials necessary to connect with saas.
I created a [benchmark](https://grafana.dev.zeebe.io/d/zeebe-dashboard/zeebe?orgId=1&var-DS_PROMETHEUS=prometheus&var-cluster=$__all&var-namespace=rl-starter-and-worker-fix&var-pod=$__all&var-partition=$__all&var-memory_state=committed&from=now-6h&to=now&timezone=browser) based on this branch to make sure that we dont break the base case where the starter connects to the cluster in its own namespace. The fix works in conjuction with this [PR](https://github.com/camunda/camunda-docs/pull/6794) in the benchmar repo.

I also changed the name of the variables to be in line with the ones generated when we create the Saas API client so that we can copy directly the env variables to our local environment and deploy the worker and starter this way to run against saas, only needing to additionally add `ZEEBE_AUTH_TYPE=OAUTH`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
