### PR TITLE
build: add now required charset config to mvn-javadoc-plugin

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -54,6 +54,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${plugin.version.javadoc}</version>
           <configuration>
+            <charset>UTF-8</charset>
             <source>${version.java}</source>
             <quiet>true</quiet>
             <additionalOptions>-Xdoclint:none</additionalOptions>


### PR DESCRIPTION
## Description

Since last upgrade of `maven-javadoc-plugin` charset difinition is required. Ref: https://github.com/apache/maven-javadoc-plugin/pull/1245

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
