### PR TITLE
Name of namespace was too long.

### DIFF
--- a/.github/workflows/camunda-scheduled-release-migration-test.yml
+++ b/.github/workflows/camunda-scheduled-release-migration-test.yml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/camunda-release-migration-test.yml
     secrets: inherit
     with:
-      name: scheduled-release-migration-test
+      name: scheduled-release-migration
       ref: stable/8.8
       cluster: 'zeebe-cluster'
       cluster-region: 'europe-west1-b'
@@ -26,9 +26,9 @@ jobs:
     needs: [ migration-test ]
     # Current behavior of needs and dependency handling on a calling workflow is
     # If the last job of the called workflow is skipped, because of a previous job failure, the
-    # depending jobs are skipped as well. This is the case for jobs in the caller workflow as well.
+    # depending on jobs are skipped as well. This is the case for jobs in the caller workflow as well.
     # This can be avoided by using always and checking the result directly.
-    # See context 
+    # See context
     #  https://camunda.slack.com/archives/C013MEVQ4M9/p1760428530690699?thread_ts=1760426224.174949&cid=C013MEVQ4M9
     # We need to run always and check for dependency outcome
     if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') )


### PR DESCRIPTION
## Description

This PR shortens the name of the namespace. Since that when we would concatenate the name of the namespace with the ES pods, this would be too large, causing these to fail to deploy.
```
Warning  FailedCreate      74s (x20 over 39m)  statefulset-controller  create Pod scheduled-release-migration-test-elasticsearch-master-0 in StatefulSet scheduled-release-migration-test-elasticsearch-master failed error: Pod "scheduled-release-migration-test-elasticsearch-master-0" is invalid: metadata.labels: Invalid value: "scheduled-release-migration-test-elasticsearch-master-658f87bcf5": must be no more than 63 characters
```

See investigation [here](https://camunda.slack.com/archives/C013MEVQ4M9/p1760589549254829).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
