### PR TITLE
ci: re-enable Operate importer/zeebe integration tests in 8.8

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -358,8 +358,8 @@ jobs:
   run-importer-tests:
     if: inputs.runBeTests
     name: "Integration / Importer ITs"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    runs-on: gcp-core-32-default
+    timeout-minutes: 30
     env:
       TEST_TYPE: Integration
       TEST_OWNER: Data Layer
@@ -378,7 +378,7 @@ jobs:
       - name: Build Operate
         run: ./mvnw -B -T1C -DskipChecks -DskipTests -P skipFrontendBuild clean install
       - name: Run Tests
-        run: ./mvnw -pl operate -am verify -T1C -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2
+        run: ./mvnw -pl operate/qa/integration-tests -P skipFrontendBuild,operateItImport,parallel-tests -B -Dfailsafe.rerunFailingTestsCount=0 verify
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -59,7 +59,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: ./mvnw -f operate/qa/integration-tests verify -P operateCoreFeaturesIT -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw -f operate/qa/integration-tests verify -P operateCoreFeaturesIT,parallel-tests -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
       test-type: Core Features ITs
       runner-type: gcp-core-32-default
 
@@ -69,6 +69,6 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: ./mvnw -f operate/qa/integration-tests verify -P operateItOpensearch,docker-opensearch -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw -f operate/qa/integration-tests verify -P operateItOpensearch,parallel-tests,docker-opensearch -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
       test-type: Opensearch ITs
       runner-type: gcp-core-32-default

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -30,7 +30,6 @@
     <maven.compiler.source>21</maven.compiler.source>
 
     <skipSurefire>false</skipSurefire>
-    <testForkCount>${env.LIMITS_CPU}</testForkCount>
     <includeITNames>**/*IT.java</includeITNames>
     <excludeITNames>**/OpenSearch*IT.java, **/Opensearch*IT.java</excludeITNames>
     <excludeUnitTestNames>**/*IT.java</excludeUnitTestNames>
@@ -59,20 +58,6 @@
               </configuration>
             </execution>
           </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <skip>${skipSurefire}</skip>
-            <forkCount>${testForkCount}</forkCount>
-            <reuseForks>true</reuseForks>
-            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-            <systemPropertyVariables>
-              <testForkNumber>$${surefire.forkNumber}</testForkNumber>
-            </systemPropertyVariables>
-          </configuration>
         </plugin>
 
         <plugin>
@@ -154,6 +139,21 @@
         <excludeITNames>none</excludeITNames>
         <skipSurefire>true</skipSurefire>
       </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <environmentVariables>
+                  <CAMUNDA_OPERATE_IMPORTERENABLED>true</CAMUNDA_OPERATE_IMPORTERENABLED>
+                </environmentVariables>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
 
     <profile>

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -484,20 +484,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.5.4</version>
         <configuration>
-          <skipITs>false</skipITs>
           <includes>
             <include>${includeITNames}</include>
           </includes>
           <excludes>
             <exclude>${excludeITNames}</exclude>
           </excludes>
-          <forkCount>1</forkCount>
-          <reuseForks>true</reuseForks>
-          <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <systemPropertyVariables>
-            <testForkNumber>$${surefire.forkNumber}</testForkNumber>
             <spring.profiles.active>test</spring.profiles.active>
           </systemPropertyVariables>
           <environmentVariables>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/39797
