### PR TITLE
[Backport main] fix: handle incidents missing treePath after migration from 8.7

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -137,6 +137,14 @@ public final class IncidentUpdateTask implements BackgroundTask {
     }
     logger.trace("Applying the following pending incident updates: {}", batch.newIncidentStates());
     searchForInstances(data);
+    data.incidents()
+        .forEach(
+            (key, incidentDocument) -> {
+              if (incidentDocument.incident().getTreePath() == null) {
+                final var treePath = data.incidentTreePaths().get(key);
+                incidentDocument.incident().setTreePath(treePath);
+              }
+            });
     return CompletableFuture.completedFuture(processIncidents(data, batch))
         .thenComposeAsync(
             documentsUpdated -> {


### PR DESCRIPTION
# Description
Backport of #39329 to `main`.

relates to #39267