### PR TITLE
test: reenable and fix failing operate ITs

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/OperationZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/OperationZeebeIT.java
@@ -21,12 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.operate.entities.BatchOperationEntity;
-import io.camunda.operate.entities.FlowNodeInstanceEntity;
-import io.camunda.operate.entities.IncidentEntity;
-import io.camunda.operate.entities.OperationEntity;
-import io.camunda.operate.entities.OperationState;
-import io.camunda.operate.entities.OperationType;
+import io.camunda.operate.entities.*;
 import io.camunda.operate.entities.dmn.DecisionInstanceEntity;
 import io.camunda.operate.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.operate.schema.templates.DecisionInstanceTemplate;
@@ -35,29 +30,17 @@ import io.camunda.operate.util.ConversionUtils;
 import io.camunda.operate.util.OperateZeebeAbstractIT;
 import io.camunda.operate.util.ZeebeTestUtil;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
-import io.camunda.operate.webapp.reader.BatchOperationReader;
-import io.camunda.operate.webapp.reader.IncidentReader;
-import io.camunda.operate.webapp.reader.ListViewReader;
-import io.camunda.operate.webapp.reader.OperationReader;
-import io.camunda.operate.webapp.reader.VariableReader;
+import io.camunda.operate.webapp.reader.*;
 import io.camunda.operate.webapp.rest.dto.OperationDto;
 import io.camunda.operate.webapp.rest.dto.VariableDto;
 import io.camunda.operate.webapp.rest.dto.VariableRequestDto;
 import io.camunda.operate.webapp.rest.dto.incidents.IncidentDto;
-import io.camunda.operate.webapp.rest.dto.listview.ListViewProcessInstanceDto;
-import io.camunda.operate.webapp.rest.dto.listview.ListViewQueryDto;
-import io.camunda.operate.webapp.rest.dto.listview.ListViewRequestDto;
-import io.camunda.operate.webapp.rest.dto.listview.ListViewResponseDto;
-import io.camunda.operate.webapp.rest.dto.listview.ProcessInstanceStateDto;
+import io.camunda.operate.webapp.rest.dto.listview.*;
 import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
 import io.camunda.operate.webapp.rest.dto.operation.BatchOperationRequestDto;
 import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
 import io.camunda.operate.webapp.rest.dto.operation.OperationTypeDto;
