### PR TITLE
build: add required charset config to mvn-javadoc-plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2330,6 +2330,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${plugin.version.javadoc}</version>
           <configuration>
+            <charset>UTF-8</charset>
             <source>${version.java}</source>
             <quiet>true</quiet>
             <additionalOptions>-Xdoclint:none</additionalOptions>


### PR DESCRIPTION
## Description

This pull request makes a small configuration improvement to the Maven Javadoc plugin by explicitly setting the character encoding to UTF-8. This ensures consistent documentation generation across different environments.

* Set `<charset>UTF-8</charset>` in the `maven-javadoc-plugin` configuration in `parent/pom.xml` to standardize documentation encoding.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
