### PR TITLE
Add `apps_integration` default role

### DIFF
--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DefaultRole.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DefaultRole.java
@@ -11,7 +11,7 @@ public enum DefaultRole {
   ADMIN("admin"),
   RPA("rpa"),
   CONNECTORS("connectors"),
-  APPS_INTEGRATION("apps_integration");
+  APPS_INTEGRATION("apps-integration");
 
   private final String id;
 

--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DefaultRole.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DefaultRole.java
@@ -11,7 +11,7 @@ public enum DefaultRole {
   ADMIN("admin"),
   RPA("rpa"),
   CONNECTORS("connectors"),
-  APPS_INTEGRATION("apps-integration");
+  APP_INTEGRATIONS("app-integrations");
 
   private final String id;
 

--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DefaultRole.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DefaultRole.java
@@ -10,7 +10,8 @@ package io.camunda.zeebe.protocol.record.value;
 public enum DefaultRole {
   ADMIN("admin"),
   RPA("rpa"),
-  CONNECTORS("connectors");
+  CONNECTORS("connectors"),
+  APPS_INTEGRATION("apps_integration");
 
   private final String id;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -83,6 +83,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
     setupAdminRole(setupRecord);
     setupRpaRole(setupRecord);
     setupConnectorsRole(setupRecord);
+    setupAppIntegrationsRole(setupRecord);
 
     initialization
         .getUsers()
@@ -228,6 +229,40 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             .setTenantId(DEFAULT_TENANT_ID)
             .setEntityType(EntityType.ROLE)
             .setEntityId(connectorsRoleId));
+  }
+
+  private static void setupAppIntegrationsRole(final IdentitySetupRecord setupRecord) {
+    final var appIntegrationsRoleId = DefaultRole.APPS_INTEGRATION.getId();
+    setupRecord.addRole(
+        new RoleRecord().setRoleId(appIntegrationsRoleId).setName("App Integrations"));
+    setupRecord.addAuthorization(
+        new AuthorizationRecord()
+            .setOwnerType(AuthorizationOwnerType.ROLE)
+            .setOwnerId(appIntegrationsRoleId)
+            .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .setResourceMatcher(WILDCARD.getMatcher())
+            .setResourceId(WILDCARD.getResourceId())
+            .setPermissionTypes(
+                Set.of(
+                    PermissionType.READ_PROCESS_DEFINITION,
+                    PermissionType.CREATE_PROCESS_INSTANCE,
+                    PermissionType.READ_PROCESS_INSTANCE,
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.READ_USER_TASK,
+                    PermissionType.UPDATE_USER_TASK)));
+    setupRecord.addAuthorization(
+        new AuthorizationRecord()
+            .setOwnerType(AuthorizationOwnerType.ROLE)
+            .setOwnerId(appIntegrationsRoleId)
+            .setResourceType(AuthorizationResourceType.DOCUMENT)
+            .setResourceMatcher(WILDCARD.getMatcher())
+            .setResourceId(WILDCARD.getResourceId())
+            .setPermissionTypes(Set.of(PermissionType.CREATE)));
+    setupRecord.addTenantMember(
+        new TenantRecord()
+            .setTenantId(DEFAULT_TENANT_ID)
+            .setEntityType(EntityType.ROLE)
+            .setEntityId(appIntegrationsRoleId));
   }
 
   private static void setupRpaRole(final IdentitySetupRecord setupRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -232,7 +232,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   }
 
   private static void setupAppIntegrationsRole(final IdentitySetupRecord setupRecord) {
-    final var appIntegrationsRoleId = DefaultRole.APPS_INTEGRATION.getId();
+    final var appIntegrationsRoleId = DefaultRole.APP_INTEGRATIONS.getId();
     setupRecord.addRole(
         new RoleRecord().setRoleId(appIntegrationsRoleId).setName("App Integrations"));
     setupRecord.addAuthorization(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
@@ -312,14 +312,14 @@ public class IdentitySetupInitializeDefaultsTest {
             RecordingExporter.records()
                 .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
                 .authorizationRecords()
-                .withOwnerId(DefaultRole.APPS_INTEGRATION.getId()))
+                .withOwnerId(DefaultRole.APP_INTEGRATIONS.getId()))
         .extracting(Record::getValue)
         .describedAs(
             "Expect all apps_integration role authorizations to be owned by the apps_integration role")
         .allSatisfy(
             auth ->
                 Assertions.assertThat(auth)
-                    .hasOwnerId(DefaultRole.APPS_INTEGRATION.getId())
+                    .hasOwnerId(DefaultRole.APP_INTEGRATIONS.getId())
                     .hasOwnerType(AuthorizationOwnerType.ROLE))
         .describedAs(
             "Expect the apps_integration role authorizations to have specific resource permissions")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
@@ -306,6 +306,41 @@ public class IdentitySetupInitializeDefaultsTest {
   }
 
   @Test
+  public void shouldCreateAppsIntegrationRoleByDefault() {
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .authorizationRecords()
+                .withOwnerId(DefaultRole.APPS_INTEGRATION.getId()))
+        .extracting(Record::getValue)
+        .describedAs(
+            "Expect all apps_integration role authorizations to be owned by the apps_integration role")
+        .allSatisfy(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasOwnerId(DefaultRole.APPS_INTEGRATION.getId())
+                    .hasOwnerType(AuthorizationOwnerType.ROLE))
+        .describedAs(
+            "Expect the apps_integration role authorizations to have specific resource permissions")
+        .satisfiesExactlyInAnyOrder(
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                    .hasOnlyPermissionTypes(
+                        PermissionType.READ_PROCESS_DEFINITION,
+                        PermissionType.CREATE_PROCESS_INSTANCE,
+                        PermissionType.READ_PROCESS_INSTANCE,
+                        PermissionType.UPDATE_PROCESS_INSTANCE,
+                        PermissionType.READ_USER_TASK,
+                        PermissionType.UPDATE_USER_TASK),
+            auth ->
+                Assertions.assertThat(auth)
+                    .hasResourceType(AuthorizationResourceType.DOCUMENT)
+                    .hasOnlyPermissionTypes(PermissionType.CREATE));
+  }
+
+  @Test
   public void shouldCreateRpaRoleByDefault() {
     // then
     assertThat(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add a new default role for Apps Integrations that allows Zeebe to define the necessary permissions for these integrations.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39687
