### PR TITLE
[Backport stable/optimize-8.6] fix: Bump version of logback-core and spring boot

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -51,7 +51,7 @@
     <apache.http5-client.version>5.5</apache.http5-client.version>
     <apache.http5-core.version>5.3.4</apache.http5-core.version>
     <guava.version>33.3.1-jre</guava.version>
-    <spring.boot.version>3.5.5</spring.boot.version>
+    <spring.boot.version>3.5.6</spring.boot.version>
     <spring.version>6.2.10</spring.version>
     <spring.security.version>6.4.7</spring.security.version>
     <version.tomcat>10.1.44</version.tomcat>
@@ -60,7 +60,7 @@
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
     <netty.version>4.1.124.Final</netty.version>
     <lombok.version>1.18.34</lombok.version>
-    <logback.version>1.5.8</logback.version>
+    <logback.version>1.5.19</logback.version>
     <slf4j.version>2.0.16</slf4j.version>
     <commons.io.version>2.17.0</commons.io.version>
 
@@ -288,6 +288,18 @@
         <groupId>jakarta.ws.rs</groupId>
         <artifactId>jakarta.ws.rs-api</artifactId>
         <version>${jakarta.rs-api.version}</version>
+      </dependency>
+
+      <!-- Override Spring Boot's logback version to address CVEs -->
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -99,12 +99,10 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>${logback.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>${logback.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -100,7 +100,7 @@
     <version.rest-assured>5.5.0</version.rest-assured>
     <version.spring>6.2.10</version.spring>
     <version.spring-security>6.4.7</version.spring-security>
-    <version.spring-boot>3.5.5</version.spring-boot>
+    <version.spring-boot>3.5.6</version.spring-boot>
     <version.tomcat>10.1.44</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.0</version.kryo>


### PR DESCRIPTION
# Description
Backport of #39317 to `stable/optimize-8.6`.

relates to camunda/camunda#39316
original author: @georgios-goulos