### PR TITLE
fix: add a mixin to ignore auth info field on previous version records

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
@@ -49,6 +50,8 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResult87Mixin.class)
           .addMixIn(UserTaskRecordValue.class, UserTask87Mixin.class)
           .addMixIn(JobRecordValue.class, Job87Mixin.class)
+          .addMixIn(
+              CommandDistributionRecordValue.class, CommandDistributionPreviousVersionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -64,6 +67,7 @@ final class BulkIndexRequest implements ContentProducer {
   private static final String ELEMENT_INSTANCE_PATH_PROPERTY = "elementInstancePath";
   private static final String PROCESS_DEFINITION_PATH_PROPERTY = "processDefinitionPath";
   private static final String CALLING_ELEMENT_PATH_PROPERTY = "callingElementPath";
+  private static final String AUTH_INFO_PROPERTY = "authInfo";
   private final List<BulkOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -212,4 +216,7 @@ final class BulkIndexRequest implements ContentProducer {
 
   @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY})
   private static final class Job87Mixin {}
+
+  @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
+  private static final class CommandDistributionPreviousVersionMixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
@@ -49,6 +50,8 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResult87Mixin.class)
           .addMixIn(UserTaskRecordValue.class, UserTask87Mixin.class)
           .addMixIn(JobRecordValue.class, Job87Mixin.class)
+          .addMixIn(
+              CommandDistributionRecordValue.class, CommandDistributionPreviousVersionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -64,6 +67,7 @@ final class BulkIndexRequest implements ContentProducer {
   private static final String ELEMENT_INSTANCE_PATH_PROPERTY = "elementInstancePath";
   private static final String PROCESS_DEFINITION_PATH_PROPERTY = "processDefinitionPath";
   private static final String CALLING_ELEMENT_PATH_PROPERTY = "callingElementPath";
+  private static final String AUTH_INFO_PROPERTY = "authInfo";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -213,4 +217,7 @@ final class BulkIndexRequest implements ContentProducer {
 
   @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY})
   private static final class Job87Mixin {}
+
+  @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
+  private static final class CommandDistributionPreviousVersionMixin {}
 }


### PR DESCRIPTION
This forward-ports another ignore of the new `authInfo` field that we noticed was necessary while backporting to `stable/8.8`.

Apparently, a simple `@JsonIgnore` on the record itself is not enough to exclude that field from exporting _if_ that record was written by the previous version. In that case, a mixin is needed.

Relates to https://github.com/camunda/camunda/pull/39529, https://github.com/camunda/camunda/issues/39430