### PR TITLE
[Backport release-8.8.0] fix: add RESOLVE IncidentState which was missing

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/incident/IncidentState.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/incident/IncidentState.java
@@ -15,6 +15,7 @@ public enum IncidentState {
   ACTIVE("CREATED"),
   MIGRATED("MIGRATED"),
   RESOLVED("RESOLVED"),
+  RESOLVE("RESOLVE"),
   PENDING(null);
 
   private static final Map<String, IncidentState> INTENT_MAP = new HashMap<>();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -353,9 +353,8 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
       if (newState == null) {
         final var errMsg =
             String.format(
-                "Pending incident has a new state of [%s], which is not a valid IncidentState, should be on of %s",
+                "Pending incident has a new state of [%s], which is not a valid IncidentState, should be one of %s",
                 entity.intent(), Arrays.toString(IncidentState.values()));
-        logger.error(errMsg);
         throw new IllegalStateException(errMsg);
       }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -33,6 +33,7 @@ import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEnt
 import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.webapps.schema.entities.post.PostImporterActionType;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -348,6 +349,16 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
     for (final var hit : hits) {
       final var entity = hit.source();
       final var newState = IncidentState.createFrom(entity.intent());
+
+      if (newState == null) {
+        final var errMsg =
+            String.format(
+                "Pending incident has a new state of [%s], which is not a valid IncidentState, should be on of %s",
+                entity.intent(), Arrays.toString(IncidentState.values()));
+        logger.error(errMsg);
+        throw new IllegalStateException(errMsg);
+      }
+
       incidents.put(entity.key(), newState);
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -19,6 +19,7 @@ import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.webapps.schema.entities.post.PostImporterActionType;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -399,6 +400,16 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
     for (final var hit : hits) {
       final var entity = hit.source();
       final var newState = IncidentState.createFrom(entity.intent());
+
+      if (newState == null) {
+        final var errMsg =
+            String.format(
+                "Pending incident has a new state of [%s], which is not a valid IncidentState, should be on of %s",
+                entity.intent(), Arrays.toString(IncidentState.values()));
+        logger.error(errMsg);
+        throw new IllegalStateException(errMsg);
+      }
+
       incidents.put(entity.key(), newState);
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -404,9 +404,8 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
       if (newState == null) {
         final var errMsg =
             String.format(
-                "Pending incident has a new state of [%s], which is not a valid IncidentState, should be on of %s",
+                "Pending incident has a new state of [%s], which is not a valid IncidentState, should be one of %s",
                 entity.intent(), Arrays.toString(IncidentState.values()));
-        logger.error(errMsg);
         throw new IllegalStateException(errMsg);
       }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -227,6 +227,28 @@ abstract class IncidentUpdateRepositoryIT {
   @Nested
   final class GetPendingIncidentsBatchTest {
     @Test
+    void shouldMatchAllIncidentIntentsToIncidentState() {
+      final var repository = createRepository();
+
+      for (final var intent : IncidentIntent.values()) {
+        setupIncidentUpdates(1, 2, e -> e.setIntent(intent.name()).setKey((long) intent.value()));
+      }
+
+      final var newIncidentStates =
+          repository
+              .getPendingIncidentsBatch(1L, IncidentIntent.values().length)
+              .toCompletableFuture()
+              .join()
+              .newIncidentStates();
+
+      for (final var intent : IncidentIntent.values()) {
+        final var matchingIncidentState = newIncidentStates.get((long) intent.value());
+        assertThat(matchingIncidentState).isNotNull();
+        assertThat(matchingIncidentState).isEqualTo(IncidentState.createFrom(intent.name()));
+      }
+    }
+
+    @Test
     void shouldGetOnlyNewUpdatesByPosition() throws PersistenceException {
       // given
       final var repository = createRepository();


### PR DESCRIPTION
# Description
Backport of #39325 to `release-8.8.0`.

relates to #39249 #37288