### PR TITLE
fix: do not export auth info to avoid introducing a new field

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.distribution;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
@@ -178,10 +179,6 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     return concreteCommandValue;
   }
 
-  public AuthInfo getAuthInfo() {
-    return authInfoProperty.getValue();
-  }
-
   public CommandDistributionRecord setCommandValue(final UnifiedRecordValue commandValue) {
     if (commandValue == null) {
       commandValueProperty.reset();
@@ -220,6 +217,11 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   public CommandDistributionRecord setPartitionId(final int partitionId) {
     partitionIdProperty.setValue(partitionId);
     return this;
+  }
+
+  @JsonIgnoreProperties
+  public AuthInfo getAuthInfo() {
+    return authInfoProperty.getValue();
   }
 
   public CommandDistributionRecord setAuthInfo(final AuthInfo authInfo) {


### PR DESCRIPTION
This fixes an accidentally breaking change introduced with https://github.com/camunda/camunda/pull/39495. It slipped past our tests because of this missing test coverage: https://github.com/camunda/camunda/issues/39577