### PR TITLE
feat: add icons and overlays for UNSPECIFIED and UNKNOWN states

### DIFF
--- a/operate/client/src/modules/components/StateIcon/index.tsx
+++ b/operate/client/src/modules/components/StateIcon/index.tsx
@@ -6,7 +6,13 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {WarningFilled, CheckmarkOutline, RadioButtonChecked} from './styled';
+import {
+  WarningFilled,
+  CheckmarkOutline,
+  RadioButtonChecked,
+  HelpFilled,
+  CircleDash,
+} from './styled';
 import {type Icon, Error} from '@carbon/react/icons';
 import type {InstanceEntityState} from 'modules/types/operate';
 import type {DecisionInstanceState} from '@camunda/camunda-api-zod-schemas/8.8';
@@ -19,10 +25,8 @@ const stateIconsMap = {
   EVALUATED: CheckmarkOutline,
   CANCELED: Error,
   TERMINATED: Error,
-  // TODO: The following icon states are temporary and will be addressed
-  // with https://github.com/camunda/camunda/issues/38966.
-  UNSPECIFIED: Error,
-  UNKNOWN: Error,
+  UNSPECIFIED: CircleDash,
+  UNKNOWN: HelpFilled,
 } as const satisfies Record<Props['state'], unknown>;
 
 type Props = {

--- a/operate/client/src/modules/components/StateIcon/styled.ts
+++ b/operate/client/src/modules/components/StateIcon/styled.ts
@@ -12,6 +12,8 @@ import {
   WarningFilled as BaseWarningFilled,
   CheckmarkOutline as BaseCheckmarkOutline,
   RadioButtonChecked as BaseRadioButtonChecked,
+  HelpFilled as BaseHelpFilled,
+  CircleDash as BaseCircleDash,
 } from '@carbon/react/icons';
 
 const WarningFilled = styled(BaseWarningFilled)`
@@ -26,4 +28,18 @@ const RadioButtonChecked = styled(BaseRadioButtonChecked)`
   fill: var(--cds-support-success);
 `;
 
-export {WarningFilled, CheckmarkOutline, RadioButtonChecked};
+const HelpFilled = styled(BaseHelpFilled)`
+  fill: var(--cds-icon-primary);
+`;
+
+const CircleDash = styled(BaseCircleDash)`
+  fill: var(--cds-icon-primary);
+`;
+
+export {
+  WarningFilled,
+  CheckmarkOutline,
+  RadioButtonChecked,
+  HelpFilled,
+  CircleDash,
+};

--- a/operate/client/src/modules/components/StateOverlay/index.tsx
+++ b/operate/client/src/modules/components/StateOverlay/index.tsx
@@ -14,6 +14,8 @@ import {
   Error,
   RadioButtonChecked,
   WarningFilled,
+  HelpFilled,
+  CircleDash,
 } from '@carbon/react/icons';
 import {observer} from 'mobx-react';
 import {currentTheme} from 'modules/stores/currentTheme';
@@ -40,11 +42,6 @@ const StateOverlay: React.FC<Props> = observer(
   }) => {
     const showStatistic = count !== undefined;
 
-    // TODO: The new states will be addressed with https://github.com/camunda/camunda/issues/38966.
-    if (state === 'UNKNOWN' || state === 'UNSPECIFIED') {
-      state = 'FAILED';
-    }
-
     return createPortal(
       <Container
         data-testid={testId}
@@ -62,6 +59,8 @@ const StateOverlay: React.FC<Props> = observer(
           <CheckmarkOutline />
         )}
         {state === 'canceled' && <Error />}
+        {state === 'UNSPECIFIED' && <CircleDash />}
+        {state === 'UNKNOWN' && <HelpFilled />}
         {showStatistic && <span>{count}</span>}
       </Container>,
       container,

--- a/operate/client/src/modules/components/StateOverlay/styled.ts
+++ b/operate/client/src/modules/components/StateOverlay/styled.ts
@@ -44,6 +44,14 @@ const backgroundColors = {
       color: staticColors.canceled,
       fadedColor: staticColors.canceled,
     },
+    UNSPECIFIED: {
+      color: 'var(--cds-layer-01)',
+      fadedColor: 'var(--cds-layer-01)',
+    },
+    UNKNOWN: {
+      color: 'var(--cds-layer-01)',
+      fadedColor: 'var(--cds-layer-01)',
+    },
   },
   dark: {
     active: {
@@ -74,6 +82,14 @@ const backgroundColors = {
       color: staticColors.canceled,
       fadedColor: staticColors.canceled,
     },
+    UNSPECIFIED: {
+      color: 'var(--cds-layer-01)',
+      fadedColor: 'var(--cds-layer-01)',
+    },
+    UNKNOWN: {
+      color: 'var(--cds-layer-01)',
+      fadedColor: 'var(--cds-layer-01)',
+    },
   },
 };
 
@@ -86,7 +102,9 @@ type ContainerProps = {
     | 'canceled'
     | 'completedEndEvents'
     | 'EVALUATED'
-    | 'FAILED';
+    | 'FAILED'
+    | 'UNSPECIFIED'
+    | 'UNKNOWN';
   $isFaded: boolean;
   $showStatistic?: boolean;
 };
@@ -109,6 +127,12 @@ const Container = styled(Stack)<ContainerProps>`
       css`
         padding-right: var(--cds-spacing-03);
         transform: translateX(-50%);
+      `}
+
+      ${($state === 'UNKNOWN' || $state === 'UNSPECIFIED') &&
+      css`
+        box-shadow: inset 0 0 0 1px var(--cds-border-inverse);
+        color: var(--cds-icon-primary);
       `}
 
       ${$state === 'completed' &&

--- a/operate/client/src/modules/types/carbon.d.ts
+++ b/operate/client/src/modules/types/carbon.d.ts
@@ -342,4 +342,6 @@ declare module '@carbon/react/icons' {
   export const CheckmarkFilled: Icon;
   export const Information: Icon;
   export const ErrorFilled: Icon;
+  export const HelpFilled: Icon;
+  export const CircleDash: Icon;
 }


### PR DESCRIPTION
## Description

This PR implements the icons for `UNSPECIFIED` and `UNKNOWN` states as specified in Figma.

Since the states do not exist in our test data, the following MSW handlers can be used to show them locally:

```ts

import {http, HttpResponse, RequestHandler, bypass} from 'msw';

const handlers: RequestHandler[] = [
  http.get('/v2/decision-instances/:id', async ({request}) => {
    const original = await fetch(bypass(request));
    const instance = await original.json();
    return HttpResponse.json({...instance, state: 'UNSPECIFIED'});
  }),
  http.post('/v2/decision-instances/search', async ({request}) => {
    const original = await fetch(bypass(request));
    const result = await original.json();

    return HttpResponse.json({
      ...result,
      items: result.items.map((item: object, i: number) => ({
        ...item,
        state: i % 2 === 0 ? 'UNSPECIFIED' : 'UNKNOWN',
      })),
    });
  }),
];
```

Preview of the new icons in Operate:
<img width="512" height="516" alt="States light mode" src="https://github.com/user-attachments/assets/47cdc5e1-0832-4750-a061-6019a5120175" />
<img width="512" height="516" alt="States dark mode" src="https://github.com/user-attachments/assets/467456d1-fe70-4133-8897-acae39da74d5" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38966
