### PR TITLE
feat: message subscriptions migration

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.test.tsx
@@ -360,4 +360,87 @@ describe('MetadataPopover <Details />', () => {
     expect(screen.getByText(/"jobType"/)).toBeInTheDocument();
     expect(screen.getByText(/"jobWorker"/)).toBeInTheDocument();
   });
+
+  it('should display message name and correlation key for service task with message subscription data', async () => {
+    const messageSubscriptionMetaData: V2MetaDataDto = {
+      ...baseMetaData,
+      instanceMetadata: {
+        ...baseMetaData.instanceMetadata!,
+        type: 'SERVICE_TASK',
+        messageName: 'orderReceived',
+        correlationKey: 'order-123',
+      },
+    };
+
+    const {user} = render(
+      <Details
+        metaData={messageSubscriptionMetaData}
+        elementId="ServiceTask_1"
+      />,
+      {wrapper: TestWrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Show more metadata'}));
+
+    expect(
+      screen.getByText(/Element "ServiceTask_1" 123456789 Metadata/),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/"messageName": "orderReceived"/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/"correlationKey": "order-123"/),
+    ).toBeInTheDocument();
+  });
+
+  it('should not display message fields when message name and correlation key are absent', async () => {
+    const serviceTaskMetaData: V2MetaDataDto = {
+      ...baseMetaData,
+      instanceMetadata: {
+        ...baseMetaData.instanceMetadata!,
+        type: 'SERVICE_TASK',
+      },
+    };
+
+    const {user} = render(
+      <Details metaData={serviceTaskMetaData} elementId="ServiceTask_3" />,
+      {wrapper: TestWrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Show more metadata'}));
+
+    expect(screen.queryByText(/"messageName"/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"correlationKey"/)).not.toBeInTheDocument();
+  });
+
+  it('should display message subscription data for message events', async () => {
+    const messageEventMetaData: V2MetaDataDto = {
+      ...baseMetaData,
+      instanceMetadata: {
+        ...baseMetaData.instanceMetadata!,
+        type: 'INTERMEDIATE_CATCH_EVENT',
+        messageName: 'clientMessage',
+        correlationKey: 'client-456',
+      },
+    };
+
+    const {user} = render(
+      <Details metaData={messageEventMetaData} elementId="MessageEvent_1" />,
+      {wrapper: TestWrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Show more metadata'}));
+
+    expect(
+      screen.getByText(/Element "MessageEvent_1" 123456789 Metadata/),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/"messageName": "clientMessage"/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/"correlationKey": "client-456"/),
+    ).toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/calledDecisions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/calledDecisions.test.tsx
@@ -48,6 +48,7 @@ import type {
   ProcessInstance,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
+import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
 
 const MOCK_EXECUTION_DATE = '21 seconds';
 
@@ -158,6 +159,11 @@ describe('MetadataPopover', () => {
     });
 
     mockSearchIncidentsByProcessInstance('2251799813685294').withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+
+    mockSearchMessageSubscriptions().withSuccess({
       items: [],
       page: {totalItems: 0},
     });

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
@@ -52,6 +52,7 @@ import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockSearchUserTasks} from 'modules/mocks/api/v2/userTasks/searchUserTasks';
 import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
+import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
 
 const MOCK_EXECUTION_DATE = '21 seconds';
 
@@ -169,6 +170,11 @@ describe('MetadataPopover', () => {
       page: {
         totalItems: 0,
       },
+    });
+
+    mockSearchMessageSubscriptions().withSuccess({
+      items: [],
+      page: {totalItems: 0},
     });
   });
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
@@ -31,6 +31,7 @@ import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefi
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import {convertBpmnJsTypeToAPIType} from './convertBpmnJsTypeToAPIType';
 import {useJobs} from 'modules/queries/jobs/useJobs';
+import {useSearchMessageSubscriptions} from 'modules/queries/messageSubscriptions/useSearchMessageSubscriptions';
 
 type Props = {
   selectedFlowNodeRef?: SVGGraphicsElement | null;
@@ -180,6 +181,20 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
     select: (data) => data.pages?.flatMap((page) => page.items),
   });
 
+  const {
+    data: messageSubscriptionSearchResult,
+    isLoading: isSearchingMessageSubscription,
+  } = useSearchMessageSubscriptions(
+    {
+      filter: {
+        elementInstanceKey: elementInstanceMetadata?.elementInstanceKey ?? '',
+      },
+    },
+    {
+      enabled: !!elementInstanceMetadata?.elementInstanceKey,
+    },
+  );
+
   if (
     elementId === undefined ||
     metaData === null ||
@@ -187,7 +202,8 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
     (!!elementInstanceId && isFetchingInstance) ||
     isSearchingUserTasks ||
     isSearchingProcessInstances ||
-    isSearchingJob
+    isSearchingJob ||
+    isSearchingMessageSubscription
   ) {
     return null;
   }
@@ -227,6 +243,7 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
                 elementInstanceMetadata,
                 jobSearchResult?.[0],
                 processInstancesSearchResult?.items?.[0],
+                messageSubscriptionSearchResult?.items?.[0],
                 elementInstanceMetadata.type === 'USER_TASK'
                   ? userTask
                   : undefined,

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
@@ -12,6 +12,7 @@ import type {
   ProcessInstance,
   Job,
   UserTask,
+  MessageSubscription,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 
 // V2 Element Instance Metadata - extends the old structure but with v2 element instance fields will be removed after other components migration
@@ -43,6 +44,8 @@ type V2InstanceMetadata = {
   jobDeadline?: string | null;
   jobCustomHeaders: Record<string, unknown> | null;
   jobKey?: string | null;
+  messageName?: string | null;
+  correlationKey?: string | null;
 } & Partial<UserTask>;
 
 type V2MetaDataDto = Omit<MetaDataDto, 'instanceMetadata' | 'incident'> & {
@@ -76,6 +79,7 @@ function createV2InstanceMetadata(
   elementInstance: ElementInstance,
   job?: Job,
   calledProcess?: ProcessInstance,
+  messageSubscription?: MessageSubscription,
   userTask: Partial<UserTaskSubset> | null = {},
 ): V2InstanceMetadata {
   const {
@@ -93,6 +97,8 @@ function createV2InstanceMetadata(
     candidateUsers,
     externalFormReference,
   } = userTask ?? {};
+
+  const {messageName, correlationKey} = messageSubscription ?? {};
 
   return {
     calledProcessInstanceId: calledProcess?.processInstanceKey ?? null,
@@ -136,6 +142,9 @@ function createV2InstanceMetadata(
     candidateGroups,
     candidateUsers,
     externalFormReference,
+
+    messageName,
+    correlationKey,
   };
 }
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -52,6 +52,7 @@ import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/inciden
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
+import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
 
 const mockIncidents = {
   count: 1,
@@ -239,6 +240,11 @@ describe('TopPanel', () => {
       page: {totalItems: 0},
     });
     mockSearchProcessInstances().withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+
+    mockSearchMessageSubscriptions().withSuccess({
       items: [],
       page: {totalItems: 0},
     });


### PR DESCRIPTION
## Description

Migrates MetadataPopover to use v2 message subscriptions search endpoint to get  message subscriptions data

## Related issues

related to #33219 
