### PR TITLE
Decouple Load tests of Camunda Platform Helm chart

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -1,33 +1,36 @@
-# description: This step for helm install deploys a camunda cluster in zeebe-io with additional tools for benchmarking. We use this worklow to start weekly medic benchmarks. The health of the cluster and results of the benchmarks are monitored by the zeebe team regularly. https://grafana.dev.zeebe.io/login
+# description: This step for helm install deploys a camunda cluster in zeebe-io with additional tools for load testing.
+# We use this worklow to start weekly medic load tests.
+# The health of the cluster and results of the load tests are monitored by Core team's regularly.
+# https://grafana.dev.zeebe.io/login
 # called by: zeebe-medic-benchmarks.yml, zeebe-pr-benchmark.yaml
 # type: CI
 # owner: @camunda/core-features
-name: Zeebe Benchmark
+name: Camunda load test
 on:
   workflow_dispatch:
     inputs:
       name:
-        description: 'Specifies the name of the benchmark'
+        description: 'Specifies the name of the load test'
         required: true
       reuse-tag:
-        description: 'Docker image tag, that should be reused for benchmark. Allows to skip the docker image build step'
+        description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
         type: string
         default: ""
         required: false
       ref:
-        description: 'Specifies the ref (e.g. main or a commit sha) to benchmark'
+        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
         default: 'main'
         required: false
       cluster:
-        description: 'Specifies which cluster to deploy the benchmark on'
+        description: 'Specifies which cluster to deploy the load test on'
         default: 'zeebe-cluster'
         required: false
       cluster-region:
         description: 'Specifies the cluster region. Needed to retrieve cluster credentials'
         default: europe-west1-b
         required: false
-      benchmark-load:
-        description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitrary helm arguments, like --set starter.rate=100'
+      load-test-load:
+        description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
       stable-vms:
         description: 'Deploy to non-spot VMs'
@@ -35,33 +38,33 @@ on:
         required: false
         default: false
       operate-tag:
-        description: 'Specifies the tag of operate, when Operate should be included in the Benchmark'
+        description: 'Specifies the tag of operate, when Operate should be included in the load test'
         type: string
         default: ""
         required: false
       realistic:
-        description: 'Should run a realistic benchmark, with real-world process and load'
+        description: 'Should run a realistic load test, with real-world process and load'
         type: boolean
         required: false
         default: false
   workflow_call:
     inputs:
       name:
-        description: 'Specifies the name of the benchmark'
+        description: 'Specifies the name of the load test'
         type: string
         required: true
       reuse-tag:
-        description: 'Docker image tag, that should be reused for benchmark. Allows to skip the docker image build step'
+        description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
         type: string
         default: ""
         required: false
       ref:
-        description: 'Specifies the ref (e.g. main or a commit sha) to benchmark'
+        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
         default: 'main'
         type: string
         required: false
       cluster:
-        description: 'Specifies which cluster to deploy the benchmark on'
+        description: 'Specifies which cluster to deploy the load test on'
         default: 'zeebe-cluster'
         type: string
         required: false
@@ -70,8 +73,8 @@ on:
         default: europe-west1-b
         type: string
         required: false
-      benchmark-load:
-        description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitrary helm arguments, like --set starter.rate=100'
+      load-test-load:
+        description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         type: string
         required: false
       publish:
@@ -85,12 +88,12 @@ on:
         required: false
         default: false
       operate-tag:
-        description: 'Specifies the tag of operate, when Operate should be included in the Benchmark'
+        description: 'Specifies the tag of operate, when Operate should be included in the load test'
         type: string
         default: ""
         required: false
       realistic:
-        description: 'Should run a realistic benchmark, with real-world process and load'
+        description: 'Should run a realistic load test, with real-world process and load'
         type: boolean
         required: false
         default: false
@@ -172,7 +175,7 @@ jobs:
           distball: ${{ steps.build-zeebe.outputs.distball }}
           dockerfile: 'camunda.Dockerfile'
 
-  build-benchmark-images:
+  build-load-test-images:
     name: Build Starter and Worker
     if: ${{ inputs.reuse-tag == '' }}
     runs-on: ubuntu-latest
