### PR TITLE
fix: use self-hosted runners to run fossa analysis

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -29,9 +29,9 @@ jobs:
       # Needed for camunda/infra-global-github-actions/fossa/info
       actions: read
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-8-default
     # If you change the job timeout, update the timeout in camunda/infra-global-github-actions/fossa/pr-check accordingly.
-    timeout-minutes: 21
+    timeout-minutes: 31
     strategy:
       fail-fast: false
       # The matrix is necessary to run separate analyses
@@ -84,11 +84,11 @@ jobs:
         echo "${MAVEN_CONFIG}" | tee ./.mvn/maven.config
 
     - name: Setup fossa-cli
-      uses: camunda/infra-global-github-actions/fossa/setup@bff7e8672595d56541af77d473a6070bd5335b5f
+      uses: camunda/infra-global-github-actions/fossa/setup@0cefec60b9a847594d0e33cddef4857772e3b09a
 
     - name: Get context info
       id: info
-      uses: camunda/infra-global-github-actions/fossa/info@bff7e8672595d56541af77d473a6070bd5335b5f
+      uses: camunda/infra-global-github-actions/fossa/info@0cefec60b9a847594d0e33cddef4857772e3b09a
 
     - name: Adjust pom.xml files for FOSSA
       if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
@@ -111,7 +111,7 @@ jobs:
           optimize/pom.xml
 
     - name: Analyze project
-      uses: camunda/infra-global-github-actions/fossa/analyze@bff7e8672595d56541af77d473a6070bd5335b5f
+      uses: camunda/infra-global-github-actions/fossa/analyze@0cefec60b9a847594d0e33cddef4857772e3b09a
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         branch: ${{  steps.info.outputs.head-ref }}
@@ -123,7 +123,7 @@ jobs:
     # It does not fail for pre-existing issues already present in the base branch.
     - name: Check Pull Request for new License Issues
       if: steps.info.outputs.is-pull-request == 'true'
-      uses: camunda/infra-global-github-actions/fossa/pr-check@bff7e8672595d56541af77d473a6070bd5335b5f
+      uses: camunda/infra-global-github-actions/fossa/pr-check@0cefec60b9a847594d0e33cddef4857772e3b09a
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         base-ref: ${{ steps.info.outputs.base-ref }}
@@ -137,7 +137,7 @@ jobs:
         path: ${{ matrix.project.path }}
         project: ${{ matrix.project.name }}
         revision: ${{ steps.info.outputs.head-revision }}
-        timeout: 20 # must be less than overall job timeout
+        timeout: 30 # must be less than overall job timeout
         timeout-start-time: ${{ steps.info.outputs.job-start-time }}
     - name: Observe build status
       if: always()


### PR DESCRIPTION
## Description

Related to [inc-3818](https://camunda.slack.com/archives/C09M8Q0F0C8/p1760452561794769).

This PR updates the `check-licenses.yml` workflow to use self-hosted runners for FOSSA analysis jobs, since GitHub-hosted runners can be preempted under FOSSA load.

Increased the timeout to 10+ minutes since FOSSA analysis takes a bit longer.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
