### PR TITLE
fix: Unblock data migration on empty task dated indices

### DIFF
--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -492,7 +492,9 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
 
     try {
       final var reindexResponse = client.reindex(createMissingRequest);
-      return reindexResponse.total() != null && reindexResponse.total() > 0;
+      return reindexResponse != null
+          && reindexResponse.total() != null
+          && reindexResponse.total() > 0;
     } catch (final IOException e) {
       throw new MigrationException(e);
     }

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -138,9 +138,17 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
   @Override
   public void reindexLegacyDatedIndex(final String legacyDatedIndex) throws MigrationException {
     final String newDatedIndex = MigrationUtils.generateNewIndexNameFromLegacy(legacyDatedIndex);
-    reindex(legacyDatedIndex, newDatedIndex);
-    updateIndexAlias(newDatedIndex);
-    setIndexLifecycle(newDatedIndex);
+    final var documentsWereProcessed = reindex(legacyDatedIndex, newDatedIndex);
+    if (documentsWereProcessed) {
+      updateIndexAlias(newDatedIndex);
+      setIndexLifecycle(newDatedIndex);
+    } else {
+      LOG.info(
+          "No documents were reindexed from {} to {}. {} was not created.",
+          legacyDatedIndex,
+          newDatedIndex,
+          newDatedIndex);
+    }
   }
 
   @Override
@@ -465,7 +473,7 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
     }
   }
 
-  private void reindex(final String source, final String destination) throws MigrationException {
+  private boolean reindex(final String source, final String destination) throws MigrationException {
     final ReindexRequest createMissingRequest =
         new ReindexRequest.Builder()
             .source(
@@ -483,7 +491,8 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
             .build();
 
     try {
-      client.reindex(createMissingRequest);
+      final var reindexResponse = client.reindex(createMissingRequest);
+      return reindexResponse.total() != null && reindexResponse.total() > 0;
     } catch (final IOException e) {
       throw new MigrationException(e);
     }
@@ -505,7 +514,7 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
       client.indices().updateAliases(indicesAliasesRequest);
     } catch (final Exception e) {
       throw new MigrationException(
-          "Failed to disable writes for legacy index: %s".formatted(newDatedIndex), e);
+          "Failed to disable writes for new dated index: %s".formatted(newDatedIndex), e);
     }
   }
 

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
@@ -152,9 +152,17 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
   @Override
   public void reindexLegacyDatedIndex(final String legacyDatedIndex) throws MigrationException {
     final String newDatedIndex = MigrationUtils.generateNewIndexNameFromLegacy(legacyDatedIndex);
-    reindex(legacyDatedIndex, newDatedIndex);
-    updateIndexAlias(newDatedIndex);
-    setIndexLifecycle(newDatedIndex);
+    final var documentsWereProcessed = reindex(legacyDatedIndex, newDatedIndex);
+    if (documentsWereProcessed) {
+      updateIndexAlias(newDatedIndex);
+      setIndexLifecycle(newDatedIndex);
+    } else {
+      LOG.info(
+          "No documents were reindexed from {} to {}. {} was not created.",
+          legacyDatedIndex,
+          newDatedIndex,
+          newDatedIndex);
+    }
   }
 
   @Override
@@ -521,7 +529,7 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
                                         FieldValue.of(TaskJoinRelationshipType.TASK.getType())))));
   }
 
