### PR TITLE
feat: implement API to search for element incidents

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -211,6 +211,7 @@ public class CamundaServicesConfiguration {
       final SecurityContextProvider securityContextProvider,
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient,
       final ProcessCache processCache,
+      final IncidentServices incidentServices,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new ElementInstanceServices(
@@ -218,6 +219,7 @@ public class CamundaServicesConfiguration {
         securityContextProvider,
         flowNodeInstanceSearchClient,
         processCache,
+        incidentServices,
         null,
         executorProvider,
         brokerRequestAuthorizationConverter);

--- a/service/src/main/java/io/camunda/service/ElementInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ElementInstanceServices.java
@@ -12,7 +12,10 @@ import static io.camunda.service.authorization.Authorizations.ELEMENT_INSTANCE_R
 
 import io.camunda.search.clients.FlowNodeInstanceSearchClient;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -32,14 +35,17 @@ public final class ElementInstanceServices
     extends SearchQueryService<
         ElementInstanceServices, FlowNodeInstanceQuery, FlowNodeInstanceEntity> {
 
+  private static final String FNI_ELEMENT_INSTANCE_PATTERN = "*FNI_%d*";
   private final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient;
   private final ProcessCache processCache;
+  private final IncidentServices incidentServices;
 
   public ElementInstanceServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient,
       final ProcessCache processCache,
+      final IncidentServices incidentServices,
       final CamundaAuthentication authentication,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
@@ -51,6 +57,7 @@ public final class ElementInstanceServices
         brokerRequestAuthorizationConverter);
     this.flowNodeInstanceSearchClient = flowNodeInstanceSearchClient;
     this.processCache = processCache;
+    this.incidentServices = incidentServices;
   }
 
   @Override
@@ -60,6 +67,7 @@ public final class ElementInstanceServices
         securityContextProvider,
         flowNodeInstanceSearchClient,
         processCache,
+        incidentServices,
         authentication,
         executorProvider,
         brokerRequestAuthorizationConverter);
@@ -145,6 +153,26 @@ public final class ElementInstanceServices
     return item.hasFlowNodeName()
         ? item
         : item.withFlowNodeName(cachedItem.getElementName(item.flowNodeId()));
