### PR TITLE
build: add flag to yarn1 frontent maven plugin config

### DIFF
--- a/identity/client/pom.xml
+++ b/identity/client/pom.xml
@@ -58,7 +58,7 @@
             </goals>
             <configuration>
               <skip>${skip.fe.build}</skip>
-              <arguments>version ${project.version}</arguments>
+              <arguments>version --new-version ${project.version}</arguments>
             </configuration>
           </execution>
 


### PR DESCRIPTION
## Description

Yarn v1 expects --new-version in the yarn version command because without that flag, [Yarn treats version as a script name](https://classic.yarnpkg.com/lang/en/docs/cli/version/?utm_source=chatgpt.com), not as an instruction to set a new version number.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
