### PR TITLE
deps(optimize): bump optimize version

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -376,9 +376,9 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Build Operate
-        run: ./mvnw -B -T1C -DskipChecks -DskipTests -P skipFrontendBuild -P\!include-optimize clean install
+        run: ./mvnw -B -T1C -DskipChecks -DskipTests -P skipFrontendBuild clean install
       - name: Run Tests
-        run: ./mvnw -pl operate -am verify -T1C -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2 -P\!include-optimize
+        run: ./mvnw -pl operate -am verify -T1C -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -420,7 +420,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -T1C -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker
         id: build-operate-docker
         with:
@@ -431,7 +431,7 @@ jobs:
           distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Run Operate backup restore Tests
         shell: bash
-        run: ./mvnw -B -pl operate/qa/backup-restore-tests -DskipChecks -P -docker,-skipTests -P\!include-optimize verify | tee "${BUILD_OUTPUT_FILE_PATH}"
+        run: ./mvnw -B -pl operate/qa/backup-restore-tests -DskipChecks -P -docker,-skipTests verify | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Upload Test Report
         if: failure()
         uses: ./.github/actions/collect-test-artifacts

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -86,7 +86,7 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Build Maven
         run: |
-          ./mvnw clean deploy -B -T1C -P -docker,skipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true -P\!include-optimize
+          ./mvnw clean deploy -B -T1C -P -docker,skipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       # Build the docker image to verify the built artifacts and the Dockerfile
       # It does NOT push the image to the registry
       - name: Build Docker image

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -325,7 +325,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -T1C -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker
         id: build-tasklist-docker
         with:
@@ -344,7 +344,7 @@ jobs:
           distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Run Tasklist backup restore Tests
         shell: bash
-        run: ./mvnw -B -pl tasklist/qa/backup-restore-tests -DskipChecks -DtasklistDatabase=${{ matrix.database }} -DskipTests=false -P\!include-optimize verify | tee "${BUILD_OUTPUT_FILE_PATH}"
+        run: ./mvnw -B -pl tasklist/qa/backup-restore-tests -DskipChecks -DtasklistDatabase=${{ matrix.database }} -DskipTests=false verify | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Upload Test Report
         if: failure()
         uses: ./.github/actions/collect-test-artifacts
@@ -405,7 +405,7 @@ jobs:
       - id: build-backend
         uses: ./.github/actions/build-zeebe
         with:
-          maven-extra-args: -D skip.fe.build -D skipOptimize -P\!include-optimize
+          maven-extra-args: -D skip.fe.build -D skipOptimize
       - uses: ./.github/actions/build-platform-docker
         with:
           repository: localhost:5000/camunda/tasklist
@@ -414,7 +414,7 @@ jobs:
           distball: ${{ steps.build-backend.outputs.distball }}
           dockerfile: tasklist.Dockerfile
       - name: Run Docker tests
-        run: ./mvnw --no-snapshot-updates -pl tasklist/qa/integration-tests -DskipChecks -Dtest=StartupIT -Dsurefire.failIfNoSpecifiedTests=false -Dspring.profiles.active=docker-test test -P\!include-optimize
+        run: ./mvnw --no-snapshot-updates -pl tasklist/qa/integration-tests -DskipChecks -Dtest=StartupIT -Dsurefire.failIfNoSpecifiedTests=false -Dspring.profiles.active=docker-test test
       - name: Upload Test Report
         if: failure()
         uses: ./.github/actions/collect-test-artifacts

--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -65,7 +65,7 @@ jobs:
           -Dsurefire.failIfNoSpecifiedTests=false -B -T 2 --no-snapshot-updates
           -D forkCount=7 -D skipITs -D skipQaBuild=true -D skipChecks -Dskip.docker
           -D surefire.rerunFailingTestsCount=3 -D junitThreadCount=16 -P skipFrontendBuild
-          -P\!include-optimize
+          -pl '-:optimize-schema-integrity-tests'
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -T1C -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker
         id: build-zeebe-docker
         # Currently only Linux runners support building docker images without further ado
