### PR TITLE
Increase Action Timeouts For Flaky CI Test Behaviour

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -275,7 +275,7 @@ test.describe('task details page', () => {
     await taskPanelPage.openTask('processWithDeployedForm');
 
     await taskDetailsPage.clickAssignToMeButton();
-    await expect(taskDetailsPage.unassignButton).toBeVisible();
+    await expect(taskDetailsPage.unassignButton).toBeVisible({timeout: 30000});
     await taskDetailsPage.fillTextInput('Client Name*', 'Jon');
     await taskDetailsPage.fillTextInput('Client Address*', 'Earth');
     await taskDetailsPage.fillDatetimeField('Invoice Date', '1/1/3000');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
@@ -193,7 +193,7 @@ test.describe('variables page', () => {
     await taskPanelPage.filterBy('Completed');
     await taskPanelPage.openTask('usertask_with_variables');
 
-    await expect(page.getByText('newVariableName')).toBeVisible();
+    await expect(page.getByText('newVariableName')).toBeVisible({timeout: 30000});
     await expect(page.getByText('newVariableValue')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR increases a couple action timeouts to account for some tests being flaky on the nightly test run.

Successful test run [here](https://github.com/camunda/camunda/actions/runs/18368977507).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
