### PR TITLE
ci: rollback incread timeout for General / Unit - Back End

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "General / Unit - Back End"
     needs: [ detect-changes, setup-unit-tests ]
-    timeout-minutes: 25
+    timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     steps:


### PR DESCRIPTION
## Description

Based on this discussions:
- https://github.com/camunda/camunda/pull/39482#discussion_r2431590353
- https://camunda.slack.com/archives/C090HGYE5T2/p1760476179973509?thread_ts=1760471637.226439&cid=C090HGYE5T2

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
