### PR TITLE
Detect old node id version

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -21,8 +21,19 @@ import java.util.UUID;
 /** Controller cluster identity. */
 public class MemberId extends NodeId {
 
+  private long idVersion;
+
   public MemberId(final String id) {
     super(id);
+  }
+
+  public MemberId(final String id, final long version) {
+    super(id);
+    idVersion = version;
+  }
+
+  public long getIdVersion() {
+    return idVersion;
   }
 
   /**
@@ -42,5 +53,24 @@ public class MemberId extends NodeId {
    */
   public static MemberId from(final String id) {
     return new MemberId(id);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + Long.hashCode(idVersion);
+    return result;
+  }
+
+  @Override
+  public final boolean equals(final Object o) {
+    if (!(o instanceof final MemberId memberId)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    return idVersion == memberId.idVersion;
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -54,23 +54,23 @@ public class MemberId extends NodeId {
   public static MemberId from(final String id) {
     return new MemberId(id);
   }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + Long.hashCode(idVersion);
-    return result;
-  }
-
-  @Override
-  public final boolean equals(final Object o) {
-    if (!(o instanceof final MemberId memberId)) {
-      return false;
-    }
-    if (!super.equals(o)) {
-      return false;
-    }
-
-    return idVersion == memberId.idVersion;
-  }
+  //
+  //  @Override
+  //  public int hashCode() {
+  //    int result = super.hashCode();
+  //    result = 31 * result + Long.hashCode(idVersion);
+  //    return result;
+  //  }
+  //
+  //  @Override
+  //  public final boolean equals(final Object o) {
+  //    if (!(o instanceof final MemberId memberId)) {
+  //      return false;
+  //    }
+  //    if (!super.equals(o)) {
+  //      return false;
+  //    }
+  //
+  //    return idVersion == memberId.idVersion;
+  //  }
 }


### PR DESCRIPTION
Member id contains a version which is used by swim to detect older nodes ids. Updates from old node ids are ignored. Communication Service already reject incoming requests from unknown addresses. So it automatically rejects incoming requests from older versions.
