### PR TITLE
Enforce authorization checks on signal broadcast processor

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -196,6 +196,7 @@ public class AdHocSubProcessInstructionActivateProcessor
                 adHocSubProcessElementInstance.getValue().getTenantId())
             .addResourceId(adHocSubProcessElementInstance.getValue().getBpmnProcessId());
 
-    return authCheckBehavior.isAuthorized(authRequest);
+    return authCheckBehavior.isAuthorized(
+        authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -196,7 +196,6 @@ public class AdHocSubProcessInstructionActivateProcessor
                 adHocSubProcessElementInstance.getValue().getTenantId())
             .addResourceId(adHocSubProcessElementInstance.getValue().getBpmnProcessId());
 
-    return authCheckBehavior.isAuthorized(
-        authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
+    return authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
@@ -78,9 +78,7 @@ public final class BatchOperationCancelProcessor
       final TypedRecord<BatchOperationLifecycleManagementRecord> command) {
     final var request =
         new AuthorizationRequest(command, AuthorizationResourceType.BATCH, PermissionType.UPDATE);
-    final var authorizationResult =
-        authCheckBehavior.isAuthorized(
-            request, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var authorizationResult = authCheckBehavior.isAuthorizedOrInternalCommand(request);
     if (authorizationResult.isLeft()) {
       final Rejection rejection = authorizationResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
@@ -78,7 +78,9 @@ public final class BatchOperationCancelProcessor
       final TypedRecord<BatchOperationLifecycleManagementRecord> command) {
     final var request =
         new AuthorizationRequest(command, AuthorizationResourceType.BATCH, PermissionType.UPDATE);
-    final var authorizationResult = authCheckBehavior.isAuthorized(request);
+    final var authorizationResult =
+        authCheckBehavior.isAuthorized(
+            request, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (authorizationResult.isLeft()) {
       final Rejection rejection = authorizationResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -131,10 +131,11 @@ public final class BatchOperationCreateProcessor
       final TypedRecord<BatchOperationCreationRecord> command) {
 
     // first check for general CREATE_BATCH_OPERATION permission
+    final var request =
+        new AuthorizationRequest(command, AuthorizationResourceType.BATCH, PermissionType.CREATE);
     final var isAuthorized =
         authCheckBehavior.isAuthorized(
-            new AuthorizationRequest(
-                command, AuthorizationResourceType.BATCH, PermissionType.CREATE));
+            request, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       // if that's not present, check for the BO type dependent permission
       final var permission =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -133,9 +133,7 @@ public final class BatchOperationCreateProcessor
     // first check for general CREATE_BATCH_OPERATION permission
     final var request =
         new AuthorizationRequest(command, AuthorizationResourceType.BATCH, PermissionType.CREATE);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            request, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(request);
     if (isAuthorized.isLeft()) {
       // if that's not present, check for the BO type dependent permission
       final var permission =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
@@ -89,9 +89,7 @@ public final class BatchOperationResumeProcessor
       final TypedRecord<BatchOperationLifecycleManagementRecord> command) {
     final var request =
         new AuthorizationRequest(command, AuthorizationResourceType.BATCH, PermissionType.UPDATE);
-    final var authorizationResult =
-        authCheckBehavior.isAuthorized(
-            request, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var authorizationResult = authCheckBehavior.isAuthorizedOrInternalCommand(request);
     if (authorizationResult.isLeft()) {
       final Rejection rejection = authorizationResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
@@ -89,7 +89,9 @@ public final class BatchOperationResumeProcessor
       final TypedRecord<BatchOperationLifecycleManagementRecord> command) {
     final var request =
         new AuthorizationRequest(command, AuthorizationResourceType.BATCH, PermissionType.UPDATE);
-    final var authorizationResult = authCheckBehavior.isAuthorized(request);
+    final var authorizationResult =
+        authCheckBehavior.isAuthorized(
+            request, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (authorizationResult.isLeft()) {
       final Rejection rejection = authorizationResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
@@ -81,9 +81,7 @@ public final class BatchOperationSuspendProcessor
       final TypedRecord<BatchOperationLifecycleManagementRecord> command) {
     final var request =
         new AuthorizationRequest(command, AuthorizationResourceType.BATCH, PermissionType.UPDATE);
-    final var authorizationResult =
-        authCheckBehavior.isAuthorized(
-            request, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var authorizationResult = authCheckBehavior.isAuthorizedOrInternalCommand(request);
     if (authorizationResult.isLeft()) {
       final Rejection rejection = authorizationResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
@@ -81,7 +81,9 @@ public final class BatchOperationSuspendProcessor
       final TypedRecord<BatchOperationLifecycleManagementRecord> command) {
     final var request =
         new AuthorizationRequest(command, AuthorizationResourceType.BATCH, PermissionType.UPDATE);
-    final var authorizationResult = authCheckBehavior.isAuthorized(request);
+    final var authorizationResult =
+        authCheckBehavior.isAuthorized(
+            request, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (authorizationResult.isLeft()) {
       final Rejection rejection = authorizationResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessor.java
@@ -58,7 +58,9 @@ public final class ClockProcessor implements DistributedTypedRecordProcessor<Clo
   public void processNewCommand(final TypedRecord<ClockRecord> command) {
     final var authRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.SYSTEM, PermissionType.UPDATE);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessor.java
@@ -58,9 +58,7 @@ public final class ClockProcessor implements DistributedTypedRecordProcessor<Clo
   public void processNewCommand(final TypedRecord<ClockRecord> command) {
     final var authRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.SYSTEM, PermissionType.UPDATE);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -137,7 +137,11 @@ public final class DeploymentCreateProcessor
             PermissionType.CREATE,
             command.getValue().getTenantId(),
             newResourceAuthorization);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -137,11 +137,7 @@ public final class DeploymentCreateProcessor
             PermissionType.CREATE,
             command.getValue().getTenantId(),
             newResourceAuthorization);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
@@ -74,9 +74,7 @@ public class DecisionEvaluationEvaluteProcessor
                   record.getTenantId())
               .addResourceId(decisionId);
 
-      final var isAuthorized =
-          authCheckBehavior.isAuthorized(
-              authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
+      final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
       if (isAuthorized.isLeft()) {
         final var rejection = isAuthorized.getLeft();
         final String errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
@@ -74,7 +74,9 @@ public class DecisionEvaluationEvaluteProcessor
                   record.getTenantId())
               .addResourceId(decisionId);
 
-      final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
+      final var isAuthorized =
+          authCheckBehavior.isAuthorized(
+              authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
       if (isAuthorized.isLeft()) {
         final var rejection = isAuthorized.getLeft();
         final String errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -130,11 +130,9 @@ public final class AuthorizationCheckBehavior {
     }
   }
 
-  public Either<Rejection, Void> isAuthorized(
-      final AuthorizationRequest request,
-      final boolean hasRequestMetadata,
-      final long batchOperationReference) {
-    if (isInternalCommand(hasRequestMetadata, batchOperationReference)) {
+  public Either<Rejection, Void> isAuthorizedOrInternalCommand(final AuthorizationRequest request) {
+    final var command = request.command;
+    if (isInternalCommand(command.hasRequestMetadata(), command.getBatchOperationReference())) {
       return Either.right(null);
     }
     return isAuthorized(request);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -568,13 +568,6 @@ public final class AuthorizationCheckBehavior {
     if (!multiTenancyEnabled) {
       return true;
     }
-
-    if (!request.hasRequestMetadata()) {
-      // The command is written by Zeebe internally. Internal Zeebe commands are always allowed to
-      // access all tenants
-      return true;
-    }
-
     return getAuthorizedTenantIds(request.claims()).isAuthorizedForTenantId(request.tenantId());
   }
 
@@ -642,9 +635,7 @@ public final class AuthorizationCheckBehavior {
       boolean isNewResource,
       boolean isTenantOwnedResource,
       String tenantId,
-      Set<AuthorizationScope> authorizationScopes,
-      boolean hasRequestMetadata,
-      long batchOperationReference) {
+      Set<AuthorizationScope> authorizationScopes) {
 
     public String getForbiddenErrorMessage() {
       final var authorizationScopesContainsOnlyWildcard =
@@ -784,9 +775,7 @@ public final class AuthorizationCheckBehavior {
             isNewResource,
             isTenantOwnedResource,
             tenantId,
-            Collections.unmodifiableSet(authorizationScopes),
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+            Collections.unmodifiableSet(authorizationScopes));
       }
       return new AuthorizationRequestMetadata(
           authorizationClaims,
@@ -795,9 +784,7 @@ public final class AuthorizationCheckBehavior {
           isNewResource,
           isTenantOwnedResource,
           tenantId,
-          Collections.unmodifiableSet(authorizationScopes),
-          true,
-          RecordMetadataDecoder.batchOperationReferenceNullValue());
+          Collections.unmodifiableSet(authorizationScopes));
     }
 
     public static AuthorizationRequest builder() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
 import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
 import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
-import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -66,7 +66,11 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.UPDATE)
             .addResourceId(record.getGroupId());
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -66,11 +66,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.UPDATE)
             .addResourceId(record.getGroupId());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
@@ -55,7 +55,11 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
   public void processNewCommand(final TypedRecord<GroupRecord> command) {
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.CREATE);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
 
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
@@ -55,11 +55,7 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
   public void processNewCommand(final TypedRecord<GroupRecord> command) {
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.CREATE);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
 
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
@@ -70,7 +70,11 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.DELETE)
             .addResourceId(groupId);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
@@ -70,11 +70,7 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.DELETE)
             .addResourceId(groupId);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -67,11 +67,7 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.UPDATE)
             .addResourceId(groupId);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -67,7 +67,11 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.UPDATE)
             .addResourceId(groupId);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
@@ -58,11 +58,7 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.UPDATE)
             .addResourceId(groupId);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
@@ -58,7 +58,11 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.UPDATE)
             .addResourceId(groupId);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
@@ -62,7 +62,11 @@ public class MappingRuleCreateProcessor
     final var authorizationRequest =
         new AuthorizationRequest(
             command, AuthorizationResourceType.MAPPING_RULE, PermissionType.CREATE);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
@@ -62,11 +62,7 @@ public class MappingRuleCreateProcessor
     final var authorizationRequest =
         new AuthorizationRequest(
             command, AuthorizationResourceType.MAPPING_RULE, PermissionType.CREATE);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
@@ -96,7 +96,11 @@ public class MappingRuleDeleteProcessor
     final var authorizationRequest =
         new AuthorizationRequest(
             command, AuthorizationResourceType.MAPPING_RULE, PermissionType.DELETE);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
@@ -96,11 +96,7 @@ public class MappingRuleDeleteProcessor
     final var authorizationRequest =
         new AuthorizationRequest(
             command, AuthorizationResourceType.MAPPING_RULE, PermissionType.DELETE);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
@@ -93,11 +93,7 @@ public class MappingRuleUpdateProcessor
         new AuthorizationRequest(
                 command, AuthorizationResourceType.MAPPING_RULE, PermissionType.UPDATE)
             .addResourceId(mappingRuleId);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
@@ -93,7 +93,11 @@ public class MappingRuleUpdateProcessor
         new AuthorizationRequest(
                 command, AuthorizationResourceType.MAPPING_RULE, PermissionType.UPDATE)
             .addResourceId(mappingRuleId);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -49,10 +49,7 @@ public class PermissionsBehavior {
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.AUTHORIZATION, permissionType);
     return authCheckBehavior
-        .isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference())
+        .isAuthorizedOrInternalCommand(authorizationRequest)
         .map(unused -> command.getValue());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -48,7 +48,12 @@ public class PermissionsBehavior {
       final TypedRecord<AuthorizationRecord> command, final PermissionType permissionType) {
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.AUTHORIZATION, permissionType);
-    return authCheckBehavior.isAuthorized(authorizationRequest).map(unused -> command.getValue());
+    return authCheckBehavior
+        .isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference())
+        .map(unused -> command.getValue());
   }
 
   public Either<Rejection, PersistedAuthorization> authorizationExists(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -75,11 +75,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.UPDATE)
             .addResourceId(record.getRoleId());
 
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -75,7 +75,11 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.UPDATE)
             .addResourceId(record.getRoleId());
 
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
@@ -55,11 +55,7 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
   public void processNewCommand(final TypedRecord<RoleRecord> command) {
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.CREATE);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
@@ -55,7 +55,11 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
   public void processNewCommand(final TypedRecord<RoleRecord> command) {
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.CREATE);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -71,7 +71,11 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.DELETE)
             .addResourceId(roleId);
 
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -71,11 +71,7 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.DELETE)
             .addResourceId(roleId);
 
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -74,11 +74,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.UPDATE)
             .addResourceId(record.getRoleId());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -74,7 +74,11 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.UPDATE)
             .addResourceId(record.getRoleId());
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
@@ -57,7 +57,11 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.UPDATE)
             .addResourceId(record.getRoleId());
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
@@ -57,11 +57,7 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.UPDATE)
             .addResourceId(record.getRoleId());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -100,7 +100,9 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 incident.getTenantId())
             .addResourceId(incident.getBpmnProcessId());