@@ -137,7 +137,7 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - uses: ./.github/actions/build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -T1C -PskipFrontendBuild
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build
@@ -196,7 +196,7 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - uses: ./.github/actions/build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -T1C -PskipFrontendBuild
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build
@@ -270,7 +270,7 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - uses: ./.github/actions/build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -T1C -PskipFrontendBuild
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build
@@ -351,7 +351,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -T1C -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker
         id: build-zeebe-docker
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - run: ./mvnw spotless:check -P\!include-optimize
+      - run: ./mvnw spotless:check
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -177,7 +177,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       # Not running Maven Spotless here since it is checked in a dedicated job
-      - run: ./mvnw -T1C -B -D skipTests -Dspotless.check.skip=true -P !autoFormat,checkFormat,spotbugs,skipFrontendBuild -P\!include-optimize verify
+      - run: ./mvnw -T1C -B -D skipTests -Dspotless.check.skip=true -P !autoFormat,checkFormat,spotbugs,skipFrontendBuild verify
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -289,7 +289,6 @@ jobs:
           -D junitThreadCount=16
           -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ env.GENERAL_UT_MODULES }}
-          -P\!include-optimize
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs
@@ -377,7 +376,6 @@ jobs:
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=3
           -D junitThreadCount=16
           -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
-          -P\!include-optimize
           -pl ${{ matrix.maven-modules }}
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
@@ -479,7 +477,6 @@ jobs:
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
           -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -P\!include-optimize
           -D test.integration.camunda.database.type=es
           -pl ${{ matrix.module.maven_module }}
           verify
@@ -588,7 +585,6 @@ jobs:
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
           -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -P\!include-optimize
           -D test.integration.camunda.database.type=os
           -pl ${{ matrix.module.maven_module }}
           verify
@@ -639,7 +635,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -T1C -PskipFrontendBuild
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       # Run specific integration tests with H2 inmemory database
@@ -657,7 +653,6 @@ jobs:
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
           -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -P\!include-optimize
           -D test.integration.camunda.database.type=rdbms
           -pl 'qa/acceptance-tests'
           verify
@@ -704,7 +699,7 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - uses: ./.github/actions/build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -T1C -PskipFrontendBuild
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       # Run integration tests with RDBMS database
@@ -718,7 +713,6 @@ jobs:
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
           -P rdbms,extract-flaky-tests
           -pl qa/acceptance-tests
-          -P\!include-optimize
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs
@@ -851,7 +845,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild -P\!include-optimize
+          maven-extra-args: -T1C -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker
         if: ${{ matrix.docker-file != '' }}
         with:
@@ -891,7 +885,6 @@ jobs:
           -Dio.camunda.process.test.camundaVersion="${{ env.DOCKER_IMAGE_TAG }}"
           -P parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ matrix.maven-modules }}
-          -P\!include-optimize
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs
@@ -956,7 +949,6 @@ jobs:
           ./mvnw -B --no-snapshot-updates
           -D skipITs -D skipQaBuild=false -D skipChecks -Dsurefire.rerunFailingTestsCount=3
           -P skipFrontendBuild,extract-flaky-tests
-          -P\!include-optimize
           -pl :camunda-archunit-tests
           -am
           -Dtest='*ArchTest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "General / Unit - Back End"
     needs: [ detect-changes, setup-unit-tests ]
-    timeout-minutes: 25
+    timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     steps:

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -212,6 +212,10 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -618,7 +622,7 @@
     <dependency>
       <groupId>com.github.wnameless.json</groupId>
       <artifactId>json-base</artifactId>
-      <version>2.5.0</version>
+      <version>2.5.1</version>
     </dependency>
 
     <dependency>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.8.0-SNAPSHOT</version>
+    <version>8.8.1-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
## Description

