### PR TITLE
Revert "[Backport stable/8.8] fix: add RESOLVE IncidentState which was missing"

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/incident/IncidentState.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/incident/IncidentState.java
@@ -15,7 +15,6 @@ public enum IncidentState {
   ACTIVE("CREATED"),
   MIGRATED("MIGRATED"),
   RESOLVED("RESOLVED"),
-  RESOLVE("RESOLVE"),
   PENDING(null);
 
   private static final Map<String, IncidentState> INTENT_MAP = new HashMap<>();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -33,7 +33,6 @@ import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEnt
 import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.webapps.schema.entities.post.PostImporterActionType;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -349,15 +348,6 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
     for (final var hit : hits) {
       final var entity = hit.source();
       final var newState = IncidentState.createFrom(entity.intent());
-
-      if (newState == null) {
-        final var errMsg =
-            String.format(
-                "Pending incident has a new state of [%s], which is not a valid IncidentState, should be one of %s",
-                entity.intent(), Arrays.toString(IncidentState.values()));
-        throw new IllegalStateException(errMsg);
-      }
-
       incidents.put(entity.key(), newState);
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -19,7 +19,6 @@ import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.webapps.schema.entities.post.PostImporterActionType;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -400,15 +399,6 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
     for (final var hit : hits) {
       final var entity = hit.source();
       final var newState = IncidentState.createFrom(entity.intent());
-
-      if (newState == null) {
-        final var errMsg =
-            String.format(
-                "Pending incident has a new state of [%s], which is not a valid IncidentState, should be one of %s",
-                entity.intent(), Arrays.toString(IncidentState.values()));
-        throw new IllegalStateException(errMsg);
-      }
-
       incidents.put(entity.key(), newState);
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -227,28 +227,6 @@ abstract class IncidentUpdateRepositoryIT {
   @Nested
   final class GetPendingIncidentsBatchTest {
     @Test
-    void shouldMatchAllIncidentIntentsToIncidentState() {
-      final var repository = createRepository();
-
-      for (final var intent : IncidentIntent.values()) {
-        setupIncidentUpdates(1, 2, e -> e.setIntent(intent.name()).setKey((long) intent.value()));
-      }
-
-      final var newIncidentStates =
-          repository
-              .getPendingIncidentsBatch(1L, IncidentIntent.values().length)
-              .toCompletableFuture()
-              .join()
-              .newIncidentStates();
-
-      for (final var intent : IncidentIntent.values()) {
-        final var matchingIncidentState = newIncidentStates.get((long) intent.value());
-        assertThat(matchingIncidentState).isNotNull();
-        assertThat(matchingIncidentState).isEqualTo(IncidentState.createFrom(intent.name()));
-      }
-    }
-
-    @Test
     void shouldGetOnlyNewUpdatesByPosition() throws PersistenceException {
       // given
       final var repository = createRepository();


### PR DESCRIPTION
Reverts camunda/camunda#39325

Since we are still not sure about the solution, and that 8.8.1 will be released soon, I think it is better we revert the initial fix, to avoid storing new Enum value that we may not able to process