### PR TITLE
feat: distributed commands carry auth info

### DIFF
--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.processing;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -135,5 +136,10 @@ record MockTypedCheckpointRecord(
   @Override
   public int getLength() {
     return 0;
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return null;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -108,7 +108,8 @@ public final class BatchOperationCreateProcessor
     commandDistributionBehavior
         .withKey(key)
         .inQueue(DistributionQueue.BATCH_OPERATION)
-        .distribute(command.getValueType(), command.getIntent(), recordWithKey);
+        .distribute(
+            command.getValueType(), command.getIntent(), recordWithKey, command.getAuthInfo());
 
     metrics.recordCreated(recordWithKey.getBatchOperationType());
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
@@ -257,7 +257,8 @@ public final class BatchOperationExecuteProcessor
           .distribute(
               ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
               BatchOperationIntent.COMPLETE_PARTITION,
-              batchInternalComplete);
+              batchInternalComplete,
+              command.getAuthInfo());
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationFailProcessor.java
@@ -101,7 +101,8 @@ public final class BatchOperationFailProcessor
           .distribute(
               ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
               BatchOperationIntent.FAIL_PARTITION,
-              batchInternalFail);
+              batchInternalFail,
+              command.getAuthInfo());
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionContinueProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionContinueProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 @ExcludeAuthorizationCheck
@@ -41,7 +42,12 @@ public class CommandDistributionContinueProcessor
     final var continuationRecord = distributionState.getContinuationRecord(queue, key);
     final var intent = continuationRecord.getIntent();
     final var continuationCommand = continuationRecord.getCommandValue();
-    commandWriter.appendFollowUpCommand(key, intent, continuationCommand);
+    commandWriter.appendFollowUpCommand(
+        key,
+        intent,
+        continuationCommand,
+        FollowUpCommandMetadata.of(
+            metadata -> metadata.authInfo(distributionRecord.getAuthInfo())));
 
     stateWriter.appendFollowUpEvent(key, CommandDistributionIntent.CONTINUED, distributionRecord);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.incident;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
@@ -144,5 +145,10 @@ public final class RetryTypedRecord<T extends UnifiedRecordValue> implements Typ
   @Override
   public int getLength() {
     return 0;
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return null;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehaviour.java
@@ -486,7 +486,8 @@ public class ProcessInstanceMigrationCatchEventBehaviour {
           .distribute(
               ValueType.MESSAGE_SUBSCRIPTION,
               MessageSubscriptionIntent.MIGRATE,
-              messageSubscription);
+              messageSubscription,
+              null);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedCommandWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedCommandWriter.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
-import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -65,11 +64,8 @@ final class ResultBuilderBackedTypedCommandWriter extends AbstractResultBuilderB
             .rejectionType(RejectionType.NULL_VAL)
             .rejectionReason("")
             .operationReference(commandMetadata.operationReference())
-            .batchOperationReference(commandMetadata.batchOperationReference());
-
-    if (commandMetadata.claims() != null) {
-      metadata.authorization(new AuthInfo().setClaims(commandMetadata.claims()));
-    }
+            .batchOperationReference(commandMetadata.batchOperationReference())
+            .authorization(commandMetadata.authInfo());
 
     resultBuilder().appendRecord(key, value, metadata);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -122,15 +122,12 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
         persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord);
     responseWriter.writeEventOnCommand(
         persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord, command);
-    distributeUpdate(updatedRecord);
-  }
 
