### PR TITLE
fix: Prevent spring boot from pulling vulnerabile logback version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -101,6 +101,7 @@
     <version.spring>6.2.10</version.spring>
     <version.spring-security>6.4.7</version.spring-security>
     <version.spring-boot>3.5.6</version.spring-boot>
+    <version.logback>1.5.19</version.logback>
     <version.tomcat>10.1.44</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.0</version.kryo>
@@ -2005,6 +2006,17 @@
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-websocket</artifactId>
         <version>${version.tomcat}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${version.logback}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${version.logback}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

Define the version of logback explicitly in the parent POM.

Before these changes a `./mvnw dependency:tree -Dincludes=ch.qos.logback:logback-core` shows

```
[INFO] -------------------< io.camunda:zeebe-gateway-rest >--------------------
[INFO] Building Zeebe Gateway REST API server 8.6.0-SNAPSHOT           [53/141]
[INFO]   from zeebe/gateway-rest/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- dependency:3.8.0:tree (default-cli) @ zeebe-gateway-rest ---
[INFO] io.camunda:zeebe-gateway-rest:jar:8.6.0-SNAPSHOT
[INFO] \- org.springframework.boot:spring-boot-starter-web:jar:3.5.6:test
[INFO]    \- org.springframework.boot:spring-boot-starter:jar:3.5.6:test
[INFO]       \- org.springframework.boot:spring-boot-starter-logging:jar:3.5.6:test
[INFO]          \- ch.qos.logback:logback-classic:jar:1.5.18:test
[INFO]             \- ch.qos.logback:logback-core:jar:1.5.18:test
```

After the changes

```
[INFO] --- dependency:3.8.0:tree (default-cli) @ zeebe-gateway-rest ---
[INFO] io.camunda:zeebe-gateway-rest:jar:8.6.0-SNAPSHOT
[INFO] \- org.springframework.boot:spring-boot-starter-web:jar:3.5.6:test
[INFO]    \- org.springframework.boot:spring-boot-starter:jar:3.5.6:test
[INFO]       \- org.springframework.boot:spring-boot-starter-logging:jar:3.5.6:test
[INFO]          \- ch.qos.logback:logback-classic:jar:1.5.19:test
[INFO]             \- ch.qos.logback:logback-core:jar:1.5.19:test
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/39316
