### PR TITLE
migration correctly apply ilm policies

### DIFF
--- a/migration/task-migration/src/main/java/io/camunda/migration/task/TaskMigrator.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/TaskMigrator.java
@@ -72,6 +72,7 @@ public class TaskMigrator implements Migrator {
         performReindexForMainIndex();
         performReindexForDatedIndices();
         performBatchUpdatesForExportedDocuments();
+        adapter.applyRetentionOnLegacyRuntimeIndex();
         adapter.markMigrationAsCompleted();
         LOG.info("Task Migration completed successfully");
         LOG.info("Resuming archiver");

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/TaskMigrationAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/TaskMigrationAdapter.java
@@ -33,8 +33,6 @@ public interface TaskMigrationAdapter {
 
   void deleteLegacyIndex(String legacyIndex) throws MigrationException;
 
-  void deleteLegacyMainIndex() throws MigrationException;
-
   String getLastMigratedTaskId() throws MigrationException;
 
   void writeLastMigratedTaskId(String taskId) throws MigrationException;
@@ -44,6 +42,8 @@ public interface TaskMigrationAdapter {
   String updateAcrossAllIndices(List<TaskWithIndex> tasksWithIndex) throws MigrationException;
 
   Set<ImportPositionEntity> getImportPositions() throws MigrationException;
+
+  void applyRetentionOnLegacyRuntimeIndex() throws MigrationException;
 
   void blockArchiving() throws MigrationException;
 

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -165,11 +165,6 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
   }
 
   @Override
-  public void deleteLegacyMainIndex() throws MigrationException {
-    deleteLegacyIndex(legacyIndex.getFullQualifiedName());
-  }
-
-  @Override
   public String getLastMigratedTaskId() throws MigrationException {
     final var migrationStepContent = getLastMigratedContent();
     return MigrationUtils.getTaskIdFromMigrationStepContent(migrationStepContent);
@@ -308,6 +303,11 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
         .map(Hit::source)
         .filter(Objects::nonNull)
         .collect(Collectors.toSet());
+  }
+
+  @Override
+  public void applyRetentionOnLegacyRuntimeIndex() throws MigrationException {
+    /// This is already handled by the {@link #applyPolicy()}
   }
 
   @Override
@@ -550,7 +550,9 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
                               s.index(
                                   i ->
                                       i.lifecycle(
-                                          l -> l.name(LEGACY_INDEX_RETENTION_POLICY_NAME)))));
+                                          l ->
+                                              l.name(LEGACY_INDEX_RETENTION_POLICY_NAME)
+                                                  .originationDate(System.currentTimeMillis())))));
     } catch (final IOException e) {
       final var message =
           "Failed to apply index lifecycle policy '%s' to '%s' index"

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
@@ -204,15 +204,19 @@ public class MigrationITExtension
         closables.add(elasticsearchContainer);
         databaseUrl = "http://" + elasticsearchContainer.getHttpHostAddress();
         suppressEsWarnings();
+        increaseIlmPolling();
         expectedDescriptors = new IndexDescriptors(indexPrefix, true).all();
       }
       case ES -> {
-        expectedDescriptors = new IndexDescriptors(indexPrefix, true).all();
         databaseUrl = DEFAULT_ES_URL;
+        suppressEsWarnings();
+        increaseIlmPolling();
+        expectedDescriptors = new IndexDescriptors(indexPrefix, true).all();
       }
       case OS -> {
         expectedDescriptors = new IndexDescriptors(indexPrefix, false).all();
         databaseUrl = DEFAULT_OS_URL;
+        increaseIsmPolling();
       }
       default -> throw new IllegalArgumentException("Unsupported database type: " + databaseType);
     }
@@ -240,7 +244,36 @@ public class MigrationITExtension
                   .build(),
               BodyHandlers.ofString());
     } catch (final IOException | InterruptedException ignore) {
-      // ignore
+    }
+  }
+
+  private void increaseIlmPolling() {
+    try {
+      HttpClient.newHttpClient()
+          .send(
+              HttpRequest.newBuilder(URI.create(databaseUrl + "/_cluster/settings"))
+                  .PUT(
+                      BodyPublishers.ofString(
+                          "{\"persistent\": {\"indices.lifecycle.poll_interval\": \"10s\"}}"))
+                  .header("Content-Type", "application/json")
+                  .build(),
+              BodyHandlers.ofString());
+    } catch (final IOException | InterruptedException ignore) {
+    }
+  }
+
+  private void increaseIsmPolling() {
+    try {
+      HttpClient.newHttpClient()
+          .send(
+              HttpRequest.newBuilder(URI.create(databaseUrl + "/_cluster/settings"))
+                  .PUT(
+                      BodyPublishers.ofString(
+                          "{\"persistent\": {\"plugins.index_state_management.job_interval\": \"1\"	}}"))
+                  .header("Content-Type", "application/json")
+                  .build(),
+              BodyHandlers.ofString());
+    } catch (final IOException | InterruptedException ignore) {
     }
   }
 

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
@@ -244,6 +244,7 @@ public class MigrationITExtension
                   .build(),
               BodyHandlers.ofString());
     } catch (final IOException | InterruptedException ignore) {
+      // ignore
     }
   }
 
@@ -259,21 +260,23 @@ public class MigrationITExtension
                   .build(),
               BodyHandlers.ofString());
     } catch (final IOException | InterruptedException ignore) {
+      // ignore
     }
   }
 
   private void increaseIsmPolling() {
+    final var requestBody =
+        "{\"persistent\":{\"plugins.index_state_management.job_interval\":\"1\"}}";
     try {
       HttpClient.newHttpClient()
           .send(
               HttpRequest.newBuilder(URI.create(databaseUrl + "/_cluster/settings"))
-                  .PUT(
-                      BodyPublishers.ofString(
-                          "{\"persistent\": {\"plugins.index_state_management.job_interval\": \"1\"	}}"))
+                  .PUT(BodyPublishers.ofString(requestBody))
                   .header("Content-Type", "application/json")
                   .build(),
               BodyHandlers.ofString());
     } catch (final IOException | InterruptedException ignore) {
+      // ignore
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Different approaches for ILM and ISM policy application:
- Elasticsearch: Make use of `originationDate(System.currentTimeMillis())` to determine policy trigger time from the time the policy is applied instead of the index creation date which is the default approach for deletion
- Opensearch: Clone & delete previous runtime index to have the policy applied on the new created index to match the desired retention
  - We then clone & delete back to the original name for easier tracing & debugging
  - In case this operation fails the migration should complete normally but log that it failed to process the legacy index
- Override ISM/ILM policy polling rate to verify the application in tests - this introduces some extra delay in the tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39576
