### PR TITLE
ci: add new metadata print composite action

### DIFF
--- a/.github/actions/print-metadata/action.yml
+++ b/.github/actions/print-metadata/action.yml
@@ -1,0 +1,43 @@
+# This action expects the environment variables TEST_OWNER, TEST_PRODUCT and TEST_TYPE to be set
+# or their respective inputs to be populated.
+---
+name: Print Metadata
+
+# owner: @camunda/monorepo-devops-team
+
+description: Prints the job's metadata for easier owner attribution in build logs.
+
+inputs:
+  test_owner:
+    description: When specified, will take precedence over TEST_OWNER environment variable. Declares who owns the tests performed by this GHA job.
+    required: false
+  test_product:
+    description: When specified, will take precedence over TEST_PRODUCT environment variable. Declares what component is tested by this GHA job.
+    required: false
+  test_type:
+    description: When specified, will take precedence over TEST_TYPE environment variable. Declares what kind of test is performed by this GHA job.
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Check inputs
+      shell: bash
+      run: |
+        if [[ "${{ inputs.test_owner != '' && inputs.test_owner || env.TEST_OWNER }}" == "" ]]; then
+          echo "::error::No information about test owner given, cannot print metadata! Please specify either 'test_owner' input value or TEST_OWNER environment variable."
+          exit 1
+        fi
+        if [[ "${{ inputs.test_product != '' && inputs.test_product || env.TEST_PRODUCT }}" == "" ]]; then
+          echo "::error::No information about test product given, cannot print metadata! Please specify either 'test_product' input value or TEST_PRODUCT environment variable."
+          exit 1
+        fi
+        if [[ "${{ inputs.test_type != '' && inputs.test_type || env.TEST_TYPE }}" == "" ]]; then
+          echo "::error::No information about test type given, cannot print metadata! Please specify either 'test_type' input value or TEST_TYPE environment variable."
+          exit 1
+        fi
+
+    - name: Log Test Details
+      shell: bash
+      run: |
+        echo "This is a ${{ inputs.test_type != '' && inputs.test_type || env.TEST_TYPE }} test for ${{ inputs.test_product != '' && inputs.test_product || env.TEST_PRODUCT }} owned by ${{ inputs.test_owner != '' && inputs.test_owner || env.TEST_OWNER }}"

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -73,8 +73,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: ./.github/actions/setup-build
         name: Build setup
         with:
@@ -119,8 +119,8 @@ jobs:
         working-directory: operate/client
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -153,8 +153,8 @@ jobs:
         working-directory: operate/client
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -188,8 +188,8 @@ jobs:
         working-directory: operate/client
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -227,8 +227,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
@@ -276,8 +276,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
@@ -324,8 +324,8 @@ jobs:
         working-directory: operate/client
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -371,9 +371,9 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
       - uses: actions/checkout@v4
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - uses: ./.github/actions/setup-build

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -75,8 +75,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - name: "Parse pom.xml for versions"
         id: "pom_info"
         uses: YunaBraska/java-info-action@main
@@ -129,9 +129,9 @@ jobs:
             "optimize.Dockerfile",
           ]
     steps:
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           dockerfile: ${{ matrix.dockerfile }}

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -72,8 +72,8 @@ jobs:
         working-directory: tasklist/client
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -106,8 +106,8 @@ jobs:
         working-directory: tasklist/client
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -140,8 +140,8 @@ jobs:
         working-directory: tasklist/client
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -174,8 +174,8 @@ jobs:
         working-directory: tasklist/client
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -212,8 +212,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
@@ -261,8 +261,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
@@ -313,8 +313,8 @@ jobs:
           - 5000:5000
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - uses: ./.github/actions/setup-build
@@ -390,8 +390,8 @@ jobs:
           - 5000:5000
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: hadolint/hadolint-action@v3.1.0
         with:
           ignore: DL3018 # redundant when pinning the base image

--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -41,9 +41,11 @@ jobs:
     timeout-minutes: 10
     permissions: { }
     steps:
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ inputs.componentName }} owned by ${{ env.TEST_OWNER}}"
       - uses: actions/checkout@v4
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+        with:
+          test_product: "${{ inputs.componentName }}"
       - uses: ./.github/actions/setup-build
         with:
           maven-cache-key-modifier: ut-be-${{inputs.componentName}}

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -56,8 +56,8 @@ jobs:
             arch: arm64
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly:  ${{ matrix.os != 'macos' && matrix.os != 'windows' }}
@@ -128,8 +128,8 @@ jobs:
       TEST_TYPE: Unit
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: ./.github/actions/setup-build
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}
@@ -187,8 +187,8 @@ jobs:
       TEST_TYPE: Performance
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: ./.github/actions/setup-build
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}
@@ -257,8 +257,8 @@ jobs:
       TEST_TYPE: Unit
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - name: Install and allow strace tests
         run: |
           sudo apt-get -qq update && sudo apt-get install -y strace
@@ -327,8 +327,8 @@ jobs:
       TEST_TYPE: Build
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: hadolint/hadolint-action@v3.1.0
         with:
           config: ./.hadolint.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,8 +328,8 @@ jobs:
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     env:
-        TEST_TYPE: "Unit"
-        TEST_PRODUCT: "Zeebe"
+      TEST_TYPE: "Unit"
+      TEST_PRODUCT: "Zeebe"
     strategy:
       fail-fast: false
       matrix:
@@ -357,8 +357,10 @@ jobs:
             maven-modules: ${{ needs.setup-unit-tests.outputs.ZEEBE_CLIENT_MODULES }}
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ matrix.suite}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+        with:
+          test_owner: "${{ matrix.suite }}"
       - uses: ./.github/actions/setup-build
         with:
           maven-cache-key-modifier: ut-zeebe
@@ -823,6 +825,7 @@ jobs:
       CAMUNDA_TEST_DOCKER_IMAGE: localhost:5000/camunda/camunda:current-test
       CAMUNDA_DOCKER_IMAGE_NAME: localhost:5000/camunda/camunda
       DOCKER_IMAGE_TAG: current-test
+      TEST_TYPE: Integration
     services:
       registry:
         image: registry:3
@@ -830,8 +833,11 @@ jobs:
           - 5000:5000
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a Integration test for ${{ matrix.name }} owned by ${{ matrix.owner}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+        with:
+          test_product: "${{ matrix.name }}"
+          test_owner: "${{ matrix.owner }}"
       - uses: ./.github/actions/setup-build
         with:
           maven-cache-key-modifier: it-${{ matrix.group }}
@@ -932,8 +938,8 @@ jobs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
       - uses: actions/checkout@v4
-      - name: Log Test Details
-        run: echo "This is a ${{ env.TEST_TYPE}} test for ${{ env.TEST_PRODUCT}} owned by ${{ env.TEST_OWNER}}"
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
       - uses: ./.github/actions/setup-build
         with:
           maven-cache-key-modifier: archunit-tests


### PR DESCRIPTION
## Description

This PR adds a new composite action to print metadata related to GHA jobs from either environment variables, or inputs as overwrites when specified.
It also adds a linting rule as we want to ensure that the new action is used consistently in Unified CI. This makes attribution of jobs running software tests easier.

Examples from this PR that show new composite action is working:

* https://github.com/camunda/camunda/actions/runs/18590666346/job/53005162335?pr=39680#step:5:31
* https://github.com/camunda/camunda/actions/runs/18590666346/job/53005169391?pr=39680#step:4:20

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)). -- Backporting to `stable/8.8` because we have the attribution logic that this PR refactors on that branch as well.

## Related issues

Related to #38990 
