### PR TITLE
refactor: move v1 tasklist to separate folder

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -172,11 +172,11 @@ jobs:
           fi
 
           if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
-            echo "Running focused tests in V2 mode: Tasklist + HTO flows (excluding @v1-only tests)"
-            npm run test -- --project=chromium tests/tasklist/ tests/common-flows/hto-user-flows.spec.ts --grep-invert "@v1-only"
+            echo "Running all tests in V2 mode, excluding V1-specific tests"
+            npm run test -- --project=chromium --ignore="tests/common-flows/v1/**" --ignore="tests/tasklist/v1/**""
           else
-            echo "Running all tests in V1 mode"
-            npm run test -- --project=chromium
+            echo "Running V1 specific tests only: common-flows/v1/ and tests/tasklist/v1/"
+            npm run test -- --project=chromium tests/common-flows/v1/ tests/tasklist/v1/"
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -205,8 +205,23 @@ jobs:
             export CORE_APPLICATION_URL="http://localhost:8080"
             export ZEEBE_REST_ADDRESS="http://localhost:8080"
             TEST_ARGS=(--project=chromium)
+            
             if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
-              TEST_ARGS+=(tests/tasklist/ tests/common-flows/hto-user-flows.spec.ts --grep-invert '@v1-only')
+              echo "Running all tests in V2 mode"
+              TEST_ARGS+=(
+                tests/api/
+                tests/operate/
+                tests/identity/
+                tests/tasklist/
+                tests/common-flows/
+                --grep-invert="v1/"
+              )
+            else
+              echo "Running V1 mode tests from specific directories"
+              TEST_ARGS+=(
+                tests/tasklist/v1/
+                tests/common-flows/v1/
+              )
             fi
           fi
           echo "Running tests with args: ${TEST_ARGS[*]}"

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -69,6 +69,7 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-tests-validate-release
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
@@ -257,8 +258,23 @@ jobs:
             export CORE_APPLICATION_URL="http://localhost:8080"
             export ZEEBE_REST_ADDRESS="http://localhost:8080"
             TEST_ARGS=(--project=chromium)
+            
             if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
-              TEST_ARGS+=(tests/tasklist/ tests/common-flows/hto-user-flows.spec.ts --grep-invert '@v1-only')
+              echo "Running All tests in V2 mode, excluding V1 specific tests"
+              TEST_ARGS+=(
+                tests/api/
+                tests/operate/
+                tests/identity/
+                tests/tasklist/
+                tests/common-flows/
+                --grep-invert="v1/"
+              )
+            else
+              echo "Running V1 mode tests from specific V1 directories only"
+              TEST_ARGS+=(
+                tests/tasklist/v1/
+                tests/common-flows/v1/
+              )
             fi
           fi
           echo "Running tests with args: ${TEST_ARGS[*]}"
@@ -297,7 +313,7 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
-          job_name: c8-orchestration-cluster-e2e-tests
+          job_name: c8-orchestration-cluster-e2e-tests-release
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
@@ -346,6 +362,7 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-tests-notify-result
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/README.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/README.md
@@ -132,10 +132,30 @@ Reports and artifacts:
 
 This test suite follows the **Page Object Model (POM)** pattern for reusability and maintainability.
 
-- Page objects: `qa/c8-orchestration-cluster-e2e-test-suite/pages`
-- Test specs: `qa/c8-orchestration-cluster-e2e-test-suite/tests`
-- Utilities/fixtures: `qa/c8-orchestration-cluster-e2e-test-suite/utils`
-- Test data: `qa/c8-orchestration-cluster-e2e-test-suite/resources`
+### Directory Structure
+
+- **Page objects**: `qa/c8-orchestration-cluster-e2e-test-suite/pages`
+  - `pages/`: V2 page objects (default)
+  - `pages/v1/`: Tasklist V1-specific page objects
+- **Test specs**: `qa/c8-orchestration-cluster-e2e-test-suite/tests`
+  - `tests/tasklist/`: V2 Tasklist tests
+  - `tests/tasklist/v1/`: V1 Tasklist tests
+  - `tests/common-flows/`: V2 common flow tests
+  - `tests/common-flows/v1/`: V1 common flow tests
+  - `tests/operate/`: Operate tests
+  - `tests/identity/`: Identity tests
+  - `tests/api/`: API tests
+- **Utilities/fixtures**: `qa/c8-orchestration-cluster-e2e-test-suite/utils`
+- **Test data**: `qa/c8-orchestration-cluster-e2e-test-suite/resources`
+
+### Test Mode Separation
+
+Starting with Camunda 8.8, Tasklist V2 is the default mode. The test suite reflects this:
+
+- **V2 Mode (Default)**: All tests run against Tasklist V2 unless specified otherwise
+- **V1 Mode (Explicit)**: V1 tests require explicit project specification
+- Tests are organized into mode-specific directories for clear separation
+- Page objects are separated by mode to eliminate compatibility overhead
 
 ---
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -10,6 +10,7 @@ import {test as base} from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import {OperateHomePage} from '@pages/OperateHomePage';
 import {TaskPanelPage} from '@pages/TaskPanelPage';
+import {TaskPanelPageV1} from '@pages/v1/TaskPanelPage';
 import {LoginPage} from '@pages/LoginPage';
 import {OperateProcessesPage} from '@pages/OperateProcessesPage';
 import {OperateProcessInstancePage} from '@pages/OperateProcessInstancePage';
@@ -19,6 +20,9 @@ import {OperateDiagramPage} from '@pages/OperateDiagramPage';
 import {TaskDetailsPage} from '@pages/TaskDetailsPage';
 import {TasklistHeader} from '@pages/TasklistHeader';
 import {TasklistProcessesPage} from '@pages/TasklistProcessesPage';
+import {TaskDetailsPageV1} from '@pages/v1/TaskDetailsPage';
+import {TasklistHeaderV1} from '@pages/v1/TasklistHeader';
+import {TasklistProcessesPageV1} from '@pages/v1/TasklistProcessesPage';
 import {PublicFormsPage} from '@pages/PublicFormsPage';
 import {IdentityHeader} from '@pages/IdentityHeader';
 import {IdentityAuthorizationsPage} from '@pages/IdentityAuthorizationsPage';
