### PR TITLE
feat: add monitoring to uc

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Camunda.java
+++ b/configuration/src/main/java/io/camunda/configuration/Camunda.java
@@ -24,6 +24,7 @@ public class Camunda {
   @NestedConfigurationProperty private Data data = new Data();
   @NestedConfigurationProperty private Api api = new Api();
   @NestedConfigurationProperty private Processing processing = new Processing();
+  @NestedConfigurationProperty private Monitoring monitoring = new Monitoring();
 
   public Cluster getCluster() {
     return cluster;
@@ -63,5 +64,13 @@ public class Camunda {
 
   public void setProcessing(final Processing processing) {
     this.processing = processing;
+  }
+
+  public Monitoring getMonitoring() {
+    return monitoring;
+  }
+
+  public void setMonitoring(final Monitoring monitoring) {
+    this.monitoring = monitoring;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Metrics.java
+++ b/configuration/src/main/java/io/camunda/configuration/Metrics.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import java.util.Set;
+
+public class Metrics {
+
+  private static final String PREFIX = "camunda.monitoring.metrics";
+
+  private static final Set<String> LEGACY_ENABLE_ACTOR_METRICS_PPROPERTIES =
+      Set.of("zeebe.broker.experimental.features.enableActorMetrics");
+
+  /** Controls whether to collect metrics about actor usage such as actor job execution latencies */
+  private boolean actor = true;
+
+  public boolean isActor() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".actor",
+        actor,
+        Boolean.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_ENABLE_ACTOR_METRICS_PPROPERTIES);
+  }
+
+  public void setActor(final boolean actor) {
+    this.actor = actor;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Monitoring.java
+++ b/configuration/src/main/java/io/camunda/configuration/Monitoring.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+public class Monitoring {
+
+  /** Configure metrics */
+  @NestedConfigurationProperty Metrics metrics = new Metrics();
+
+  public Metrics getMetrics() {
+    return metrics;
+  }
+
+  public void setMetrics(final Metrics metrics) {
+    this.metrics = metrics;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -22,6 +22,7 @@ import io.camunda.configuration.InterceptorPlugin;
 import io.camunda.configuration.InternalApi;
 import io.camunda.configuration.KeyStore;
 import io.camunda.configuration.Membership;
+import io.camunda.configuration.Metrics;
 import io.camunda.configuration.PrimaryStorage;
 import io.camunda.configuration.Processing;
 import io.camunda.configuration.Rdbms;
@@ -129,6 +130,8 @@ public class BrokerBasedPropertiesOverride {
     }
 
     populateFromExporters(override);
+
+    populateFromMonitoring(override);
 
     // TODO: Populate the rest of the bean using unifiedConfiguration
     //  override.setSampleField(unifiedConfiguration.getSampleField());
@@ -767,6 +770,15 @@ public class BrokerBasedPropertiesOverride {
         args, "batchOperationItemInsertBlockSize", database.getBatchOperationItemInsertBlockSize());
 
     exporter.setArgs(args);
+  }
+
+  private void populateFromMonitoring(final BrokerBasedProperties override) {
+    populateFromMetrics(override);
+  }
+
+  private void populateFromMetrics(final BrokerBasedProperties override) {
+    final Metrics metrics = unifiedConfiguration.getCamunda().getMonitoring().getMetrics();
+    override.getExperimental().getFeatures().setEnableActorMetrics(metrics.isActor());
   }
 
   private void setArgIfNotNull(

--- a/configuration/src/test/java/io/camunda/configuration/MetricsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/MetricsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class MetricsTest {
+
+  private static final boolean EXPECTED_ACTOR = true;
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.monitoring.metrics.actor=" + EXPECTED_ACTOR,
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetMetrics() {
+      assertThat(brokerCfg.getExperimental().getFeatures().isEnableActorMetrics())
+          .isEqualTo(EXPECTED_ACTOR);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.features.enableActorMetrics=" + EXPECTED_ACTOR,
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetMetricsFromLegacy() {
+      assertThat(brokerCfg.getExperimental().getFeatures().isEnableActorMetrics())
+          .isEqualTo(EXPECTED_ACTOR);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.monitoring.metrics.actor=" + EXPECTED_ACTOR,
+        // legacy
+        "zeebe.broker.experimental.features.enableActorMetrics=false"
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetMetrics() {
+      assertThat(brokerCfg.getExperimental().getFeatures().isEnableActorMetrics())
+          .isEqualTo(EXPECTED_ACTOR);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.monitoring.metrics in unified config.

The legacy properties are:
zeebe.broker.experimental.features.enableActorMetrics

The new properties are:
camunda.monitoring.metrics.actor

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.

## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to 