### PR TITLE
[Backport stable/8.8] ci: fix npm version

### DIFF
--- a/operate/client/pom.xml
+++ b/operate/client/pom.xml
@@ -51,7 +51,7 @@
             </goals>
             <configuration>
               <skip>${skip.fe.build}</skip>
-              <arguments>version --new-version=${project.version} --no-git-tag-version</arguments>
+              <arguments>version ${project.version} --no-git-tag-version --allow-same-version</arguments>
             </configuration>
           </execution>
 

--- a/tasklist/client/pom.xml
+++ b/tasklist/client/pom.xml
@@ -45,7 +45,7 @@
             </goals>
             <configuration>
               <skip>${skip.fe.build}</skip>
-              <arguments>version --new-version=${project.version} --no-git-tag-version</arguments>
+              <arguments>version ${project.version} --no-git-tag-version --allow-same-version</arguments>
             </configuration>
           </execution>
 


### PR DESCRIPTION
# Description
Backport of #39562 to `stable/8.8`.

relates to #39559