### PR TITLE
build: bump javadoc version

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -42,7 +42,7 @@
     <license.header.file>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header.file>
 
     <plugin.version.flatten>1.7.2</plugin.version.flatten>
-    <plugin.version.javadoc>3.11.3</plugin.version.javadoc>
+    <plugin.version.javadoc>3.12.0</plugin.version.javadoc>
     <plugin.version.license>5.0.0</plugin.version.license>
     <plugin.version.spotless>2.44.5</plugin.version.spotless>
 


### PR DESCRIPTION
## Description

After reading [this issue ](https://github.com/apache/maven-javadoc-plugin/pull/1245) thoroughly I understood that the actual fix 
was provided on javadoc 3.12.0 version

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
