### PR TITLE
[Backport stable/8.7] fix: add 409 to PI migration API responses

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -857,6 +857,14 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
+        "409":
+          description: >
+            The process instance migration failed.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
         "500":
           description: An internal error occurred while processing the request.
           content:


### PR DESCRIPTION
# Description
Backport of #39461 to `stable/8.7`.

relates to #39336