### PR TITLE
feat: Publish ZIP with SQLs as GitHub asset

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -222,6 +222,7 @@ jobs:
           ARTIFACT_DIR=$(mktemp -d)
           cp target/checkout/dist/target/camunda-zeebe-"${RELEASE_VERSION}".tar.gz "${ARTIFACT_DIR}/"
           cp target/checkout/dist/target/camunda-zeebe-"${RELEASE_VERSION}".zip "${ARTIFACT_DIR}/"
+          cp target/checkout/db/rdbms-schema/target/camunda-db-rdbms-schema-"${RELEASE_VERSION}".zip "${ARTIFACT_DIR}/"
           echo "dir=${ARTIFACT_DIR}" >> "$GITHUB_OUTPUT"
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

* During the Maven build, we create a ZIP archive that contains Liquibase changesets and SQL scripts for RDBMS schema setup. This archive is now published as an asset to GitHub during the release process

No backports needed prior to 8.9.

## Related issues

Belongs to #38412
