### PR TITLE
feat: implement ui changes for operate incidents table v2

### DIFF
--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.test.tsx
@@ -41,7 +41,7 @@ describe('IncidentsFilter', () => {
 
     await fetchIncidents('1');
 
-    const {user} = render(<IncidentsFilter />, {
+    const {user} = render(<IncidentsFilter processInstanceKey="1" />, {
       wrapper: Wrapper,
     });
 
@@ -72,7 +72,7 @@ describe('IncidentsFilter', () => {
 
     await fetchIncidents('1');
 
-    const {user} = render(<IncidentsFilter />, {
+    const {user} = render(<IncidentsFilter processInstanceKey="1" />, {
       wrapper: Wrapper,
     });
 

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.tsx
@@ -12,8 +12,19 @@ import {observer} from 'mobx-react';
 import {tracking} from 'modules/tracking';
 import {Button, MultiSelect} from '@carbon/react';
 import {useIncidentsElements} from 'modules/hooks/incidents';
+import {IS_INCIDENTS_PANEL_V2} from 'modules/feature-flags';
+import {useProcessInstanceIncidentsErrorTypes} from 'modules/queries/incidents/useGetIncidentsByProcessInstance';
+import {getIncidentErrorName} from 'modules/utils/incidents';
 
-const IncidentsFilter: React.FC = observer(() => {
+type Props = {
+  processInstanceKey: string;
+};
+
+const IncidentsFilter: React.FC<Props> = observer(({processInstanceKey}) => {
+  if (IS_INCIDENTS_PANEL_V2) {
+    return <IncidentsFilterV2 processInstanceKey={processInstanceKey} />;
+  }
+
   const {
     errorTypes,
     setFlowNodeSelection,
@@ -71,6 +82,52 @@ const IncidentsFilter: React.FC = observer(() => {
             disabled={
               selectedFlowNodes.length === 0 && selectedErrorTypes.length === 0
             }
+            title="Reset Filters"
+            size="sm"
+          >
+            Reset Filters
+          </Button>
+        </Stack>
+      </Container>
+    </Layer>
+  );
+});
+
+const IncidentsFilterV2: React.FC<Props> = observer(({processInstanceKey}) => {
+  const {
+    setErrorTypeSelection,
+    clearSelection,
+    state: {selectedErrorTypes},
+  } = incidentsStore;
+  const availableErrorTypes =
+    useProcessInstanceIncidentsErrorTypes(processInstanceKey);
+
+  return (
+    <Layer>
+      <Container>
+        <Stack orientation="horizontal" gap={5}>
+          <MultiSelect
+            id="incidents-by-errorType"
+            data-testid="incidents-by-errorType"
+            items={availableErrorTypes}
+            itemToString={(selectedItem) => getIncidentErrorName(selectedItem)}
+            label="Filter by Incident Type"
+            titleText="Filter by Incident Type"
+            hideLabel
+            onChange={({selectedItems}) => {
+              setErrorTypeSelection(selectedItems);
+            }}
+            size="sm"
+          />
+          <Button
+            kind="ghost"
+            onClick={() => {
+              clearSelection();
+              tracking.track({
+                eventName: 'incident-filters-cleared',
+              });
+            }}
+            disabled={selectedErrorTypes.length === 0}
             title="Reset Filters"
             size="sm"
           >

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.tsx
@@ -66,10 +66,6 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
 
     const isJobKeyPresent = sortedIncidents.some(({jobKey}) => !!jobKey);
 
-    const hasIncidentInCalledInstance = sortedIncidents.some(
-      (i) => i.processInstanceKey !== processInstanceKey,
-    );
-
     return (
       <>
         <SortableTable
@@ -135,14 +131,6 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
               key: 'errorMessage',
               isDisabled: true,
             },
-            ...(hasIncidentInCalledInstance
-              ? [
-                  {
-                    header: 'Root Cause Instance',
-                    key: 'rootCauseInstance',
-                  },
-                ]
-              : []),
             ...(hasPermissionForRetryOperation
               ? [
                   {
@@ -161,7 +149,22 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
               id: incident.incidentKey,
               // TODO: Error type is no longer the same readable message...
               errorType: incident.errorType,
-              elementName: incident.elementName,
+              elementName:
+                processInstanceKey === incident.processInstanceKey ? (
+                  incident.elementName
+                ) : (
+                  <Link
+                    to={{
+                      pathname: Paths.processInstance(
+                        incident.processInstanceKey,
+                      ),
+                      search: `?elementId=${incident.elementId}`,
+                    }}
+                    title={`View root cause instance ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
+                  >
+                    {`${incident.elementId} ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
+                  </Link>
+                ),
               jobId: incident.jobKey || '--',
               creationTime: formatDate(incident.creationTime),
               errorMessage: (
@@ -190,21 +193,6 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
                   )}
                 </FlexContainer>
               ),
-              // TODO: This is wrong...
-              rootCauseInstance:
-                processInstanceKey === incident.processInstanceKey ? (
-                  '--'
-                ) : (
-                  <Link
-                    to={{
-                      pathname: Paths.processInstance(processInstanceKey),
-                    }}
-                    title={`View root cause instance ${incident.processDefinitionKey} - ${processInstanceKey}`}
-                  >
-                    {`${incident.processDefinitionKey} - ${processInstanceKey}`}
-                  </Link>
-                ),
-
               operations:
                 hasPermissionForRetryOperation && areOperationsVisible ? (
                   <IncidentOperation

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.tsx
@@ -62,7 +62,7 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
     ) => {
       setIsModalVisible(true);
       setModalContent(errorMessage);
-      setModalTitle(`Flow Node "${elementName}" Error`);
+      setModalTitle(`Element "${elementName}" Error`);
     };
 
     const sortedIncidents = sortIncidents(incidents, sortBy, sortOrder);
@@ -116,7 +116,7 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
               key: 'errorType',
             },
             {
-              header: 'Failing Flow Node',
+              header: 'Failing Element',
               key: 'elementName',
             },
             {
@@ -164,7 +164,7 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
                     }}
                     title={`View root cause instance ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
                   >
-                    {`${incident.elementId} ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
+                    {`${incident.elementId} - ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
                   </Link>
                 ),
               jobId: incident.jobKey || '--',

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.tsx
@@ -21,7 +21,10 @@ import {SortableTable} from 'modules/components/SortableTable';
 import {useState} from 'react';
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
 import {useHasPermissions} from 'modules/queries/permissions/useHasPermissions';
-import {isSingleIncidentSelectedV2} from 'modules/utils/incidents';
+import {
+  getIncidentErrorName,
+  isSingleIncidentSelectedV2,
+} from 'modules/utils/incidents';
 import {clearSelection, selectFlowNode} from 'modules/utils/flowNodeSelection';
 import {useRootNode} from 'modules/hooks/flowNodeSelection';
 import type {EnhancedIncident} from 'modules/hooks/incidents';
@@ -147,8 +150,7 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
 
             return {
               id: incident.incidentKey,
-              // TODO: Error type is no longer the same readable message...
-              errorType: incident.errorType,
+              errorType: getIncidentErrorName(incident.errorType),
               elementName:
                 processInstanceKey === incident.processInstanceKey ? (
                   incident.elementName

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/sorting.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/sorting.test.tsx
@@ -35,7 +35,7 @@ describe('Sorting', () => {
 
     expect(screen.getByText('Job Id')).toBeEnabled();
     expect(screen.getByText('Incident Type')).toBeEnabled();
-    expect(screen.getByText('Failing Flow Node')).toBeEnabled();
+    expect(screen.getByText('Failing Element')).toBeEnabled();
     expect(screen.getByText('Job Id')).toBeEnabled();
     expect(screen.getByText('Creation Date')).toBeEnabled();
     expect(screen.getByText('Error Message')).toBeEnabled();

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/index.tsx
@@ -77,7 +77,9 @@ const IncidentsWrapper: React.FC<Props> = observer(
               count={filteredIncidents.length}
               size="sm"
             >
-              <IncidentsFilter />
+              <IncidentsFilter
+                processInstanceKey={processInstance.processInstanceKey}
+              />
             </PanelHeader>
             <IncidentsTable />
           </IncidentsOverlay>
@@ -118,7 +120,9 @@ const IncidentsWrapperV2: React.FC<Props> = observer(
               count={filteredIncidents.length}
               size="sm"
             >
-              <IncidentsFilter />
+              <IncidentsFilter
+                processInstanceKey={processInstance.processInstanceKey}
+              />
             </PanelHeader>
             <IncidentsTableV2
               processInstanceKey={processInstance.processInstanceKey}

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Incident/resolveIncidentErrorType.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Incident/resolveIncidentErrorType.ts
@@ -7,28 +7,15 @@
  */
 
 import type {Incident} from 'modules/stores/incidents';
+import type {IncidentErrorType} from '@camunda/camunda-api-zod-schemas/8.8';
+import {getIncidentErrorName} from 'modules/utils/incidents';
 
-const ERROR_TYPE_NAMES: Record<string, string> = {
-  UNSPECIFIED: 'Unspecified',
-  UNKNOWN: 'Unknown error',
-  IO_MAPPING_ERROR: 'IO mapping error.',
-  JOB_NO_RETRIES: 'No more retries left.',
-  EXECUTION_LISTENER_NO_RETRIES: 'Execution listener error (no retries left).',
-  TASK_LISTENER_NO_RETRIES: 'Task listener error (no retries left).',
-  CONDITION_ERROR: 'Condition error.',
-  EXTRACT_VALUE_ERROR: 'Extract value error.',
-  CALLED_ELEMENT_ERROR: 'Called element error.',
-  UNHANDLED_ERROR_EVENT: 'Unhandled error event.',
-  MESSAGE_SIZE_EXCEEDED: 'Message size exceeded.',
-  CALLED_DECISION_ERROR: 'Called decision error.',
-  DECISION_EVALUATION_ERROR: 'Decision evaluation error.',
-  FORM_NOT_FOUND: 'Form not found.',
-  RESOURCE_NOT_FOUND: 'Resource not found.',
-};
-const resolveIncidentErrorType = (id: string): Incident['errorType'] => {
+const resolveIncidentErrorType = (
+  id: IncidentErrorType,
+): Incident['errorType'] => {
   return {
     id,
-    name: ERROR_TYPE_NAMES[id] ?? id.replace(/_/g, ' ').toLowerCase(),
+    name: getIncidentErrorName(id) ?? id.replace(/_/g, ' ').toLowerCase(),
   };
 };
 

--- a/operate/client/src/modules/hooks/incidents.ts
+++ b/operate/client/src/modules/hooks/incidents.ts
@@ -13,7 +13,6 @@ import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusiness
 import type {Incident} from '@camunda/camunda-api-zod-schemas/8.8';
 import {useProcessInstancesSearch} from 'modules/queries/processInstance/useProcessInstancesSearch';
 import {useGetIncidentsByProcessInstance} from 'modules/queries/incidents/useGetIncidentsByProcessInstance';
-import {useMemo} from 'react';
 
 type EnhancedIncident = Incident & {
   processDefinitionName: string;
@@ -72,30 +71,24 @@ const useIncidentsV2 = (
     },
   );
 
-  const enhancedIncidents = useMemo<EnhancedIncident[]>(() => {
-    if (!incidents) {
-      return [];
-    }
-
-    return incidents.map((incident) => {
-      return {
-        ...incident,
-        elementName: getFlowNodeName({
-          businessObjects,
-          flowNodeId: incident.elementId,
-        }),
-        isSelected: flowNodeSelectionStore.isSelected({
-          flowNodeId: incident.elementId,
-          flowNodeInstanceId: incident.elementInstanceKey,
-          isMultiInstance: false,
-        }),
-        processDefinitionName:
-          processDefinitionNames?.[incident.processInstanceKey] ?? '',
-      };
-    });
-  }, [incidents, businessObjects, processDefinitionNames]);
-
-  return enhancedIncidents;
+  return incidents
+    ? incidents.map((incident) => {
+        return {
+          ...incident,
+          elementName: getFlowNodeName({
+            businessObjects,
+            flowNodeId: incident.elementId,
+          }),
+          isSelected: flowNodeSelectionStore.isSelected({
+            flowNodeId: incident.elementId,
+            flowNodeInstanceId: incident.elementInstanceKey,
+            isMultiInstance: false,
+          }),
+          processDefinitionName:
+            processDefinitionNames?.[incident.processInstanceKey] ?? '',
+        };
+      })
+    : [];
 };
 
 const useIncidentsElements = () => {

--- a/operate/client/src/modules/hooks/incidents.ts
+++ b/operate/client/src/modules/hooks/incidents.ts
@@ -51,14 +51,11 @@ const useIncidentsV2 = (
     {enablePeriodicRefetch, select: (res) => res.items},
   );
 
-  const instancesWithIncident = useMemo(() => {
-    if (!incidents) {
-      return [];
-    }
-    return Array.from(
-      new Set(incidents.map((incident) => incident.processInstanceKey)),
-    );
-  }, [incidents]);
+  const instancesWithIncident = incidents
+    ? Array.from(
+        new Set(incidents.map((incident) => incident.processInstanceKey)),
+      )
+    : [];
 
   const {data: processDefinitionNames} = useProcessInstancesSearch(
     {

--- a/operate/client/src/modules/queries/incidents/useGetIncidentsByProcessInstance.ts
+++ b/operate/client/src/modules/queries/incidents/useGetIncidentsByProcessInstance.ts
@@ -6,7 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {QueryProcessInstanceIncidentsResponseBody} from '@camunda/camunda-api-zod-schemas/8.8';
+import type {
+  IncidentErrorType,
+  QueryProcessInstanceIncidentsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
 import {useQuery} from '@tanstack/react-query';
 import {searchIncidentsByProcessInstance} from 'modules/api/v2/incidents/searchIncidentsByProcessInstance';
 import {queryKeys} from '../queryKeys';
@@ -49,4 +52,21 @@ function useProcessInstanceIncidentsCount(processInstanceKey: string): number {
   return data ?? 0;
 }
 
-export {useGetIncidentsByProcessInstance, useProcessInstanceIncidentsCount};
+function useProcessInstanceIncidentsErrorTypes(
+  processInstanceKey: string,
+): IncidentErrorType[] {
+  const {data} = useGetIncidentsByProcessInstance(processInstanceKey, {
+    select: (incidents) =>
+      Array.from(
+        new Set(incidents.items.map((incident) => incident.errorType)),
+      ),
+  });
+
+  return data ?? [];
+}
+
+export {
+  useGetIncidentsByProcessInstance,
+  useProcessInstanceIncidentsCount,
+  useProcessInstanceIncidentsErrorTypes,
+};

--- a/operate/client/src/modules/queries/processInstance/useProcessInstancesSearch.ts
+++ b/operate/client/src/modules/queries/processInstance/useProcessInstancesSearch.ts
@@ -6,15 +6,23 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {QueryProcessInstancesRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
+import type {
+  QueryProcessInstancesRequestBody,
+  QueryProcessInstancesResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
 import {useQuery} from '@tanstack/react-query';
 import {searchProcessInstances} from 'modules/api/v2/processInstances/searchProcessInstances';
 
 const PROCESS_INSTANCES_SEARCH_QUERY_KEY = 'processInstancesSearch';
 
-const useProcessInstancesSearch = (
+type QueryOptions<T> = {
+  enabled?: boolean;
+  select?: (result: QueryProcessInstancesResponseBody) => T;
+};
+
+const useProcessInstancesSearch = <T = QueryProcessInstancesResponseBody>(
   payload: QueryProcessInstancesRequestBody,
-  {enabled} = {enabled: true},
+  options?: QueryOptions<T>,
 ) => {
   return useQuery({
     queryKey: [PROCESS_INSTANCES_SEARCH_QUERY_KEY, payload],
@@ -25,7 +33,8 @@ const useProcessInstancesSearch = (
       }
       throw error;
     },
-    enabled,
+    enabled: options?.enabled,
+    select: options?.select,
   });
 };
 

--- a/operate/client/src/modules/testUtils.tsx
+++ b/operate/client/src/modules/testUtils.tsx
@@ -86,6 +86,7 @@ const createEnhancedIncidentV2 = (
   const incident = createIncidentV2(options);
   return {
     ...incident,
+    processDefinitionName: 'Some Process Name',
     elementName: 'Always Failing Task',
     isSelected: false,
     ...options,

--- a/operate/client/src/modules/utils/incidents.ts
+++ b/operate/client/src/modules/utils/incidents.ts
@@ -6,11 +6,36 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
+import type {
+  ProcessInstance,
+  IncidentErrorType,
+} from '@camunda/camunda-api-zod-schemas/8.8';
 import {autorun} from 'mobx';
 import {incidentsStore, type Incident} from 'modules/stores/incidents';
 import {isInstanceRunning} from './instance';
 import type {EnhancedIncident} from 'modules/hooks/incidents';
+
+const ERROR_TYPE_NAMES: Record<IncidentErrorType, string> = {
+  UNSPECIFIED: 'Unspecified',
+  UNKNOWN: 'Unknown error',
+  IO_MAPPING_ERROR: 'IO mapping error.',
+  JOB_NO_RETRIES: 'No more retries left.',
+  EXECUTION_LISTENER_NO_RETRIES: 'Execution listener error (no retries left).',
+  TASK_LISTENER_NO_RETRIES: 'Task listener error (no retries left).',
+  CONDITION_ERROR: 'Condition error.',
+  EXTRACT_VALUE_ERROR: 'Extract value error.',
+  CALLED_ELEMENT_ERROR: 'Called element error.',
+  UNHANDLED_ERROR_EVENT: 'Unhandled error event.',
+  MESSAGE_SIZE_EXCEEDED: 'Message size exceeded.',
+  CALLED_DECISION_ERROR: 'Called decision error.',
+  DECISION_EVALUATION_ERROR: 'Decision evaluation error.',
+  FORM_NOT_FOUND: 'Form not found.',
+  RESOURCE_NOT_FOUND: 'Resource not found.',
+};
+
+const getIncidentErrorName = (errorType: IncidentErrorType): string => {
+  return ERROR_TYPE_NAMES[errorType];
+};
 
 const init = (processInstance?: ProcessInstance) => {
   incidentsStore.disposer = autorun(() => {
@@ -129,6 +154,7 @@ const getFilteredIncidentsV2 = (incidents: EnhancedIncident[]) => {
 };
 
 export {
+  getIncidentErrorName,
   init,
   startPolling,
   isSingleIncidentSelected,


### PR DESCRIPTION
## Description

This PR addresses the UI changes requested by the incidents-table migration issue #27325:
- The flow-node filter select has been removed
- Renamed "Failed Flow Node" to "Failed Element"
- Merged the root-cause instance column into the failed element column

Note: I reverted back from tackling the requested metadata popover changes (see #27325) in this PR as well, as the requirements around them have changed a bit. They will be tackled through a sub-issue.

## Checklist

- [ ] Note that this PR is stacked on #39380

## Related issues

relates #27325
