### PR TITLE
fix: remove impossible states from decision instances

### DIFF
--- a/clients/java/revapi.json
+++ b/clients/java/revapi.json
@@ -50,6 +50,42 @@
           "code": "java.annotation.attributeValueChanged",
           "annotationType": "io.camunda.client.api.ExperimentalApi",
           "justification": "The ExperimentalApi annotation is used to mark methods as 'in-development'. It is okay to change value field"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.removed",
+          "old": "field io.camunda.client.api.search.response.DecisionDefinitionType.UNSPECIFIED",
+          "justification": "Removed impossible state that was never returned by the system - decision definitions are always either DECISION_TABLE or LITERAL_EXPRESSION"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.removed",
+          "old": "field io.camunda.client.api.search.response.DecisionInstanceState.UNKNOWN",
+          "justification": "Removed impossible state - decision instances can only be EVALUATED or FAILED, never UNKNOWN"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.removed",
+          "old": "field io.camunda.client.api.search.response.DecisionInstanceState.UNSPECIFIED",
+          "justification": "Removed impossible state - decision instances can only be EVALUATED or FAILED, never UNSPECIFIED"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.removed",
+          "old": "field io.camunda.client.protocol.rest.DecisionDefinitionTypeEnum.UNSPECIFIED",
+          "justification": "Removed impossible state from REST protocol enum - aligned with API response enum cleanup"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.removed",
+          "old": "field io.camunda.client.protocol.rest.DecisionInstanceStateEnum.UNKNOWN",
+          "justification": "Removed impossible state from REST protocol enum - aligned with API response enum cleanup"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.removed",
+          "old": "field io.camunda.client.protocol.rest.DecisionInstanceStateEnum.UNSPECIFIED",
+          "justification": "Removed impossible state from REST protocol enum - aligned with API response enum cleanup"
         }
       ]
     }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionDefinitionType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionDefinitionType.java
