### PR TITLE
Only trigger signal subscriptions when authorized even with multiple partitions

### DIFF
--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.processing;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -135,5 +136,10 @@ record MockTypedCheckpointRecord(
   @Override
   public int getLength() {
     return 0;
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return null;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -172,6 +172,14 @@ final class InterPartitionCommandReceiverImpl {
       final var value = ReflectUtil.newInstance(valueClass);
 
       value.wrap(messageBuffer, commandOffset, commandLength);
+
+      final var authInfo = recordMetadata.getAuthorization();
+      authInfo.reset();
+      final var authOffset =
+          commandOffset + commandLength + InterPartitionMessageDecoder.authHeaderLength();
+      final var authLength = messageDecoder.authLength();
+      authInfo.wrap(messageBuffer, authOffset, authLength);
+
       return new DecodedMessage(checkpointId, recordKey, recordMetadata, value);
     }
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.protocol.InterPartitionMessageEncoder;
 import io.camunda.zeebe.broker.protocol.MessageHeaderEncoder;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -54,6 +55,17 @@ final class InterPartitionCommandSenderImpl implements InterPartitionCommandSend
       final Intent intent,
       final Long recordKey,
       final UnifiedRecordValue command) {
+    sendCommand(receiverPartitionId, valueType, intent, recordKey, command, null);
+  }
+
+  @Override
+  public void sendCommand(
+      final int receiverPartitionId,
+      final ValueType valueType,
+      final Intent intent,
+      final Long recordKey,
+      final UnifiedRecordValue command,
+      final AuthInfo authInfo) {
     if (!partitionLeaders.containsKey(receiverPartitionId)) {
       LOG.warn(
           "Not sending command {} {} to {}, no known leader for this partition",
@@ -72,7 +84,8 @@ final class InterPartitionCommandSenderImpl implements InterPartitionCommandSend
         partitionLeader);
 
     final var message =
-        Encoder.encode(checkpointId, receiverPartitionId, valueType, intent, recordKey, command);
+        Encoder.encode(
+            checkpointId, receiverPartitionId, valueType, intent, recordKey, command, authInfo);
 
     communicationService.unicast(
         TOPIC_PREFIX + receiverPartitionId,
@@ -98,7 +111,8 @@ final class InterPartitionCommandSenderImpl implements InterPartitionCommandSend
         final ValueType valueType,
         final Intent intent,
         final Long recordKey,
-        final BufferWriter command) {
+        final BufferWriter command,
+        final BufferWriter authInfo) {
       final var messageLength =
           MessageHeaderEncoder.ENCODED_LENGTH
               + InterPartitionMessageEncoder.BLOCK_LENGTH
@@ -108,15 +122,18 @@ final class InterPartitionCommandSenderImpl implements InterPartitionCommandSend
       final var headerEncoder = new MessageHeaderEncoder();
       final var bodyEncoder = new InterPartitionMessageEncoder();
       final var commandBuffer = new UnsafeBuffer(new byte[command.getLength()]);
+      final var authBuffer = new UnsafeBuffer(new byte[authInfo.getLength()]);
       final var messageBuffer = new UnsafeBuffer(new byte[messageLength]);
       command.write(commandBuffer, 0);
+      authInfo.write(authBuffer, 0);
       bodyEncoder
           .wrapAndApplyHeader(messageBuffer, 0, headerEncoder)
           .checkpointId(checkpointId)
           .receiverPartitionId(receiverPartitionId)
           .valueType(valueType.value())
           .intent(intent.value())
-          .putCommand(commandBuffer, 0, command.getLength());
+          .putCommand(commandBuffer, 0, command.getLength())
+          .putAuth(authBuffer, 0, authInfo.getLength());
 
       bodyEncoder.recordKey(
           Objects.requireNonNullElseGet(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.transport.partitionapi;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListener;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -53,6 +54,20 @@ public final class InterPartitionCommandSenderService extends Actor
     actor.submit(
         () ->
             commandSender.sendCommand(receiverPartitionId, valueType, intent, recordKey, command));
+  }
+
+  @Override
+  public void sendCommand(
+      final int receiverPartitionId,
+      final ValueType valueType,
+      final Intent intent,
+      final Long recordKey,
+      final UnifiedRecordValue command,
+      final AuthInfo authInfo) {
+    actor.submit(
+        () ->
+            commandSender.sendCommand(
+                receiverPartitionId, valueType, intent, recordKey, command, authInfo));
   }
 
   @Override

--- a/zeebe/broker/src/main/resources/broker-protocol.xml
+++ b/zeebe/broker/src/main/resources/broker-protocol.xml
@@ -22,6 +22,7 @@
     <field name="checkpointId" id="4" type="int64"/>
 
     <data name="command" id="32" type="varDataEncoding"/>
+    <data name="auth" id="33" type="varDataEncoding"/>
   </sbe:message>
 
 </sbe:messageSchema>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -108,7 +108,8 @@ public final class BatchOperationCreateProcessor
     commandDistributionBehavior
         .withKey(key)
         .inQueue(DistributionQueue.BATCH_OPERATION)
-        .distribute(command.getValueType(), command.getIntent(), recordWithKey);
+        .distribute(
+            command.getValueType(), command.getIntent(), recordWithKey, command.getAuthInfo());
 
     metrics.recordCreated(recordWithKey.getBatchOperationType());
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
@@ -257,7 +257,8 @@ public final class BatchOperationExecuteProcessor
           .distribute(
               ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
               BatchOperationIntent.COMPLETE_PARTITION,
-              batchInternalComplete);
+              batchInternalComplete,
+              command.getAuthInfo());
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationFailProcessor.java
@@ -101,7 +101,8 @@ public final class BatchOperationFailProcessor
           .distribute(
               ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
               BatchOperationIntent.FAIL_PARTITION,
-              batchInternalFail);
+              batchInternalFail,
+              command.getAuthInfo());
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionContinueProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionContinueProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 @ExcludeAuthorizationCheck
@@ -41,6 +42,8 @@ public class CommandDistributionContinueProcessor
     final var continuationRecord = distributionState.getContinuationRecord(queue, key);
     final var intent = continuationRecord.getIntent();
     final var continuationCommand = continuationRecord.getCommandValue();
+    final var metadata =
+        FollowUpCommandMetadata.of(b -> b.claims(continuationRecord.getAuthInfo().getClaims()));
     commandWriter.appendFollowUpCommand(key, intent, continuationCommand);
 
     stateWriter.appendFollowUpEvent(key, CommandDistributionIntent.CONTINUED, distributionRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.incident;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
@@ -144,5 +145,10 @@ public final class RetryTypedRecord<T extends UnifiedRecordValue> implements Typ
   @Override
   public int getLength() {
     return 0;
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return null;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
@@ -179,7 +180,11 @@ public class ProcessInstanceMigrationMigrateProcessor
     while (!elementInstances.isEmpty()) {
       final var elementInstance = elementInstances.poll();
       tryMigrateElementInstance(
-          elementInstance, sourceProcessDefinition, targetProcessDefinition, mappedElementIds);
+          elementInstance,
+          sourceProcessDefinition,
+          targetProcessDefinition,
+          mappedElementIds,
+          command.getAuthInfo());
       final List<ElementInstance> children =
           elementInstanceState.getChildren(elementInstance.getKey());
       elementInstances.addAll(children);
@@ -232,7 +237,8 @@ public class ProcessInstanceMigrationMigrateProcessor
       final ElementInstance elementInstance,
       final DeployedProcess sourceProcessDefinition,
       final DeployedProcess targetProcessDefinition,
-      final Map<String, String> sourceElementIdToTargetElementId) {
+      final Map<String, String> sourceElementIdToTargetElementId,
+      final AuthInfo authInfo) {
 
     final var elementInstanceRecord = elementInstance.getValue();
     final long processInstanceKey = elementInstanceRecord.getProcessInstanceKey();
@@ -433,7 +439,8 @@ public class ProcessInstanceMigrationMigrateProcessor
           updatedElementInstanceRecord,
           targetElementId,
           processInstanceKey,
-          elementId);
+          elementId,
+          authInfo);
     }
 
     if (updatedElementInstanceRecord.getBpmnElementType() == BpmnElementType.CALL_ACTIVITY) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -135,7 +135,10 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
     signalSubscriptionState.visitBySignalName(
         value.getSignalNameBuffer(),
         value.getTenantId(),
-        subscription -> activateElement(subscription.getRecord(), value.getVariablesBuffer()));
+        subscription -> {
+          checkAuthorization(command, false, subscription.getRecord());
+          activateElement(subscription.getRecord(), value.getVariablesBuffer());
+        });
 
     stateWriter.appendFollowUpEvent(command.getKey(), SignalIntent.BROADCASTED, command.getValue());
     commandDistributionBehavior.acknowledgeCommand(command);
@@ -155,6 +158,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
                 AuthorizationResourceType.PROCESS_DEFINITION,
                 permissionType,
                 command.getValue().getTenantId())
