### PR TITLE
feat: inter-partition commands carry `AuthInfo`

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -197,6 +197,9 @@ final class InterPartitionCommandReceiverImpl {
     private static void decodeAuthInfo(
         final InterPartitionMessageDecoder messageDecoder, final RecordMetadata recordMetadata) {
       final var length = messageDecoder.authLength();
+      if (length <= 0) {
+        return;
+      }
       final var offset = messageDecoder.limit() + InterPartitionMessageDecoder.authHeaderLength();
       recordMetadata.getAuthorization().wrap(messageDecoder.buffer(), offset, length);
       messageDecoder.skipAuth();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -139,11 +139,7 @@ final class InterPartitionCommandReceiverImpl {
     private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
 
     DecodedMessage decodeMessage(final byte[] message) {
-      final var messageBuffer = new UnsafeBuffer();
-      final var recordMetadata = new RecordMetadata();
-
-      messageBuffer.wrap(message);
-      messageDecoder.wrapAndApplyHeader(messageBuffer, 0, headerDecoder);
+      messageDecoder.wrapAndApplyHeader(new UnsafeBuffer(message), 0, headerDecoder);
 
       final var checkpointId = messageDecoder.checkpointId();
       Optional<Long> recordKey = Optional.empty();
@@ -151,18 +147,31 @@ final class InterPartitionCommandReceiverImpl {
         recordKey = Optional.of(messageDecoder.recordKey());
       }
 
-      final var valueType = ValueType.get(messageDecoder.valueType());
-      final var intent = Intent.fromProtocolValue(valueType, messageDecoder.intent());
+      final var recordMetadata = new RecordMetadata();
+      final var value = decodeCommand(messageDecoder, recordMetadata);
+      decodeAuthInfo(messageDecoder, recordMetadata);
 
-      // rebuild the record metadata first, all messages must contain commands
-      recordMetadata.reset().recordType(RecordType.COMMAND).valueType(valueType).intent(intent);
+      return new DecodedMessage(checkpointId, recordKey, recordMetadata, value);
+    }
 
-      // wrap the command buffer around the rest of the message
-      // this does not try to parse the command, we are just assuming that these bytes
-      // are a valid command
-      final var commandOffset =
+    /**
+     * Reads out the command from the message decoder and updates the record metadata accordingly.
+     *
+     * @param messageDecoder The current message decoder, with {@link
+     *     InterPartitionMessageDecoder#limit()} pointing to the start of the command. After reading
+     *     the command, the decoder is advanced to the next section.
+     * @param recordMetadata The record metadata to update with record type, intent and value type.
+     * @return a new instance of the command, read from the message decoder.
+     */
+    private static UnifiedRecordValue decodeCommand(
+        final InterPartitionMessageDecoder messageDecoder, final RecordMetadata recordMetadata) {
+      final var offset =
           messageDecoder.limit() + InterPartitionMessageDecoder.commandHeaderLength();
       final var commandLength = messageDecoder.commandLength();
+
+      final var valueType = ValueType.get(messageDecoder.valueType());
+      final var intent = Intent.fromProtocolValue(valueType, messageDecoder.intent());
+      recordMetadata.recordType(RecordType.COMMAND).intent(intent).valueType(valueType);
 
       final var valueClass = TypedEventRegistry.EVENT_REGISTRY.get(valueType);
       if (valueClass == null) {
@@ -170,17 +179,27 @@ final class InterPartitionCommandReceiverImpl {
             "No value type mapped to %s, can't decode message".formatted(valueType));
       }
       final var value = ReflectUtil.newInstance(valueClass);
+      value.wrap(messageDecoder.buffer(), offset, commandLength);
+      messageDecoder.skipCommand();
+      return value;
+    }
 
-      value.wrap(messageBuffer, commandOffset, commandLength);
-
-      final var authInfo = recordMetadata.getAuthorization();
-      authInfo.reset();
-      final var authOffset =
-          commandOffset + commandLength + InterPartitionMessageDecoder.authHeaderLength();
-      final var authLength = messageDecoder.authLength();
-      authInfo.wrap(messageBuffer, authOffset, authLength);
-
-      return new DecodedMessage(checkpointId, recordKey, recordMetadata, value);
+    /**
+     * Reads out the authorization info from the message decoder and updates the record metadata
+     * accordingly.
+     *
+     * @param messageDecoder The current message decoder, with {@link
+     *     InterPartitionMessageDecoder#limit()} pointing to the start of the auth info. After
+     *     reading the auth info, the decoder is advanced to the next section.
+     * @param recordMetadata The record metadata to update with the authorization info. If no auth
+     *     info is present, the authorization in the metadata is left unchanged.
+     */
+    private static void decodeAuthInfo(
+        final InterPartitionMessageDecoder messageDecoder, final RecordMetadata recordMetadata) {
+      final var length = messageDecoder.authLength();
+      final var offset = messageDecoder.limit() + InterPartitionMessageDecoder.authHeaderLength();
+      recordMetadata.getAuthorization().wrap(messageDecoder.buffer(), offset, length);
+      messageDecoder.skipAuth();
     }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -172,6 +172,14 @@ final class InterPartitionCommandReceiverImpl {
       final var value = ReflectUtil.newInstance(valueClass);
 
       value.wrap(messageBuffer, commandOffset, commandLength);
+
+      final var authInfo = recordMetadata.getAuthorization();
+      authInfo.reset();
+      final var authOffset =
+          commandOffset + commandLength + InterPartitionMessageDecoder.authHeaderLength();
+      final var authLength = messageDecoder.authLength();
+      authInfo.wrap(messageBuffer, authOffset, authLength);
+
       return new DecodedMessage(checkpointId, recordKey, recordMetadata, value);
     }
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.protocol.InterPartitionMessageEncoder;
 import io.camunda.zeebe.broker.protocol.MessageHeaderEncoder;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -54,6 +55,17 @@ final class InterPartitionCommandSenderImpl implements InterPartitionCommandSend
       final Intent intent,
       final Long recordKey,
       final UnifiedRecordValue command) {
+    sendCommand(receiverPartitionId, valueType, intent, recordKey, command, null);
+  }
+
+  @Override
+  public void sendCommand(
+      final int receiverPartitionId,
+      final ValueType valueType,
+      final Intent intent,
+      final Long recordKey,
+      final UnifiedRecordValue command,
+      final AuthInfo authInfo) {
     if (!partitionLeaders.containsKey(receiverPartitionId)) {
       LOG.warn(
           "Not sending command {} {} to {}, no known leader for this partition",
@@ -72,7 +84,8 @@ final class InterPartitionCommandSenderImpl implements InterPartitionCommandSend
         partitionLeader);
 
     final var message =
-        Encoder.encode(checkpointId, receiverPartitionId, valueType, intent, recordKey, command);
+        Encoder.encode(
+            checkpointId, receiverPartitionId, valueType, intent, recordKey, command, authInfo);
 
     communicationService.unicast(
         TOPIC_PREFIX + receiverPartitionId,
@@ -98,7 +111,8 @@ final class InterPartitionCommandSenderImpl implements InterPartitionCommandSend
         final ValueType valueType,
         final Intent intent,
         final Long recordKey,
-        final BufferWriter command) {
+        final BufferWriter command,
+        final BufferWriter authInfo) {
       final var messageLength =
           MessageHeaderEncoder.ENCODED_LENGTH
               + InterPartitionMessageEncoder.BLOCK_LENGTH
@@ -108,15 +122,18 @@ final class InterPartitionCommandSenderImpl implements InterPartitionCommandSend
       final var headerEncoder = new MessageHeaderEncoder();
       final var bodyEncoder = new InterPartitionMessageEncoder();
       final var commandBuffer = new UnsafeBuffer(new byte[command.getLength()]);
+      final var authBuffer = new UnsafeBuffer(new byte[authInfo.getLength()]);
       final var messageBuffer = new UnsafeBuffer(new byte[messageLength]);
       command.write(commandBuffer, 0);
+      authInfo.write(authBuffer, 0);
       bodyEncoder
           .wrapAndApplyHeader(messageBuffer, 0, headerEncoder)
           .checkpointId(checkpointId)
           .receiverPartitionId(receiverPartitionId)
           .valueType(valueType.value())
           .intent(intent.value())
-          .putCommand(commandBuffer, 0, command.getLength());
+          .putCommand(commandBuffer, 0, command.getLength())
+          .putAuth(authBuffer, 0, authInfo.getLength());
 
       bodyEncoder.recordKey(
           Objects.requireNonNullElseGet(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.transport.partitionapi;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListener;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -53,6 +54,20 @@ public final class InterPartitionCommandSenderService extends Actor
     actor.submit(
         () ->
             commandSender.sendCommand(receiverPartitionId, valueType, intent, recordKey, command));
+  }
+
+  @Override
+  public void sendCommand(
+      final int receiverPartitionId,
+      final ValueType valueType,
+      final Intent intent,
+      final Long recordKey,
+      final UnifiedRecordValue command,
+      final AuthInfo authInfo) {
+    actor.submit(
+        () ->
+            commandSender.sendCommand(
+                receiverPartitionId, valueType, intent, recordKey, command, authInfo));
   }
 
   @Override

--- a/zeebe/broker/src/main/resources/broker-protocol.xml
+++ b/zeebe/broker/src/main/resources/broker-protocol.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude"
-  package="io.camunda.zeebe.broker.protocol" id="5" version="3"
+  package="io.camunda.zeebe.broker.protocol" id="5" version="4"
   semanticVersion="0.1.0" description="Zeebe Broker Communication Protocol" byteOrder="littleEndian" >
 
   <xi:include href="../../../../protocol/src/main/resources/common-types.xml"/>
@@ -22,7 +22,7 @@
     <field name="checkpointId" id="4" type="int64"/>
 
     <data name="command" id="32" type="varDataEncoding"/>
-    <data name="auth" id="33" type="varDataEncoding"/>
+    <data name="auth" id="33" type="varDataEncoding" sinceVersion="4"/>
   </sbe:message>
 
 </sbe:messageSchema>

--- a/zeebe/broker/src/main/resources/broker-protocol.xml
+++ b/zeebe/broker/src/main/resources/broker-protocol.xml
@@ -22,6 +22,7 @@
     <field name="checkpointId" id="4" type="int64"/>
 
     <data name="command" id="32" type="varDataEncoding"/>
+    <data name="auth" id="33" type="varDataEncoding"/>
   </sbe:message>
 
 </sbe:messageSchema>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/InterPartitionCommandSender.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/InterPartitionCommandSender.java
@@ -17,35 +17,50 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
  * silently, it is up to the caller to detect this and retry.
  */
 public interface InterPartitionCommandSender {
-  void sendCommand(
+  /**
+   * Sends a command without a specific record key or authentication info to the given partition.
+   *
+   * @see InterPartitionCommandSender#sendCommand(int, ValueType, Intent, Long, UnifiedRecordValue,
+   *     AuthInfo)
+   */
+  default void sendCommand(
       final int receiverPartitionId,
       final ValueType valueType,
       final Intent intent,
-      final UnifiedRecordValue command);
+      final UnifiedRecordValue command) {
+    sendCommand(receiverPartitionId, valueType, intent, null, command, null);
+  }
 
   /**
-   * Uses the given record key when writing the command. Otherwise, behaves like {@link
-   * InterPartitionCommandSender#sendCommand}. This may be used in cases where the key has been
-   * provided to the users, and the entity must be available on the receiving partition with that
-   * specific key. This also helps inform the receiving partition that this command was sent from
-   * another partition (and from which partition as the key encodes the partition id).
+   * Sends a command without authentication info to the given partition.
    *
-   * @param recordKey Record key to use when writing the command. Ignored if null.
+   * @see InterPartitionCommandSender#sendCommand(int, ValueType, Intent, Long, UnifiedRecordValue,
+   *     AuthInfo)
+   */
+  default void sendCommand(
+      final int receiverPartitionId,
+      final ValueType valueType,
+      final Intent intent,
+      final Long recordKey,
+      final UnifiedRecordValue command) {
+    sendCommand(receiverPartitionId, valueType, intent, recordKey, command, null);
+  }
+
+  /**
+   * Sends a command to the given partition.
+   *
+   * @param recordKey This may be used in cases where the key has been provided to the users, and
+   *     the entity must be available on the receiving partition with that specific key. This also
+   *     helps inform the receiving partition that this command was sent from another partition (and
+   *     from which partition as the key encodes the partition id). May be null, in which case it is
+   *     ignored.
+   * @param authInfo May be null if authentication at the receiving partition is not required.
    */
   void sendCommand(
       final int receiverPartitionId,
       final ValueType valueType,
       final Intent intent,
       final Long recordKey,
-      final UnifiedRecordValue command);
-
-  default void sendCommand(
-      final int receiverPartitionId,
-      final ValueType valueType,
-      final Intent intent,
-      final Long recordKey,
       final UnifiedRecordValue command,
-      final AuthInfo authInfo) {
-    sendCommand(receiverPartitionId, valueType, intent, command);
-  }
+      final AuthInfo authInfo);
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/InterPartitionCommandSender.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/InterPartitionCommandSender.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.api;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -37,4 +38,14 @@ public interface InterPartitionCommandSender {
       final Intent intent,
       final Long recordKey,
       final UnifiedRecordValue command);
+
+  default void sendCommand(
+      final int receiverPartitionId,
+      final ValueType valueType,
+      final Intent intent,
+      final Long recordKey,
+      final UnifiedRecordValue command,
+      final AuthInfo authInfo) {
+    sendCommand(receiverPartitionId, valueType, intent, command);
+  }
 }


### PR DESCRIPTION
Allows inter-partition commands to carry `AuthInfo`. The SBE protocol has a new version with a new binary blob `auth` in `InterPartitionMessage`. By default, no auth data is included, resulting in a zero-length blob and eventually to a `RecordMetadata` where `authInfo` is left to default values. This is what all production usages of IPC rely on at the moment.

relates to #39430
