### PR TITLE
ci: change versions used on release dry run to be compatible with japicmp

### DIFF
--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -39,7 +39,6 @@ jobs:
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: ${{ matrix.latest }}
       dryRun: true
-      mvnGoals: "-Djapicmp.skip=true" # Skip japicmp checks to avoid issues with older versions
 
   notify:
     name: Send Slack notification

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -39,6 +39,7 @@ jobs:
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: ${{ matrix.latest }}
       dryRun: true
+      mvnGoals: "-Djapicmp.skip=true" # Skip japicmp checks to avoid issues with older versions
 
   notify:
     name: Send Slack notification

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -23,11 +23,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ 1.0.2, 1.0.0-alpha1 ]
+        # These versions were selected to ensure compatibility with the japicmp plugin
+        # which requires webapps-schema artifact (introduced Sep 13, 2024).
+        # Earlier versions from 2021 predate this dependency and cause build failures.
+        # See discussion at: https://camunda.slack.com/archives/C06UWQNCU7M/p1760468857576009?thread_ts=1760406101.424439&cid=C06UWQNCU7M
+        version: [ 8.6.1, 8.7.0-alpha1 ]
         include:
-          - version: 1.0.2
+          - version: 8.6.1
             latest: true
-          - version: 1.0.0-alpha1
+          - version: 8.7.0-alpha1
             latest: false
     with:
       releaseBranch: ${{ inputs.branch || 'main' }}

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -23,15 +23,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # These versions were selected to ensure compatibility with the japicmp plugin
+        # These versions were selected to ensure compatibility with the japicmp plugin (introduced Oct 10, 2025),
         # which requires webapps-schema artifact (introduced Sep 13, 2024).
         # Earlier versions from 2021 predate this dependency and cause build failures.
         # See discussion at: https://camunda.slack.com/archives/C06UWQNCU7M/p1760468857576009?thread_ts=1760406101.424439&cid=C06UWQNCU7M
-        version: [ 8.6.1, 8.7.0-alpha1 ]
+        version: [ 8.6.1, 8.8.0-alpha8 ]
         include:
           - version: 8.6.1
             latest: true
-          - version: 8.7.0-alpha1
+          - version: 8.8.0-alpha8
             latest: false
     with:
       releaseBranch: ${{ inputs.branch || 'main' }}

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -32,11 +32,6 @@ on:
         description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven Central, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
         type: boolean
         default: false
-      mvnGoals:
-        description: 'Additional Maven goals or options to pass to the release commands, e.g. to skip certain checks. Space delimited.'
-        type: string
-        required: false
-        default: ''
   workflow_dispatch:
     inputs:
       releaseBranch:
@@ -65,11 +60,6 @@ on:
         description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven Central, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
         type: boolean
         default: false
-      mvnGoals:
-        description: 'Additional Maven goals or options to pass to the release commands, e.g. to skip certain checks. Space delimited.'
-        type: string
-        required: false
-        default: ''
 defaults:
   run:
     shell: bash
@@ -217,7 +207,7 @@ jobs:
             -P-autoFormat \
             -P\!include-optimize \
             -Darguments='-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -P!include-optimize -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"' \
-            ${{ inputs.dryRun && inputs.mvnGoals || '' }}
+            ${{ inputs.dryRun && '-Djapicmp.skip=true' || '' }}
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -32,6 +32,11 @@ on:
         description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven Central, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
         type: boolean
         default: false
+      mvnGoals:
+        description: 'Additional Maven goals or options to pass to the release commands, e.g. to skip certain checks. Space delimited.'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
     inputs:
       releaseBranch:
@@ -60,6 +65,11 @@ on:
         description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven Central, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
         type: boolean
         default: false
+      mvnGoals:
+        description: 'Additional Maven goals or options to pass to the release commands, e.g. to skip certain checks. Space delimited.'
+        type: string
+        required: false
+        default: ''
 defaults:
   run:
     shell: bash
@@ -206,7 +216,8 @@ jobs:
             -DskipQaBuild=true \
             -P-autoFormat \
             -P\!include-optimize \
-            -Darguments='-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -P!include-optimize -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
+            -Darguments='-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -P!include-optimize -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"' \
+            ${{ inputs.dryRun && inputs.mvnGoals || '' }}
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2735,6 +2735,7 @@
           <artifactId>japicmp-maven-plugin</artifactId>
           <version>${plugin.version.japicmp}</version>
           <configuration>
+            <skip>${japicmp.skip}</skip>
             <parameter>
               <accessModifier>private</accessModifier>
               <postAnalysisScript>${project.basedir}/src/main/scripts/failOnNewFieldWithoutAnnotation.groovy</postAnalysisScript>


### PR DESCRIPTION
## Description

This pull request updates the matrix of Camunda Platform versions used in the `.github/workflows/camunda-platform-release-main-dry-run.yml` workflow. The selected versions now ensure compatibility with the japicmp plugin by including only versions that contain the required `webapps-schema` artifact, preventing build failures seen with earlier releases.

Version compatibility updates:

* Updated the matrix to use `8.6.1` and `8.7.0-alpha1` instead of older versions, ensuring the japicmp plugin works correctly with the required `webapps-schema` artifact.
* Added comments explaining the rationale for the version selection and referencing the relevant Slack discussion for future maintainers.

Workflow run: https://github.com/camunda/camunda/actions/runs/18539838362

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