@@ -210,18 +213,18 @@ jobs:
       - name: Build Worker Image
         run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="gcr.io/zeebe-io/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
 
-  deploy-benchmark-cluster:
+  deploy-test-cluster:
     name: Deploy
     needs:
       - calculate-image-tag
       - build-zeebe-image
-      - build-benchmark-images
-    # To have the possibility to re-deploy the benchmarks without rebuilding the images,
+      - build-load-test-images
+    # To have the possibility to re-deploy the tests without rebuilding the images,
     # the deploy will be run, when build is skipped or successful.
     if: |
       always() &&
       (needs.build-zeebe-image.result == 'success' || needs.build-zeebe-image.result == 'skipped') &&
-      (needs.build-benchmark-images.result == 'success' || needs.build-benchmark-images.result == 'skipped')
+      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -271,8 +274,8 @@ jobs:
           --set camunda-platform.zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && '-f load-tests/setup/default/values-stable.yaml' || '' }}
-          ${{ inputs.realistic && '-f https://raw.githubusercontent.com/zeebe-io/benchmark-helm/main/charts/zeebe-benchmark/values-realistic-benchmark.yaml' || '' }}
-          ${{ inputs.benchmark-load }}
+          ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }}
+          ${{ inputs.load-test-load }}
       - name: Label namespace
         run: >
             kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite
