### PR TITLE
ci: fix npm version

### DIFF
--- a/operate/client/pom.xml
+++ b/operate/client/pom.xml
@@ -51,7 +51,7 @@
             </goals>
             <configuration>
               <skip>${skip.fe.build}</skip>
-              <arguments>version --new-version=${project.version} --no-git-tag-version</arguments>
+              <arguments>version ${project.version} --no-git-tag-version --allow-same-version</arguments>
             </configuration>
           </execution>
 

--- a/tasklist/client/pom.xml
+++ b/tasklist/client/pom.xml
@@ -45,7 +45,7 @@
             </goals>
             <configuration>
               <skip>${skip.fe.build}</skip>
-              <arguments>version --new-version=${project.version} --no-git-tag-version</arguments>
+              <arguments>version ${project.version} --no-git-tag-version --allow-same-version</arguments>
             </configuration>
           </execution>
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Since we migrated to NPM from yarn the version command wrong which causes the version in the frontend apps of Operate/Tasklist to not change. [Reported here by Ingo](https://camunda.slack.com/archives/C08MRKHJ0CD/p1760457184863979)

[Here are the docs for the NPM command](https://docs.npmjs.com/cli/v11/commands/npm-version)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39559
