### PR TITLE
fix: publicAccess extraction empty property npe

### DIFF
--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/modelreader/ProcessModelReader.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/modelreader/ProcessModelReader.java
@@ -87,7 +87,7 @@ public final class ProcessModelReader {
 
   private boolean isPublic(final ZeebeProperties properties) {
     return properties.getProperties().stream()
-        .filter(zp -> zp.getName().equals(PUBLIC_ACCESS))
+        .filter(zp -> PUBLIC_ACCESS.equals(zp.getName()))
         .findFirst()
         .map(zp -> Boolean.parseBoolean(zp.getValue()))
         .orElse(false);

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/modelreader/ProcessModelReaderTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/modelreader/ProcessModelReaderTest.java
@@ -256,6 +256,30 @@ public class ProcessModelReaderTest {
                 .isTrue());
   }
 
+  @Test
+  void shouldIgnoreEmptyProperty() throws IOException {
+    final String processId = "test-empty-property";
+    final var bpmnBytes = parseBpmnResourceXml("process-with-empty-property.bpmn");
+
+    final var reader = ProcessModelReader.of(bpmnBytes, processId);
+    assertThat(reader).isPresent();
+    final var isPublic = reader.get().extractIsPublicAccess();
+
+    assertThat(isPublic).isTrue();
+  }
+
+  @Test
+  void shouldIgnoreEmptyPropertyAndEmptyValue() throws IOException {
+    final String processId = "test-empty-property";
+    final var bpmnBytes = parseBpmnResourceXml("process-with-empty-public-value.bpmn");
+
+    final var reader = ProcessModelReader.of(bpmnBytes, processId);
+    assertThat(reader).isPresent();
+    final var isPublic = reader.get().extractIsPublicAccess();
+
+    assertThat(isPublic).isFalse();
+  }
+
   private String formOneJson() {
     return """
 {

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/modelreader/ProcessModelReaderTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/modelreader/ProcessModelReaderTest.java
@@ -257,7 +257,7 @@ public class ProcessModelReaderTest {
   }
 
   @Test
-  void shouldIgnoreEmptyProperty() throws IOException {
+  void shouldIgnoreEmptyPropertyWhenParsingPublicAccess() throws IOException {
     final String processId = "test-empty-property";
     final var bpmnBytes = parseBpmnResourceXml("process-with-empty-property.bpmn");
 

--- a/zeebe/util/src/test/resources/process/process-with-empty-property.bpmn
+++ b/zeebe/util/src/test/resources/process/process-with-empty-property.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0" camunda:diagramRelationId="92e4fb3e-b191-483d-a3ca-05319ee1c5eb">
+  <bpmn:process id="test-empty-property" name="empty-property" isExecutable="true">
+    <bpmn:sequenceFlow id="Flow_0p86gom" sourceRef="StartEvent_1" targetRef="Event_04tx5i8" />
+    <bpmn:endEvent id="Event_04tx5i8" >
+      <bpmn:incoming>Flow_0p86gom</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="StartEvent_1" name="start">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property />
+          <zeebe:property name="publicAccess" value="true" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0p86gom</bpmn:outgoing>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmn:error id="Error_1guhz1l" name="Error_400" errorCode="400" />
+  <bpmn:message id="Message_3grgq88" name="=messageName">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=messageKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="test-empty-property">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="128" y="143" width="81" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04tx5i8_di" bpmnElement="Event_04tx5i8">
+        <dc:Bounds x="442" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="420" y="143" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0p86gom_di" bpmnElement="Flow_0p86gom">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="442" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/util/src/test/resources/process/process-with-empty-public-value.bpmn
+++ b/zeebe/util/src/test/resources/process/process-with-empty-public-value.bpmn
@@ -8,6 +8,7 @@
     <bpmn:startEvent id="StartEvent_1" name="start">
       <bpmn:extensionElements>
         <zeebe:properties>
+          <zeebe:property />
           <zeebe:property name="publicAccess" />
         </zeebe:properties>
       </bpmn:extensionElements>

--- a/zeebe/util/src/test/resources/process/process-with-empty-public-value.bpmn
+++ b/zeebe/util/src/test/resources/process/process-with-empty-public-value.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0" camunda:diagramRelationId="92e4fb3e-b191-483d-a3ca-05319ee1c5eb">
+  <bpmn:process id="test-empty-property" name="empty-property" isExecutable="true">
+    <bpmn:sequenceFlow id="Flow_0p86gom" sourceRef="StartEvent_1" targetRef="Event_04tx5i8" />
+    <bpmn:endEvent id="Event_04tx5i8" >
+      <bpmn:incoming>Flow_0p86gom</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="StartEvent_1" name="start">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="publicAccess" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0p86gom</bpmn:outgoing>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmn:error id="Error_1guhz1l" name="Error_400" errorCode="400" />
+  <bpmn:message id="Message_3grgq88" name="=messageName">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=messageKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="test-empty-property">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="128" y="143" width="81" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04tx5i8_di" bpmnElement="Event_04tx5i8">
+        <dc:Bounds x="442" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="420" y="143" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0p86gom_di" bpmnElement="Flow_0p86gom">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="442" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Avoid NPE when parsing empty ZeebeProperty from XML model

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39534
