### PR TITLE
[Backport stable/8.6] test: add VersionCheck test for SNAPSHOT versions

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/VersionCompatibilityCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/VersionCompatibilityCheckTest.java
@@ -93,6 +93,11 @@ final class VersionCompatibilityCheckTest {
 
   @Nested
   final class CompatibleResults {
+    @Test
+    void shouldAcceptSnapshotUpgrades() {
+      assertThat(check("8.0.0-SNAPSHOT", "8.0.0-SNAPSHOT"))
+          .isInstanceOf(Compatible.SameVersion.class);
+    }
 
     @Test
     void shouldAcceptPatchUpgrades() {


### PR DESCRIPTION
# Description
Backport of #39458 to `stable/8.6`.

relates to 