### PR TITLE
Fix/c8run/port in print stauts on 8.8

### DIFF
--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -143,6 +143,10 @@ func getBaseCommandSettings(baseCommand string) (types.C8RunSettings, error) {
 		if err != nil {
 			return settings, fmt.Errorf("error parsing start argument: %w", err)
 		}
+		// If the user did not explicitly set --startup-url, regenerate it using the (possibly overridden) port.
+		if !flagPassed(startFlagSet, "startup-url") {
+			settings.StartupUrl = createOperateUrl(&settings)
+		}
 	case "stop":
 		err := stopFlagSet.Parse(os.Args[2:])
 		if err != nil {
@@ -151,6 +155,17 @@ func getBaseCommandSettings(baseCommand string) (types.C8RunSettings, error) {
 	}
 
 	return settings, nil
+}
+
+// flagPassed determines if a flag was explicitly set by the user.
+func flagPassed(fs *flag.FlagSet, name string) bool {
+	found := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
 }
 
 func createStartFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
@@ -165,7 +180,7 @@ func createStartFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
 	startFlagSet.BoolVar(&settings.Docker, "docker", false, "Run Camunda from docker-compose.")
 	startFlagSet.StringVar(&settings.Username, "username", "demo", "Change the first users username (default: demo)")
 	startFlagSet.StringVar(&settings.Password, "password", "demo", "Change the first users password (default: demo)")
-	startFlagSet.StringVar(&settings.StartupUrl, "startup-url", createOperateUrl(settings), "The URL to open after startup.")
+	startFlagSet.StringVar(&settings.StartupUrl, "startup-url", "", "The URL to open after startup.")
 	return startFlagSet
 }
 