@@ -18,5 +18,6 @@ package io.camunda.client.api.search.response;
 public enum DecisionDefinitionType {
   DECISION_TABLE,
   LITERAL_EXPRESSION,
+  UNKNOWN,
   UNKNOWN_ENUM_VALUE;
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionDefinitionType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionDefinitionType.java
@@ -18,7 +18,5 @@ package io.camunda.client.api.search.response;
 public enum DecisionDefinitionType {
   DECISION_TABLE,
   LITERAL_EXPRESSION,
-  UNSPECIFIED,
-  UNKNOWN,
   UNKNOWN_ENUM_VALUE;
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionInstanceState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionInstanceState.java
@@ -18,7 +18,5 @@ package io.camunda.client.api.search.response;
 public enum DecisionInstanceState {
   EVALUATED,
   FAILED,
-  UNSPECIFIED,
-  UNKNOWN,
   UNKNOWN_ENUM_VALUE;
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionInstanceFilterImpl.java
@@ -62,12 +62,6 @@ public class DecisionInstanceFilterImpl
       case FAILED:
         stateEnum = DecisionInstanceStateEnum.FAILED;
         break;
-      case UNSPECIFIED:
-        stateEnum = DecisionInstanceStateEnum.UNSPECIFIED;
-        break;
-      case UNKNOWN:
-        stateEnum = DecisionInstanceStateEnum.UNKNOWN;
-        break;
       default:
         throw new IllegalArgumentException("Unexpected DecisionInstanceState value: " + state);
     }
@@ -173,12 +167,6 @@ public class DecisionInstanceFilterImpl
         break;
       case LITERAL_EXPRESSION:
         decisionDefinitionTypeEnum = DecisionDefinitionTypeEnum.LITERAL_EXPRESSION;
-        break;
-      case UNSPECIFIED:
-        decisionDefinitionTypeEnum = DecisionDefinitionTypeEnum.UNSPECIFIED;
-        break;
-      case UNKNOWN:
-        decisionDefinitionTypeEnum = DecisionDefinitionTypeEnum.UNKNOWN;
         break;
       default:
         throw new IllegalArgumentException(

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionInstanceFilterImpl.java
@@ -168,6 +168,9 @@ public class DecisionInstanceFilterImpl
       case LITERAL_EXPRESSION:
         decisionDefinitionTypeEnum = DecisionDefinitionTypeEnum.LITERAL_EXPRESSION;
         break;
+      case UNKNOWN:
+        decisionDefinitionTypeEnum = DecisionDefinitionTypeEnum.UNKNOWN;
+        break;
       default:
         throw new IllegalArgumentException(
             "Unexpected DecisionDefinitionType value: " + decisionDefinitionType);

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionInstanceImpl.java
@@ -159,10 +159,6 @@ public class DecisionInstanceImpl implements DecisionInstance {
         return DecisionDefinitionType.DECISION_TABLE;
       case LITERAL_EXPRESSION:
         return DecisionDefinitionType.LITERAL_EXPRESSION;
-      case UNSPECIFIED:
-        return DecisionDefinitionType.UNSPECIFIED;
-      case UNKNOWN:
-        return DecisionDefinitionType.UNKNOWN;
       case UNKNOWN_DEFAULT_OPEN_API:
       default:
         EnumUtil.logUnknownEnumValue(
@@ -181,10 +177,6 @@ public class DecisionInstanceImpl implements DecisionInstance {
         return DecisionInstanceState.EVALUATED;
       case FAILED:
         return DecisionInstanceState.FAILED;
-      case UNSPECIFIED:
-        return DecisionInstanceState.UNSPECIFIED;
-      case UNKNOWN:
-        return DecisionInstanceState.UNKNOWN;
       case UNKNOWN_DEFAULT_OPEN_API:
       default:
         EnumUtil.logUnknownEnumValue(

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionInstanceImpl.java
@@ -159,6 +159,8 @@ public class DecisionInstanceImpl implements DecisionInstance {
         return DecisionDefinitionType.DECISION_TABLE;
       case LITERAL_EXPRESSION:
         return DecisionDefinitionType.LITERAL_EXPRESSION;
+      case UNKNOWN:
+        return DecisionDefinitionType.UNKNOWN;
       case UNKNOWN_DEFAULT_OPEN_API:
       default:
         EnumUtil.logUnknownEnumValue(

--- a/operate/client/src/modules/components/StateIcon/index.tsx
+++ b/operate/client/src/modules/components/StateIcon/index.tsx
@@ -27,7 +27,7 @@ type Props = {
 };
 
 const StateIcon: React.FC<Props> = ({state, ...props}) => {
-  const TargetComponent = stateIconsMap[state];
+  const TargetComponent = stateIconsMap[state as keyof typeof stateIconsMap];
   return <TargetComponent data-testid={`${state}-icon`} {...props} />;
 };
 

--- a/operate/client/src/modules/components/StateIcon/index.tsx
+++ b/operate/client/src/modules/components/StateIcon/index.tsx
@@ -27,7 +27,7 @@ type Props = {
 };
 
 const StateIcon: React.FC<Props> = ({state, ...props}) => {
-  const TargetComponent = stateIconsMap[state as keyof typeof stateIconsMap];
+  const TargetComponent = stateIconsMap[state];
   return <TargetComponent data-testid={`${state}-icon`} {...props} />;
 };
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
@@ -70,8 +70,8 @@ public class DecisionInstanceSpecificFilterIT {
     createAndSaveRandomDecisionInstances(
         rdbmsWriter,
         b ->
-            b.state(DecisionInstanceState.EVALUATED)
-                .decisionType(DecisionDefinitionType.DECISION_TABLE)
+            b.state(DecisionInstanceState.FAILED)
+                .decisionType(DecisionDefinitionType.LITERAL_EXPRESSION)
                 .decisionDefinitionKey(decisionDefinition.decisionDefinitionKey())
                 .decisionDefinitionId(decisionDefinition.decisionDefinitionId()));
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
@@ -70,8 +70,8 @@ public class DecisionInstanceSpecificFilterIT {
     createAndSaveRandomDecisionInstances(
         rdbmsWriter,
         b ->
-            b.state(DecisionInstanceState.UNSPECIFIED)
-                .decisionType(DecisionDefinitionType.UNSPECIFIED)
+            b.state(DecisionInstanceState.EVALUATED)
+                .decisionType(DecisionDefinitionType.DECISION_TABLE)
                 .decisionDefinitionKey(decisionDefinition.decisionDefinitionKey())
                 .decisionDefinitionId(decisionDefinition.decisionDefinitionId()));
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DecisionInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DecisionInstanceEntityTransformer.java
@@ -77,8 +77,7 @@ public class DecisionInstanceEntityTransformer
     return switch (source) {
       case DECISION_TABLE -> DecisionDefinitionType.DECISION_TABLE;
       case LITERAL_EXPRESSION -> DecisionDefinitionType.LITERAL_EXPRESSION;
-      case UNSPECIFIED -> DecisionDefinitionType.UNSPECIFIED;
-      default -> DecisionDefinitionType.UNKNOWN;
+      default -> throw new IllegalArgumentException("Unexpected DecisionType: " + source);
     };
   }
 
@@ -90,7 +89,6 @@ public class DecisionInstanceEntityTransformer
     return switch (source) {
       case EVALUATED -> DecisionInstanceState.EVALUATED;
       case FAILED -> DecisionInstanceState.FAILED;
-      default -> DecisionInstanceState.UNKNOWN;
     };
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DecisionInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DecisionInstanceEntityTransformer.java
@@ -77,7 +77,7 @@ public class DecisionInstanceEntityTransformer
     return switch (source) {
       case DECISION_TABLE -> DecisionDefinitionType.DECISION_TABLE;
       case LITERAL_EXPRESSION -> DecisionDefinitionType.LITERAL_EXPRESSION;
-      default -> throw new IllegalArgumentException("Unexpected DecisionType: " + source);
+      case UNKNOWN -> DecisionDefinitionType.UNKNOWN;
     };
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DecisionInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DecisionInstanceEntityTransformer.java
@@ -77,7 +77,7 @@ public class DecisionInstanceEntityTransformer
     return switch (source) {
       case DECISION_TABLE -> DecisionDefinitionType.DECISION_TABLE;
       case LITERAL_EXPRESSION -> DecisionDefinitionType.LITERAL_EXPRESSION;
-      case UNKNOWN -> DecisionDefinitionType.UNKNOWN;
+      default -> DecisionDefinitionType.UNKNOWN;
     };
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
@@ -205,9 +205,7 @@ public record DecisionInstanceEntity(
 
   public enum DecisionDefinitionType {
     DECISION_TABLE,
-    LITERAL_EXPRESSION,
-    UNSPECIFIED,
-    UNKNOWN;
+    LITERAL_EXPRESSION;
 
     public static DecisionDefinitionType fromValue(final String value) {
       for (final DecisionDefinitionType b : DecisionDefinitionType.values()) {
@@ -221,9 +219,7 @@ public record DecisionInstanceEntity(
 
   public enum DecisionInstanceState {
     EVALUATED,
-    FAILED,
-    UNKNOWN,
-    UNSPECIFIED;
+    FAILED;
 
     public static DecisionInstanceState fromValue(final String value) {
       for (final DecisionInstanceState b : DecisionInstanceState.values()) {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
@@ -205,7 +205,8 @@ public record DecisionInstanceEntity(
 
   public enum DecisionDefinitionType {
     DECISION_TABLE,
-    LITERAL_EXPRESSION;
+    LITERAL_EXPRESSION,
+    UNKNOWN;
 
     public static DecisionDefinitionType fromValue(final String value) {
       for (final DecisionDefinitionType b : DecisionDefinitionType.values()) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionType.java
@@ -12,23 +12,19 @@ import org.slf4j.LoggerFactory;
 
 public enum DecisionType {
   DECISION_TABLE,
-  LITERAL_EXPRESSION,
-
-  UNSPECIFIED,
-  UNKNOWN;
+  LITERAL_EXPRESSION;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DecisionType.class);
 
   public static DecisionType fromString(final String decisionType) {
     if (decisionType == null) {
-      return UNSPECIFIED;
+      throw new IllegalArgumentException("Decision type cannot be null");
     }
     try {
       return DecisionType.valueOf(decisionType);
     } catch (final IllegalArgumentException ex) {
-      LOGGER.error(
-          "Decision type not found for value [{}]. UNKNOWN type will be assigned.", decisionType);
-      return UNKNOWN;
+      LOGGER.error("Decision type not found for value [{}].", decisionType);
+      throw new IllegalArgumentException("Unexpected decision type value: " + decisionType, ex);
     }
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionType.java
@@ -12,19 +12,21 @@ import org.slf4j.LoggerFactory;
 
 public enum DecisionType {
   DECISION_TABLE,
-  LITERAL_EXPRESSION;
+  LITERAL_EXPRESSION,
+  UNKNOWN;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DecisionType.class);
 
   public static DecisionType fromString(final String decisionType) {
     if (decisionType == null) {
-      throw new IllegalArgumentException("Decision type cannot be null");
+      return UNKNOWN;
     }
     try {
       return DecisionType.valueOf(decisionType);
     } catch (final IllegalArgumentException ex) {
-      LOGGER.error("Decision type not found for value [{}].", decisionType);
-      throw new IllegalArgumentException("Unexpected decision type value: " + decisionType, ex);
+      LOGGER.error(
+          "Decision type not found for value [{}]. UNKNOWN type will be assigned.", decisionType);
+      return UNKNOWN;
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -11175,16 +11175,12 @@ components:
       enum:
         - DECISION_TABLE
         - LITERAL_EXPRESSION
-        - UNSPECIFIED
-        - UNKNOWN
     DecisionInstanceStateEnum:
       description: The state of the decision instance.
       type: string
       enum:
         - EVALUATED
         - FAILED
-        - UNSPECIFIED
-        - UNKNOWN
     SortOrderEnum:
       description: The order in which to sort the related field.
       type: string

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -11175,6 +11175,7 @@ components:
       enum:
         - DECISION_TABLE
         - LITERAL_EXPRESSION
+        - UNKNOWN
     DecisionInstanceStateEnum:
       description: The state of the decision instance.
       type: string

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -1103,8 +1103,6 @@ public final class SearchQueryResponseMapper {
     return switch (state) {
       case EVALUATED -> DecisionInstanceStateEnum.EVALUATED;
       case FAILED -> DecisionInstanceStateEnum.FAILED;
-      case UNSPECIFIED -> DecisionInstanceStateEnum.UNSPECIFIED;
-      default -> DecisionInstanceStateEnum.UNKNOWN;
     };
   }
 
@@ -1116,8 +1114,6 @@ public final class SearchQueryResponseMapper {
     return switch (decisionDefinitionType) {
       case DECISION_TABLE -> DecisionDefinitionTypeEnum.DECISION_TABLE;
       case LITERAL_EXPRESSION -> DecisionDefinitionTypeEnum.LITERAL_EXPRESSION;
-      case UNSPECIFIED -> DecisionDefinitionTypeEnum.UNSPECIFIED;
-      default -> DecisionDefinitionTypeEnum.UNKNOWN;
     };
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -1114,6 +1114,7 @@ public final class SearchQueryResponseMapper {
     return switch (decisionDefinitionType) {
       case DECISION_TABLE -> DecisionDefinitionTypeEnum.DECISION_TABLE;
       case LITERAL_EXPRESSION -> DecisionDefinitionTypeEnum.LITERAL_EXPRESSION;
+      default -> DecisionDefinitionTypeEnum.UNKNOWN;
     };
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

[Turns out that the states `UNSPECIFIED` and `UNKNOWN` are impossible in an decision instance](https://camunda.slack.com/archives/C088A1LL5CZ/p1760541672411389), so I'm opening a PR to remove them from our codebase.

~@pedesen @christoph-fricke Please check the frontend code, there's a commit that's just formatting (I need to check the ESLint config since it doesn't cover some folders)~ I removed the FE changes from this PR

@tmetzke I tried to remove the the states from the backend but I'm pretty sure there are some details that must be fixed before merging.

## Breaking changes

* BREAKING CHANGE: The decision instance states `UNSPECIFIED` and `UNKNOWN` don't exist in the API and Java client anymore. It was never written by exporters, so it never occurred.
* BREAKING CHANGE: The decision definition type `UNSPECIFIED` doesn't exist in the API and Java client anymore. It was never written by exporters, so it never occurred.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