-  private void reindex(final String source, final String destination) throws MigrationException {
+  private boolean reindex(final String source, final String destination) throws MigrationException {
     final ReindexRequest createMissingRequest =
         new ReindexRequest.Builder()
             .source(
@@ -539,7 +547,8 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
             .build();
 
     try {
-      client.reindex(createMissingRequest);
+      final var reindexResponse = client.reindex(createMissingRequest);
+      return reindexResponse.total() != null && reindexResponse.total() > 0;
     } catch (final IOException e) {
       throw new MigrationException(e);
     }
@@ -561,7 +570,7 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
       client.indices().updateAliases(indicesAliasesRequest);
     } catch (final Exception e) {
       throw new MigrationException(
-          "Failed to disable writes for legacy index: %s".formatted(newDatedIndex), e);
+          "Failed to disable writes for new dated index: %s".formatted(newDatedIndex), e);
     }
   }
 

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
@@ -548,7 +548,9 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
 
     try {
       final var reindexResponse = client.reindex(createMissingRequest);
-      return reindexResponse.total() != null && reindexResponse.total() > 0;
+      return reindexResponse != null
+          && reindexResponse.total() != null
+          && reindexResponse.total() > 0;
     } catch (final IOException e) {
       throw new MigrationException(e);
     }

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/SearchAndCreateTaskMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/SearchAndCreateTaskMigrationIT.java
@@ -60,6 +60,7 @@ public class SearchAndCreateTaskMigrationIT extends UserTaskMigrationHelper {
                 setup(db, migrator, null);
                 completeUserTaskAndWaitForArchiving(
                     migrator, USER_TASK_KEYS.get("first"), ARCHIVING_WAITING_PERIOD_SECONDS * 3);
+                createEmpty87TaskDatedIndex(migrator);
               })
           .withInitialEnvOverrides(
               Map.of(

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/UserTaskMigrationHelper.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/UserTaskMigrationHelper.java
@@ -99,17 +99,16 @@ public abstract class UserTaskMigrationHelper {
     try {
       final var legacyIndex =
           new TaskLegacyIndex(migrator.getIndexPrefix(), migrator.isElasticsearch());
-      final var response =
-          migrator.request(
-              b ->
-                  b.PUT(HttpRequest.BodyPublishers.noBody())
-                      .uri(
-                          URI.create(
-                              migrator.getDatabaseUrl()
-                                  + "/"
-                                  + legacyIndex.getFullQualifiedName()
-                                  + "2025-01-01")),
-              BodyHandlers.discarding());
+      migrator.request(
+          b ->
+              b.PUT(HttpRequest.BodyPublishers.noBody())
+                  .uri(
+                      URI.create(
+                          migrator.getDatabaseUrl()
+                              + "/"
+                              + legacyIndex.getFullQualifiedName()
+                              + "2025-01-01")),
+          BodyHandlers.discarding());
     } catch (final Exception e) {
       throw new UncheckedException(e);
     }

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/UserTaskMigrationHelper.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/usertask/UserTaskMigrationHelper.java
@@ -95,6 +95,26 @@ public abstract class UserTaskMigrationHelper {
     waitFor87TaskToBeArchived(migrator, taskKey, waitPeriodSeconds);
   }
 
+  protected static void createEmpty87TaskDatedIndex(final CamundaMigrator migrator) {
+    try {
+      final var legacyIndex =
+          new TaskLegacyIndex(migrator.getIndexPrefix(), migrator.isElasticsearch());
+      final var response =
+          migrator.request(
+              b ->
+                  b.PUT(HttpRequest.BodyPublishers.noBody())
+                      .uri(
+                          URI.create(
+                              migrator.getDatabaseUrl()
+                                  + "/"
+                                  + legacyIndex.getFullQualifiedName()
+                                  + "2025-01-01")),
+              BodyHandlers.discarding());
+    } catch (final Exception e) {
+      throw new UncheckedException(e);
+    }
+  }
+
   protected static long startProcessInstance(
       final CamundaClient client, final long processDefinitionKey) {
     return client

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/CamundaMigrator.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/CamundaMigrator.java
@@ -244,6 +244,10 @@ public class CamundaMigrator extends ApiCallable implements AutoCloseable {
     return searchClients;
   }
 
+  public String getDatabaseUrl() {
+    return databaseUrl;
+  }
+
   public IndexDescriptor indexFor(final Class<? extends IndexDescriptor> clazz) {
     return new IndexDescriptors(indexPrefix, true).get(clazz);
   }


### PR DESCRIPTION
## Description

This PR introduces a check for the number of documents processed from a legacy dated index of `tasklist-task`. If no documents were processed we do not expect the corresponding new dated index to exist, so we skip certain operations.

This error was observed in a SaaS cluster and you can see part of the stack trace in the following image

<img width="1422" height="217" alt="Screenshot 2025-10-15 at 17 50 26" src="https://github.com/user-attachments/assets/4b41726f-e41b-4192-8881-cedb7d452a73" />

I was able to reproduce the issue with the updated integration tests ([Elasticsearch](https://github.com/camunda/camunda/actions/runs/18536444803/job/52832718900?pr=39607), [Opensearch](https://github.com/camunda/camunda/actions/runs/18536444803/job/52832718904?pr=39607)). The implementation changes 

```
Caused by: java.lang.Exception: migration failed
	...
	Suppressed: io.camunda.migration.api.MigrationException: Failed to disable writes for new dated index: searchandcreatetaskmigrationit-tasklist-task-8.8.0_2025-01-01
	...
	Caused by: io.camunda.migration.api.MigrationException: Failed to disable writes for new dated index: searchandcreatetaskmigrationit-tasklist-task-8.8.0_2025-01-01
	...
	Caused by: co.elastic.clients.elasticsearch._types.ElasticsearchException: [es/indices.update_aliases] failed: [index_not_found_exception] no such index [searchandcreatetaskmigrationit-tasklist-task-8.8.0_2025-01-01]
```

The updated implementation makes these tests pass.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/39606
