### PR TITLE
Run load tests from `main` against 8.9

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -99,7 +99,7 @@ on:
         default: false
 
 env:
-  HELM_CHART: camunda-platform-8.8
+  HELM_CHART: camunda-platform-8.9
 
 jobs:
   calculate-image-tag:


### PR DESCRIPTION
## Description

 * On main we target now 8.9, so we should make use of the newer charts as well


## Example deployment

https://github.com/camunda/camunda/actions/runs/18530226190

<img width="1749" height="574" alt="2025-10-15_16-23_1" src="https://github.com/user-attachments/assets/19c735e2-6b71-4bf1-9ae9-d25aca926f7b" />


<img width="804" height="398" alt="2025-10-15_16-23" src="https://github.com/user-attachments/assets/b25fd5e0-3772-40eb-9680-385b8df84e16" />

## Related issues

related https://github.com/camunda/camunda/issues/39376