-    final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -100,9 +100,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 incident.getTenantId())
             .addResourceId(incident.getBpmnProcessId());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
@@ -81,6 +81,8 @@ public final class DefaultJobCommandPreconditionGuard {
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 job.getTenantId())
             .addResourceId(job.getBpmnProcessId());
-    return authCheckBehavior.isAuthorized(request).map(unused -> job);
+    return authCheckBehavior
+        .isAuthorized(request, command.hasRequestMetadata(), command.getBatchOperationReference())
+        .map(unused -> job);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
@@ -81,8 +81,6 @@ public final class DefaultJobCommandPreconditionGuard {
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 job.getTenantId())
             .addResourceId(job.getBpmnProcessId());
-    return authCheckBehavior
-        .isAuthorized(request, command.hasRequestMetadata(), command.getBatchOperationReference())
-        .map(unused -> job);
+    return authCheckBehavior.isAuthorizedOrInternalCommand(request).map(unused -> job);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -209,6 +209,8 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 job.getTenantId())
             .addResourceId(job.getBpmnProcessId());
-    return authCheckBehavior.isAuthorized(request).map(unused -> job);
+    return authCheckBehavior
+        .isAuthorized(request, command.hasRequestMetadata(), command.getBatchOperationReference())
+        .map(unused -> job);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -209,8 +209,6 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 job.getTenantId())
             .addResourceId(job.getBpmnProcessId());
