### PR TITLE
fix: process-instance-incidents-search request body aliases wrong schema

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,10 +1,24 @@
 # Changelog
 
+## v0.0.10
+
+### 🩹 Fixes
+
+- process-instance-incidents-search request body aliases wrong schema ([#39753](https://github.com/camunda/camunda/pull/39753))
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.9
 
 ### 🚀 Enhancements
 
 - use aliased incidents search request/response types ([de6fa21](https://github.com/camunda/camunda/commit/b6e683e959fdb7727cf53363e3eba95ec8a77646))
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
 
 ## v0.0.8
 

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/process-instance.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/process-instance.ts
@@ -28,7 +28,7 @@ import {
 	type StatisticName,
 } from './processes';
 import {batchOperationTypeSchema} from './batch-operation';
-import {queryIncidentsResponseBodySchema} from './incident';
+import {queryIncidentsRequestBodySchema, queryIncidentsResponseBodySchema} from './incident';
 
 const processInstanceVariableFilterSchema = z.object({
 	name: z.string(),
@@ -153,7 +153,7 @@ const cancelProcessInstance: Endpoint<Pick<ProcessInstance, 'processInstanceKey'
 	getUrl: ({processInstanceKey}) => `/${API_VERSION}/process-instances/${processInstanceKey}/cancellation`,
 };
 
-const queryProcessInstanceIncidentsRequestBodySchema = queryIncidentsResponseBodySchema;
+const queryProcessInstanceIncidentsRequestBodySchema = queryIncidentsRequestBodySchema;
 type QueryProcessInstanceIncidentsRequestBody = z.infer<typeof queryProcessInstanceIncidentsRequestBodySchema>;
 
 const queryProcessInstanceIncidentsResponseBodySchema = queryIncidentsResponseBodySchema;

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

The `queryProcessInstanceIncidentsRequestBodySchema` aliased the wrong schema. Should alias the incidents request and not response.

## Checklist

- [ ] Changes have to be released. 

## Related issues