+            .forceAuthorization()
             .addResourceId(subscriptionRecord.getBpmnProcessId());
 
     final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
 import io.camunda.zeebe.engine.state.tenant.PersistedTenant;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -122,15 +123,15 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
         persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord);
     responseWriter.writeEventOnCommand(
         persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord, command);
-    distributeUpdate(updatedRecord);
+    distributeUpdate(updatedRecord, command.getAuthInfo());
   }
 
-  private void distributeUpdate(final TenantRecord updatedTenant) {
+  private void distributeUpdate(final TenantRecord updatedTenant, final AuthInfo authInfo) {
     final long distributionKey = keyGenerator.nextKey();
     commandDistributionBehavior
         .withKey(distributionKey)
         .inQueue(DistributionQueue.IDENTITY.getQueueId())
-        .distribute(ValueType.TENANT, TenantIntent.UPDATE, updatedTenant);
+        .distribute(ValueType.TENANT, TenantIntent.UPDATE, updatedTenant, authInfo);
   }
 
   private void rejectCommandWithUnauthorizedError(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -250,7 +250,8 @@ public class DbDistributionState implements MutableDistributionState {
         .setQueueId(persistedDistribution.getQueueId().orElse(null))
         .setValueType(persistedDistribution.getValueType())
         .setIntent(persistedDistribution.getIntent())
-        .setCommandValue(persistedDistribution.getCommandValue());
+        .setCommandValue(persistedDistribution.getCommandValue())
+        .setAuthInfo(persistedDistribution.getAuthInfo());
   }
 
   @Override
@@ -387,6 +388,7 @@ public class DbDistributionState implements MutableDistributionState {
         .setQueueId(queue)
         .setValueType(persistedCommandDistribution.getValueType())
         .setIntent(persistedCommandDistribution.getIntent())
-        .setCommandValue(persistedCommandDistribution.getCommandValue());
+        .setCommandValue(persistedCommandDistribution.getCommandValue())
+        .setAuthInfo(persistedCommandDistribution.getAuthInfo());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
@@ -10,45 +10,75 @@ package io.camunda.zeebe.engine.processing.signal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.client.SignalClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class BroadcastSignalMultiplePartitionsTest {
 
-  public static final String PROCESS_ID = "process";
-  public static final int PARTITION_COUNT = 3;
-  @ClassRule public static final EngineRule ENGINE = EngineRule.multiplePartition(PARTITION_COUNT);
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
 
-  private static final String SIGNAL_NAME = "a";
+  private static final int PARTITION_COUNT = 3;
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.multiplePartition(PARTITION_COUNT)
+          .withIdentitySetup()
+          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg ->
+                  cfg.getInitialization()
+                      .getDefaultRoles()
+                      .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername()))));
+
+  private final String signalName = UUID.randomUUID().toString();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
-  private final SignalClient signalClient = ENGINE.signal().withSignalName(SIGNAL_NAME);
+  private final SignalClient signalClient = ENGINE.signal().withSignalName(signalName);
 
   @Test
   public void shouldWriteDistributingRecordsForOtherPartitions() {
     // given
+    final var processId = Strings.newRandomValidBpmnId();
     final var process =
-        Bpmn.createExecutableProcess(PROCESS_ID).startEvent().signal(SIGNAL_NAME).endEvent().done();
+        Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
     // when
-    ENGINE.deployment().withXmlResource(process).deploy();
+    ENGINE.deployment().withXmlResource(process).deploy(DEFAULT_USER.getUsername());
 
     // then
-    final var signalKey = signalClient.broadcast().getKey();
+    final var signalKey = signalClient.broadcast(DEFAULT_USER.getUsername()).getKey();
     final var commandDistributionRecords =
         RecordingExporter.commandDistributionRecords()
             .withIntent(CommandDistributionIntent.DISTRIBUTING)
@@ -71,32 +101,32 @@ public class BroadcastSignalMultiplePartitionsTest {
         Bpmn.createExecutableProcess("wf_1")
             .startEvent()
             .intermediateCatchEvent("catch1")
-            .signal(SIGNAL_NAME)
+            .signal(signalName)
             .endEvent()
             .done();
     final var process2 =
         Bpmn.createExecutableProcess("wf_2")
             .startEvent()
             .intermediateCatchEvent("catch2")
-            .signal(SIGNAL_NAME)
+            .signal(signalName)
             .endEvent()
             .done();
 
-    ENGINE.deployment().withXmlResource(process1).deploy();
-    ENGINE.deployment().withXmlResource(process2).deploy();
+    ENGINE.deployment().withXmlResource(process1).deploy(DEFAULT_USER.getUsername());
+    ENGINE.deployment().withXmlResource(process2).deploy(DEFAULT_USER.getUsername());
 
     final var processInstanceKey1 = ENGINE.processInstance().ofBpmnProcessId("wf_1").create();
     final var processInstanceKey2 = ENGINE.processInstance().ofBpmnProcessId("wf_2").create();
 
     assertThat(
             RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
-                .withSignalName(SIGNAL_NAME)
+                .withSignalName(signalName)
                 .limit(2))
         .extracting(record -> record.getValue().getCatchEventId())
         .containsOnly("catch1", "catch2");
 
     // when
-    signalClient.broadcast();
+    signalClient.broadcast(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -120,5 +150,94 @@ public class BroadcastSignalMultiplePartitionsTest {
             tuple("catch2", ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple("wf_2", ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple("wf_2", ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldAuthorizeOnAllPartitions() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var otherProcessId = Strings.newRandomValidBpmnId();
+    final var user = createUser();
+    deployProcess(processId);
+    deployProcess(otherProcessId);
+    addPermissionsToUser(user.getUsername(), PermissionType.UPDATE_PROCESS_INSTANCE, processId);
+    createProcessInstance(processId, 1);
+    createProcessInstance(otherProcessId, 2);
+
+    // wait until both subscriptions are created
+    assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+                .withSignalName(signalName)
+                .limit(2)
+                .count())
+        .isEqualTo(2);
+
+    // when
+    ENGINE.signal().withSignalName(signalName).broadcast(user.getUsername());
+
+    // then
+    RecordingExporter.signalRecords(SignalIntent.BROADCAST)
+        .withSignalName(signalName)
+        .limit(1)
+        .withPartitionId(2)
+        .withRecordType(RecordType.COMMAND_REJECTION)
+        .withRejectionReason(
+            "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
+                .formatted(otherProcessId))
+        .exists();
+  }
+
+  private long createProcessInstance(final String processId, final int partitionId) {
+    return ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .onPartition(partitionId)
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  private UserRecordValue createUser() {
+    return ENGINE
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create(DEFAULT_USER.getUsername())
+        .getValue();
+  }
+
+  private static void addPermissionsToUser(
+      final String username, final PermissionType permissionType, final String processId) {
+    addPermissionsToUser(username, permissionType, processId, AuthorizationResourceMatcher.ID);
+  }
+
+  private static void addPermissionsToUser(
+      final String username,
+      final PermissionType permissionType,
+      final String processId,
+      final AuthorizationResourceMatcher matcher) {
+    ENGINE
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissionType)
+        .withOwnerId(username)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withResourceMatcher(matcher)
+        .withResourceId(processId)
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  private void deployProcess(final String processId) {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .intermediateCatchEvent()
+                .signal(signalName)
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.util;
 
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.Record;
@@ -147,5 +148,10 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   @Override
   public String toJson() {
     throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return metadata.getAuthorization();
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
@@ -58,6 +59,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private static final StringValue VALUE_TYPE_KEY = new StringValue("valueType");
   private static final StringValue INTENT_KEY = new StringValue("intent");
   private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
+  private static final StringValue AUTH_INFO_KEY = new StringValue("authInfo");
 
   // You'll need to register any of the records value's that you want to distribute
   static {
@@ -90,6 +92,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private final IntegerProperty intentProperty = new IntegerProperty(INTENT_KEY, Intent.NULL_VAL);
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>(COMMAND_VALUE_KEY, new UnifiedRecordValue(10));
+  private final ObjectProperty<AuthInfo> authInfoProperty =
+      new ObjectProperty<>(AUTH_INFO_KEY, new AuthInfo());
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
 
@@ -99,7 +103,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
         .declareProperty(queueIdProperty)
         .declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)
-        .declareProperty(commandValueProperty);
+        .declareProperty(commandValueProperty)
+        .declareProperty(authInfoProperty);
   }
 
   public CommandDistributionRecord wrap(final CommandDistributionRecord other) {
@@ -107,7 +112,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
         .setQueueId(other.getQueueId())
         .setValueType(other.getValueType())
         .setIntent(other.getIntent())
-        .setCommandValue(other.getCommandValue());
+        .setCommandValue(other.getCommandValue())
+        .setAuthInfo(other.getAuthInfo());
     return this;
   }
 
@@ -172,6 +178,10 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     return concreteCommandValue;
   }
 
+  public AuthInfo getAuthInfo() {
+    return authInfoProperty.getValue();
+  }
+
   public CommandDistributionRecord setCommandValue(final UnifiedRecordValue commandValue) {
     if (commandValue == null) {
       commandValueProperty.reset();
@@ -209,6 +219,11 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
 
   public CommandDistributionRecord setPartitionId(final int partitionId) {
     partitionIdProperty.setValue(partitionId);
+    return this;
+  }
+
+  public CommandDistributionRecord setAuthInfo(final AuthInfo authInfo) {
+    authInfoProperty.getValue().copyFrom(authInfo);
     return this;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/InterPartitionCommandSender.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/InterPartitionCommandSender.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.api;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -37,4 +38,14 @@ public interface InterPartitionCommandSender {
       final Intent intent,
       final Long recordKey,
       final UnifiedRecordValue command);
+
+  default void sendCommand(
+      final int receiverPartitionId,
+      final ValueType valueType,
+      final Intent intent,
+      final Long recordKey,
+      final UnifiedRecordValue command,
+      final AuthInfo authInfo) {
+    sendCommand(receiverPartitionId, valueType, intent, command);
+  }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/records/TypedRecord.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/records/TypedRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.stream.api.records;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
@@ -21,6 +22,9 @@ public interface TypedRecord<T extends UnifiedRecordValue> extends Record<T> {
 
   @Override
   T getValue();
+
+  @JsonIgnore
+  AuthInfo getAuthInfo();
 
   int getRequestStreamId();
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.stream.impl.records;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -91,6 +92,11 @@ public final class TypedRecordImpl implements TypedRecord {
   @Override
   public Map<String, Object> getAuthorizations() {
     return metadata.getAuthorization().toDecodedMap();
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return metadata.getAuthorization();
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.impl.records;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -126,5 +127,10 @@ public class UnwrittenRecord implements TypedRecord {
   @Override
   public int getLength() {
     return metadata.getLength() + value.getLength();
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return metadata.getAuthorization();
   }
 }


### PR DESCRIPTION
## Description

This PR fixes a bug where a signal broadcast may trigger subscriptions on remote partitions even without the appropriate authorization. This is because of two reasons:
1. The authorization is not distributed with the command, and
2. If a command has no operation reference or request metadata, we _skip the authorization_.

This PR does 4 things:

1. `AuthInfo` can now be sent over the `InterPartitionCommandSender`
2. `AuthInfo` can now be distributed along with a command
3. You can enforce doing the auth check even if we would normally skip it; this is making a test fail FYI because we now can never skip, even when disabling auth, but yknow :shrug:  <---- THIS IS A HACK, SHOULD BE DONE BETTER.
4. Signal broadcast is also authorized again at the resource level after distribution

This PR should be split into 4 (see above), and more tests added. Additionally, I only added one test to verify it - use that as a sample.

I would also strongly challenge writing a rejection just because on PI is not authorized but others are, but I can imagine _some_ reasons to have that.

## Related issues

closes #39430 
