### PR TITLE
ci: add newly released 8.8 version to night release dry run 

### DIFF
--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -12,6 +12,18 @@ on:
 
 jobs:
   # Camunda Platform release
+  dry-run-release-88:
+    name: "Release from stable/8.8"
+    uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.8
+    secrets: inherit
+    strategy:
+      fail-fast: false
+    with:
+      releaseBranch: stable/8.8
+      releaseVersion: 0.8.8
+      nextDevelopmentVersion: 0.0.0-SNAPSHOT
+      isLatest: true
+      dryRun: true
   dry-run-release-87:
     name: "Release from stable/8.7"
     uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.7
@@ -33,20 +45,6 @@ jobs:
     with:
       releaseBranch: stable/8.6
       releaseVersion: 0.8.6
-      nextDevelopmentVersion: 0.0.0-SNAPSHOT
-      isLatest: true
-      dryRun: true
-
-  # Zeebe release
-  dry-run-release-85:
-    name: "Release from stable/8.5"
-    uses: camunda/camunda/.github/workflows/zeebe-release.yml@stable/8.5
-    secrets: inherit
-    strategy:
-      fail-fast: false
-    with:
-      releaseBranch: stable/8.5
-      releaseVersion: 0.8.5
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
@@ -93,69 +91,6 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": "Please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>."
-                  }
-                }
-              ]
-            }
-
-  notify-zeebe:
-    name: Send Slack notification for Zeebe up to 8.5
-    runs-on: ubuntu-latest
-    needs: [dry-run-release-85]
-    if: always()
-    timeout-minutes: 5
-    permissions: {}  # GITHUB_TOKEN unused in this job
-    steps:
-      - id: slack-notify-failure
-        name: Send failure slack notification
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        if: ${{ always() && needs.dry-run-release-85.result != 'success' }}
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          # For posting a rich message using Block Kit
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":alarm: *Release Dry Run* from `stable/*` failed! :alarm:\n"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-                  }
-                }
-              ]
-            }
-      - id: slack-notify-success
-        name: Send success slack notification
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        if: ${{ always() && needs.dry-run-release-85.result == 'success' }}
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          # For posting a rich message using Block Kit
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":tada: *Release Dry Run* from `stable/*` succeeded! :tada:\n"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Nothing to check today. Good job! :clap:\n"
                   }
                 }
               ]


### PR DESCRIPTION
## Description

This pull request updates the Zeebe release dry run workflow to focus on newer release branches and streamlines notification jobs. The most important changes are the addition of a dry run for the 8.8 release and the removal of jobs related to the 8.5 release, including its Slack notifications.

**Release workflow updates:**

* Added a new dry run release job for the `stable/8.8` branch, ensuring automated release checks for the latest version.
* Removed the dry run release job for the `stable/8.5` branch, discontinuing automated checks for this older version.

**Notification job cleanup:**

* Removed the Slack notification job (`notify-zeebe`) that reported success or failure for the 8.5 dry run release job, as it is no longer needed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
