### PR TITLE
pg/fix-concurrent-set

### DIFF
--- a/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/v8_7/processors/processors/ProcessZeebeRecordProcessor.java
+++ b/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/v8_7/processors/processors/ProcessZeebeRecordProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.operate.zeebeimport.util.XMLUtil;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.ProcessEntity;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
@@ -56,8 +57,7 @@ public class ProcessZeebeRecordProcessor {
   public void processDeploymentRecord(final Record record, final BatchRequest batchRequest)
       throws PersistenceException {
     final String intentStr = record.getIntent().name();
-
-    if (STATES.contains(intentStr)) {
+    if (record.getPartitionId() == Protocol.DEPLOYMENT_PARTITION && STATES.contains(intentStr)) {
       final ProcessMetadataValue recordValue = (ProcessMetadataValue) record.getValue();
       persistProcess((Process) recordValue, batchRequest);
     }

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/RecordsReaderHolder.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/RecordsReaderHolder.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
@@ -44,7 +45,7 @@ public class RecordsReaderHolder {
 
   @Autowired private OperateProperties operateProperties;
 
-  private final Set<Integer> partitionsCompletedImporting = new HashSet<>();
+  private final Set<Integer> partitionsCompletedImporting = ConcurrentHashMap.newKeySet();
 
   private final Map<RecordsReader, Integer> countEmptyBatchesAfterImportingDone = new HashMap<>();
 

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderHolder.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderHolder.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
@@ -37,7 +38,7 @@ public class RecordsReaderHolder {
 
   private Set<RecordsReader> recordsReader = null;
 
-  private final Set<Integer> partitionsCompletedImporting = new HashSet<>();
+  private final Set<Integer> partitionsCompletedImporting = ConcurrentHashMap.newKeySet();
 
   private final Map<RecordsReader, Integer> countEmptyBatchesAfterImportingDone = new HashMap<>();
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Operate importer only imports Process Definitions from partition 1 (default deployment partition). Unfortunately we can't remove the RecordReaders entirely as the partition prefixed documents should already be present in the `operate-import-position` index by the time of the 8.8 update
- RecordsReaderHolder for Operate & Tasklist use a `ConcurrentHashMap.keyset` for tracking partitions available for completion [context](https://camunda.slack.com/archives/C09J1F6NJJ0/p1760121660045499?thread_ts=1760098570.050819&cid=C09J1F6NJJ0)
- Make migration tests run against multi-partition Zeebe 8.7 and 8.8 deployments

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39467
