### PR TITLE
spike: support initilizing authorizations for users

### DIFF
--- a/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredAuthorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredAuthorization.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.Set;
+
+public class ConfiguredAuthorization {
+  private String ownerId;
+  private String resourceType;
+  private String resourceId;
+  private Set<PermissionType> permissions;
+
+  public ConfiguredAuthorization(
+      final String ownerId,
+      final String resourceType,
+      final String resourceId,
+      final Set<PermissionType> permissions) {
+    this.ownerId = ownerId;
+    this.resourceType = resourceType;
+    this.resourceId = resourceId;
+    this.permissions = permissions;
+  }
+
+  public String getOwnerId() {
+    return ownerId;
+  }
+
+  public void setOwnerId(final String ownerId) {
+    this.ownerId = ownerId;
+  }
+
+  public String getResourceType() {
+    return resourceType;
+  }
+
+  public void setResourceType(final String resourceType) {
+    this.resourceType = resourceType;
+  }
+
+  public String getResourceId() {
+    return resourceId;
+  }
+
+  public void setResourceId(final String resourceId) {
+    this.resourceId = resourceId;
+  }
+
+  public Set<PermissionType> getPermissions() {
+    return permissions;
+  }
+
+  public void setPermissions(final Set<PermissionType> permissions) {
+    this.permissions = permissions;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
@@ -23,6 +23,7 @@ public class InitializationConfiguration {
   private List<ConfiguredUser> users = new ArrayList<>();
   private List<ConfiguredMappingRule> mappingRules = new ArrayList<>();
   private Map<String, Map<String, Collection<String>>> defaultRoles = new HashMap<>();
+  private Map<String, List<ConfiguredAuthorization>> authorizations = new HashMap<>();
 
   public List<ConfiguredUser> getUsers() {
     return users;
@@ -46,5 +47,13 @@ public class InitializationConfiguration {
 
   public void setDefaultRoles(final Map<String, Map<String, Collection<String>>> defaultRoles) {
     this.defaultRoles = defaultRoles;
+  }
+
+  public Map<String, List<ConfiguredAuthorization>> getAuthorizations() {
+    return authorizations;
+  }
+
+  public void setAuthorizations(final Map<String, List<ConfiguredAuthorization>> authorizations) {
+    this.authorizations = authorizations;
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Spike branch to see how authorizations could be configured for creation during initialization.

Authorizations are defined in env variables i.e. 
```
CAMUNDA_SECURITY_INITIALIZATION_AUTHORIZATIONS_USERS_1_OWNERID=test
CAMUNDA_SECURITY_INITIALIZATION_AUTHORIZATIONS_USERS_1_RESOURCETYPE=ROLE
CAMUNDA_SECURITY_INITIALIZATION_AUTHORIZATIONS_USERS_1_RESOURCEID=*
CAMUNDA_SECURITY_INITIALIZATION_AUTHORIZATIONS_USERS_1_PERMISSIONS=READ,UPDATE
```

## Related issues

closes #