@@ -36,6 +40,10 @@ type PlaywrightFixtures = {
   operateHomePage: OperateHomePage;
   loginPage: LoginPage;
   taskPanelPage: TaskPanelPage;
+  taskPanelPageV1: TaskPanelPageV1;
+  taskDetailsPageV1: TaskDetailsPageV1;
+  tasklistHeaderV1: TasklistHeaderV1;
+  tasklistProcessesPageV1: TasklistProcessesPageV1;
   operateProcessesPage: OperateProcessesPage;
   operateProcessInstancePage: OperateProcessInstancePage;
   operateFiltersPanelPage: OperateFiltersPanelPage;
@@ -160,6 +168,18 @@ const test = base.extend<PlaywrightFixtures>({
 
   identityRolesDetailsPage: async ({page}, use) => {
     await use(new IdentityRolesDetailsPage(page));
+  },
+  taskPanelPageV1: async ({page}, use) => {
+    await use(new TaskPanelPageV1(page));
+  },
+  taskDetailsPageV1: async ({page}, use) => {
+    await use(new TaskDetailsPageV1(page));
+  },
+  tasklistHeaderV1: async ({page}, use) => {
+    await use(new TasklistHeaderV1(page));
+  },
+  tasklistProcessesPageV1: async ({page}, use) => {
+    await use(new TasklistProcessesPageV1(page));
   },
 });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
@@ -40,6 +40,10 @@ class TaskPanelPage {
   }
 
   async openTask(name: string) {
+    // V1/V2 mode difference:
+    // V1: displays process name ("User registration")
+    // V2: always displays process ID ("user_registration") regardless of task name
+
     // Mapping of processes names to process IDs for V2 mode compatibility
     const processNameToIdMapping: Record<string, string> = {
       'User registration': 'user_registration',
@@ -60,6 +64,16 @@ class TaskPanelPage {
       Zeebe_user_task: 'Zeebe_user_task',
     };
 
+    // Strategy 1: Try with original name (for V1)
+    try {
+      await this.availableTasks
+        .getByText(name, {exact: true})
+        .nth(0)
+        .click({timeout: 10000});
+      return;
+    } catch {}
+
+    // Strategy 2: Try with mapped process ID (for V2 mode)
     const processId = processNameToIdMapping[name] || name;
     if (processId !== name) {
       try {
@@ -69,12 +83,7 @@ class TaskPanelPage {
           .click({timeout: 10000});
         return;
       } catch {
-        console.log(
-          'Failed to open task with name:',
-          name,
-          'and process ID:',
-          processId,
-        );
+        console.log('Failed to open task with name:', name);
       }
     }
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
@@ -40,10 +40,6 @@ class TaskPanelPage {
   }
 
   async openTask(name: string) {
-    // V1/V2 mode difference:
-    // V1: displays process name ("User registration")
-    // V2: always displays process ID ("user_registration") regardless of task name
-
     // Mapping of processes names to process IDs for V2 mode compatibility
     const processNameToIdMapping: Record<string, string> = {
       'User registration': 'user_registration',
@@ -64,16 +60,6 @@ class TaskPanelPage {
       Zeebe_user_task: 'Zeebe_user_task',
     };
 
-    // Strategy 1: Try with original name (for V1)
-    try {
-      await this.availableTasks
-        .getByText(name, {exact: true})
-        .nth(0)
-        .click({timeout: 10000});
-      return;
-    } catch {}
-
-    // Strategy 2: Try with mapped process ID (for V2 mode)
     const processId = processNameToIdMapping[name] || name;
     if (processId !== name) {
       try {
@@ -83,7 +69,12 @@ class TaskPanelPage {
           .click({timeout: 10000});
         return;
       } catch {
-        console.log('Failed to open task with name:', name);
+        console.log(
+          'Failed to open task with name:',
+          name,
+          'and process ID:',
+          processId,
+        );
       }
     }
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
@@ -40,7 +40,11 @@ class TaskPanelPage {
   }
 
   async openTask(name: string) {
-    // V2 mode: always displays process ID regardless of task name
+    // V1/V2 mode difference:
+    // V1: displays process name ("User registration")
+    // V2: always displays process ID ("user_registration") regardless of task name
+
+    // Mapping of processes names to process IDs for V2 mode compatibility
     const processNameToIdMapping: Record<string, string> = {
       'User registration': 'user_registration',
       'Some user activity': 'usertask_to_be_completed', // Process ID from BPMN
@@ -60,16 +64,27 @@ class TaskPanelPage {
       Zeebe_user_task: 'Zeebe_user_task',
     };
 
-    const processId = processNameToIdMapping[name] || name;
-
+    // Strategy 1: Try with original name (for V1)
     try {
       await this.availableTasks
-        .getByText(processId, {exact: true})
+        .getByText(name, {exact: true})
         .nth(0)
         .click({timeout: 10000});
       return;
-    } catch {
-      console.log('Failed to open task with name:', name);
+    } catch {}
+
+    // Strategy 2: Try with mapped process ID (for V2 mode)
+    const processId = processNameToIdMapping[name] || name;
+    if (processId !== name) {
+      try {
+        await this.availableTasks
+          .getByText(processId, {exact: true})
+          .nth(0)
+          .click({timeout: 10000});
+        return;
+      } catch {
+        console.log('Failed to open task with name:', name);
+      }
     }
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskDetailsPage.ts
@@ -1,0 +1,344 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator, expect} from '@playwright/test';
+import {sleep} from 'utils/sleep';
+import {waitForAssertion} from 'utils/waitForAssertion';
+
+function cardinalToOrdinal(numberValue: number): string {
+  const realOrderIndex = numberValue.toString();
+
+  if (['11', '12', '13'].includes(realOrderIndex.slice(-2))) {
+    return `${realOrderIndex}th`;
+  }
+
+  switch (realOrderIndex.slice(-1)) {
+    case '1':
+      return `${realOrderIndex}st`;
+    case '2':
+      return `${realOrderIndex}nd`;
+    case '3':
+      return `${realOrderIndex}rd`;
+    default:
+      return `${realOrderIndex}th`;
+  }
+}
+
+class TaskDetailsPageV1 {
+  private page: Page;
+  readonly assignToMeButton: Locator;
+  readonly completeButton: Locator;
+  readonly unassignButton: Locator;
+  readonly assignee: Locator;
+  readonly completeTaskButton: Locator;
+  readonly addVariableButton: Locator;
+  readonly detailsPanel: Locator;
+  readonly detailsHeader: Locator;
+  readonly pendingTaskDescription: Locator;
+  readonly pickATaskHeader: Locator;
+  readonly emptyTaskMessage: Locator;
+  readonly nameInput: Locator;
+  readonly addressInput: Locator;
+  readonly ageInput: Locator;
+  readonly variablesTable: Locator;
+  readonly nameColumnHeader: Locator;
+  readonly valueColumnHeader: Locator;
+  readonly form: Locator;
+  readonly numberInput: Locator;
+  readonly incrementButton: Locator;
+  readonly decrementButton: Locator;
+  readonly dateInput: Locator;
+  readonly timeInput: Locator;
+  readonly checkbox: Locator;
+  readonly selectDropdown: Locator;
+  readonly tagList: Locator;
+  readonly detailsInfo: Locator;
+  readonly taskCompletedBanner: Locator;
+  readonly addDynamicListRowButton: Locator;
+  readonly processTab: Locator;
+  readonly bpmnDiagram: Locator;
+  readonly assignedToMeText: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.assignToMeButton = page.getByRole('button', {name: 'Assign to me'});
+    this.completeButton = page.getByRole('button', {name: 'Complete'});
+    this.unassignButton = page.getByRole('button', {name: 'Unassign'});
+    this.assignee = page.getByTestId('assignee');
+    this.completeTaskButton = page.getByRole('button', {name: 'Complete Task'});
+    this.addVariableButton = page.getByRole('button', {name: 'Add Variable'});
+    this.detailsPanel = this.page.getByRole('complementary', {
+      name: 'Task details right panel',
+    });
+    this.detailsHeader = page.getByTitle('Task details header');
+    this.pendingTaskDescription = page.getByText('Pending task');
+    this.pickATaskHeader = page.getByRole('heading', {
+      name: 'Pick a task to work on',
+    });
+    this.emptyTaskMessage = page.getByRole('heading', {
+      name: 'task has no variables',
+    });
+    this.nameInput = page.getByLabel('Name*');
+    this.addressInput = page.getByLabel('Address*');
+    this.ageInput = page.getByLabel('Age');
+    this.variablesTable = page.getByTestId('variables-table');
+    this.nameColumnHeader = this.variablesTable.getByRole('columnheader', {
+      name: 'Name',
+    });
+    this.valueColumnHeader = this.variablesTable.getByRole('columnheader', {
+      name: 'Value',
+    });
+    this.form = page.getByTestId('embedded-form');
+    this.numberInput = this.form.getByLabel('Number');
+    this.incrementButton = page.getByRole('button', {name: 'Increment'});
+    this.decrementButton = page.getByRole('button', {name: 'Decrement'});
+    this.dateInput = page.getByPlaceholder('mm/dd/yyyy');
+    this.timeInput = page.getByPlaceholder('hh:mm ?m');
+    this.checkbox = this.form.getByLabel('Checkbox');
+    this.selectDropdown = this.form.getByText('Select').last();
+    this.tagList = page.getByPlaceholder('Search');
+    this.detailsInfo = page.getByTestId('details-info');
+    this.taskCompletedBanner = this.page.getByText('Task completed');
+    this.addDynamicListRowButton = page.getByRole('button', {name: 'add new'});
+    this.processTab = page.getByRole('link', {
+      name: 'show associated bpmn process',
+    });
+    this.bpmnDiagram = page.getByTestId('diagram');
+    this.assignedToMeText = page
+      .getByTestId('assignee')
+      .getByText('Assigned to me');
+  }
+
+  async clickAssignToMeButton() {
+    await expect(this.assignToMeButton).toBeVisible({timeout: 60000});
+    await this.assignToMeButton.click({timeout: 60000});
+  }
+
+  async clickUnassignButton() {
+    await expect(this.unassignButton).toBeVisible({timeout: 30000});
+    await this.unassignButton.click();
+  }
+
+  async clickCompleteTaskButton() {
+    await this.completeTaskButton.click({timeout: 60000});
+  }
+
+  async clickAddVariableButton() {
+    await this.addVariableButton.click({timeout: 60000});
+  }
+
+  async replaceExistingVariableValue(values: {name: string; value: string}) {
+    const {name, value} = values;
+    await this.page.getByTitle(name).clear();
+    await this.page.getByTitle(name).fill(value);
+  }
+
+  getNthVariableNameInput(nth: number) {
+    return this.page.getByRole('textbox', {
+      name: `${cardinalToOrdinal(nth)} variable name`,
+    });
+  }
+
+  getNthVariableValueInput(nth: number) {
+    return this.page.getByRole('textbox', {
+      name: `${cardinalToOrdinal(nth)} variable value`,
+    });
+  }
+
+  async addVariable(payload: {name: string; value: string}) {
+    const {name, value} = payload;
+
+    await this.clickAddVariableButton();
+    await this.getNthVariableNameInput(1).fill(name);
+    await this.getNthVariableValueInput(1).fill(value);
+  }
+
+  async fillNumber(number: string): Promise<void> {
+    await this.numberInput.fill(number);
+  }
+
+  async clickIncrementButton(): Promise<void> {
+    await this.incrementButton.click({timeout: 60000});
+  }
+
+  async clickDecrementButton(): Promise<void> {
+    await this.decrementButton.click({timeout: 60000});
+  }
+
+  async fillDatetimeField(label: string, value: string) {
+    const input = this.page.getByRole('textbox', {name: label});
+    await expect(input).toBeVisible();
+    await input.click();
+    await input.fill(value);
+    await this.page.keyboard.press('Enter');
+    await expect(input).toHaveValue(value);
+  }
+
+  async checkCheckbox(): Promise<void> {
+    await this.checkbox.check();
+  }
+
+  async selectDropdownValue(value: string): Promise<void> {
+    await this.selectDropdown.click();
+    await this.page.getByText(value).click();
+  }
+
+  async selectDropdownOption(label: string, value: string) {
+    await this.page.getByText(label).click();
+    await this.page.getByText(value).click();
+  }
+
+  async clickRadioButton(label: string): Promise<void> {
+    await this.page.getByText(label).click();
+  }
+
+  async checkChecklistBox(label: string): Promise<void> {
+    await this.page.getByLabel(label).check();
+  }
+
+  async enterTwoValuesInTagList(value1: string, value2: string): Promise<void> {
+    await this.tagList.click();
+    await this.page.getByText(value1).click();
+    await this.page.getByText(value2, {exact: true}).click();
+  }
+
+  async fillTextInput(label: string, value: string): Promise<void> {
+    const input = this.page.getByLabel(label, {exact: true});
+    const maxRetries = 3;
+    let attempt = 0;
+    while (attempt < maxRetries) {
+      try {
+        await input.click({timeout: 120000});
+        await input.fill(value);
+        await input.blur();
+        await expect(input).toHaveValue(value);
+        return;
+      } catch (error) {
+        attempt++;
+        console.log(
+          `Attempt ${attempt} to fill input "${label}" failed with error: ${error}`,
+        );
+        if (attempt === maxRetries) {
+          throw new Error(
+            `Failed to set value "${value}" for label "${label}" after ${maxRetries} attempts.`,
+          );
+        }
+        await sleep(500);
+      }
+    }
+  }
+
+  async priorityAssertion(priority: string): Promise<void> {
+    let retryCount = 0;
+    const maxRetries = 2;
+    while (retryCount < maxRetries) {
+      try {
+        await expect(this.detailsPanel.getByText(priority)).toBeVisible({
+          timeout: 45000,
+        });
+        return; // Exit the function if the expectation is met
+      } catch {
+        retryCount++;
+        console.log(`Attempt ${retryCount} failed. Retrying...`);
+        await this.page.reload();
+        await sleep(10000);
+      }
+    }
+    throw new Error(`Active icon not visible after ${maxRetries} attempts.`);
+  }
+
+  async taskAssertion(name: string): Promise<void> {
+    let retryCount = 0;
+    const maxRetries = 2;
+    while (retryCount < maxRetries) {
+      try {
+        await expect(this.detailsInfo.getByText(name)).toBeVisible({
+          timeout: 45000,
+        });
+        return; // Exit the function if the expectation is met
+      } catch {
+        retryCount++;
+        console.log(`Attempt ${retryCount} failed. Retrying...`);
+        await this.page.reload();
+        await sleep(10000);
+      }
+    }
+    throw new Error(`Active icon not visible after ${maxRetries} attempts.`);
+  }
+
+  async assertVariableValue(
+    variableName: string,
+    variableValue: string,
+  ): Promise<void> {
+    await expect(this.page.getByTitle(variableName + ' Value')).toHaveValue(
+      variableValue,
+    );
+  }
+
+  async fillDynamicList(label: string, value: string) {
+    const locator = this.page.getByLabel(label);
+    const elements = await locator.all();
+    if (elements.length === 0) {
+      throw new Error(
+        `No elements found for label "${label}" in the dynamic list`,
+      );
+    }
+
+    for (const [index, element] of elements.entries()) {
+      const expectedValue = `${value}${index + 1}`;
+      await element.fill(expectedValue);
+
+      // Assert that the value was added correctly
+      await expect(element).toHaveValue(expectedValue);
+    }
+  }
+
+  async getDynamicListValues(label: string): Promise<string[]> {
+    const locator = this.page.getByLabel(label);
+    const elements = await locator.all();
+    if (elements.length === 0) {
+      throw new Error(`No elements found for label "${label}"`);
+    }
+
+    return Promise.all(elements.map((element) => element.inputValue()));
+  }
+
+  async addDynamicListRow(): Promise<void> {
+    await this.addDynamicListRowButton.click();
+  }
+
+  async assertFieldValue(label: string, expectedValue: string): Promise<void> {
+    const input = this.page.getByLabel(label, {exact: true});
+    await waitForAssertion({
+      assertion: async () => {
+        const actualValue = input;
+        await expect(actualValue).toHaveValue(expectedValue);
+      },
+      onFailure: async () => {
+        console.log(`Retrying assertion for field "${label}"...`);
+      },
+    });
+  }
+
+  async assertItemChecked(label: string): Promise<void> {
+    await expect(this.page.getByLabel(label)).toBeChecked();
+  }
+
+  async selectTaglistValues(values: string[]) {
+    await this.tagList.click();
+    for (const value of values) {
+      await this.page.getByText(value, {exact: true}).click();
+    }
+  }
+
+  async clickProcessTab(): Promise<void> {
+    await this.processTab.click();
+  }
+}
+
+export {TaskDetailsPageV1};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskListLoginPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskListLoginPage.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator, expect} from '@playwright/test';
+
+class TaskListLoginPageV1 {
+  private page: Page;
+  readonly usernameInput: Locator;
+  readonly passwordInput: Locator;
+  readonly loginButton: Locator;
+  readonly errorMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.usernameInput = page.getByLabel('Username');
+    this.passwordInput = page.getByRole('textbox', {name: 'password'});
+    this.loginButton = page.getByRole('button', {name: 'Login'});
+    this.errorMessage = page.getByRole('alert').first();
+  }
+
+  async fillUsername(username: string): Promise<void> {
+    await this.usernameInput.fill(username);
+  }
+
+  async clickUsername(): Promise<void> {
+    await this.usernameInput.click({timeout: 60000});
+  }
+
+  async fillPassword(password: string): Promise<void> {
+    await this.passwordInput.fill(password);
+  }
+
+  async clickLoginButton(): Promise<void> {
+    await this.loginButton.click({timeout: 60000});
+  }
+
+  async login(username: string, password: string) {
+    await expect(this.usernameInput).toBeVisible({timeout: 180000});
+    await this.clickUsername();
+    await this.fillUsername(username);
+    await this.fillPassword(password);
+    await expect(this.loginButton).toBeVisible({timeout: 120000});
+    await this.clickLoginButton();
+  }
+}
+export {TaskListLoginPageV1};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskPanelPage.ts
@@ -10,7 +10,7 @@ import {Page, Locator} from '@playwright/test';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {expect} from '@playwright/test';
 
-class TaskPanelPage {
+class TaskPanelPageV1 {
   readonly availableTasks: Locator;
   readonly collapseSidePanelButton: Locator;
   readonly expandSidePanelButton: Locator;
@@ -40,37 +40,10 @@ class TaskPanelPage {
   }
 
   async openTask(name: string) {
-    // V2 mode: always displays process ID regardless of task name
-    const processNameToIdMapping: Record<string, string> = {
-      'User registration': 'user_registration',
-      'Some user activity': 'usertask_to_be_completed', // Process ID from BPMN
-      usertask_to_be_completed: 'usertask_to_be_completed', // Allow process ID as input too
-      'User registration with vars': 'user_registration_with_vars',
-      'User Task with form rerender 1': 'user_task_with_form_rerender_1',
-      'User Task with form rerender 2': 'user_task_with_form_rerender_2',
-      UserTask_Number: 'UserTask_Number',
-      'Date and Time Task': 'Date_and_Time_Task',
-      'Checkbox Task': 'Checkbox_User_Task',
-      'Select User Task': 'Select',
-      'Radio Button Task': 'Radio_Button_User_Task',
-      'Checklist User Task': 'Checklist_Task',
-      'Tag list Task': 'Tag_List_Task',
-      Text_Templating_Form_Task: 'Text_Templating_Form_Task',
-      processWithDeployedForm: 'processWithDeployedForm',
-      Zeebe_user_task: 'Zeebe_user_task',
-    };
-
-    const processId = processNameToIdMapping[name] || name;
-
-    try {
-      await this.availableTasks
-        .getByText(processId, {exact: true})
-        .nth(0)
-        .click({timeout: 10000});
-      return;
-    } catch {
-      console.log('Failed to open task with name:', name);
-    }
+    await this.availableTasks
+      .getByText(name, {exact: true})
+      .nth(0)
+      .click({timeout: 10000});
   }
 
   async filterBy(
@@ -121,4 +94,4 @@ class TaskPanelPage {
   }
 }
 
-export {TaskPanelPage};
+export {TaskPanelPageV1};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TasklistHeader.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TasklistHeader.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator, expect} from '@playwright/test';
+
+class TasklistHeaderV1 {
+  private page: Page;
+  readonly openSettingsButton: Locator;
+  readonly languageSelector: Locator;
+  readonly processesTab: Locator;
+  readonly logoutButton: Locator;
+  readonly tasksTab: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.openSettingsButton = page.getByRole('button', {name: 'Open Settings'});
+    this.languageSelector = page.getByRole('combobox', {name: 'Language'});
+    this.processesTab = page.getByRole('link', {name: 'Processes'});
+    this.logoutButton = page.getByRole('button', {name: 'Log out'});
+    this.tasksTab = page.getByRole('link', {name: 'Tasks'});
+  }
+
+  async logout() {
+    await this.openSettingsButton.click();
+    await this.logoutButton.click();
+  }
+
+  async changeLanguage(option: 'Français' | 'English' | 'Deutsch' | 'Español') {
+    await this.openSettingsButton.click();
+    await expect(this.languageSelector).toBeVisible();
+    await this.languageSelector.click();
+    await this.page.getByRole('option', {name: option, exact: true}).click();
+  }
+
+  async clickTasksTab() {
+    await this.tasksTab.click();
+  }
+
+  async clickProcessesTab() {
+    await this.processesTab.click();
+  }
+}
+
+export {TasklistHeaderV1};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TasklistProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TasklistProcessesPage.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {Page, Locator} from '@playwright/test';
+
+class TasklistProcessesPageV1 {
+  private page: Page;
+  readonly continueButton: Locator;
+  readonly cancelButton: Locator;
+  readonly startProcessButton: Locator;
+  readonly docsLink: Locator;
+  readonly searchProcessesInput: Locator;
+  readonly processTile: Locator;
+  readonly startProcessSubButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.continueButton = page.getByRole('button', {name: 'Continue'});
+    this.cancelButton = page.getByRole('button', {name: 'Cancel'});
+    this.startProcessButton = page.getByRole('button', {name: 'Start process'});
+    this.startProcessSubButton = page
+      .getByRole('button', {name: 'Start process'})
+      .last();
+    this.docsLink = page.getByRole('link', {name: 'here'});
+    this.searchProcessesInput = page.getByPlaceholder('Search processes');
+    this.processTile = page.getByTestId('process-tile');
+  }
+
+  async goto() {
+    await this.page.goto('/processes', {
+      waitUntil: 'load',
+    });
+  }
+
+  public async searchForProcess(process: string) {
+    await this.searchProcessesInput.click();
+    await this.searchProcessesInput.fill(process);
+    await this.searchProcessesInput.press('Enter');
+  }
+
+  async getModalStartProcessButton(processName: string): Promise<Locator> {
+    return this.page
+      .getByLabel(`Start process ${processName}`)
+      .getByRole('button', {name: 'Start process'});
+  }
+
+  async clickStartProcessButton(name: string): Promise<void> {
+    await this.processTile
+      .filter({hasText: name})
+      .nth(0)
+      .getByRole('button', {name: 'Start process'})
+      .click({timeout: 60000});
+  }
+
+  async clickStartProcessSubButton(): Promise<void> {
+    await this.startProcessSubButton.click();
+  }
+}
+
+export {TasklistProcessesPageV1};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/UtilitiesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/UtilitiesPage.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, expect} from '@playwright/test';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {TaskPanelPageV1} from '@pages/v1/TaskPanelPage';
+import {TaskDetailsPageV1} from '@pages/v1/TaskDetailsPage';
+import {sleep} from 'utils/sleep';
+
+export async function navigateToApp(
+  page: Page,
+  appName: string,
+): Promise<void> {
+  if (appName == 'operate') {
+    await page.goto(
+      process.env.CORE_APPLICATION_URL + '/' + appName.toLowerCase() + '/login',
+    );
+  } else if (appName == 'tasklist') {
+    await page.goto(
+      process.env.CORE_APPLICATION_URL + '/' + appName.toLowerCase() + '/login',
+    );
+  } else if (appName == 'identity') {
+    await page.goto(
+      process.env.CORE_APPLICATION_URL + '/' + appName.toLowerCase() + '/login',
+    );
+  }
+}
+
+export async function validateURL(page: Page, URL: RegExp): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises, playwright/missing-playwright-await
+  expect(page).toHaveURL(URL);
+}
+
+export async function completeTaskWithRetryV1(
+  taskPanelPageV1: TaskPanelPageV1,
+  taskDetailsPageV1: TaskDetailsPageV1,
+  taskName: string,
+  taskPriority: string,
+  maxRetries: number = 3,
+): Promise<void> {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      await taskPanelPageV1.openTask(taskName);
+      await sleep(500);
+      if (!(await taskDetailsPageV1.assignedToMeText.isVisible())) {
+        await taskDetailsPageV1.clickAssignToMeButton();
+      }
+      await expect(
+        taskDetailsPageV1.detailsPanel.getByText(taskPriority),
+      ).toBeVisible();
+      await taskDetailsPageV1.clickCompleteTaskButton();
+      let assertionPassed = false;
+      try {
+        await waitForAssertion({
+          assertion: async () => {
+            await expect(
+              taskPanelPageV1.availableTasks
+                .getByText(taskName, {exact: true})
+                .first(),
+            ).not.toBeVisible({timeout: 10000});
+          },
+          onFailure: async () => {
+            console.log(
+              `Task ${taskName} still visible, retrying waitForAssertion...`,
+            );
+          },
+          maxRetries: 4,
+        });
+        assertionPassed = true;
+      } catch (error) {
+        console.log(`waitForAssertion failed for task ${taskName}: ${error}`);
+      }
+
+      if (assertionPassed) {
+        return;
+      }
+    } catch (error) {
+      if (attempt < maxRetries - 1) {
+        console.warn(
+          `Attempt ${
+            attempt + 1
+          } failed for completing task ${taskName}. Retrying...`,
+        );
+      } else {
+        console.error(error);
+        throw new Error(`Assertion failed after ${maxRetries} attempts`);
+      }
+    }
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { devices, defineConfig } from '@playwright/test';
+import {devices, defineConfig} from '@playwright/test';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
@@ -12,13 +12,14 @@ const testRailOptions = {
 const isV2StatelessTestsOnly = process.env.V2_STATELESS_TESTS === 'true';
 
 // Default: V2 mode (unless explicitly disabled with CAMUNDA_TASKLIST_V2_MODE_ENABLED=false)
-const isV2ModeEnabled = process.env.CAMUNDA_TASKLIST_V2_MODE_ENABLED !== 'false';
+const isV2ModeEnabled =
+  process.env.CAMUNDA_TASKLIST_V2_MODE_ENABLED !== 'false';
 
 // Reporters
 const useReportersWithoutSlack: any[] = [
   ['list'],
   ['junit', testRailOptions],
-  ['html', { outputFolder: 'html-report' }],
+  ['html', {outputFolder: 'html-report'}],
 ];
 
 const useReportersWithSlack: any[] = [
@@ -57,59 +58,103 @@ const normalProjects = [
     use: devices['Desktop Chrome'],
     testMatch: changedFolders.includes('chromium')
       ? changedFolders.map((folder) => `**/${folder}/*.spec.ts`)
-      : ['tests/**/*.spec.ts'],
-    testIgnore: ['tests/tasklist/task-panel.spec.ts', 'v2-stateless-tests/**'],
+      : isV2ModeEnabled
+        ? ['tests/**/*.spec.ts']
+        : [
+            'tests/tasklist/v1/**/*.spec.ts',
+            'tests/common-flows/v1/**/*.spec.ts',
+          ],
+    testIgnore: isV2ModeEnabled
+      ? [
+          'tests/tasklist/task-panel.spec.ts',
+          'v2-stateless-tests/**',
+          'tests/tasklist/v1/**',
+          'tests/common-flows/v1/**',
+        ]
+      : ['tests/tasklist/v1/task-panel.spec.ts', 'v2-stateless-tests/**'],
     teardown: 'chromium-subset',
   },
   {
     name: 'chromium-subset',
-    testMatch: 'tests/tasklist/task-panel.spec.ts',
-    grep: /^(?!.*@v1-only).*$/,
+    testMatch: isV2ModeEnabled
+      ? 'tests/tasklist/task-panel.spec.ts'
+      : 'tests/tasklist/v1/task-panel.spec.ts',
     use: devices['Desktop Chrome'],
     testIgnore: 'v2-stateless-tests/**',
   },
   {
     name: 'firefox',
     use: devices['Desktop Firefox'],
-    testIgnore: ['tests/tasklist/task-panel.spec.ts', 'v2-stateless-tests/**'],
+    testMatch: changedFolders.includes('firefox')
+      ? changedFolders.map((folder) => `**/${folder}/*.spec.ts`)
+      : isV2ModeEnabled
+        ? ['tests/**/*.spec.ts']
+        : [
+            'tests/tasklist/v1/**/*.spec.ts',
+            'tests/common-flows/v1/**/*.spec.ts',
+          ],
+    testIgnore: isV2ModeEnabled
+      ? [
+          'tests/tasklist/task-panel.spec.ts',
+          'v2-stateless-tests/**',
+          'tests/tasklist/v1/**',
+          'tests/common-flows/v1/**',
+        ]
+      : ['tests/tasklist/v1/task-panel.spec.ts', 'v2-stateless-tests/**'],
     teardown: 'firefox-subset',
   },
   {
     name: 'firefox-subset',
-    testMatch: 'tests/tasklist/task-panel.spec.ts',
+    testMatch: isV2ModeEnabled
+      ? 'tests/tasklist/task-panel.spec.ts'
+      : 'tests/tasklist/v1/task-panel.spec.ts',
     use: devices['Desktop Firefox'],
     testIgnore: 'v2-stateless-tests/**',
   },
   {
     name: 'msedge',
     use: devices['Desktop Edge'],
-    testIgnore: ['tests/tasklist/task-panel.spec.ts', 'v2-stateless-tests/**'],
+    testMatch: changedFolders.includes('msedge')
+      ? changedFolders.map((folder) => `**/${folder}/*.spec.ts`)
+      : isV2ModeEnabled
+        ? ['tests/**/*.spec.ts']
+        : [
+            'tests/tasklist/v1/**/*.spec.ts',
+            'tests/common-flows/v1/**/*.spec.ts',
+          ],
+    testIgnore: isV2ModeEnabled
+      ? [
+          'tests/tasklist/task-panel.spec.ts',
+          'v2-stateless-tests/**',
+          'tests/tasklist/v1/**',
+          'tests/common-flows/v1/**',
+        ]
+      : ['tests/tasklist/v1/task-panel.spec.ts', 'v2-stateless-tests/**'],
     teardown: 'msedge-subset',
   },
   {
     name: 'msedge-subset',
-    testMatch: 'tests/tasklist/task-panel.spec.ts',
+    testMatch: isV2ModeEnabled
+      ? 'tests/tasklist/task-panel.spec.ts'
+      : 'tests/tasklist/v1/task-panel.spec.ts',
     use: devices['Desktop Edge'],
     testIgnore: 'v2-stateless-tests/**',
   },
   {
     name: 'tasklist-v1-e2e',
-    testMatch: ['tests/tasklist/*.spec.ts', 'tests/tasklist/v1/*.spec.ts'],
+    testMatch: ['tests/tasklist/v1/*.spec.ts'],
     use: devices['Desktop Edge'],
-    testIgnore: ['tests/tasklist/task-panel.spec.ts', 'v2-stateless-tests/**'],
-    grep: /@v1-only/, // explicitly run v1 tests
+    testIgnore: [
+      'tests/tasklist/v1/task-panel.spec.ts',
+      'v2-stateless-tests/**',
+    ],
     teardown: 'chromium-subset',
   },
   {
     name: 'tasklist-v2-e2e',
     testMatch: ['tests/tasklist/*.spec.ts'],
     use: devices['Desktop Edge'],
-    testIgnore: [
-      'tests/tasklist/task-panel.spec.ts',
-      'tests/tasklist/v1/*.spec.ts',
-      'v2-stateless-tests/**',
-    ],
-    grep: /^(?!.*@v1-only).*$/, // exclude v1-only
+    testIgnore: ['tests/tasklist/task-panel.spec.ts', 'v2-stateless-tests/**'],
     teardown: 'chromium-subset',
   },
   {
@@ -133,7 +178,6 @@ export default defineConfig({
   timeout: 12 * 60 * 1000,
   workers: 4,
   retries: 1,
-  grep: isV2ModeEnabled ? /^(?!.*@v1-only).*$/ : undefined,
   expect: {
     timeout: 10_000,
   },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
@@ -1,0 +1,402 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {relativizePath, Paths} from 'utils/relativizePath';
+import {createTestData} from 'utils/constants';
+import {navigateToApp} from '@pages/v1/UtilitiesPage';
+import {verifyAccess} from 'utils/accessVerification';
+import {waitForItemInList} from 'utils/waitForItemInList';
+import {createInstances, deploy} from 'utils/zeebeClient';
+import {sleep} from 'utils/sleep';
+import {cleanupUsers} from 'utils/usersCleanup';
+
+test.describe('Identity User Flows', () => {
+  test.beforeAll(async () => {
+    await deploy(['./resources/simpleProcessForIdentity.bpmn']);
+    await sleep(500);
+    await createInstances('identityProcess', 1, 1);
+  });
+
+  const createdUsernames: string[] = [];
+
+  test.beforeEach(async ({loginPage, page}) => {
+    await navigateToApp(page, 'identity');
+    await loginPage.login('demo', 'demo');
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupUsers(request, createdUsernames);
+  });
+
+  test('Admin user can delete user', async ({
+    page,
+    loginPage,
+    identityUsersPage,
+    identityHeader,
+  }) => {
+    const testData = createTestData({user: true});
+    const testUser = testData.user!;
+    await identityUsersPage.createUser({
+      username: testUser.username,
+      password: testUser.password,
+      email: testUser.email!,
+      name: testUser.name,
+    });
+
+    await expect(identityUsersPage.usersList).toBeVisible();
+    await expect(identityUsersPage.usersList).toContainText(testUser.username);
+    await identityUsersPage.deleteUser(testUser);
+    await identityHeader.logout();
+    await expect(page).toHaveURL(
+      `${relativizePath(Paths.login('identity'))}?next=/identity/`,
+    );
+
+    await test.step(`Deleted user cannot access Identity`, async () => {
+      await navigateToApp(page, `identity`);
+      await loginPage.login(testUser.username, testUser.password);
+      await expect(page).toHaveURL(new RegExp(`identity`));
+      await loginPage.expectInvalidCredentialsError();
+    });
+
+    await test.step(`Deleted user cannot access Tasklist`, async () => {
+      await navigateToApp(page, `tasklist`);
+      await loginPage.login(testUser.username, testUser.password);
+      await expect(page).toHaveURL(new RegExp(`tasklist`));
+      await loginPage.expectInvalidCredentialsError();
+    });
+
+    await test.step(`Deleted user cannot access Operate`, async () => {
+      await navigateToApp(page, `operate`);
+      await loginPage.login(testUser.username, testUser.password);
+      await expect(page).toHaveURL(new RegExp(`operate`));
+      await loginPage.expectInvalidCredentialsError();
+    });
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('Brand new user cannot access any OC cluster apps', async ({
+    page,
+    loginPage,
+    identityUsersPage,
+    identityHeader,
+  }) => {
+    let testUser:
+      | {username: string; password: string; email?: string; name?: string}
+      | undefined;
+
+    await test.step(`Create new user`, async () => {
+      const testData = createTestData({user: true});
+      testUser = testData.user!;
+
+      await identityUsersPage.createUser({
+        username: testUser.username,
+        password: testUser.password,
+        email: testUser.email!,
+        name: testUser.name ?? testUser.username,
+      });
+
+      createdUsernames.push(testUser.username);
+    });
+
+    await test.step(`Login with the new user and verify Identity access is denied`, async () => {
+      await identityHeader.logout();
+      await loginPage.login(testUser!.username, testUser!.password);
+      await verifyAccess(page, false);
+    });
+
+    await test.step(`Verify Tasklist access is denied`, async () => {
+      await verifyAccess(page, false, 'tasklist');
+    });
+
+    await test.step(`Verify Operate access is denied`, async () => {
+      await verifyAccess(page, false, 'operate');
+    });
+  });
+
+  test('Admin user can grant and revoke component authorization for user', async ({
+    page,
+    loginPage,
+    identityUsersPage,
+    identityHeader,
+    identityAuthorizationsPage,
+  }) => {
+    test.slow();
+    let testUser: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+
+    await test.step(`Create new user`, async () => {
+      const testData = createTestData({user: true});
+      testUser = testData.user!;
+
+      await identityUsersPage.createUser({
+        username: testUser.username,
+        password: testUser.password,
+        email: testUser.email,
+        name: testUser.name,
+      });
+
+      createdUsernames.push(testUser.username);
+    });
+
+    await test.step(`Grant Authorizations to user for all applications`, async () => {
+      await identityAuthorizationsPage.navigateToAuthorizations();
+      await expect(page).toHaveURL(relativizePath(Paths.authorizations()));
+
+      await identityAuthorizationsPage.createAuthorization({
+        ownerType: 'User',
+        ownerId: testUser.name,
+        resourceType: 'Component',
+        resourceId: '*',
+        accessPermissions: ['Access'],
+      });
+
+      const authorizationItem = identityAuthorizationsPage.getAuthorizationCell(
+        testUser!.username,
+      );
+      await waitForItemInList(page, authorizationItem, {
+        shouldBeVisible: true,
+        timeout: 10000,
+        onAfterReload: () =>
+          identityAuthorizationsPage.selectResourceTypeTab('Component'),
+        clickNext: true,
+      });
+    });
+
+    await test.step(`Login with the new user and verify Identity access`, async () => {
+      await identityHeader.logout();
+      await loginPage.login(testUser!.username, testUser!.password);
+      await expect(page).toHaveURL(new RegExp(`identity`));
+      await verifyAccess(page);
+    });
+
+    await test.step(`Verify Operate access`, async () => {
+      await verifyAccess(page, true, 'operate');
+    });
+
+    await test.step(`Verify Tasklist access`, async () => {
+      await page.goto(`${process.env.CORE_APPLICATION_URL}/tasklist`);
+      await loginPage.login(testUser!.username, testUser!.password);
+      await expect(page).toHaveURL(new RegExp(`tasklist`));
+      await verifyAccess(page, true, 'tasklist');
+    });
+
+    await test.step(`Logout, login with demo and delete the created authorization`, async () => {
+      await identityAuthorizationsPage.navigateToAuthorizations();
+      await loginPage.login('demo', 'demo');
+      await expect(page).toHaveURL(relativizePath(Paths.authorizations()));
+
+      await identityAuthorizationsPage.selectResourceTypeTab('Component');
+      await identityAuthorizationsPage.clickDeleteAuthorizationButton(
+        testUser!.username,
+      );
+
+      await expect(
+        identityAuthorizationsPage.deleteAuthorizationModal,
+      ).toBeVisible();
+      await identityAuthorizationsPage.clickDeleteAuthorizationSubButton();
+      await expect(
+        identityAuthorizationsPage.deleteAuthorizationModal,
+      ).toBeHidden();
+
+      const authorizationItem = identityAuthorizationsPage.getAuthorizationCell(
+        testUser!.username,
+      );
+      await waitForItemInList(page, authorizationItem, {
+        shouldBeVisible: false,
+        timeout: 15000,
+        onAfterReload: () =>
+          identityAuthorizationsPage.selectResourceTypeTab('Component'),
+      });
+    });
+
+    await test.step(`Logout and login with the new user`, async () => {
+      await identityHeader.logout();
+      await loginPage.login(testUser!.username, testUser!.password);
+    });
+
+    await test.step(`Verify Identity access is denied`, async () => {
+      await verifyAccess(page, false);
+    });
+
+    await test.step(`Verify Tasklist access is denied`, async () => {
+      await verifyAccess(page, false, 'tasklist');
+    });
+
+    await test.step(`Verify Operate access is denied`, async () => {
+      await verifyAccess(page, false, 'operate');
+    });
+  });
+
+  test('New user can inherit permissions when assigned to a group', async ({
+    page,
+    identityGroupsPage,
+    identityAuthorizationsPage,
+    identityUsersPage,
+    identityHeader,
+    loginPage,
+    operateHomePage,
+    tasklistHeader,
+  }) => {
+    const testData = createTestData({
+      group: true,
+      user: true,
+    });
+    const TEST_GROUP = testData.group!;
+    const TEST_USER = testData.user!;
+
+    await test.step('Create test user', async () => {
+      await identityUsersPage.createUser({
+        username: TEST_USER.username,
+        password: TEST_USER.password,
+        email: TEST_USER.email!,
+        name: TEST_USER.name ?? TEST_USER.username,
+      });
+
+      const userName = identityUsersPage.userCell(TEST_USER.username);
+      await waitForItemInList(page, userName, {
+        timeout: 60000,
+        clickNext: true,
+      });
+    });
+
+    await test.step('Create test group', async () => {
+      await identityGroupsPage.navigateToGroups();
+      await identityGroupsPage.createGroup(
+        TEST_GROUP.groupId,
+        TEST_GROUP.name,
+        TEST_GROUP.description,
+      );
+      const item = identityGroupsPage.groupCell(TEST_GROUP.groupId);
+      await waitForItemInList(page, item, {
+        clickNext: true,
+        timeout: 60000,
+        onAfterReload: async () => {
+          await identityGroupsPage.navigateToGroups();
+          await expect(identityGroupsPage.groupsList).toBeVisible({
+            timeout: 60000,
+          });
+        },
+      });
+    });
+
+    await test.step('Create authorization for the test group', async () => {
+      await identityHeader.navigateToAuthorizations();
+      await expect(page).toHaveURL(relativizePath(Paths.authorizations()));
+      await identityAuthorizationsPage.createAuthorization({
+        ownerType: 'Group',
+        ownerId: TEST_GROUP.name,
+        resourceType: 'Component',
+        resourceId: '*',
+        accessPermissions: ['Access'],
+      });
+    });
+
+    await test.step('Assign test user to group', async () => {
+      await identityGroupsPage.navigateToGroups();
+      await identityGroupsPage.clickGroupId(TEST_GROUP.groupId);
+      await identityGroupsPage.assignUserToGroup(
+        TEST_USER.username,
+        TEST_USER.email!,
+      );
+      await page.reload();
+    });
+
+    await test.step('Verify authorization was created', async () => {
+      await identityHeader.navigateToAuthorizations();
+      await identityAuthorizationsPage.clickResourceType('Component');
+
+      const authorizationItem = identityAuthorizationsPage.getAuthorizationCell(
+        TEST_GROUP.groupId,
+      );
+      await waitForItemInList(page, authorizationItem, {
+        shouldBeVisible: true,
+        timeout: 10000,
+        onAfterReload: () =>
+          identityAuthorizationsPage.selectResourceTypeTab('Component'),
+        clickNext: true,
+      });
+    });
+
+    await test.step('Verify test user can access Identity', async () => {
+      await identityHeader.logout();
+      await loginPage.login(TEST_USER.username, TEST_USER.password);
+      await expect(page).toHaveURL(new RegExp('identity'), {timeout: 10000});
+      await sleep(2000);
+      await verifyAccess(page, true);
+    });
+
+    await test.step('Verify test user can access Operate but cannot view process instances', async () => {
+      await page.goto(`${process.env.CORE_APPLICATION_URL}/operate`);
+      await operateHomePage.clickProcessesTab();
+      await expect(page.getByText('identityProcess')).not.toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step('Verify test user can access Tasklist but cannot view the userTask', async () => {
+      await page.goto(`${process.env.CORE_APPLICATION_URL}/tasklist`);
+      console.log('sero ' + page.url());
+      await expect(page).toHaveURL(new RegExp(`tasklist`));
+      await verifyAccess(page, true);
+      await expect(page.getByText('identityProcess')).not.toBeVisible({
+        timeout: 30000,
+      });
+      await tasklistHeader.logout();
+    });
+
+    await test.step('Login with demo user and create authorization for the group', async () => {
+      await navigateToApp(page, 'identity');
+      await loginPage.login('demo', 'demo');
+      await identityHeader.navigateToAuthorizations();
+      await identityAuthorizationsPage.createAuthorization({
+        ownerType: 'Group',
+        ownerId: TEST_GROUP.name,
+        resourceType: 'Authorization',
+        resourceId: '*',
+        accessPermissions: ['Read'],
+      });
+    });
+
+    await test.step('Verify authorization was created', async () => {
+      await identityAuthorizationsPage.clickResourceType('Authorization');
+      await identityAuthorizationsPage.assertAuthorizationExists(
+        TEST_GROUP.groupId,
+        'Group',
+        ['Read'],
+      );
+    });
+
+    await test.step('Verify test user can view process instances in Operate', async () => {
+      await page.goto(`${process.env.CORE_APPLICATION_URL}/operate`);
+      await operateHomePage.clickProcessesTab();
+      await expect(page.getByText('identityProcess').first()).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step('Verify test user can view the userTask in Tasklist', async () => {
+      await page.goto(`${process.env.CORE_APPLICATION_URL}/tasklist`);
+      await expect(page).toHaveURL(new RegExp(`tasklist`));
+      await expect(page.getByText('identityProcess').first()).toBeVisible({
+        timeout: 30000,
+      });
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/login.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/login.spec.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {navigateToApp} from '@pages/v1/UtilitiesPage';
+import {expect} from '@playwright/test';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+
+test.describe('Login Tests', () => {
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Basic Login on Operate', async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -66,110 +66,6 @@ test.describe('Process Instances Filters', () => {
     await captureScreenshot(page, testInfo);
     await captureFailureVideo(page, testInfo);
   });
-  test('Filter process instances by parent key, date range, and error message', async ({
-    page,
-    operateProcessesPage,
-    operateFiltersPanelPage,
-  }) => {
-    await test.step('Filter by Parent Process Instance Key and assert results', async () => {
-      const callActivityProcessInstanceKey =
-        callActivityProcessInstance.processInstanceKey.toString();
-
-      await operateFiltersPanelPage.displayOptionalFilter(
-        'Parent Process Instance Key',
-      );
-      await operateFiltersPanelPage.fillParentProcessInstanceKeyFilter(
-        callActivityProcessInstanceKey,
-      );
-      await expect(
-        operateProcessesPage.noMatchingInstancesMessage,
-      ).toBeVisible();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(page.getByText('1 result')).toBeVisible();
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
-      });
-      await expect(operateProcessesPage.parentInstanceIdCell).toHaveText(
-        callActivityProcessInstanceKey,
-      );
-      expect(await operateProcessesPage.processInstancesTable.count()).toBe(1);
-    });
-
-    await test.step('Reset filter', async () => {
-      await operateFiltersPanelPage.clickResetFilters();
-      await expect(
-        operateFiltersPanelPage.parentProcessInstanceKey,
-      ).toBeHidden();
-      await expect
-        .poll(() => operateProcessesPage.processInstancesTable.count())
-        .toBeGreaterThan(1);
-    });
-
-    await test.step('Filter by End Date Range and assert results', async () => {
-      await operateProcessesPage.clickProcessCompletedCheckbox();
-
-      let currentRowCount =
-        await operateProcessesPage.processInstancesTable.count();
-      const endDate = await operateProcessesPage.endDateCell.innerText();
-      const day =
-        endDate === '--' ? new Date().getDate() : new Date(endDate).getDate();
-
-      await operateFiltersPanelPage.displayOptionalFilter('End Date Range');
-      await operateFiltersPanelPage.pickDateTimeRange({
-        fromDay: '1',
-        toDay: `${day}`,
-      });
-      await operateFiltersPanelPage.clickApply();
-      await expect
-        .poll(() => operateProcessesPage.processInstancesTable.count())
-        .toBeLessThan(currentRowCount);
-
-      currentRowCount =
-        await operateProcessesPage.processInstancesTable.count();
-      await operateFiltersPanelPage.clickResetFilters();
-      await expect
-        .poll(() => operateProcessesPage.processInstancesTable.count())
-        .toBeGreaterThan(currentRowCount);
-    });
-
-    await test.step('Filter by Error Message and assert results', async () => {
-      let currentRowCount =
-        await operateProcessesPage.processInstancesTable.count();
-      await operateFiltersPanelPage.displayOptionalFilter('Error Message');
-      await operateFiltersPanelPage.fillErrorMessageFilter(
-        "failed to evaluate expression 'nonExistingClientId': no variable found for name 'nonExistingClientId'",
-      );
-      await expect
-        .poll(() => operateProcessesPage.processInstancesTable.count())
-        .toBeLessThan(currentRowCount);
-    });
-
-    await test.step('Filter by Start Date Range and assert results', async () => {
-      await operateFiltersPanelPage.displayOptionalFilter('Start Date Range');
-      await operateFiltersPanelPage.pickDateTimeRange({
-        fromDay: '1',
-        toDay: '1',
-        fromTime: '00:00:00',
-        toTime: '00:00:00',
-      });
-      await operateFiltersPanelPage.clickApply();
-      await expect(
-        operateProcessesPage.noMatchingInstancesMessage,
-      ).toBeVisible();
-
-      await operateFiltersPanelPage.clickResetFilters();
-      await expect(
-        operateProcessesPage.noMatchingInstancesMessage,
-      ).toBeHidden();
-
-      await expect(operateFiltersPanelPage.errorMessageFilter).toBeHidden();
-      await expect(operateFiltersPanelPage.startDateFilter).toBeHidden();
-    });
-  });
 
   test('Interaction between diagram and filters', async ({
     operateProcessesPage,
@@ -335,6 +231,111 @@ test.describe('Process Instances Filters', () => {
           {exact: true},
         ),
       ).toBeVisible();
+    });
+  });
+
+  test('Filter process instances by parent key, date range, and error message', async ({
+    page,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+  }) => {
+    await test.step('Filter by Parent Process Instance Key and assert results', async () => {
+      const callActivityProcessInstanceKey =
+        callActivityProcessInstance.processInstanceKey.toString();
+
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Parent Process Instance Key',
+      );
+      await operateFiltersPanelPage.fillParentProcessInstanceKeyFilter(
+        callActivityProcessInstanceKey,
+      );
+      await expect(
+        operateProcessesPage.noMatchingInstancesMessage,
+      ).toBeVisible();
+      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('1 result')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+      await expect(operateProcessesPage.parentInstanceIdCell).toHaveText(
+        callActivityProcessInstanceKey,
+      );
+      expect(await operateProcessesPage.processInstancesTable.count()).toBe(1);
+    });
+
+    await test.step('Reset filter', async () => {
+      await operateFiltersPanelPage.clickResetFilters();
+      await expect(
+        operateFiltersPanelPage.parentProcessInstanceKey,
+      ).toBeHidden();
+      await expect
+        .poll(() => operateProcessesPage.processInstancesTable.count())
+        .toBeGreaterThan(1);
+    });
+
+    await test.step('Filter by End Date Range and assert results', async () => {
+      await operateProcessesPage.clickProcessCompletedCheckbox();
+
+      let currentRowCount =
+        await operateProcessesPage.processInstancesTable.count();
+      const endDate = await operateProcessesPage.endDateCell.innerText();
+      const day =
+        endDate === '--' ? new Date().getDate() : new Date(endDate).getDate();
+
+      await operateFiltersPanelPage.displayOptionalFilter('End Date Range');
+      await operateFiltersPanelPage.pickDateTimeRange({
+        fromDay: '1',
+        toDay: `${day}`,
+      });
+      await operateFiltersPanelPage.clickApply();
+      await expect
+        .poll(() => operateProcessesPage.processInstancesTable.count())
+        .toBeLessThan(currentRowCount);
+
+      currentRowCount =
+        await operateProcessesPage.processInstancesTable.count();
+      await operateFiltersPanelPage.clickResetFilters();
+      await expect
+        .poll(() => operateProcessesPage.processInstancesTable.count())
+        .toBeGreaterThan(currentRowCount);
+    });
+
+    await test.step('Filter by Error Message and assert results', async () => {
+      let currentRowCount =
+        await operateProcessesPage.processInstancesTable.count();
+      await operateFiltersPanelPage.displayOptionalFilter('Error Message');
+      await operateFiltersPanelPage.fillErrorMessageFilter(
+        "failed to evaluate expression 'nonExistingClientId': no variable found for name 'nonExistingClientId'",
+      );
+      await expect
+        .poll(() => operateProcessesPage.processInstancesTable.count())
+        .toBeLessThan(currentRowCount);
+    });
+
+    await test.step('Filter by Start Date Range and assert results', async () => {
+      await operateFiltersPanelPage.displayOptionalFilter('Start Date Range');
+      await operateFiltersPanelPage.pickDateTimeRange({
+        fromDay: '1',
+        toDay: '1',
+        fromTime: '00:00:00',
+        toTime: '00:00:00',
+      });
+      await operateFiltersPanelPage.clickApply();
+      await expect(
+        operateProcessesPage.noMatchingInstancesMessage,
+      ).toBeVisible();
+
+      await operateFiltersPanelPage.clickResetFilters();
+      await expect(
+        operateProcessesPage.noMatchingInstancesMessage,
+      ).toBeHidden();
+
+      await expect(operateFiltersPanelPage.errorMessageFilter).toBeHidden();
+      await expect(operateFiltersPanelPage.startDateFilter).toBeHidden();
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -168,74 +168,6 @@ test.describe('task details page', () => {
     await expect(taskDetailsPage.completeTaskButton).toBeHidden();
   });
 
-  test('complete zeebe and job worker tasks @v1-only', async ({
-    page,
-    taskPanelPage,
-    taskDetailsPage,
-  }) => {
-    test.slow();
-    await taskPanelPage.openTask('Zeebe_user_task');
-    await taskDetailsPage.clickUnassignButton();
-    await taskDetailsPage.clickAssignToMeButton();
-    await expect(taskDetailsPage.completeTaskButton).toBeEnabled();
-    await taskDetailsPage.addVariable({
-      name: 'zeebeVar',
-      value: '{"Name":"John","Age":20}',
-    });
-    await taskDetailsPage.clickCompleteTaskButton();
-    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
-
-    await taskPanelPage.openTask('JobWorker_user_task');
-    await expect(taskDetailsPage.completeTaskButton).toBeDisabled({
-      timeout: 60000,
-    });
-    await taskDetailsPage.clickAssignToMeButton();
-    await expect(taskDetailsPage.completeTaskButton).toBeEnabled();
-    await taskDetailsPage.addVariable({
-      name: 'jobWorkerVar',
-      value: '{"Name":"John","Age":22}',
-    });
-    await taskDetailsPage.clickCompleteTaskButton();
-    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
-
-    await taskPanelPage.filterBy('Completed');
-    await taskPanelPage.assertCompletedHeadingVisible();
-    await taskPanelPage.openTask('Zeebe_user_task');
-    await waitForAssertion({
-      assertion: async () => {
-        await expect(page.getByRole('cell', {name: 'zeebeVar'})).toBeVisible({
-          timeout: 60000,
-        });
-      },
-      onFailure: async () => {
-        await page.reload();
-      },
-    });
-    await expect(taskDetailsPage.assignToMeButton).toBeHidden();
-    await expect(taskDetailsPage.unassignButton).toBeHidden();
-    await expect(taskDetailsPage.completeTaskButton).toBeHidden();
-
-    await taskPanelPage.openTask('JobWorker_user_task');
-
-    // this is necessary because sometimes the importer takes some time to receive the variables
-    await waitForAssertion({
-      assertion: async () => {
-        await expect(
-          page.getByRole('cell', {name: 'jobWorkerVar'}),
-        ).toBeVisible();
-        await expect(page.getByRole('cell', {name: 'zeebeVar'})).toBeVisible({
-          timeout: 60000,
-        });
-      },
-      onFailure: async () => {
-        await page.reload();
-      },
-    });
-    await expect(taskDetailsPage.assignToMeButton).toBeHidden();
-    await expect(taskDetailsPage.unassignButton).toBeHidden();
-    await expect(taskDetailsPage.completeTaskButton).toBeHidden();
-  });
-
   test('task completion with form', async ({
     taskPanelPage,
     taskDetailsPage,
@@ -460,7 +392,9 @@ test.describe('task details page', () => {
     await taskDetailsPage.fillDatetimeField('Date', '1/1/3000');
     await taskDetailsPage.fillDatetimeField('Time', '12:00 PM');
     await taskDetailsPage.clickCompleteTaskButton();
-    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({timeout: 30000});
+    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
+      timeout: 30000,
+    });
     await taskPanelPage.filterBy('Completed');
     await taskPanelPage.assertCompletedHeadingVisible();
     await taskPanelPage.openTask('Date and Time Task');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/login.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/login.spec.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {expect} from '@playwright/test';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+
+test.describe.parallel('Login Tests', () => {
+  test.beforeEach(async ({page}) => {
+    await navigateToApp(page, 'tasklist');
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Basic Login on TaskList', async ({loginPage, taskPanelPageV1}) => {
+    await loginPage.login('demo', 'demo');
+    await expect(taskPanelPageV1.taskListPageBanner).toBeVisible();
+  });
+
+  test('have no a11y violations', async ({makeAxeBuilder}) => {
+    const results = await makeAxeBuilder().analyze();
+
+    expect(results.violations).toHaveLength(0);
+    expect(results.passes.length).toBeGreaterThan(0);
+  });
+
+  test('show error message on login failure', async ({
+    loginPage,
+    makeAxeBuilder,
+    page,
+  }) => {
+    await loginPage.login('demo', 'wrong');
+    await expect(page).toHaveURL('/tasklist/login');
+    await expect(loginPage.errorMessage).toContainText(
+      'Username and password do not match',
+    );
+
+    const results = await makeAxeBuilder().analyze();
+
+    expect(results.violations).toHaveLength(0);
+    expect(results.passes.length).toBeGreaterThan(0);
+  });
+
+  test('block form submission with empty fields', async ({loginPage, page}) => {
+    await loginPage.loginButton.click();
+    await expect(page).toHaveURL('/tasklist/login');
+
+    await loginPage.usernameInput.fill('demo');
+    await loginPage.loginButton.click();
+    await expect(page).toHaveURL('/tasklist/login');
+
+    await loginPage.usernameInput.fill(' ');
+    await loginPage.passwordInput.fill('demo');
+    await loginPage.loginButton.click();
+    await expect(page).toHaveURL('/tasklist/login');
+  });
+
+  test('log out redirect', async ({loginPage, tasklistHeaderV1, page}) => {
+    await loginPage.login('demo', 'demo');
+    await expect(page).toHaveURL('/tasklist');
+
+    await tasklistHeaderV1.logout();
+    await expect(page).toHaveURL('/tasklist/login');
+  });
+
+  test('persistency of a session', async ({loginPage, page}) => {
+    await loginPage.login('demo', 'demo');
+
+    await expect(page).toHaveURL('/tasklist');
+    await page.reload();
+    await expect(page).toHaveURL('/tasklist');
+  });
+
+  test('redirect to the correct URL after login', async ({
+    loginPage,
+    tasklistHeaderV1,
+    page,
+  }) => {
+    await page.goto('tasklist/123');
+
+    await loginPage.login('demo', 'demo');
+    await expect(page).toHaveURL('/tasklist/123');
+
+    await tasklistHeaderV1.logout();
+
+    await page.goto('/tasklist?filter=unassigned');
+    await loginPage.login('demo', 'demo');
+    await expect(page).toHaveURL('/tasklist?filter=unassigned');
+
+    await tasklistHeaderV1.logout();
+
+    await page.goto('/tasklist/123?filter=unassigned');
+    await loginPage.login('demo', 'demo');
+    await expect(page).toHaveURL('/tasklist/123?filter=unassigned');
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {deploy} from 'utils/zeebeClient';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {waitForAssertion} from 'utils/waitForAssertion';
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/user_process.bpmn',
+    './resources/processWithStartNodeFormDeployed.bpmn',
+    './resources/create_invoice.form',
+  ]);
+  await sleep(2000);
+});
+
+test.describe('process page', () => {
+  test.beforeEach(async ({page, loginPage, taskPanelPageV1}) => {
+    await navigateToApp(page, 'tasklist');
+    await loginPage.login('demo', 'demo');
+    await expect(taskPanelPageV1.taskListPageBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('process page navigation', async ({
+    tasklistHeaderV1,
+    page,
+    tasklistProcessesPageV1,
+  }) => {
+    await tasklistHeaderV1.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await expect(page.getByText('Start your process on demand')).toBeVisible();
+    await tasklistProcessesPageV1.cancelButton.click();
+    await expect(page.getByText('Welcome to Tasklist')).toBeVisible();
+
+    await tasklistHeaderV1.clickProcessesTab();
+    await tasklistProcessesPageV1.continueButton.click();
+    await expect(page.getByText('Search processes')).toBeVisible();
+  });
+
+  test('process searching', async ({
+    page,
+    tasklistHeaderV1,
+    tasklistProcessesPageV1,
+  }) => {
+    await tasklistHeaderV1.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistProcessesPageV1.continueButton.click();
+
+    await tasklistProcessesPageV1.searchForProcess('fake_process');
+    await expect(
+      page.getByText('We could not find any process with that name'),
+    ).toBeVisible();
+
+    await tasklistProcessesPageV1.searchForProcess('User_Process');
+    await expect(
+      page.getByText('We could not find any process with that name'),
+    ).toBeHidden();
+
+    await expect(tasklistProcessesPageV1.processTile).toHaveCount(1);
+    await expect(tasklistProcessesPageV1.processTile).toContainText(
+      'User_Process',
+    );
+  });
+
+  test('start process instance', async ({
+    page,
+    tasklistHeaderV1,
+    tasklistProcessesPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await tasklistHeaderV1.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistProcessesPageV1.continueButton.click();
+
+    await tasklistProcessesPageV1.searchForProcess('User_Process');
+    await expect(tasklistProcessesPageV1.processTile).toHaveCount(1);
+
+    await tasklistProcessesPageV1.startProcessButton.click();
+    await expect(page.getByText('Process has started')).toBeVisible();
+    await expect(tasklistProcessesPageV1.startProcessButton).toBeHidden();
+    await expect(page.getByText('Waiting for tasks...')).toBeVisible();
+    await expect(taskDetailsPageV1.assignToMeButton).toBeVisible({
+      timeout: 60000,
+    });
+  });
+
+  test('complete task started by process instance', async ({
+    page,
+    tasklistHeaderV1,
+    tasklistProcessesPageV1,
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await tasklistHeaderV1.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistProcessesPageV1.continueButton.click();
+
+    await tasklistProcessesPageV1.searchForProcess('User_Process');
+    await expect(tasklistProcessesPageV1.processTile).toHaveCount(1);
+
+    await tasklistProcessesPageV1.startProcessButton.click();
+    await tasklistHeaderV1.clickTasksTab();
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(
+          taskPanelPageV1.availableTasks.getByText('User_Task'),
+        ).toBeVisible();
+      },
+      onFailure: async () => {
+        console.log('User_Task not visible yet, retrying...');
+      },
+    });
+
+    await taskPanelPageV1.openTask('User_Task');
+
+    await taskDetailsPageV1.clickAssignToMeButton();
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(page.getByText('Task completed')).toBeVisible();
+  });
+
+  test('complete process with start node having deployed form', async ({
+    page,
+    tasklistHeaderV1,
+    taskDetailsPageV1,
+    tasklistProcessesPageV1,
+    taskPanelPageV1,
+  }) => {
+    test.slow();
+    await tasklistHeaderV1.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistProcessesPageV1.continueButton.click();
+
+    await tasklistProcessesPageV1.searchForProcess(
+      'processWithStartNodeFormDeployed',
+    );
+    await expect(tasklistProcessesPageV1.processTile).toHaveCount(1, {
+      timeout: 30000,
+    });
+
+    await tasklistProcessesPageV1.clickStartProcessButton(
+      'processWithStartNodeFormDeployed',
+    );
+    await taskDetailsPageV1.fillTextInput('Client Name*', 'Jon');
+    await taskDetailsPageV1.fillTextInput('Client Address*', 'Earth');
+    await taskDetailsPageV1.fillDatetimeField('Invoice Date', '1/1/3000');
+    await taskDetailsPageV1.fillDatetimeField('Due Date', '1/2/3000');
+    await taskDetailsPageV1.selectDropdownOption(
+      'USD - United States Dollar',
+      'EUR - Euro',
+    );
+    await taskDetailsPageV1.fillTextInput('Invoice Number*', '123');
+    await taskDetailsPageV1.addDynamicListRow();
+
+    await taskDetailsPageV1.fillDynamicList('Item Name*', 'Laptop');
+    await taskDetailsPageV1.fillDynamicList('Unit Price*', '1');
+    await taskDetailsPageV1.fillDynamicList('Quantity*', '2');
+
+    await expect(page.getByText('EUR 231')).toBeVisible();
+    await expect(page.getByText('EUR 264')).toBeVisible();
+    await expect(page.getByText('Total: EUR 544.5')).toBeVisible();
+    await tasklistProcessesPageV1.clickStartProcessSubButton();
+
+    await tasklistHeaderV1.clickTasksTab();
+    await taskPanelPageV1.openTask('processStartedByForm_user_task');
+    await expect(
+      page.getByText('{"name":"jon","address":"earth"}'),
+    ).toBeVisible({timeout: 60000});
+    await expect(page.getByText('EUR')).toBeVisible();
+    await expect(page.getByText('3000-01-01')).toBeVisible();
+    await expect(page.getByText('3000-01-02')).toBeVisible();
+    await expect(page.getByText('123')).toBeVisible();
+    await expect(
+      page.getByText(
+        '[{"itemName":"laptop1","unitPrice":11,"quantity":21},{"itemName":"laptop2","unitPrice":12,"quantity":22}]',
+      ),
+    ).toBeVisible();
+    await taskDetailsPageV1.clickAssignToMeButton();
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible({
+      timeout: 60000,
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/public-start-form.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/public-start-form.spec.ts
@@ -17,10 +17,7 @@ test.describe('public start process', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('should submit form @v1-only', async ({
-    makeAxeBuilder,
-    publicFormsPage,
-  }) => {
+  test('should submit form', async ({makeAxeBuilder, publicFormsPage}) => {
     await deploy([
       './resources/subscribeFormProcess.bpmn',
       './resources/subscribeForm.form',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/settings.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/settings.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureFailureVideo, captureScreenshot} from '@setup';
+
+test.describe('settings', () => {
+  test.beforeEach(async ({page, loginPage}) => {
+    await navigateToApp(page, 'tasklist');
+    await loginPage.login('demo', 'demo');
+    await expect(page).toHaveURL('/tasklist');
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('change language', async ({page, tasklistHeaderV1}) => {
+    await tasklistHeaderV1.changeLanguage('Français');
+    await expect(
+      page.getByRole('heading', {name: 'Bienvenue dans Tasklist'}),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', {name: 'Tâches ouvertes'}),
+    ).toBeVisible();
+    await expect(page.getByRole('button', {name: 'Déconnexion'})).toBeVisible();
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-details.spec.ts
@@ -1,0 +1,612 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {test} from 'fixtures';
+import {deploy, createInstances} from 'utils/zeebeClient';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/usertask_to_be_completed.bpmn',
+    './resources/user_task_with_form.bpmn',
+    './resources/user_task_form.form',
+    './resources/user_task_with_form_and_vars.bpmn',
+    './resources/user_task_with_form_rerender_1.bpmn',
+    './resources/user_task_with_form_rerender_2.bpmn',
+    './resources/checkbox_task_with_form.bpmn',
+    './resources/form_with_checkbox.form',
+    './resources/checklist_task_with_form.bpmn',
+    './resources/form_with_checklist.form',
+    './resources/date_and_time_task_with_form.bpmn',
+    './resources/form_with_date_and_time.form',
+    './resources/number_task_with_form.bpmn',
+    './resources/form_with_number.form',
+    './resources/radio_button_task_with_form.bpmn',
+    './resources/form_with_radio_button.form',
+    './resources/select_task_with_form.bpmn',
+    './resources/form_with_select.form',
+    './resources/tag_list_task_with_form.bpmn',
+    './resources/form_with_tag_list.form',
+    './resources/text_templating_form_task.bpmn',
+    './resources/form_with_text_templating.form',
+    './resources/processWithDeployedForm.bpmn',
+    './resources/create_invoice.form',
+    './resources/zeebe_and_job_worker_process.bpmn',
+  ]);
+  await sleep(1000);
+
+  await Promise.all([
+    createInstances('usertask_to_be_completed', 1, 1),
+    createInstances('user_registration', 1, 3),
+    createInstances('user_registration_with_vars', 1, 2, {
+      name: 'Jane',
+      age: '50',
+    }),
+    createInstances('user_task_with_form_rerender_1', 1, 1, {
+      name: 'Mary',
+      age: '20',
+    }),
+    createInstances('user_task_with_form_rerender_2', 1, 1, {
+      name: 'Stuart',
+      age: '30',
+    }),
+    createInstances('Checkbox_User_Task', 1, 1),
+    createInstances('Checklist_Task', 1, 1),
+    createInstances('Date_and_Time_Task', 1, 1),
+    createInstances('Number_Task', 1, 2),
+    createInstances('Tag_List_Task', 1, 1),
+    createInstances('Radio_Button_User_Task', 1, 1),
+    createInstances('Select', 1, 1),
+
+    createInstances('Text_Templating_Form_Task', 1, 1, {
+      name: 'Jane',
+      age: '50',
+    }),
+    createInstances('processWithDeployedForm', 1, 1),
+    createInstances('zeebe_and_job_worker_process', 1, 1),
+  ]);
+
+  await sleep(1000);
+});
+
+test.describe('task details page', () => {
+  test.beforeEach(async ({page, loginPage}) => {
+    await navigateToApp(page, 'tasklist');
+    await loginPage.login('demo', 'demo');
+    await expect(page).toHaveURL('/tasklist');
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('load task details when a task is selected', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.openTask('usertask_to_be_completed');
+
+    await expect(taskDetailsPageV1.detailsHeader).toBeVisible();
+    await expect(taskDetailsPageV1.detailsHeader).toContainText(
+      'Some user activity',
+    );
+    await expect(taskDetailsPageV1.detailsHeader).toContainText(
+      'usertask_to_be_completed',
+    );
+    await expect(taskDetailsPageV1.detailsHeader).toContainText('Unassigned');
+    await expect(taskDetailsPageV1.assignToMeButton).toBeVisible();
+
+    await expect(taskDetailsPageV1.detailsPanel).toBeVisible();
+    await expect(taskDetailsPageV1.detailsPanel).toContainText('Creation date');
+    await expect(
+      taskDetailsPageV1.detailsPanel.getByText(
+        /^\d{2}\s\w{3}\s\d{4}\s-\s\d{1,2}:\d{2}\s(AM|PM)$/,
+      ),
+    ).toBeVisible();
+    await expect(taskDetailsPageV1.detailsPanel).toContainText('Candidates');
+    await expect(taskDetailsPageV1.detailsPanel).toContainText('No candidates');
+    await expect(taskDetailsPageV1.detailsPanel).toContainText('Due date');
+    await expect(taskDetailsPageV1.detailsPanel).toContainText('No due date');
+    await expect(taskDetailsPageV1.detailsPanel).not.toContainText(
+      'Completion date',
+    );
+  });
+
+  test('assign and unassign task', async ({
+    page,
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.openTask('usertask_to_be_completed');
+
+    await expect(taskDetailsPageV1.assignToMeButton).toBeVisible({
+      timeout: 60000,
+    });
+    await expect(taskDetailsPageV1.completeTaskButton).toBeDisabled();
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await expect(taskDetailsPageV1.unassignButton).toBeVisible({
+      timeout: 60000,
+    });
+    await expect(taskDetailsPageV1.completeTaskButton).toBeEnabled();
+    await expect(taskDetailsPageV1.assignee).toHaveText('Assigned to me', {
+      useInnerText: true,
+    });
+
+    await taskDetailsPageV1.unassignButton.click();
+    await expect(taskDetailsPageV1.assignToMeButton).toBeVisible();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeDisabled();
+    await expect(taskDetailsPageV1.assignee).toHaveText('Unassigned', {
+      useInnerText: true,
+    });
+
+    await expect(taskDetailsPageV1.completeTaskButton).toBeDisabled({
+      timeout: 60000,
+    });
+  });
+
+  test('complete task', async ({page, taskPanelPageV1, taskDetailsPageV1}) => {
+    await taskPanelPageV1.openTask('usertask_to_be_completed');
+
+    const taskUrl = page.url();
+    await taskDetailsPageV1.clickAssignToMeButton();
+    await taskDetailsPageV1.completeTaskButton.click();
+    await expect(taskDetailsPageV1.pickATaskHeader).toBeVisible();
+
+    await page.goto(taskUrl);
+
+    await expect(taskDetailsPageV1.assignToMeButton).toBeHidden();
+    await expect(taskDetailsPageV1.unassignButton).toBeHidden();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeHidden();
+  });
+
+  test('complete zeebe and job worker tasks', async ({
+    page,
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    test.slow();
+    await taskPanelPageV1.openTask('Zeebe_user_task');
+    await taskDetailsPageV1.clickUnassignButton();
+    await taskDetailsPageV1.clickAssignToMeButton();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeEnabled();
+    await taskDetailsPageV1.addVariable({
+      name: 'zeebeVar',
+      value: '{"Name":"John","Age":20}',
+    });
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.openTask('JobWorker_user_task');
+    await expect(taskDetailsPageV1.completeTaskButton).toBeDisabled({
+      timeout: 60000,
+    });
+    await taskDetailsPageV1.clickAssignToMeButton();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeEnabled();
+    await taskDetailsPageV1.addVariable({
+      name: 'jobWorkerVar',
+      value: '{"Name":"John","Age":22}',
+    });
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await taskPanelPageV1.openTask('Zeebe_user_task');
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(page.getByRole('cell', {name: 'zeebeVar'})).toBeVisible({
+          timeout: 60000,
+        });
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+    await expect(taskDetailsPageV1.assignToMeButton).toBeHidden();
+    await expect(taskDetailsPageV1.unassignButton).toBeHidden();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeHidden();
+
+    await taskPanelPageV1.openTask('JobWorker_user_task');
+
+    // this is necessary because sometimes the importer takes some time to receive the variables
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(
+          page.getByRole('cell', {name: 'jobWorkerVar'}),
+        ).toBeVisible();
+        await expect(page.getByRole('cell', {name: 'zeebeVar'})).toBeVisible({
+          timeout: 60000,
+        });
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+    await expect(taskDetailsPageV1.assignToMeButton).toBeHidden();
+    await expect(taskDetailsPageV1.unassignButton).toBeHidden();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeHidden();
+  });
+
+  test('task completion with form', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.openTask('User registration');
+
+    await expect(taskDetailsPageV1.nameInput).toBeVisible();
+    await taskDetailsPageV1.clickAssignToMeButton();
+    await expect(taskDetailsPageV1.unassignButton).toBeVisible();
+
+    await taskDetailsPageV1.fillTextInput('Name*', 'Jon');
+    await taskDetailsPageV1.fillTextInput('Address*', 'Earth');
+    await taskDetailsPageV1.fillTextInput('Age', '21');
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await taskPanelPageV1.openTask('User registration');
+
+    await taskDetailsPageV1.assertFieldValue('Name*', 'Jon');
+    await taskDetailsPageV1.assertFieldValue('Address*', 'Earth');
+    await taskDetailsPageV1.assertFieldValue('Age', '21');
+  });
+
+  test('task completion with deployed form', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await expect(async () => {
+      await expect(
+        taskPanelPageV1.availableTasks
+          .getByText('processWithDeployedForm')
+          .first(),
+      ).toBeVisible();
+    }).toPass();
+    await taskPanelPageV1.openTask('processWithDeployedForm');
+
+    await taskDetailsPageV1.clickAssignToMeButton();
+    await expect(taskDetailsPageV1.unassignButton).toBeVisible({
+      timeout: 30000,
+    });
+    await taskDetailsPageV1.fillTextInput('Client Name*', 'Jon');
+    await taskDetailsPageV1.fillTextInput('Client Address*', 'Earth');
+    await taskDetailsPageV1.fillDatetimeField('Invoice Date', '1/1/3000');
+    await taskDetailsPageV1.fillDatetimeField('Due Date', '1/2/3000');
+    await taskDetailsPageV1.fillTextInput('Invoice Number*', '123');
+
+    await taskDetailsPageV1.selectDropdownOption(
+      'USD - United States Dollar',
+      'EUR - Euro',
+    );
+
+    await taskDetailsPageV1.addDynamicListRow();
+    await taskDetailsPageV1.fillDynamicList('Item Name*', 'Laptop');
+    await taskDetailsPageV1.fillDynamicList('Unit Price*', '1');
+    await taskDetailsPageV1.fillDynamicList('Quantity*', '2');
+
+    await expect(taskDetailsPageV1.form).toContainText('EUR 231');
+    await expect(taskDetailsPageV1.form).toContainText('EUR 264');
+    await expect(taskDetailsPageV1.form).toContainText('Total: EUR 544.5');
+
+    await taskDetailsPageV1.completeTaskButton.click();
+
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible({
+      timeout: 60000,
+    });
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await expect(async () => {
+      await expect(
+        taskPanelPageV1.availableTasks
+          .getByText('processWithDeployedForm')
+          .first(),
+      ).toBeVisible();
+    }).toPass();
+    await taskPanelPageV1.openTask('processWithDeployedForm');
+
+    await taskDetailsPageV1.assertFieldValue('Client Name*', 'Jon');
+    await taskDetailsPageV1.assertFieldValue('Client Address*', 'Earth');
+    await taskDetailsPageV1.assertFieldValue('Invoice Date*', '1/1/3000');
+    await taskDetailsPageV1.assertFieldValue('Due Date*', '1/2/3000');
+    await taskDetailsPageV1.assertFieldValue('Invoice Number*', '123');
+
+    expect(await taskDetailsPageV1.getDynamicListValues('Item Name*')).toEqual([
+      'Laptop1',
+      'Laptop2',
+    ]);
+
+    expect(await taskDetailsPageV1.getDynamicListValues('Unit Price*')).toEqual(
+      ['11', '12'],
+    );
+
+    expect(await taskDetailsPageV1.getDynamicListValues('Quantity*')).toEqual([
+      '21',
+      '22',
+    ]);
+
+    await expect(taskDetailsPageV1.form).toContainText('EUR 231');
+    await expect(taskDetailsPageV1.form).toContainText('EUR 264');
+    await expect(taskDetailsPageV1.form).toContainText('Total: EUR 544.5');
+  });
+
+  test('task completion with form from assigned to me filter', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.openTask('User registration');
+
+    await expect(taskDetailsPageV1.nameInput).toBeVisible();
+    await taskDetailsPageV1.clickAssignToMeButton();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeEnabled();
+
+    await taskPanelPageV1.filterBy('Assigned to me');
+    await taskPanelPageV1.openTask('User registration');
+
+    await expect(taskDetailsPageV1.nameInput).toBeVisible();
+    await taskDetailsPageV1.fillTextInput('Name*', 'Gaius Julius Caesar');
+    await taskDetailsPageV1.fillTextInput('Address*', 'Rome');
+    await taskDetailsPageV1.fillTextInput('Age', '55');
+
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await taskPanelPageV1.openTask('User registration');
+
+    await taskDetailsPageV1.assertFieldValue('Name*', 'Gaius Julius Caesar');
+    await taskDetailsPageV1.assertFieldValue('Address*', 'Rome');
+    await taskDetailsPageV1.assertFieldValue('Age', '55');
+  });
+
+  test('task completion with prefilled form', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('User registration with vars');
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await taskDetailsPageV1.assertFieldValue('Name*', 'Jane');
+    await taskDetailsPageV1.assertFieldValue('Address*', '');
+    await taskDetailsPageV1.assertFieldValue('Age', '50');
+
+    await taskDetailsPageV1.fillTextInput('Name*', 'Jon');
+    await taskDetailsPageV1.fillTextInput('Address*', 'Earth');
+    await taskDetailsPageV1.fillTextInput('Age', '21');
+
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await taskPanelPageV1.openTask('User registration with vars');
+
+    await taskDetailsPageV1.assertFieldValue('Name*', 'Jon');
+    await taskDetailsPageV1.assertFieldValue('Address*', 'Earth');
+    await taskDetailsPageV1.assertFieldValue('Age', '21');
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('should rerender forms properly', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.openTask('User Task with form rerender 1');
+    await taskDetailsPageV1.assertFieldValue('Name*', 'Mary');
+
+    await taskPanelPageV1.openTask('User Task with form rerender 2');
+    await taskDetailsPageV1.assertFieldValue('Name*', 'Stuart');
+  });
+
+  test('task completion with number form by input', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('UserTask_Number');
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await taskDetailsPageV1.fillTextInput('Number', '4');
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await taskPanelPageV1.openTask('UserTask_Number');
+
+    await taskDetailsPageV1.assertFieldValue('Number', '4');
+  });
+
+  test('task completion with number form by buttons', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('UserTask_Number');
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await taskDetailsPageV1.clickIncrementButton();
+    await taskDetailsPageV1.assertFieldValue('Number', '1');
+    await taskDetailsPageV1.clickIncrementButton();
+    await taskDetailsPageV1.assertFieldValue('Number', '2');
+    await taskDetailsPageV1.clickDecrementButton();
+    await taskDetailsPageV1.assertFieldValue('Number', '1');
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await taskPanelPageV1.openTask('UserTask_Number');
+    await taskDetailsPageV1.assertFieldValue('Number', '1');
+  });
+
+  test('task completion with date and time form', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('Date and Time Task');
+    await taskDetailsPageV1.clickAssignToMeButton();
+    await taskDetailsPageV1.fillDatetimeField('Date', '1/1/3000');
+    await taskDetailsPageV1.fillDatetimeField('Time', '12:00 PM');
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible({
+      timeout: 30000,
+    });
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await taskPanelPageV1.openTask('Date and Time Task');
+    await taskDetailsPageV1.assertFieldValue('Date', '1/1/3000');
+    await taskDetailsPageV1.assertFieldValue('Time', '12:00 PM');
+  });
+
+  test('task completion with checkbox form', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('Checkbox Task');
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await taskDetailsPageV1.checkCheckbox();
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await taskPanelPageV1.openTask('Checkbox Task');
+
+    await expect(taskDetailsPageV1.checkbox).toBeChecked({timeout: 60000});
+  });
+
+  test('task completion with select form', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('Select User Task');
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await expect(taskDetailsPageV1.unassignButton).toBeVisible();
+    await taskDetailsPageV1.selectDropdownValue('Value');
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await taskPanelPageV1.openTask('Select User Task');
+
+    await expect(taskDetailsPageV1.form).toContainText('Value', {
+      timeout: 30000,
+    });
+  });
+
+  test('task completion with radio button form', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('Radio Button Task');
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await taskDetailsPageV1.clickRadioButton('Value');
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await taskPanelPageV1.openTask('Radio Button Task');
+
+    await taskDetailsPageV1.assertItemChecked('Value');
+  });
+
+  test('task completion with checklist form', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('Checklist User Task');
+    await taskDetailsPageV1.clickAssignToMeButton();
+    await taskDetailsPageV1.checkChecklistBox('Value1');
+    await taskDetailsPageV1.checkChecklistBox('Value2');
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await taskPanelPageV1.openTask('Checklist User Task');
+
+    await taskDetailsPageV1.assertItemChecked('Value1');
+    await taskDetailsPageV1.assertItemChecked('Value2');
+  });
+
+  // TODO issue #3719
+  // eslint-disable-next-line playwright/no-skipped-test
+  test.skip('task completion with tag list form', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    test.slow();
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('Tag list Task');
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await taskDetailsPageV1.selectTaglistValues(['Value 2', 'Value']);
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.assertCompletedHeadingVisible();
+    await taskPanelPageV1.openTask('Tag list Task');
+
+    await expect(
+      taskDetailsPageV1.form.getByText('Value', {exact: true}),
+    ).toBeVisible();
+    await expect(taskDetailsPageV1.form.getByText('Value 2')).toBeVisible();
+  });
+
+  // TODO issue #3719
+  // eslint-disable-next-line playwright/no-skipped-test
+  test.skip('task completion with text template form', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    test.slow();
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('Text_Templating_Form_Task');
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await expect(taskDetailsPageV1.form).toContainText('Hello Jane');
+    await expect(taskDetailsPageV1.form).toContainText('You are 50 years old');
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.openTask('Text_Templating_Form_Task');
+
+    await expect(taskDetailsPageV1.form).toContainText('Hello Jane');
+    await expect(taskDetailsPageV1.form).toContainText('You are 50 years old');
+  });
+
+  test('show process model', async ({taskPanelPageV1, taskDetailsPageV1}) => {
+    await taskPanelPageV1.openTask('User registration');
+
+    await expect(taskDetailsPageV1.processTab).toBeVisible();
+    await taskDetailsPageV1.processTab.click();
+
+    await expect(taskDetailsPageV1.bpmnDiagram).toBeVisible();
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -112,8 +112,6 @@ test.describe('task panel page', () => {
   });
 
   test('scrolling', async ({page, taskPanelPageV1}) => {
-    // TODO: This test fails in V2 mode - investigate if this is expected behavior or a bug
-    // V2 mode may have different scrolling/pagination behavior that affects task count expectations
     test.slow();
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -46,103 +46,105 @@ test.describe('task panel page', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('filter selection', async ({taskPanelPage}) => {
+  test('filter selection', async ({taskPanelPageV1}) => {
     test.slow();
     await expect(
-      taskPanelPage.availableTasks.getByText('Some user activity'),
+      taskPanelPageV1.availableTasks.getByText('Some user activity'),
     ).toHaveCount(50);
 
-    await taskPanelPage.filterBy('Assigned to me');
-    await expect(taskPanelPage.availableTasks).toContainText('No tasks found');
+    await taskPanelPageV1.filterBy('Assigned to me');
+    await expect(taskPanelPageV1.availableTasks).toContainText(
+      'No tasks found',
+    );
 
-    await taskPanelPage.filterBy('All open tasks');
+    await taskPanelPageV1.filterBy('All open tasks');
     await expect(
-      taskPanelPage.availableTasks.getByText('Some user activity'),
+      taskPanelPageV1.availableTasks.getByText('Some user activity'),
     ).toHaveCount(50);
     await expect(
-      taskPanelPage.availableTasks.getByText('No tasks found'),
+      taskPanelPageV1.availableTasks.getByText('No tasks found'),
     ).toHaveCount(0);
   });
 
   test('update task list according to user actions', async ({
     page,
-    taskPanelPage,
-    taskDetailsPage,
+    taskPanelPageV1,
+    taskDetailsPageV1,
   }) => {
-    await taskPanelPage.filterBy('Unassigned');
+    await taskPanelPageV1.filterBy('Unassigned');
     await expect(async () => {
       await expect(
-        taskPanelPage.availableTasks.getByText('usertask_to_be_assigned'),
+        taskPanelPageV1.availableTasks.getByText('usertask_to_be_assigned'),
       ).toBeVisible();
     }).toPass();
-    await taskPanelPage.openTask('usertask_to_be_assigned');
-    await expect(taskDetailsPage.emptyTaskMessage).toBeVisible();
-    await taskDetailsPage.clickAssignToMeButton();
-    await expect(taskDetailsPage.unassignButton).toBeVisible();
+    await taskPanelPageV1.openTask('usertask_to_be_assigned');
+    await expect(taskDetailsPageV1.emptyTaskMessage).toBeVisible();
+    await taskDetailsPageV1.clickAssignToMeButton();
+    await expect(taskDetailsPageV1.unassignButton).toBeVisible();
     await page.reload();
 
     await expect(async () => {
       await expect(
-        taskPanelPage.availableTasks.getByText('usertask_to_be_assigned'),
+        taskPanelPageV1.availableTasks.getByText('usertask_to_be_assigned'),
       ).toHaveCount(0);
     }).toPass({timeout: 5000});
 
-    await taskPanelPage.filterBy('Assigned to me');
-    await taskPanelPage.openTask('usertask_to_be_assigned');
+    await taskPanelPageV1.filterBy('Assigned to me');
+    await taskPanelPageV1.openTask('usertask_to_be_assigned');
 
-    await expect(taskDetailsPage.completeTaskButton).toBeEnabled();
-    await taskDetailsPage.clickCompleteTaskButton();
-    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
-
-    await expect(async () => {
-      await expect(taskPanelPage.availableTasks.getByText('user')).toHaveCount(
-        0,
-      );
-    }).toPass();
-
-    await taskPanelPage.filterBy('Completed');
+    await expect(taskDetailsPageV1.completeTaskButton).toBeEnabled();
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
 
     await expect(async () => {
       await expect(
-        taskPanelPage.availableTasks.getByText(/some text/),
+        taskPanelPageV1.availableTasks.getByText('user'),
+      ).toHaveCount(0);
+    }).toPass();
+
+    await taskPanelPageV1.filterBy('Completed');
+
+    await expect(async () => {
+      await expect(
+        taskPanelPageV1.availableTasks.getByText(/some text/),
       ).not.toHaveCount(50);
     }).toPass({timeout: 5000});
   });
 
-  // TODO: This test fails in V2 mode - investigate if this is expected behavior or a bug
-  // V2 mode may have different scrolling/pagination behavior that affects task count expectations
-  test.skip('scrolling', async ({page, taskPanelPage}) => {
+  test('scrolling', async ({page, taskPanelPageV1}) => {
+    // TODO: This test fails in V2 mode - investigate if this is expected behavior or a bug
+    // V2 mode may have different scrolling/pagination behavior that affects task count expectations
     test.slow();
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
     await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(49);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
-    await taskPanelPage.scrollToLastTask('usertask_for_scrolling_2');
+    await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
     await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(99);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
-    await taskPanelPage.scrollToLastTask('usertask_for_scrolling_2');
+    await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
     await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(149);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
-    await taskPanelPage.scrollToLastTask('usertask_for_scrolling_2');
+    await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
     await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
-    await taskPanelPage.scrollToLastTask('usertask_for_scrolling_2');
+    await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(0);
     await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(1);
 
-    await taskPanelPage.scrollToFirstTask('usertask_for_scrolling_2');
+    await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
     await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -112,6 +112,8 @@ test.describe('task panel page', () => {
   });
 
   test('scrolling', async ({page, taskPanelPageV1}) => {
+    // TODO: This test fails in V2 mode - investigate if this is expected behavior or a bug
+    // V2 mode may have different scrolling/pagination behavior that affects task count expectations
     test.slow();
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/variables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/variables.spec.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {deploy, createInstances} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/usertask_with_variables.bpmn',
+    './resources/usertask_without_variables.bpmn',
+  ]);
+  await createInstances('usertask_without_variables', 1, 1);
+  await createInstances('usertask_with_variables', 1, 4, {
+    testData: 'something',
+  });
+});
+
+test.describe('variables page', () => {
+  test.beforeEach(async ({page, loginPage}) => {
+    await navigateToApp(page, 'tasklist');
+    await loginPage.login('demo', 'demo');
+    await expect(page).toHaveURL('/tasklist');
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('display info message when task has no variables', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.openTask('usertask_without_variables');
+    await expect(taskDetailsPageV1.emptyTaskMessage).toBeVisible({
+      timeout: 30000,
+    });
+  });
+
+  test('display variables when task has variables', async ({
+    taskPanelPageV1,
+    taskDetailsPageV1,
+  }) => {
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('usertask_with_variables');
+
+    await expect(taskDetailsPageV1.emptyTaskMessage).toBeHidden();
+    await expect(taskDetailsPageV1.nameColumnHeader).toBeVisible();
+    await expect(taskDetailsPageV1.valueColumnHeader).toBeVisible();
+    await expect(
+      taskDetailsPageV1.variablesTable.getByRole('cell', {name: 'testData'}),
+    ).toBeVisible();
+    await expect(
+      taskDetailsPageV1.variablesTable.getByText('something'),
+    ).toBeVisible();
+  });
+
+  test('edited variable is saved after refresh if task is completed', async ({
+    page,
+    taskDetailsPageV1,
+    taskPanelPageV1,
+  }) => {
+    await taskPanelPageV1.openTask('usertask_with_variables');
+
+    await expect(taskDetailsPageV1.assignToMeButton).toBeVisible();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeDisabled();
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await expect(taskDetailsPageV1.unassignButton).toBeVisible();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeEnabled();
+    await expect(taskDetailsPageV1.assignee).toHaveText('Assigned to me');
+    await expect(
+      taskDetailsPageV1.variablesTable.getByTitle('testData value'),
+    ).toHaveValue('"something"');
+    await taskDetailsPageV1.replaceExistingVariableValue({
+      name: 'testData value',
+      value: '"updatedValue"',
+    });
+    await taskDetailsPageV1.clickCompleteTaskButton();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+
+    await expect(taskDetailsPageV1.pickATaskHeader).toBeVisible();
+    await page.reload();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.openTask('usertask_with_variables');
+
+    await expect(
+      taskDetailsPageV1.variablesTable.getByText('something'),
+    ).toBeHidden();
+    await expect(
+      taskDetailsPageV1.variablesTable.getByText('updatedValue'),
+    ).toBeVisible();
+  });
+
+  test('edited variable is not saved after refresh', async ({
+    page,
+    taskDetailsPageV1,
+    taskPanelPageV1,
+  }) => {
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('usertask_with_variables');
+
+    await expect(taskDetailsPageV1.assignToMeButton).toBeVisible();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeDisabled();
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await expect(taskDetailsPageV1.unassignButton).toBeVisible();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeEnabled();
+    await expect(taskDetailsPageV1.assignee).toHaveText('Assigned to me');
+    await expect(
+      taskDetailsPageV1.variablesTable.getByTitle('testData value'),
+    ).toBeVisible();
+    await expect(
+      taskDetailsPageV1.variablesTable.getByTitle('testData value'),
+    ).toHaveValue('"something"');
+
+    await taskDetailsPageV1.replaceExistingVariableValue({
+      name: 'testData value',
+      value: '"updatedValue"',
+    });
+    await page.reload();
+    await expect(
+      taskDetailsPageV1.variablesTable.getByTitle('testData value'),
+    ).toHaveValue('"something"');
+    await expect(
+      taskDetailsPageV1.variablesTable.getByTitle('testData value'),
+    ).not.toHaveValue('"updatedValue"');
+  });
+
+  test('new variable disappears after refresh', async ({
+    page,
+    taskDetailsPageV1,
+    taskPanelPageV1,
+  }) => {
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('usertask_with_variables');
+
+    await expect(taskDetailsPageV1.addVariableButton).toBeHidden();
+    await expect(taskDetailsPageV1.assignToMeButton).toBeVisible();
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await taskDetailsPageV1.addVariable({
+      name: 'newVariableName',
+      value: '"newVariableValue"',
+    });
+
+    await page.reload();
+
+    await expect(
+      taskDetailsPageV1.variablesTable.getByText('newVariableName'),
+    ).toBeHidden();
+    await expect(
+      taskDetailsPageV1.variablesTable.getByText('newVariableValue'),
+    ).toBeHidden();
+  });
+
+  test('new variable still exists after refresh if task is completed', async ({
+    page,
+    taskDetailsPageV1,
+    taskPanelPageV1,
+  }) => {
+    test.slow();
+    await taskPanelPageV1.filterBy('Unassigned');
+    await taskPanelPageV1.openTask('usertask_with_variables');
+
+    await expect(taskDetailsPageV1.addVariableButton).toBeHidden();
+    await expect(taskDetailsPageV1.assignToMeButton).toBeVisible();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeDisabled();
+    await taskDetailsPageV1.clickAssignToMeButton();
+
+    await expect(taskDetailsPageV1.unassignButton).toBeVisible();
+    await expect(taskDetailsPageV1.completeTaskButton).toBeEnabled();
+    await expect(taskDetailsPageV1.assignee).toHaveText('Assigned to me');
+
+    await taskDetailsPageV1.addVariable({
+      name: 'newVariableName',
+      value: '"newVariableValue"',
+    });
+
+    await taskDetailsPageV1.completeTaskButton.click();
+    await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
+    await expect(taskDetailsPageV1.pickATaskHeader).toBeVisible();
+
+    await page.reload();
+
+    await taskPanelPageV1.filterBy('Completed');
+    await taskPanelPageV1.openTask('usertask_with_variables');
+
+    await expect(page.getByText('newVariableName')).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(page.getByText('newVariableValue')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description
Implements complete separation of Tasklist V1 and V2 test execution, treating them as distinct applications. V2 is now the default test mode.

## Changes

### Test Architecture
- Separated V1 and V2 test execution contexts
- Created dedicated page objects for each mode (`pages/v1/` for V1, main `pages/` for V2)
- Updated Playwright config with distinct projects: `tasklist-v1-e2e` and `tasklist-v2-e2e`

### Configuration
- **playwright.config.ts**: Added mode-specific project configurations with proper test matching patterns
- **GitHub Actions**: Updated workflows to handle both modes independently with conditional Docker service startup
- **Environment**: Mode-specific variable configuration (`CAMUNDA_TASKLIST_V2_MODE_ENABLED`)


## 🧪 Testing
- [Release workflow](https://github.com/camunda/camunda/actions/runs/18713833871/job/53368352091)
- [8.7 Release workflow](https://github.com/camunda/camunda/actions/runs/18714086387/job/53369304146)
- [On-demand workflow](https://github.com/camunda/camunda/actions/runs/18719343265/job/53387280968)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38266

