### PR TITLE
feat: generate fossa releases and attribution/SBOM documentation upon a successful release

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -787,9 +787,9 @@ jobs:
             secret/data/products/camunda/ci/camunda FOSSA_API_KEY;
       - name: Get FOSSA context
         id: fossa-context
-        uses: camunda/infra-global-github-actions/fossa/info@ec4caca36050ad1b7fee536facf95bc02515ddc6
+        uses: camunda/infra-global-github-actions/fossa/info@3be9c0625ab9879b87b483d48d1bddfde496c70b
       - name: Wait for FOSSA scan completion
-        uses: camunda/infra-global-github-actions/fossa/wait-for-scan@infra-gh-854-publish-sboms
+        uses: camunda/infra-global-github-actions/fossa/wait-for-scan@3be9c0625ab9879b87b483d48d1bddfde496c70b
         with:
           fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
           branch: ${{ steps.fossa-context.outputs.head-ref }}
@@ -797,7 +797,7 @@ jobs:
           revision-id: ${{ steps.fossa-context.outputs.head-revision }}
           dry-run: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
       - name: Create FOSSA releases and generate reports
-        uses: camunda/infra-global-github-actions/fossa/release@infra-gh-854-publish-sboms
+        uses: camunda/infra-global-github-actions/fossa/release@3be9c0625ab9879b87b483d48d1bddfde496c70b
         with:
           fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
           branch: ${{ steps.fossa-context.outputs.head-ref }}

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -762,14 +762,14 @@ jobs:
 
   # This job waits for the existing FOSSA scan (triggered by check-licenses.yml on tag push)
   # then creates releases and generates attribution/SBOM reports for single-app only
-  # Skipped for:
-  # - Dry runs (dryRun=true or releaseProcessDryRun=true)
-  # - Non-stable versions (containing '-' like SNAPSHOT, alpha, rc)
+  # Flags impact:
+  # - With dryRun=true or releaseProcessDryRun=true: Runs in dry-run mode (no actual release creation)
+  # - Skipped for non-stable versions (containing '-' like SNAPSHOT, alpha, rc)
   fossa-release:
     name: Create FOSSA releases and generate attribution/SBOM reports
     runs-on: ubuntu-latest
     needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk]
-    if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && !contains(inputs.releaseVersion, '-') }}
+    if: ${{ !contains(inputs.releaseVersion, '-') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -795,11 +795,12 @@ jobs:
           branch: ${{ steps.fossa-context.outputs.head-ref }}
           project-id: "custom+50756/camunda/camunda@single-app"
           revision-id: ${{ steps.fossa-context.outputs.head-revision }}
+          dry-run: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
       - name: Create FOSSA releases and generate reports
         uses: camunda/infra-global-github-actions/fossa/release@infra-gh-854-publish-sboms
         with:
           fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
-          branch: ${{ steps.info.outputs.head-ref }}
+          branch: ${{ steps.fossa-context.outputs.head-ref }}
           project-id: "custom+50756/camunda/camunda@single-app"
           attribution-release-group-id: "4904" # https://app.fossa.com/projects/group/4904
           sbom-release-group-id: "4905"        # https://app.fossa.com/projects/group/4905
@@ -807,6 +808,7 @@ jobs:
           revision-id: ${{ steps.fossa-context.outputs.head-revision }}
           attribution-format: "TXT"
           sbom-format: "CYCLONEDX_JSON"
+          dry-run: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -764,14 +764,12 @@ jobs:
   # then creates releases and generates attribution/SBOM reports for single-app only
   # Flags impact:
   # - With dryRun=true or releaseProcessDryRun=true: Runs in dry-run mode (no actual release creation)
-  # - Skipped for non-stable versions (containing '-' like SNAPSHOT, alpha, rc)
   fossa-release:
     name: Create FOSSA releases and generate attribution/SBOM reports
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk]
-    if: ${{ !contains(inputs.releaseVersion, '-') }}
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.RELEASE_BRANCH }}
       - name: Import Secrets

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -788,25 +788,25 @@ jobs:
       - name: Get FOSSA context
         id: fossa-context
         uses: camunda/infra-global-github-actions/fossa/info@ec4caca36050ad1b7fee536facf95bc02515ddc6
