### PR TITLE
[Backport release-8.8.1] build: add required charset config to mvn-javadoc-plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2330,6 +2330,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${plugin.version.javadoc}</version>
           <configuration>
+            <charset>UTF-8</charset>
             <source>${version.java}</source>
             <quiet>true</quiet>
             <additionalOptions>-Xdoclint:none</additionalOptions>


### PR DESCRIPTION
# Description
Backport of #39710 to `release-8.8.1`.

relates to 