-    return authCheckBehavior
-        .isAuthorized(request, command.hasRequestMetadata(), command.getBatchOperationReference())
-        .map(unused -> job);
+    return authCheckBehavior.isAuthorizedOrInternalCommand(request).map(unused -> job);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
@@ -64,10 +64,7 @@ public class JobUpdateBehaviour {
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 job.getTenantId())
             .addResourceId(job.getBpmnProcessId());
-    return authCheckBehavior
-        .isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference())
-        .map(unused -> job);
+    return authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).map(unused -> job);
   }
 
   public Optional<String> updateJobRetries(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
@@ -64,7 +64,10 @@ public class JobUpdateBehaviour {
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 job.getTenantId())
             .addResourceId(job.getBpmnProcessId());
-    return authCheckBehavior.isAuthorized(authRequest).map(unused -> job);
+    return authCheckBehavior
+        .isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference())
+        .map(unused -> job);
   }
 
   public Optional<String> updateJobRetries(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -89,13 +89,19 @@ public final class MessageCorrelationCorrelateProcessor
   public void processRecord(final TypedRecord<MessageCorrelationRecord> command) {
     final var messageCorrelationRecord = command.getValue();
 
-    if (!authCheckBehavior.isAssignedToTenant(command, messageCorrelationRecord.getTenantId())) {
-      final var message =
-          "Expected to correlate message for tenant '%s', but user is not assigned to this tenant."
-              .formatted(messageCorrelationRecord.getTenantId());
-      rejectionWriter.appendRejection(command, RejectionType.FORBIDDEN, message);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.FORBIDDEN, message);
-      return;
+    // Check tenant authorization if not an internal command
+    final var isInternal =
+        authCheckBehavior.isInternalCommand(
+            command.hasRequestMetadata(), command.getBatchOperationReference());
+    if (!isInternal) {
+      if (!authCheckBehavior.isAssignedToTenant(command, messageCorrelationRecord.getTenantId())) {
+        final var message =
+            "Expected to correlate message for tenant '%s', but user is not assigned to this tenant."
+                .formatted(messageCorrelationRecord.getTenantId());
+        rejectionWriter.appendRejection(command, RejectionType.FORBIDDEN, message);
+        responseWriter.writeRejectionOnCommand(command, RejectionType.FORBIDDEN, message);
+        return;
+      }
     }
 
     final long messageKey = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -206,7 +206,11 @@ public final class MessageCorrelationCorrelateProcessor
 
               final var processIdString = bufferAsString(subscription.getBpmnProcessId());
               request.get().addResourceId(processIdString);
-              final var rejectionOrAuthorized = authCheckBehavior.isAuthorized(request.get());
+              final var rejectionOrAuthorized =
+                  authCheckBehavior.isAuthorized(
+                      request.get(),
+                      command.hasRequestMetadata(),
+                      command.getBatchOperationReference());
               rejectionOrAuthorized.ifLeft(rejection::set);
               return rejectionOrAuthorized.isRight();
             },

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -213,10 +213,7 @@ public final class MessageCorrelationCorrelateProcessor
               final var processIdString = bufferAsString(subscription.getBpmnProcessId());
               request.get().addResourceId(processIdString);
               final var rejectionOrAuthorized =
-                  authCheckBehavior.isAuthorized(
-                      request.get(),
-                      command.hasRequestMetadata(),
-                      command.getBatchOperationReference());
+                  authCheckBehavior.isAuthorizedOrInternalCommand(request.get());
               rejectionOrAuthorized.ifLeft(rejection::set);
               return rejectionOrAuthorized.isRight();
             },

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -102,7 +102,9 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
             PermissionType.CREATE,
             command.getValue().getTenantId(),
             true);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -102,9 +102,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
             PermissionType.CREATE,
             command.getValue().getTenantId(),
             true);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
