### PR TITLE
[Backport stable/8.8] fix: use self-hosted runners to run fossa analysis

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -29,9 +29,9 @@ jobs:
       # Needed for camunda/infra-global-github-actions/fossa/info
       actions: read
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-8-default
     # If you change the job timeout, update the timeout in camunda/infra-global-github-actions/fossa/pr-check accordingly.
-    timeout-minutes: 21
+    timeout-minutes: 31
     strategy:
       fail-fast: false
       # The matrix is necessary to run separate analyses
@@ -137,7 +137,7 @@ jobs:
         path: ${{ matrix.project.path }}
         project: ${{ matrix.project.name }}
         revision: ${{ steps.info.outputs.head-revision }}
-        timeout: 20 # must be less than overall job timeout
+        timeout: 30 # must be less than overall job timeout
         timeout-start-time: ${{ steps.info.outputs.job-start-time }}
     - name: Observe build status
       if: always()


### PR DESCRIPTION
# Description
Backport of #39560 to `stable/8.8`.

relates to 