### PR TITLE
ci: tests need to be built instead of pulling snapshot artifacts

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -156,7 +156,7 @@ jobs:
         name: Build Camunda Platform
         id: build-camunda
         with:
-          maven-extra-args: -PskipFrontendBuild -P\!include-optimize -Dmaven.test.skip=true
+          maven-extra-args: -PskipFrontendBuild -P\!include-optimize
       - uses: google-github-actions/auth@v2
         id: auth
         with:

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -116,7 +116,7 @@ jobs:
         name: Build Zeebe
         id: build-zeebe
         with:
-          maven-extra-args: -PskipFrontendBuild -P\!include-optimize -Dmaven.test.skip=true
+          maven-extra-args: -PskipFrontendBuild -P\!include-optimize
       - uses: google-github-actions/auth@v2
         id: auth
         with:


### PR DESCRIPTION
With maven.test.skip set, the snapshot test jar wasn't built, requiring maven to pull a SNAPSHOT artifact from somewhere. Most of the time, this worked and didn't cause problems because we don't actually exercise the tests. It [would fail occasionally](https://github.com/camunda/camunda/actions/runs/18582025820) because shortly after a release, the SNAPSHOT artifacts for the next version weren't available yet.

We can make this more robust by just accepting that we need to build test code too.