### PR TITLE
fix(c8run): set Elasticsearch replicas to 0 for single-node setup

### DIFF
--- a/c8run/configuration/application.yaml
+++ b/c8run/configuration/application.yaml
@@ -27,6 +27,9 @@ camunda:
       unprotected-api: true
     authorizations:
       enabled: false
+  database:
+    index:
+      numberOfReplicas: 0
 
 zeebe:
   broker:


### PR DESCRIPTION

## Description

<!-- Describe the goal and purpose of this PR. -->

Camunda 8.8+ sets numberOfReplicas to 1 by default, which causes Elasticsearch to stay in YELLOW status on single-node setups. This prevents health checks from passing on subsequent startups.

Configure numberOfReplicas to 0 for single-node development environments to ensure GREEN cluster status.

fix for `stable/8.8`: https://github.com/camunda/camunda/pull/39727

related to https://github.com/camunda/camunda/issues/39665

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
