### PR TITLE
fix: override partitionId only if it is valid

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
@@ -68,9 +68,25 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
     return key;
   }
 
+  /**
+   * Sets the key for this command request.
+   *
+   * <p>Note: This method also extracts and sets the partitionId from the key if valid. The
+   * partitionId should only be updated when it falls within the valid range, otherwise it remains
+   * unchanged keeping the default value from {@link
+   * ExecuteCommandRequestEncoder#partitionIdNullValue()} and will be handled by {@link
+   * io.camunda.zeebe.broker.client.impl.BrokerRequestManager}.
+   *
+   * @param key the key to set
+   * @return this request instance for method chaining
+   */
   public ExecuteCommandRequest setKey(final long key) {
     this.key = key;
-    partitionId = Protocol.decodePartitionId(key);
+    final int decodedPartitionId = Protocol.decodePartitionId(key);
+    if (decodedPartitionId >= Protocol.START_PARTITION_ID
+        && decodedPartitionId <= Protocol.MAXIMUM_PARTITIONS) {
+      this.partitionId = decodedPartitionId;
+    }
 
     return this;
   }


### PR DESCRIPTION
## Description

Issue reported from `/v2/jobs/:jobKey/completion` endpoint, though issue exists in all `ExecuteCommandRequest` related classes, specifically when `setKey` method is called.
`:jobKey` does not have any validation yet, so it is up to the client to place a proper key

If not valid `:jobKey` is placed on request .e.g. 0, `partitionId` ends up taking wrong value = 0, overriding initial `partitionIdNullValue()` = 65535 .
Error thrown is 503 `PartitionNotFoundException`, while job with key 404 `NOT_FOUND` is expected.

### Quick Fix 
**Add condition, only if true update partitionId**
On `Protocol.decodePartitionId(key)` -- we decode the partitionId from `:jobKey`
- if partitionId valid, then update `ExecuteCommandRequest` with proper partitionId
- else let `BrokerRequestManager` handle this and return job key not found as it is expected

### Other possible solution
Find all places keys are supplied in request and apply a `KeyValidator`
decode `:jobKey` -- partitionId (PARTITION_BITS = 13) + key (KEY_BITS = 51)
and validate:
- `START_PARTITION_ID < partitionId < MAXIMUM_PARTITIONS`
- `key >= 0`
➕Fast fail
➖ Will take more time, investigate and add this validation in many places. + backport might need special handling

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #39672
