### PR TITLE
Bring back Zeebe benchmark workflow

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -1,0 +1,287 @@
+# description: This step for helm install deploys a camunda cluster in zeebe-io with additional tools for benchmarking. We use this worklow to start weekly medic benchmarks. The health of the cluster and results of the benchmarks are monitored by the zeebe team regularly. https://grafana.dev.zeebe.io/login
+# called by: zeebe-medic-benchmarks.yml, zeebe-pr-benchmark.yaml
+# type: CI
+# owner: @camunda/core-features
+name: Zeebe Benchmark
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Specifies the name of the benchmark'
+        required: true
+      reuse-tag:
+        description: 'Docker image tag, that should be reused for benchmark. Allows to skip the docker image build step'
+        type: string
+        default: ""
+        required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to benchmark'
+        default: 'main'
+        required: false
+      cluster:
+        description: 'Specifies which cluster to deploy the benchmark on'
+        default: 'zeebe-cluster'
+        required: false
+      cluster-region:
+        description: 'Specifies the cluster region. Needed to retrieve cluster credentials'
+        default: europe-west1-b
+        required: false
+      benchmark-load:
+        description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitrary helm arguments, like --set starter.rate=100'
+        required: false
+      stable-vms:
+        description: 'Deploy to non-spot VMs'
+        type: boolean
+        required: false
+        default: false
+      operate-tag:
+        description: 'Specifies the tag of operate, when Operate should be included in the Benchmark'
+        type: string
+        default: ""
+        required: false
+      realistic:
+        description: 'Should run a realistic benchmark, with real-world process and load'
+        type: boolean
+        required: false
+        default: false
+  workflow_call:
+    inputs:
+      name:
+        description: 'Specifies the name of the benchmark'
+        type: string
+        required: true
+      reuse-tag:
+        description: 'Docker image tag, that should be reused for benchmark. Allows to skip the docker image build step'
+        type: string
+        default: ""
+        required: false
+      ref:
+        description: 'Specifies the ref (e.g. main or a commit sha) to benchmark'
+        default: 'main'
+        type: string
+        required: false
+      cluster:
+        description: 'Specifies which cluster to deploy the benchmark on'
+        default: 'zeebe-cluster'
+        type: string
+        required: false
+      cluster-region:
+        description: 'Specifies the cluster region. Needed to retrieve cluster credentials'
+        default: europe-west1-b
+        type: string
+        required: false
+      benchmark-load:
+        description: 'Specifies which benchmark components to deploy. `starter`, `timer` and `publisher` can be assigned with the rate at which they publish. Allows arbitrary helm arguments, like --set starter.rate=100'
+        type: string
+        required: false
+      publish:
+        description: 'Where to publish the results, can be "slack" or "comment"'
+        default: ""
+        type: string
+        required: false
+      stable-vms:
+        description: 'Deploy to non-spot VMs'
+        type: boolean
+        required: false
+        default: false
+      operate-tag:
+        description: 'Specifies the tag of operate, when Operate should be included in the Benchmark'
+        type: string
+        default: ""
+        required: false
+      realistic:
+        description: 'Should run a realistic benchmark, with real-world process and load'
+        type: boolean
+        required: false
+        default: false
+jobs:
+  calculate-image-tag:
+    name: Calculate Image Tag
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ inputs.reuse-tag != '' && inputs.reuse-tag || steps.image-tag.outputs.image-tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Get image tag
+        id: image-tag
+        run: |
+          echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+  build-zeebe-image:
+    name: Build Zeebe
+    needs: calculate-image-tag
+    if: ${{ inputs.reuse-tag == '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: ./.github/actions/build-frontend
+        name: Build Operate Frontend
+        id: build-operate-fe
+        with:
+          directory: ./operate/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Tasklist Frontend
+        id: build-tasklist-fe
+        with:
+          directory: ./tasklist/client
+          package-manager: "npm"
+      - uses: ./.github/actions/build-frontend
+        name: Build Identity Frontend
+        id: build-identity-fe
+        with:
+          directory: ./identity/client
+      - uses: ./.github/actions/build-zeebe
+        name: Build Zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -PskipFrontendBuild -P\!include-optimize -Dmaven.test.skip=true
+      - uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - name: Login to GCR
+        uses: docker/login-action@v3
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+      - uses: ./.github/actions/build-platform-docker
+        name: Build Camunda Docker Image
+        with:
+          repository: 'gcr.io/zeebe-io/zeebe'
+          revision: ${{ inputs.ref }}
+          push: true
+          version: ${{ needs.calculate-image-tag.outputs.image-tag }}
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+          dockerfile: 'camunda.Dockerfile'
+
+  build-benchmark-images:
+    name: Build Starter and Worker
+    if: ${{ inputs.reuse-tag == '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: calculate-image-tag
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - name: Login to GAR
+        uses: docker/login-action@v3
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - run: ./mvnw -B -D skipTests -D skipChecks -P\!include-optimize -pl load-tests/load-tester -am install
+      - name: Build Starter Image
+        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -P\!include-optimize -D image="gcr.io/zeebe-io/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
+      - name: Build Worker Image
+        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -P\!include-optimize -D image="gcr.io/zeebe-io/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
+
+  deploy-benchmark-cluster:
+    name: Deploy
+    needs:
+      - calculate-image-tag
+      - build-zeebe-image
+      - build-benchmark-images
+    # To have the possibility to re-deploy the benchmarks without rebuilding the images,
+    # the deploy will be run, when build is skipped or successful.
+    if: |
+      always() &&
+      (needs.build-zeebe-image.result == 'success' || needs.build-zeebe-image.result == 'skipped') &&
+      (needs.build-benchmark-images.result == 'success' || needs.build-benchmark-images.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - uses: google-github-actions/get-gke-credentials@v2.3.4
+        with:
+          cluster_name: ${{ inputs.cluster }}
+          location: ${{ inputs.cluster-region }}
+      - name: Add camunda helm repo
+        run: |
+          helm repo add zeebe-benchmark https://camunda.github.io/zeebe-benchmark-helm
+          helm repo update
+
+      - name: Find previous Helm chart release version
+        id: find-chart-release
+        run: |
+          echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }} | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
+      - name: Helm install
+        run: >
+          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 35m0s
+          --namespace ${{ inputs.name }}
+          --create-namespace
+          --reuse-values
+          --render-subchart-notes
+          --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set camunda-platform.orchestration.image.registry=gcr.io
+          --set camunda-platform.orchestration.image.repository=zeebe-io/zeebe
+          --set camunda-platform.orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          # Keep this for compatibility with older versions of the benchmark chart
+          --set camunda-platform.core.image.registry=gcr.io
+          --set camunda-platform.core.image.repository=zeebe-io/zeebe
+          --set camunda-platform.core.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe
+          --set camunda-platform.zeebe.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set camunda-platform.zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe
+          --set camunda-platform.zeebe-gateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set camunda-platform.zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
+          --set camunda-platform.zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
+          ${{ inputs.stable-vms && '-f load-tests/setup/default/values-stable.yaml' || '' }}
+          ${{ inputs.realistic && '-f https://raw.githubusercontent.com/zeebe-io/benchmark-helm/main/charts/zeebe-benchmark/values-realistic-benchmark.yaml' || '' }}
+          ${{ inputs.benchmark-load }}
+      - name: Label namespace
+        run: >
+          kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite
+      - name: Summarize deployment
+        if: success()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Benchmark \`${{ inputs.name }}\` values
+            \`\`\`yaml
+            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            \`\`\`
+          EOF


### PR DESCRIPTION
## Description

 * The current release benchmarks and release process depends on the Zeebe Benchmark
 * We first need to prepare the values files of the older charts
 * Migrate the release load tests to the decoupled charts setup
 * Change the release process to reference the Camunda Load test workflow
 * ONLY then can we remove the Zeebe benchmark

 See context https://camunda.slack.com/archives/C0807665N8G/p1760695609232739?thread_ts=1760021722.853319&cid=C0807665N8G
 This was restored from commit 79364b8dc6f160caeaf0839d268ba2d1464b3408
<!-- Describe the goal and purpose of this PR. -->


## Related issues

related to https://github.com/camunda/camunda/pull/39532
related to https://github.com/camunda/camunda/issues/38829