@@ -107,9 +107,7 @@ public final class ProcessInstanceCancelProcessor
                 PermissionType.CANCEL_PROCESS_INSTANCE,
                 elementInstance.getValue().getTenantId())
             .addResourceId(elementInstance.getValue().getBpmnProcessId());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            request, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(request);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       final String errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
@@ -107,7 +107,9 @@ public final class ProcessInstanceCancelProcessor
                 PermissionType.CANCEL_PROCESS_INSTANCE,
                 elementInstance.getValue().getTenantId())
             .addResourceId(elementInstance.getValue().getBpmnProcessId());
-    final var isAuthorized = authCheckBehavior.isAuthorized(request);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            request, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       final String errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -149,9 +149,7 @@ public final class ProcessInstanceCreationCreateProcessor
                 command.getValue().getTenantId())
             .addResourceId(processId);
 
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            request, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(request);
     if (isAuthorized.isRight()) {
       return Either.right(deployedProcess);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -149,7 +149,9 @@ public final class ProcessInstanceCreationCreateProcessor
                 command.getValue().getTenantId())
             .addResourceId(processId);
 
-    final var isAuthorized = authCheckBehavior.isAuthorized(request);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            request, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (isAuthorized.isRight()) {
       return Either.right(deployedProcess);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -140,7 +140,11 @@ public class ProcessInstanceMigrationMigrateProcessor
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 processInstance.getValue().getTenantId())
             .addResourceId(processInstance.getValue().getBpmnProcessId());
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       final String errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -140,11 +140,7 @@ public class ProcessInstanceMigrationMigrateProcessor
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 processInstance.getValue().getTenantId())
             .addResourceId(processInstance.getValue().getBpmnProcessId());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       final String errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -201,7 +201,9 @@ public final class ProcessInstanceModificationModifyProcessor
                 PermissionType.MODIFY_PROCESS_INSTANCE,
                 processInstance.getValue().getTenantId())
             .addResourceId(processInstance.getValue().getBpmnProcessId());
-    final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       final String errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -201,9 +201,7 @@ public final class ProcessInstanceModificationModifyProcessor
                 PermissionType.MODIFY_PROCESS_INSTANCE,
                 processInstance.getValue().getTenantId())
             .addResourceId(processInstance.getValue().getBpmnProcessId());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       final String errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -448,10 +448,7 @@ public class ResourceDeletionDeleteProcessor
         new AuthorizationRequest(command, resourceType, permissionType, tenantId)
             .addResourceId(resourceId);
 
-    if (authCheckBehavior
-        .isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference())
-        .isLeft()) {
+    if (authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).isLeft()) {
       throw new ForbiddenException(authRequest);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -448,7 +448,10 @@ public class ResourceDeletionDeleteProcessor
         new AuthorizationRequest(command, resourceType, permissionType, tenantId)
             .addResourceId(resourceId);
 
-    if (authCheckBehavior.isAuthorized(authRequest).isLeft()) {
+    if (authCheckBehavior
+        .isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference())
+        .isLeft()) {
       throw new ForbiddenException(authRequest);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchProcessor.java
@@ -143,10 +143,7 @@ public class ResourceFetchProcessor implements TypedRecordProcessor<ResourceReco
                 PermissionType.READ,
                 resource.getTenantId())
             .addResourceId(BufferUtil.bufferAsString(resource.getResourceId()));
-    if (authorizationCheckBehavior
-        .isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference())
-        .isLeft()) {
+    if (authorizationCheckBehavior.isAuthorizedOrInternalCommand(authRequest).isLeft()) {
       throw new ForbiddenException(authRequest);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchProcessor.java
@@ -143,7 +143,10 @@ public class ResourceFetchProcessor implements TypedRecordProcessor<ResourceReco
                 PermissionType.READ,
                 resource.getTenantId())
             .addResourceId(BufferUtil.bufferAsString(resource.getResourceId()));
-    if (authorizationCheckBehavior.isAuthorized(authRequest).isLeft()) {
+    if (authorizationCheckBehavior
+        .isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference())
+        .isLeft()) {
       throw new ForbiddenException(authRequest);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -120,8 +120,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
             .addResourceId(subscriptionRecord.getBpmnProcessId());
 
     final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
+        authCheckBehavior.isAuthorized(authRequest);
     if (isAuthorized.isLeft()) {
       throw new ForbiddenException(authRequest);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -81,7 +81,11 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.UPDATE)
             .addResourceId(tenantId);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -81,11 +81,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.UPDATE)
             .addResourceId(tenantId);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
@@ -90,7 +90,11 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
   private boolean isAuthorizedToCreate(final TypedRecord<TenantRecord> command) {
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.CREATE);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
       return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
@@ -90,11 +90,7 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
   private boolean isAuthorizedToCreate(final TypedRecord<TenantRecord> command) {
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.CREATE);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
       return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -86,7 +86,11 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.DELETE)
             .addResourceId(persistedTenantRecord.get().getTenantId());
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -86,11 +86,7 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.DELETE)
             .addResourceId(persistedTenantRecord.get().getTenantId());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -77,7 +77,11 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.UPDATE)
             .addResourceId(tenantId);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -77,11 +77,7 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.UPDATE)
             .addResourceId(tenantId);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -89,7 +89,11 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.UPDATE)
             .addResourceId(persistedTenant.getTenantId());
