### PR TITLE
refactor: enforce types over interface convention in operate

### DIFF
--- a/operate/client/eslint.config.js
+++ b/operate/client/eslint.config.js
@@ -164,6 +164,7 @@ const config = defineConfig([
     },
     rules: {
       ...tsPlugin.configs.recommended.rules,
+      '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
       '@typescript-eslint/no-unused-vars': [
         'error',
         {

--- a/operate/client/src/__mocks__/@devbookhq/splitter/index.tsx
+++ b/operate/client/src/__mocks__/@devbookhq/splitter/index.tsx
@@ -13,7 +13,7 @@ const SplitDirection = {
   Vertical: 'vertical',
 } as const;
 
-interface SplitterProps {
+type SplitterProps = {
   children: React.ReactNode;
   direction: (typeof SplitDirection)[keyof typeof SplitDirection];
   classes?: string[];
@@ -24,7 +24,7 @@ interface SplitterProps {
   draggerClassName?: string;
   onResizeStarted?: () => void;
   onResizeFinished?: (pairIdx: number, newSizes: number[]) => void;
-}
+};
 
 const Splitter: React.FC<SplitterProps> = ({children}) => {
   return <div data-testid="splitter-mock">{children}</div>;

--- a/operate/client/src/modules/components/IconInput/IconTextArea.tsx
+++ b/operate/client/src/modules/components/IconInput/IconTextArea.tsx
@@ -13,13 +13,13 @@ import {
 } from '@carbon/react';
 import {Container, IconContainer, TextArea, IconButton} from './styled';
 
-interface Props extends React.ComponentProps<typeof BaseTextArea> {
+type Props = {
   Icon: Icon;
   invalid?: boolean;
   onIconClick: () => void;
   buttonLabel: string;
   tooltipPosition?: React.ComponentProps<typeof BaseIconButton>['align'];
-}
+} & React.ComponentProps<typeof BaseTextArea>;
 
 const IconTextArea: React.FC<Props> = ({
   Icon,

--- a/operate/client/src/modules/components/IconInput/IconTextInput.tsx
+++ b/operate/client/src/modules/components/IconInput/IconTextInput.tsx
@@ -13,13 +13,13 @@ import {
 } from '@carbon/react';
 import {Container, IconContainer, TextInput, IconButton} from './styled';
 
-interface Props extends React.ComponentProps<typeof BaseTextInput> {
+type Props = {
   Icon: Icon;
   invalid?: boolean;
   onIconClick: () => void;
   buttonLabel: string;
   tooltipPosition?: React.ComponentProps<typeof BaseIconButton>['align'];
-}
+} & React.ComponentProps<typeof BaseTextInput>;
 
 const IconTextInput: React.FC<Props> = ({
   Icon,

--- a/operate/client/src/modules/components/OptionalFilters/index.tsx
+++ b/operate/client/src/modules/components/OptionalFilters/index.tsx
@@ -11,11 +11,11 @@ import {OverflowMenuItem} from '@carbon/react';
 import {Filter} from '@carbon/react/icons';
 import {ButtonStack, OverflowMenu, Container} from './styled';
 
-interface Props<T> {
+type Props<T> = {
   visibleFilters: T[];
   optionalFilters: {id: T; label: string}[];
   onFilterSelect: (filter: T) => void;
-}
+};
 
 const OptionalFiltersMenu = <T extends string>({
   visibleFilters,

--- a/operate/client/src/modules/types/carbon.d.ts
+++ b/operate/client/src/modules/types/carbon.d.ts
@@ -29,6 +29,7 @@ type PolymorphicComponentPropWithRef<
 declare module '@carbon/react' {
   import type {TooltipProps as BaseTooltipProps} from '@carbon/react';
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface TooltipProps extends BaseTooltipProps {
     align:
       | 'bottom-left'

--- a/operate/client/src/modules/types/global.d.ts
+++ b/operate/client/src/modules/types/global.d.ts
@@ -24,6 +24,7 @@ type Appcues = {
 };
 
 export declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Window {
     clientConfig?: {
       isEnterprise?: boolean;
@@ -54,6 +55,7 @@ export declare global {
   }
 
   namespace NodeJS {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
     interface ProcessEnv {
       REACT_APP_DEV_ENV_URL: string;
       REACT_APP_INT_ENV_URL: string;

--- a/operate/client/src/modules/types/operate.ts
+++ b/operate/client/src/modules/types/operate.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-interface VariableEntity {
+type VariableEntity = {
   isFirst: boolean;
   hasActiveOperation: boolean;
   id?: string;
@@ -14,7 +14,7 @@ interface VariableEntity {
   value: string;
   sortValues: [string] | null;
   isPreview: boolean;
-}
+};
 
 type OperationEntityType =
   | 'RESOLVE_INCIDENT'
@@ -39,7 +39,7 @@ type InstanceEntityState =
 
 type DecisionInstanceEntityState = 'EVALUATED' | 'FAILED';
 
-interface OperationEntity {
+type OperationEntity = {
   id: string;
   name: null | string;
   type: OperationEntityType;
@@ -51,16 +51,16 @@ interface OperationEntity {
   sortValues?: [string, string];
   failedOperationsCount?: number; // Should become required when BE issue #6294 gets resolved
   completedOperationsCount?: number; // Should become required when BE issue #6294 gets resolved
-}
+};
 
-interface InstanceOperationEntity {
+type InstanceOperationEntity = {
   id?: string;
   batchOperationId?: string;
   type: OperationEntityType;
   state: 'SENT' | 'COMPLETED' | 'SCHEDULED' | 'LOCKED' | 'FAILED';
   errorMessage: null | string;
   completedDate: null | string;
-}
+};
 
 type ResourceBasedPermissionDto =
   | 'READ'
@@ -68,7 +68,7 @@ type ResourceBasedPermissionDto =
   | 'UPDATE_PROCESS_INSTANCE'
   | 'DELETE_PROCESS_INSTANCE';
 
-interface ProcessInstanceEntity {
+type ProcessInstanceEntity = {
   id: string;
   processId: string;
   processName: string;
@@ -88,9 +88,9 @@ interface ProcessInstanceEntity {
   }>;
   permissions?: ResourceBasedPermissionDto[] | null;
   tenantId: string;
-}
+};
 
-interface DecisionInstanceEntity {
+type DecisionInstanceEntity = {
   id: string;
   decisionName: string;
   decisionVersion: number;
@@ -99,7 +99,7 @@ interface DecisionInstanceEntity {
   processInstanceId: string | null;
   state: DecisionInstanceEntityState;
   sortValues: [string, string];
-}
+};
 
 type SortOrder = 'asc' | 'desc';
 


### PR DESCRIPTION
## Description

Some days ago we had a chat about `type` vs `interface` in a recent PR and the guideline in operate. I mentioned that we could enforce the usage of `type` through ESLint to turn the preference into a convention.

Back then, I successfully changed it on this branch. However, it also affected some places where you (@vsgoulart) would use an interface for extending types - as far as I understand your preference. Therefore, I initially did not create this PR. Let's have a look at it and than we can decide to merge or reject it.

## Checklist


## Related issues

closes #