-import io.camunda.operate.webapp.zeebe.operation.CancelProcessInstanceHandler;
-import io.camunda.operate.webapp.zeebe.operation.DeleteDecisionDefinitionHandler;
-import io.camunda.operate.webapp.zeebe.operation.DeleteProcessDefinitionHandler;
-import io.camunda.operate.webapp.zeebe.operation.ResolveIncidentHandler;
-import io.camunda.operate.webapp.zeebe.operation.UpdateVariableHandler;
+import io.camunda.operate.webapp.zeebe.operation.*;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.net.HttpURLConnection;
@@ -69,7 +52,6 @@ import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MvcResult;
@@ -133,7 +115,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testBatchOperationsPersisted() throws Exception {
     // given
     final int instanceCount = 10;
@@ -184,7 +165,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testOperationPersisted() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -229,7 +209,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testSeveralOperationsPersistedForSeveralIncidents() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstanceWithIncidents();
@@ -280,7 +259,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testNoOperationsPersistedForNoIncidents() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -330,7 +308,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testResolveIncidentExecutedOnOneInstance() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -385,7 +362,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testResolveIncidentForExecutionListener() throws Exception {
 
     // given
@@ -418,7 +394,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testUpdateVariableOnProcessInstance() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -485,7 +460,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testAddVariableOnProcessInstance() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -869,7 +843,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testRetryOperationOnZeebeNotAvailable() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -900,7 +873,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testFailResolveIncidentBecauseOfNoIncidents() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -943,7 +915,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testFailCancelOnCanceledInstance() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -977,7 +948,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testFailCancelOnCompletedInstance() throws Exception {
     // given
     final String bpmnProcessId = "startEndProcess";
@@ -1016,7 +986,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testFailAddVariableOperationAsVariableAlreadyExists() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -1026,17 +995,20 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
     final CreateOperationRequestDto op = new CreateOperationRequestDto(OperationType.ADD_VARIABLE);
     op.setVariableName(newVarName);
     op.setVariableValue("\"newValue\"");
-    op.setVariableScopeId(ConversionUtils.toStringOrNull(processInstanceKey));
+    final String scope = ConversionUtils.toStringOrNull(processInstanceKey);
+    op.setVariableScopeId(scope);
     final MvcResult mvcResult =
         postOperation(processInstanceKey, op, HttpURLConnection.HTTP_BAD_REQUEST);
 
     // then
     assertThat(mvcResult.getResolvedException().getMessage())
-        .isEqualTo(String.format("Variable with the name \"%s\" already exists.", newVarName));
+        .isEqualTo(
+            String.format(
+                "Cannot add variable \"%s\" in scope \"%s\" of processInstanceId=%s: a variable with this name already exists.",
+                newVarName, scope, processInstanceKey));
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testFailAddVariableOperationAsOperationAlreadyExists() throws Exception {
     // given
     final Long processInstanceKey = startDemoProcessInstance();
@@ -1046,7 +1018,8 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
     final CreateOperationRequestDto op = new CreateOperationRequestDto(OperationType.ADD_VARIABLE);
     op.setVariableName(newVarName);
     op.setVariableValue("\"newValue\"");
-    op.setVariableScopeId(ConversionUtils.toStringOrNull(processInstanceKey));
+    final String scope = ConversionUtils.toStringOrNull(processInstanceKey);
+    op.setVariableScopeId(scope);
     // then it succeeds
     postOperation(processInstanceKey, op, HttpURLConnection.HTTP_OK);
 
@@ -1056,7 +1029,10 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
 
     // then
     assertThat(mvcResult.getResolvedException().getMessage())
-        .isEqualTo(String.format("Variable with the name \"%s\" already exists.", newVarName));
+        .isEqualTo(
+            String.format(
+                "Cannot add variable \"%s\" in scope \"%s\" of processInstanceId=%s: an ADD_VARIABLE operation for this variable already exists.",
+                newVarName, scope, processInstanceKey));
   }
 
   @Test
@@ -1127,7 +1103,6 @@ public class OperationZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testDeleteProcessDefinitionFailsWhenRunning() throws Exception {
 
     // given

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/ImporterMetricsMockedZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/ImporterMetricsMockedZeebeImportIT.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -33,7 +32,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(initializers = ManagementPropertyRemoval.class)
-@Ignore("https://github.com/camunda/camunda/issues/39185")
 public class ImporterMetricsMockedZeebeImportIT extends OperateZeebeAbstractIT {
 
   @Autowired private ZeebeImporter zeebeImporter;
@@ -80,7 +78,7 @@ public class ImporterMetricsMockedZeebeImportIT extends OperateZeebeAbstractIT {
     assertThatMetricsFrom(
         mockMvc,
         new MetricAssert.ValueMatcher(
-            "operate_import_queue_size{partition=\"1\",type=\"PROCESS_INSTANCE\",}",
+            "operate_import_queue_size{partition=\"1\",type=\"PROCESS_INSTANCE\"}",
             d -> d.doubleValue() >= 1.0));
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/ImporterMetricsZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/ImporterMetricsZeebeImportIT.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.util.HashMap;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContextInitializer;
@@ -35,7 +34,6 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(initializers = ManagementPropertyRemoval.class)
-@Ignore("https://github.com/camunda/camunda/issues/39185")
 public class ImporterMetricsZeebeImportIT extends OperateZeebeAbstractIT {
 
   @Autowired private CancelProcessInstanceHandler cancelProcessInstanceHandler;
@@ -123,7 +121,7 @@ public class ImporterMetricsZeebeImportIT extends OperateZeebeAbstractIT {
                 + OperationState.SENT
                 + "\",type=\""
                 + OperationType.UPDATE_VARIABLE
-                + "\",}",
+                + "\"}",
             d -> d.doubleValue() == 1));
   }
 
@@ -153,7 +151,7 @@ public class ImporterMetricsZeebeImportIT extends OperateZeebeAbstractIT {
                 + OperationState.FAILED
                 + "\",type=\""
                 + OperationType.CANCEL_PROCESS_INSTANCE
-                + "\",}",
+                + "\"}",
             d -> d.doubleValue() == 1));
   }
 
@@ -184,12 +182,12 @@ public class ImporterMetricsZeebeImportIT extends OperateZeebeAbstractIT {
                 Metrics.GAUGE_BPMN_MODEL_COUNT.replace('.', '_')
                     + "{"
                     + Metrics.TAG_KEY_ORGANIZATIONID
-                    + "=\"orga\",} 2.0"),
+                    + "=\"orga\"} 2.0"),
             containsString(
                 Metrics.GAUGE_DMN_MODEL_COUNT.replace('.', '_')
                     + "{"
                     + Metrics.TAG_KEY_ORGANIZATIONID
-                    + "=\"orga\",} 2.0")));
+                    + "=\"orga\"} 2.0")));
   }
 
   public static class ManagementPropertyRemoval

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchOperateZeebeRuleProvider.java
@@ -73,25 +73,36 @@ public class ElasticsearchOperateZeebeRuleProvider implements OperateZeebeRulePr
   @Override
   public void updateRefreshInterval(final String value) {
     try {
-      final GetComponentTemplatesRequest getRequest = new GetComponentTemplatesRequest(prefix);
+      final GetComponentTemplatesRequest getRequest =
+          new GetComponentTemplatesRequest(prefix + "*");
       final GetComponentTemplatesResponse response =
           zeebeEsClient.cluster().getComponentTemplate(getRequest, RequestOptions.DEFAULT);
-      final ComponentTemplate componentTemplate = response.getComponentTemplates().get(prefix);
-      final Settings settings = componentTemplate.template().settings();
-
-      final PutComponentTemplateRequest request = new PutComponentTemplateRequest().name(prefix);
-      final Settings newSettings =
-          Settings.builder().put(settings).put("index.refresh_interval", value).build();
-      final Template newTemplate =
-          new Template(newSettings, componentTemplate.template().mappings(), null);
-      final ComponentTemplate newComponentTemplate = new ComponentTemplate(newTemplate, null, null);
-      request.componentTemplate(newComponentTemplate);
-      assertThat(
-              zeebeEsClient
-                  .cluster()
-                  .putComponentTemplate(request, RequestOptions.DEFAULT)
-                  .isAcknowledged())
-          .isTrue();
+      response
+          .getComponentTemplates()
+          .entrySet()
+          .forEach(
+              componentTemplate -> {
+                final Template template = componentTemplate.getValue().template();
+                final Settings settings = template.settings();
+                final PutComponentTemplateRequest request =
+                    new PutComponentTemplateRequest().name(prefix);
+                final Settings newSettings =
+                    Settings.builder().put(settings).put("index.refresh_interval", value).build();
+                final Template newTemplate = new Template(newSettings, template.mappings(), null);
+                final ComponentTemplate newComponentTemplate =
+                    new ComponentTemplate(newTemplate, null, null);
+                request.componentTemplate(newComponentTemplate);
+                try {
+                  assertThat(
+                          zeebeEsClient
+                              .cluster()
+                              .putComponentTemplate(request, RequestOptions.DEFAULT)
+                              .isAcknowledged())
+                      .isTrue();
+                } catch (final IOException e) {
+                  throw new RuntimeException(e);
+                }
+              });
     } catch (final IOException ex) {
       throw new RuntimeException(ex);
     }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
@@ -63,18 +63,25 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
 
   @Override
   public void updateRefreshInterval(final String value) {
-    final ComponentTemplateSummary template =
-        zeebeRichOpenSearchClient.template().getComponentTemplate().get(prefix).template();
-    final IndexSettings indexSettings = template.settings().get("index");
-    final IndexSettings newSettings =
-        IndexSettings.of(b -> b.index(indexSettings).refreshInterval(ri -> ri.time(value)));
-    final IndexState newTemplate =
-        IndexState.of(t -> t.settings(newSettings).mappings(template.mappings()));
-    final var requestBuilder = componentTemplateRequestBuilder(prefix).template(newTemplate);
-    assertTrue(
-        zeebeRichOpenSearchClient
-            .template()
-            .createComponentTemplateWithRetries(requestBuilder.build(), true));
+    zeebeRichOpenSearchClient.template().getComponentTemplate().entrySet().stream()
+        .filter(entry -> entry.getKey().startsWith(prefix))
+        .forEach(
+            componentTemplateSummary -> {
+              final ComponentTemplateSummary template =
+                  componentTemplateSummary.getValue().template();
+              final IndexSettings indexSettings = template.settings().get("index");
+              final IndexSettings newSettings =
+                  IndexSettings.of(
+                      b -> b.index(indexSettings).refreshInterval(ri -> ri.time(value)));
+              final IndexState newTemplate =
+                  IndexState.of(t -> t.settings(newSettings).mappings(template.mappings()));
+              final var requestBuilder =
+                  componentTemplateRequestBuilder(prefix).template(newTemplate);
+              assertTrue(
+                  zeebeRichOpenSearchClient
+                      .template()
+                      .createComponentTemplateWithRetries(requestBuilder.build(), true));
+            });
   }
 
   @Override

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/BasicZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/BasicZeebeImportIT.java
@@ -51,13 +51,11 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.function.Predicate;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-@Ignore("https://github.com/camunda/camunda/issues/39185")
 public class BasicZeebeImportIT extends OperateZeebeAbstractIT {
 
   @Autowired private ProcessInstanceReader processInstanceReader;
@@ -575,8 +573,9 @@ public class BasicZeebeImportIT extends OperateZeebeAbstractIT {
     final List<Integer> operatePartitions = partitionHolder.getPartitionIds();
     final int zeebePartitionsCount =
         zeebeClient.newTopologyRequest().send().join().getPartitionsCount();
-    assertThat(operatePartitions).hasSize(zeebePartitionsCount);
-    assertThat(operatePartitions).allMatch(id -> id <= zeebePartitionsCount && id >= 1);
+    assertThat(operatePartitions)
+        .hasSize(zeebePartitionsCount)
+        .allMatch(id -> id <= zeebePartitionsCount && id >= 1);
   }
 
   @Test
@@ -614,11 +613,11 @@ public class BasicZeebeImportIT extends OperateZeebeAbstractIT {
             decisionInstanceTemplate.getAlias(), DecisionInstanceEntity.class);
 
     assertThat(decisionEntities).hasSize(1);
-    assertThat(decisionEntities.get(0).getEvaluatedInputs()).hasSize(1);
-    assertThat(decisionEntities.get(0).getEvaluatedInputs().get(0).getValue())
+    assertThat(decisionEntities.getFirst().getEvaluatedInputs()).hasSize(1);
+    assertThat(decisionEntities.getFirst().getEvaluatedInputs().getFirst().getValue())
         .contains(bigJSONVariablePayload);
-    assertThat(decisionEntities.get(0).getEvaluatedOutputs()).hasSize(1);
-    assertThat(decisionEntities.get(0).getEvaluatedOutputs().get(0).getValue())
+    assertThat(decisionEntities.getFirst().getEvaluatedOutputs()).hasSize(1);
+    assertThat(decisionEntities.getFirst().getEvaluatedOutputs().getFirst().getValue())
         .contains(bigJSONVariablePayload);
   }
 
@@ -660,7 +659,7 @@ public class BasicZeebeImportIT extends OperateZeebeAbstractIT {
             decisionInstanceTemplate.getAlias(), DecisionInstanceEntity.class);
 
     assertThat(decisionEntities).hasSize(1);
-    final DecisionInstanceEntity entity = decisionEntities.get(0);
+    final DecisionInstanceEntity entity = decisionEntities.getFirst();
     assertThat(entity.getId()).isNotNull();
     assertThat(entity.getKey()).isNotNull();
     assertThat(entity.getExecutionIndex()).isNotNull();
@@ -675,8 +674,8 @@ public class BasicZeebeImportIT extends OperateZeebeAbstractIT {
     assertThat(entity.getDecisionRequirementsKey()).isNotNull();
     assertThat(entity.getElementId()).isEqualTo(elementId);
     assertThat(entity.getElementInstanceKey()).isNotNull();
-    assertThat(entity.getEvaluationFailure()).isNotNull();
-    assertThat(entity.getEvaluationFailure())
+    assertThat(entity.getEvaluationFailureMessage())
+        .isNotNull()
         .containsIgnoringCase("no variable found for name 'amount'");
     assertThat(entity.getEvaluationDate()).isNotNull();
     assertThat(entity.getPosition()).isNotNull();
@@ -689,8 +688,9 @@ public class BasicZeebeImportIT extends OperateZeebeAbstractIT {
     assertThat(entity.getRootDecisionDefinitionId()).isNotNull();
     assertThat(entity.getDecisionType()).isEqualTo(DecisionType.DECISION_TABLE);
     assertThat(entity.getRootDecisionName()).isEqualTo(decision2Name);
-    assertThat(entity.getRootDecisionDefinitionId()).isNotNull();
-    assertThat(entity.getRootDecisionDefinitionId()).isNotEqualTo(entity.getDecisionDefinitionId());
+    assertThat(entity.getRootDecisionDefinitionId())
+        .isNotNull()
+        .isNotEqualTo(entity.getDecisionDefinitionId());
   }
 
   @Test
@@ -752,7 +752,7 @@ public class BasicZeebeImportIT extends OperateZeebeAbstractIT {
           assertThat(entity.getDecisionRequirementsKey()).isNotNull();
           assertThat(entity.getElementId()).isEqualTo(elementId);
           assertThat(entity.getElementInstanceKey()).isNotNull();
-          assertThat(entity.getEvaluationFailure()).isNull();
+          assertThat(entity.getEvaluationFailureMessage()).isNull();
           assertThat(entity.getEvaluationDate()).isNotNull();
           assertThat(entity.getPosition()).isNotNull();
           assertThat(entity.getProcessDefinitionKey()).isNotNull();
@@ -820,7 +820,7 @@ public class BasicZeebeImportIT extends OperateZeebeAbstractIT {
     assertThat(entity.getDecisionRequirementsKey()).isNotNull();
     assertThat(entity.getElementId()).isEqualTo(elementId);
     assertThat(entity.getElementInstanceKey()).isNotNull();
-    assertThat(entity.getEvaluationFailure()).isNull();
+    assertThat(entity.getEvaluationFailureMessage()).isNull();
     assertThat(entity.getEvaluationDate()).isNotNull();
     assertThat(entity.getPosition()).isNotNull();
     assertThat(entity.getProcessDefinitionKey()).isNotNull();
@@ -846,8 +846,9 @@ public class BasicZeebeImportIT extends OperateZeebeAbstractIT {
     assertThat(activity.getBpmnProcessId()).isNotNull();
     assertThat(activity.getState()).isEqualTo(FlowNodeState.ACTIVE);
     assertThat(activity.getIncidentKey()).isNotNull();
-    assertThat(activity.getStartDate()).isAfterOrEqualTo(testStartTime);
-    assertThat(activity.getStartDate()).isBeforeOrEqualTo(OffsetDateTime.now());
+    assertThat(activity.getStartDate())
+        .isAfterOrEqualTo(testStartTime)
+        .isBeforeOrEqualTo(OffsetDateTime.now());
   }
 
   private void assertFlowNodeIsCompleted(
@@ -856,10 +857,12 @@ public class BasicZeebeImportIT extends OperateZeebeAbstractIT {
     assertThat(activity.getProcessDefinitionKey()).isNotNull();
     assertThat(activity.getBpmnProcessId()).isNotNull();
     assertThat(activity.getState()).isEqualTo(FlowNodeState.COMPLETED);
-    assertThat(activity.getStartDate()).isAfterOrEqualTo(testStartTime);
-    assertThat(activity.getStartDate()).isBeforeOrEqualTo(OffsetDateTime.now());
-    assertThat(activity.getEndDate()).isAfterOrEqualTo(activity.getStartDate());
-    assertThat(activity.getEndDate()).isBeforeOrEqualTo(OffsetDateTime.now());
+    assertThat(activity.getStartDate())
+        .isAfterOrEqualTo(testStartTime)
+        .isBeforeOrEqualTo(OffsetDateTime.now());
+    assertThat(activity.getEndDate())
+        .isAfterOrEqualTo(activity.getStartDate())
+        .isBeforeOrEqualTo(OffsetDateTime.now());
   }
 
   private String query() {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ImportMidnightZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ImportMidnightZeebeImportIT.java
@@ -38,7 +38,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,7 +74,6 @@ public class ImportMidnightZeebeImportIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/39185")
   public void testProcessInstancesCompletedNextDay() throws IOException {
     // having
     final String processId = "demoProcess";

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/RetryAfterFailureZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/RetryAfterFailureZeebeImportIT.java
@@ -11,7 +11,6 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.TestApplication;
 import io.camunda.operate.util.apps.retry_after_failure.RetryAfterFailureTestConfig;
 import org.junit.After;
-import org.junit.Ignore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -24,7 +23,6 @@ import org.springframework.boot.test.context.SpringBootTest;
       "spring.main.allow-bean-definition-overriding=true",
       "spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER"
     })
-@Ignore("https://github.com/camunda/camunda/issues/39185")
 public class RetryAfterFailureZeebeImportIT extends BasicZeebeImportIT {
 
   @Autowired


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We recently started running the Operate ITs again (after realising they weren't running). This PR reenables the tests that were initially failing, by removing the annotation and fixing the underlying problem with the test.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #39185
