### PR TITLE
spike: initialize versioned data directory

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -422,7 +422,7 @@ public class BrokerBasedPropertiesOverride {
   private void populateFromPrimaryStorage(final BrokerBasedProperties override) {
     final var primaryStorage = unifiedConfiguration.getCamunda().getData().getPrimaryStorage();
     final var data = override.getData();
-    data.setDirectory(primaryStorage.getDirectory());
+    data.setRootDirectory(primaryStorage.getDirectory());
     data.setRuntimeDirectory(primaryStorage.getRuntimeDirectory());
     data.setLogIndexDensity(primaryStorage.getLogStream().getLogIndexDensity());
     data.setLogSegmentSize(primaryStorage.getLogStream().getLogSegmentSize());

--- a/configuration/src/test/java/io/camunda/configuration/PrimaryStoragePropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/PrimaryStoragePropertiesTest.java
@@ -49,7 +49,7 @@ public class PrimaryStoragePropertiesTest {
 
     @Test
     void shouldSetDirectory() {
-      assertThat(brokerCfg.getData().getDirectory()).isEqualTo("/custom/data");
+      assertThat(brokerCfg.getData().getRootDirectory()).isEqualTo("/custom/data");
     }
 
     @Test
@@ -112,7 +112,7 @@ public class PrimaryStoragePropertiesTest {
 
     @Test
     void shouldSetDirectory() {
-      assertThat(brokerCfg.getData().getDirectory()).isEqualTo("/legacy/data");
+      assertThat(brokerCfg.getData().getRootDirectory()).isEqualTo("/legacy/data");
     }
 
     @Test
@@ -185,7 +185,7 @@ public class PrimaryStoragePropertiesTest {
 
     @Test
     void shouldSetDirectoryFromNew() {
-      assertThat(brokerCfg.getData().getDirectory()).isEqualTo("/unified/data");
+      assertThat(brokerCfg.getData().getRootDirectory()).isEqualTo("/unified/data");
     }
 
     @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -259,7 +259,7 @@ public class BackupRestoreIT {
     unifiedRestoreConfig
         .getData()
         .getPrimaryStorage()
-        .setDirectory(brokerCfg.getData().getDirectory());
+        .setDirectory(brokerCfg.getData().getRootDirectory());
     unifiedRestoreConfig.getCluster().setSize(brokerCfg.getCluster().getClusterSize());
 
     try (final var restoreApp = new TestRestoreApp(unifiedRestoreConfig).withBackupId(BACKUP_ID)) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -45,9 +45,9 @@ public final class BrokerStartupProcess {
 
   private List<StartupStep<BrokerStartupContext>> buildStartupSteps(final BrokerCfg config) {
     final var result = new ArrayList<StartupStep<BrokerStartupContext>>();
-    // result.add(
-    //     new NodeIdMapperStartupStep(config.getLeaseConfig(),
-    // config.getCluster().getClusterSize()));
+
+    result.add(new DataDirectorySetupStep());
+
     result.add(new ClusterServicesStep());
     result.add(new ClusterConfigurationManagerStep());
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CopyFromPreviousVersionStrategy.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CopyFromPreviousVersionStrategy.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Strategy that initializes data directory by copying from the latest valid previous version, or
+ * creates an empty directory if no valid previous version exists.
+ */
+public class CopyFromPreviousVersionStrategy implements DataDirectoryInitializationStrategy {
+  private static final Logger LOG = LoggerFactory.getLogger(CopyFromPreviousVersionStrategy.class);
+  private static final String DIRECTORY_INITIALIZED_FILE = "directory-initialized.json";
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public Path initializeDataDirectory(
+      final String rootDataDirectory, final int nodeId, final long currentNodeVersion)
+      throws IOException {
+    final Path nodeDirectory = Path.of(rootDataDirectory, "node-" + nodeId);
+    final var dataDirectory = nodeDirectory.resolve("v" + currentNodeVersion);
+    if (Files.exists(dataDirectory) && isDirectoryInitialized(dataDirectory)) {
+      LOG.info("Data directory {} already exists and is initialized", dataDirectory);
+      return dataDirectory;
+    }
+
+    // Find the latest valid previous version
+    final Long validPreviousVersion =
+        findLatestValidPreviousVersion(nodeDirectory, currentNodeVersion);
+
+    if (validPreviousVersion != null) {
+      final Path previousDataDirectory = nodeDirectory.resolve("v" + validPreviousVersion);
+      LOG.info(
+          "Found valid previous version {} at {}, copying to {}",
+          validPreviousVersion,
+          previousDataDirectory,
+          dataDirectory);
+
+      // Create parent directories if they don't exist
+      Files.createDirectories(dataDirectory.getParent());
+
+      // TODO: Mark the previousDataDirectory as read-only to prevent writes during copying incase
+      // the old broker is still running.
+
+      // Copy the previous directory to the current one
+      copyDirectory(previousDataDirectory, dataDirectory);
+
+      // Write the initialization file with information about the copy
+      writeDirectoryInitializedFile(dataDirectory, validPreviousVersion);
+
+      LOG.info(
+          "Setup data directory at {} by copying from version {} : {}",
+          dataDirectory,
+          validPreviousVersion,
+          previousDataDirectory);
+    } else {
+      LOG.info("No valid previous version found, creating empty directory at {}", dataDirectory);
+
+      // Create empty directory and initialize
+      Files.createDirectories(dataDirectory);
+      writeDirectoryInitializedFile(dataDirectory, null);
+    }
+    return dataDirectory;
+  }
+
+  @Override
+  public String getStrategyName() {
+    return "CopyFromPreviousVersion";
+  }
+
+  private Long findLatestValidPreviousVersion(
+      final Path dataDirectoryPrefix, final long currentNodeVersion) {
+    for (long version = currentNodeVersion - 1; version >= 0; version--) {
+      final Path versionDirectory = dataDirectoryPrefix.resolve("v" + version);
+      if (Files.exists(versionDirectory) && isDirectoryInitialized(versionDirectory)) {
+        LOG.debug("Found valid previous version: {}", version);
+        return version;
+      }
+    }
+    return null;
+  }
+
+  private boolean isDirectoryInitialized(final Path directory) {
+    final Path initFile = directory.resolve(DIRECTORY_INITIALIZED_FILE);
+    return Files.exists(initFile) && Files.isRegularFile(initFile);
+  }
+
+  private void copyDirectory(final Path source, final Path target) throws IOException {
+    try (final Stream<Path> pathStream = Files.walk(source)) {
+      pathStream.forEach(
+          sourcePath -> {
+            try {
+              final Path targetPath = target.resolve(source.relativize(sourcePath));
+              if (Files.isDirectory(sourcePath)) {
+                Files.createDirectories(targetPath);
+              } else {
+                Files.copy(sourcePath, targetPath, StandardCopyOption.REPLACE_EXISTING);
+              }
+            } catch (final IOException e) {
+              throw new RuntimeException("Failed to copy " + sourcePath + " to " + target, e);
+            }
+          });
+    }
+  }
+
+  private void writeDirectoryInitializedFile(
+      final Path dataDirectory, final Long initializedFromVersion) throws IOException {
+    final DirectoryInitializationInfo initInfo =
+        initializedFromVersion != null
+            ? DirectoryInitializationInfo.copiedFrom(initializedFromVersion)
+            : DirectoryInitializationInfo.createdEmpty();
+
+    final Path initFile = dataDirectory.resolve(DIRECTORY_INITIALIZED_FILE);
+    objectMapper.writeValue(initFile.toFile(), initInfo);
+    LOG.info("Written directory initialization file to {}", initFile);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DataDirectoryInitializationStrategy.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DataDirectoryInitializationStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Strategy interface for initializing data directories. Different implementations can provide
+ * different approaches for setting up the data directory for a broker node.
+ */
+public interface DataDirectoryInitializationStrategy {
+
+  /**
+   * Initializes the data directory according to the specific strategy implementation.
+   *
+   * @param dataDirectoryPrefix The base directory containing versioned data directories
+   * @param currentNodeVersion The current node version
+   * @throws IOException If an error occurs during directory setup
+   */
+  Path initializeDataDirectory(String rootDataDirectory, int nodeId, long currentNodeVersion)
+      throws IOException;
+
+  /**
+   * @return The name of this initialization strategy for logging purposes
+   */
+  String getStrategyName();
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DataDirectoryInitializationStrategyFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DataDirectoryInitializationStrategyFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.camunda.zeebe.broker.system.configuration.DataDirectoryInitializationMode;
+
+/**
+ * Factory class responsible for creating the appropriate data directory initialization strategy
+ * based on the configuration.
+ */
+public final class DataDirectoryInitializationStrategyFactory {
+
+  private DataDirectoryInitializationStrategyFactory() {
+    // Utility class
+  }
+
+  /**
+   * Creates the appropriate data directory initialization strategy based on the provided mode.
+   *
+   * @param mode The initialization mode from configuration
+   * @return The corresponding strategy implementation
+   */
+  public static DataDirectoryInitializationStrategy createStrategy(
+      final DataDirectoryInitializationMode mode) {
+    return switch (mode) {
+      case SHARED_ROOT_VERSIONED_NODE -> new CopyFromPreviousVersionStrategy();
+      case USE_PRECONFIGURED_DIRECTORY -> new UsePreConfiguredDirectoryStrategy();
+    };
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DataDirectorySetupStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DataDirectorySetupStep.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataDirectorySetupStep extends AbstractBrokerStartupStep {
+  private static final Logger LOG = LoggerFactory.getLogger(DataDirectorySetupStep.class);
+
+  @Override
+  public String getName() {
+    return "DataDirectorySetupStep";
+  }
+
+  @Override
+  void startupInternal(
+      final BrokerStartupContext brokerStartupContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+
+    try {
+      final var dataCfg = brokerStartupContext.getBrokerConfiguration().getData();
+      final var rootDataDirectory = dataCfg.getRootDirectory();
+
+      // Create the appropriate strategy based on configuration
+      final var strategy =
+          DataDirectoryInitializationStrategyFactory.createStrategy(
+              dataCfg.getInitializationMode());
+
+      LOG.info("Using data directory initialization strategy: {}", strategy.getStrategyName());
+
+      // Initialize the data directory using the selected strategy
+      final long currentNodeVersion =
+          brokerStartupContext.getBrokerConfiguration().getCluster().getNodeIdVersion();
+
+      final var initializedDataDirectory =
+          strategy.initializeDataDirectory(
+              rootDataDirectory,
+              brokerStartupContext.getBrokerConfiguration().getCluster().getNodeId(),
+              currentNodeVersion);
+      brokerStartupContext
+          .getBrokerConfiguration()
+          .getData()
+          .setBrokerDataDirectory(initializedDataDirectory);
+
+      startupFuture.complete(brokerStartupContext);
+    } catch (final Exception e) {
+      LOG.error("Failed to setup data directory", e);
+      startupFuture.completeExceptionally(e);
+    }
+  }
+
+  @Override
+  void shutdownInternal(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+    // No cleanup needed for data directory setup
+    shutdownFuture.complete(brokerShutdownContext);
+  }
+
+  private Path getDataDirectoryPrefix(final BrokerStartupContext brokerStartupContext) {
+    final var dataCfg = brokerStartupContext.getBrokerConfiguration().getData();
+
+    // For USE_PRECONFIGURED_DIRECTORY mode, return the configured directory directly
+    if (dataCfg.getInitializationMode()
+        == io.camunda.zeebe.broker.system.configuration.DataDirectoryInitializationMode
+            .USE_PRECONFIGURED_DIRECTORY) {
+      return Paths.get(dataCfg.getRootDirectory());
+    }
+
+    // For COPY_FROM_PREVIOUS_VERSION mode, return the versioned directory structure
+    return Paths.get(
+        dataCfg.getRootDirectory(),
+        String.valueOf(brokerStartupContext.getBrokerConfiguration().getCluster().getNodeId()));
+  }
+
+  private Path getDataDirectory(
+      final BrokerStartupContext brokerStartupContext, final Path dataDirectoryPrefix) {
+    final var dataCfg = brokerStartupContext.getBrokerConfiguration().getData();
+
+    // For USE_PRECONFIGURED_DIRECTORY mode, use the prefix as the actual directory
+    if (dataCfg.getInitializationMode()
+        == io.camunda.zeebe.broker.system.configuration.DataDirectoryInitializationMode
+            .USE_PRECONFIGURED_DIRECTORY) {
+      return dataDirectoryPrefix;
+    }
+
+    // For COPY_FROM_PREVIOUS_VERSION mode, append the version number
+    final long currentNodeVersion =
+        brokerStartupContext.getBrokerConfiguration().getCluster().getNodeIdVersion();
+    return dataDirectoryPrefix.resolve(String.valueOf(currentNodeVersion));
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DirectoryInitializationInfo.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DirectoryInitializationInfo.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+
+/**
+ * Represents the contents of the directory-initialized.json file that tracks when a data directory
+ * was initialized and optionally from which version it was copied.
+ *
+ * @param initialized The timestamp when the directory was initialized
+ * @param initializedFrom The version from which this directory was copied, null if created empty
+ */
+public record DirectoryInitializationInfo(
+    @JsonProperty("initialized") long initialized,
+    @JsonProperty("initializedFrom") Long initializedFrom) {
+
+  @JsonCreator
+  public DirectoryInitializationInfo(
+      @JsonProperty("initialized") final long initialized,
+      @JsonProperty("initializedFrom") final Long initializedFrom) {
+    this.initialized = initialized;
+    this.initializedFrom = initializedFrom;
+  }
+
+  /**
+   * Creates a new DirectoryInitializationInfo for a directory that was copied from a previous
+   * version.
+   *
+   * @param initializedFrom The version from which the directory was copied
+   * @return A new DirectoryInitializationInfo instance
+   */
+  public static DirectoryInitializationInfo copiedFrom(final long initializedFrom) {
+    return new DirectoryInitializationInfo(Instant.now().toEpochMilli(), initializedFrom);
+  }
+
+  /**
+   * Creates a new DirectoryInitializationInfo for a directory that was created empty.
+   *
+   * @return A new DirectoryInitializationInfo instance
+   */
+  public static DirectoryInitializationInfo createdEmpty() {
+    return new DirectoryInitializationInfo(Instant.now().toEpochMilli(), null);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DiskSpaceUsageMonitorStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DiskSpaceUsageMonitorStep.java
@@ -76,7 +76,7 @@ class DiskSpaceUsageMonitorStep extends AbstractBrokerStartupStep {
       final ActorFuture<BrokerStartupContext> startupFuture,
       final DataCfg data) {
     try {
-      FileUtil.ensureDirectoryExists(Paths.get(data.getDirectory()));
+      FileUtil.ensureDirectoryExists(Paths.get(data.getRootDirectory()));
     } catch (final IOException e) {
       startupFuture.completeExceptionally(e);
       return;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/UsePreConfiguredDirectoryStrategy.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/UsePreConfiguredDirectoryStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Strategy that uses the pre-configured data directory directly without versioning or copying. This
+ * approach simply ensures the directory exists and creates an initialization marker if needed.
+ */
+public class UsePreConfiguredDirectoryStrategy implements DataDirectoryInitializationStrategy {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(UsePreConfiguredDirectoryStrategy.class);
+  private static final String DIRECTORY_INITIALIZED_FILE = "directory-initialized.json";
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public Path initializeDataDirectory(
+      final String rootDirectory, final int nodeId, final long currentNodeVersion)
+      throws IOException {
+
+    final var rootDirectoryPath = Path.of(rootDirectory);
+    LOG.info("Using pre-configured data directory at {}", rootDirectory);
+
+    // Create the directory if it doesn't exist
+    Files.createDirectories(rootDirectoryPath);
+
+    return rootDirectoryPath;
+  }
+
+  @Override
+  public String getStrategyName() {
+    return "UsePreConfiguredDirectory";
+  }
+
+  private boolean isDirectoryInitialized(final Path directory) {
+    final Path initFile = directory.resolve(DIRECTORY_INITIALIZED_FILE);
+    return Files.exists(initFile) && Files.isRegularFile(initFile);
+  }
+
+  private void writeDirectoryInitializedFile(final Path dataDirectory) throws IOException {
+    final DirectoryInitializationInfo initInfo = DirectoryInitializationInfo.createdEmpty();
+
+    final Path initFile = dataDirectory.resolve(DIRECTORY_INITIALIZED_FILE);
+    objectMapper.writeValue(initFile.toFile(), initInfo);
+    LOG.info("Written directory initialization file to {}", initFile);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -23,7 +23,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import org.slf4j.Logger;
 
@@ -39,7 +38,9 @@ public final class RaftPartitionFactory {
   public RaftPartition createRaftPartition(
       final PartitionMetadata partitionMetadata, final MeterRegistry partitionMeterRegistry) {
     final var partitionDirectory =
-        Paths.get(brokerCfg.getData().getDirectory())
+        brokerCfg
+            .getData()
+            .getBrokerDataDirectory()
             .resolve(GROUP_NAME)
             .resolve("partitions")
             .resolve(partitionMetadata.id().id().toString());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionDirectoryStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionDirectoryStep.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
-import java.nio.file.Paths;
 
 public final class PartitionDirectoryStep implements StartupStep<PartitionStartupContext> {
 
@@ -32,7 +31,7 @@ public final class PartitionDirectoryStep implements StartupStep<PartitionStartu
   @Override
   public ActorFuture<PartitionStartupContext> startup(final PartitionStartupContext context) {
     final var result = context.concurrencyControl().<PartitionStartupContext>createFuture();
-    final var dataDirectory = Paths.get(context.brokerConfig().getData().getDirectory());
+    final var dataDirectory = context.brokerConfig().getData().getBrokerDataDirectory();
     final var partitionId = context.partitionMetadata().id().id();
     final var partitionDirectory =
         dataDirectory.resolve(GROUP_NAME).resolve("partitions").resolve(partitionId.toString());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import java.nio.file.Path;
 
 public class DynamicClusterConfigurationService implements ClusterConfigurationService {
 
@@ -154,7 +153,7 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
   private ClusterConfigurationManagerService getClusterTopologyManagerService(
       final BrokerStartupContext brokerStartupContext) {
     final var rootDirectory =
-        Path.of(brokerStartupContext.getBrokerConfiguration().getData().getDirectory());
+        brokerStartupContext.getBrokerConfiguration().getData().getBrokerDataDirectory();
     return new ClusterConfigurationManagerService(
         rootDirectory,
         brokerStartupContext.getClusterServices().getCommunicationService(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -46,6 +46,7 @@ public final class ClusterCfg implements ConfigurationEntry {
 
   private List<Integer> partitionIds;
   private int nodeId = DEFAULT_NODE_ID;
+  private final long nodeIdVersion = 0;
   private String clusterId;
   private int partitionsCount = DEFAULT_PARTITIONS_COUNT;
   private int replicationFactor = DEFAULT_REPLICATION_FACTOR;
@@ -116,6 +117,10 @@ public final class ClusterCfg implements ConfigurationEntry {
 
   public void setNodeId(final int nodeId) {
     this.nodeId = nodeId;
+  }
+
+  public long getNodeIdVersion() {
+    return nodeIdVersion;
   }
 
   public int getPartitionsCount() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataDirectoryInitializationMode.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataDirectoryInitializationMode.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+/** Enumeration of available data directory initialization modes. */
+public enum DataDirectoryInitializationMode {
+  /**
+   * Copy data from the latest valid previous version, or create empty directory if no valid
+   * previous version exists. This is useful when multiple nodes share the same root data directory,
+   * but each node has its own versioned subdirectory.
+   */
+  SHARED_ROOT_VERSIONED_NODE,
+
+  /**
+   * Use the pre-configured data directory directly without versioning or copying. Simply ensures
+   * the directory exists and creates initialization marker. (This must be default)
+   */
+  USE_PRECONFIGURED_DIRECTORY
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitorActor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitorActor.java
@@ -30,7 +30,7 @@ public class DiskSpaceUsageMonitorActor extends Actor implements DiskSpaceUsageM
   public DiskSpaceUsageMonitorActor(final DataCfg dataCfg) {
     final var diskCfg = dataCfg.getDisk();
     monitoringDelay = diskCfg.getMonitoringInterval();
-    final var directory = new File(dataCfg.getDirectory());
+    final var directory = new File(dataCfg.getRootDirectory());
     if (!directory.exists()) {
       throw new UncheckedIOException(new IOException("Folder '" + directory + "' does not exist."));
     }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CopyFromPreviousVersionStrategyTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CopyFromPreviousVersionStrategyTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CopyFromPreviousVersionStrategyTest {
+
+  private static final String DIRECTORY_INITIALIZED_FILE = "directory-initialized.json";
+
+  @TempDir Path tempDir;
+
+  private CopyFromPreviousVersionStrategy strategy;
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    strategy = new CopyFromPreviousVersionStrategy();
+    objectMapper = new ObjectMapper();
+  }
+
+  @Test
+  void shouldCreateEmptyDirectoryWhenNoPreviousVersionExists() throws IOException {
+    // given
+    final long currentNodeVersion = 1L;
+
+    // when
+    final Path result = strategy.initializeDataDirectory(tempDir.toString(), 1, currentNodeVersion);
+
+    // then
+    assertThat(result).isEqualTo(tempDir.resolve("node-1/v1"));
+    assertThat(Files.exists(result)).isTrue();
+    assertThat(Files.isDirectory(result)).isTrue();
+
+    // Verify initialization file was created
+    final Path initFile = result.resolve(DIRECTORY_INITIALIZED_FILE);
+    assertThat(Files.exists(initFile)).isTrue();
+
+    // Verify initialization file contents
+    final DirectoryInitializationInfo initInfo =
+        objectMapper.readValue(initFile.toFile(), DirectoryInitializationInfo.class);
+    assertThat(initInfo.initialized()).isNotNull();
+    assertThat(initInfo.initializedFrom()).isNull();
+  }
+
+  @Test
+  void shouldCopyFromLatestValidPreviousVersion() throws IOException {
+    // given
+    final Path dataDirectoryPrefix = tempDir.resolve("node-1");
+    final long currentNodeVersion = 3L;
+
+    // Create previous version directories with data
+    createValidVersionDirectory(dataDirectoryPrefix, 0L, "file0.txt", "content0");
+    createValidVersionDirectory(dataDirectoryPrefix, 2L, "file2.txt", "content2");
+
+    // when
+    final Path result = strategy.initializeDataDirectory(tempDir.toString(), 1, currentNodeVersion);
+
+    // then
+    assertThat(result).isEqualTo(dataDirectoryPrefix.resolve("v3"));
+    assertThat(Files.exists(result)).isTrue();
+
+    // Verify data was copied from version 2 (latest valid)
+    final Path copiedFile = result.resolve("file2.txt");
+    assertThat(Files.exists(copiedFile)).isTrue();
+    assertThat(Files.readString(copiedFile)).isEqualTo("content2");
+
+    // Verify initialization file was created with correct info
+    final Path initFile = result.resolve(DIRECTORY_INITIALIZED_FILE);
+    assertThat(Files.exists(initFile)).isTrue();
+
+    final DirectoryInitializationInfo initInfo =
+        objectMapper.readValue(initFile.toFile(), DirectoryInitializationInfo.class);
+    assertThat(initInfo.initialized()).isNotNull();
+    assertThat(initInfo.initializedFrom()).isEqualTo(2L);
+  }
+
+  @Test
+  void shouldSkipInvalidPreviousVersionsAndUseLatestValid() throws IOException {
+    // given
+    final Path dataDirectoryPrefix = tempDir.resolve("node-1");
+    final long currentNodeVersion = 4L;
+
+    // Create valid version 1
+    createValidVersionDirectory(dataDirectoryPrefix, 1L, "file1.txt", "content1");
+
+    // Create invalid version 2 (directory exists but no initialization file)
+    final Path invalidVersion = dataDirectoryPrefix.resolve("2");
+    Files.createDirectories(invalidVersion);
+    Files.writeString(invalidVersion.resolve("file2.txt"), "content2");
+    // Note: no directory-initialized.json file
+
+    // Create valid version 3
+    createValidVersionDirectory(dataDirectoryPrefix, 3L, "file3.txt", "content3");
+
+    // when
+    final Path result = strategy.initializeDataDirectory(tempDir.toString(), 1, currentNodeVersion);
+
+    // then
+    assertThat(result).isEqualTo(dataDirectoryPrefix.resolve("v4"));
+
+    // Verify data was copied from version 3 (latest valid), not version 2
+    final Path copiedFile = result.resolve("file3.txt");
+    assertThat(Files.exists(copiedFile)).isTrue();
+    assertThat(Files.readString(copiedFile)).isEqualTo("content3");
+
+    // Verify file from invalid version 2 was not copied
+    assertThat(Files.exists(result.resolve("file2.txt"))).isFalse();
+
+    // Verify initialization info
+    final DirectoryInitializationInfo initInfo = readInitializationInfo(result);
+    assertThat(initInfo.initializedFrom()).isEqualTo(3L);
+  }
+
+  @Test
+  void shouldReturnExistingDirectoryWhenAlreadyInitialized() throws IOException {
+    // given
+    final Path dataDirectoryPrefix = tempDir.resolve("node-1");
+    final long currentNodeVersion = 1L;
+    final Path targetDirectory = dataDirectoryPrefix.resolve("v1");
+
+    // Create already initialized directory
+    Files.createDirectories(targetDirectory);
+    Files.writeString(targetDirectory.resolve("existing-file.txt"), "existing content");
+    writeInitializationFile(targetDirectory, null);
+
+    // when
+    final Path result = strategy.initializeDataDirectory(tempDir.toString(), 1, currentNodeVersion);
+
+    // then
+    assertThat(result).isEqualTo(targetDirectory);
+    assertThat(Files.exists(result.resolve("existing-file.txt"))).isTrue();
+    assertThat(Files.readString(result.resolve("existing-file.txt"))).isEqualTo("existing content");
+  }
+
+  @Test
+  void shouldCopyDirectoryStructureRecursively() throws IOException {
+    // given
+    final Path dataDirectoryPrefix = tempDir.resolve("node-1");
+    final long currentNodeVersion = 2L;
+
+    // Create previous version with nested directory structure
+    final Path previousVersion = dataDirectoryPrefix.resolve("v1");
+    Files.createDirectories(previousVersion.resolve("subdir1/subdir2"));
+    Files.writeString(previousVersion.resolve("root-file.txt"), "root content");
+    Files.writeString(previousVersion.resolve("subdir1/file1.txt"), "file1 content");
+    Files.writeString(previousVersion.resolve("subdir1/subdir2/file2.txt"), "file2 content");
+    writeInitializationFile(previousVersion, null);
+
+    // when
+    final Path result = strategy.initializeDataDirectory(tempDir.toString(), 1, currentNodeVersion);
+
+    // then
+    assertThat(result).isEqualTo(dataDirectoryPrefix.resolve("v2"));
+
+    // Verify all files and directories were copied
+    assertThat(Files.exists(result.resolve("root-file.txt"))).isTrue();
+    assertThat(Files.exists(result.resolve("subdir1/file1.txt"))).isTrue();
+    assertThat(Files.exists(result.resolve("subdir1/subdir2/file2.txt"))).isTrue();
+
+    assertThat(Files.readString(result.resolve("root-file.txt"))).isEqualTo("root content");
+    assertThat(Files.readString(result.resolve("subdir1/file1.txt"))).isEqualTo("file1 content");
+    assertThat(Files.readString(result.resolve("subdir1/subdir2/file2.txt")))
+        .isEqualTo("file2 content");
+  }
+
+  @Test
+  void shouldHandleVersionZero() throws IOException {
+    // given
+    final Path dataDirectoryPrefix = tempDir.resolve("node-1");
+    final long currentNodeVersion = 1L;
+
+    // Create version 0
+    createValidVersionDirectory(dataDirectoryPrefix, 0L, "file0.txt", "version 0 content");
+
+    // when
+    final Path result = strategy.initializeDataDirectory(tempDir.toString(), 1, currentNodeVersion);
+
+    // then
+    assertThat(result).isEqualTo(dataDirectoryPrefix.resolve("v1"));
+    assertThat(Files.exists(result.resolve("file0.txt"))).isTrue();
+    assertThat(Files.readString(result.resolve("file0.txt"))).isEqualTo("version 0 content");
+
+    final DirectoryInitializationInfo initInfo = readInitializationInfo(result);
+    assertThat(initInfo.initializedFrom()).isEqualTo(0L);
+  }
+
+  @Test
+  void shouldReturnCorrectStrategyName() {
+    // when
+    final String strategyName = strategy.getStrategyName();
+
+    // then
+    assertThat(strategyName).isEqualTo("CopyFromPreviousVersion");
+  }
+
+  @Test
+  void shouldHandleIOExceptionDuringCopy() throws IOException {
+    // given
+    final Path dataDirectoryPrefix = tempDir.resolve("node-1");
+    final long currentNodeVersion = 2L;
+
+    // Create previous version
+    final Path previousVersion = dataDirectoryPrefix.resolve("1");
+    Files.createDirectories(previousVersion);
+    writeInitializationFile(previousVersion, null);
+
+    // Create a file that will cause issues during copy (simulate by making target read-only after
+    // creation)
+    Files.writeString(previousVersion.resolve("test-file.txt"), "content");
+
+    // Make the temp directory read-only to cause copy failure
+    tempDir.toFile().setReadOnly();
+
+    try {
+      // when/then
+      assertThatThrownBy(
+              () -> strategy.initializeDataDirectory(tempDir.toString(), 1, currentNodeVersion))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Failed to copy");
+    } finally {
+      // Cleanup: make directory writable again
+      tempDir.toFile().setWritable(true);
+    }
+  }
+
+  private void createValidVersionDirectory(
+      final Path baseDir, final long version, final String fileName, final String content)
+      throws IOException {
+    final Path versionDir = baseDir.resolve("v" + version);
+    Files.createDirectories(versionDir);
+    Files.writeString(versionDir.resolve(fileName), content);
+    writeInitializationFile(versionDir, null);
+  }
+
+  private void writeInitializationFile(final Path directory, final Long initializedFrom)
+      throws IOException {
+    final DirectoryInitializationInfo initInfo =
+        initializedFrom != null
+            ? DirectoryInitializationInfo.copiedFrom(initializedFrom)
+            : DirectoryInitializationInfo.createdEmpty();
+
+    final Path initFile = directory.resolve(DIRECTORY_INITIALIZED_FILE);
+    objectMapper.writeValue(initFile.toFile(), initInfo);
+  }
+
+  private DirectoryInitializationInfo readInitializationInfo(final Path directory)
+      throws IOException {
+    final Path initFile = directory.resolve(DIRECTORY_INITIALIZED_FILE);
+    return objectMapper.readValue(initFile.toFile(), DirectoryInitializationInfo.class);
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -236,7 +236,7 @@ public final class BrokerCfgTest {
 
     // then
     assertWithDefaultConfigurations(
-        config -> assertThat(config.getData().getDirectory()).isEqualTo(expectedDataDirectory));
+        config -> assertThat(config.getData().getRootDirectory()).isEqualTo(expectedDataDirectory));
   }
 
   @Test
@@ -246,7 +246,7 @@ public final class BrokerCfgTest {
     final String expectedDataDirectory = Paths.get(BROKER_BASE, "foo").toString();
 
     // then
-    assertThat(config.getData().getDirectory()).isEqualTo(expectedDataDirectory);
+    assertThat(config.getData().getRootDirectory()).isEqualTo(expectedDataDirectory);
   }
 
   @Test
@@ -257,7 +257,7 @@ public final class BrokerCfgTest {
 
     // then
     assertWithDefaultConfigurations(
-        config -> assertThat(config.getData().getDirectory()).isEqualTo(expectedDataDirectory));
+        config -> assertThat(config.getData().getRootDirectory()).isEqualTo(expectedDataDirectory));
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitorTest.java
@@ -19,7 +19,7 @@ public class DiskSpaceUsageMonitorTest {
   public void shouldThrowUncheckedIOExceptionIfFolderDoesNotExist() {
     // given
     final var dataCfg = new DataCfg();
-    dataCfg.setDirectory("something-that-does-not-exist");
+    dataCfg.setRootDirectory("something-that-does-not-exist");
 
     // when + then
     assertThatThrownBy(() -> new DiskSpaceUsageMonitorActor(dataCfg))

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -294,7 +294,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
       }
     }
 
-    dataDirectory = broker.getSystemContext().getBrokerConfiguration().getData().getDirectory();
+    dataDirectory = broker.getSystemContext().getBrokerConfiguration().getData().getRootDirectory();
   }
 
   public void configureBroker(final BrokerCfg brokerCfg) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
@@ -241,7 +241,7 @@ class BackupMultiPartitionTest {
     unifiedRestoreConfig
         .getData()
         .getPrimaryStorage()
-        .setDirectory(broker.brokerConfig().getData().getDirectory());
+        .setDirectory(broker.brokerConfig().getData().getRootDirectory());
     unifiedRestoreConfig.getCluster().setSize(broker.brokerConfig().getCluster().getClusterSize());
 
     // backup config s3

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ContinuousBackupIT.java
@@ -126,7 +126,7 @@ final class ContinuousBackupIT {
 
     // when - restoring from all three backups
     broker.stop();
-    final var dataDirectory = Path.of(broker.brokerConfig().getData().getDirectory()).getParent();
+    final var dataDirectory = Path.of(broker.brokerConfig().getData().getRootDirectory()).getParent();
     FileUtil.deleteFolder(dataDirectory);
     FileUtil.ensureDirectoryExists(dataDirectory);
     final var restore =
@@ -169,7 +169,7 @@ final class ContinuousBackupIT {
 
     // when/then - restoring from backup 1 and 3, but skipping backup 2
     broker.stop();
-    final var dataDirectory = Path.of(broker.brokerConfig().getData().getDirectory()).getParent();
+    final var dataDirectory = Path.of(broker.brokerConfig().getData().getRootDirectory()).getParent();
     FileUtil.deleteFolder(dataDirectory);
     FileUtil.ensureDirectoryExists(dataDirectory);
     final var restore =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -811,7 +811,7 @@ public class ClusteringRule extends ExternalResource {
   }
 
   public Path getSegmentsDirectory(final Broker broker) {
-    final String dataDir = broker.getConfig().getData().getDirectory();
+    final String dataDir = broker.getConfig().getData().getRootDirectory();
     return Paths.get(dataDir).resolve(RAFT_PARTITION_PATH);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -140,7 +140,7 @@ public class ScaleUpPartitionsTest {
     unifiedRestoreConfig
         .getData()
         .getPrimaryStorage()
-        .setDirectory(brokerCfg.getData().getDirectory());
+        .setDirectory(brokerCfg.getData().getRootDirectory());
     unifiedRestoreConfig
         .getCluster()
         .setReplicationFactor(brokerCfg.getCluster().getReplicationFactor());
@@ -314,7 +314,7 @@ public class ScaleUpPartitionsTest {
 
     final var partition1Leader = cluster.leaderForPartition(1);
 
-    final var directory = Path.of(partition1Leader.brokerConfig().getData().getDirectory());
+    final var directory = Path.of(partition1Leader.brokerConfig().getData().getRootDirectory());
     final var bootstrapSnapshotDirectory =
         directory.resolve("raft-partition/partitions/1/bootstrap-snapshots/1-1-0-0-0");
     scaleToPartitions(targetPartitionCount);
@@ -594,7 +594,7 @@ public class ScaleUpPartitionsTest {
       throws IOException {
     for (final var broker : cluster.brokers().values()) {
       LOG.debug("Restoring broker: {}", broker.nodeId());
-      final var dataFolder = Path.of(broker.brokerConfig().getData().getDirectory());
+      final var dataFolder = Path.of(broker.brokerConfig().getData().getRootDirectory());
       FileUtil.deleteFolderIfExists(dataFolder);
 
       Files.createDirectories(dataFolder);

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -70,7 +70,9 @@ public class RestoreManager {
   public void restore(
       final long[] backupIds, final boolean validateConfig, final List<String> ignoreFilesInTarget)
       throws IOException, ExecutionException, InterruptedException {
-    final var dataDirectory = Path.of(configuration.getData().getDirectory());
+
+    // TODO: Restore should also use versioned directories based on configuration.
+    final var dataDirectory = Path.of(configuration.getData().getRootDirectory());
     if (!dataFolderIsEmpty(dataDirectory, ignoreFilesInTarget)) {
       LOG.error(
           "Brokers's data directory {} is not empty. Aborting restore to avoid overwriting data. Please restart with a clean directory.",
@@ -108,8 +110,9 @@ public class RestoreManager {
   private void restoreTopologyFile() throws ExecutionException, InterruptedException, IOException {
     final var coordinatorId = MemberId.from("0");
     LOG.info("Restoring topology file");
+    // TODO: Use versioned directory based on configuration.
     final var file =
-        Path.of(configuration.getData().getDirectory())
+        Path.of(configuration.getData().getRootDirectory())
             .resolve(ClusterConfigurationManagerService.TOPOLOGY_FILE_NAME);
     final var staticConfiguration =
         StaticConfigurationGenerator.getStaticConfiguration(configuration, coordinatorId);

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreManagerTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreManagerTest.java
@@ -25,7 +25,7 @@ final class RestoreManagerTest {
   void shouldFailWhenDirectoryIsNotEmpty(@TempDir final Path dir) throws IOException {
     // given
     final var configuration = new BrokerCfg();
-    configuration.getData().setDirectory(dir.toString());
+    configuration.getData().setRootDirectory(dir.toString());
     final var restoreManager =
         new RestoreManager(
             configuration, new TestRestorableBackupStore(), new SimpleMeterRegistry());
@@ -42,7 +42,7 @@ final class RestoreManagerTest {
   void shouldIgnoreConfigurableFilesInTarget(@TempDir final Path dir) throws IOException {
     // given
     final var configuration = new BrokerCfg();
-    configuration.getData().setDirectory(dir.toString());
+    configuration.getData().setRootDirectory(dir.toString());
     final var restoreManager =
         new RestoreManager(
             configuration, new TestRestorableBackupStore(), new SimpleMeterRegistry());
@@ -63,7 +63,7 @@ final class RestoreManagerTest {
   void shouldFailWhenNonIgnoredFileExists(@TempDir final Path dir) throws IOException {
     // given
     final var configuration = new BrokerCfg();
-    configuration.getData().setDirectory(dir.toString());
+    configuration.getData().setRootDirectory(dir.toString());
     final var restoreManager =
         new RestoreManager(
             configuration, new TestRestorableBackupStore(), new SimpleMeterRegistry());


### PR DESCRIPTION
Based on the configuration, we set up a versioned data directory which is initialized by copying from the previous versions data.