-  private void distributeUpdate(final TenantRecord updatedTenant) {
     final long distributionKey = keyGenerator.nextKey();
     commandDistributionBehavior
         .withKey(distributionKey)
         .inQueue(DistributionQueue.IDENTITY.getQueueId())
-        .distribute(ValueType.TENANT, TenantIntent.UPDATE, updatedTenant);
+        .distribute(ValueType.TENANT, TenantIntent.UPDATE, updatedRecord, command.getAuthInfo());
   }
 
   private void rejectCommandWithUnauthorizedError(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -250,7 +250,8 @@ public class DbDistributionState implements MutableDistributionState {
         .setQueueId(persistedDistribution.getQueueId().orElse(null))
         .setValueType(persistedDistribution.getValueType())
         .setIntent(persistedDistribution.getIntent())
-        .setCommandValue(persistedDistribution.getCommandValue());
+        .setCommandValue(persistedDistribution.getCommandValue())
+        .setAuthInfo(persistedDistribution.getAuthInfo());
   }
 
   @Override
@@ -387,6 +388,7 @@ public class DbDistributionState implements MutableDistributionState {
         .setQueueId(queue)
         .setValueType(persistedCommandDistribution.getValueType())
         .setIntent(persistedCommandDistribution.getIntent())
-        .setCommandValue(persistedCommandDistribution.getCommandValue());
+        .setCommandValue(persistedCommandDistribution.getCommandValue())
+        .setAuthInfo(persistedCommandDistribution.getAuthInfo());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Optional;
-import org.agrona.concurrent.UnsafeBuffer;
 
 public class PersistedCommandDistribution extends UnpackedObject implements DbValue {
 
@@ -52,18 +51,8 @@ public class PersistedCommandDistribution extends UnpackedObject implements DbVa
     valueTypeProperty.setValue(commandDistributionRecord.getValueType());
     intentProperty.setValue(commandDistributionRecord.getIntent().value());
 
-    final var commandValue = commandDistributionRecord.getCommandValue();
-    final var valueBuffer = new UnsafeBuffer(0, 0);
-    final int encodedLength = commandValue.getLength();
-    valueBuffer.wrap(new byte[encodedLength]);
-    commandValue.write(valueBuffer, 0);
-    commandValueProperty.getValue().wrap(valueBuffer, 0, encodedLength);
-
-    final var authInfo = commandDistributionRecord.getAuthInfo();
-    final int authLength = authInfo.getLength();
-    final var authBuffer = new UnsafeBuffer(new byte[authLength]);
-    authInfo.write(authBuffer, 0);
-    authInfoProperty.getValue().wrap(authBuffer, 0, authLength);
+    commandValueProperty.getValue().copyFrom(commandDistributionRecord.getCommandValue());
+    authInfoProperty.getValue().copyFrom(commandDistributionRecord.getAuthInfo());
 
     return this;
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
@@ -109,9 +109,9 @@ public class CommandDistributionScalingTest {
     fakeProcessingResultBuilder.flushPostCommitTasks();
     // then command is sent immediately to partition 2
     verify(mockInterpartitionCommandSender)
-        .sendCommand(eq(2), eq(valueType), eq(intent), eq(key), any());
+        .sendCommand(eq(2), eq(valueType), eq(intent), eq(key), any(), any());
     verify(mockInterpartitionCommandSender, never())
-        .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any());
+        .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any(), any());
     verifyNoMoreInteractions(mockInterpartitionCommandSender);
     assertThat(distributionState.hasPendingDistribution(key, 3)).isTrue();
     assertThat(distributionState.hasRetriableDistribution(key, 3)).isTrue();
@@ -149,14 +149,14 @@ public class CommandDistributionScalingTest {
     fakeProcessingResultBuilder.flushPostCommitTasks();
     // then command is sent immediately to partition 2 for the first record
     verify(mockInterpartitionCommandSender)
-        .sendCommand(eq(2), eq(valueType), eq(intent), eq(key), any());
+        .sendCommand(eq(2), eq(valueType), eq(intent), eq(key), any(), any());
     verify(mockInterpartitionCommandSender, never())
-        .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any());
+        .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any(), any());
     // the second command is enqueued for partitions 2 and 3
     verify(mockInterpartitionCommandSender, never())
-        .sendCommand(eq(2), eq(valueType), eq(intent), eq(otherKey), any());
+        .sendCommand(eq(2), eq(valueType), eq(intent), eq(otherKey), any(), any());
     verify(mockInterpartitionCommandSender, never())
-        .sendCommand(eq(3), eq(valueType), eq(intent), eq(otherKey), any());
+        .sendCommand(eq(3), eq(valueType), eq(intent), eq(otherKey), any(), any());
     verifyNoMoreInteractions(mockInterpartitionCommandSender);
 
     assertThat(distributionState.hasPendingDistribution(key, 2)).isTrue();
@@ -196,14 +196,14 @@ public class CommandDistributionScalingTest {
     // then command is sent immediately to partition 2 for the first record
     fakeProcessingResultBuilder.flushPostCommitTasks();
     verify(mockInterpartitionCommandSender)
-        .sendCommand(eq(2), eq(valueType), eq(intent), eq(key), any());
+        .sendCommand(eq(2), eq(valueType), eq(intent), eq(key), any(), any());
     verify(mockInterpartitionCommandSender, never())
-        .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any());
+        .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any(), any());
 
     verify(mockInterpartitionCommandSender, never())
