### PR TITLE
Increase Timeouts For Slow Test Behaviour

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
@@ -171,7 +171,7 @@ test.describe('variables page', () => {
     await taskPanelPage.openTask('usertask_with_variables');
 
     await expect(taskDetailsPage.addVariableButton).toBeHidden();
-    await expect(taskDetailsPage.assignToMeButton).toBeVisible({timeout: 30000});
+    await expect(taskDetailsPage.assignToMeButton).toBeVisible({timeout: 60000});
     await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
     await taskDetailsPage.clickAssignToMeButton();
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
@@ -171,7 +171,7 @@ test.describe('variables page', () => {
     await taskPanelPage.openTask('usertask_with_variables');
 
     await expect(taskDetailsPage.addVariableButton).toBeHidden();
-    await expect(taskDetailsPage.assignToMeButton).toBeVisible();
+    await expect(taskDetailsPage.assignToMeButton).toBeVisible({timeout: 30000});
     await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
     await taskDetailsPage.clickAssignToMeButton();
 
@@ -193,7 +193,7 @@ test.describe('variables page', () => {
     await taskPanelPage.filterBy('Completed');
     await taskPanelPage.openTask('usertask_with_variables');
 
-    await expect(page.getByText('newVariableName')).toBeVisible({timeout: 30000});
+    await expect(page.getByText('newVariableName')).toBeVisible({timeout: 60000});
     await expect(page.getByText('newVariableValue')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In order to mitigate a test failing on the nightly run due to slow test behaviour, timeouts have been increased.

Successful test run [here](https://github.com/camunda/camunda/actions/runs/18492662845).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
