### PR TITLE
ci: update chart versions

### DIFF
--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -331,7 +331,7 @@ jobs:
           --set orchestration.security.authentication.oidc.backwardsCompatibleAudiences[0]=zeebe-api \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
           --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \
-          --version 13.0.0
+          --version 13.x
       - name: Summarize deployment
         if: success()
         run: |

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -172,6 +172,7 @@ jobs:
           --namespace ${{ inputs.name }}
           --create-namespace
           --render-subchart-notes
+          --version 12.6.2
       - name: Summarize deployment
         if: success()
         run: |
@@ -263,9 +264,6 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: 'camunda/camunda-platform-helm'
-          ref: 'main'
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
@@ -308,8 +306,7 @@ jobs:
       - name: Upgrade platform
         id: upgrade-platform
         run: |
-          helm dependency build charts/camunda-platform-8.8/
-          helm upgrade ${{ inputs.name }} charts/camunda-platform-8.8/ \
+          helm upgrade ${{ inputs.name }} camunda/camunda-platform \
           --wait --wait-for-jobs --timeout 35m0s \
           --namespace ${{ inputs.name }} \
           --render-subchart-notes \
@@ -333,7 +330,8 @@ jobs:
           --set orchestration.migration.identity.secret.existingSecretKey=identity-orchestration-client-token \
           --set orchestration.security.authentication.oidc.backwardsCompatibleAudiences[0]=zeebe-api \
           --set orchestration.security.authentication.oidc.secret.existingSecret=camunda-credentials \
-          --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token          
+          --set orchestration.security.authentication.oidc.secret.existingSecretKey=identity-orchestration-client-token \
+          --version 13.0.0
       - name: Summarize deployment
         if: success()
         run: |


### PR DESCRIPTION
## Description

 * 13.0.0 chart (or Camunda 8.8) has been release
 * We need to use the correct versions now
 * For previous we use the 12.x to install 8.7
 * To update we use 13.x
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
