### PR TITLE
refactor: create shallow clones using Cloneable

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Backup.java
+++ b/configuration/src/main/java/io/camunda/configuration/Backup.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-public class Backup {
+public class Backup implements Cloneable {
   private static final String PREFIX = "camunda.data.backup";
 
   private static final Map<String, String> LEGACY_OPERATE_BACKUP_PROPERTIES =
@@ -176,34 +176,28 @@ public class Backup {
   }
 
   @Override
-  public Backup clone() {
-    final Backup copy = new Backup();
-    copy.repositoryName = repositoryName;
-    copy.snapshotTimeout = snapshotTimeout;
-    copy.incompleteCheckTimeout = incompleteCheckTimeout;
-    copy.store = store;
-    copy.s3 = s3;
-    copy.gcs = gcs;
-    copy.filesystem = filesystem;
-    copy.azure = azure;
-
-    return copy;
+  public Object clone() {
+    try {
+      return super.clone();
+    } catch (final CloneNotSupportedException e) {
+      throw new AssertionError("Unexpected: Class must implement Cloneable", e);
+    }
   }
 
   public Backup withOperateBackupProperties() {
-    final Backup copy = clone();
+    final var copy = (Backup) clone();
     copy.legacyPropertyMap = LEGACY_OPERATE_BACKUP_PROPERTIES;
     return copy;
   }
 
   public Backup withTasklistBackupProperties() {
-    final Backup copy = clone();
+    final var copy = (Backup) clone();
     copy.legacyPropertyMap = LEGACY_TASKLIST_BACKUP_PROPERTIES;
     return copy;
   }
 
   public Backup withBrokerBackupProperties() {
-    final Backup copy = clone();
+    final var copy = (Backup) clone();
     copy.legacyPropertyMap = LEGACY_BROKER_BACKUP_PROPERTIES;
     return copy;
   }

--- a/configuration/src/main/java/io/camunda/configuration/Grpc.java
+++ b/configuration/src/main/java/io/camunda/configuration/Grpc.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class Grpc {
+public class Grpc implements Cloneable {
   private static final String PREFIX = "camunda.api.grpc";
   private static final Map<String, String> LEGACY_GATEWAY_PROPERTIES =
       Map.of(
@@ -126,26 +126,22 @@ public class Grpc {
   }
 
   @Override
-  public Grpc clone() {
-    final Grpc copy = new Grpc();
-    copy.address = address;
-    copy.port = port;
-    copy.minKeepAliveInterval = minKeepAliveInterval;
-    copy.ssl = ssl;
-    copy.interceptors = interceptors;
-    copy.managementThreads = managementThreads;
-
-    return copy;
+  public Object clone() {
+    try {
+      return super.clone();
+    } catch (final CloneNotSupportedException e) {
+      throw new AssertionError("Unexpected: Class must implement Cloneable", e);
+    }
   }
 
   public Grpc withBrokerNetworkProperties() {
-    final var copy = clone();
+    final var copy = (Grpc) clone();
     copy.legacyPropertiesMap = LEGACY_BROKER_PROPERTIES;
     return copy;
   }
 
   public Grpc withGatewayNetworkProperties() {
-    final var copy = clone();
+    final var copy = (Grpc) clone();
     copy.legacyPropertiesMap = LEGACY_GATEWAY_PROPERTIES;
     return copy;
   }

--- a/configuration/src/main/java/io/camunda/configuration/InternalApi.java
+++ b/configuration/src/main/java/io/camunda/configuration/InternalApi.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults;
 import java.util.Map;
 import java.util.Set;
 
-public class InternalApi {
+public class InternalApi implements Cloneable {
   private static final String PREFIX = "camunda.cluster.network.internal-api";
 
   private static final Map<String, String> LEGACY_GATEWAY_NETWORK_INTERNAL_API_PROPERTIES =
@@ -112,25 +112,23 @@ public class InternalApi {
   }
 
   @Override
-  public InternalApi clone() {
-    final InternalApi copy = new InternalApi();
-    copy.host = host;
-    copy.port = port;
-    copy.advertisedHost = advertisedHost;
-    copy.advertisedPort = advertisedPort;
-
-    return copy;
+  public Object clone() {
+    try {
+      return super.clone();
+    } catch (final CloneNotSupportedException e) {
+      throw new AssertionError("Unexpected: Class must implement Cloneable", e);
+    }
   }
 
   public InternalApi withBrokerInternalApiProperties() {
-    final var copy = clone();
+    final var copy = (InternalApi) clone();
     copy.legacyPropertiesMap = LEGACY_BROKER_NETWORK_INTERNAL_API_PROPERTIES;
     copy.port = copy.port == null ? NetworkCfg.DEFAULT_INTERNAL_API_PORT : copy.port;
     return copy;
   }
 
   public InternalApi withGatewayInternalApiProperties() {
-    final var copy = clone();
+    final var copy = (InternalApi) clone();
     copy.legacyPropertiesMap = LEGACY_GATEWAY_NETWORK_INTERNAL_API_PROPERTIES;
     copy.port = copy.port == null ? ConfigurationDefaults.DEFAULT_CLUSTER_PORT : copy.port;
     return copy;

--- a/configuration/src/main/java/io/camunda/configuration/KeyStore.java
+++ b/configuration/src/main/java/io/camunda/configuration/KeyStore.java
@@ -12,7 +12,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.Set;
 
-public class KeyStore {
+public class KeyStore implements Cloneable {
   private static final String PREFIX = "camunda.api.grpc.ssl.key-store";
   private static final Map<String, String> LEGACY_GATEWAY_KEY_STORE_PROPERTIES =
       Map.of(
@@ -58,22 +58,22 @@ public class KeyStore {
   }
 
   @Override
-  public KeyStore clone() {
-    final KeyStore copy = new KeyStore();
-    copy.filePath = filePath;
-    copy.password = password;
-
-    return copy;
+  public Object clone() {
+    try {
+      return super.clone();
+    } catch (final CloneNotSupportedException e) {
+      throw new AssertionError("Unexpected: Class must implement Cloneable", e);
+    }
   }
 
   public KeyStore withBrokerKeyStoreProperties() {
-    final var copy = clone();
+    final var copy = (KeyStore) clone();
     copy.legacyPropertiesMap = LEGACY_BROKER_KEY_STORE_PROPERTIES;
     return copy;
   }
 
   public KeyStore withGatewayKeyStoreProperties() {
-    final var copy = clone();
+    final var copy = (KeyStore) clone();
     copy.legacyPropertiesMap = LEGACY_GATEWAY_KEY_STORE_PROPERTIES;
     return copy;
   }

--- a/configuration/src/main/java/io/camunda/configuration/LongPolling.java
+++ b/configuration/src/main/java/io/camunda/configuration/LongPolling.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults;
 import java.util.Map;
 import java.util.Set;
 
-public class LongPolling {
+public class LongPolling implements Cloneable {
   private static final String PREFIX = "camunda.api.long-polling";
 
   private static final Map<String, String> LEGACY_GATEWAY_PROPERTIES =
@@ -100,24 +100,22 @@ public class LongPolling {
   }
 
   @Override
-  public LongPolling clone() {
-    final LongPolling copy = new LongPolling();
-    copy.enabled = enabled;
-    copy.timeout = timeout;
-    copy.probeTimeout = probeTimeout;
-    copy.minEmptyResponses = minEmptyResponses;
-
-    return copy;
+  public Object clone() {
+    try {
+      return super.clone();
+    } catch (final CloneNotSupportedException e) {
+      throw new AssertionError("Unexpected: Class must implement Cloneable", e);
+    }
   }
 
   public LongPolling withBrokerLongPollingProperties() {
-    final var copy = clone();
+    final var copy = (LongPolling) clone();
     copy.legacyPropertiesMap = LEGACY_BROKER_PROPERTIES;
     return copy;
   }
 
   public LongPolling withGatewayLongPollingProperties() {
-    final var copy = clone();
+    final var copy = (LongPolling) clone();
     copy.legacyPropertiesMap = LEGACY_GATEWAY_PROPERTIES;
     return copy;
   }

--- a/configuration/src/main/java/io/camunda/configuration/Membership.java
+++ b/configuration/src/main/java/io/camunda/configuration/Membership.java
@@ -12,7 +12,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 
-public class Membership {
+public class Membership implements Cloneable {
   private static final String PREFIX = "camunda.cluster.membership";
 
   private static final Map<String, String> LEGACY_GATEWAY_PROPERTIES =
@@ -214,30 +214,22 @@ public class Membership {
   }
 
   @Override
-  public Membership clone() {
-    final Membership copy = new Membership();
-    copy.broadcastUpdates = broadcastUpdates;
-    copy.broadcastDisputes = broadcastDisputes;
-    copy.notifySuspect = notifySuspect;
-    copy.gossipInterval = gossipInterval;
-    copy.gossipFanout = gossipFanout;
-    copy.probeInterval = probeInterval;
-    copy.probeTimeout = probeTimeout;
-    copy.suspectProbes = suspectProbes;
-    copy.failureTimeout = failureTimeout;
-    copy.syncInterval = syncInterval;
-
-    return copy;
+  public Object clone() {
+    try {
+      return super.clone();
+    } catch (final CloneNotSupportedException e) {
+      throw new AssertionError("Unexpected: Class must implement Cloneable", e);
+    }
   }
 
   public Membership withBrokerMembershipProperties() {
-    final var copy = clone();
+    final var copy = (Membership) clone();
     copy.legacyPropertiesMap = LEGACY_BROKER_PROPERTIES;
     return copy;
   }
 
   public Membership withGatewayMembershipProperties() {
-    final var copy = clone();
+    final var copy = (Membership) clone();
     copy.legacyPropertiesMap = LEGACY_GATEWAY_PROPERTIES;
     return copy;
   }

--- a/configuration/src/main/java/io/camunda/configuration/Network.java
+++ b/configuration/src/main/java/io/camunda/configuration/Network.java
@@ -14,7 +14,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.util.unit.DataSize;
 
 /** Network configuration for cluster communication. */
-public class Network {
+public class Network implements Cloneable {
 
   private static final String PREFIX = "camunda.cluster.network";
 
@@ -212,29 +212,22 @@ public class Network {
   }
 
   @Override
-  public Network clone() {
-    final Network copy = new Network();
-    copy.host = host;
-    copy.advertisedHost = advertisedHost;
-    copy.portOffset = portOffset;
-    copy.maxMessageSize = maxMessageSize;
-    copy.socketSendBuffer = socketSendBuffer;
-    copy.socketReceiveBuffer = socketReceiveBuffer;
-    copy.heartbeatTimeout = heartbeatTimeout;
-    copy.heartbeatInterval = heartbeatInterval;
-    copy.internalApi = internalApi;
-
-    return copy;
+  public Object clone() {
+    try {
+      return super.clone();
+    } catch (final CloneNotSupportedException e) {
+      throw new AssertionError("Unexpected: Class must implement Cloneable", e);
+    }
   }
 
   public Network withBrokerNetworkProperties() {
-    final var copy = clone();
+    final var copy = (Network) clone();
     copy.legacyPropertiesMap = LEGACY_BROKER_NETWORK_PROPERTIES;
     return copy;
   }
 
   public Network withGatewayNetworkProperties() {
-    final var copy = clone();
+    final var copy = (Network) clone();
     copy.legacyPropertiesMap = LEGACY_GATEWAY_NETWORK_PROPERTIES;
     return copy;
   }

--- a/configuration/src/main/java/io/camunda/configuration/Ssl.java
+++ b/configuration/src/main/java/io/camunda/configuration/Ssl.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-public class Ssl {
+public class Ssl implements Cloneable {
   private static final String PREFIX = "camunda.api.grpc.ssl";
   private static final Map<String, String> LEGACY_GATEWAY_SSL_PROPERTIES =
       Map.of(
@@ -93,24 +93,22 @@ public class Ssl {
   }
 
   @Override
-  public Ssl clone() {
-    final Ssl copy = new Ssl();
-    copy.enabled = enabled;
-    copy.certificate = certificate;
-    copy.certificatePrivateKey = certificatePrivateKey;
-    copy.keyStore = keyStore.clone();
-
-    return copy;
+  public Object clone() {
+    try {
+      return super.clone();
+    } catch (final CloneNotSupportedException e) {
+      throw new AssertionError("Unexpected: Class must implement Cloneable", e);
+    }
   }
 
   public Ssl withBrokerSslProperties() {
-    final var copy = clone();
+    final var copy = (Ssl) clone();
     copy.legacyPropertiesMap = LEGACY_BROKER_SSL_PROPERTIES;
     return copy;
   }
 
   public Ssl withGatewaySslProperties() {
-    final var copy = clone();
+    final var copy = (Ssl) clone();
     copy.legacyPropertiesMap = LEGACY_GATEWAY_SSL_PROPERTIES;
     return copy;
   }


### PR DESCRIPTION
## Description

This PR refactors the clone methods of the Unified Configuration classes by using Cloneable instead of cloning field by field.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

#39405 