-    final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authorizationRequest,
+            command.hasRequestMetadata(),
+            command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
       return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -89,11 +89,7 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.UPDATE)
             .addResourceId(persistedTenant.getTenantId());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authorizationRequest,
-            command.hasRequestMetadata(),
-            command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
       return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
@@ -104,19 +104,13 @@ public class UserCreateInitialAdminProcessor implements TypedRecordProcessor<Use
   private Either<String, Void> checkUserCreateAuthorization(final TypedRecord<UserRecord> command) {
     final var authRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.USER, PermissionType.CREATE);
-    return authCheckBehavior
-        .isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference())
-        .mapLeft(Rejection::reason);
+    return authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).mapLeft(Rejection::reason);
   }
 
   private Either<String, Void> checkRoleUpdateAuthorization(final TypedRecord<UserRecord> command) {
     final var authRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.UPDATE);
-    return authCheckBehavior
-        .isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference())
-        .mapLeft(Rejection::reason);
+    return authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).mapLeft(Rejection::reason);
   }
 
   private Either<String, Void> checkUserDoesNotExist(final String username) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
@@ -104,13 +104,19 @@ public class UserCreateInitialAdminProcessor implements TypedRecordProcessor<Use
   private Either<String, Void> checkUserCreateAuthorization(final TypedRecord<UserRecord> command) {
     final var authRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.USER, PermissionType.CREATE);
-    return authCheckBehavior.isAuthorized(authRequest).mapLeft(Rejection::reason);
+    return authCheckBehavior
+        .isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference())
+        .mapLeft(Rejection::reason);
   }
 
   private Either<String, Void> checkRoleUpdateAuthorization(final TypedRecord<UserRecord> command) {
     final var authRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.UPDATE);
-    return authCheckBehavior.isAuthorized(authRequest).mapLeft(Rejection::reason);
+    return authCheckBehavior
+        .isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference())
+        .mapLeft(Rejection::reason);
   }
 
   private Either<String, Void> checkUserDoesNotExist(final String username) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -65,9 +65,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
   public void processNewCommand(final TypedRecord<UserRecord> command) {
     final var authRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.USER, PermissionType.CREATE);
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -65,7 +65,9 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
   public void processNewCommand(final TypedRecord<UserRecord> command) {
     final var authRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.USER, PermissionType.CREATE);
-    final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -99,9 +99,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
     final var authRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.USER, PermissionType.DELETE)
             .addResourceId(user.getUsername());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -99,7 +99,9 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
     final var authRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.USER, PermissionType.DELETE)
             .addResourceId(user.getUsername());
-    final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -72,7 +72,9 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
     final var authRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.USER, PermissionType.UPDATE)
             .addResourceId(persistedUser.getUsername());
-    final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -72,9 +72,7 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
     final var authRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.USER, PermissionType.UPDATE)
             .addResourceId(persistedUser.getUsername());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
@@ -79,7 +79,9 @@ public class UserTaskCommandPreconditionChecker {
                 PermissionType.UPDATE_USER_TASK,
                 persistedRecord.getTenantId())
             .addResourceId(persistedRecord.getBpmnProcessId());
-    final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       return Either.left(isAuthorized.getLeft());
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
@@ -79,9 +79,7 @@ public class UserTaskCommandPreconditionChecker {
                 PermissionType.UPDATE_USER_TASK,
                 persistedRecord.getTenantId())
             .addResourceId(persistedRecord.getBpmnProcessId());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authRequest, command.hasRequestMetadata(), command.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
     if (isAuthorized.isLeft()) {
       return Either.left(isAuthorized.getLeft());
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -66,12 +66,12 @@ public final class VariableDocumentUpdateProcessor
       final MutableUserTaskState userTaskState,
       final AsyncRequestBehavior asyncRequestBehavior,
       final AuthorizationCheckBehavior authCheckBehavior) {
-    this.elementInstanceState = processingState.getElementInstanceState();
+    elementInstanceState = processingState.getElementInstanceState();
     this.userTaskState = userTaskState;
-    this.processState = processingState.getProcessState();
+    processState = processingState.getProcessState();
     this.keyGenerator = keyGenerator;
-    this.variableBehavior = bpmnBehaviors.variableBehavior();
-    this.jobBehavior = bpmnBehaviors.jobBehavior();
+    variableBehavior = bpmnBehaviors.variableBehavior();
+    jobBehavior = bpmnBehaviors.jobBehavior();
     this.writers = writers;
     this.asyncRequestBehavior = asyncRequestBehavior;
     this.authCheckBehavior = authCheckBehavior;
@@ -96,7 +96,9 @@ public final class VariableDocumentUpdateProcessor
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 scope.getValue().getTenantId())
             .addResourceId(scope.getValue().getBpmnProcessId());
