### PR TITLE
Smoke migration test improvements

### DIFF
--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -145,7 +145,7 @@ jobs:
   deploy-camunda-cluster-prev-version:
     name: Deploy previous version of Camunda Platform
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -416,7 +416,8 @@ jobs:
     name: Notify on failure
     runs-on: ubuntu-latest
     needs: [ target-version-complete-job ]
-    if: failure()
+    # We are only interested in notifications for scheduled runs
+    if: (failure() || cancelled()) && github.event.schedule != null
     steps:
       - uses: actions/checkout@v4
       - id: slack-notify
@@ -447,7 +448,8 @@ jobs:
     name: Notify on Success
     runs-on: ubuntu-latest
     needs: [ target-version-complete-job ]
-    if: success()
+    # We are only interested in notifications for scheduled runs
+    if: success() && github.event.schedule != null
     steps:
       - uses: actions/checkout@v4
       - id: slack-notify

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -190,7 +190,7 @@ jobs:
     needs:
       - deploy-camunda-cluster-prev-version
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -260,7 +260,7 @@ jobs:
     # the deploy will be run, when build is skipped or successful.
     if: always() && (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped')
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -17,7 +17,7 @@ on:
         required: false
       ref:
         description: 'Specifies the ref (e.g. main or a commit sha) to test the migration to'
-        default: 'release-8.8.0'
+        default: 'stable/8.8'
         type: string
         required: false
       cluster:
@@ -44,7 +44,7 @@ on:
         required: false
       ref:
         description: 'Specifies the ref (e.g. main or a commit sha) to test the migration to'
-        default: 'release-8.8.0'
+        default: 'stable/8.8'
         type: string
         required: false
       cluster:

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -1,11 +1,8 @@
-# description: Workflow to run Camunda Platform release migration tests
+# description: Reusable workflow to run Camunda Platform release migration tests
 # type: CI
 # owner: @Chris
 name: Camunda Release migration test
 on:
-  schedule:
-    # Runs at 04:00. every day https://crontab.guru/#0_4_*_*_*
-    - cron: 0 4 * * *
   workflow_dispatch:
     inputs:
       name:
@@ -412,60 +409,3 @@ jobs:
             $(helm get values ${{ inputs.name || 'release-migration-test' }} -n ${{ inputs.name || 'release-migration-test' }})
             \`\`\`
           EOF
-  notify:
-    name: Notify on failure
-    runs-on: ubuntu-latest
-    needs: [ target-version-complete-job ]
-    # We are only interested in notifications for scheduled runs
-    if: (failure() || cancelled()) && github.event.schedule != null
-    steps:
-      - uses: actions/checkout@v4
-      - id: slack-notify
-        uses: slackapi/slack-github-action@v2.1.1
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":alarm: *Daily Camunda migration test failed:*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "@zeebe-medic Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-                  }
-                }
-              ]
-            }
-  notify-success:
-    name: Notify on Success
-    runs-on: ubuntu-latest
-    needs: [ target-version-complete-job ]
-    # We are only interested in notifications for scheduled runs
-    if: success() && github.event.schedule != null
-    steps:
-      - uses: actions/checkout@v4
-      - id: slack-notify
-        uses: slackapi/slack-github-action@v2.1.1
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":white_check_mark: *Daily Camunda migration test succeeded against branch:* ${{ inputs.ref || 'release-8.8.0' }}"
-                  }
-                }
-              ]
-            }

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -60,7 +60,7 @@ on:
 
 concurrency:
   cancel-in-progress: true
-  group: ${{ inputs.name || 'release-migration-test' }}
+  group: ${{ inputs.name }}
 
 jobs:
   calculate-image-tag:
@@ -71,11 +71,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || 'release-8.8.0' }}
+          ref: ${{ inputs.ref }}
       - name: Get image tag
         id: image-tag
         run: |
-          echo "image-tag=${{ inputs.name || 'release-migration-test' }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
   build-camunda-image:
     name: Build Zeebe
     needs: calculate-image-tag
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || 'release-8.8.0' }}
+          ref: ${{ inputs.ref }}
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -133,7 +133,7 @@ jobs:
         name: Build Camunda Docker Image
         with:
           repository: 'gcr.io/zeebe-io/zeebe'
-          revision: ${{ inputs.ref || 'release-8.8.0' }}
+          revision: ${{ inputs.ref }}
           push: true
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}
           distball: ${{ steps.build-zeebe.outputs.distball }}
@@ -149,36 +149,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || 'release-8.8.0' }}
+          ref: ${{ inputs.ref }}
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v2.3.4
         with:
-          cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
-          location: ${{ inputs.cluster-region || 'europe-west1-b' }}
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
       - name: Clean up existing namespace
         run: |
-          kubectl delete namespace ${{ inputs.name || 'release-migration-test' }} --ignore-not-found=true
+          kubectl delete namespace ${{ inputs.name }} --ignore-not-found=true
       - name: Add camunda helm repo
         run: |
           helm repo add camunda https://helm.camunda.io
           helm repo update
       - name: Helm install
         run: >
-          helm install ${{ inputs.name || 'release-migration-test' }} camunda/camunda-platform
+          helm install ${{ inputs.name }} camunda/camunda-platform
           --wait --timeout 35m0s
-          --namespace ${{ inputs.name || 'release-migration-test' }}
+          --namespace ${{ inputs.name }}
           --create-namespace
           --render-subchart-notes
       - name: Summarize deployment
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Test \`${{ inputs.name || 'release-migration-test' }}\` values
+            ## Test \`${{ inputs.name }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name || 'release-migration-test' }} -n ${{ inputs.name || 'release-migration-test' }})
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
             \`\`\`
           EOF
 
@@ -201,15 +201,15 @@ jobs:
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v2.3.4
         with:
-          cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
-          location: ${{ inputs.cluster-region || 'europe-west1-b' }}
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
       - name: Port-forward to gateway
         run: |
-          release="${{ inputs.name || 'release-migration-test' }}"
+          release="${{ inputs.name }}"
           kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
       - name: Port-forward to Keycloak
         run: |
-          release="${{ inputs.name || 'release-migration-test' }}"
+          release="${{ inputs.name }}"
           kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
       - name: Install zbctl
         run: |
@@ -218,7 +218,7 @@ jobs:
           chmod +x zbctl
       - name: Add load
         run: |
-          release="${{ inputs.name || 'release-migration-test' }}"
+          release="${{ inputs.name }}"
           # Get secret for connectors - to communicate with the cluster
           ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" "$release-zeebe-identity-secret" -o json | jq -r '.data."zeebe-secret"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
@@ -241,9 +241,9 @@ jobs:
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Test \`${{ inputs.name || 'release-migration-test' }}\` values
+            ## Test \`${{ inputs.name }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name || 'release-migration-test' }} -n ${{ inputs.name || 'release-migration-test' }})
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
             \`\`\`
           EOF
 
@@ -272,8 +272,8 @@ jobs:
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v2.3.4
         with:
-          cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
-          location: ${{ inputs.cluster-region || 'europe-west1-b' }}
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
       - name: Add camunda helm repo
         run: |
           helm repo add camunda https://helm.camunda.io
@@ -281,7 +281,7 @@ jobs:
       - name: Extract secrets
         id: extract-secrets
         run: |
-          release=${{ inputs.name || 'release-migration-test' }}
+          release=${{ inputs.name }}
           OPTIMIZE_SECRET=$(kubectl get secret --namespace "$release" "$release-optimize-identity-secret" -o jsonpath="{.data.optimize-secret}" | base64 --decode)
           export OPTIMIZE_SECRET
           CONNECTORS_SECRET=$(kubectl get secret --namespace "$release" "$release-connectors-identity-secret" -o jsonpath="{.data.connectors-secret}" | base64 --decode)
@@ -309,9 +309,9 @@ jobs:
         id: upgrade-platform
         run: |
           helm dependency build charts/camunda-platform-8.8/
-          helm upgrade ${{ inputs.name || 'release-migration-test' }} charts/camunda-platform-8.8/ \
+          helm upgrade ${{ inputs.name }} charts/camunda-platform-8.8/ \
           --wait --wait-for-jobs --timeout 35m0s \
-          --namespace ${{ inputs.name || 'release-migration-test' }} \
+          --namespace ${{ inputs.name }} \
           --render-subchart-notes \
           --set connectors.image.tag=SNAPSHOT \
           --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials \
@@ -338,9 +338,9 @@ jobs:
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Test \`${{ inputs.name || 'release-migration-test' }}\` values
+            ## Test \`${{ inputs.name }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name || 'release-migration-test' }} -n ${{ inputs.name || 'release-migration-test' }})
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
             \`\`\`
           EOF
 
@@ -356,22 +356,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || 'release-8.8.0' }}
+          ref: ${{ inputs.ref }}
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: google-github-actions/get-gke-credentials@v2.3.4
         with:
-          cluster_name: ${{ inputs.cluster || 'zeebe-cluster' }}
-          location: ${{ inputs.cluster-region || 'europe-west1-b' }}
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
       - name: Port-forward to gateway
         run: |
-          release="${{ inputs.name || 'release-migration-test' }}"
+          release="${{ inputs.name }}"
           kubectl port-forward --namespace "$release" svc/$release-zeebe-gateway 26500 &
       - name: Port-forward to Keycloak
         run: |
-          release="${{ inputs.name || 'release-migration-test' }}"
+          release="${{ inputs.name }}"
           kubectl port-forward --namespace "$release" svc/$release-keycloak 18080:80 &
       - name: Install zbctl
         run: |
@@ -380,7 +380,7 @@ jobs:
           chmod +x zbctl
       - name: Add load
         run: |
-          release="${{ inputs.name || 'release-migration-test' }}"
+          release="${{ inputs.name }}"
           # Get client secret from camunda credentials - which has been extracted during the upgrade
           ZEEBE_CLIENT_SECRET=$(kubectl get secrets --namespace "$release" camunda-credentials -o json | jq -r '.data."identity-orchestration-client-token"' | base64 -d)
           # Set env vars to get zbctl working with the cluster
@@ -404,8 +404,8 @@ jobs:
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Test \`${{ inputs.name || 'release-migration-test' }}\` values
+            ## Test \`${{ inputs.name }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name || 'release-migration-test' }} -n ${{ inputs.name || 'release-migration-test' }})
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
             \`\`\`
           EOF

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -352,7 +352,7 @@ jobs:
     needs:
       - upgrade-camunda-cluster-to-new-version
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/camunda-scheduled-release-migration-test.yml
+++ b/.github/workflows/camunda-scheduled-release-migration-test.yml
@@ -1,0 +1,73 @@
+# description: Workflow to run Camunda Platform release migration tests on scheduled manner
+# type: CI
+# owner: @Chris
+name: Camunda Release migration test
+on:
+  schedule:
+    # Runs at 04:00. every day https://crontab.guru/#0_4_*_*_*
+    - cron: 0 4 * * *
+
+jobs:
+  migration-test:
+    uses: ./.github/workflows/camunda-release-migration-test.yml@main
+    secrets: inherit
+    with:
+      name: scheduled-release-migration-test
+      ref: release-8.8.0
+
+  notify-failure:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    needs: [ migration-test ]
+    if: (failure() || cancelled())
+    steps:
+      - uses: actions/checkout@v4
+      - id: slack-notify
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Daily Camunda migration test failed:*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "@zeebe-medic Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+
+  notify-success:
+    name: Notify on Success
+    runs-on: ubuntu-latest
+    needs: [ migration-test ]
+    if: success()
+    steps:
+      - uses: actions/checkout@v4
+      - id: slack-notify
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":white_check_mark: *Daily Camunda migration test succeeded against branch:* ${{ inputs.ref || 'release-8.8.0' }}"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/camunda-scheduled-release-migration-test.yml
+++ b/.github/workflows/camunda-scheduled-release-migration-test.yml
@@ -14,6 +14,8 @@ jobs:
     with:
       name: scheduled-release-migration-test
       ref: release-8.8.0
+      cluster: 'zeebe-cluster'
+      cluster-region: 'europe-west1-b'
 
   notify-failure:
     name: Notify on failure

--- a/.github/workflows/camunda-scheduled-release-migration-test.yml
+++ b/.github/workflows/camunda-scheduled-release-migration-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   migration-test:
-    uses: ./.github/workflows/camunda-release-migration-test.yml@main
+    uses: ./.github/workflows/camunda-release-migration-test.yml
     secrets: inherit
     with:
       name: scheduled-release-migration-test

--- a/.github/workflows/camunda-scheduled-release-migration-test.yml
+++ b/.github/workflows/camunda-scheduled-release-migration-test.yml
@@ -66,7 +66,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":white_check_mark: *Daily Camunda migration test succeeded against branch:* ${{ inputs.ref || 'release-8.8.0' }}"
+                    "text": ":white_check_mark: *Daily Camunda migration test succeeded against branch:* `release-8.8.0`"
                   }
                 }
               ]

--- a/.github/workflows/camunda-scheduled-release-migration-test.yml
+++ b/.github/workflows/camunda-scheduled-release-migration-test.yml
@@ -13,7 +13,7 @@ jobs:
     secrets: inherit
     with:
       name: scheduled-release-migration-test
-      ref: release-8.8.0
+      ref: stable/8.8
       cluster: 'zeebe-cluster'
       cluster-region: 'europe-west1-b'
 


### PR DESCRIPTION
## Description


 * Split the migration test workflow into two
   * one to be reusable and manual 
   * another for being scheduled
 * The split allows to reduce the cognitive load of the workflow (as everything is not passed in as inputs)
 * Notifications are only necessary for scheduled runs and were be moved out with this change
 * Adjust timeouts to have better failure and timeout handling