-        with:
-          fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
       - name: Wait for FOSSA scan completion
         uses: camunda/infra-global-github-actions/fossa/wait-for-scan@infra-gh-854-publish-sboms
         with:
           fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
-          project-id: camunda/camunda@single-app
-          branch: ${{ steps.fossa-context.outputs.branch }}
-          revision: ${{ steps.fossa-context.outputs.revision }}
+          branch: ${{ steps.fossa-context.outputs.head-ref }}
+          project-id: "custom+50756/camunda/camunda@single-app"
+          revision-id: ${{ steps.fossa-context.outputs.head-revision }}
       - name: Create FOSSA releases and generate reports
         uses: camunda/infra-global-github-actions/fossa/release@infra-gh-854-publish-sboms
         with:
           fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
-          project-id: camunda/camunda@single-app
-          branch: ${{ steps.fossa-context.outputs.branch }}
-          revision: ${{ steps.fossa-context.outputs.revision }}
-          release-group-attribution: TODO_ATTRIBUTION_GROUP_ID
-          release-group-sbom: TODO_SBOM_GROUP_ID
-          release-title: ${{ inputs.releaseVersion }}
+          branch: ${{ steps.info.outputs.head-ref }}
+          project-id: "custom+50756/camunda/camunda@single-app"
+          attribution-release-group-id: "4904" # https://app.fossa.com/projects/group/4904
+          sbom-release-group-id: "4905"        # https://app.fossa.com/projects/group/4905
+          release-number: ${{ env.RELEASE_VERSION }}
+          revision-id: ${{ steps.fossa-context.outputs.head-revision }}
+          attribution-format: "TXT"
+          sbom-format: "CYCLONEDX_JSON"
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -760,6 +760,63 @@ jobs:
       dockerImage: ${{ (inputs.dryRun || inputs.releaseProcessDryRun) && '' || format('camunda/zeebe:{0}', inputs.releaseVersion) }}
     secrets: inherit
 
+  # This job waits for the existing FOSSA scan (triggered by check-licenses.yml on tag push)
+  # then creates releases and generates attribution/SBOM reports for single-app only
+  # Skipped for:
+  # - Dry runs (dryRun=true or releaseProcessDryRun=true)
+  # - Non-stable versions (containing '-' like SNAPSHOT, alpha, rc)
+  fossa-release:
+    name: Create FOSSA releases and generate attribution/SBOM reports
+    runs-on: ubuntu-latest
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk]
+    if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && !contains(inputs.releaseVersion, '-') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/camunda FOSSA_API_KEY;
+      - name: Get FOSSA context
+        id: fossa-context
+        uses: camunda/infra-global-github-actions/fossa/info@ec4caca36050ad1b7fee536facf95bc02515ddc6
+        with:
+          fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+      - name: Wait for FOSSA scan completion
+        uses: camunda/infra-global-github-actions/fossa/wait-for-scan@infra-gh-854-publish-sboms
+        with:
+          fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+          project-id: camunda/camunda@single-app
+          branch: ${{ steps.fossa-context.outputs.branch }}
+          revision: ${{ steps.fossa-context.outputs.revision }}
+      - name: Create FOSSA releases and generate reports
+        uses: camunda/infra-global-github-actions/fossa/release@infra-gh-854-publish-sboms
+        with:
+          fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+          project-id: camunda/camunda@single-app
+          branch: ${{ steps.fossa-context.outputs.branch }}
+          revision: ${{ steps.fossa-context.outputs.revision }}
+          release-group-attribution: TODO_ATTRIBUTION_GROUP_ID
+          release-group-sbom: TODO_SBOM_GROUP_ID
+          release-title: ${{ inputs.releaseVersion }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   # Slack notification jobs send release status updates to the team's Slack channel.
   # Both jobs are conditional and only run for actual releases (not dry runs or E2E testing).
   # Flags impact:
@@ -770,7 +827,7 @@ jobs:
   notify-on-success:
     name: Send Slack notification on success
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk, fossa-release]
     # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
     # else => send slack notification as an actual release succeeded
     if: ${{ always() && (
@@ -780,7 +837,8 @@ jobs:
       needs.operate-docker.result == 'success' &&
       needs.tasklist-docker.result == 'success' &&
       needs.camunda-docker.result == 'success' &&
-      (needs.snyk.result == 'success' || needs.snyk.result == 'skipped')
+      (needs.snyk.result == 'success' || needs.snyk.result == 'skipped') &&
+      (needs.fossa-release.result == 'success' || needs.fossa-release.result == 'skipped')
       ) && !inputs.dryRun && !inputs.releaseProcessDryRun }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
@@ -819,7 +877,7 @@ jobs:
   notify-if-failed:
     name: Send Slack notification on failure
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk, fossa-release]
     # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
     # else => send slack notification as an actual release failed
     if: ${{ always() && (
@@ -829,7 +887,8 @@ jobs:
         needs.operate-docker.result == 'failure' ||
         needs.tasklist-docker.result == 'failure' ||
         needs.camunda-docker.result == 'failure' ||
-        needs.snyk.result == 'failure'
+        needs.snyk.result == 'failure' ||
+        needs.fossa-release.result == 'failure'
         ) && !inputs.dryRun && !inputs.releaseProcessDryRun }}
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job


