### PR TITLE
Fix Camunda migration smoke test

### DIFF
--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -328,10 +328,10 @@ jobs:
           --set orchestration.image.repository=zeebe-io/zeebe \
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
           --set orchestration.migration.data.enabled=true \
-          --set orchestration.migration.identity.backwardsCompatibleAudiences[0]=zeebe-api \
           --set orchestration.migration.identity.enabled=true \
           --set orchestration.migration.identity.secret.existingSecret=camunda-credentials \
           --set orchestration.migration.identity.secret.existingSecretKey=identity-orchestration-client-token \
+          --set orchestration.security.authentication.oidc.backwardsCompatibleAudiences[0]=zeebe-api \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token          
       - name: Summarize deployment

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -313,12 +313,12 @@ jobs:
           --wait --wait-for-jobs --timeout 35m0s \
           --namespace ${{ inputs.name }} \
           --render-subchart-notes \
-          --set connectors.image.tag=SNAPSHOT \
+          --set connectors.image.tag=8.8.0 \
           --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set connectors.security.authentication.oidc.secret.existingSecretKey=identity-connectors-client-token \
           --set identity.enabled=true \
           --set identity.firstUser.enabled=false \
-          --set identity.image.tag=8.8-SNAPSHOT \
+          --set identity.image.tag=8.8.0 \
           --set identityKeycloak.enabled=true \
           --set global.identity.auth.enabled=true \
           --set "orchestration.env[0].name=CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK" \

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -313,6 +313,7 @@ jobs:
           --wait --wait-for-jobs --timeout 35m0s \
           --namespace ${{ inputs.name }} \
           --render-subchart-notes \
+          --set global.security.authentication.method=oidc \
           --set connectors.image.tag=8.8.0 \
           --set connectors.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set connectors.security.authentication.oidc.secret.existingSecretKey=identity-connectors-client-token \
@@ -332,8 +333,7 @@ jobs:
           --set orchestration.migration.identity.secret.existingSecret=camunda-credentials \
           --set orchestration.migration.identity.secret.existingSecretKey=identity-orchestration-client-token \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
-          --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \
-          --set orchestration.security.authentication.method=oidc \
+          --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token          
       - name: Summarize deployment
         if: success()
         run: |


### PR DESCRIPTION
## Description

Our Helm chart migration smoke test was broken, because we recently changed several values in the Helm chart before the release. For context see [here](https://camunda.slack.com/archives/C09J1F6NJJ0/p1760098598356939)


 * Instead of using the snapshot version, we now use the released 8.8.0 versions for connectors and management identity
 * Set oidc global to set it for OC and connectors.
 * Set the audiences correctly, otherwise our zbctl can't connect with the cluster
 * 
<!-- Describe the goal and purpose of this PR. -->