### PR TITLE
fix: do not wrap parse exceptions as problems

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
@@ -17,7 +17,6 @@ package io.camunda.zeebe.client.impl.http;
 
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
-import io.camunda.zeebe.client.api.command.ProblemException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -78,12 +77,12 @@ public class HttpZeebeFuture<RespT> extends CompletableFuture<RespT> implements 
     }
   }
 
-  private ProblemException unwrapExecutionException(final ExecutionException e) {
+  private ClientException unwrapExecutionException(final ExecutionException e) {
     final Throwable cause = e.getCause();
-    if (cause instanceof ProblemException) {
-      throw (ProblemException) cause;
+    if (cause instanceof ClientException) {
+      return (ClientException) cause;
     } else {
-      throw new ClientException(cause);
+      return new ClientException(cause);
     }
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
@@ -93,17 +93,10 @@ public interface TypedApiEntityConsumer<T> {
 
     @Override
     public ApiEntity<T> generateContent() throws IOException {
-      try {
-        if (isResponse) {
-          return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), type));
-        }
-        return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
-      } catch (final IOException ioe) {
-        // write the original JSON response into an error response
-        final String jsonString = getJsonString();
-        return ApiEntity.of(
-            new ProblemDetail().title("Unexpected server response").status(500).detail(jsonString));
+      if (isResponse) {
+        return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), type));
       }
+      return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
     }
 
     @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumerTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumerTest.java
@@ -16,8 +16,10 @@
 package io.camunda.zeebe.client.impl.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import io.camunda.zeebe.client.impl.http.ApiEntity.Error;
 import io.camunda.zeebe.client.impl.http.ApiEntity.Response;
 import io.camunda.zeebe.client.impl.http.ApiEntity.Unknown;
@@ -68,15 +70,9 @@ class ApiEntityConsumerTest {
     consumer.streamStart(ContentType.APPLICATION_JSON);
     // Feed the data
     consumer.data(byteBuffer, true);
-    // Generate the content
-    final ApiEntity<TestEntity> entity = consumer.generateContent();
 
-    // then
-    assertThat(entity).isInstanceOf(Error.class);
-    final ProblemDetail response = entity.problem();
-    assertThat(response).isNotNull();
-    assertThat(response.getTitle()).isEqualTo("Unexpected server response");
-    assertThat(response.getDetail()).isEqualTo(jsonResponse);
+    // when-then Generate the content
+    assertThatThrownBy(consumer::generateContent).isInstanceOf(UnrecognizedPropertyException.class);
   }
 
   @Test
@@ -92,15 +88,9 @@ class ApiEntityConsumerTest {
     consumer.streamStart(ContentType.APPLICATION_PROBLEM_JSON);
     // Feed the data
     consumer.data(byteBuffer, true);
-    // Generate the content
-    final ApiEntity<TestEntity> entity = consumer.generateContent();
 
-    // then
-    assertThat(entity).isInstanceOf(Error.class);
-    final ProblemDetail response = entity.problem();
-    assertThat(response).isNotNull();
-    assertThat(response.getTitle()).isEqualTo("Unexpected server response");
-    assertThat(response.getDetail()).isEqualTo(jsonResponse);
+    // when-then Generate the content
+    assertThatThrownBy(consumer::generateContent).isInstanceOf(UnrecognizedPropertyException.class);
   }
 
   @Test


### PR DESCRIPTION
## Description

The client wrapped parsing errors as problems which are intended to represent server side error responses.
This obfuscated client side errors as potential server errors.

This simplifies handling of such exceptions by just letting the client fail without wrapping such Exceptions into a ProblemDetail as well as not redundantly wrapping ClientExceptions into another ClientException as currently happening in `HttpZeebeFuture.unwrapExecutionException`

Before:
```
Exception in thread "main" io.camunda.zeebe.client.api.command.ClientException: io.camunda.zeebe.client.api.command.MalformedResponseException: Expected to receive a response body, but got a problem: class ProblemDetail {
    type: about:blank
    title: Unexpected server response
    status: 500
    detail: {"jobs":[{"type":"check-inventory","processDefinitionId":"process1","processDefinitionVersion":1,"elementId":"Activity_0tw2fu0","customHeaders":{},"worker":"default","retries":3,"deadline":1760695339434,"variables":{"item":"special widget"},"tenantId":"<default>","jobKey":"2251799813815741","processInstanceKey":"2251799813815735","processDefinitionKey":"2251799813815732","elementInstanceKey":"2251799813815740","kind":"BPMN_ELEMENT","listenerEventType":"UNSPECIFIED","tags":[]}]}
    instance: null
}
	at io.camunda.zeebe.client.impl.http.HttpZeebeFuture.unwrapExecutionException(HttpZeebeFuture.java:86)
	at io.camunda.zeebe.client.impl.http.HttpZeebeFuture.join(HttpZeebeFuture.java:42)
	at io.camunda.zeebe.client.TestWorker.main(TestWorker.java:65)
Caused by: io.camunda.zeebe.client.api.command.MalformedResponseException: Expected to receive a response body, but got a problem: class ProblemDetail {
    type: about:blank
    title: Unexpected server response
    status: 500
    detail: {"jobs":[{"type":"check-inventory","processDefinitionId":"process1","processDefinitionVersion":1,"elementId":"Activity_0tw2fu0","customHeaders":{},"worker":"default","retries":3,"deadline":1760695339434,"variables":{"item":"special widget"},"tenantId":"<default>","jobKey":"2251799813815741","processInstanceKey":"2251799813815735","processDefinitionKey":"2251799813815732","elementInstanceKey":"2251799813815740","kind":"BPMN_ELEMENT","listenerEventType":"UNSPECIFIED","tags":[]}]}
    instance: null
}
	at io.camunda.zeebe.client.impl.http.ApiCallback.handleSuccessResponse(ApiCallback.java:139)
```

After:
```
Exception in thread "main" io.camunda.zeebe.client.api.command.ClientException: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "kind" (class io.camunda.zeebe.client.protocol.rest.ActivatedJob), not marked as ignorable (14 known properties: "jobKey", "tenantId", "retries", "elementInstanceKey", "customHeaders", "processDefinitionVersion", "elementId", "deadline", "type", "processInstanceKey", "processDefinitionKey", "worker", "variables", "processDefinitionId"])
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: io.camunda.zeebe.client.protocol.rest.JobActivationResponse["jobs"]->java.util.ArrayList[0]->io.camunda.zeebe.client.protocol.rest.ActivatedJob["kind"])
	at io.camunda.zeebe.client.impl.http.ApiCallback.failed(ApiCallback.java:73)
	at org.apache.hc.core5.concurrent.BasicFuture.failed(BasicFuture.java:166)
	at org.apache.hc.core5.concurrent.ComplexFuture.failed(ComplexFuture.java:79)
	at org.apache.hc.client5.http.impl.async.InternalAbstractHttpAsyncClient$2.failed(InternalAbstractHttpAsyncClient.java:364)
	at org.apache.hc.client5.http.impl.async.AsyncRedirectExec$1.failed(AsyncRedirectExec.java:246)
	at org.apache.hc.client5.http.impl.async.AsyncHttpRequestRetryExec$1.failed(AsyncHttpRequestRetryExec.java:195)
	at org.apache.hc.client5.http.impl.async.AsyncProtocolExec$1.failed(AsyncProtocolExec.java:295)
	at org.apache.hc.client5.http.impl.async.HttpAsyncMainClientExec$1.failed(HttpAsyncMainClientExec.java:135)
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
