### PR TITLE
[Backport main] fix: support zoned ISO 8601 date-time in camunda client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/util/ParseUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/ParseUtil.java
@@ -16,8 +16,13 @@
 package io.camunda.client.impl.util;
 
 import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ParseUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(ParseUtil.class);
 
   public static Long parseLongOrNull(final String input) {
     return input == null ? null : Long.parseLong(input);
@@ -36,7 +41,14 @@ public class ParseUtil {
       return null;
     }
     try {
-      return OffsetDateTime.parse(dateTime);
+      try {
+        return OffsetDateTime.parse(dateTime);
+      } catch (final DateTimeParseException e) {
+        LOG.debug(
+            "Failed parsing '{}' as ISO-8601 date-time, trying to parse as zoned ISO-8601 date-time.",
+            dateTime);
+        return ZonedDateTime.parse(dateTime).toOffsetDateTime();
+      }
     } catch (final Exception e) {
       throw new IllegalArgumentException("Failed to parse date: " + dateTime, e);
     }

--- a/clients/java/src/test/java/io/camunda/client/impl/util/ParseUtilTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/util/ParseUtilTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+public class ParseUtilTest {
+  @Test
+  void shouldReturnNullWhenDateTimeIsNull() {
+    // when
+    final OffsetDateTime result = ParseUtil.parseOffsetDateTimeOrNull(null);
+
+    // then
+    assertThat(result).isNull();
+  }
+
+  /** {@link java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME} format */
+  @Test
+  void shouldParseIsoOffsetDateTime() {
+    // given
+    final String dateTime = "2025-12-03T12:00:00+03:00";
+
+    // when
+    final OffsetDateTime result = ParseUtil.parseOffsetDateTimeOrNull(dateTime);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getYear()).isEqualTo(2025);
+    assertThat(result.getMonthValue()).isEqualTo(12);
+    assertThat(result.getDayOfMonth()).isEqualTo(3);
+    assertThat(result.getHour()).isEqualTo(12);
+    assertThat(result.getMinute()).isEqualTo(0);
+    assertThat(result.getSecond()).isEqualTo(0);
+    assertThat(result.getOffset()).isEqualTo(ZoneOffset.ofHours(3));
+  }
+
+  /** {@link java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME} format */
+  @Test
+  void shouldParseIsoZonedDateTime() {
+    // given
+    final String dateTime = "2025-12-04T12:00:00+01:00[Europe/Paris]";
+
+    // when
+    final OffsetDateTime result = ParseUtil.parseOffsetDateTimeOrNull(dateTime);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getYear()).isEqualTo(2025);
+    assertThat(result.getMonthValue()).isEqualTo(12);
+    assertThat(result.getDayOfMonth()).isEqualTo(4);
+    assertThat(result.getHour()).isEqualTo(12);
+    assertThat(result.getMinute()).isEqualTo(0);
+    assertThat(result.getSecond()).isEqualTo(0);
+    assertThat(result.getOffset()).isEqualTo(ZoneOffset.ofHours(1));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidDateFormat() {
+    // given
+    final String invalidDateTime = "not-a-date";
+
+    // when/then
+    assertThatThrownBy(() -> ParseUtil.parseOffsetDateTimeOrNull(invalidDateTime))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Failed to parse date: " + invalidDateTime);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -520,6 +520,17 @@ public final class ActivateJobsRestTest extends ClientRestTest {
               assertThat(props.getPriority()).isEqualTo(10);
               assertThat(props.getUserTaskKey()).isEqualTo(123);
             }),
+        // regression test for https://github.com/camunda/camunda/issues/39474
+        // DateTimeFormatter.ISO_ZONED_DATE_TIME format
+        new ActivateJobWithUserTaskPropsTestCase(
+            "should activate job with zoned ISO 8601 date time (FEEL expression format)",
+            new UserTaskProperties()
+                .dueDate("2025-12-03T12:00Z[GMT]")
+                .followUpDate("2025-12-04T12:00+01:00[Europe/Paris]"),
+            props -> {
+              assertThat(props.getDueDate()).isEqualTo("2025-12-03T12:00:00Z");
+              assertThat(props.getFollowUpDate()).isEqualTo("2025-12-04T12:00:00+01:00");
+            }),
         new ActivateJobWithUserTaskPropsTestCase(
             "should activate job with empty user task properties",
             new UserTaskProperties(),


### PR DESCRIPTION
# Description
Backport of #39611 to `main`.

relates to #39474