### PR TITLE
fix: large batch sizes can cause OOM in importer

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -19,6 +19,8 @@ public class OperateProperties {
 
   public static final long BATCH_OPERATION_MAX_SIZE_DEFAULT = 1_000_000L;
 
+  public static final long BATCH_SIZE_MAX_BYTES_DEFAULT = 20 * (1024 * 1024);
+
   private static final String UNKNOWN_VERSION = "unknown-version";
 
   private boolean importerEnabled = false;
@@ -42,6 +44,8 @@ public class OperateProperties {
 
   /** Maximum size of batch operation. */
   private Long batchOperationMaxSize = BATCH_OPERATION_MAX_SIZE_DEFAULT;
+
+  private long importerMaxBatchSizeBytes = BATCH_SIZE_MAX_BYTES_DEFAULT;
 
   private boolean enterprise = false;
 
@@ -129,6 +133,14 @@ public class OperateProperties {
 
   public void setBatchOperationMaxSize(final Long batchOperationMaxSize) {
     this.batchOperationMaxSize = batchOperationMaxSize;
+  }
+
+  public long getImporterMaxBatchSizeBytes() {
+    return importerMaxBatchSizeBytes;
+  }
+
+  public void setImporterMaxBatchSizeBytes(final long importerMaxBatchSizeBytes) {
+    this.importerMaxBatchSizeBytes = importerMaxBatchSizeBytes;
   }
 
   public boolean isCsrfPreventionEnabled() {
@@ -352,7 +364,6 @@ public class OperateProperties {
     return switch (databaseType) {
       case Elasticsearch -> getElasticsearch() == null ? null : getElasticsearch().getIndexPrefix();
       case Opensearch -> getOpensearch() == null ? null : getOpensearch().getIndexPrefix();
-      default -> null;
     };
   }
 

--- a/operate/importer/pom.xml
+++ b/operate/importer/pom.xml
@@ -104,6 +104,18 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.20.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo</artifactId>
+      <version>5.6.2</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportJob.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportJob.java
@@ -7,8 +7,11 @@
  */
 package io.camunda.operate.zeebeimport;
 
+import static org.apache.commons.io.output.NullOutputStream.*;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.entities.HitEntity;
 import io.camunda.operate.exceptions.NoSuchIndexException;
@@ -22,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
+import org.apache.commons.io.output.CountingOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,9 +46,7 @@ public class ImportJob implements Callable<Boolean> {
   private ImportBatch importBatch;
   private ImportPositionEntity lastProcessedPosition;
   @Autowired private ImportBatchProcessorFactory importBatchProcessorFactory;
-
   @Autowired private ImportPositionHolder importPositionHolder;
-
   @Autowired private RecordsReaderHolder recordsReaderHolder;
 
   @Autowired(required = false)
@@ -69,7 +71,7 @@ public class ImportJob implements Callable<Boolean> {
     processPossibleIndexChange();
 
     // separate importBatch in sub-batches per index
-    final List<ImportBatch> subBatches = createSubBatchesPerIndexName();
+    final List<ImportBatch> subBatches = createSizeLimitedSubBatchesByIndexName();
 
     for (final ImportBatch subBatch : subBatches) {
       final boolean success = processOneIndexBatch(subBatch);
@@ -160,6 +162,7 @@ public class ImportJob implements Callable<Boolean> {
 
       final ImportBatchProcessor importBatchProcessor =
           importBatchProcessorFactory.getImportBatchProcessor(version);
+
       importBatchProcessor.performImport(subBatch);
 
       return true;
@@ -169,18 +172,24 @@ public class ImportJob implements Callable<Boolean> {
     }
   }
 
-  private List<ImportBatch> createSubBatchesPerIndexName() {
+  private List<ImportBatch> createSizeLimitedSubBatchesByIndexName() {
     final List<ImportBatch> subBatches = new ArrayList<>();
     if (importBatch.getHits().size() <= 1) {
       subBatches.add(importBatch);
       return subBatches;
     } else {
+      final long maxBatchSizeBytes = operateProperties.getImporterMaxBatchSizeBytes();
       String previousIndexName = null;
       List<HitEntity> subBatchHits = new ArrayList<>();
+      long subBatchSize = 0;
       for (final HitEntity hit : importBatch.getHits()) {
         final String indexName = hit.getIndex();
-        if (previousIndexName != null && !indexName.equals(previousIndexName)) {
-          // start new sub-batch
+        final long hitSize = EntitySizeEstimator.estimateEntitySize(hit);
+        final boolean indexChanged =
+            previousIndexName != null && !indexName.equals(previousIndexName);
+        final boolean sizeExceeded = subBatchSize + hitSize > maxBatchSizeBytes;
+        // If index name changed or max size exceeded, finalize current batch and start a new one
+        if ((indexChanged && !subBatchHits.isEmpty()) || sizeExceeded) {
           subBatches.add(
               new ImportBatch(
                   importBatch.getPartitionId(),
@@ -188,16 +197,22 @@ public class ImportJob implements Callable<Boolean> {
                   subBatchHits,
                   previousIndexName));
           subBatchHits = new ArrayList<>();
+          subBatchSize = 0;
         }
+        // Add current hit to the batch and update size
         subBatchHits.add(hit);
+        subBatchSize += hitSize;
         previousIndexName = indexName;
       }
-      subBatches.add(
-          new ImportBatch(
-              importBatch.getPartitionId(),
-              importBatch.getImportValueType(),
-              subBatchHits,
-              previousIndexName));
+      // Add any remaining hits as the final batch
+      if (!subBatchHits.isEmpty()) {
+        subBatches.add(
+            new ImportBatch(
+                importBatch.getPartitionId(),
+                importBatch.getImportValueType(),
+                subBatchHits,
+                previousIndexName));
+      }
       return subBatches;
     }
   }
@@ -276,5 +291,28 @@ public class ImportJob implements Callable<Boolean> {
 
   public OffsetDateTime getCreationTime() {
     return creationTime;
+  }
+
+  private static final class EntitySizeEstimator {
+    private static final ThreadLocal<Kryo> THREAD_LOCAL_KRYO =
+        ThreadLocal.withInitial(
+            () -> {
+              final Kryo kryo = new Kryo();
+              kryo.setRegistrationRequired(false);
+              kryo.setReferences(false);
+              return kryo;
+            });
+
+    public static long estimateEntitySize(final HitEntity entity) {
+      final Kryo kryo = THREAD_LOCAL_KRYO.get();
+      try (final CountingOutputStream countingStream = new CountingOutputStream(INSTANCE);
+          final Output output = new Output(countingStream, 8192)) {
+        kryo.writeObject(output, entity);
+        kryo.reset();
+        return countingStream.getByteCount();
+      } catch (final Exception e) {
+        throw new RuntimeException("Failed to estimate object size", e);
+      }
+    }
   }
 }

--- a/operate/importer/src/test/java/io/camunda/operate/zeebeimport/ImportListenerIT.java
+++ b/operate/importer/src/test/java/io/camunda/operate/zeebeimport/ImportListenerIT.java
@@ -11,11 +11,17 @@ import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.operate.Metrics;
+import io.camunda.operate.entities.HitEntity;
 import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.ImportStore;
@@ -28,6 +34,9 @@ import io.camunda.operate.zeebe.ImportValueType;
 import io.camunda.operate.zeebeimport.v8_7.processors.processors.ImportBulkProcessor;
 import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.Before;
 import org.junit.Test;
@@ -132,6 +141,47 @@ public class ImportListenerIT extends NoBeansIT {
     assertTrue(importListener.isFailedCalled());
     assertFalse(importListener.isFinishedCalled());
     assertEquals(importListener.getImportBatch(), importBatch);
+  }
+
+  @Test
+  public void testBatchSizeLimitingSplitsBatchesCorrectly() throws Exception {
+    // given a small configured batch size (e.g., 1000 bytes)
+    doReturn(1000L).when(operateProperties).getImporterMaxBatchSizeBytes();
+
+    // with 5 hits of ~600 bytes
+    final List<HitEntity> hits =
+        IntStream.range(0, 5)
+            .mapToObj(
+                i -> {
+                  final HitEntity hit = new HitEntity();
+                  hit.setIndex("test_index");
+                  hit.setSourceAsString("x".repeat(500));
+                  return hit;
+                })
+            .collect(Collectors.toList());
+
+    final ImportBatch importBatch =
+        new ImportBatch(1, ImportValueType.PROCESS_INSTANCE, hits, "test_index");
+    final ImportPositionEntity previousPosition =
+        new ImportPositionEntity()
+            .setAliasName("alias")
+            .setPartitionId(1)
+            .setPosition(0)
+            .setSequence(0L);
+    final ImportJob importJob = beanFactory.getBean(ImportJob.class, importBatch, previousPosition);
+
+    final ImportBulkProcessor processorSpy = spy(elasticsearchBulkProcessor);
+
+    when(importBatchProcessorFactory.getImportBatchProcessor(anyString())).thenReturn(processorSpy);
+    doNothing()
+        .when(processorSpy)
+        .performImport(org.mockito.ArgumentMatchers.any(ImportBatch.class));
+
+    // when
+    importJob.call();
+
+    // then the import is made the expected number of times (3 batches - 2/2/1)
+    verify(processorSpy, times(3)).performImport(argThat(batch -> batch.getHits().size() <= 2));
   }
 
   @Component

--- a/operate/schema/src/main/java/io/camunda/operate/store/BatchRequest.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/BatchRequest.java
@@ -37,15 +37,6 @@ public interface BatchRequest {
       String index, String id, ExporterEntity entity, String script, Map<String, Object> parameters)
       throws PersistenceException;
 
-  BatchRequest upsertWithScriptAndRouting(
-      String index,
-      String id,
-      ExporterEntity entity,
-      String script,
-      Map<String, Object> parameters,
-      String routing)
-      throws PersistenceException;
-
   BatchRequest update(String index, String id, Map<String, Object> updateFields)
       throws PersistenceException;
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchBatchRequest.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchBatchRequest.java
@@ -202,42 +202,6 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   }
 
   @Override
-  public BatchRequest upsertWithScriptAndRouting(
-      final String index,
-      final String id,
-      final ExporterEntity entity,
-      final String script,
-      final Map<String, Object> parameters,
-      final String routing)
-      throws PersistenceException {
-    LOGGER.debug(
-        "Add upsert request with routing {} for index {} id {} entity {} and script {} with parameters {} ",
-        routing,
-        index,
-        id,
-        entity,
-        script,
-        parameters);
-    try {
-      bulkRequest.add(
-          new UpdateRequest()
-              .index(index)
-              .id(id)
-              .script(getScriptWithParameters(script, parameters))
-              .upsert(objectMapper.writeValueAsString(entity), XContentType.JSON)
-              .routing(routing)
-              .retryOnConflict(UPDATE_RETRY_COUNT));
-    } catch (final JsonProcessingException e) {
-      throw new PersistenceException(
-          String.format(
-              "Error preparing the query to upsert [%s] of entity type [%s] with script and routing",
-              entity.getClass().getName(), entity),
-          e);
-    }
-    return this;
-  }
-
-  @Override
   public BatchRequest update(
       final String index, final String id, final Map<String, Object> updateFields)
       throws PersistenceException {

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchBatchRequest.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchBatchRequest.java
@@ -175,42 +175,6 @@ public class OpensearchBatchRequest implements BatchRequest {
   }
 
   @Override
-  public BatchRequest upsertWithScriptAndRouting(
-      final String index,
-      final String id,
-      final ExporterEntity entity,
-      final String script,
-      final Map<String, Object> parameters,
-      final String routing)
-      throws PersistenceException {
-    LOGGER.debug(
-        "Add upsert request with routing {} for index {} id {} entity {} and script {} with parameters {} ",
-        routing,
-        index,
-        id,
-        entity,
-        script,
-        parameters);
-    withPersistenceException(
-        () ->
-            bulkRequestBuilder.operations(
-                op ->
-                    op.update(
-                        upd ->
-                            upd.index(index)
-                                .id(id)
-                                .upsert(entity)
-                                .script(script(script, parameters))
-                                .routing(routing)
-                                .retryOnConflict(UPDATE_RETRY_COUNT))),
-        () ->
-            String.format(
-                "Error preparing the query to upsert [%s] of entity type [%s] with script and routing",
-                entity, entity.getClass().getName()));
-    return this;
-  }
-
-  @Override
   public BatchRequest update(
       final String index, final String id, final Map<String, Object> updateFields)
       throws PersistenceException {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ImportProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ImportProperties.java
@@ -27,6 +27,8 @@ public class ImportProperties {
 
   private static final int DEFAULT_MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER = 5;
 
+  private static final int DEFAULT_MAX_BATCH_SIZE_BYTES = 20 * (1024 * 1024);
+
   private int threadsCount = DEFAULT_IMPORT_THREADS_COUNT;
 
   private int queueSize = DEFAULT_IMPORT_QUEUE_SIZE;
@@ -36,6 +38,8 @@ public class ImportProperties {
   private int readerThreadsCount = DEFAULT_READER_THREADS_COUNT;
 
   private boolean useOnlyPosition = false;
+
+  private int maxBatchSizeBytes = DEFAULT_MAX_BATCH_SIZE_BYTES;
 
   /**
    * The property is not used anymore. Instead of a backoff, the records reader gets rescheduled
@@ -151,6 +155,15 @@ public class ImportProperties {
   public ImportProperties setCompletedReaderMinEmptyBatches(
       final int completedReaderMinEmptyBatches) {
     this.completedReaderMinEmptyBatches = completedReaderMinEmptyBatches;
+    return this;
+  }
+
+  public int getMaxBatchSizeBytes() {
+    return maxBatchSizeBytes;
+  }
+
+  public ImportProperties setMaxBatchSizeBytes(final int maxBatchSizeBytes) {
+    this.maxBatchSizeBytes = maxBatchSizeBytes;
     return this;
   }
 }

--- a/tasklist/importer/pom.xml
+++ b/tasklist/importer/pom.xml
@@ -171,6 +171,10 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportJob.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportJob.java
@@ -26,5 +26,5 @@ public interface ImportJob extends Callable<Boolean> {
 
   public void processPossibleIndexChange();
 
-  public List<ImportBatch> createSubBatchesPerIndexName();
+  public List<ImportBatch> createSizeLimitedSubBatchesPerIndexName();
 }

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/ImportJobElasticSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/ImportJobElasticSearch.java
@@ -19,8 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.SearchHit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
@@ -33,57 +31,64 @@ import org.springframework.stereotype.Component;
 @Conditional(ElasticSearchCondition.class)
 public class ImportJobElasticSearch extends ImportJobAbstract {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ImportJobElasticSearch.class);
-
   @Autowired
   @Qualifier("tasklistZeebeEsClient")
   private RestHighLevelClient zeebeEsClient;
 
-  public ImportJobElasticSearch(ImportBatch importBatch, ImportPositionEntity previousPosition) {
+  public ImportJobElasticSearch(
+      final ImportBatch importBatch, final ImportPositionEntity previousPosition) {
     this.importBatch = importBatch;
     this.previousPosition = previousPosition;
-    this.creationTime = OffsetDateTime.now();
+    creationTime = OffsetDateTime.now();
   }
 
-  public List<ImportBatch> createSubBatchesPerIndexName() {
-    final List<ImportBatch> subBatches = new ArrayList<>();
-    if (importBatch.getHits().size() <= 1) {
-      subBatches.add(importBatch);
-      return subBatches;
-    } else {
-      String previousIndexName = null;
-      List<SearchHit> subBatchHits = new ArrayList<>();
-      final List<SearchHit> importResult = importBatch.getHits();
-      for (SearchHit hit : importResult) {
-        final String indexName = hit.getIndex();
-        if (previousIndexName != null && !indexName.equals(previousIndexName)) {
-          // start new sub-batch
-          subBatches.add(
-              new ImportBatchElasticSearch(
-                  importBatch.getPartitionId(),
-                  importBatch.getImportValueType(),
-                  subBatchHits,
-                  previousIndexName));
-          subBatchHits = new ArrayList<>();
-        }
-        subBatchHits.add(hit);
-        previousIndexName = indexName;
-      }
-      subBatches.add(
-          new ImportBatchElasticSearch(
-              importBatch.getPartitionId(),
-              importBatch.getImportValueType(),
-              subBatchHits,
-              previousIndexName));
-      return subBatches;
-    }
-  }
-
+  @Override
   public void refreshZeebeIndices() {
     final String indexPattern =
         importBatch
             .getImportValueType()
             .getIndicesPattern(tasklistProperties.getZeebeElasticsearch().getPrefix());
     ElasticsearchUtil.refreshIndicesFor(zeebeEsClient, indexPattern);
+  }
+
+  @Override
+  public List<ImportBatch> createSizeLimitedSubBatchesPerIndexName() {
+    final List<SearchHit> hits = importBatch.getHits();
+    final int maxBatchSizeBytes = tasklistProperties.getImporter().getMaxBatchSizeBytes();
+    final List<ImportBatch> subBatches = new ArrayList<>();
+    ImportBatchElasticSearch currentBatch = null;
+    int currentBatchSize = 0;
+    String currentIndex = null;
+    List<SearchHit> currentHits = null;
+    for (final SearchHit hit : hits) {
+      final String hitIndex = hit.getIndex();
+      final int hitSize = EntitySizeEstimator.estimateSize(hit);
+      if (currentBatch == null
+          || !hitIndex.equals(currentIndex)
+          || currentBatchSize + hitSize > maxBatchSizeBytes) {
+        if (currentBatch != null) {
+          currentBatch.setHits(currentHits);
+          currentBatch.setLastRecordIndexName(currentIndex);
+          subBatches.add(currentBatch);
+        }
+        currentBatch =
+            new ImportBatchElasticSearch(
+                importBatch.getPartitionId(),
+                importBatch.getImportValueType(),
+                new ArrayList<>(),
+                hitIndex);
+        currentHits = new ArrayList<>();
+        currentBatchSize = 0;
+        currentIndex = hitIndex;
+      }
+      currentHits.add(hit);
+      currentBatchSize += hitSize;
+    }
+    if (currentBatch != null && currentHits != null && !currentHits.isEmpty()) {
+      currentBatch.setHits(currentHits);
+      currentBatch.setLastRecordIndexName(currentIndex);
+      subBatches.add(currentBatch);
+    }
+    return subBatches;
   }
 }

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportJobOpenSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportJobOpenSearch.java
@@ -19,8 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.core.search.Hit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
@@ -32,57 +30,64 @@ import org.springframework.stereotype.Component;
 @Conditional(OpenSearchCondition.class)
 public class ImportJobOpenSearch extends ImportJobAbstract {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ImportJobOpenSearch.class);
-
   @Autowired
   @Qualifier("tasklistZeebeOsClient")
   private OpenSearchClient zeebeOsClient;
 
-  public ImportJobOpenSearch(ImportBatch importBatch, ImportPositionEntity previousPosition) {
+  public ImportJobOpenSearch(
+      final ImportBatch importBatch, final ImportPositionEntity previousPosition) {
     this.importBatch = importBatch;
     this.previousPosition = previousPosition;
-    this.creationTime = OffsetDateTime.now();
+    creationTime = OffsetDateTime.now();
   }
 
-  public List<ImportBatch> createSubBatchesPerIndexName() {
-    final List<ImportBatch> subBatches = new ArrayList<>();
-    if (importBatch.getHits().size() <= 1) {
-      subBatches.add(importBatch);
-      return subBatches;
-    } else {
-      String previousIndexName = null;
-      List<Hit> subBatchHits = new ArrayList<>();
-      final List<Hit> importResult = importBatch.getHits();
-      for (Hit hit : importResult) {
-        final String indexName = hit.index();
-        if (previousIndexName != null && !indexName.equals(previousIndexName)) {
-          // start new sub-batch
-          subBatches.add(
-              new ImportBatchOpenSearch(
-                  importBatch.getPartitionId(),
-                  importBatch.getImportValueType(),
-                  subBatchHits,
-                  previousIndexName));
-          subBatchHits = new ArrayList<>();
-        }
-        subBatchHits.add(hit);
-        previousIndexName = indexName;
-      }
-      subBatches.add(
-          new ImportBatchOpenSearch(
-              importBatch.getPartitionId(),
-              importBatch.getImportValueType(),
-              subBatchHits,
-              previousIndexName));
-      return subBatches;
-    }
-  }
-
+  @Override
   public void refreshZeebeIndices() {
     final String indexPattern =
         importBatch
             .getImportValueType()
             .getIndicesPattern(tasklistProperties.getZeebeElasticsearch().getPrefix());
     OpenSearchUtil.refreshIndicesFor(zeebeOsClient, indexPattern);
+  }
+
+  @Override
+  public List<ImportBatch> createSizeLimitedSubBatchesPerIndexName() {
+    final List<Hit> hits = importBatch.getHits();
+    final int maxBatchSizeBytes = tasklistProperties.getImporter().getMaxBatchSizeBytes();
+    final List<ImportBatch> subBatches = new ArrayList<>();
+    ImportBatchOpenSearch currentBatch = null;
+    int currentBatchSize = 0;
+    String currentIndex = null;
+    List<Hit> currentHits = null;
+    for (final Hit hit : hits) {
+      final String hitIndex = hit.index();
+      final int hitSize = EntitySizeEstimator.estimateSize(hit);
+      if (currentBatch == null
+          || !hitIndex.equals(currentIndex)
+          || currentBatchSize + hitSize > maxBatchSizeBytes) {
+        if (currentBatch != null) {
+          currentBatch.setHits(currentHits);
+          currentBatch.setLastRecordIndexName(currentIndex);
+          subBatches.add(currentBatch);
+        }
+        currentBatch =
+            new ImportBatchOpenSearch(
+                importBatch.getPartitionId(),
+                importBatch.getImportValueType(),
+                new ArrayList<>(),
+                hitIndex);
+        currentHits = new ArrayList<>();
+        currentBatchSize = 0;
+        currentIndex = hitIndex;
+      }
+      currentHits.add(hit);
+      currentBatchSize += hitSize;
+    }
+    if (currentBatch != null && currentHits != null && !currentHits.isEmpty()) {
+      currentBatch.setHits(currentHits);
+      currentBatch.setLastRecordIndexName(currentIndex);
+      subBatches.add(currentBatch);
+    }
+    return subBatches;
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We have seen in some customer support issues and internally that the importer can run into memory problems during batch processing and executing, when the memory footprint of the batch is too large. While we limit batch size based on the number of records read, we do not do this in such a way that considers object sizing.

This approach adds a size condition to further split into sub-batches. This is only a problem in 8.8 importer and would need to be backported to 8.7 and 8.6. The equivalent fix in the exporter has already been made for 8.8+ versions

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #37844
