### PR TITLE
test: re-enable rolling update tests

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -42,7 +42,6 @@ import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -57,8 +56,6 @@ import org.testcontainers.utility.DockerImageName;
  * <p>The important part is that we should be aware whether rolling update is possible between
  * versions.
  */
-@Disabled(
-    "Requires 8.8 artifacts to be published to avoid NPE, see https://github.com/camunda/camunda/issues/37517")
 final class RollingUpdateTest {
 
   private static final BpmnModelInstance PROCESS =


### PR DESCRIPTION
8.8.0 is released, we can run these tests again :tada: 

closes #37517