This pull request primarily removes the usage of the `!include-optimize` Maven profile from all CI workflow jobs, since `zeebe-partent` for Optimize was bumped to `8.8.1-SNAPSHOT`, as we did in all other components on Monorepo, and now the [Optimize module is able to find `zeebe-partent`, no need to be skipped](https://camunda.slack.com/archives/C06UWQNCU7M/p1760121197927529?thread_ts=1760012606.937389&cid=C06UWQNCU7M).

**CI Workflow Simplification:**

* Removed the `-P\!include-optimize` Maven profile from all relevant `ci.yml`, `ci-operate.yml`, `ci-tasklist.yml`, `ci-webapp-run-ut-reuseable.yml`, and `ci-zeebe.yml` workflow jobs, simplifying the Maven command invocations and reducing unnecessary configuration complexity. [[1]](diffhunk://#diff-652891ddeb2c8a12c29837dd9c3f9dcdb63adb4ca8279a88104fd5cd3653cb59L89-R89) [[2]](diffhunk://#diff-652891ddeb2c8a12c29837dd9c3f9dcdb63adb4ca8279a88104fd5cd3653cb59L379-R381) [[3]](diffhunk://#diff-652891ddeb2c8a12c29837dd9c3f9dcdb63adb4ca8279a88104fd5cd3653cb59L423-R423) [[4]](diffhunk://#diff-652891ddeb2c8a12c29837dd9c3f9dcdb63adb4ca8279a88104fd5cd3653cb59L434-R434) [[5]](diffhunk://#diff-081d1b1d35055dd1af9ad5fe3e5f6cf207900b228c64b22efea1391c476a5ff7L328-R328) [[6]](diffhunk://#diff-081d1b1d35055dd1af9ad5fe3e5f6cf207900b228c64b22efea1391c476a5ff7L347-R347) [[7]](diffhunk://#diff-081d1b1d35055dd1af9ad5fe3e5f6cf207900b228c64b22efea1391c476a5ff7L408-R408) [[8]](diffhunk://#diff-081d1b1d35055dd1af9ad5fe3e5f6cf207900b228c64b22efea1391c476a5ff7L417-R417) [[9]](diffhunk://#diff-3551c281180b31caeb72c73964907be7d02d64d790e0dde0b2560144516a8718L70-R70) [[10]](diffhunk://#diff-3551c281180b31caeb72c73964907be7d02d64d790e0dde0b2560144516a8718L140-R140) [[11]](diffhunk://#diff-3551c281180b31caeb72c73964907be7d02d64d790e0dde0b2560144516a8718L199-R199) [[12]](diffhunk://#diff-3551c281180b31caeb72c73964907be7d02d64d790e0dde0b2560144516a8718L273-R273) [[13]](diffhunk://#diff-3551c281180b31caeb72c73964907be7d02d64d790e0dde0b2560144516a8718L354-R354) [[14]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL153-R153) [[15]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL180-R180) [[16]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL292) [[17]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL380) [[18]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL482) [[19]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL591) [[20]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL642-R638) [[21]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL660) [[22]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL707-R702) [[23]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL721) [[24]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL854-R848) [[25]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL894) [[26]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL959) [[27]](diffhunk://#diff-b23a15d05db67bc85377adffc3c2a3124a83be9ff89ca1637c20308016b6db41L68-R68)

* Reduced the timeout for the "General / Unit - Back End" job from 25 to 10 minutes in `ci.yml`, likely to catch stuck jobs faster and optimize CI resource usage.

**Dependency Updates (Optimize Backend):**

* Excluded the `jakarta.xml.bind:jakarta.xml.bind-api` transitive dependency from a backend dependency in `optimize/backend/pom.xml` to prevent unnecessary or conflicting dependencies.
* Upgraded `com.github.wnameless.json:json-base` from version 2.5.0 to 2.5.1 in `optimize/backend/pom.xml` for bug fixes or improvements.
* Updated the parent POM version in `optimize/pom.xml` from `8.8.0-SNAPSHOT` to `8.8.1-SNAPSHOT` to track the latest parent build.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