@@ -280,7 +283,7 @@ jobs:
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Benchmark \`${{ inputs.name }}\` values
+            ## Load test \`${{ inputs.name }}\` values
             \`\`\`yaml
             $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
             \`\`\`

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -297,6 +297,8 @@ jobs:
   deploy-load-test:
     name: Deploy
     needs:
+      # We need to depend on calculate-image-tag, so that we can use the output in the job
+      - calculate-image-tag
       - deploy-cluster-under-test
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -343,6 +343,6 @@ jobs:
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
             ## Load test \`${{ inputs.name }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            $(helm get values ${{ inputs.name }}-test -n ${{ inputs.name }})
             \`\`\`
           EOF

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -112,8 +112,8 @@ jobs:
         run: |
           echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-  build-zeebe-image:
-    name: Build Zeebe
+  build-camunda-image:
+    name: Build Camunda
     needs: calculate-image-tag
     if: ${{ inputs.reuse-tag == '' }}
     runs-on: ubuntu-latest
@@ -149,8 +149,8 @@ jobs:
         with:
           directory: ./identity/client
       - uses: ./.github/actions/build-zeebe
-        name: Build Zeebe
-        id: build-zeebe
+        name: Build Camunda Platform
+        id: build-camunda
         with:
           maven-extra-args: -PskipFrontendBuild -P\!include-optimize -Dmaven.test.skip=true
       - uses: google-github-actions/auth@v2
@@ -172,7 +172,7 @@ jobs:
           revision: ${{ inputs.ref }}
           push: true
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}
-          distball: ${{ steps.build-zeebe.outputs.distball }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
           dockerfile: 'camunda.Dockerfile'
 
   build-load-test-images:
@@ -217,13 +217,13 @@ jobs:
     name: Deploy
     needs:
       - calculate-image-tag
-      - build-zeebe-image
+      - build-camunda-image
       - build-load-test-images
     # To have the possibility to re-deploy the tests without rebuilding the images,
     # the deploy will be run, when build is skipped or successful.
     if: |
       always() &&
-      (needs.build-zeebe-image.result == 'success' || needs.build-zeebe-image.result == 'skipped') &&
+      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
       (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -218,7 +218,7 @@ jobs:
         run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="gcr.io/zeebe-io/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
 
   deploy-cluster-under-test:
-    name: Deploy
+    name: Deploy cluster under test
     needs:
       - calculate-image-tag
       - build-camunda-image
@@ -295,7 +295,7 @@ jobs:
           EOF
 
   deploy-load-test:
-    name: Deploy
+    name: Deploy load test
     needs:
       # We need to depend on calculate-image-tag, so that we can use the output in the job
       - calculate-image-tag

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -97,6 +97,10 @@ on:
         type: boolean
         required: false
         default: false
+
+env:
+  HELM_CHART: camunda-platform-8.8
+
 jobs:
   calculate-image-tag:
     name: Calculate Image Tag
@@ -213,7 +217,7 @@ jobs:
       - name: Build Worker Image
         run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="gcr.io/zeebe-io/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
 
-  deploy-test-cluster:
+  deploy-cluster-under-test:
     name: Deploy
     needs:
       - calculate-image-tag
@@ -233,7 +237,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          repository: 'camunda/camunda-platform-helm'
+          ref: 'main'
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
@@ -242,18 +247,19 @@ jobs:
         with:
           cluster_name: ${{ inputs.cluster }}
           location: ${{ inputs.cluster-region }}
-      - name: Add camunda helm repo
+      - name: Add Camunda Helm repo
         run: |
-          helm repo add zeebe-benchmark https://camunda.github.io/zeebe-benchmark-helm
+          helm repo add camunda https://helm.camunda.io/
           helm repo update
-
       - name: Find previous Helm chart release version
         id: find-chart-release
         run: |
           echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }} | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
-      - name: Helm install
+      - name: Build dependencies of Camunda Platform
+        run: helm dependency build charts/${{ env.HELM_CHART }}/
+      - name: Install latest Camunda Platform
         run: >
-          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 35m0s
+          helm upgrade --install ${{ inputs.name }} charts/${{ env.HELM_CHART }}/ --wait --timeout 35m0s
           --namespace ${{ inputs.name }}
           --create-namespace
           --reuse-values
@@ -272,13 +278,63 @@ jobs:
           --set camunda-platform.zeebe-gateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set camunda-platform.zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          -f load-tests/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && '-f load-tests/setup/default/values-stable.yaml' || '' }}
-          ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }}
-          ${{ inputs.load-test-load }}
       - name: Label namespace
         run: >
             kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite
+      - name: Summarize deployment
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Camunda platform \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            \`\`\`
+          EOF
+
+  deploy-load-test:
+    name: Deploy
+    needs:
+      - deploy-cluster-under-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v2.3.4
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Add Load test Helm repo
+        run: |
+          helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/
+          helm repo update
+      - name: Find previous Helm chart release version
+        id: find-chart-release
+        run: |
+          echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }}-test | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
+      - name: Install load test
+        run: >
+          helm upgrade --install ${{ inputs.name }}-test camunda-load-tests/camunda-load-tests
+          --wait --timeout 35m0s
+          --namespace ${{ inputs.name }}
+          --create-namespace
+          --reuse-values
+          --render-subchart-notes
+          --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
+          ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }}
+          ${{ inputs.load-test-load }}
       - name: Summarize deployment
         if: success()
         run: |

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -290,6 +290,14 @@ jobs:
       # We need to depend on calculate-image-tag, so that we can use the output in the job
       - calculate-image-tag
       - deploy-cluster-under-test
+      - build-camunda-image
+      - build-load-test-images
+      # To have the possibility to re-deploy the tests without rebuilding the images,
+      # the deploy will be run, when build is skipped or successful.
+    if: |
+      always() &&
+      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
+      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -1,4 +1,4 @@
-# description: This step for helm install deploys a camunda cluster in zeebe-io with additional tools for load testing.
+# description: This workflow deploys a load test with a camunda cluster under test.
 # We use this worklow to start weekly medic load tests.
 # The health of the cluster and results of the load tests are monitored by Core team's regularly.
 # https://grafana.dev.zeebe.io/login

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -278,7 +278,7 @@ jobs:
           --set camunda-platform.zeebe-gateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set camunda-platform.zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          -f load-tests/camunda-platform-values.yaml
+          -f https://raw.githubusercontent.com/camunda/camunda/refs/heads/${{ inputs.ref }}/load-tests/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && '-f load-tests/setup/default/values-stable.yaml' || '' }}
       - name: Label namespace

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -265,19 +265,9 @@ jobs:
           --reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set camunda-platform.orchestration.image.registry=gcr.io
-          --set camunda-platform.orchestration.image.repository=zeebe-io/zeebe
-          --set camunda-platform.orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          # Keep this for compatibility with older versions of the benchmark chart
-          --set camunda-platform.core.image.registry=gcr.io
-          --set camunda-platform.core.image.repository=zeebe-io/zeebe
-          --set camunda-platform.core.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe
-          --set camunda-platform.zeebe.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set camunda-platform.zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe
-          --set camunda-platform.zeebe-gateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set camunda-platform.zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
-          --set camunda-platform.zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set orchestration.image.registry=gcr.io
+          --set orchestration.image.repository=zeebe-io/zeebe
+          --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           -f https://raw.githubusercontent.com/camunda/camunda/refs/heads/${{ inputs.ref }}/load-tests/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && '-f load-tests/setup/default/values-stable.yaml' || '' }}

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -106,8 +106,7 @@ jobs:
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
-      benchmark-load: >
-        -f https://raw.githubusercontent.com/camunda/zeebe-benchmark-helm/refs/heads/main/charts/zeebe-benchmark/values-realistic-benchmark.yaml
+      realistic: 'true'
   setup-latency-benchmark:
     name: Latency Benchmark
     uses: ./.github/workflows/camunda-load-test.yml
@@ -121,7 +120,7 @@ jobs:
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
-      benchmark-load: >
+      load-test-load: >
         --set starter.rate=1
         --set workers.worker.replicas=1
 

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -84,7 +84,7 @@ jobs:
     needs:
       - benchmark-data
       - delete-old-benchmarks
-    uses: ./.github/workflows/zeebe-benchmark.yml
+    uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}
@@ -95,7 +95,7 @@ jobs:
       publish: "slack"
   setup-mixed-benchmark:
     name: Mixed Benchmark
-    uses: ./.github/workflows/zeebe-benchmark.yml
+    uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     needs:
       - benchmark-data
@@ -110,7 +110,7 @@ jobs:
         -f https://raw.githubusercontent.com/camunda/zeebe-benchmark-helm/refs/heads/main/charts/zeebe-benchmark/values-realistic-benchmark.yaml
   setup-latency-benchmark:
     name: Latency Benchmark
-    uses: ./.github/workflows/zeebe-benchmark.yml
+    uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     needs:
       - benchmark-data

--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -16,7 +16,7 @@ jobs:
     if: >
       (github.event.action == 'labeled' && github.event.label.name == 'benchmark') ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
-    uses: ./.github/workflows/zeebe-benchmark.yml
+    uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
       name: ${{github.event.pull_request.head.ref}}-benchmark

--- a/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
+++ b/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Update Long Running Migrating Benchmark with mixed load
     needs:
       - fetch-release
-    uses: ./.github/workflows/zeebe-benchmark.yml
+    uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
       name: release-rolling

--- a/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
+++ b/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
@@ -30,7 +30,7 @@ jobs:
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: refs/tags/${{ needs.fetch-release.outputs.release-tag }}
-      benchmark-load: >
+      load-test-load: >
         --set starter.rate=5
         --set worker.replicas=1
         --set timer.replicas=1

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -1,0 +1,223 @@
+# Values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This file is used to override the default values of the chart.
+# The values are optimized for running the load tests with a Camunda cluster on GKE.
+#
+# This is a YAML-formatted file.
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  # Disable global ingress
+  ingress:
+    enabled: false
+  image:
+    # Image.repository defines the repository from which to fetch the docker images
+    repository: "gcr.io/zeebe-io"
+    # Image.tag defines the tag / version which should be used in the chart
+    tag: SNAPSHOT
+    ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+    pullPolicy: Always
+    ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets: []
+  # By default, we run without Identity
+  identity:
+    auth:
+      enabled: false
+
+identity:
+  enabled: false
+
+identityKeycloak:
+  enabled: false
+
+optimize:
+  enabled: false
+
+connectors:
+  enabled: false
+
+webModeler:
+  enabled: false
+
+postgresql:
+  enabled: false
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  security:
+    authentication:
+      unprotectedApi: true
+    authorizations:
+      enabled: false
+  # For simplicity of the deployment, we override the names to camunda
+  # This means we will have pods like: camunda-0, camunda-1, camunda-2
+  fullnameOverride: camunda
+  image:
+    tag: "SNAPSHOT"
+  ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
+  clusterSize: "3"
+  ## @param core.partitionCount defines how many partitions are set up in the cluster
+  partitionCount: "3"
+  ## @param core.replicationFactor defines how each partition is replicated, the value defines the number of nodes
+  replicationFactor: "3"
+  ## @param core.cpuThreadCount defines how many threads can be used for the processing on each broker pod
+  cpuThreadCount: "3"
+  ## @param core.ioThreadCount defines how many threads can be used for the exporting on each broker pod
+  ioThreadCount: "3"
+  # Resources of the orchestration cluster
+  resources:
+    requests:
+      cpu: 2000m
+      memory: 2Gi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+
+  nodeSelector:
+    cloud.google.com/gke-nodepool: n2-standard-4
+
+  ## @param core.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+  pvcSize: "64Gi"
+  ## @param core.pvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim.
+  # It is recommended to use a storage class, which is backed with a SSD. Set to "-" to disable use of default storage class.
+  pvcStorageClassName: "ssd"
+  # @extra core.containerSecurityContext defines the security options the container should be run with
+  containerSecurityContext:
+    ## @param core.containerSecurityContext.allowPrivilegeEscalation
+    allowPrivilegeEscalation: true
+    ## @param core.containerSecurityContext.privileged
+    privileged: true
+    ## @param core.containerSecurityContext.runAsNonRoot
+    runAsNonRoot: true
+    ## @param core.containerSecurityContext.runAsUser
+    runAsUser: 1000
+    capabilities:
+      add: ["NET_ADMIN"]
+  javaOpts: >-
+    -XX:MaxRAMPercentage=25.0
+    -XX:+ExitOnOutOfMemoryError
+    -XX:+HeapDumpOnOutOfMemoryError
+    -XX:HeapDumpPath=/usr/local/camunda/data
+    -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log
+    -XX:NativeMemoryTracking=summary
+    -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M
+
+  # We set extra configuration to configure additional settings for Broker and Gateway, that are part
+  # of the orchestration cluster.
+  # This allows adding configurations without the need of overwriting all environment variables from the Platform chart.
+  extraConfiguration:
+    application.yml: |
+      zeebe.gateway.monitoring.enabled: "true"
+      zeebe.gateway.threads.managementThreads: "1"
+      zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+      zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+      zeebe.broker.executionMetricsExporterEnabled: "true"
+      zeebe.broker.data.disk.freeSpace.processing: "3GB"
+      zeebe.broker.data.disk.freeSpace.replication: "2GB"
+      # Configure index suffix with hour pattern, so we create every hour a new index
+      # such that ILM can clean it up quickly
+      # We need to configure it for the ES exporter AND the CamundaExporter
+      zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat: "yyyy-MM-dd-HH"
+      zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval: "1h"
+      zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+      zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+      # We moved the archiver configuration under retention at some point, but still need to support the previous
+      # versions for now, so the configurations for retention are duplicated
+      zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
+      # 0s causes ILM to move data asap - it is normally the default
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
+      zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge: "70m"
+      zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
+      # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+      zeebe.broker.flowControl.write.enabled: "true"
+      zeebe.broker.flowControl.write.limit: 4000
+      zeebe.broker.flowControl.write.throttling.enabled: "true"
+      # Disable the importers
+      camunda.tasklist.importerEnabled: "false"
+      camunda.operate.importerEnabled: "false"
+      camunda.operate.elasticsearch.numberOfShards: 3
+      # Schema management has been moved out of exporter - to be bootstrap at start; once
+      camunda.database.retention.enabled: "true"
+      # 0s causes ILM to move data asap - it is normally the default
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
+      camunda.database.retention.minimumAge: "70m"
+      camunda.database.retention.policyName: "camunda-retention-policy"
+      #Metrics:
+      camunda.flags.jfr.metrics: "true"
+      # RocksDB memory limit setting, limits the overall RocksDB memory usage
+      # ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYLIMIT
+      zeebe.broker.experimental.rocksdb.memoryLimit: "64MB"
+
+  # Zeebe config
+  extraVolumes:
+    - name: logs
+      emptyDir: {}
+  ## @param core.extraVolumeMounts can be used to mount extra volumes for the broker pods, useful for additional exporters
+  extraVolumeMounts:
+    - name: logs
+      mountPath: /usr/local/camunda/logs
+  history:
+    retention:
+      ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.
+      enabled: true
+      ## @param core.history.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
+      minimumAge: 70m
+  # @param core.env can be used to set extra environment variables in each broker container
+  env:
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      value: "/usr/local/camunda/config/application.yml"
+
+# Change these settings to configure a different way to collect metrics
+prometheusServiceMonitor:
+  enabled: true
+  labels:
+    release: monitoring
+  scrapeInterval: 30s
+
+########################################################################################
+################################################### Elasticsearch cluster configuration
+########################################################################################
+elasticsearch:
+  master:
+    fullnameOverride: elastic
+    nameOverride: elastic
+    ## @param elasticsearch.master.replicaCount defines number of master-elegible replicas to deploy
+    replicaCount: 3
+    pdb:
+      minAvailable: 2
+    ## @param elasticsearch.master.heapSize
+    heapSize: 3g
+    persistence:
+      ## @param elasticsearch.master.persistence.size
+      size: 128Gi
+      storageClass: "ssd"
+      accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        cpu: 1
+        memory: 3Gi
+      limits:
+        cpu: 2
+        memory: 6Gi
+  extraConfig:
+    logger.org.elasticsearch.deprecation: "OFF"

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -214,10 +214,10 @@ elasticsearch:
       accessModes: ["ReadWriteOnce"]
     resources:
       requests:
-        cpu: 1
+        cpu: 3
         memory: 3Gi
       limits:
-        cpu: 2
+        cpu: 3
         memory: 6Gi
   extraConfig:
     logger.org.elasticsearch.deprecation: "OFF"


### PR DESCRIPTION
## Description


> The current benchmark Helm charts https://github.com/camunda/zeebe-benchmark-helm (used for load tests) have a significant issue. 
> 
> We always depend on an older released version of the charts. This means we are not testing the real release artifact; we use snapshot or weekly images, but older configurations from the charts.
> 
> In the past, this caused several issues:
> 
> 1. We had to fix configuration issues in the Platform charts and load test charts (we sometimes missed one part)
> 2. We updated the load tests after an alpha release, and ran into new issues (found new bugs)
> 
> Generally, we have a long feedback loop/cycle, which we can do better. 

To overcome this (and other issues like [this](https://github.com/camunda/camunda/issues/38829)), we wanted to decouple the load tests and the cluster creation/installation. 

## What this PR does

 * 🔧 To decouple our load tests from the platform chart, we will install the Camunda
   platform chart separately
   * To do this, we added a values file that configures the platform so we can make use of it
     for our load tests
       * Ideally, the default values would be enough, but this is not the case right now
       * Values are based on the previous benchmark chart, see
      https://github.com/camunda/zeebe-benchmark-helm/blob/49a219f30295fedb047262805d6b49640d143b75/charts/zeebe-benchmark/values.yaml#L1
  * 🧹 Rename to Camunda load test, rename all occurrences of benchmark
  * 🧹 Rename jobs to mention Camunda and not Zeebe
  * 🔧 Decoupling of installation
     * Separate the installation of the Platform and Load test helm chart
     * First, install the cluster under test with the platform helm chart
       We check out the Helm chart repository and take the version from main
       to always be up to date.
       * ☝🏼 Note: we need to update this soon to 8.9 chart
     * We reference the previously added values file, which contains the necessary
       values to be used for such load tests
     * Afterwards, we install the load test chart from the new Helm chart
  * 🔧 We allow to skip building docker images, and can run load tests with pre-built images


<img width="1992" height="514" alt="2025-10-14_13-59" src="https://github.com/user-attachments/assets/dbac6e96-154b-41cb-98d0-0b70570dc94a" />


<img width="1881" height="830" alt="2025-10-14_16-14" src="https://github.com/user-attachments/assets/250e49ab-a0ca-48c1-a0fd-76a0b3b5749e" />

<!-- Describe the goal and purpose of this PR. -->

## Related issues

closes https://github.com/camunda/camunda/issues/39376
closes https://github.com/camunda/camunda/issues/37279

