### PR TITLE
build: Update backwards compatibility version to 8.8

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -236,7 +236,7 @@
     <extension.version.os-maven-plugin>1.7.1</extension.version.os-maven-plugin>
 
     <!-- version against which backwards compatibility is checked -->
-    <backwards.compat.version>8.7.7</backwards.compat.version>
+    <backwards.compat.version>8.8.0</backwards.compat.version>
     <ignored.changes.file>ignored-changes.json</ignored.changes.file>
 
     <!--

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -262,9 +262,10 @@ final class ElasticsearchExporterTest {
       verify(client, never()).putIndexTemplate(valueType);
     }
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("io.camunda.zeebe.exporter.TestSupport#provideValueTypes")
-    void shouldCreateAllTemplatesOnPreviousVersion(final ValueType valueType) {
+    @ParameterizedTest(name = "{0} - version: {1}")
+    @MethodSource(
+        "io.camunda.zeebe.exporter.TestSupport#provideValueTypesWithCurrentAndPreviousVersions")
+    void shouldExportOnlyRequiredRecords(final ValueType valueType, final String version) {
       // given
       config.index.createTemplate = true;
       config.setIncludeEnabledRecords(false);
@@ -275,11 +276,21 @@ final class ElasticsearchExporterTest {
       // when
       final var recordMock = mock(Record.class);
       when(recordMock.getValueType()).thenReturn(valueType);
-      when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getPreviousVersion());
+      when(recordMock.getBrokerVersion()).thenReturn(version);
       exporter.export(recordMock);
 
       // then
-      verify(client, times(1)).putIndexTemplate(valueType, VersionUtil.getPreviousVersion());
+      if (valueType == ValueType.PROCESS_INSTANCE
+          || valueType == ValueType.PROCESS
+          || valueType == ValueType.VARIABLE
+          || valueType == ValueType.INCIDENT
+          || valueType == ValueType.USER_TASK
+          || valueType == ValueType.DEPLOYMENT
+          || valueType == ValueType.JOB) {
+        verify(client, times(1)).putIndexTemplate(valueType, version);
+      } else {
+        verify(client, never()).putIndexTemplate(any(), any());
+      }
     }
   }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -10,8 +10,10 @@ package io.camunda.zeebe.exporter;
 import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VersionUtil;
 import java.util.EnumSet;
 import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
 
 /** Collection of utilities for unit and integration tests. */
 final class TestSupport {
@@ -130,5 +132,14 @@ final class TestSupport {
             ValueType.USAGE_METRIC,
             ValueType.MULTI_INSTANCE);
     return EnumSet.complementOf(excludedValueTypes).stream();
+  }
+
+  static Stream<Arguments> provideValueTypesWithCurrentAndPreviousVersions() {
+    return TestSupport.provideValueTypes()
+        .flatMap(
+            valueType ->
+                Stream.of(
+                    Arguments.of(valueType, VersionUtil.getVersionLowerCase()),
+                    Arguments.of(valueType, VersionUtil.getPreviousVersion().toLowerCase())));
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -10,8 +10,10 @@ package io.camunda.zeebe.exporter.opensearch;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VersionUtil;
 import java.util.EnumSet;
 import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
 
 /** Collection of utilities for unit and integration tests. */
 final class TestSupport {
@@ -131,5 +133,14 @@ final class TestSupport {
             ValueType.USAGE_METRIC,
             ValueType.MULTI_INSTANCE);
     return EnumSet.complementOf(excludedValueTypes).stream();
+  }
+
+  static Stream<Arguments> provideValueTypesWithCurrentAndPreviousVersions() {
+    return TestSupport.provideValueTypes()
+        .flatMap(
+            valueType ->
+                Stream.of(
+                    Arguments.of(valueType, VersionUtil.getVersionLowerCase()),
+                    Arguments.of(valueType, VersionUtil.getPreviousVersion().toLowerCase())));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Bumping backward compatibility version from 8.7 to 8.8
Exporter tests required to be updated. since 8.8, some records are not exported anymore, by default 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