### PR DESCRIPTION
## Description

This PR introduces a new job in the release workflow. The job generates new releases in FOSSA release groups and publishes the project SBOM and attribution reports to FOSSA public portal.
The job is meant to be running only when a release is succeeded, hence the public reports need to be updated for the new release version.

As the release groups have to be created only once, and the process needs an API token with access rights that the machine accounts don't have, I created the release groups manually, using the recent 8.8.0 as the initial release:
```
fossa release-group create \
    -t camunda8-attribution \
    -r 8.8.0 \
    --project-locator custom+50756/camunda/camunda@single-app \
    --project-branch release-8.8.0 \
    --project-revision 92fbec27b9ec5e724367c0fbbbda860e36ddedd6 \
    --license-policy "Camunda8 Distribution" \
    --security-policy "Default Camunda" \
    --quality-policy "Major - 3 Policy" \
    --team "Monorepo Team"

----> Created release group with id: 4904
----> and a new release with id: 21393

fossa release-group create \
    -t camunda8-sbom \
    -r 8.8.0 \
    --project-locator custom+50756/camunda/camunda@single-app \
    --project-branch release-8.8.0 \
    --project-revision 92fbec27b9ec5e724367c0fbbbda860e36ddedd6 \
    --license-policy "Camunda8 Distribution" \
    --security-policy "Default Camunda" \
    --quality-policy "Major - 3 Policy" \
    --team "Monorepo Team"

----> Created release group with id: 4905
----> and a new release with id: 21395
```
- On the FOSSA UI I did set the release groups' FOSSA portal settings to "public"
- Then, using the Monorepo's FOSSA machine account's API key, I published the attribution and SBOM reports to the FOSSA portal:
```
curl \
    --request POST \
    --header "accept: application/json" \
    --header "Authorization: Bearer $FOSSA_API_KEY" \
    --url "https://app.fossa.com/api/project_group/4904/release/21393/attribution/TXT"\
"?includeDeepDependencies=true"\
"&includeDirectDependencies=true"\
"&includeLicenseList=true"\
"&includeLicenseScan=true"\
"&includeProjectLicense=true"\
"&includeCopyrightList=true"\
"&includeFileMatches=true"\
"&includeOpenVulnerabilities=true"\
"&includeClosedVulnerabilities=true"\
"&includeDependencySummary=true"\
"&includeLicenseHeaders=true"\
"&isPublishing=true"

curl \
    --request POST \
    --header "accept: application/json" \
    --header "Authorization: Bearer $FOSSA_API_KEY" \
    --url "https://app.fossa.com/api/project_group/4905/release/21395/attribution/CYCLONEDX_JSON"\
"?includeDeepDependencies=true"\
"&includeDirectDependencies=true"\
"&includeLicenseList=true"\
"&includeLicenseScan=true"\
"&includeProjectLicense=true"\
"&includeCopyrightList=true"\
"&includeFileMatches=true"\
"&includeOpenVulnerabilities=true"\
"&includeClosedVulnerabilities=true"\
"&includeDependencySummary=true"\
"&includeLicenseHeaders=true"\
"&isPublishing=true"
```

The reports can be checked below
- [Attribution TXT](https://portal.fossa.com/p/camunda/release/4904/21393)
- [SBOM](https://portal.fossa.com/p/camunda/release/4905/21395)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related #https://github.com/camunda/team-infrastructure/issues/854
