### PR TITLE
Fix C8Run CI for 8.9

### DIFF
--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -41,7 +41,7 @@ if [[ "$returnCode" != 0 ]]; then
 fi
 printf "\nTest: test --config flag\n"
 
-PREFIX="$(curl localhost:9600/actuator/configprops | jq '.contexts.camunda.beans.["camunda.tasklist-io.camunda.configuration.beanoverrides.LegacyTasklistProperties"].properties.zeebeElasticsearch.prefix')"
+PREFIX="$(curl localhost:9600/actuator/configprops | jq '.contexts.camunda.beans.["camunda-io.camunda.configuration.Camunda"].properties.data.secondaryStorage.elasticsearch.indexPrefix')"
 echo $PREFIX
 if [[ "$PREFIX" != "\"extra-prefix-zeebe-record\"" ]]; then
         echo "test failed"

--- a/c8run/e2e_tests/prefix-config.yaml
+++ b/c8run/e2e_tests/prefix-config.yaml
@@ -1,7 +1,5 @@
 camunda:
-  operate:
-    zeebeElasticsearch:
-      prefix: "extra-prefix-zeebe-record"
-  tasklist:
-    zeebeElasticsearch:
-      prefix: "extra-prefix-zeebe-record"
+  data:
+    secondaryStorage:
+      elasticsearch:
+        indexPrefix: "extra-prefix-zeebe-record"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->


The Ci for 8.9 is failing (we recently released 8.8 and still need to do the adjustments for 8.9 related to latest 8.9 SNAPSHOT c8run). 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
