### PR TITLE
fix: the process definition has a start form

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessDefinition.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessDefinition.java
@@ -51,4 +51,9 @@ public interface ProcessDefinition {
    * @return the tenant id of the process definition
    */
   String getTenantId();
+
+  /**
+   * @return whether the start event of the process has an associated form key
+   */
+  Boolean getHasStartForm();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessDefinitionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessDefinitionImpl.java
@@ -30,6 +30,7 @@ public class ProcessDefinitionImpl implements ProcessDefinition, Process {
   private final String versionTag;
   private final String processDefinitionId;
   private final String tenantId;
+  private final Boolean hasStartForm;
 
   public ProcessDefinitionImpl(final ProcessDefinitionResult item) {
     processDefinitionKey = ParseUtil.parseLongOrNull(item.getProcessDefinitionKey());
@@ -39,6 +40,7 @@ public class ProcessDefinitionImpl implements ProcessDefinition, Process {
     versionTag = item.getVersionTag();
     processDefinitionId = item.getProcessDefinitionId();
     tenantId = item.getTenantId();
+    hasStartForm = item.getHasStartForm();
   }
 
   @Override
@@ -77,6 +79,11 @@ public class ProcessDefinitionImpl implements ProcessDefinition, Process {
   }
 
   @Override
+  public Boolean getHasStartForm() {
+    return hasStartForm;
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return processDefinitionId;
   }
@@ -90,7 +97,8 @@ public class ProcessDefinitionImpl implements ProcessDefinition, Process {
         version,
         versionTag,
         processDefinitionId,
-        tenantId);
+        tenantId,
+        hasStartForm);
   }
 
   @Override
@@ -105,7 +113,8 @@ public class ProcessDefinitionImpl implements ProcessDefinition, Process {
         && Objects.equals(version, that.version)
         && Objects.equals(versionTag, that.versionTag)
         && Objects.equals(processDefinitionId, that.processDefinitionId)
-        && Objects.equals(tenantId, that.tenantId);
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(hasStartForm, that.hasStartForm);
   }
 
   @Override
@@ -130,6 +139,8 @@ public class ProcessDefinitionImpl implements ProcessDefinition, Process {
         + ", tenantId='"
         + tenantId
         + '\''
+        + ", hasStartForm="
+        + hasStartForm
         + '}';
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
@@ -264,6 +264,25 @@ public class ProcessDefinitionSearchTest {
   }
 
   @Test
+  void shouldGetProcessDefinitionWithFormByKey() {
+    // given
+    final var processEvent =
+        DEPLOYED_PROCESSES.stream()
+            .filter(p -> Objects.equals(PROCESS_ID_WITH_START_FORM, p.getBpmnProcessId()))
+            .findFirst()
+            .orElseThrow();
+    final var processDefinitionKey = processEvent.getProcessDefinitionKey();
+
+    // when
+    final var result =
+        camundaClient.newProcessDefinitionGetRequest(processDefinitionKey).send().join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getHasStartForm()).isTrue();
+  }
+
+  @Test
   void shouldRetrieveAllProcessDefinitionsByDefault() {
     // given
     final var expectedProcessDefinitionIds =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the missing field `hasStartForm` to the client response interface for the `ProcessDefinition`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38941 
