### PR TITLE
[Backport stable/optimize-8.6] fix: Prevent spring boot from pulling vulnerabile logback version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -101,6 +101,7 @@
     <version.spring>6.2.10</version.spring>
     <version.spring-security>6.4.7</version.spring-security>
     <version.spring-boot>3.5.6</version.spring-boot>
+    <version.logback>1.5.19</version.logback>
     <version.tomcat>10.1.44</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.0</version.kryo>
@@ -2005,6 +2006,17 @@
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-websocket</artifactId>
         <version>${version.tomcat}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${version.logback}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${version.logback}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
# Description
Backport of #39656 to `stable/optimize-8.6`.

relates to camunda/camunda#39316
original author: @georgios-goulos