### PR TITLE
feat: alternative configuration options for authorization server url

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProvider.java
@@ -237,7 +237,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
   }
 
   private SSLSocketFactory createSSLContext() {
-    return SSLContextUtil.createSSLContext(
+    return SSLContextUtil.createSSLFactory(
         keystorePath, keystorePassword, truststorePath, truststorePassword, keystoreKeyPassword);
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProvider.java
@@ -52,7 +52,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSocketFactory;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -232,13 +231,14 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
   private void maybeConfigureCustomSSLContext(final HttpURLConnection connection) {
     if (connection instanceof HttpsURLConnection) {
       final HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
-      httpsConnection.setSSLSocketFactory(createSSLContext());
+      httpsConnection.setSSLSocketFactory(
+          SSLContextUtil.createSSLFactory(
+              keystorePath,
+              keystorePassword,
+              truststorePath,
+              truststorePassword,
+              keystoreKeyPassword));
     }
-  }
-
-  private SSLSocketFactory createSSLContext() {
-    return SSLContextUtil.createSSLFactory(
-        keystorePath, keystorePassword, truststorePath, truststorePassword, keystoreKeyPassword);
   }
 
   private String getClientAssertion() {

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProvider.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.impl.CamundaClientCredentials;
+import io.camunda.client.impl.util.SSLContextUtil;
 import io.camunda.client.impl.util.VersionUtil;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -39,13 +40,8 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
-import java.security.KeyManagementException;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -58,8 +54,6 @@ import java.util.stream.Collectors;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import net.jcip.annotations.ThreadSafe;
-import org.apache.hc.core5.ssl.SSLContextBuilder;
-import org.apache.hc.core5.ssl.SSLContexts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -243,30 +237,8 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
   }
 
   private SSLSocketFactory createSSLContext() {
-    if (keystorePath == null && truststorePath == null) {
-      return SSLContexts.createSystemDefault().getSocketFactory();
-    }
-    final SSLContextBuilder builder = SSLContexts.custom();
-    try {
-      if (keystorePath != null) {
-        builder.loadKeyMaterial(
-            keystorePath,
-            keystorePassword == null ? null : keystorePassword.toCharArray(),
-            keystoreKeyPassword == null ? new char[0] : keystoreKeyPassword.toCharArray());
-      }
-      if (truststorePath != null) {
-        builder.loadTrustMaterial(
-            truststorePath, truststorePassword == null ? null : truststorePassword.toCharArray());
-      }
-      return builder.build().getSocketFactory();
-    } catch (final NoSuchAlgorithmException
-        | KeyManagementException
-        | KeyStoreException
-        | UnrecoverableKeyException
-        | CertificateException
-        | IOException e) {
-      throw new RuntimeException("Failed to create SSL context", e);
-    }
+    return SSLContextUtil.createSSLContext(
+        keystorePath, keystorePassword, truststorePath, truststorePassword, keystoreKeyPassword);
   }
 
   private String getClientAssertion() {

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -485,7 +485,7 @@ public final class OAuthCredentialsProviderBuilder {
   }
 
   private SSLSocketFactory createSSLContext() {
-    return SSLContextUtil.createSSLContext(
+    return SSLContextUtil.createSSLFactory(
         keystorePath, keystorePassword, truststorePath, truststorePassword, keystoreKeyPassword);
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -407,16 +407,16 @@ public final class OAuthCredentialsProviderBuilder {
   private void findAuthorizationServerUrl() {
     final AuthorizationServerUrlSource source = detectSource();
     switch (source) {
+      case unset:
+        authorizationServerUrl = DEFAULT_AUTHZ_SERVER;
+        break;
+      case authorizationServerUrl:
+        break;
       case wellKnownConfigurationUrl:
         authorizationServerUrlFromWellKnownConfigurationUrl();
         break;
       case issuerUrl:
         authorizationServerUrlFromIssuerUrl();
-        break;
-      case unset:
-        authorizationServerUrl = DEFAULT_AUTHZ_SERVER;
-        break;
-      case authorizationServerUrl:
         break;
       default:
         throw new IllegalArgumentException(

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -34,11 +34,22 @@ import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_TOKEN_AUDIENCE;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_TOKEN_RESOURCE;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_TOKEN_SCOPE;
+import static java.lang.Math.toIntExact;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import io.camunda.client.impl.LegacyZeebeClientEnvironmentVariables;
+import io.camunda.client.impl.util.SSLContextUtil;
+import io.camunda.client.impl.util.VersionUtil;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -48,6 +59,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.Objects;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
 
 public final class OAuthCredentialsProviderBuilder {
   public static final String INVALID_ARGUMENT_MSG = "Expected valid %s but none was provided.";
@@ -64,6 +77,8 @@ public final class OAuthCredentialsProviderBuilder {
   private String scope;
   private String resource;
   private String authorizationServerUrl;
+  private String wellKnownConfigurationUrl;
+  private String issuerUrl;
   private URL authorizationServer;
   private Path keystorePath;
   private String keystorePassword;
@@ -152,10 +167,23 @@ public final class OAuthCredentialsProviderBuilder {
     return this;
   }
 
+  /** The well known configuration URL of the issuer that will issue the access token. */
+  public OAuthCredentialsProviderBuilder wellKnownConfigurationUrl(
+      final String wellKnownConfigurationUrl) {
+    this.wellKnownConfigurationUrl = wellKnownConfigurationUrl;
+    return this;
+  }
+
+  /** The URL of the issuer that will issue the access token. */
+  public OAuthCredentialsProviderBuilder issuerUrl(final String issuerUrl) {
+    this.issuerUrl = issuerUrl;
+    return this;
+  }
+
   /**
    * @see OAuthCredentialsProviderBuilder#authorizationServerUrl(String)
    */
-  URL getAuthorizationServer() {
+  public URL getAuthorizationServer() {
     return authorizationServer;
   }
 
@@ -372,9 +400,107 @@ public final class OAuthCredentialsProviderBuilder {
       applySSLClientCertConfiguration();
     }
     applyDefaults();
-
+    findAuthorizationServerUrl();
     validate();
     return new OAuthCredentialsProvider(this);
+  }
+
+  private void findAuthorizationServerUrl() {
+    final AuthorizationServerUrlSource source = detectSource();
+    switch (source) {
+      case wellKnownConfigurationUrl:
+        authorizationServerUrlFromWellKnownConfigurationUrl();
+        break;
+      case issuerUrl:
+        authorizationServerUrlFromIssuerUrl();
+        break;
+      default:
+        break;
+    }
+    if (authorizationServerUrl == null) {
+      authorizationServerUrl = DEFAULT_AUTHZ_SERVER;
+    }
+  }
+
+  private void authorizationServerUrlFromIssuerUrl() {
+    if (issuerUrl.endsWith("/")) {
+      issuerUrl = issuerUrl.substring(0, issuerUrl.length() - 1);
+    }
+    wellKnownConfigurationUrl = issuerUrl + "/.well-known/openid-configuration";
+    authorizationServerUrlFromWellKnownConfigurationUrl();
+  }
+
+  private void authorizationServerUrlFromWellKnownConfigurationUrl() {
+    try {
+      final WellKnownConfiguration wellKnownConfiguration = fetchWellKnownConfiguration();
+      authorizationServerUrl = wellKnownConfiguration.getTokenEndpoint();
+    } catch (final IOException e) {
+      throw new IllegalArgumentException("Failed to retrieve well known configuration", e);
+    }
+  }
+
+  private WellKnownConfiguration fetchWellKnownConfiguration() throws IOException {
+    final HttpURLConnection connection =
+        (HttpURLConnection) new URL(wellKnownConfigurationUrl).openConnection();
+    maybeConfigureCustomSSLContext(connection);
+    connection.setRequestMethod("GET");
+    connection.setRequestProperty("Accept", "application/json");
+    connection.setDoOutput(true);
+    connection.setReadTimeout(toIntExact(readTimeout.toMillis()));
+    connection.setConnectTimeout(toIntExact(connectTimeout.toMillis()));
+    connection.setRequestProperty("User-Agent", "camunda-client-java/" + VersionUtil.getVersion());
+
+    if (connection.getResponseCode() != 200) {
+      throw new IOException(
+          String.format(
+              "Failed while requesting well known configuration with status code %d and message %s.",
+              connection.getResponseCode(), connection.getResponseMessage()));
+    }
+
+    try (final InputStream in = connection.getInputStream();
+        final InputStreamReader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+      final ObjectReader wellKnownConfigurationReader =
+          new ObjectMapper()
+              .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+              .readerFor(WellKnownConfiguration.class);
+      final WellKnownConfiguration wellKnownConfiguration =
+          wellKnownConfigurationReader.readValue(reader);
+
+      if (wellKnownConfiguration == null) {
+        throw new IOException("Expected valid well known configuration but got null instead.");
+      }
+
+      return wellKnownConfiguration;
+    }
+  }
+
+  private void maybeConfigureCustomSSLContext(final HttpURLConnection connection) {
+    if (connection instanceof HttpsURLConnection) {
+      final HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
+      httpsConnection.setSSLSocketFactory(createSSLContext());
+    }
+  }
+
+  private SSLSocketFactory createSSLContext() {
+    return SSLContextUtil.createSSLContext(
+        keystorePath, keystorePassword, truststorePath, truststorePassword, keystoreKeyPassword);
+  }
+
+  private AuthorizationServerUrlSource detectSource() {
+    if (isSet(authorizationServerUrl)) {
+      return AuthorizationServerUrlSource.authorizationServerUrl;
+    }
+    if (isSet(wellKnownConfigurationUrl)) {
+      return AuthorizationServerUrlSource.wellKnownConfigurationUrl;
+    }
+    if (isSet(issuerUrl)) {
+      return AuthorizationServerUrlSource.issuerUrl;
+    }
+    return null;
+  }
+
+  private boolean isSet(final String value) {
+    return value != null && !value.isEmpty();
   }
 
   private void applySSLClientCertConfiguration() {
@@ -452,10 +578,6 @@ public final class OAuthCredentialsProviderBuilder {
       credentialsCachePath = DEFAULT_CREDENTIALS_CACHE_PATH;
     }
 
-    if (authorizationServerUrl == null) {
-      authorizationServerUrl = DEFAULT_AUTHZ_SERVER;
-    }
-
     if (connectTimeout == null) {
       connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     }
@@ -523,5 +645,24 @@ public final class OAuthCredentialsProviderBuilder {
               "%s timeout is %s milliseconds, expected timeout to be a positive number of milliseconds smaller than %s.",
               timeoutName, timeout.toMillis(), Integer.MAX_VALUE));
     }
+  }
+
+  static class WellKnownConfiguration {
+    @JsonProperty("token_endpoint")
+    private String tokenEndpoint;
+
+    public String getTokenEndpoint() {
+      return tokenEndpoint;
+    }
+
+    public void setTokenEndpoint(final String tokenEndpoint) {
+      this.tokenEndpoint = tokenEndpoint;
+    }
+  }
+
+  private enum AuthorizationServerUrlSource {
+    authorizationServerUrl,
+    wellKnownConfigurationUrl,
+    issuerUrl
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -70,7 +70,7 @@ public final class OAuthCredentialsProviderBuilder {
       Paths.get(System.getProperty("user.home"), ".camunda", "credentials")
           .toAbsolutePath()
           .toString();
-  private static final String DEFAULT_AUTHZ_SERVER = "https://login.cloud.camunda.io/oauth/token/";
+  public static final String DEFAULT_AUTHZ_SERVER = "https://login.cloud.camunda.io/oauth/token/";
   private String clientId;
   private String clientSecret;
   private String audience;
@@ -414,11 +414,14 @@ public final class OAuthCredentialsProviderBuilder {
       case issuerUrl:
         authorizationServerUrlFromIssuerUrl();
         break;
-      default:
+      case unset:
+        authorizationServerUrl = DEFAULT_AUTHZ_SERVER;
         break;
-    }
-    if (authorizationServerUrl == null) {
-      authorizationServerUrl = DEFAULT_AUTHZ_SERVER;
+      case authorizationServerUrl:
+        break;
+      default:
+        throw new IllegalArgumentException(
+            "Unsupported authorization server url source: " + source);
     }
   }
 
@@ -496,7 +499,7 @@ public final class OAuthCredentialsProviderBuilder {
     if (isSet(issuerUrl)) {
       return AuthorizationServerUrlSource.issuerUrl;
     }
-    return null;
+    return AuthorizationServerUrlSource.unset;
   }
 
   private boolean isSet(final String value) {
@@ -663,6 +666,7 @@ public final class OAuthCredentialsProviderBuilder {
   private enum AuthorizationServerUrlSource {
     authorizationServerUrl,
     wellKnownConfigurationUrl,
-    issuerUrl
+    issuerUrl,
+    unset
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -60,7 +60,6 @@ import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.Objects;
 import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSocketFactory;
 
 public final class OAuthCredentialsProviderBuilder {
   public static final String INVALID_ARGUMENT_MSG = "Expected valid %s but none was provided.";
@@ -480,13 +479,14 @@ public final class OAuthCredentialsProviderBuilder {
   private void maybeConfigureCustomSSLContext(final HttpURLConnection connection) {
     if (connection instanceof HttpsURLConnection) {
       final HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
-      httpsConnection.setSSLSocketFactory(createSSLContext());
+      httpsConnection.setSSLSocketFactory(
+          SSLContextUtil.createSSLFactory(
+              keystorePath,
+              keystorePassword,
+              truststorePath,
+              truststorePassword,
+              keystoreKeyPassword));
     }
-  }
-
-  private SSLSocketFactory createSSLContext() {
-    return SSLContextUtil.createSSLFactory(
-        keystorePath, keystorePassword, truststorePath, truststorePassword, keystoreKeyPassword);
   }
 
   private AuthorizationServerUrlSource detectSource() {

--- a/clients/java/src/main/java/io/camunda/client/impl/util/SSLContextUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/SSLContextUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import javax.net.ssl.SSLSocketFactory;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.apache.hc.core5.ssl.SSLContexts;
+
+public final class SSLContextUtil {
+  private SSLContextUtil() {}
+
+  public static SSLSocketFactory createSSLContext(
+      final Path keystorePath,
+      final String keystorePassword,
+      final Path truststorePath,
+      final String truststorePassword,
+      final String keystoreKeyPassword) {
+    if (keystorePath == null && truststorePath == null) {
+      return SSLContexts.createSystemDefault().getSocketFactory();
+    }
+    final SSLContextBuilder builder = SSLContexts.custom();
+    try {
+      if (keystorePath != null) {
+        builder.loadKeyMaterial(
+            keystorePath,
+            keystorePassword == null ? null : keystorePassword.toCharArray(),
+            keystoreKeyPassword == null ? new char[0] : keystoreKeyPassword.toCharArray());
+      }
+      if (truststorePath != null) {
+        builder.loadTrustMaterial(
+            truststorePath, truststorePassword == null ? null : truststorePassword.toCharArray());
+      }
+      return builder.build().getSocketFactory();
+    } catch (final NoSuchAlgorithmException
+        | KeyManagementException
+        | KeyStoreException
+        | UnrecoverableKeyException
+        | CertificateException
+        | IOException e) {
+      throw new RuntimeException("Failed to create SSL context", e);
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/util/SSLContextUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/SSLContextUtil.java
@@ -29,7 +29,7 @@ import org.apache.hc.core5.ssl.SSLContexts;
 public final class SSLContextUtil {
   private SSLContextUtil() {}
 
-  public static SSLSocketFactory createSSLContext(
+  public static SSLSocketFactory createSSLFactory(
       final Path keystorePath,
       final String keystorePassword,
       final Path truststorePath,

--- a/clients/java/src/main/java/io/camunda/client/impl/util/SSLContextUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/SSLContextUtil.java
@@ -43,8 +43,8 @@ public final class SSLContextUtil {
       if (keystorePath != null) {
         builder.loadKeyMaterial(
             keystorePath,
-            keystorePassword == null ? null : keystorePassword.toCharArray(),
-            keystoreKeyPassword == null ? new char[0] : keystoreKeyPassword.toCharArray());
+            toPasswordChars(keystorePassword, null),
+            toPasswordChars(keystoreKeyPassword, new char[0]));
       }
       if (truststorePath != null) {
         builder.loadTrustMaterial(
@@ -59,5 +59,9 @@ public final class SSLContextUtil {
         | IOException e) {
       throw new RuntimeException("Failed to create SSL context", e);
     }
+  }
+
+  private static char[] toPasswordChars(final String password, final char[] defaultPassword) {
+    return password != null ? password.toCharArray() : defaultPassword;
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderBuilderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderBuilderTest.java
@@ -232,7 +232,8 @@ public final class OAuthCredentialsProviderBuilderTest {
   @Test
   void shouldUseDefaultAuthorizationServerUrl() {
     // given
-    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder().audience("a").clientId("b").clientSecret("c");
+    final OAuthCredentialsProviderBuilder builder =
+        new OAuthCredentialsProviderBuilder().audience("a").clientId("b").clientSecret("c");
     // when
     builder.build();
     // then

--- a/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderBuilderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderBuilderTest.java
@@ -15,8 +15,14 @@
  */
 package io.camunda.client;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -27,9 +33,8 @@ import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+@WireMockTest
 public final class OAuthCredentialsProviderBuilderTest {
-
-  private final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
 
   @Test
   void shouldFailWithNoClientId() {
@@ -175,5 +180,66 @@ public final class OAuthCredentialsProviderBuilderTest {
     assertThatCode(builder::build)
         .hasMessageContaining("Keystore path does not exist")
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldDetectTokenEndpointFromWellKnownConfigurationUrl(
+      final WireMockRuntimeInfo wmRuntimeInfo) {
+    stubFor(
+        get("/.well-known/openid-configuration")
+            .willReturn(ok().withBody("{\"token_endpoint\": \"http://token-endpoint\"}")));
+    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+    builder
+        .audience("a")
+        .clientId("b")
+        .clientSecret("c")
+        .wellKnownConfigurationUrl(
+            "http://localhost:"
+                + wmRuntimeInfo.getHttpPort()
+                + "/.well-known/openid-configuration");
+    builder.build();
+    final String authorizationServerUrl = builder.getAuthorizationServer().toString();
+    assertThat(authorizationServerUrl).isEqualTo("http://token-endpoint");
+  }
+
+  @Test
+  void shouldDetectTokenEndpointFromIssuerUrl(final WireMockRuntimeInfo wmRuntimeInfo) {
+    stubFor(
+        get("/.well-known/openid-configuration")
+            .willReturn(ok().withBody("{\"token_endpoint\": \"http://token-endpoint\"}")));
+    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+    builder
+        .audience("a")
+        .clientId("b")
+        .clientSecret("c")
+        .issuerUrl("http://localhost:" + wmRuntimeInfo.getHttpPort());
+    builder.build();
+    final String authorizationServerUrl = builder.getAuthorizationServer().toString();
+    assertThat(authorizationServerUrl).isEqualTo("http://token-endpoint");
+  }
+
+  @Test
+  void shouldFailWhenWellKnownConfigurationIsWrong() {
+    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+    builder.audience("a").clientId("b").clientSecret("c").issuerUrl("http://some-issuer");
+    // then
+    assertThatCode(builder::build)
+        .hasMessageContaining("Failed to retrieve well known configuration")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void testAgainstReal() {
+    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+    builder
+        .audience("a")
+        .clientId("b")
+        .clientSecret("c")
+        .issuerUrl("https://keycloak.consulting-sandbox.camunda.cloud/realms/jonny");
+    builder.build();
+    final String authorizationServerUrl = builder.getAuthorizationServer().toString();
+    assertThat(authorizationServerUrl)
+        .isEqualTo(
+            "https://keycloak.consulting-sandbox.camunda.cloud/realms/jonny/protocol/openid-connect/token");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderBuilderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderBuilderTest.java
@@ -18,6 +18,7 @@ package io.camunda.client;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder.DEFAULT_AUTHZ_SERVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
@@ -229,17 +230,13 @@ public final class OAuthCredentialsProviderBuilderTest {
   }
 
   @Test
-  void testAgainstReal() {
-    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
-    builder
-        .audience("a")
-        .clientId("b")
-        .clientSecret("c")
-        .issuerUrl("https://keycloak.consulting-sandbox.camunda.cloud/realms/jonny");
+  void shouldUseDefaultAuthorizationServerUrl() {
+    // given
+    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder().audience("a").clientId("b").clientSecret("c");
+    // when
     builder.build();
+    // then
     final String authorizationServerUrl = builder.getAuthorizationServer().toString();
-    assertThat(authorizationServerUrl)
-        .isEqualTo(
-            "https://keycloak.consulting-sandbox.camunda.cloud/realms/jonny/protocol/openid-connect/token");
+    assertThat(authorizationServerUrl).isEqualTo(DEFAULT_AUTHZ_SERVER);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds new options to configure the `authorizationServerUrl` to the `OAuthCredentialsProviderBuilder`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #39411 

Will be closed after the spring boot starter has the same properties implemented as well.
