### PR TITLE
[backport stable/8.8] fix: fix issue with byte[] serialization.

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
@@ -58,9 +58,7 @@ public record ReplicatableJournalRecord(
   public String toString() {
     final var recordToString =
         serializedJournalRecord != null
-            ? "{rawToString="
-                + serializedJournalRecord
-                + ", length="
+            ? "{length="
                 + serializedJournalRecord.length
                 + ", hashCode="
                 + Arrays.hashCode(serializedJournalRecord)


### PR DESCRIPTION
## Description

Resolves spotbugs violation [DMI_INVOKING_TOSTRING_ON_ARRAY](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#useless-string-invocation-of-tostring-on-an-array-dmi-invoking-tostring-on-array).

Turned out we do not want to print out the array https://github.com/camunda/camunda/pull/39733#discussion_r2444057746 .

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

context: recent CI failures because of a spotbugs violation see https://camunda.slack.com/archives/C08F5RD5X8B/p1760934217451279