+  }
+
+  public SearchQueryResult<IncidentEntity> searchIncidents(
+      final long elementInstanceKey, final IncidentQuery query) {
+    final IncidentQuery safeQuery = (query != null) ? query : IncidentQuery.of(b -> b);
+    final var authenticatedIncidentServices = incidentServices.withAuthentication(authentication);
+    if (authenticatedIncidentServices == null) {
+      return SearchQueryResult.of();
+    }
+    return authenticatedIncidentServices.search(
+        IncidentQuery.of(
+            b ->
+                b.filter(
+                        f ->
+                            f.treePathOperations(
+                                Operation.like(
+                                    String.format(
+                                        FNI_ELEMENT_INSTANCE_PATTERN, elementInstanceKey))))
+                    .sort(safeQuery.sort())
+                    .page(safeQuery.page())));
   }
 
   public record SetVariablesRequest(

--- a/service/src/main/java/io/camunda/service/ElementInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ElementInstanceServices.java
@@ -157,7 +157,6 @@ public final class ElementInstanceServices
 
   public SearchQueryResult<IncidentEntity> searchIncidents(
       final long elementInstanceKey, final IncidentQuery query) {
-    final IncidentQuery safeQuery = (query != null) ? query : IncidentQuery.of(b -> b);
     final var authenticatedIncidentServices = incidentServices.withAuthentication(authentication);
     if (authenticatedIncidentServices == null) {
       return SearchQueryResult.of();
@@ -171,8 +170,8 @@ public final class ElementInstanceServices
                                 Operation.like(
                                     String.format(
                                         FNI_ELEMENT_INSTANCE_PATTERN, elementInstanceKey))))
-                    .sort(safeQuery.sort())
-                    .page(safeQuery.page())));
+                    .sort(query.sort())
+                    .page(query.page())));
   }
 
   public record SetVariablesRequest(

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -202,6 +202,7 @@ public final class ElementInstanceServiceTest {
     class SearchIncidents {
       @Test
       void shouldReturnIncidentsForValidQuery() {
+        // given
         final long elementInstanceKey = 123L;
         final IncidentQuery query = IncidentQuery.of(q -> q);
         final IncidentEntity incident =
@@ -211,26 +212,22 @@ public final class ElementInstanceServiceTest {
 
         final SearchQueryResult<IncidentEntity> result = SearchQueryResult.of(incident);
         when(incidentServices.search(any(IncidentQuery.class))).thenReturn(result);
+        // when
         final var searchResult = services.searchIncidents(elementInstanceKey, query);
+        // then
         assertThat(searchResult.items()).containsExactly(incident);
       }
 
       @Test
       void shouldReturnEmptyListIfNoIncidentsFound() {
+        // given
         final long elementInstanceKey = 456L;
         final IncidentQuery query = IncidentQuery.of(q -> q);
         final SearchQueryResult<IncidentEntity> result = SearchQueryResult.of();
         when(incidentServices.search(any(IncidentQuery.class))).thenReturn(result);
+        // when
         final var searchResult = services.searchIncidents(elementInstanceKey, query);
-        assertThat(searchResult.items()).isEmpty();
-      }
-
-      @Test
-      void shouldHandleNullQueryGracefully() {
-        final long elementInstanceKey = 789L;
-        final SearchQueryResult<IncidentEntity> result = SearchQueryResult.of();
-        when(incidentServices.search(any(IncidentQuery.class))).thenReturn(result);
-        final var searchResult = services.searchIncidents(elementInstanceKey, null);
+        // then
         assertThat(searchResult.items()).isEmpty();
       }
     }

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -16,10 +16,13 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.FlowNodeInstanceSearchClient;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.authorization.Authorizations;
 import io.camunda.service.cache.ProcessCache;
 import io.camunda.service.cache.ProcessCacheItem;
@@ -35,27 +38,33 @@ import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 
 public final class ElementInstanceServiceTest {
 
   private ElementInstanceServices services;
   private FlowNodeInstanceSearchClient client;
   private ProcessCache processCache;
+  @Mock private IncidentServices incidentServices;
+  @Mock private CamundaAuthentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(FlowNodeInstanceSearchClient.class);
     processCache = mock(ProcessCache.class);
+    incidentServices = mock(IncidentServices.class);
     services =
         new ElementInstanceServices(
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,
             processCache,
+            incidentServices,
             null,
             mock(ApiServicesExecutorProvider.class),
             null);
 
+    when(incidentServices.withAuthentication(authentication)).thenReturn(incidentServices);
     when(client.withSecurityContext(any())).thenReturn(client);
     when(processCache.getCacheItems(any())).thenReturn(ProcessCacheResult.EMPTY);
   }
@@ -187,6 +196,43 @@ public final class ElementInstanceServiceTest {
 
       // then
       assertThat(foundEntity.flowNodeName()).isEqualTo(entity.flowNodeId());
+    }
+
+    @Nested
+    class SearchIncidents {
+      @Test
+      void shouldReturnIncidentsForValidQuery() {
+        final long elementInstanceKey = 123L;
+        final IncidentQuery query = IncidentQuery.of(q -> q);
+        final IncidentEntity incident =
+            Instancio.of(IncidentEntity.class)
+                .set(field(IncidentEntity::flowNodeInstanceKey), elementInstanceKey)
+                .create();
+
+        final SearchQueryResult<IncidentEntity> result = SearchQueryResult.of(incident);
+        when(incidentServices.search(any(IncidentQuery.class))).thenReturn(result);
+        final var searchResult = services.searchIncidents(elementInstanceKey, query);
+        assertThat(searchResult.items()).containsExactly(incident);
+      }
+
+      @Test
+      void shouldReturnEmptyListIfNoIncidentsFound() {
+        final long elementInstanceKey = 456L;
+        final IncidentQuery query = IncidentQuery.of(q -> q);
+        final SearchQueryResult<IncidentEntity> result = SearchQueryResult.of();
+        when(incidentServices.search(any(IncidentQuery.class))).thenReturn(result);
+        final var searchResult = services.searchIncidents(elementInstanceKey, query);
+        assertThat(searchResult.items()).isEmpty();
+      }
+
+      @Test
+      void shouldHandleNullQueryGracefully() {
+        final long elementInstanceKey = 789L;
+        final SearchQueryResult<IncidentEntity> result = SearchQueryResult.of();
+        when(incidentServices.search(any(IncidentQuery.class))).thenReturn(result);
+        final var searchResult = services.searchIncidents(elementInstanceKey, null);
+        assertThat(searchResult.items()).isEmpty();
+      }
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5241,7 +5241,7 @@ paths:
       operationId: searchElementInstanceIncidents
       summary: Search for incidents of a specific element instance
       description: |
-        Search for incidents caused by the specified element instance. Supported only for document-based backends (Elasticsearch/OpenSearch).
+        Search for incidents caused by the specified element instance, including incidents of any child instances created from this element instance.
       parameters:
         - name: elementInstanceKey
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5234,6 +5234,48 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+  /element-instances/{elementInstanceKey}/incidents/search:
+    post:
+      tags:
+        - Element instance
+      operationId: searchElementInstanceIncidents
+      summary: Search for incidents of a specific element instance
+      description: |
+        Search for incidents caused by the specified element instance. Supported only for document-based backends (Elasticsearch/OpenSearch).
+      parameters:
+        - name: elementInstanceKey
+          in: path
+          required: true
+          description: The unique key of the element instance to search incidents for.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ElementInstanceIncidentSearchQuery"
+      responses:
+        "200":
+          description: The element instance incident search result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IncidentSearchQueryResult"
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The element instance with the given key was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation:
     post:
@@ -7083,6 +7125,16 @@ components:
         incidentKey:
           description: Incident key associated with this element instance.
           type: string
+    ElementInstanceIncidentSearchQuery:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: "#/components/schemas/IncidentSearchQuerySortRequest"
     AdHocSubProcessActivateActivitiesInstruction:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -290,17 +290,6 @@ public final class SearchQueryResponseMapper {
                 .orElseGet(Collections::emptyList));
   }
 
-  public static IncidentSearchQueryResult toElementIncidentSearchQueryResponse(
-      final SearchQueryResult<IncidentEntity> result) {
-    final var page = toSearchQueryPageResponse(result);
-    return new IncidentSearchQueryResult()
-        .page(page)
-        .items(
-            ofNullable(result.items())
-                .map(SearchQueryResponseMapper::toIncidents)
-                .orElseGet(Collections::emptyList));
-  }
-
   public static JobSearchQueryResult toJobSearchQueryResponse(
       final SearchQueryResult<JobEntity> result) {
     final var page = toSearchQueryPageResponse(result);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -290,6 +290,17 @@ public final class SearchQueryResponseMapper {
                 .orElseGet(Collections::emptyList));
   }
 
+  public static IncidentSearchQueryResult toElementIncidentSearchQueryResponse(
+      final SearchQueryResult<IncidentEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return new IncidentSearchQueryResult()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(SearchQueryResponseMapper::toIncidents)
+                .orElseGet(Collections::emptyList));
+  }
+
   public static JobSearchQueryResult toJobSearchQueryResponse(
       final SearchQueryResult<JobEntity> result) {
     final var page = toSearchQueryPageResponse(result);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -482,8 +482,10 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
 
   @Test
   void shouldSearchIncidentsForElementInstance() {
+    // given
     when(elementInstanceServices.searchIncidents(any(Long.class), any(IncidentQuery.class)))
         .thenReturn(INCIDENT_SEARCH_RESULT);
+    // when / then
     webClient
         .post()
         .uri(String.format(INCIDENTS_SEARCH_URL, 1L))
@@ -501,8 +503,10 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
 
   @Test
   void shouldSearchIncidentsForElementInstanceWithNullBody() {
+    // given
     when(elementInstanceServices.searchIncidents(any(Long.class), any(IncidentQuery.class)))
         .thenReturn(INCIDENT_SEARCH_RESULT);
+    // when / then
     webClient
         .post()
         .uri(String.format(INCIDENTS_SEARCH_URL, 1L))


### PR DESCRIPTION
## Description

This PR implements the API to search for element-level incidents as described in  
[camunda/camunda#38806](https://github.com/camunda/camunda/issues/38806), based on the requirements outlined in [sub-task #39311](https://github.com/camunda/camunda/issues/39311).

### Implementation Note

To enable searching for incidents related to a specific element instance, the implementation uses the `elementInstanceKey` provided in the request. A prefix is constructed using the format `FNI_<elementInstanceKey>`. This constructed string is then used in a `like` query on the `treePath` field of the incident index.

This approach aligns with how incident tree paths are structured internally.  
If there is a more efficient or idiomatic way to perform this filtering in Elasticsearch, suggestions are welcome!

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (e.g. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Closes [#38806](https://github.com/camunda/camunda/issues/38806)