### PR TITLE
[Backport stable/8.7] fix: enable full annotation processing for protocol module

### DIFF
--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -133,6 +133,7 @@
           <compilerArgs combine.children="append">
             <!-- required by javac detection logic in immutables -->
             <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+            <arg>-proc:full</arg>
           </compilerArgs>
           <fork>true</fork>
         </configuration>


### PR DESCRIPTION
# Description
Backport of #25660 to `stable/8.7`.

relates to 