-        .sendCommand(eq(2), eq(valueType), eq(intent), eq(otherKey), any());
+        .sendCommand(eq(2), eq(valueType), eq(intent), eq(otherKey), any(), any());
     verify(mockInterpartitionCommandSender, never())
-        .sendCommand(eq(3), eq(valueType), eq(intent), eq(otherKey), any());
+        .sendCommand(eq(3), eq(valueType), eq(intent), eq(otherKey), any(), any());
     verifyNoMoreInteractions(mockInterpartitionCommandSender);
 
     assertThat(distributionState.hasPendingDistribution(key, 3)).isTrue();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributorTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.state.routing.RoutingInfo.StaticRoutingInfo;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.engine.util.stream.FakeProcessingResultBuilder;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -115,7 +116,8 @@ public class CommandRedistributorTest {
 
     // then
     verify(mockCommandSender, times(1))
-        .sendCommand(1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue);
+        .sendCommand(
+            1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
   }
 
   private CommandRedistributor getCommandRedistributor(
@@ -168,11 +170,14 @@ public class CommandRedistributorTest {
 
       // then
       verify(mockCommandSender, times(1))
-          .sendCommand(1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue);
+          .sendCommand(
+              1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
       verify(mockCommandSender, times(1))
-          .sendCommand(2, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue);
+          .sendCommand(
+              2, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
       verify(mockCommandSender, never())
-          .sendCommand(3, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue);
+          .sendCommand(
+              3, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
     }
 
     @Test
@@ -185,11 +190,14 @@ public class CommandRedistributorTest {
 
       // then
       verify(mockCommandSender, times(1))
-          .sendCommand(1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue);
+          .sendCommand(
+              1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
       verify(mockCommandSender, times(1))
-          .sendCommand(2, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue);
+          .sendCommand(
+              2, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
       verify(mockCommandSender, never())
-          .sendCommand(3, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue);
+          .sendCommand(
+              3, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
 
       // then
       // Partition 3 is now scaled up, so it should be redistributed to
@@ -199,7 +207,8 @@ public class CommandRedistributorTest {
       commandRedistributor.runRetryCycle();
       commandRedistributor.runRetryCycle();
       verify(mockCommandSender, times(1))
-          .sendCommand(3, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue);
+          .sendCommand(
+              3, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
     }
   }
 
@@ -258,9 +267,11 @@ public class CommandRedistributorTest {
       // Cycle 9: no retry
 
       verify(mockCommandSender, times(4))
-          .sendCommand(1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue);
+          .sendCommand(
+              1, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
       verify(mockCommandSender, times(4))
-          .sendCommand(2, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue);
+          .sendCommand(
+              2, ValueType.USER, UserIntent.CREATE, distributionKey, recordValue, new AuthInfo());
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.util;
 
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.Record;
@@ -147,5 +148,10 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   @Override
   public String toJson() {
     throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return metadata.getAuthorization();
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -41,10 +41,6 @@ public class AuthInfo extends UnpackedObject {
     return this;
   }
 
-  public DirectBuffer getAuthDataBuffer() {
-    return authDataProp.getValue();
-  }
-
   public String getAuthData() {
     return BufferUtil.bufferAsString(authDataProp.getValue());
   }
@@ -68,16 +64,29 @@ public class AuthInfo extends UnpackedObject {
     return this;
   }
 
-  @JsonIgnore
-  public DirectBuffer getClaimsBuffer() {
-    return claimsProp.getValue();
-  }
-
   @Override
   public void reset() {
     formatProp.setValue(AuthDataFormat.UNKNOWN);
     authDataProp.setValue("");
     claimsProp.reset();
+  }
+
+  @Override
+  @JsonIgnore
+  public int getEncodedLength() {
+    return super.getEncodedLength();
+  }
+
+  @Override
+  @JsonIgnore
+  public boolean isEmpty() {
+    return super.isEmpty();
+  }
+
+  @Override
+  @JsonIgnore
+  public int getLength() {
+    return super.getLength();
   }
 
   public DirectBuffer toDirectBuffer() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
@@ -58,6 +59,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private static final StringValue VALUE_TYPE_KEY = new StringValue("valueType");
   private static final StringValue INTENT_KEY = new StringValue("intent");
   private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
+  private static final StringValue AUTH_INFO_KEY = new StringValue("authInfo");
 
   // You'll need to register any of the records value's that you want to distribute
   static {
@@ -90,6 +92,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private final IntegerProperty intentProperty = new IntegerProperty(INTENT_KEY, Intent.NULL_VAL);
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>(COMMAND_VALUE_KEY, new UnifiedRecordValue(10));
+  private final ObjectProperty<AuthInfo> authInfoProperty =
+      new ObjectProperty<>(AUTH_INFO_KEY, new AuthInfo());
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
 
@@ -99,7 +103,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
         .declareProperty(queueIdProperty)
         .declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)
-        .declareProperty(commandValueProperty);
+        .declareProperty(commandValueProperty)
+        .declareProperty(authInfoProperty);
   }
 
   public CommandDistributionRecord wrap(final CommandDistributionRecord other) {
@@ -107,7 +112,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
         .setQueueId(other.getQueueId())
         .setValueType(other.getValueType())
         .setIntent(other.getIntent())
-        .setCommandValue(other.getCommandValue());
+        .setCommandValue(other.getCommandValue())
+        .setAuthInfo(other.getAuthInfo());
     return this;
   }
 
@@ -172,6 +178,10 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     return concreteCommandValue;
   }
 
+  public AuthInfo getAuthInfo() {
+    return authInfoProperty.getValue();
+  }
+
   public CommandDistributionRecord setCommandValue(final UnifiedRecordValue commandValue) {
     if (commandValue == null) {
       commandValueProperty.reset();
@@ -209,6 +219,11 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
 
   public CommandDistributionRecord setPartitionId(final int partitionId) {
     partitionIdProperty.setValue(partitionId);
+    return this;
+  }
+
+  public CommandDistributionRecord setAuthInfo(final AuthInfo authInfo) {
+    authInfoProperty.getValue().copyFrom(authInfo);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2402,7 +2402,8 @@ final class JsonSerializableToJsonTest {
                   .setQueueId("totally-random-queue-id")
                   .setValueType(ValueType.DEPLOYMENT)
                   .setIntent(DeploymentIntent.CREATE)
-                  .setCommandValue(deploymentRecord);
+                  .setCommandValue(deploymentRecord)
+                  .setAuthInfo(new AuthInfo().setClaims(Map.of("claim-a", "foo")));
             },
         """
         {
@@ -2433,7 +2434,7 @@ final class JsonSerializableToJsonTest {
             "tenantId": "<default>",
             "deploymentKey": -1
           },
-          "authInfo":{"format":"UNKNOWN","claims":{},"authData":""}
+          "authInfo":{"format":"UNKNOWN","claims":{"claim-a": "foo"},"authData":""}
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2432,7 +2432,8 @@ final class JsonSerializableToJsonTest {
             "resourceMetadata":[],
             "tenantId": "<default>",
             "deploymentKey": -1
-          }
+          },
+          "authInfo":{"format":"UNKNOWN","claims":{},"authData":""}
         }
         """
       },
@@ -2449,7 +2450,8 @@ final class JsonSerializableToJsonTest {
           "queueId": null,
           "valueType": "NULL_VAL",
           "intent": "UNKNOWN",
-          "commandValue": null
+          "commandValue": null,
+          "authInfo":{"format":"UNKNOWN","claims":{},"authData":""}
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
@@ -31,6 +32,7 @@ import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -57,6 +59,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private static final StringValue VALUE_TYPE_KEY = new StringValue("valueType");
   private static final StringValue INTENT_KEY = new StringValue("intent");
   private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
+  private static final StringValue AUTH_INFO_KEY = new StringValue("authInfo");
 
   // You'll need to register any of the records value's that you want to distribute
   static {
@@ -79,6 +82,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
         BatchOperationLifecycleManagementRecord::new);
     RECORDS_BY_TYPE.put(
         ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE, BatchOperationPartitionLifecycleRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.CLUSTER_VARIABLE, ClusterVariableRecord::new);
   }
 
   private final IntegerProperty partitionIdProperty = new IntegerProperty(PARTITION_ID_KEY);
@@ -88,6 +92,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private final IntegerProperty intentProperty = new IntegerProperty(INTENT_KEY, Intent.NULL_VAL);
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>(COMMAND_VALUE_KEY, new UnifiedRecordValue(10));
+  private final ObjectProperty<AuthInfo> authInfoProperty =
+      new ObjectProperty<>(AUTH_INFO_KEY, new AuthInfo());
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
 
@@ -97,7 +103,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
         .declareProperty(queueIdProperty)
         .declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)
-        .declareProperty(commandValueProperty);
+        .declareProperty(commandValueProperty)
+        .declareProperty(authInfoProperty);
   }
 
   public CommandDistributionRecord wrap(final CommandDistributionRecord other) {
@@ -105,7 +112,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
         .setQueueId(other.getQueueId())
         .setValueType(other.getValueType())
         .setIntent(other.getIntent())
-        .setCommandValue(other.getCommandValue());
+        .setCommandValue(other.getCommandValue())
+        .setAuthInfo(other.getAuthInfo());
     return this;
   }
 
@@ -170,6 +178,10 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     return concreteCommandValue;
   }
 
+  public AuthInfo getAuthInfo() {
+    return authInfoProperty.getValue();
+  }
+
   public CommandDistributionRecord setCommandValue(final UnifiedRecordValue commandValue) {
     if (commandValue == null) {
       commandValueProperty.reset();
@@ -207,6 +219,11 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
 
   public CommandDistributionRecord setPartitionId(final int partitionId) {
     partitionIdProperty.setValue(partitionId);
+    return this;
+  }
+
+  public CommandDistributionRecord setAuthInfo(final AuthInfo authInfo) {
+    authInfoProperty.getValue().copyFrom(authInfo);
     return this;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/FollowUpCommandMetadata.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/FollowUpCommandMetadata.java
@@ -7,13 +7,13 @@
  */
 package io.camunda.zeebe.stream.api;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
 public record FollowUpCommandMetadata(
-    long operationReference, long batchOperationReference, Map<String, Object> claims) {
+    long operationReference, long batchOperationReference, AuthInfo authInfo) {
 
   public static FollowUpCommandMetadata empty() {
     return of(builder -> {});
@@ -28,7 +28,7 @@ public record FollowUpCommandMetadata(
   public static class Builder {
     private long operationReference = RecordMetadataDecoder.operationReferenceNullValue();
     private long batchOperationReference = RecordMetadataDecoder.batchOperationReferenceNullValue();
-    private Map<String, Object> claims = null;
+    private final AuthInfo authInfo = new AuthInfo();
 
     public Builder operationReference(final long operationReference) {
       this.operationReference = operationReference;
@@ -40,22 +40,18 @@ public record FollowUpCommandMetadata(
       return this;
     }
 
-    public Builder claims(final Map<String, Object> claims) {
-      this.claims = claims;
+    public Builder authInfo(final AuthInfo authInfo) {
+      this.authInfo.copyFrom(authInfo);
       return this;
     }
 
-    public Builder claim(final String key, final Object value) {
-      if (claims == null) {
-        claims = new HashMap<>();
-      }
-
-      claims.put(key, value);
+    public Builder claims(final Map<String, Object> claims) {
+      authInfo.setClaims(claims);
       return this;
     }
 
     public FollowUpCommandMetadata build() {
-      return new FollowUpCommandMetadata(operationReference, batchOperationReference, claims);
+      return new FollowUpCommandMetadata(operationReference, batchOperationReference, authInfo);
     }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/records/TypedRecord.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/records/TypedRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.stream.api.records;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
@@ -21,6 +22,9 @@ public interface TypedRecord<T extends UnifiedRecordValue> extends Record<T> {
 
   @Override
   T getValue();
+
+  @JsonIgnore
+  AuthInfo getAuthInfo();
 
   int getRequestStreamId();
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
@@ -63,7 +63,8 @@ public final class BufferedTaskResultBuilder implements TaskResultBuilder {
             .rejectionReason("")
             .valueType(valueType)
             .operationReference(metadata.operationReference())
-            .batchOperationReference(metadata.batchOperationReference());
+            .batchOperationReference(metadata.batchOperationReference())
+            .authorization(metadata.authInfo());
     final var either = mutableRecordBatch.appendRecord(key, recordMetadata, -1, value);
 
     either.ifRight(ok -> cache.add(intent, key));
@@ -85,7 +86,8 @@ public final class BufferedTaskResultBuilder implements TaskResultBuilder {
             .rejectionReason("")
             .valueType(ValueType.NULL_VAL) // every value type has the same size in the record
             .operationReference(metadata.operationReference())
-            .batchOperationReference(metadata.batchOperationReference());
+            .batchOperationReference(metadata.batchOperationReference())
+            .authorization(metadata.authInfo());
 
     // we need to calculate the total size of all records, but we optimize it with not
     // recalculating the metadata size again for each entry

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.stream.impl.records;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -91,6 +92,11 @@ public final class TypedRecordImpl implements TypedRecord {
   @Override
   public Map<String, Object> getAuthorizations() {
     return metadata.getAuthorization().toDecodedMap();
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return metadata.getAuthorization();
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.impl.records;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -126,5 +127,10 @@ public class UnwrittenRecord implements TypedRecord {
   @Override
   public int getLength() {
     return metadata.getLength() + value.getLength();
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return metadata.getAuthorization();
   }
 }


### PR DESCRIPTION
We now store auth info alongside distributable commands and continuations. On every distribution attempt, that auth data is sent over the inter-partition command, as prepared in https://github.com/camunda/camunda/pull/39480.

We make this opt-out: processors which don't want to include auth info will have to provide `null`, there are no convenience methods where you could forget to pass auth info. For some commands, I needed to find appropriate auth info because the original auth info from the user command wasn't readily available. Only on message subscription migration we actually need to opt-out, there wasn't a clear path to pass down the auth info.

To allow auth info in continuation commands (written once a queue of command distributions is done), I have built on top of an API extension used by batch operations, that allowed processors to pass record metadata, including auth info, to follow-up commands.

relates to #39430
