### PR TITLE
[Backport stable/8.8] fix: avoid redistribution of signals that fail auth checks

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -175,6 +175,11 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
           command, exception.getRejectionType(), exception.getMessage());
       responseWriter.writeRejectionOnCommand(
           command, exception.getRejectionType(), exception.getMessage());
+      if (command.isCommandDistributed()) {
+        // If the command was distributed but doesn't pass auth checks on this partition, we still
+        // need to acknowledge the command to avoid it being stuck in retry.
+        commandDistributionBehavior.acknowledgeCommand(command);
+      }
       return ProcessingError.EXPECTED_ERROR;
     }
     return ProcessingError.UNEXPECTED_ERROR;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
@@ -170,6 +170,14 @@ public class BroadcastSignalMultiplePartitionsTest {
                         .formatted(otherProcessId))
                 .exists())
         .isTrue();
+
+    // then - the signal distribution is still finished because a redistribution is not necessary
+    assertThat(
+            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+                .withDistributionValueType(ValueType.SIGNAL)
+                .withDistributionIntent(SignalIntent.BROADCAST)
+                .exists())
+        .isTrue();
   }
 
   @Test
@@ -192,7 +200,7 @@ public class BroadcastSignalMultiplePartitionsTest {
     // when
     ENGINE.signal().withSignalName(signalName).broadcastWithMetadata(user.getUsername());
 
-    // then
+    // then - the command is rejected on the partition that hosts the unauthorized process instance
     assertThat(
             RecordingExporter.signalRecords(SignalIntent.BROADCAST)
                 .withSignalName(signalName)
@@ -201,6 +209,14 @@ public class BroadcastSignalMultiplePartitionsTest {
                 .withRejectionReason(
                     "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                         .formatted(otherProcessId))
+                .exists())
+        .isTrue();
+
+    // then - the signal distribution is still finished because a redistribution is not necessary
+    assertThat(
+            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+                .withDistributionValueType(ValueType.SIGNAL)
+                .withDistributionIntent(SignalIntent.BROADCAST)
                 .exists())
         .isTrue();
   }


### PR DESCRIPTION
# Description
Backport of #39617 to `stable/8.8`.

relates to #39523