### PR TITLE
ci: send results in slack

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -297,6 +297,7 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-tests
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -63,6 +63,16 @@ jobs:
           echo "Detected base branch: $base"
           echo "base=$base" >> "$GITHUB_OUTPUT"
 
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   c8-orchestration-cluster-e2e-tests:
     name: C8 Orchestration Cluster E2E Tests Release (Tasklist ${{ matrix.tasklist_mode }} mode)
     strategy:
@@ -71,6 +81,8 @@ jobs:
         tasklist_mode: ${{ fromJSON( (needs.validate-release.outputs.base == 'stable/8.6' || needs.validate-release.outputs.base == 'stable/8.7') && '["v1"]' || '["v1","v2"]' ) }}
     needs: validate-release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions: {}
     steps:
       - name: Print release info
         run: |
@@ -278,3 +290,61 @@ jobs:
           name: C8 Orchestration Cluster E2E Test Result Release v${{ needs.validate-release.outputs.release_version }} (Tasklist ${{ matrix.tasklist_mode }} mode)
           path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 10
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  notify-result:
+    name: Send notification based on test results
+    runs-on: ubuntu-latest
+    needs: [validate-release, c8-orchestration-cluster-e2e-tests]
+    if: always()
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@2c5827061f1ad91ca97897d6257ebe638e033699
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ needs.c8-orchestration-cluster-e2e-tests.result == 'success' && format('<@qa-automated-release-manager> :test_tube: C8 Orchestration Cluster E2E Tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<@qa-automated-release-manager> :warning: C8 Orchestration Cluster E2E Tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
+                  }
+                }
+              ]
+            }
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description
Adds Slack notifications to inform the QA team about C8 Orchestration Cluster E2E test results during monorepo releases.

## Changes
- **New job**: `notify-result` - sends notifications for both success and failure scenarios
- **QA team mentions**: `@qa-automated-release-manager` for immediate attention  
- **Direct links**: "test run overview" links to GitHub Actions workflow run
- **Context-aware**: Different emojis for success (🧪) vs failure (⚠️)

## Message Format
- **Success**: `@qa-automated-release-manager 🧪 C8 Orchestration Cluster E2E Tests for {version} succeeded. See test run overview for details.`
- **Failure**: `@qa-automated-release-manager ⚠️ C8 Orchestration Cluster E2E Tests for {version} failed. See test run overview for details.`


## Testing
Below test runs are tested with only echoing the results:
[8.7 successful run](https://github.com/camunda/camunda/actions/runs/18376564391/job/52352690292)
[8.8 test run with failures](https://github.com/camunda/camunda/actions/runs/18376559483/job/52353231415)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to: #38655
