### PR TITLE
feat: Store and search process instance tags

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -71,8 +71,29 @@
       <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
     </modifySql>
     <modifySql dbms="mssql">
-      <replace  replace="datetime2" with="DATETIMEOFFSET"/>
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
     </modifySql>
+  </changeSet>
+
+  <changeSet id="create_process_instance_tag_table" author="camunda">
+    <createTable tableName="${prefix}PROCESS_INSTANCE_TAG">
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT">
+        <constraints
+          primaryKey="true"
+          foreignKeyName="${prefix}FK_PROCESS_INSTANCE_TAG_PROCESS_INSTANCE"
+          referencedTableName="${prefix}PROCESS_INSTANCE"
+          referencedColumnNames="PROCESS_INSTANCE_KEY"
+          deleteCascade="true"/>
+        />
+      </column>
+      <column name="TAG_VALUE" type="VARCHAR(100)">
+        <constraints primaryKey="true"/>
+      </column>
+    </createTable>
+    <createIndex tableName="${prefix}PROCESS_INSTANCE_TAG"
+      indexName="${prefix}IDX_PROCESS_INSTANCE_TAG_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
   </changeSet>
 
   <changeSet id="create_variable_table" author="camunda">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.ProcessInstanceTagDbModel;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import java.time.OffsetDateTime;
@@ -24,6 +25,8 @@ public interface ProcessInstanceMapper extends ProcessBasedHistoryCleanupMapper 
 
   void decrementIncidentCount(Long processInstanceKey);
 
+  void insertTags(ProcessInstanceTagsDto tagList);
+
   ProcessInstanceEntity findOne(Long processInstanceKey);
 
   Long count(ProcessInstanceDbQuery filter);
@@ -36,4 +39,6 @@ public interface ProcessInstanceMapper extends ProcessBasedHistoryCleanupMapper 
       long processInstanceKey,
       ProcessInstanceEntity.ProcessInstanceState state,
       OffsetDateTime endDate) {}
