### PR TITLE
feat: use element instances incidents to show incidents for elements 

### DIFF
--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.tsx
@@ -15,6 +15,7 @@ import {useIncidentsElements} from 'modules/hooks/incidents';
 import {IS_INCIDENTS_PANEL_V2} from 'modules/feature-flags';
 import {useProcessInstanceIncidentsErrorTypes} from 'modules/queries/incidents/useGetIncidentsByProcessInstance';
 import {getIncidentErrorName} from 'modules/utils/incidents';
+import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
 
 type Props = {
   processInstanceKey: string;
@@ -94,11 +95,6 @@ const IncidentsFilter: React.FC<Props> = observer(({processInstanceKey}) => {
 });
 
 const IncidentsFilterV2: React.FC<Props> = observer(({processInstanceKey}) => {
-  const {
-    setErrorTypeSelection,
-    clearSelection,
-    state: {selectedErrorTypes},
-  } = incidentsStore;
   const availableErrorTypes =
     useProcessInstanceIncidentsErrorTypes(processInstanceKey);
 
@@ -110,24 +106,25 @@ const IncidentsFilterV2: React.FC<Props> = observer(({processInstanceKey}) => {
             id="incidents-by-errorType"
             data-testid="incidents-by-errorType"
             items={availableErrorTypes}
+            selectedItems={incidentsPanelStore.state.selectedErrorTypes}
             itemToString={(selectedItem) => getIncidentErrorName(selectedItem)}
             label="Filter by Incident Type"
             titleText="Filter by Incident Type"
             hideLabel
             onChange={({selectedItems}) => {
-              setErrorTypeSelection(selectedItems);
+              incidentsPanelStore.setErrorTypeSelection(selectedItems);
             }}
             size="sm"
           />
           <Button
             kind="ghost"
             onClick={() => {
-              clearSelection();
+              incidentsPanelStore.clearSelection();
               tracking.track({
                 eventName: 'incident-filters-cleared',
               });
             }}
-            disabled={selectedErrorTypes.length === 0}
+            disabled={!incidentsPanelStore.hasActiveFilters}
             title="Reset Filters"
             size="sm"
           >

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/index.tsx
@@ -152,8 +152,8 @@ const IncidentsWrapperContent: React.FC<IncidentsWrapperContentProps> =
 
     const headerTitle =
       selectedElementInstance !== null
-        ? `Incidents View for Element "${selectedElementInstance.elementName}"`
-        : 'Incidents View';
+        ? `Incidents - Filtered by "${selectedElementInstance.elementName}"`
+        : 'Incidents';
 
     return (
       <Transition

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/index.tsx
@@ -19,12 +19,18 @@ import {
   getFilteredIncidentsV2,
   init,
 } from 'modules/utils/incidents';
-import {useIncidents, useIncidentsV2} from 'modules/hooks/incidents';
-import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
+import {useIncidents, useEnhancedIncidents} from 'modules/hooks/incidents';
+import {
+  type Incident,
+  type ProcessInstance,
+} from '@camunda/camunda-api-zod-schemas/8.8';
 import {useEffect} from 'react';
 import {IS_INCIDENTS_PANEL_V2} from 'modules/feature-flags';
 import {isInstanceRunning} from 'modules/utils/instance';
 import {modificationsStore} from 'modules/stores/modifications';
+import {useGetIncidentsByProcessInstance} from 'modules/queries/incidents/useGetIncidentsByProcessInstance';
+import {useGetIncidentsByElementInstance} from 'modules/queries/incidents/useGetIncidentsByElementInstance';
+import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
 
 type Props = {
   processInstance: ProcessInstance;
@@ -91,48 +97,131 @@ const IncidentsWrapper: React.FC<Props> = observer(
 
 const IncidentsWrapperV2: React.FC<Props> = observer(
   ({setIsInTransition, processInstance}) => {
-    const incidents = useIncidentsV2(processInstance.processInstanceKey, {
-      enablePeriodicRefetch:
-        isInstanceRunning(processInstance) &&
-        !modificationsStore.isModificationModeEnabled,
-    });
-    const filteredIncidents = getFilteredIncidentsV2(incidents);
+    const enablePeriodicRefetch =
+      isInstanceRunning(processInstance) &&
+      !modificationsStore.isModificationModeEnabled;
+    const selectedElementInstance =
+      incidentsPanelStore.state.selectedElementInstance;
 
-    if (incidents.length === 0) {
-      return null;
+    if (selectedElementInstance !== null) {
+      return (
+        <IncidentsByElementInstance
+          elementInstanceKey={selectedElementInstance.elementInstanceKey}
+          enablePeriodicRefetch={enablePeriodicRefetch}
+        >
+          {(incidents) => (
+            <IncidentsWrapperContent
+              incidents={incidents}
+              processInstanceKey={processInstance.processInstanceKey}
+              setIsInTransition={setIsInTransition}
+            />
+          )}
+        </IncidentsByElementInstance>
+      );
     }
 
     return (
-      <>
-        <Transition
-          in={incidentsStore.state.isIncidentBarOpen}
-          onEnter={() => setIsInTransition(true)}
-          onEntered={() => setIsInTransition(false)}
-          onExit={() => setIsInTransition(true)}
-          onExited={() => setIsInTransition(false)}
-          mountOnEnter
-          unmountOnExit
-          timeout={400}
-        >
-          <IncidentsOverlay>
-            <PanelHeader
-              title="Incidents View"
-              count={filteredIncidents.length}
-              size="sm"
-            >
-              <IncidentsFilter
-                processInstanceKey={processInstance.processInstanceKey}
-              />
-            </PanelHeader>
-            <IncidentsTableV2
-              processInstanceKey={processInstance.processInstanceKey}
-              incidents={filteredIncidents}
-            />
-          </IncidentsOverlay>
-        </Transition>
-      </>
+      <IncidentsByProcessInstance
+        processInstanceKey={processInstance.processInstanceKey}
+        enablePeriodicRefetch={enablePeriodicRefetch}
+      >
+        {(incidents) => (
+          <IncidentsWrapperContent
+            incidents={incidents}
+            processInstanceKey={processInstance.processInstanceKey}
+            setIsInTransition={setIsInTransition}
+          />
+        )}
+      </IncidentsByProcessInstance>
     );
   },
 );
+
+type IncidentsWrapperContentProps = {
+  incidents: Incident[];
+  processInstanceKey: string;
+  setIsInTransition: Props['setIsInTransition'];
+};
+
+const IncidentsWrapperContent: React.FC<IncidentsWrapperContentProps> =
+  observer((props) => {
+    const enhancedIncidents = useEnhancedIncidents(props.incidents ?? []);
+    const filteredIncidents = getFilteredIncidentsV2(enhancedIncidents);
+    const selectedElementInstance =
+      incidentsPanelStore.state.selectedElementInstance;
+
+    const headerTitle =
+      selectedElementInstance !== null
+        ? `Incidents View for Element "${selectedElementInstance.elementName}"`
+        : 'Incidents View';
+
+    return (
+      <Transition
+        in={incidentsPanelStore.state.isPanelVisible}
+        onEnter={() => props.setIsInTransition(true)}
+        onEntered={() => props.setIsInTransition(false)}
+        onExit={() => props.setIsInTransition(true)}
+        onExited={() => props.setIsInTransition(false)}
+        mountOnEnter
+        unmountOnExit
+        timeout={400}
+      >
+        <IncidentsOverlay>
+          <PanelHeader
+            title={headerTitle}
+            count={filteredIncidents.length}
+            size="sm"
+          >
+            <IncidentsFilter processInstanceKey={props.processInstanceKey} />
+          </PanelHeader>
+          <IncidentsTableV2
+            processInstanceKey={props.processInstanceKey}
+            incidents={filteredIncidents}
+          />
+        </IncidentsOverlay>
+      </Transition>
+    );
+  });
+
+type IncidentsSourceProps<Source> = Source & {
+  enablePeriodicRefetch: boolean;
+  children: (incidents: Incident[]) => React.ReactNode;
+};
+
+const IncidentsByProcessInstance: React.FC<
+  IncidentsSourceProps<{processInstanceKey: string}>
+> = (props) => {
+  const {data: incidents} = useGetIncidentsByProcessInstance(
+    props.processInstanceKey,
+    {
+      enablePeriodicRefetch: props.enablePeriodicRefetch,
+      select: (res) => res.items,
+    },
+  );
+
+  if (!incidents || incidents.length === 0) {
+    return null;
+  }
+
+  return props.children(incidents);
+};
+
+const IncidentsByElementInstance: React.FC<
+  IncidentsSourceProps<{elementInstanceKey: string}>
+> = (props) => {
+  const {data: incidents} = useGetIncidentsByElementInstance(
+    props.elementInstanceKey,
+    {
+      enablePeriodicRefetch: props.enablePeriodicRefetch,
+      select: (res) => res.items,
+    },
+  );
+
+  if (!incidents || incidents.length === 0) {
+    return null;
+  }
+
+  return props.children(incidents);
+};
 
 export {IncidentsWrapper, IncidentsWrapperV2};

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
@@ -34,6 +34,8 @@ import {useJobs} from 'modules/queries/jobs/useJobs';
 import {useSearchMessageSubscriptions} from 'modules/queries/messageSubscriptions/useSearchMessageSubscriptions';
 import {useDecisionInstancesSearch} from 'modules/queries/decisionInstances/useDecisionInstancesSearch';
 import {useDecisionDefinition} from 'modules/queries/decisionDefinitions/useDecisionDefinition';
+import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
+import {IS_INCIDENTS_PANEL_V2} from 'modules/feature-flags';
 
 type Props = {
   selectedFlowNodeRef?: SVGGraphicsElement | null;
@@ -308,6 +310,12 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
               incidentV2={singleIncident}
               incident={incident}
               onButtonClick={() => {
+                if (IS_INCIDENTS_PANEL_V2 && elementInstanceMetadata) {
+                  return incidentsPanelStore.showIncidentsForElementInstance(
+                    elementInstanceMetadata.elementInstanceKey,
+                    elementInstanceMetadata.elementName,
+                  );
+                }
                 incidentsStore.clearSelection();
                 incidentsStore.toggleFlowNodeSelection(elementId);
                 incidentsStore.toggleErrorTypeSelection(
@@ -324,6 +332,12 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
             <MultiIncidents
               count={elementInstancesIncidentsSearchResult?.length}
               onButtonClick={() => {
+                if (IS_INCIDENTS_PANEL_V2 && elementInstanceMetadata) {
+                  return incidentsPanelStore.showIncidentsForElementInstance(
+                    elementInstanceMetadata.elementInstanceKey,
+                    elementInstanceMetadata.elementName,
+                  );
+                }
                 incidentsStore.clearSelection();
                 incidentsStore.toggleFlowNodeSelection(elementId);
                 incidentsStore.setIncidentBarOpen(true);

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -72,6 +72,7 @@ import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
 import {isRequestError} from 'modules/request';
 import {useProcessInstanceIncidentsCount} from 'modules/queries/incidents/useGetIncidentsByProcessInstance';
 import {IS_INCIDENTS_PANEL_V2} from 'modules/feature-flags';
+import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
 
 const OVERLAY_TYPE_STATE = 'flowNodeState';
 const OVERLAY_TYPE_MODIFICATIONS_BADGE = 'modificationsBadge';
@@ -234,11 +235,9 @@ const TopPanel: React.FC = observer(() => {
   const incidentsCount = IS_INCIDENTS_PANEL_V2
     ? useProcessInstanceIncidentsCount(processInstanceId)
     : incidentsStore.incidentsCount;
-
-  const {
-    setIncidentBarOpen,
-    state: {isIncidentBarOpen},
-  } = incidentsStore;
+  const isIncidentBarOpen = IS_INCIDENTS_PANEL_V2
+    ? incidentsPanelStore.state.isPanelVisible
+    : incidentsStore.state.isIncidentBarOpen;
 
   const {isModificationModeEnabled} = modificationsStore;
 
@@ -289,9 +288,13 @@ const TopPanel: React.FC = observer(() => {
                 : 'incidents-panel-opened',
             });
 
-            setIncidentBarOpen(!isIncidentBarOpen);
+            if (IS_INCIDENTS_PANEL_V2) {
+              incidentsPanelStore.setPanelOpen(!isIncidentBarOpen);
+            } else {
+              incidentsStore.setIncidentBarOpen(!isIncidentBarOpen);
+            }
           }}
-          isOpen={incidentsStore.state.isIncidentBarOpen}
+          isOpen={isIncidentBarOpen}
         />
       )}
       {modificationsStore.state.status === 'moving-token' &&

--- a/operate/client/src/modules/stores/incidentsPanel.ts
+++ b/operate/client/src/modules/stores/incidentsPanel.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {IncidentErrorType} from '@camunda/camunda-api-zod-schemas/8.8';
+import {makeAutoObservable} from 'mobx';
+import {tracking} from 'modules/tracking';
+
+type State = {
+  selectedElementInstance: {
+    elementInstanceKey: string;
+    elementName: string;
+  } | null;
+  selectedErrorTypes: IncidentErrorType[];
+  isPanelVisible: boolean;
+};
+
+const DEFAULT_STATE: State = {
+  selectedElementInstance: null,
+  selectedErrorTypes: [],
+  isPanelVisible: false,
+};
+
+class IncidentsPanel {
+  state: State = {...DEFAULT_STATE};
+
+  constructor() {
+    makeAutoObservable(this);
+  }
+
+  get hasActiveFilters(): boolean {
+    return (
+      this.state.selectedElementInstance !== null ||
+      this.state.selectedErrorTypes.length > 0
+    );
+  }
+
+  showIncidentsForElementInstance(
+    elementInstanceKey: string,
+    elementName: string,
+  ) {
+    this.clearSelection();
+    this.state.selectedElementInstance = {elementInstanceKey, elementName};
+    this.setPanelOpen(true);
+  }
+
+  setPanelOpen(isOpen: boolean) {
+    this.state.isPanelVisible = isOpen;
+
+    if (isOpen) {
+      tracking.track({
+        eventName: 'flow-node-incident-details-opened',
+      });
+    }
+  }
+
+  setErrorTypeSelection(errorTypes: IncidentErrorType[]) {
+    this.state.selectedErrorTypes = errorTypes;
+  }
+
+  clearSelection() {
+    this.state.selectedElementInstance = null;
+    this.state.selectedErrorTypes = [];
+  }
+}
+
+export const incidentsPanelStore = new IncidentsPanel();

--- a/operate/client/src/modules/utils/incidents.ts
+++ b/operate/client/src/modules/utils/incidents.ts
@@ -14,6 +14,7 @@ import {autorun} from 'mobx';
 import {incidentsStore, type Incident} from 'modules/stores/incidents';
 import {isInstanceRunning} from './instance';
 import type {EnhancedIncident} from 'modules/hooks/incidents';
+import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
 
 const ERROR_TYPE_NAMES: Record<IncidentErrorType, string> = {
   UNSPECIFIED: 'Unspecified',
@@ -127,29 +128,14 @@ const isSingleIncidentSelectedV2 = (
 };
 
 const getFilteredIncidentsV2 = (incidents: EnhancedIncident[]) => {
-  const {selectedFlowNodes, selectedErrorTypes} = incidentsStore.state;
+  const {selectedErrorTypes} = incidentsPanelStore.state;
 
-  const hasSelectedFlowNodes = selectedFlowNodes.length > 0;
-  const hasSelectedErrorTypes = selectedErrorTypes.length > 0;
-
-  if (!hasSelectedFlowNodes && !hasSelectedErrorTypes) {
+  if (selectedErrorTypes.length === 0) {
     return incidents;
   }
 
   return incidents.filter((incident) => {
-    if (hasSelectedErrorTypes && hasSelectedFlowNodes) {
-      return (
-        selectedErrorTypes.includes(incident.errorType) &&
-        selectedFlowNodes.includes(incident.elementId)
-      );
-    }
-    if (hasSelectedErrorTypes) {
-      return selectedErrorTypes.includes(incident.errorType);
-    }
-    if (hasSelectedFlowNodes) {
-      return selectedFlowNodes.includes(incident.elementId);
-    }
-    return [];
+    return selectedErrorTypes.includes(incident.errorType);
   });
 };
 


### PR DESCRIPTION
## Description

Uses the new element instances incidents search endpoint to show incidents after a user selects "show incidents" in the metadata popover.

To achieve this, the incidents metadata popover has to toggle it's data source between two React query hooks. Since we are talking about React, the best "legal" approach is rendering different components. It would be more elegant and straightforward to conditionally switch between the query hooks. But while the rendered hooks length won't change (no runtime error), it will probably introduce subtle problems with Reacts internal hook<=>components implementation.

Furthermore, the UI state for the incidents panel v2 has been moved into a separate `incidentsPanelStore`. Once we remove the v1 implementation, it will make easier to "just" remove the `incidentsStore` to detect most "old" code.

## Checklist

- [x] ~The approach for displaying "incidents are scoped to an element instance" has need been approved by a designer yet. See: https://github.com/camunda/camunda/issues/39591#issuecomment-3421460457~
- [x] Notice that this PR is stacked on #39588.

## Related issues

closes #39591
