### PR TITLE
refactor: rename exporter to exporting config

### DIFF
--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -32,7 +32,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
@@ -238,7 +238,7 @@ final class ClusterApiUtilsTest {
   private static ClusterConfiguration getConfigWithTwoPartitions(final State exporterState) {
     final DynamicPartitionConfig partitionConfig =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of(
                     "exporter-1",
                     new ExporterState(0, exporterState, Optional.empty()),
@@ -264,7 +264,7 @@ final class ClusterApiUtilsTest {
   }
 
   private static MemberState updateExporterState(
-      final MemberState m, final UnaryOperator<ExportersConfig> exporterUpdater) {
+      final MemberState m, final UnaryOperator<ExportingConfig> exporterUpdater) {
     return m.updatePartition(1, p -> p.updateConfig(c -> c.updateExporting(exporterUpdater)));
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.dynamic.config.StaticConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import java.util.HashMap;
 import java.util.List;
@@ -108,6 +108,6 @@ public final class StaticConfigurationGenerator {
         .forEach(
             (exporterId, ignore) ->
                 exporters.put(exporterId, new ExporterState(0, State.ENABLED, Optional.empty())));
-    return new DynamicPartitionConfig(new ExportersConfig(Map.copyOf(exporters)));
+    return new DynamicPartitionConfig(new ExportingConfig(Map.copyOf(exporters)));
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/PartitionConfigurationManagerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/PartitionConfigurationManagerTest.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.broker.exporter.util.TestExporterFactory;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
@@ -50,7 +50,7 @@ final class PartitionConfigurationManagerTest {
     private final String exporterId = "exporterA";
     private final DynamicPartitionConfig partitionConfig =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of(exporterId, new ExporterState(0, State.ENABLED, Optional.empty()))));
 
     @BeforeEach
@@ -132,7 +132,7 @@ final class PartitionConfigurationManagerTest {
     private final String exporterId = "exporterA";
     private final DynamicPartitionConfig partitionConfig =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of(
                     exporterId, new ExporterState(0, State.CONFIG_NOT_FOUND, Optional.empty()))));
 
@@ -213,7 +213,7 @@ final class PartitionConfigurationManagerTest {
     private final String exporterWithSameCustomExporterFactory = "exporterWithFactoryB";
     private final DynamicPartitionConfig partitionConfig =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of(
                     validExporterToInitialize,
                     new ExporterState(0, State.ENABLED, Optional.empty()))));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -30,7 +30,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionT
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
@@ -237,7 +237,7 @@ class ExporterDirectorPartitionTransitionStepTest {
     // new config removes expB entirely
     final var updatedConfig =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of(enabledExporterId, new ExporterState(0, State.ENABLED, Optional.empty()))));
     transitionContext.setDynamicPartitionConfig(updatedConfig);
     startingFuture.complete(null);
@@ -312,7 +312,7 @@ class ExporterDirectorPartitionTransitionStepTest {
       final String exporterTwo,
       final State exporterTwoState) {
     return new DynamicPartitionConfig(
-        new ExportersConfig(
+        new ExportingConfig(
             Map.of(
                 exporterOne,
                 new ExporterState(0, exporterOneState, Optional.empty()),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -111,11 +111,11 @@ public class ExporterStateInitializer implements ClusterConfigurationModifier {
         .updateConfig(c -> c.updateExporting(e -> e.addExporters(newlyAddedExporters)));
   }
 
-  private ExportersConfig reEnableExporters(
-      final ExportersConfig exportersConfig,
+  private ExportingConfig reEnableExporters(
+      final ExportingConfig exportingConfig,
       final List<Entry<String, ExporterState>> configReaddedExporters) {
 
-    ExportersConfig updating = exportersConfig;
+    ExportingConfig updating = exportingConfig;
     for (final var entry : configReaddedExporters) {
       final var exporterName = entry.getKey();
       final var exporterState = entry.getValue();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -57,7 +57,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
@@ -229,8 +229,8 @@ public class ProtoBufSerializer
     return new DynamicPartitionConfig(decodeExportingConfig(config.getExporting()));
   }
 
-  private ExportersConfig decodeExportingConfig(final Topology.ExportersConfig exporting) {
-    return new ExportersConfig(
+  private ExportingConfig decodeExportingConfig(final Topology.ExportingConfig exporting) {
+    return new ExportingConfig(
         exporting.getExportersMap().entrySet().stream()
             .map(e -> Map.entry(e.getKey(), decodeExporterState(e.getValue())))
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
@@ -292,8 +292,8 @@ public class ProtoBufSerializer
         .build();
   }
 
-  private Topology.ExportersConfig encodeExportingConfig(final ExportersConfig exporting) {
-    return Topology.ExportersConfig.newBuilder()
+  private Topology.ExportingConfig encodeExportingConfig(final ExportingConfig exporting) {
+    return Topology.ExportingConfig.newBuilder()
         .putAllExporters(
             exporting.exporters().entrySet().stream()
                 .map(e -> Map.entry(e.getKey(), encodeExporterState(e.getValue())))

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.dynamic.config.state;
 import java.util.function.UnaryOperator;
 
 /** Represents configuration of a partition that can be updated during runtime. */
-public record DynamicPartitionConfig(ExportersConfig exporting) {
+public record DynamicPartitionConfig(ExportingConfig exporting) {
 
   public static DynamicPartitionConfig uninitialized() {
     // This is temporary until we have a way to initialize this during bootstrap or first update to
@@ -22,19 +22,19 @@ public record DynamicPartitionConfig(ExportersConfig exporting) {
   public static DynamicPartitionConfig init() {
     // This is temporary until we have a way to initialize this during bootstrap or first update to
     // the version that added this
-    return new DynamicPartitionConfig(ExportersConfig.empty());
+    return new DynamicPartitionConfig(ExportingConfig.empty());
   }
 
   public boolean isInitialized() {
     return exporting != null;
   }
 
-  public DynamicPartitionConfig updateExporting(final ExportersConfig exporter) {
-    return new DynamicPartitionConfig(exporter);
+  public DynamicPartitionConfig updateExporting(final ExportingConfig exporting) {
+    return new DynamicPartitionConfig(exporting);
   }
 
   public DynamicPartitionConfig updateExporting(
-      final UnaryOperator<ExportersConfig> exporterUpdater) {
-    return new DynamicPartitionConfig(exporterUpdater.apply(exporting));
+      final UnaryOperator<ExportingConfig> exportingUpdater) {
+    return new DynamicPartitionConfig(exportingUpdater.apply(exporting));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
@@ -18,23 +18,23 @@ import java.util.Optional;
  *
  * @param exporters the state of each exporter in this partition
  */
-public record ExportersConfig(Map<String, ExporterState> exporters) {
+public record ExportingConfig(Map<String, ExporterState> exporters) {
 
-  public static ExportersConfig empty() {
-    return new ExportersConfig(Map.of());
+  public static ExportingConfig empty() {
+    return new ExportingConfig(Map.of());
   }
 
-  private ExportersConfig updateExporter(
+  private ExportingConfig updateExporter(
       final String exporterName, final ExporterState exporterState) {
     final var newExporters =
         ImmutableMap.<String, ExporterState>builder()
             .putAll(exporters)
             .put(exporterName, exporterState)
             .buildKeepingLast(); // choose last one if there are duplicate keys
-    return new ExportersConfig(newExporters);
+    return new ExportingConfig(newExporters);
   }
 
-  public ExportersConfig disableExporter(final String exporterName) {
+  public ExportingConfig disableExporter(final String exporterName) {
     return updateExporter(
         exporterName,
         new ExporterState(
@@ -43,15 +43,15 @@ public record ExportersConfig(Map<String, ExporterState> exporters) {
             Optional.empty()));
   }
 
-  public ExportersConfig deleteExporter(final String exporterName) {
+  public ExportingConfig deleteExporter(final String exporterName) {
     final var newExporters =
         exporters.entrySet().stream()
             .filter(entry -> !entry.getKey().equals(exporterName))
             .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
-    return new ExportersConfig(newExporters);
+    return new ExportingConfig(newExporters);
   }
 
-  public ExportersConfig disableExporters(final Collection<String> exporterNames) {
+  public ExportingConfig disableExporters(final Collection<String> exporterNames) {
     final var builder = ImmutableMap.<String, ExporterState>builder().putAll(exporters);
 
     exporterNames.forEach(
@@ -65,21 +65,21 @@ public record ExportersConfig(Map<String, ExporterState> exporters) {
 
     final var newExporters =
         builder.buildKeepingLast(); // choose last one if there are duplicate keys
-    return new ExportersConfig(newExporters);
+    return new ExportingConfig(newExporters);
   }
 
-  public ExportersConfig enableExporter(final String exporterName, final long metadataVersion) {
+  public ExportingConfig enableExporter(final String exporterName, final long metadataVersion) {
     return enableExporter(exporterName, null, metadataVersion);
   }
 
-  public ExportersConfig enableExporter(
+  public ExportingConfig enableExporter(
       final String exporterName, final String initializeFrom, final long metadataVersion) {
     return updateExporter(
         exporterName,
         new ExporterState(metadataVersion, State.ENABLED, Optional.ofNullable(initializeFrom)));
   }
 
-  public ExportersConfig addExporters(final Collection<String> exporterNames) {
+  public ExportingConfig addExporters(final Collection<String> exporterNames) {
     exporterNames.forEach(
         exporterName -> {
           if (exporters.containsKey(exporterName)) {
@@ -96,16 +96,16 @@ public record ExportersConfig(Map<String, ExporterState> exporters) {
 
     final var newExporters =
         builder.buildKeepingLast(); // choose last one if there are duplicate keys
-    return new ExportersConfig(newExporters);
+    return new ExportingConfig(newExporters);
   }
 
   /**
    * Updates existing exporters to state {@link ExporterState.State#CONFIG_NOT_FOUND}.
    *
    * @param exporterNames the names of exporters for which the state should be updated
-   * @return a new {@link ExportersConfig} with the updated state for the specified exporters
+   * @return a new {@link ExportingConfig} with the updated state for the specified exporters
    */
-  public ExportersConfig withConfigNotFoundFor(final Collection<String> exporterNames) {
+  public ExportingConfig withConfigNotFoundFor(final Collection<String> exporterNames) {
     final var builder = ImmutableMap.<String, ExporterState>builder().putAll(exporters);
 
     exporterNames.forEach(
@@ -119,6 +119,6 @@ public record ExportersConfig(Map<String, ExporterState> exporters) {
 
     final var newExporters =
         builder.buildKeepingLast(); // choose last one if there are duplicate keys
-    return new ExportersConfig(newExporters);
+    return new ExportingConfig(newExporters);
   }
 }

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -56,9 +56,9 @@ message PartitionState {
   PartitionConfig config = 3;
 }
 
-message PartitionConfig { ExportersConfig exporting = 1; }
+message PartitionConfig { ExportingConfig exporting = 1; }
 
-message ExportersConfig { map<string, ExporterState> exporters = 1; }
+message ExportingConfig { map<string, ExporterState> exporters = 1; }
 
 message ExporterState {
   ExporterStateEnum state = 1;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -46,7 +46,7 @@ final class ClusterConfigurationModifierTest {
                     Map.of(
                         1,
                         PartitionState.active(
-                            1, new DynamicPartitionConfig(new ExportersConfig(Map.of()))))));
+                            1, new DynamicPartitionConfig(new ExportingConfig(Map.of()))))));
 
     @Test
     void shouldInitializeRoutingStateIfPartitionScalingIsEnabled() {
@@ -110,7 +110,7 @@ final class ClusterConfigurationModifierTest {
 
       final var expectedConfig =
           new DynamicPartitionConfig(
-              new ExportersConfig(
+              new ExportingConfig(
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -156,7 +156,7 @@ final class ClusterConfigurationModifierTest {
     private static Arguments exporterAddedAndRemoved() {
       final var expectedConfig =
           new DynamicPartitionConfig(
-              new ExportersConfig(
+              new ExportingConfig(
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -179,7 +179,7 @@ final class ClusterConfigurationModifierTest {
     private static Arguments enabledExporterRemoved() {
       final var expectedConfig =
           new DynamicPartitionConfig(
-              new ExportersConfig(
+              new ExportingConfig(
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -195,7 +195,7 @@ final class ClusterConfigurationModifierTest {
     private static Arguments exporterAdded() {
       final var expectedConfig =
           new DynamicPartitionConfig(
-              new ExportersConfig(
+              new ExportingConfig(
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -217,7 +217,7 @@ final class ClusterConfigurationModifierTest {
     private static Arguments exporterReadded() {
       final var initialConfig =
           new DynamicPartitionConfig(
-              new ExportersConfig(
+              new ExportingConfig(
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -237,7 +237,7 @@ final class ClusterConfigurationModifierTest {
 
       final var expectedConfig =
           new DynamicPartitionConfig(
-              new ExportersConfig(
+              new ExportingConfig(
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -253,7 +253,7 @@ final class ClusterConfigurationModifierTest {
     private static Arguments disabledExporterConfigRemoved() {
       final var initialConfig =
           new DynamicPartitionConfig(
-              new ExportersConfig(
+              new ExportingConfig(
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -281,7 +281,7 @@ final class ClusterConfigurationModifierTest {
     private static ClusterConfiguration withTwoEnabledExporters() {
       final DynamicPartitionConfig config =
           new DynamicPartitionConfig(
-              new ExportersConfig(
+              new ExportingConfig(
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -40,7 +40,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
@@ -441,7 +441,7 @@ final class ClusterConfigurationManagementApiTest {
         new ClusterConfigurationManagementRequest.ExporterDisableRequest(exporterId, false);
     final var partitionConfigWithExporter =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var configurationWithExporter =
         initialTopology.updateMember(
@@ -464,7 +464,7 @@ final class ClusterConfigurationManagementApiTest {
         new ClusterConfigurationManagementRequest.ExporterDeleteRequest(exporterId, false);
     final var partitionConfigWithExporter =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var configurationWithExporter =
         initialTopology.updateMember(
@@ -488,7 +488,7 @@ final class ClusterConfigurationManagementApiTest {
             exporterId, Optional.empty(), false);
     final var partitionConfigWithExporter =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of(exporterId, new ExporterState(1, State.DISABLED, Optional.empty()))));
     final var configurationWithExporter =
         initialTopology.updateMember(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import java.util.Map;
@@ -123,13 +123,13 @@ final class ClusterPurgeRequestTransformerTest {
   void shouldCreateBootstrapOperationWithExporterConfig() {
     // given
     final var transformer = new PurgeRequestTransformer();
-    final ExportersConfig exportersConfig =
-        new ExportersConfig(
+    final ExportingConfig exportingConfig =
+        new ExportingConfig(
             Map.of(
                 "exporter",
                 new ExporterState(1, ExporterState.State.ENABLED, Optional.of("config"))));
     final var partitionConfigWithExporter =
-        DynamicPartitionConfig.init().updateExporting(exportersConfig);
+        DynamicPartitionConfig.init().updateExporting(exportingConfig);
 
     final ClusterConfiguration currentTopology =
         ClusterConfiguration.init()
@@ -160,14 +160,14 @@ final class ClusterPurgeRequestTransformerTest {
     final DynamicPartitionConfig config0 =
         DynamicPartitionConfig.init()
             .updateExporting(
-                new ExportersConfig(
+                new ExportingConfig(
                     Map.of(
                         "exporter",
                         new ExporterState(1, ExporterState.State.ENABLED, Optional.of("config")))));
     final DynamicPartitionConfig config1 =
         DynamicPartitionConfig.init()
             .updateExporting(
-                new ExportersConfig(
+                new ExportingConfig(
                     Map.of(
                         "exporter", new ExporterState(1, State.DISABLED, Optional.of("config")))));
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformerTest.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -30,7 +30,7 @@ final class ExporterDeleteRequestTransformerTest {
   private final MemberId id1 = MemberId.from("1");
   private final DynamicPartitionConfig config =
       new DynamicPartitionConfig(
-          new ExportersConfig(
+          new ExportingConfig(
               Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -30,7 +30,7 @@ final class ExporterDisableRequestTransformerTest {
   private final MemberId id1 = MemberId.from("1");
   private final DynamicPartitionConfig config =
       new DynamicPartitionConfig(
-          new ExportersConfig(
+          new ExportingConfig(
               Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformerTest.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -30,7 +30,7 @@ final class ExporterEnableRequestTransformerTest {
   private final MemberId id1 = MemberId.from("1");
   private final DynamicPartitionConfig config =
       new DynamicPartitionConfig(
-          new ExportersConfig(
+          new ExportingConfig(
               Map.of(exporterId, new ExporterState(1, State.DISABLED, Optional.empty()))));
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/DeleteHistoryApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/DeleteHistoryApplierTest.java
@@ -11,7 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationAssert;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -57,7 +57,7 @@ public class DeleteHistoryApplierTest {
                     m.addPartition(
                         partitionId,
                         PartitionState.active(
-                            1, new DynamicPartitionConfig(new ExportersConfig(Map.of())))));
+                            1, new DynamicPartitionConfig(new ExportingConfig(Map.of())))));
     // when
     final var result = deleteHistoryApplier.init(clusterConfigWithPartition);
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplierTest.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
@@ -167,7 +167,7 @@ final class PartitionBootstrapApplierTest {
       final DynamicPartitionConfig partitionConfig =
           DynamicPartitionConfig.init()
               .updateExporting(
-                  new ExportersConfig(
+                  new ExportingConfig(
                       Map.of(
                           "exporter",
                           new ExporterState(
@@ -202,7 +202,7 @@ final class PartitionBootstrapApplierTest {
       final DynamicPartitionConfig nonEmptyPartitionConfig =
           DynamicPartitionConfig.init()
               .updateExporting(
-                  new ExportersConfig(
+                  new ExportingConfig(
                       Map.of(
                           "exporter",
                           new ExporterState(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplierTest.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -97,7 +97,7 @@ final class PartitionDeleteExporterApplierTest {
     // given
     final var configWithExporter =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var clusterConfiguration =
         ClusterConfiguration.init()
@@ -122,7 +122,7 @@ final class PartitionDeleteExporterApplierTest {
     // given
     final var configWithExporter =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of(
                     exporterId, new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty()))));
     final var clusterConfiguration =
@@ -162,7 +162,7 @@ final class PartitionDeleteExporterApplierTest {
   void shouldCompleteFutureAndUpdateStateIfApplySucceeds() {
     // given
     final var exporterState = new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty());
-    final var exporterConfig = new ExportersConfig(Map.of(exporterId, exporterState));
+    final var exporterConfig = new ExportingConfig(Map.of(exporterId, exporterState));
     final var partitionConfig = new DynamicPartitionConfig(exporterConfig);
     final var memberState =
         MemberState.initializeAsActive(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplierTest.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -97,7 +97,7 @@ final class PartitionDisableExporterApplierTest {
     // given
     final var configWithExporter =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var clusterConfiguration =
         ClusterConfiguration.init()
@@ -136,7 +136,7 @@ final class PartitionDisableExporterApplierTest {
   void shouldCompleteFutureAndUpdateStateIfApplySucceeds() {
     // given
     final var exporterState = new ExporterState(1, State.ENABLED, Optional.empty());
-    final var exporterConfig = new ExportersConfig(Map.of(exporterId, exporterState));
+    final var exporterConfig = new ExportingConfig(Map.of(exporterId, exporterState));
     final var partitionConfig = new DynamicPartitionConfig(exporterConfig);
     final var memberState =
         MemberState.initializeAsActive(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionEnableExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionEnableExporterApplierTest.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -48,7 +48,7 @@ final class PartitionEnableExporterApplierTest {
                   m.addPartition(
                       partitionId,
                       PartitionState.active(
-                          1, new DynamicPartitionConfig(new ExportersConfig(Map.of())))));
+                          1, new DynamicPartitionConfig(new ExportingConfig(Map.of())))));
 
   @Test
   void shouldRejectWhenMemberDoesNotExist() {
@@ -99,7 +99,7 @@ final class PartitionEnableExporterApplierTest {
     // given
     final var configWithDisabledExporter =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of("other", new ExporterState(0, State.DISABLED, Optional.empty()))));
     final var clusterConfiguration =
         clusterConfigWithPartition.updateMember(
@@ -121,7 +121,7 @@ final class PartitionEnableExporterApplierTest {
     // given
     final var configWithOtherExporter =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of("other", new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var clusterConfiguration =
         ClusterConfiguration.init()
@@ -163,7 +163,7 @@ final class PartitionEnableExporterApplierTest {
 
     final var configWithOtherExporter =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of("other", new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var clusterConfiguration =
         ClusterConfiguration.init()

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplierTest.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.dynamic.config.PartitionStateAssert;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
@@ -223,7 +223,7 @@ final class PartitionJoinApplierTest {
     // given
     final var config =
         new DynamicPartitionConfig(
-            new ExportersConfig(
+            new ExportingConfig(
                 Map.of(
                     "expA",
                     new ExporterState(1, ExporterState.State.ENABLED, Optional.of("expB")))));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -266,7 +266,7 @@ class ClusterConfigurationTest {
     // given
     final String exporterName = "exporter";
     final var exportersConfig =
-        new ExportersConfig(
+        new ExportingConfig(
             Map.of(exporterName, new ExporterState(1, ENABLED, Optional.of("other"))));
     final var config = new DynamicPartitionConfig(exportersConfig);
 
@@ -312,7 +312,7 @@ class ClusterConfigurationTest {
 
     final DynamicPartitionConfig validConfig =
         new DynamicPartitionConfig(
-            new ExportersConfig(Map.of("expA", new ExporterState(1, ENABLED, Optional.empty()))));
+            new ExportingConfig(Map.of("expA", new ExporterState(1, ENABLED, Optional.empty()))));
     final var topologyWithValidConfig =
         new ClusterConfiguration(
             0,

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
@@ -118,13 +118,13 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   }
 
   @Provide
-  Arbitrary<ExportersConfig> exportersConfigs() {
-    return Arbitraries.forType(ExportersConfig.class).enableRecursion();
+  Arbitrary<ExportingConfig> exportersConfigs() {
+    return Arbitraries.forType(ExportingConfig.class).enableRecursion();
   }
 
   @Provide
   Arbitrary<DynamicPartitionConfig> dynamicPartitionConfigs() {
-    return Arbitraries.forType(ExportersConfig.class)
+    return Arbitraries.forType(ExportingConfig.class)
         .enableRecursion()
         .map(DynamicPartitionConfig::new)
         .filter(DynamicPartitionConfig::isInitialized);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.dynamic.config.PartitionStateAssert;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
@@ -31,7 +31,7 @@ class ConfigurationUtilTest {
   private static final String GROUP_NAME = "test";
   private final DynamicPartitionConfig partitionConfig =
       new DynamicPartitionConfig(
-          new ExportersConfig(
+          new ExportingConfig(
               Map.of("expA", new ExporterState(1, ExporterState.State.ENABLED, Optional.empty()))));
 
   @Test


### PR DESCRIPTION
This dynamic config will not just contain the exporters and their state but will also determine whether exporting is paused or not. In some places, we already used the more accurate "exporting", for example in Javadocs and as OpenAPI component name. This renames the Java and Protobuf types.

BREAKING CHANGE: Buf says this change violates the [FIELD_WIRE_COMPATIBLE_TYPE](https://buf.build/docs/breaking/rules/#field_wire_compatible_type) rule but it's too strict: https://github.com/bufbuild/buf/issues/2318

relates to #39743
