### PR TITLE
feat: add Java client and QA test support for element incident search API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -130,6 +130,7 @@ import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
 import io.camunda.client.api.search.request.GroupsByTenantSearchRequest;
 import io.camunda.client.api.search.request.GroupsSearchRequest;
 import io.camunda.client.api.search.request.IncidentSearchRequest;
+import io.camunda.client.api.search.request.IncidentsByElementInstanceSearchRequest;
 import io.camunda.client.api.search.request.IncidentsByProcessInstanceSearchRequest;
 import io.camunda.client.api.search.request.JobSearchRequest;
 import io.camunda.client.api.search.request.MappingRulesByGroupSearchRequest;
@@ -2757,4 +2758,21 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the correlated message subscription search request
    */
   CorrelatedMessageSubscriptionSearchRequest newCorrelatedMessageSubscriptionSearchRequest();
+
+  /**
+   * Executes a search request to query incidents by element instance key.
+   *
+   * <pre>
+   *   camundaClient
+   *    .newIncidentsByElementInstanceSearchRequest(elementInstanceKey)
+   *    .sort((s) -> s.incidentKey().desc())
+   *    .page((p) -> p.limit(100))
+   *    .send();
+   * </pre>
+   *
+   * @param elementInstanceKey the key of the element instance
+   * @return a builder for the incidents by element instance search request
+   */
+  IncidentsByElementInstanceSearchRequest newIncidentsByElementInstanceSearchRequest(
+      long elementInstanceKey);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/IncidentsByElementInstanceSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/IncidentsByElementInstanceSearchRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.sort.IncidentSort;
+
+public interface IncidentsByElementInstanceSearchRequest
+    extends TypedSortableRequest<IncidentSort, IncidentsByElementInstanceSearchRequest>,
+        TypedPageableRequest<IncidentsByElementInstanceSearchRequest>,
+        FinalSearchRequestStep<Incident> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -141,6 +141,7 @@ import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
 import io.camunda.client.api.search.request.GroupsByTenantSearchRequest;
 import io.camunda.client.api.search.request.GroupsSearchRequest;
 import io.camunda.client.api.search.request.IncidentSearchRequest;
+import io.camunda.client.api.search.request.IncidentsByElementInstanceSearchRequest;
 import io.camunda.client.api.search.request.IncidentsByProcessInstanceSearchRequest;
 import io.camunda.client.api.search.request.JobSearchRequest;
 import io.camunda.client.api.search.request.MappingRulesByGroupSearchRequest;
@@ -278,6 +279,7 @@ import io.camunda.client.impl.search.request.GroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupsByRoleSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupsByTenantSearchRequestImpl;
 import io.camunda.client.impl.search.request.IncidentSearchRequestImpl;
+import io.camunda.client.impl.search.request.IncidentsByElementInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.IncidentsByProcessInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.JobSearchRequestImpl;
 import io.camunda.client.impl.search.request.MappingRulesByGroupSearchRequestImpl;
