### PR TITLE
fix(c8run) update docker ports to match OC ports

### DIFF
--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -92,9 +92,9 @@ func PrintStatus(settings types.C8RunSettings) error {
 
 	// Overwrite ports if Docker is enabled
 	if settings.Docker {
-		operatePort = 8081
-		tasklistPort = 8082
-		identityPort = 8084
+		operatePort = 8088
+		tasklistPort = 8088
+		identityPort = 8088
 		camundaPort = 8088
 	}
 


### PR DESCRIPTION
This pull request updates the default ports used when Docker is enabled in the Camunda health check logic. Now, all Camunda services (`operate`, `tasklist`, and `identity`) use port 8088 instead of separate ports.

Configuration changes for Docker environments:

* Updated `operatePort`, `tasklistPort`, and `identityPort` to use port 8088 when Docker is enabled in `PrintStatus` within `c8run/internal/health/camunda.go`.

On docker we are printing

Operate:          http://localhost:8081/operate
Tasklist:          http://localhost:8082/tasklist
Identity:          http://localhost:8084/identity

while it should be using 8088 port since we are now using OC.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
