### PR TITLE
fix: align OpenAPI spec with externally managed one

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
@@ -9575,7 +9575,7 @@ components:
         instance:
           type: string
           format: uri
-          description: A URI identifying the origin of the problem.
+          description: A URI path identifying the origin of the problem.
           example: /v2/jobs/activation
     SearchQueryRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
@@ -145,7 +145,12 @@ paths:
         "400":
           $ref: "#/components/responses/InvalidData"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          description: |
+            An Internal Error occurred. More details are provided in the response body. If the response body contains RESOURCE_EXHAUSTED, this signals back pressure.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
   /jobs/search:
@@ -4460,6 +4465,8 @@ paths:
                 $ref: "#/components/schemas/DocumentReference"
         "400":
           $ref: "#/components/responses/InvalidData"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
   /documents/batch:
     post:
       tags:
@@ -4535,6 +4542,8 @@ paths:
                 $ref: "#/components/schemas/DocumentCreationBatchResponse"
         "400":
           $ref: "#/components/responses/InvalidData"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
   /documents/{documentId}:
     get:
       tags:
@@ -9426,6 +9435,7 @@ components:
         - AD_HOC_SUB_PROCESS
     JobListenerEventTypeEnum:
       description: The listener event type of the job.
+      type: string
       enum:
         - ASSIGNING
         - CANCELING
@@ -9546,22 +9556,26 @@ components:
           format: uri
           description: A URI identifying the problem type.
           default: about:blank
+          example: about:blank
         title:
           type: string
           description: A summary of the problem type.
+          example: Bad Request
         status:
           type: integer
           format: int32
           description: The HTTP status code for this problem.
+          example: 400
           minimum: 400
           maximum: 600
         detail:
           type: string
           description: An explanation of the problem in more detail.
+          example: Request property [maxJobsToActivates] cannot be parsed
         instance:
           type: string
-          format: uri
           description: A URI identifying the origin of the problem.
+          example: /v2/jobs/activation
     SearchQueryRequest:
       type: object
       properties:
@@ -11175,6 +11189,13 @@ components:
             $ref: "#/components/schemas/ProblemDetail"
     InvalidData:
       description: The provided data is not valid.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+    UnsupportedMediaType:
+      description: |
+        The server cannot process the request because the media type (Content-Type) of the request payload is not supported  by the server for the requested resource and method.
       content:
         application/problem+json:
           schema:

--- a/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
@@ -11205,6 +11205,7 @@ components:
       description: >
         The service is currently unavailable. This may happen only on some requests where the system
         creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures.
+        In this case, the title of the error object contains `RESOURCE_EXHAUSTED`.
         Clients are recommended to eventually retry those requests after a backoff period.
         You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .
       content:

--- a/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/internal/generation-spec.yaml
@@ -9574,6 +9574,7 @@ components:
           example: Request property [maxJobsToActivates] cannot be parsed
         instance:
           type: string
+          format: uri
           description: A URI identifying the origin of the problem.
           example: /v2/jobs/activation
     SearchQueryRequest:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -10399,7 +10399,7 @@ components:
         instance:
           type: string
           format: uri
-          description: A URI identifying the origin of the problem.
+          description: A URI path identifying the origin of the problem.
           example: /v2/jobs/activation
     SearchQueryRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -10398,6 +10398,7 @@ components:
           example: Request property [maxJobsToActivates] cannot be parsed
         instance:
           type: string
+          format: uri
           description: A URI identifying the origin of the problem.
           example: /v2/jobs/activation
     SearchQueryRequest:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -154,7 +154,12 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
         "500":
-          $ref: "#/components/responses/InternalServerError"
+          description: |
+            An Internal Error occurred. More details are provided in the response body. If the response body contains RESOURCE_EXHAUSTED, this signals back pressure.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
   /jobs/search:
@@ -4501,6 +4506,8 @@ paths:
                 $ref: "#/components/schemas/DocumentReference"
         "400":
           $ref: "#/components/responses/InvalidData"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
       x-eventually-consistent: false
   /documents/batch:
     post:
@@ -4578,6 +4585,8 @@ paths:
                 $ref: "#/components/schemas/DocumentCreationBatchResponse"
         "400":
           $ref: "#/components/responses/InvalidData"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
       x-eventually-consistent: false
   /documents/{documentId}:
     get:
@@ -10250,6 +10259,7 @@ components:
     JobListenerEventTypeEnum:
       example: UNSPECIFIED
       description: The listener event type of the job.
+      type: string
       enum:
         - ASSIGNING
         - CANCELING
@@ -10370,22 +10380,26 @@ components:
           format: uri
           description: A URI identifying the problem type.
           default: about:blank
+          example: about:blank
         title:
           type: string
           description: A summary of the problem type.
+          example: Bad Request
         status:
           type: integer
           format: int32
           description: The HTTP status code for this problem.
+          example: 400
           minimum: 400
           maximum: 600
         detail:
           type: string
           description: An explanation of the problem in more detail.
+          example: Request property [maxJobsToActivates] cannot be parsed
         instance:
           type: string
-          format: uri
           description: A URI identifying the origin of the problem.
+          example: /v2/jobs/activation
     SearchQueryRequest:
       type: object
       properties:
@@ -12317,6 +12331,13 @@ components:
             $ref: "#/components/schemas/ProblemDetail"
     InvalidData:
       description: The provided data is not valid.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+    UnsupportedMediaType:
+      description: |
+        The server cannot process the request because the media type (Content-Type) of the request payload is not supported  by the server for the requested resource and method.
       content:
         application/problem+json:
           schema:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -12347,6 +12347,7 @@ components:
       description: >
         The service is currently unavailable. This may happen only on some requests where the system
         creates backpressure to prevent the server's compute resources from being exhausted, avoiding more severe failures.
+        In this case, the title of the error object contains `RESOURCE_EXHAUSTED`.
         Clients are recommended to eventually retry those requests after a backoff period.
         You can learn more about the backpressure mechanism here: https://docs.camunda.io/docs/components/zeebe/technical-concepts/internal-processing/#handling-backpressure .
       content:


### PR DESCRIPTION
## Description

Adds missing fixes to the V2 spec to align with the latest version release in public docs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39518