+
+  record ProcessInstanceTagsDto(Long processInstanceKey, List<ProcessInstanceTagDbModel> tags) {}
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceTagDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceTagDbModel.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+
+public record ProcessInstanceTagDbModel(Long processInstanceKey, String tagValue)
+    implements DbModel<ProcessInstanceTagDbModel> {
+
+  @Override
+  public ProcessInstanceTagDbModel copy(
+      final Function<
+              ObjectBuilder<ProcessInstanceTagDbModel>, ObjectBuilder<ProcessInstanceTagDbModel>>
+          builderFunction) {
+    return builderFunction
+        .apply(
+            new ProcessInstanceTagDbModelBuilder()
+                .processInstanceKey(processInstanceKey)
+                .tagValue(tagValue))
+        .build();
+  }
+
+  public static class ProcessInstanceTagDbModelBuilder
+      implements ObjectBuilder<ProcessInstanceTagDbModel> {
+
+    private Long processInstanceKey;
+    private String tagValue;
+
+    // Public constructor to initialize the builder
+    public ProcessInstanceTagDbModelBuilder() {}
+
+    // Builder methods for each field
+    public ProcessInstanceTagDbModelBuilder processInstanceKey(final Long processInstanceKey) {
+      this.processInstanceKey = processInstanceKey;
+      return this;
+    }
+
+    public ProcessInstanceTagDbModelBuilder tagValue(final String tagValue) {
+      this.tagValue = tagValue;
+      return this;
+    }
+
+    @Override
+    public ProcessInstanceTagDbModel build() {
+      return new ProcessInstanceTagDbModel(processInstanceKey, tagValue);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
@@ -39,6 +39,7 @@ public class RdbmsPurger {
           "MESSAGE_SUBSCRIPTION",
           "PROCESS_DEFINITION",
           "PROCESS_INSTANCE",
+          "PROCESS_INSTANCE_TAG",
           "ROLE_MEMBER",
           "ROLES",
           "SEQUENCE_FLOW",

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -28,10 +28,11 @@
            pi.TREE_PATH,
            pd.NAME        AS PROCESS_DEFINITION_NAME,
            pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG,
-           NULL AS TAGS
+           pit.TAG_VALUE AS TAG_VALUE
     FROM ${prefix}PROCESS_INSTANCE pi
            LEFT JOIN ${prefix}PROCESS_DEFINITION pd ON (pi.PROCESS_DEFINITION_KEY = pd.PROCESS_DEFINITION_KEY)
-    WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
+           LEFT JOIN ${prefix}PROCESS_INSTANCE_TAG pit ON (pit.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY)
+    WHERE pi.PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </select>
 
   <select id="count" resultType="java.lang.Long">
@@ -46,6 +47,24 @@
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery"
     resultMap="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchResultMap">
     SELECT * FROM (
+    SELECT
+    pif.PROCESS_INSTANCE_KEY,
+    pif.PROCESS_DEFINITION_ID,
+    pif.PROCESS_DEFINITION_KEY,
+    pif.STATE,
+    pif.START_DATE,
+    pif.END_DATE,
+    pif.TENANT_ID,
+    pif.HAS_INCIDENT,
+    pif.PARENT_PROCESS_INSTANCE_KEY,
+    pif.PARENT_ELEMENT_INSTANCE_KEY,
+    pif.PROCESS_DEFINITION_VERSION,
+    pif.TREE_PATH,
+    pif.PROCESS_DEFINITION_NAME,
+    pif.PROCESS_DEFINITION_VERSION_TAG,
+    pit.TAG_VALUE AS TAG_VALUE
+    FROM (
+    SELECT *  FROM (
     SELECT
     pi.PROCESS_INSTANCE_KEY,
     pi.PROCESS_DEFINITION_ID,
@@ -63,15 +82,23 @@
     pi.VERSION PROCESS_DEFINITION_VERSION,
     pi.TREE_PATH,
     pd.NAME AS PROCESS_DEFINITION_NAME,
-    pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG,
-    NULL AS TAGS
+    pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG
     FROM ${prefix}PROCESS_INSTANCE pi
     LEFT JOIN ${prefix}PROCESS_DEFINITION pd ON (pi.PROCESS_DEFINITION_KEY = pd.PROCESS_DEFINITION_KEY)
     <include refid="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchAndAuthFilter"/>
-    ) t
+    ) filtered
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+    ) pif
+    LEFT JOIN ${prefix}PROCESS_INSTANCE_TAG pit ON (pit.PROCESS_INSTANCE_KEY = pif.PROCESS_INSTANCE_KEY)
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <if test="_databaseId == 'mssql'">
+      <!-- MSSQL needs an OFFSET when sorting in subselects -->
+      OFFSET 0 ROWS
+    </if>
+    ) sorted
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
   </select>
 
   <sql id="searchAndAuthFilter">
@@ -302,6 +329,17 @@
       </foreach>
       )
     </if>
+    <!-- Tag filters -->
+    <if test="filter.tags != null and !filter.tags.isEmpty()">
+      <foreach collection="filter.tags" item="tag" open="AND (" separator=" AND " close=")">
+        EXISTS (
+          SELECT 1
+          FROM ${prefix}PROCESS_INSTANCE_TAG pit
+          WHERE pit.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+            AND pit.TAG_VALUE = #{tag}
+        )
+      </foreach>
+    </if>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.ProcessInstanceEntity">
@@ -320,10 +358,10 @@
       <arg column="HAS_INCIDENT" javaType="java.lang.Boolean"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>
       <arg column="TREE_PATH" javaType="java.lang.String"/>
-      <arg column="TAGS" javaType="java.util.Set"
-           typeHandler="io.camunda.db.rdbms.typehandler.EmptyStringSetTypeHandler"/>
     </constructor>
-
+    <collection property="tags" ofType="java.lang.String" javaType="java.util.Set">
+      <id column="TAG_VALUE"/>
+    </collection>
   </resultMap>
 
   <select id="flowNodeStatistics"
@@ -400,6 +438,14 @@
     SET NUM_INCIDENTS = NUM_INCIDENTS - 1
     WHERE PROCESS_INSTANCE_KEY = #{id}
   </update>
+
+  <insert id="insertTags" parameterType="io.camunda.db.rdbms.sql.ProcessInstanceMapper$ProcessInstanceTagsDto">
+    INSERT INTO ${prefix}PROCESS_INSTANCE_TAG (PROCESS_INSTANCE_KEY, TAG_VALUE)
+    VALUES
+      <foreach collection="tags" item="item" separator=",">
+        (#{processInstanceKey}, #{item.tagValue})
+      </foreach>
+  </insert>
 
   <update id="updateHistoryCleanupDate">
     UPDATE ${prefix}PROCESS_INSTANCE

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateTest.java
@@ -21,10 +21,8 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 public class ProcessInstanceCreateTest {
 
   private static CamundaClient camundaClient;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchWithTagsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchWithTagsTest.java
@@ -22,10 +22,8 @@ import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 public class ProcessInstanceSearchWithTagsTest {
 
   private static CamundaClient client;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessInstanceFixtures.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.it.rdbms.db.fixtures;
 
+import io.camunda.db.rdbms.sql.ProcessInstanceMapper.ProcessInstanceTagsDto;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel.ProcessInstanceDbModelBuilder;
+import io.camunda.db.rdbms.write.domain.ProcessInstanceTagDbModel;
+import io.camunda.db.rdbms.write.domain.ProcessInstanceTagDbModel.ProcessInstanceTagDbModelBuilder;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -80,6 +83,27 @@ public final class ProcessInstanceFixtures extends CommonFixtures {
     for (final ProcessInstanceDbModel processInstance : processInstanceList) {
       rdbmsWriter.getProcessInstanceWriter().create(processInstance);
     }
+    rdbmsWriter.flush();
+  }
+
+  public static ProcessInstanceTagDbModel createRandomizedTag(
+      final Function<ProcessInstanceTagDbModelBuilder, ProcessInstanceTagDbModelBuilder>
+          builderFunction) {
+    final var builder =
+        new ProcessInstanceTagDbModelBuilder()
+            .processInstanceKey(nextKey())
+            .tagValue("tag-" + RANDOM.nextInt(10000));
+
+    return builderFunction.apply(builder).build();
+  }
+
+  public static void addProcessInstanceTags(
+      final RdbmsWriter rdbmsWriter,
+      final Long processInstanceKey,
+      final List<ProcessInstanceTagDbModel> processInstanceTags) {
+    rdbmsWriter
+        .getProcessInstanceWriter()
+        .createTags(new ProcessInstanceTagsDto(processInstanceKey, processInstanceTags));
     rdbmsWriter.flush();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceTagIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceTagIT.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.processinstance;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.addProcessInstanceTags;
+import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndSaveProcessInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
+import io.camunda.search.query.ProcessInstanceQuery;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.assertj.core.data.TemporalUnitWithinOffset;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class ProcessInstanceTagIT {
+
+  public static final int PARTITION_ID = 0;
+  public static final OffsetDateTime NOW = OffsetDateTime.now();
+  public static final String TAG_VALUE_FOO = "foo_tag";
+  public static final String TAG_VALUE_BAR = "bar_tag";
+
+  @TestTemplate
+  public void shouldSaveAndFindProcessInstanceByTag(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
+
+    final Long processInstanceKey = nextKey();
+    createAndSaveProcessInstance(
+        rdbmsWriter,
+        ProcessInstanceFixtures.createRandomized(
+            b ->
+                b.processInstanceKey(processInstanceKey)
+                    .processDefinitionId("test-process")
+                    .processDefinitionKey(1337L)
+                    .state(ProcessInstanceState.ACTIVE)
+                    .startDate(NOW)
+                    .parentProcessInstanceKey(-1L)
+                    .parentElementInstanceKey(-1L)
+                    .version(1)));
+
+    addProcessInstanceTags(
+        rdbmsWriter,
+        processInstanceKey,
+        List.of(
+            ProcessInstanceFixtures.createRandomizedTag(
+                b -> b.processInstanceKey(processInstanceKey).tagValue(TAG_VALUE_FOO))));
+
+    final var searchResult =
+        processInstanceReader.search(
+            ProcessInstanceQuery.of(
+                b ->
+                    b.filter(f -> f.tags(Set.of(TAG_VALUE_FOO)))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(10))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+
+    final var instance = searchResult.items().getFirst();
+
+    assertThat(instance).isNotNull();
+    assertThat(instance.processInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(instance.processDefinitionId()).isEqualTo("test-process");
+    assertThat(instance.processDefinitionKey()).isEqualTo(1337L);
+    assertThat(instance.state()).isEqualTo(ProcessInstanceState.ACTIVE);
+    assertThat(instance.startDate())
+        .isCloseTo(NOW, new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
+    assertThat(instance.parentProcessInstanceKey()).isEqualTo(-1L);
+    assertThat(instance.parentFlowNodeInstanceKey()).isEqualTo(-1L);
+    assertThat(instance.processDefinitionVersion()).isEqualTo(1);
+    assertThat(instance.tags()).containsOnly(TAG_VALUE_FOO);
+    assertThat(instance.hasIncident()).isFalse();
+  }
+
+  @TestTemplate
+  public void shouldSaveAndFindProcessInstanceWithMultipleTags(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
+
+    final var processInstanceKeys = new ArrayList<Long>();
+
+    for (int i = 0; i < 20; i++) {
+      final Long processInstanceKey = nextKey();
+      createAndSaveProcessInstance(
+          rdbmsWriter,
+          ProcessInstanceFixtures.createRandomized(
+              b ->
+                  b.processInstanceKey(processInstanceKey)
+                      .processDefinitionId("test-process")
+                      .processDefinitionKey(1337L)
+                      .state(ProcessInstanceState.ACTIVE)
+                      .startDate(NOW)
+                      .parentProcessInstanceKey(-1L)
+                      .parentElementInstanceKey(-1L)
+                      .version(1)));
+      processInstanceKeys.add(processInstanceKey);
+    }
+
+    processInstanceKeys.forEach(
+        processInstanceKey -> {
+          addProcessInstanceTags(
+              rdbmsWriter,
+              processInstanceKey,
+              List.of(
+                  ProcessInstanceFixtures.createRandomizedTag(
+                      b -> b.processInstanceKey(processInstanceKey).tagValue(TAG_VALUE_FOO)),
+                  ProcessInstanceFixtures.createRandomizedTag(
+                      b -> b.processInstanceKey(processInstanceKey).tagValue(TAG_VALUE_BAR))));
+        });
+
+    final var searchResult =
+        processInstanceReader.search(
+            ProcessInstanceQuery.of(
+                b ->
+                    b.filter(f -> f.tags(Set.of(TAG_VALUE_FOO, TAG_VALUE_BAR)))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(20);
+    assertThat(searchResult.items()).hasSize(5);
+
+    final var instance = searchResult.items().getFirst();
+
+    assertThat(instance).isNotNull();
+    assertThat(instance.tags()).hasSize(2);
+    assertThat(instance.tags()).containsExactlyInAnyOrder(TAG_VALUE_FOO, TAG_VALUE_BAR);
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
@@ -9,6 +9,7 @@ package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.OffsetDateTime;
+import java.util.HashSet;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -29,6 +30,40 @@ public record ProcessInstanceEntity(
     String treePath,
     Set<String> tags)
     implements TenantOwnedEntity {
+
+  public ProcessInstanceEntity(
+      final Long processInstanceKey,
+      final String processDefinitionId,
+      final String processDefinitionName,
+      final Integer processDefinitionVersion,
+      final String processDefinitionVersionTag,
+      final Long processDefinitionKey,
+      final Long parentProcessInstanceKey,
+      final Long parentFlowNodeInstanceKey,
+      final OffsetDateTime startDate,
+      final OffsetDateTime endDate,
+      final ProcessInstanceState state,
+      final Boolean hasIncident,
+      final String tenantId,
+      final String treePath) {
+
+    this(
+        processInstanceKey,
+        processDefinitionId,
+        processDefinitionName,
+        processDefinitionVersion,
+        processDefinitionVersionTag,
+        processDefinitionKey,
+        parentProcessInstanceKey,
+        parentFlowNodeInstanceKey,
+        startDate,
+        endDate,
+        state,
+        hasIncident,
+        tenantId,
+        treePath,
+        new HashSet<>());
+  }
 
   public enum ProcessInstanceState {
     ACTIVE,

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
@@ -7,8 +7,10 @@
  */
 package io.camunda.exporter.rdbms.handlers;
 
+import io.camunda.db.rdbms.sql.ProcessInstanceMapper.ProcessInstanceTagsDto;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel.ProcessInstanceDbModelBuilder;
+import io.camunda.db.rdbms.write.domain.ProcessInstanceTagDbModel;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.db.rdbms.write.service.ProcessInstanceWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
@@ -25,6 +27,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.util.DateUtil;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +61,15 @@ public class ProcessInstanceExportHandler
     final var value = record.getValue();
     if (record.getIntent().equals(ProcessInstanceIntent.ELEMENT_ACTIVATING)) {
       processInstanceWriter.create(map(record));
+
+      if (value.getTags() != null && !value.getTags().isEmpty()) {
+        processInstanceWriter.createTags(
+            new ProcessInstanceTagsDto(
+                value.getProcessInstanceKey(),
+                value.getTags().stream()
+                    .map(tag -> new ProcessInstanceTagDbModel(value.getProcessInstanceKey(), tag))
+                    .collect(Collectors.toList())));
+      }
     } else if (record.getIntent().equals(ProcessInstanceIntent.ELEMENT_COMPLETED)) {
       final OffsetDateTime endDate = DateUtil.toOffsetDateTime(record.getTimestamp());
       processInstanceWriter.finish(


### PR DESCRIPTION
## Description

* Store process instance tags
* Select tags together with process instance
* Filter process instances by tags

Note: Inheriting process instance tags to jobs will be part of another PR.

## Related issues

Belongs to #37958
