### PR TITLE
feat: implement resolve incident for operate incidents table v2

### DIFF
--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {IncidentOperation} from 'modules/components/IncidentOperation';
+import {IncidentOperationV2} from 'modules/components/IncidentOperation';
 import {formatDate} from 'modules/utils/date';
 import {getSortParams} from 'modules/utils/filter';
 import {sortIncidents} from './service';
@@ -197,10 +197,9 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
               ),
               operations:
                 hasPermissionForRetryOperation && areOperationsVisible ? (
-                  <IncidentOperation
-                    instanceId={incident.processInstanceKey}
+                  <IncidentOperationV2
                     incidentKey={incident.incidentKey}
-                    showSpinner={true} // TODO: What to do here?
+                    jobKey={incident.jobKey}
                   />
                 ) : undefined,
             };

--- a/operate/client/src/modules/api/v2/incidents/resolveIncident.ts
+++ b/operate/client/src/modules/api/v2/incidents/resolveIncident.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
+import {request} from 'modules/request';
+
+const resolveIncident = (incidentKey: string) => {
+  return request({
+    url: endpoints.resolveIncident.getUrl({incidentKey}),
+    method: endpoints.resolveIncident.method,
+  });
+};
+
+export {resolveIncident};

--- a/operate/client/src/modules/api/v2/jobs/updateJob.ts
+++ b/operate/client/src/modules/api/v2/jobs/updateJob.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type UpdateJobRequestBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import {request} from 'modules/request';
+
+const updateJob = (
+  jobKey: string,
+  changeset: UpdateJobRequestBody['changeset'],
+) => {
+  return request({
+    url: endpoints.updateJob.getUrl({jobKey}),
+    method: endpoints.updateJob.method,
+    body: {changeset},
+  });
+};
+
+export {updateJob};

--- a/operate/client/src/modules/mutations/incidents/useResolveIncident.ts
+++ b/operate/client/src/modules/mutations/incidents/useResolveIncident.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {resolveIncident} from 'modules/api/v2/incidents/resolveIncident';
+import {updateJob} from 'modules/api/v2/jobs/updateJob';
+import {queryKeys} from 'modules/queries/queryKeys';
+
+function useResolveIncident(incidentKey: string, jobKey?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, {status: number; statusText: string}>({
+    scope: {id: incidentKey},
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: queryKeys.incidents.search()});
+    },
+    mutationFn: async () => {
+      if (jobKey) {
+        const response = await updateJob(jobKey, {retries: 1});
+        if (!response.ok) {
+          throw {status: response.status, statusText: response.statusText};
+        }
+      }
+
+      const response = await resolveIncident(incidentKey);
+      if (!response.ok) {
+        throw {status: response.status, statusText: response.statusText};
+      }
+    },
+  });
+}
+
+export {useResolveIncident};

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -51,12 +51,15 @@ const queryKeys = {
     ],
   },
   incidents: {
+    search: () => ['incidentsSearch'],
     searchByProcessInstanceKey: (processInstanceKey: string) => [
-      'incidentsSearchByProcessInstanceKey',
+      queryKeys.incidents.search()[0],
+      'searchByProcessInstanceKey',
       processInstanceKey,
     ],
     searchByElementInstanceKey: (elementInstanceKey: string) => [
-      'incidentsSearchByElementInstanceKey',
+      queryKeys.incidents.search()[0],
+      'searchByElementInstanceKey',
       elementInstanceKey,
     ],
   },


### PR DESCRIPTION
## Description

Implements a new `IncidentOperation` component that uses a query mutation to resolve an incident through the C8 API.

## Checklist

- [x] There is ~two~ one open question regarding the usability that have to be tackled before merging:
  - ~https://github.com/camunda/camunda/issues/39550#issuecomment-3401999841~
  - ~https://github.com/camunda/camunda/issues/39550#issuecomment-3406186284~
- [x] Notice that this PR is stacked on #39588.

## Related issues

closes #39550