@@ -1359,6 +1361,13 @@ public final class CamundaClientImpl implements CamundaClient {
   public CorrelatedMessageSubscriptionSearchRequest
       newCorrelatedMessageSubscriptionSearchRequest() {
     return new CorrelatedMessageSubscriptionSearchRequestImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public IncidentsByElementInstanceSearchRequest newIncidentsByElementInstanceSearchRequest(
+      final long elementInstanceKey) {
+    return new IncidentsByElementInstanceSearchRequestImpl(
+        httpClient, jsonMapper, elementInstanceKey);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/IncidentsByElementInstanceSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/IncidentsByElementInstanceSearchRequestImpl.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.incidentSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+import static io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider.provideSearchRequestProperty;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.IncidentsByElementInstanceSearchRequest;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.IncidentSort;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.ElementInstanceIncidentSearchQuery;
+import io.camunda.client.protocol.rest.IncidentSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class IncidentsByElementInstanceSearchRequestImpl
+    implements IncidentsByElementInstanceSearchRequest {
+
+  private final ElementInstanceIncidentSearchQuery request;
+  private final long elementInstanceKey;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public IncidentsByElementInstanceSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final long elementInstanceKey) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    this.elementInstanceKey = elementInstanceKey;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new ElementInstanceIncidentSearchQuery();
+  }
+
+  @Override
+  public FinalSearchRequestStep<Incident> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public IncidentsByElementInstanceSearchRequest sort(final IncidentSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toIncidentSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public IncidentsByElementInstanceSearchRequest sort(final Consumer<IncidentSort> fn) {
+    return sort(incidentSort(fn));
+  }
+
+  @Override
+  public IncidentsByElementInstanceSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public IncidentsByElementInstanceSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<Incident>> send() {
+    final HttpCamundaFuture<SearchResponse<Incident>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        String.format("/element-instances/%d/incidents/search", elementInstanceKey),
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        IncidentSearchQueryResult.class,
+        SearchResponseMapper::toIncidentSearchResponse,
+        result);
+    return result;
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceIncidentSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceIncidentSearchTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilElementInstanceHasIncidents;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.search.enums.IncidentErrorType;
+import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@MultiDbTest
+class ElementInstanceIncidentSearchTest {
+
+  private static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
+  private static final int AMOUNT_OF_ELEMENT_INSTANCES_WITH_INCIDENTS = 4;
+  private static final int AMOUNT_OF_INCIDENTS = 2;
+
+  private static List<ElementInstance> elementInstancesSortedByKey;
+  private static List<Incident> incidentsSortedByKey;
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    final var processes =
+        List.of(
+            "process_with_call_activity_1_v1.bpmn",
+            "process_with_call_activity_2_and_incident_v1.bpmn",
+            "process_with_incident_v1.bpmn");
+    processes.forEach(
+        process ->
+            DEPLOYED_PROCESSES.addAll(
+                deployResource(camundaClient, String.format("process/%s", process))
+                    .getProcesses()));
+
+    waitForProcessesToBeDeployed(camundaClient, 3);
+    startProcessInstance(camundaClient, "process_with_call_activity_1_v1");
+    waitForProcessInstancesToStart(camundaClient, 3);
+    waitUntilElementInstanceHasIncidents(camundaClient, AMOUNT_OF_ELEMENT_INSTANCES_WITH_INCIDENTS);
+    waitUntilIncidentsAreActive(camundaClient, AMOUNT_OF_INCIDENTS);
+
+    elementInstancesSortedByKey =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.hasIncident(true))
+            .sort(s -> s.elementInstanceKey().asc())
+            .send()
+            .join()
+            .items();
+    incidentsSortedByKey =
+        camundaClient
+            .newIncidentSearchRequest()
+            .sort(s -> s.incidentKey().asc())
+            .send()
+            .join()
+            .items();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    DEPLOYED_PROCESSES.clear();
+  }
+
+  @Test
+  void shouldThrowNotFoundExceptionIfElementInstanceKeyNotFound() {
+    // given
+    final var elementInstanceKey = 1234567890L;
+
+    // when
+    final var exception =
+        (ProblemException)
+            assertThatThrownBy(
+                    () ->
+                        camundaClient
+                            .newIncidentsByElementInstanceSearchRequest(elementInstanceKey)
+                            .send()
+                            .join())
+                .isInstanceOf(ProblemException.class)
+                .actual();
+
+    // then
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+    assertThat(exception.details().getDetail())
+        .contains("Element Instance with key '%s' not found".formatted(elementInstanceKey));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideElementInstanceKeyAndExpectedAmountOfIncidents")
+  void testAllIncidentsAreFetched(
+      final long elementInstanceKey, final List<Incident> expectedIncidents) {
+    // when
+    final SearchResponse<Incident> incidentsResult =
+        camundaClient.newIncidentsByElementInstanceSearchRequest(elementInstanceKey).send().join();
+
+    // then
+    assertThat(incidentsResult.items().size()).isEqualTo(expectedIncidents.size());
+    assertThat(incidentsResult.items()).containsExactlyElementsOf(expectedIncidents);
+  }
+
+  @Test
+  void shouldSortByIncidentKeyDescending() {
+    // given
+    final long elementInstanceKey = elementInstancesSortedByKey.getFirst().getElementInstanceKey();
+
+    // when
+    final SearchResponse<Incident> incidentsResult =
+        camundaClient
+            .newIncidentsByElementInstanceSearchRequest(elementInstanceKey)
+            .sort(s -> s.incidentKey().desc())
+            .send()
+            .join();
+
+    // then
+    assertThat(incidentsResult.items().size()).isEqualTo(incidentsSortedByKey.size());
+
+    final var sortedIncidentsInDesc =
+        incidentsSortedByKey.stream()
+            .sorted(Comparator.comparingLong(inc -> -inc.getIncidentKey()))
+            .toList();
+    assertThat(incidentsResult.items()).containsExactlyElementsOf(sortedIncidentsInDesc);
+  }
+
+  @Test
+  void shouldPaginateWithLimitAndCursor() {
+    // given
+    final var elementInstanceKey = elementInstancesSortedByKey.getFirst().getElementInstanceKey();
+
+    // when
+    final var response1 =
+        camundaClient
+            .newIncidentsByElementInstanceSearchRequest(elementInstanceKey)
+            .page(p -> p.limit(1))
+            .send()
+            .join();
+    final var response2 =
+        camundaClient
+            .newIncidentsByElementInstanceSearchRequest(elementInstanceKey)
+            .page(p -> p.after(response1.page().endCursor()))
+            .send()
+            .join();
+
+    // then
+    assertThat(response1.page().totalItems()).isEqualTo(incidentsSortedByKey.size());
+    assertThat(response1.items()).containsExactly(incidentsSortedByKey.getFirst());
+
+    assertThat(response2.page().totalItems()).isEqualTo(incidentsSortedByKey.size());
+    assertThat(response2.items()).containsExactly(incidentsSortedByKey.get(1));
+  }
+
+  private static Stream<Arguments> provideElementInstanceKeyAndExpectedAmountOfIncidents() {
+
+    final var calledErrorIncident =
+        incidentsSortedByKey.stream()
+            .filter(f -> f.getErrorType().equals(IncidentErrorType.CALLED_ELEMENT_ERROR))
+            .toList();
+
+    return Stream.of(
+        Arguments.of(
+            elementInstancesSortedByKey.getFirst().getElementInstanceKey(), incidentsSortedByKey),
+        Arguments.of(
+            elementInstancesSortedByKey.get(2).getElementInstanceKey(), calledErrorIncident),
+        Arguments.of(
+            elementInstancesSortedByKey.get(3).getElementInstanceKey(), calledErrorIncident));
+  }
+}

--- a/service/src/main/java/io/camunda/service/ElementInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ElementInstanceServices.java
@@ -161,6 +161,7 @@ public final class ElementInstanceServices
     if (authenticatedIncidentServices == null) {
       return SearchQueryResult.of();
     }
+    final var elementInstance = getByKey(elementInstanceKey);
     return authenticatedIncidentServices.search(
         IncidentQuery.of(
             b ->
@@ -169,7 +170,8 @@ public final class ElementInstanceServices
                             f.treePathOperations(
                                 Operation.like(
                                     String.format(
-                                        FNI_ELEMENT_INSTANCE_PATTERN, elementInstanceKey))))
+                                        FNI_ELEMENT_INSTANCE_PATTERN,
+                                        elementInstance.flowNodeInstanceKey()))))
                     .sort(query.sort())
                     .page(query.page())));
   }

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -205,6 +205,14 @@ public final class ElementInstanceServiceTest {
         // given
         final long elementInstanceKey = 123L;
         final IncidentQuery query = IncidentQuery.of(q -> q);
+        final FlowNodeInstanceEntity elementInstance =
+            Instancio.of(FlowNodeInstanceEntity.class)
+                .set(field(FlowNodeInstanceEntity::flowNodeInstanceKey), elementInstanceKey)
+                .create();
+
+        when(client.getFlowNodeInstance(any(Long.class))).thenReturn(elementInstance);
+        when(processCache.getCacheItem(elementInstance.processDefinitionKey()))
+            .thenReturn(new ProcessCacheItem("ProcessName", Map.of("unknown-id", "cached name")));
         final IncidentEntity incident =
             Instancio.of(IncidentEntity.class)
                 .set(field(IncidentEntity::flowNodeInstanceKey), elementInstanceKey)
@@ -224,6 +232,8 @@ public final class ElementInstanceServiceTest {
         final long elementInstanceKey = 456L;
         final IncidentQuery query = IncidentQuery.of(q -> q);
         final SearchQueryResult<IncidentEntity> result = SearchQueryResult.of();
+        final var entity = Instancio.create(FlowNodeInstanceEntity.class);
+        when(client.getFlowNodeInstance(any(Long.class))).thenReturn(entity);
         when(incidentServices.search(any(IncidentQuery.class))).thenReturn(result);
         // when
         final var searchResult = services.searchIncidents(elementInstanceKey, query);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This pull request implements the Java client support and QA test coverage for the new [Element Incident Search API](https://github.com/camunda/camunda/issues/38806), as outlined in [sub-task #39313](https://github.com/camunda/camunda/issues/39313).
	•	Adds a new method to the Java client to interact with the element incident search endpoint.
	•	Adds end-to-end QA tests to verify correct integration and behaviour across supported backends.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39313
