### PR TITLE
feat: Remove concept of key for cluster variable

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.processing.clustervariable;
 
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.util.Either;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClusterVariableCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClusterVariableCreatedApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableClusterVariableState;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 
 public class ClusterVariableCreatedApplier

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/ClusterVariableInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/ClusterVariableInstance.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.state.clustervariable;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 
 public final class ClusterVariableInstance extends UnpackedObject implements DbValue {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/DbClusterVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/DbClusterVariableState.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.clustervariable.DbClusterVariableScopeKey.Scope;
 import io.camunda.zeebe.engine.state.mutable.MutableClusterVariableState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableClusterVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableClusterVariableState.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.engine.state.mutable;
 
 import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import org.agrona.DirectBuffer;
 
 public interface MutableClusterVariableState extends ClusterVariableState {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.mock;
 
 import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
 import io.camunda.zeebe.engine.util.EngineRule;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClusterVariableClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClusterVariableClient.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.engine.util.client;
 
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ClusterVariable_CREATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ClusterVariable_CREATED_v1.golden
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableClusterVariableState;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 
 public class ClusterVariableCreatedApplier

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-cluster-variable-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-cluster-variable-template.json
@@ -2,7 +2,9 @@
   "index_patterns": [
     "zeebe-record_cluster-variable_*"
   ],
-  "composed_of": ["zeebe-record"],
+  "composed_of": [
+    "zeebe-record"
+  ],
   "priority": 20,
   "version": 1,
   "template": {
@@ -19,9 +21,6 @@
         "value": {
           "dynamic": "strict",
           "properties": {
-            "key": {
-              "type": "long"
-            },
             "name": {
               "type": "keyword"
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-cluster-variable-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-cluster-variable-template.json
@@ -19,9 +19,6 @@
         "value": {
           "dynamic": "strict",
           "properties": {
-            "key": {
-              "type": "long"
-            },
             "name": {
               "type": "keyword"
             },

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.protocol.impl.record.value.variable;
+package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -33,7 +34,6 @@ import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/ClusterVariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/ClusterVariableRecord.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.protocol.impl.record.value.variable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
-import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -21,22 +20,17 @@ import org.agrona.DirectBuffer;
 public class ClusterVariableRecord extends UnifiedRecordValue
     implements ClusterVariableRecordValue {
 
-  private static final StringValue VARIABLE_KEY_KEY = new StringValue("variableKey");
   private static final StringValue NAME_KEY = new StringValue("name");
   private static final StringValue VALUE_KEY = new StringValue("value");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
 
-  private final LongProperty variableKeyProp = new LongProperty(VARIABLE_KEY_KEY, 0L);
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
 
   public ClusterVariableRecord() {
-    super(4);
-    declareProperty(variableKeyProp)
-        .declareProperty(nameProp)
-        .declareProperty(valueProp)
-        .declareProperty(tenantIdProp);
+    super(3);
+    declareProperty(nameProp).declareProperty(valueProp).declareProperty(tenantIdProp);
   }
 
   @Override
@@ -47,11 +41,6 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   @Override
   public String getValue() {
     return MsgPackConverter.convertToJson(valueProp.getValue());
-  }
-
-  @Override
-  public long getKey() {
-    return variableKeyProp.getValue();
   }
 
   public ClusterVariableRecord setValue(final DirectBuffer value) {

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.protocol.impl.record.value.variable;
+package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
@@ -7,36 +7,30 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.variable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
-import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
 
 public class ClusterVariableRecord extends UnifiedRecordValue
     implements ClusterVariableRecordValue {
 
-  private static final StringValue VARIABLE_KEY_KEY = new StringValue("variableKey");
   private static final StringValue NAME_KEY = new StringValue("name");
   private static final StringValue VALUE_KEY = new StringValue("value");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
 
-  private final LongProperty variableKeyProp = new LongProperty(VARIABLE_KEY_KEY, 0L);
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
-  private final StringProperty tenantIdProp =
-      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
 
   public ClusterVariableRecord() {
-    super(4);
-    declareProperty(variableKeyProp)
-        .declareProperty(nameProp)
-        .declareProperty(valueProp)
-        .declareProperty(tenantIdProp);
+    super(3);
+    declareProperty(nameProp).declareProperty(valueProp).declareProperty(tenantIdProp);
   }
 
   @Override
@@ -45,17 +39,37 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   }
 
   @Override
-  public Object getValue() {
+  public String getValue() {
     return MsgPackConverter.convertToJson(valueProp.getValue());
   }
 
-  @Override
-  public long getKey() {
-    return variableKeyProp.getValue();
+  public ClusterVariableRecord setValue(final DirectBuffer value) {
+    valueProp.setValue(value);
+    return this;
+  }
+
+  public ClusterVariableRecord setName(final String name) {
+    nameProp.setValue(name);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getNameBuffer() {
+    return nameProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getValueBuffer() {
+    return valueProp.getValue();
   }
 
   @Override
   public String getTenantId() {
     return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public ClusterVariableRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CommandDistributionRecord.golden
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.distribution;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -32,7 +34,6 @@ import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -178,10 +179,6 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     return concreteCommandValue;
   }
 
-  public AuthInfo getAuthInfo() {
-    return authInfoProperty.getValue();
-  }
-
   public CommandDistributionRecord setCommandValue(final UnifiedRecordValue commandValue) {
     if (commandValue == null) {
       commandValueProperty.reset();
@@ -220,6 +217,11 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   public CommandDistributionRecord setPartitionId(final int partitionId) {
     partitionIdProperty.setValue(partitionId);
     return this;
+  }
+
+  @JsonIgnoreProperties
+  public AuthInfo getAuthInfo() {
+    return authInfoProperty.getValue();
   }
 
   public CommandDistributionRecord setAuthInfo(final AuthInfo authInfo) {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
@@ -57,11 +57,4 @@ public interface ClusterVariableRecordValue extends RecordValue, TenantOwned {
    * @return the variable value
    */
   Object getValue();
-
-  /**
-   * Returns the unique key of this cluster variable record.
-   *
-   * @return the record key
-   */
-  long getKey();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
@@ -62,7 +63,6 @@ import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
 import io.camunda.zeebe.protocol.record.ValueType;


### PR DESCRIPTION
## Description

This PR aims to remove the concept of key from cluster variables, which was wrongly introduced inside the first PR for the epic

This PR also move the `ClusterVariableRecord` to its own package

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/39730
