### PR TITLE
ci: removal of "Not sure" component

### DIFF
--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -10,7 +10,6 @@ body:
       description: In which component did the issue occur?
       # The components should be kept in alphabetical order, with "Not sure" at the top
       options:
-        - <!-- Not sure- -->
         - <!-- C8-API- -->
         - <!-- C8Run- -->
         - <!-- Camunda Process Test- -->
@@ -172,15 +171,15 @@ body:
       description: |
         Does this bug impact an automated test suite? If so:
 
-        **For the Cross Component Test Suite:**  
+        **For the Cross Component Test Suite:**
         This issue breaks a test case in the Cross Component Test Suite [Add link to the respective test case here]. Before you consider the fix as done, please check if the respective test case passes. To trigger the full test suite, follow the directions here: [GitHub Actions for Testing](https://github.com/camunda/c8-cross-component-e2e-tests/blob/main/README.md#github-actions-for-testing).
 
-        **For the Orchestration Cluster Test Suite:**  
-        This issue breaks a test case in the C8 Orchestration Cluster Test Suite [Add link to the respective test case here]. The test suite can be triggered automatically via PRs.  
+        **For the Orchestration Cluster Test Suite:**
+        This issue breaks a test case in the C8 Orchestration Cluster Test Suite [Add link to the respective test case here]. The test suite can be triggered automatically via PRs.
 
         Note: PR-triggered test runs only cover the components affected by the PR. Cross-component flows, or flows involving other components, are executed only during nightly builds and release runs. To trigger the full test suite, follow the directions here: [GitHub Actions for Testing](https://github.com/camunda/camunda/blob/main/qa/c8-orchestration-cluster-e2e-test-suite/README.md#running-the-on-demand-workflow).
 
-        **General note:**  
+        **General note:**
         The automated test cases on E2E level might not provide enough test coverage to verify if the fix works 100%. Ensure the fix is covered by a sufficient regression test. Conduct manual testing if required. Until this bug is fixed, the affected test will be skipped. Once the fix passes, create a PR in the respective test suite to re-enable the test.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/2. feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2. feature_request.yml
@@ -10,7 +10,6 @@ body:
       description: For which component your improvement idea is for?
       # The components should be kept in alphabetical order, with "Not sure" at the top
       options:
-        - <!-- Not sure- -->
         - <!-- C8-API- -->
         - <!-- C8Run- -->
         - <!-- Camunda Process Test- -->

--- a/.github/ISSUE_TEMPLATE/3. task.yml
+++ b/.github/ISSUE_TEMPLATE/3. task.yml
@@ -10,7 +10,6 @@ body:
       description: In which component shall the task be carried out?
       # The components should be kept in alphabetical order, with "Not sure" at the top
       options:
-        - <!-- Not sure- -->
         - <!-- C8-API- -->
         - <!-- C8Run- -->
         - <!-- Camunda Process Test- -->

--- a/.github/ISSUE_TEMPLATE/5. CVE.yml
+++ b/.github/ISSUE_TEMPLATE/5. CVE.yml
@@ -10,7 +10,6 @@ body:
       description: Which component is affected by this CVE?
       # The components should be kept in alphabetical order, with "Not sure" at the top
       options:
-        - <!-- Not sure- -->
         - <!-- C8-API- -->
         - <!-- C8Run- -->
         - <!-- Camunda Process Test- -->

--- a/.github/opened_issue_labeler.yml
+++ b/.github/opened_issue_labeler.yml
@@ -24,8 +24,6 @@ component/tasklist:
   '(Tasklist-)'
 component/zeebe:
   '(Zeebe-)'
-needs component label:
-  '(Not sure-)'
 severity/critical:
   '(Critical-)'
 severity/high:


### PR DESCRIPTION


## Description

This is a follow-up from a recent Core Apps Manager sync.:

>[Sebastian Bathke](mailto:sebastian.bathke@camunda.com) Topic: Triage/Delegation of issues without a specified component
In the context of the existing [Github workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/add-to-projects.yml) that adds issues to specific projects to be eventually triaged, is anyone taking care of assessing issues with the [`needs component label`](https://github.com/camunda/camunda/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22needs%20component%20label%22) (as of now 50+ issues) to delegate them to a component/team?
Outcome: We change to enforcing component selection. It’s fine if it isn’t right, we can adjust.

We rather have people selecting the "wrong" component than accumulating issues that no team will pickup for triage.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
