### PR TITLE
[Backport stable/8.8] Decouple Load tests of Camunda Platform Helm chart

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -1,0 +1,347 @@
+# description: This workflow deploys a load test with a camunda cluster under test.
+# We use this worklow to start weekly medic load tests.
+# The health of the cluster and results of the load tests are monitored by Core team's regularly.
+# https://grafana.dev.zeebe.io/login
+# called by: zeebe-medic-benchmarks.yml, zeebe-pr-benchmark.yaml
+# type: CI
+# owner: @camunda/core-features
+name: Camunda load test
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Specifies the name of the load test'
+        required: true
+      reuse-tag:
+        description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
+        type: string
+        default: ""
+        required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
+        default: 'stable/8.8'
+        required: false
+      cluster:
+        description: 'Specifies which cluster to deploy the load test on'
+        default: 'zeebe-cluster'
+        required: false
+      cluster-region:
+        description: 'Specifies the cluster region. Needed to retrieve cluster credentials'
+        default: europe-west1-b
+        required: false
+      load-test-load:
+        description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
+        required: false
+      stable-vms:
+        description: 'Deploy to non-spot VMs'
+        type: boolean
+        required: false
+        default: false
+      operate-tag:
+        description: 'Specifies the tag of operate, when Operate should be included in the load test'
+        type: string
+        default: ""
+        required: false
+      realistic:
+        description: 'Should run a realistic load test, with real-world process and load'
+        type: boolean
+        required: false
+        default: false
+  workflow_call:
+    inputs:
+      name:
+        description: 'Specifies the name of the load test'
+        type: string
+        required: true
+      reuse-tag:
+        description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
+        type: string
+        default: ""
+        required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to load test'
+        default: 'main'
+        type: string
+        required: false
+      cluster:
+        description: 'Specifies which cluster to deploy the load test on'
+        default: 'zeebe-cluster'
+        type: string
+        required: false
+      cluster-region:
+        description: 'Specifies the cluster region. Needed to retrieve cluster credentials'
+        default: europe-west1-b
+        type: string
+        required: false
+      load-test-load:
+        description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
+        type: string
+        required: false
+      publish:
+        description: 'Where to publish the results, can be "slack" or "comment"'
+        default: ""
+        type: string
+        required: false
+      stable-vms:
+        description: 'Deploy to non-spot VMs'
+        type: boolean
+        required: false
+        default: false
+      operate-tag:
+        description: 'Specifies the tag of operate, when Operate should be included in the load test'
+        type: string
+        default: ""
+        required: false
+      realistic:
+        description: 'Should run a realistic load test, with real-world process and load'
+        type: boolean
+        required: false
+        default: false
+
+env:
+  HELM_CHART: camunda-platform-8.8
+
+jobs:
+  calculate-image-tag:
+    name: Calculate Image Tag
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ inputs.reuse-tag != '' && inputs.reuse-tag || steps.image-tag.outputs.image-tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Get image tag
+        id: image-tag
+        run: |
+          echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+  build-camunda-image:
+    name: Build Camunda
+    needs: calculate-image-tag
+    if: ${{ inputs.reuse-tag == '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: ./.github/actions/build-frontend
+        name: Build Operate Frontend
+        id: build-operate-fe
+        with:
+          directory: ./operate/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Tasklist Frontend
+        id: build-tasklist-fe
+        with:
+          directory: ./tasklist/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Identity Frontend
+        id: build-identity-fe
+        with:
+          directory: ./identity/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-zeebe
+        name: Build Camunda Platform
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild -P\!include-optimize -Dmaven.test.skip=true
+      - uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - name: Login to GCR
+        uses: docker/login-action@v3
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+      - uses: ./.github/actions/build-platform-docker
+        name: Build Camunda Docker Image
+        with:
+          repository: 'gcr.io/zeebe-io/zeebe'
+          revision: ${{ inputs.ref }}
+          push: true
+          version: ${{ needs.calculate-image-tag.outputs.image-tag }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          dockerfile: 'camunda.Dockerfile'
+
+  build-load-test-images:
+    name: Build Starter and Worker
+    if: ${{ inputs.reuse-tag == '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: calculate-image-tag
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - name: Login to GAR
+        uses: docker/login-action@v3
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - run: ./mvnw -B -D skipTests -D skipChecks -P\!include-optimize -pl zeebe/benchmarks/project -am install
+      - name: Build Starter Image
+        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P starter -P\!include-optimize -D image="gcr.io/zeebe-io/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
+      - name: Build Worker Image
+        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P worker -P\!include-optimize -D image="gcr.io/zeebe-io/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
+
+  deploy-cluster-under-test:
+    name: Deploy cluster under test
+    needs:
+      - calculate-image-tag
+      - build-camunda-image
+      - build-load-test-images
+    # To have the possibility to re-deploy the tests without rebuilding the images,
+    # the deploy will be run, when build is skipped or successful.
+    if: |
+      always() &&
+      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
+      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'camunda/camunda-platform-helm'
+          ref: 'main'
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v2.3.5
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Add Camunda Helm repo
+        run: |
+          helm repo add camunda https://helm.camunda.io/
+          helm repo update
+      - name: Find previous Helm chart release version
+        id: find-chart-release
+        run: |
+          echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }} | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
+      - name: Build dependencies of Camunda Platform
+        run: helm dependency build charts/${{ env.HELM_CHART }}/
+      - name: Install latest Camunda Platform
+        run: >
+          helm upgrade --install ${{ inputs.name }} charts/${{ env.HELM_CHART }}/ --wait --timeout 35m0s
+          --namespace ${{ inputs.name }}
+          --create-namespace
+          --reuse-values
+          --render-subchart-notes
+          --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set orchestration.image.registry=gcr.io
+          --set orchestration.image.repository=zeebe-io/zeebe
+          --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          -f https://raw.githubusercontent.com/camunda/camunda/refs/heads/${{ inputs.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
+          ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
+          ${{ inputs.stable-vms && '-f zeebe/benchmarks/setup/default/values-stable.yaml' || '' }}
+      - name: Label namespace
+        run: >
+            kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite
+      - name: Summarize deployment
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Camunda platform \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            \`\`\`
+          EOF
+
+  deploy-load-test:
+    name: Deploy load test
+    needs:
+      # We need to depend on calculate-image-tag, so that we can use the output in the job
+      - calculate-image-tag
+      - deploy-cluster-under-test
+      - build-camunda-image
+      - build-load-test-images
+      # To have the possibility to re-deploy the tests without rebuilding the images,
+      # the deploy will be run, when build is skipped or successful.
+    if: |
+      always() &&
+      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
+      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v2.3.4
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Add Load test Helm repo
+        run: |
+          helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/
+          helm repo update
+      - name: Find previous Helm chart release version
+        id: find-chart-release
+        run: |
+          echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }}-test | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
+      - name: Install load test
+        run: >
+          helm upgrade --install ${{ inputs.name }}-test camunda-load-tests/camunda-load-tests
+          --wait --timeout 35m0s
+          --namespace ${{ inputs.name }}
+          --create-namespace
+          --reuse-values
+          --render-subchart-notes
+          --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
+          ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }}
+          ${{ inputs.load-test-load }}
+      - name: Summarize deployment
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Load test \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }}-test -n ${{ inputs.name }})
+            \`\`\`
+          EOF

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -84,7 +84,7 @@ jobs:
     needs:
       - benchmark-data
       - delete-old-benchmarks
-    uses: ./.github/workflows/zeebe-benchmark.yml
+    uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}
@@ -95,7 +95,7 @@ jobs:
       publish: "slack"
   setup-mixed-benchmark:
     name: Mixed Benchmark
-    uses: ./.github/workflows/zeebe-benchmark.yml
+    uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     needs:
       - benchmark-data
@@ -106,11 +106,10 @@ jobs:
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
-      benchmark-load: >
-        -f https://raw.githubusercontent.com/camunda/zeebe-benchmark-helm/refs/heads/main/charts/zeebe-benchmark/values-realistic-benchmark.yaml
+      realistic: 'true'
   setup-latency-benchmark:
     name: Latency Benchmark
-    uses: ./.github/workflows/zeebe-benchmark.yml
+    uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     needs:
       - benchmark-data
@@ -121,6 +120,6 @@ jobs:
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
       reuse-tag: ${{ inputs.reuse-tag || '' }}
-      benchmark-load: >
+      load-test-load: >
         --set starter.rate=1
         --set workers.benchmark.replicas=1

--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -16,7 +16,7 @@ jobs:
     if: >
       (github.event.action == 'labeled' && github.event.label.name == 'benchmark') ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
-    uses: ./.github/workflows/zeebe-benchmark.yml
+    uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
       name: ${{github.event.pull_request.head.ref}}-benchmark

--- a/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
+++ b/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
@@ -23,14 +23,14 @@ jobs:
     name: Update Long Running Migrating Benchmark with mixed load
     needs:
       - fetch-release
-    uses: ./.github/workflows/zeebe-benchmark.yml
+    uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
       name: release-rolling
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: refs/tags/${{ needs.fetch-release.outputs.release-tag }}
-      benchmark-load: >
+      load-test-load: >
         --set starter.rate=5
         --set worker.replicas=1
         --set timer.replicas=1

--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -1,0 +1,223 @@
+# Values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This file is used to override the default values of the chart.
+# The values are optimized for running the load tests with a Camunda cluster on GKE.
+#
+# This is a YAML-formatted file.
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  # Disable global ingress
+  ingress:
+    enabled: false
+  image:
+    # Image.repository defines the repository from which to fetch the docker images
+    repository: "gcr.io/zeebe-io"
+    # Image.tag defines the tag / version which should be used in the chart
+    tag: SNAPSHOT
+    ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+    pullPolicy: Always
+    ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets: []
+  # By default, we run without Identity
+  identity:
+    auth:
+      enabled: false
+
+identity:
+  enabled: false
+
+identityKeycloak:
+  enabled: false
+
+optimize:
+  enabled: false
+
+connectors:
+  enabled: false
+
+webModeler:
+  enabled: false
+
+postgresql:
+  enabled: false
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  security:
+    authentication:
+      unprotectedApi: true
+    authorizations:
+      enabled: false
+  # For simplicity of the deployment, we override the names to camunda
+  # This means we will have pods like: camunda-0, camunda-1, camunda-2
+  fullnameOverride: camunda
+  image:
+    tag: "SNAPSHOT"
+  ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
+  clusterSize: "3"
+  ## @param core.partitionCount defines how many partitions are set up in the cluster
+  partitionCount: "3"
+  ## @param core.replicationFactor defines how each partition is replicated, the value defines the number of nodes
+  replicationFactor: "3"
+  ## @param core.cpuThreadCount defines how many threads can be used for the processing on each broker pod
+  cpuThreadCount: "3"
+  ## @param core.ioThreadCount defines how many threads can be used for the exporting on each broker pod
+  ioThreadCount: "3"
+  # Resources of the orchestration cluster
+  resources:
+    requests:
+      cpu: 2000m
+      memory: 2Gi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+
+  nodeSelector:
+    cloud.google.com/gke-nodepool: n2-standard-4
+
+  ## @param core.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+  pvcSize: "64Gi"
+  ## @param core.pvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim.
+  # It is recommended to use a storage class, which is backed with a SSD. Set to "-" to disable use of default storage class.
+  pvcStorageClassName: "ssd"
+  # @extra core.containerSecurityContext defines the security options the container should be run with
+  containerSecurityContext:
+    ## @param core.containerSecurityContext.allowPrivilegeEscalation
+    allowPrivilegeEscalation: true
+    ## @param core.containerSecurityContext.privileged
+    privileged: true
+    ## @param core.containerSecurityContext.runAsNonRoot
+    runAsNonRoot: true
+    ## @param core.containerSecurityContext.runAsUser
+    runAsUser: 1000
+    capabilities:
+      add: ["NET_ADMIN"]
+  javaOpts: >-
+    -XX:MaxRAMPercentage=25.0
+    -XX:+ExitOnOutOfMemoryError
+    -XX:+HeapDumpOnOutOfMemoryError
+    -XX:HeapDumpPath=/usr/local/camunda/data
+    -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log
+    -XX:NativeMemoryTracking=summary
+    -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M
+
+  # We set extra configuration to configure additional settings for Broker and Gateway, that are part
+  # of the orchestration cluster.
+  # This allows adding configurations without the need of overwriting all environment variables from the Platform chart.
+  extraConfiguration:
+    application.yml: |
+      zeebe.gateway.monitoring.enabled: "true"
+      zeebe.gateway.threads.managementThreads: "1"
+      zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+      zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+      zeebe.broker.executionMetricsExporterEnabled: "true"
+      zeebe.broker.data.disk.freeSpace.processing: "3GB"
+      zeebe.broker.data.disk.freeSpace.replication: "2GB"
+      # Configure index suffix with hour pattern, so we create every hour a new index
+      # such that ILM can clean it up quickly
+      # We need to configure it for the ES exporter AND the CamundaExporter
+      zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat: "yyyy-MM-dd-HH"
+      zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval: "1h"
+      zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+      zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+      # We moved the archiver configuration under retention at some point, but still need to support the previous
+      # versions for now, so the configurations for retention are duplicated
+      zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
+      # 0s causes ILM to move data asap - it is normally the default
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
+      zeebe.broker.exporters.camundaexporter.args.history.retention.minimumAge: "70m"
+      zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
+      # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+      zeebe.broker.flowControl.write.enabled: "true"
+      zeebe.broker.flowControl.write.limit: 4000
+      zeebe.broker.flowControl.write.throttling.enabled: "true"
+      # Disable the importers
+      camunda.tasklist.importerEnabled: "false"
+      camunda.operate.importerEnabled: "false"
+      camunda.operate.elasticsearch.numberOfShards: 3
+      # Schema management has been moved out of exporter - to be bootstrap at start; once
+      camunda.database.retention.enabled: "true"
+      # 0s causes ILM to move data asap - it is normally the default
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
+      camunda.database.retention.minimumAge: "70m"
+      camunda.database.retention.policyName: "camunda-retention-policy"
+      #Metrics:
+      camunda.flags.jfr.metrics: "true"
+      # RocksDB memory limit setting, limits the overall RocksDB memory usage
+      # ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYLIMIT
+      zeebe.broker.experimental.rocksdb.memoryLimit: "64MB"
+
+  # Zeebe config
+  extraVolumes:
+    - name: logs
+      emptyDir: {}
+  ## @param core.extraVolumeMounts can be used to mount extra volumes for the broker pods, useful for additional exporters
+  extraVolumeMounts:
+    - name: logs
+      mountPath: /usr/local/camunda/logs
+  history:
+    retention:
+      ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.
+      enabled: true
+      ## @param core.history.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
+      minimumAge: 70m
+  # @param core.env can be used to set extra environment variables in each broker container
+  env:
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      value: "/usr/local/camunda/config/application.yml"
+
+# Change these settings to configure a different way to collect metrics
+prometheusServiceMonitor:
+  enabled: true
+  labels:
+    release: monitoring
+  scrapeInterval: 30s
+
+########################################################################################
+################################################### Elasticsearch cluster configuration
+########################################################################################
+elasticsearch:
+  master:
+    fullnameOverride: elastic
+    nameOverride: elastic
+    ## @param elasticsearch.master.replicaCount defines number of master-elegible replicas to deploy
+    replicaCount: 3
+    pdb:
+      minAvailable: 2
+    ## @param elasticsearch.master.heapSize
+    heapSize: 3g
+    persistence:
+      ## @param elasticsearch.master.persistence.size
+      size: 128Gi
+      storageClass: "ssd"
+      accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        cpu: 3
+        memory: 3Gi
+      limits:
+        cpu: 3
+        memory: 6Gi
+  extraConfig:
+    logger.org.elasticsearch.deprecation: "OFF"


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/camunda/pull/39532 to stable/8.8.

relates to https://github.com/camunda/camunda/issues/39376 
relates to https://github.com/camunda/camunda/issues/37279

Backport failed here https://github.com/camunda/camunda/pull/39615
mostly because load-tests haven't been moved in the stable/8.8 branch 🤔 (tbh suprised me, but ok).

## Details on why backporting

Creating a separate Camunda Load test workflow in each stable branch with adjusted values and Helm platform versions, allows us to run load tests against different versions.

Covering https://github.com/camunda/camunda/issues/38829

