### PR TITLE
[Backport stable/8.8] fix: ignore unknown response properties in zeebe client

### DIFF
--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.http;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
@@ -76,7 +77,8 @@ public class HttpClientFactory {
   /** The versioned base REST API context path the client uses for requests */
   public static final String REST_API_PATH = "/v2";
 
-  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+  private static final ObjectMapper JSON_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   private final ZeebeClientConfiguration config;
 

--- a/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
+++ b/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
@@ -48,6 +48,20 @@ public class RestGatewayService {
   /**
    * Register the given response for job activation requests.
    *
+   * @param jobActivationResponseJsonString the response to provide upon a job activation request as
+   *     json string
+   */
+  public void onActivateJobsRequest(final String jobActivationResponseJsonString) {
+    mockInfo
+        .getWireMock()
+        .register(
+            WireMock.post(RestGatewayPaths.getJobActivationUrl())
+                .willReturn(WireMock.okJson(jobActivationResponseJsonString)));
+  }
+
+  /**
+   * Register the given response for job activation requests.
+   *
    * @param jobActivationResponse the response to provide upon a job activation request
    */
   public void onActivateJobsRequest(final JobActivationResult jobActivationResponse) {


### PR DESCRIPTION
# Description
Backport of #39669 to `stable/8.8`.

relates to #39675