--- a/c8run/cmd/c8run/startupurl_test.go
+++ b/c8run/cmd/c8run/startupurl_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+    "os"
+    "testing"
+)
+
+// We test getBaseCommandSettings indirectly by constructing args and invoking parsing logic.
+
+func TestStartupUrlRecomputedWhenPortOverridden(t *testing.T) {
+    // Simulate: c8run start --port 9090 (no --startup-url)
+    osArgs := []string{"c8run", "start", "--port", "9090"}
+    oldArgs := os.Args
+    os.Args = osArgs
+    defer func(){ os.Args = oldArgs }()
+
+    settings, err := getBaseCommandSettings("start")
+    if err != nil { t.Fatalf("unexpected error: %v", err) }
+
+    expected := "http://localhost:9090/operate"
+    if settings.StartupUrl != expected {
+        t.Fatalf("expected StartupUrl to be %s, got %s", expected, settings.StartupUrl)
+    }
+}
+
+func TestStartupUrlNotRecomputedWhenProvided(t *testing.T) {
+    // Simulate: c8run start --port 9090 --startup-url http://example.test/custom
+    osArgs := []string{"c8run", "start", "--port", "9090", "--startup-url", "http://example.test/custom"}
+    oldArgs := os.Args
+    os.Args = osArgs
+    defer func(){ os.Args = oldArgs }()
+
+    settings, err := getBaseCommandSettings("start")
+    if err != nil { t.Fatalf("unexpected error: %v", err) }
+
+    if settings.StartupUrl != "http://example.test/custom" {
+        t.Fatalf("expected StartupUrl to remain custom value, got %s", settings.StartupUrl)
+    }
+}

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -88,14 +88,17 @@ func isRunning(ctx context.Context, name, url string, retries int, delay time.Du
 }
 
 func PrintStatus(settings types.C8RunSettings) error {
-	operatePort, tasklistPort, identityPort, camundaPort := 8080, 8080, 8080, 8080
-
-	// Overwrite ports if Docker is enabled
+	// For non-docker mode we respect the --port flag for all apps (they share the same port).
+	// In docker mode we keep the predefined mapped ports and ignore any custom --port value.
+	operatePort, tasklistPort, identityPort, camundaPort := settings.Port, settings.Port, settings.Port, settings.Port
 	if settings.Docker {
 		operatePort = 8081
 		tasklistPort = 8082
 		identityPort = 8084
 		camundaPort = 8088
+		if settings.Port != 8080 { // warn that user provided port is ignored in docker mode
+			log.Warn().Int("provided_port", settings.Port).Msg("--port flag is ignored in docker mode; using fixed container port mappings")
+		}
 	}
 
 	endpoints, _ := os.ReadFile("endpoints.txt")

--- a/c8run/internal/health/camunda_test.go
+++ b/c8run/internal/health/camunda_test.go
@@ -1,0 +1,84 @@
+package health
+
+import (
+    "bytes"
+    "io"
+    "os"
+    "path/filepath"
+    "strconv"
+    "strings"
+    "testing"
+
+    "github.com/camunda/camunda/c8run/internal/types"
+)
+
+// captureOutput executes f while capturing stdout output and returns it as string.
+func captureOutput(t *testing.T, f func()) string {
+    t.Helper()
+    old := os.Stdout
+    r, w, err := os.Pipe()
+    if err != nil {
+        t.Fatalf("failed to create pipe: %v", err)
+    }
+    os.Stdout = w
+    defer func() { os.Stdout = old }()
+
+    done := make(chan struct{})
+    var buf bytes.Buffer
+    go func() {
+        _, _ = io.Copy(&buf, r)
+        close(done)
+    }()
+
+    f()
+    _ = w.Close()
+    <-done
+    return buf.String()
+}
+
+func TestPrintStatus_NonDockerUsesPortFlag(t *testing.T) {
+    // Ensure working directory contains endpoints.txt
+    cwd, err := os.Getwd()
+    if err != nil { t.Fatalf("failed to get wd: %v", err) }
+    root := filepath.Clean(filepath.Join(cwd, "../..")) // c8run module root
+    if err := os.Chdir(root); err != nil { t.Fatalf("failed to chdir to module root: %v", err) }
+    t.Cleanup(func(){ _ = os.Chdir(cwd) })
+
+    settings := types.C8RunSettings{Port: 9090, Docker: false}
+    out := captureOutput(t, func() {
+        if err := PrintStatus(settings); err != nil { t.Fatalf("PrintStatus failed: %v", err) }
+    })
+
+    // Expect all dynamic component ports to equal 9090
+    for _, component := range []string{"Operate", "Tasklist", "Identity", "Orchestration Cluster API"} {
+        if !strings.Contains(out, "http://localhost:9090") {
+            t.Fatalf("expected %s endpoint to include port 9090; output: %s", component, out)
+        }
+    }
+}
+
+func TestPrintStatus_DockerModeIgnoresPortFlag(t *testing.T) {
+    // Ensure working directory contains endpoints.txt
+    cwd, err := os.Getwd()
+    if err != nil { t.Fatalf("failed to get wd: %v", err) }
+    root := filepath.Clean(filepath.Join(cwd, "../.."))
+    if err := os.Chdir(root); err != nil { t.Fatalf("failed to chdir to module root: %v", err) }
+    t.Cleanup(func(){ _ = os.Chdir(cwd) })
+
+    settings := types.C8RunSettings{Port: 9090, Docker: true}
+    out := captureOutput(t, func() {
+        if err := PrintStatus(settings); err != nil { t.Fatalf("PrintStatus failed: %v", err) }
+    })
+
+    // Verify fixed docker ports are present
+    expectedPorts := map[string]int{"Operate": 8081, "Tasklist": 8082, "Identity": 8084, "Orchestration Cluster API": 8088}
+    for name, port := range expectedPorts {
+        if !strings.Contains(out, "http://localhost:"+strconv.Itoa(port)) {
+            t.Fatalf("expected %s endpoint to include port %d; output: %s", name, port, out)
+        }
+    }
+    // Ensure the provided (ignored) port is not shown for those endpoints
+    if strings.Contains(out, "http://localhost:9090/operate") || strings.Contains(out, "http://localhost:9090/tasklist") || strings.Contains(out, "http://localhost:9090/identity") || strings.Contains(out, "http://localhost:9090/v2/") {
+        t.Fatalf("docker mode should ignore custom port 9090; output: %s", out)
+    }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Backporting https://github.com/camunda/camunda/pull/39605 against 8.8. The other PR can not be merged as 8.9 unit tests are not yet fixed and CI is not passing. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