-    final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
+    final var isAuthorized =
+        authCheckBehavior.isAuthorized(
+            authRequest, record.hasRequestMetadata(), record.getBatchOperationReference());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       final String errorMessage =
@@ -227,7 +229,7 @@ public final class VariableDocumentUpdateProcessor
     return !DocumentValue.EMPTY_DOCUMENT.equals(record.getVariablesBuffer());
   }
 
-  private static boolean isCamundaUserTask(ElementInstance elementInstance) {
+  private static boolean isCamundaUserTask(final ElementInstance elementInstance) {
     return elementInstance.getValue().getBpmnElementType() == BpmnElementType.USER_TASK
         && elementInstance.getUserTaskKey() > -1L;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -96,9 +96,7 @@ public final class VariableDocumentUpdateProcessor
                 PermissionType.UPDATE_PROCESS_INSTANCE,
                 scope.getValue().getTenantId())
             .addResourceId(scope.getValue().getBpmnProcessId());
-    final var isAuthorized =
-        authCheckBehavior.isAuthorized(
-            authRequest, record.hasRequestMetadata(), record.getBatchOperationReference());
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       final String errorMessage =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
@@ -87,6 +87,13 @@ public class AuthorizationArchTest {
         // The processor should directly check authorizations
         ArchConditions.callMethod(
                 AuthorizationCheckBehavior.class, "isAuthorized", AuthorizationRequest.class)
+            .or(
+                ArchConditions.callMethod(
+                    AuthorizationCheckBehavior.class,
+                    "isAuthorized",
+                    AuthorizationRequest.class,
+                    boolean.class,
+                    long.class))
             // Or the processor should have delegated authorization to the JobUpdateBehaviour
             .or(
                 ArchConditions.callMethod(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
@@ -90,10 +90,8 @@ public class AuthorizationArchTest {
             .or(
                 ArchConditions.callMethod(
                     AuthorizationCheckBehavior.class,
-                    "isAuthorized",
-                    AuthorizationRequest.class,
-                    boolean.class,
-                    long.class))
+                    "isAuthorizedOrInternalCommand",
+                    AuthorizationRequest.class))
             // Or the processor should have delegated authorization to the JobUpdateBehaviour
             .or(
                 ArchConditions.callMethod(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -372,7 +372,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType, null, false, false)
+        new AuthorizationRequest(command, resourceType, permissionType, null, false, false, false)
             .addResourceId(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -372,7 +372,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
 
     // when
     final var request =
-        new AuthorizationRequest(command, resourceType, permissionType, null, false, false, false)
+        new AuthorizationRequest(command, resourceType, permissionType, null, false, false)
             .addResourceId(resourceId);
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessorTest.java
@@ -61,7 +61,7 @@ class BatchOperationSuspendProcessorTest {
     when(state.getBatchOperationState()).thenReturn(batchOperationState);
 
     final var authCheckBehavior = mock(AuthorizationCheckBehavior.class);
-    when(authCheckBehavior.isAuthorized(any(AuthorizationRequest.class), anyBoolean(), anyLong()))
+    when(authCheckBehavior.isAuthorizedOrInternalCommand(any(AuthorizationRequest.class)))
         .thenReturn(Either.right(null));
 
     when(keyGenerator.nextKey()).thenReturn(1L);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessorTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.Batc
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -60,7 +61,7 @@ class BatchOperationSuspendProcessorTest {
     when(state.getBatchOperationState()).thenReturn(batchOperationState);
 
     final var authCheckBehavior = mock(AuthorizationCheckBehavior.class);
-    when(authCheckBehavior.isAuthorized(any(AuthorizationRequest.class)))
+    when(authCheckBehavior.isAuthorized(any(AuthorizationRequest.class), anyBoolean(), anyLong()))
         .thenReturn(Either.right(null));
 
     when(keyGenerator.nextKey()).thenReturn(1L);
@@ -93,7 +94,7 @@ class BatchOperationSuspendProcessorTest {
     when(batchOperationState.get(batchOperationKey)).thenReturn(Optional.of(batchOperation));
 
     // when
-    final var record = new MockTypedRecord<>(pauseKey, null, recordValue);
+    final var record = new MockTypedRecord<>(pauseKey, new RecordMetadata(), recordValue);
     processor.processNewCommand(record);
 
     // then

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -13,7 +13,6 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -96,8 +95,7 @@ public final class MessageStreamProcessorTest {
           final var processingState = processingContext.getProcessingState();
           final var scheduledTaskState = processingContext.getScheduledTaskStateFactory();
           final var mockAuthCheckBehavior = mock(AuthorizationCheckBehavior.class);
-          when(mockAuthCheckBehavior.isAuthorized(
-                  any(AuthorizationRequest.class), anyBoolean(), anyLong()))
+          when(mockAuthCheckBehavior.isAuthorizedOrInternalCommand(any(AuthorizationRequest.class)))
               .thenReturn(Either.right(null));
           MessageEventProcessors.addMessageProcessors(
               1,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -95,7 +96,8 @@ public final class MessageStreamProcessorTest {
           final var processingState = processingContext.getProcessingState();
           final var scheduledTaskState = processingContext.getScheduledTaskStateFactory();
           final var mockAuthCheckBehavior = mock(AuthorizationCheckBehavior.class);
-          when(mockAuthCheckBehavior.isAuthorized(any(AuthorizationRequest.class)))
+          when(mockAuthCheckBehavior.isAuthorized(
+                  any(AuthorizationRequest.class), anyBoolean(), anyLong()))
               .thenReturn(Either.right(null));
           MessageEventProcessors.addMessageProcessors(
               1,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
@@ -158,7 +158,7 @@ public class BroadcastSignalMultiplePartitionsTest {
     waitForSignalSubscriptions(signalName);
 
     // when
-    ENGINE.signal().withSignalName(signalName).broadcast(user.getUsername());
+    ENGINE.signal().withSignalName(signalName).broadcastWithMetadata(user.getUsername());
 
     // then (rejection on partition hosting unauthorized process)
     assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
@@ -9,99 +9,117 @@ package io.camunda.zeebe.engine.processing.signal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
 
+import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.client.SignalClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
-import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.IntStream;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class BroadcastSignalMultiplePartitionsTest {
 
-  public static final String PROCESS_ID = "process";
-  public static final int PARTITION_COUNT = 3;
-  @ClassRule public static final EngineRule ENGINE = EngineRule.multiplePartition(PARTITION_COUNT);
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
 
-  private static final String SIGNAL_NAME = "a";
+  private static final int PARTITION_COUNT = 3;
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.multiplePartition(PARTITION_COUNT)
+          .withIdentitySetup()
+          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg ->
+                  cfg.getInitialization()
+                      .getDefaultRoles()
+                      .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername()))));
+
+  private static final int LEADER_PARTITION = 1; // engine rule starts at 1
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
-  private final SignalClient signalClient = ENGINE.signal().withSignalName(SIGNAL_NAME);
-
   @Test
   public void shouldWriteDistributingRecordsForOtherPartitions() {
     // given
-    final var process =
-        Bpmn.createExecutableProcess(PROCESS_ID).startEvent().signal(SIGNAL_NAME).endEvent().done();
+    final String signalName = newRandomSignal();
+    final long deploymentKey =
+        deploySignalCatchingProcess(Strings.newRandomValidBpmnId(), signalName);
+    assertThat(deploymentKey).isPositive();
+    final SignalClient signalClient = ENGINE.signal().withSignalName(signalName);
+
     // when
-    ENGINE.deployment().withXmlResource(process).deploy();
+    final long signalKey = signalClient.broadcast(DEFAULT_USER.getUsername()).getKey();
 
     // then
-    final var signalKey = signalClient.broadcast().getKey();
-    final var commandDistributionRecords =
+    final Set<Integer> expectedTargets =
+        IntStream.rangeClosed(1, PARTITION_COUNT)
+            .filter(p -> p != LEADER_PARTITION)
+            .boxed()
+            .collect(java.util.stream.Collectors.toSet());
+
+    final var distribution =
         RecordingExporter.commandDistributionRecords()
             .withIntent(CommandDistributionIntent.DISTRIBUTING)
-            .valueFilter(v -> v.getValueType().equals(ValueType.SIGNAL))
-            .limit(2)
+            .valueFilter(v -> v.getValueType() == ValueType.SIGNAL)
+            .limit(expectedTargets.size())
             .asList();
 
-    assertThat(commandDistributionRecords).extracting(Record::getKey).containsOnly(signalKey);
-
-    assertThat(commandDistributionRecords)
-        .extracting(Record::getValue)
-        .extracting(CommandDistributionRecordValue::getPartitionId)
-        .containsExactly(2, 3);
+    assertThat(distribution).allMatch(r -> r.getKey() == signalKey);
+    assertThat(distribution)
+        .extracting(r -> r.getValue().getPartitionId())
+        .containsExactlyInAnyOrderElementsOf(expectedTargets);
   }
 
   @Test
   public void shouldTriggerMultipleSignalCatchEvent() {
     // given
-    final var process1 =
-        Bpmn.createExecutableProcess("wf_1")
-            .startEvent()
-            .intermediateCatchEvent("catch1")
-            .signal(SIGNAL_NAME)
-            .endEvent()
-            .done();
-    final var process2 =
-        Bpmn.createExecutableProcess("wf_2")
-            .startEvent()
-            .intermediateCatchEvent("catch2")
-            .signal(SIGNAL_NAME)
-            .endEvent()
-            .done();
+    final String signalName = newRandomSignal();
+    deployProcess("wf_1", "catch1", signalName);
+    deployProcess("wf_2", "catch2", signalName);
 
-    ENGINE.deployment().withXmlResource(process1).deploy();
-    ENGINE.deployment().withXmlResource(process2).deploy();
+    final long pi1 = createProcessInstance("wf_1");
+    final long pi2 = createProcessInstance("wf_2");
 
-    final var processInstanceKey1 = ENGINE.processInstance().ofBpmnProcessId("wf_1").create();
-    final var processInstanceKey2 = ENGINE.processInstance().ofBpmnProcessId("wf_2").create();
-
-    assertThat(
-            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
-                .withSignalName(SIGNAL_NAME)
-                .limit(2))
-        .extracting(record -> record.getValue().getCatchEventId())
-        .containsOnly("catch1", "catch2");
+    waitForSignalSubscriptions(signalName);
 
     // when
-    signalClient.broadcast();
+    ENGINE.signal().withSignalName(signalName).broadcast(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
             RecordingExporter.processInstanceRecords()
-                .withProcessInstanceKey(processInstanceKey1)
+                .withProcessInstanceKey(pi1)
                 .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
         .containsSubsequence(
@@ -112,7 +130,7 @@ public class BroadcastSignalMultiplePartitionsTest {
 
     assertThat(
             RecordingExporter.processInstanceRecords()
-                .withProcessInstanceKey(processInstanceKey2)
+                .withProcessInstanceKey(pi2)
                 .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
         .containsSubsequence(
@@ -120,5 +138,118 @@ public class BroadcastSignalMultiplePartitionsTest {
             tuple("catch2", ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple("wf_2", ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple("wf_2", ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldAuthorizeOnAllPartitions() {
+    // given
+    final String signalName = newRandomSignal();
+    final String processId = Strings.newRandomValidBpmnId();
+    final String otherProcessId = Strings.newRandomValidBpmnId();
+    deployProcess(processId, "catch_main", signalName);
+    deployProcess(otherProcessId, "catch_other", signalName);
+
+    createProcessInstance(processId, 1);
+    createProcessInstance(otherProcessId, 2);
+
+    final UserRecordValue user = createUser();
+    grantProcessPermission(user.getUsername(), processId);
+
+    waitForSignalSubscriptions(signalName);
+
+    // when
+    ENGINE.signal().withSignalName(signalName).broadcast(user.getUsername());
+
+    // then (rejection on partition hosting unauthorized process)
+    assertThat(
+            RecordingExporter.signalRecords(SignalIntent.BROADCAST)
+                .withSignalName(signalName)
+                .withPartitionId(2)
+                .withRecordType(RecordType.COMMAND_REJECTION)
+                .withRejectionReason(
+                    "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
+                        .formatted(otherProcessId))
+                .exists())
+        .isTrue();
+  }
+
+  // --- helpers -------------------------------------------------------------------------------
+
+  private static String newRandomSignal() {
+    return "sig_" + UUID.randomUUID();
+  }
+
+  private static long deploySignalCatchingProcess(final String bpmnId, final String signalName) {
+    return ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(bpmnId).startEvent().signal(signalName).endEvent().done())
+        .deploy(DEFAULT_USER.getUsername())
+        .getKey();
+  }
+
+  private static void deployProcess(
+      final String processId, final String catchId, final String signalName) {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .intermediateCatchEvent(catchId)
+                .signal(signalName)
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private static long createProcessInstance(final String processId) {
+    return ENGINE.processInstance().ofBpmnProcessId(processId).create(DEFAULT_USER.getUsername());
+  }
+
+  private static void createProcessInstance(final String processId, final int partition) {
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .onPartition(partition)
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  private static UserRecordValue createUser() {
+    return ENGINE
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create(DEFAULT_USER.getUsername())
+        .getValue();
+  }
+
+  private static void grantProcessPermission(final String username, final String processId) {
+    ENGINE
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
+        .withOwnerId(username)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(processId)
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  private static void waitForSignalSubscriptions(final String signalName) {
+    await("signal subscriptions created for " + signalName)
+        .pollInterval(Duration.ofMillis(10))
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        RecordingExporter.signalSubscriptionRecords(
+                                SignalSubscriptionIntent.CREATED)
+                            .withSignalName(signalName)
+                            .limit(2)
+                            .count())
+                    .isEqualTo(2));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -292,6 +292,25 @@ public class StreamProcessingComposite implements CommandWriter {
 
   @Override
   public long writeCommand(
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnifiedRecordValue recordValue,
+      final String... authorizedTenants) {
+    final var writer =
+        streams
+            .newRecord(getLogName(partitionId))
+            .recordType(RecordType.COMMAND)
+            .requestStreamId(requestStreamId)
+            .requestId(requestId)
+            .intent(intent)
+            .authorizations(authorizedTenants)
+            .event(recordValue);
+    return writeActor.submit(writer::write).join();
+  }
+
+  @Override
+  public long writeCommand(
       final long key,
       final int requestStreamId,
       final long requestId,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -286,6 +286,17 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
 
   @Override
   public long writeCommand(
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnifiedRecordValue recordValue,
+      final String... authorizedTenants) {
+    return streamProcessingComposite.writeCommand(
+        requestStreamId, requestId, intent, recordValue, authorizedTenants);
+  }
+
+  @Override
+  public long writeCommand(
       final long key,
       final int requestStreamId,
       final long requestId,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
@@ -53,6 +53,13 @@ public interface CommandWriter {
       final String... authorizedTenants);
 
   long writeCommand(
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnifiedRecordValue recordValue,
+      final String... authorizedTenants);
+
+  long writeCommand(
       final long key,
       final int requestStreamId,
       final long requestId,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/SignalClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/SignalClient.java
@@ -85,4 +85,9 @@ public class SignalClient {
     final long position = writer.writeCommand(SignalIntent.BROADCAST, username, signalRecord);
     return expectation.apply(position);
   }
+
+  public Record<SignalRecordValue> broadcastWithMetadata(final String username) {
+    final long position = writer.writeCommand(1, 1, SignalIntent.BROADCAST, signalRecord, username);
+    return expectation.apply(position);
+  }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -107,7 +107,8 @@ public class AuthInfo extends UnpackedObject {
 
   public enum AuthDataFormat {
     UNKNOWN((short) 0),
-    JWT((short) 1);
+    JWT((short) 1),
+    PRE_AUTHORIZED((short) 2);
 
     public final short id;
 


### PR DESCRIPTION
## Description

This PR enforce authorizations checks also on distributed commands in `SignalBroadcastProcessor`. The processor can differentiate between different types of command:

- if the command is external (e.g coming from outside the engine), the auth check are enforced on the primary partition and on all the others partitions 
- if the command is internal, the authorization checks are skipped

To achieve the last point we introduced a new `AuthInfo` format `PRE_AUTHORIZED` that allow the processor to easily distinguish external distributed commands from internal distributed command

closes #39430