### PR TITLE
[Backport stable/8.6] fix: use self-hosted runners to run fossa analysis

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -20,7 +20,7 @@ jobs:
   analyze:
     name: "Analyze ${{ matrix.project.name }} dependencies"
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-8-default
     timeout-minutes: 20
     strategy:
       # The matrix is necessary to run separate analyses


### PR DESCRIPTION
# Description
Backport of #39560 to `stable/8.6`.

relates to 