### PR TITLE
[Backport stable/8.6] deps: Update version.bouncycastle to v1.81 (main)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -38,7 +38,7 @@
     <version.agrona>1.23.1</version.agrona>
     <version.assertj>3.26.3</version.assertj>
     <version.awaitility>4.2.2</version.awaitility>
-    <version.bouncycastle>1.78.1</version.bouncycastle>
+    <version.bouncycastle>1.81</version.bouncycastle>
     <version.camunda>7.22.0</version.camunda>
     <version.camunda-license-check>2.9.0</version.camunda-license-check>
     <version.checkstyle>10.18.2</version.checkstyle>


### PR DESCRIPTION
# Description
Backport of #33638 to `stable/8.6`.

relates to https://github.com/camunda/camunda/issues/39690