### PR TITLE
feat: WIP multiple DBs IT job

### DIFF
--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         description: The database docker image version to be used during the tests. Will be set as env variable IMAGE_VERSION. If not set, the default value from the docker-compose file will be used.
+    outputs:
+      flakyTests:
+        description: "Flaky tests detected during database integration tests"
+        value: ${{ jobs.integration-tests.outputs.flakyTests }}
 defaults:
   run:
     shell: bash
@@ -36,6 +40,8 @@ jobs:
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
       IMAGE_VERSION: ${{inputs.database-image-version}}
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,7 +657,7 @@ jobs:
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
           -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -D test.integration.camunda.database.type=rdbms
+          -D test.integration.camunda.database.type=rdbms_h2
           -pl 'qa/acceptance-tests'
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
@@ -672,6 +672,421 @@ jobs:
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
           name: "[IT] RDBMS - H2"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: "General"
+          detailed_junit_tests: true
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  rdbms-postgres-integration-tests:
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+#   TODO: replace with schedule-only trigger before merge:
+#   if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' && github.event_name == 'schedule' }}
+    needs: [ detect-changes ]
+    name: "General / Integration / RDBMS - Postgres ITs"
+    timeout-minutes: 15
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    runs-on: gcp-perf-core-8-default
+    env:
+      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
+    services:
+      # Set up a postgres service container
+      postgres:
+        image: postgres:18-alpine
+        # Provide the password for postgres
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+        env:
+          POSTGRES_USER: camunda
+          POSTGRES_DB: camunda
+          POSTGRES_PASSWORD: camunda
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd "pg_isready"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: it-rdbms-postgres
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      # Build the platform before running the integration tests; skipping frontend
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
+      # Run specific integration tests with H2 inmemory database
+      #
+      # To communicate to the IT what database to expect and run against:
+      # -Dcamunda.it.database.type=rdbms
+      #
+      - name: Run integration test with Postgres RDBMS
+        shell: bash
+        timeout-minutes: 10
+        run: >
+          ./mvnw -B -T 2 --no-snapshot-updates
+          -D forkCount=3
+          -D maven.javadoc.skip=true
+          -D skipUTs -D skipChecks
+          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
+          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
+          -D test.integration.camunda.database.type=rdbms_postgres
+          -D camunda.secondary-storage.rdbms.url=rdbms
+          -pl 'qa/acceptance-tests'
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
+        with:
+          name: "[IT] RDBMS - Postgres"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: "General"
+          detailed_junit_tests: true
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  rdbms-mysql-integration-tests:
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    #   TODO: replace with schedule-only trigger before merge:
+    #   if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' && github.event_name == 'schedule' }}
+    needs: [ detect-changes ]
+    name: "General / Integration / RDBMS - MySQL ITs"
+    timeout-minutes: 15
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    runs-on: gcp-perf-core-8-default
+    env:
+      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
+    services:
+      # Set up a mysql service container
+      mysql:
+        image: mysql:9.4
+        # Provide the password for mysql
+        ports:
+          # Maps tcp port 3306 on service container to the host
+          - 3306:3306
+        env:
+          MYSQL_USER: camunda
+          MYSQL_PASSWORD: camunda
+          MYSQL_DATABASE: camunda
+          MYSQL_RANDOM_ROOT_PASSWORD: 1
+        # Set health checks to wait until mysql has started
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: it-rdbms-postgres
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      # Build the platform before running the integration tests; skipping frontend
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
+      - name: Run integration test with MySQL RDBMS
+        shell: bash
+        timeout-minutes: 10
+        run: >
+          ./mvnw -B -T 2 --no-snapshot-updates
+          -D forkCount=3
+          -D maven.javadoc.skip=true
+          -D skipUTs -D skipChecks
+          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
+          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
+          -D test.integration.camunda.database.type=rdbms_mysql
+          -D camunda.secondary-storage.rdbms.url=rdbms
+          -pl 'qa/acceptance-tests'
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
+        with:
+          name: "[IT] RDBMS - MySQL"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: "General"
+          detailed_junit_tests: true
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  rdbms-mariadb-integration-tests:
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    #   TODO: replace with schedule-only trigger before merge:
+    #   if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' && github.event_name == 'schedule' }}
+    needs: [ detect-changes ]
+    name: "General / Integration / RDBMS - MariaDB ITs"
+    timeout-minutes: 15
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    runs-on: gcp-perf-core-8-default
+    env:
+      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
+    services:
+      # Set up a mariadb service container
+      mariadb:
+        image: mariadb:12.0
+        # Provide the password for mariadb
+        ports:
+          # Maps tcp port 3306 on service container to the host
+          - 3306:3306
+        env:
+          MARIADB_USER: camunda
+          MARIADB_PASSWORD: camunda
+          MARIADB_DATABASE: camunda
+          MARIADB_RANDOM_ROOT_PASSWORD: 1
+        # Set health checks to wait until mariadb has started
+        options: >-
+          --health-cmd "healthcheck.sh --connect --innodb_initialized"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: it-rdbms-mariadb
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      # Build the platform before running the integration tests; skipping frontend
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
+      - name: Run integration test with MariaDB RDBMS
+        shell: bash
+        timeout-minutes: 10
+        run: >
+          ./mvnw -B -T 2 --no-snapshot-updates
+          -D forkCount=3
+          -D maven.javadoc.skip=true
+          -D skipUTs -D skipChecks
+          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
+          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
+          -D test.integration.camunda.database.type=rdbms_mariadb
+          -D camunda.secondary-storage.rdbms.url=rdbms
+          -pl 'qa/acceptance-tests'
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
+        with:
+          name: "[IT] RDBMS - MariaDB"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: "General"
+          detailed_junit_tests: true
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  rdbms-mssql-integration-tests:
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    #   TODO: replace with schedule-only trigger before merge:
+    #   if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' && github.event_name == 'schedule' }}
+    needs: [ detect-changes ]
+    name: "General / Integration / RDBMS - MSSQL ITs"
+    timeout-minutes: 15
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    runs-on: gcp-perf-core-8-default
+    env:
+      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
+    services:
+      # Set up a mssql service container
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        # Provide the password for mssql
+        ports:
+          # Maps tcp port 1433 on service container to the host
+          - 1433:1433
+        env:
+          ACCEPT_EULA: y
+          MSSQL_SA_PASSWORD: Camunda#8_demo
+        # Set health checks to wait until mssql has started
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: it-rdbms-mssql
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      # Build the platform before running the integration tests; skipping frontend
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
+      - name: Run integration test with MSSQL RDBMS
+        shell: bash
+        timeout-minutes: 10
+        run: >
+          ./mvnw -B -T 2 --no-snapshot-updates
+          -D forkCount=3
+          -D maven.javadoc.skip=true
+          -D skipUTs -D skipChecks
+          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
+          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
+          -D test.integration.camunda.database.type=rdbms_mssql
+          -D camunda.secondary-storage.rdbms.url=rdbms
+          -pl 'qa/acceptance-tests'
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
+        with:
+          name: "[IT] RDBMS - MSSQL"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: "General"
+          detailed_junit_tests: true
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  rdbms-oracle-integration-tests:
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    #   TODO: replace with schedule-only trigger before merge:
+    #   if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' && github.event_name == 'schedule' }}
+    needs: [ detect-changes ]
+    name: "General / Integration / RDBMS - Oracle ITs"
+    timeout-minutes: 15
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    runs-on: gcp-perf-core-8-default
+    env:
+      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
+    services:
+      # Set up a oracle service container
+      oracle:
+        image: gvenzl/oracle-free:23-slim-faststart
+        ports:
+          # Maps database port on service container to the host
+          - 1521:1521
+        env:
+          ORACLE_PASSWORD: sys_user_password
+          APP_USER: camunda
+          APP_USER_PASSWORD: camunda
+        # Set health checks to wait until db has started
+        options: >-
+          --health-cmd "healthcheck.sh"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: it-rdbms-oracle
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      # Build the platform before running the integration tests; skipping frontend
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
+      - name: Run integration test with Oracle RDBMS
+        shell: bash
+        timeout-minutes: 10
+        run: >
+          ./mvnw -B -T 2 --no-snapshot-updates
+          -D forkCount=3
+          -D maven.javadoc.skip=true
+          -D skipUTs -D skipChecks
+          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
+          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
+          -D test.integration.camunda.database.type=rdbms_oracle
+          -D camunda.secondary-storage.rdbms.url=rdbms
+          -pl 'qa/acceptance-tests'
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
+        with:
+          name: "[IT] RDBMS - Oracle"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -1436,6 +1851,11 @@ jobs:
       - optimize-ci
       - protobuf-checks
       - rdbms-h2-integration-tests
+      - rdbms-postgres-integration-tests
+      - rdbms-mysql-integration-tests
+      - rdbms-mariadb-integration-tests
+      - rdbms-oracle-integration-tests
+      - rdbms-mssql-integration-tests
       - rdbms-integration-tests
       - renovatelint
       - setup-unit-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,9 +686,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   rdbms-postgres-integration-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
-#   TODO: replace with schedule-only trigger before merge:
-#   if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' && github.event_name == 'schedule' }}
+    if: github.event_name == 'schedule'
     needs: [ detect-changes ]
     name: "General / Integration / RDBMS - Postgres ITs"
     timeout-minutes: 15
@@ -774,9 +772,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   rdbms-mysql-integration-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
-    #   TODO: replace with schedule-only trigger before merge:
-    #   if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' && github.event_name == 'schedule' }}
+    if: github.event_name == 'schedule'
     needs: [ detect-changes ]
     name: "General / Integration / RDBMS - MySQL ITs"
     timeout-minutes: 15
@@ -858,9 +854,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   rdbms-mariadb-integration-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
-    #   TODO: replace with schedule-only trigger before merge:
-    #   if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' && github.event_name == 'schedule' }}
+    if: github.event_name == 'schedule'
     needs: [ detect-changes ]
     name: "General / Integration / RDBMS - MariaDB ITs"
     timeout-minutes: 15
@@ -942,9 +936,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   rdbms-mssql-integration-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
-    #   TODO: replace with schedule-only trigger before merge:
-    #   if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' && github.event_name == 'schedule' }}
+    if: github.event_name == 'schedule'
     needs: [ detect-changes ]
     name: "General / Integration / RDBMS - MSSQL ITs"
     timeout-minutes: 15
@@ -1019,9 +1011,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   rdbms-oracle-integration-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
-    #   TODO: replace with schedule-only trigger before merge:
-    #   if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' && github.event_name == 'schedule' }}
+    if: github.event_name == 'schedule'
     needs: [ detect-changes ]
     name: "General / Integration / RDBMS - Oracle ITs"
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -807,7 +807,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
         with:
-          maven-cache-key-modifier: it-rdbms-postgres
+          maven-cache-key-modifier: it-rdbms-mysql
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,674 +421,96 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   elasticsearch-integration-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    name: "Database Integration Tests / Elasticsearch"
+    # if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
-    name: "General / Integration / Elasticsearch ITs"
-    timeout-minutes: 15
-    permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-16-default
-    outputs:
-      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
-    services:
-      # Set up an elastic search service container
-      # https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/about-service-containers
-      elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.18.4
-        # Exposing the ports allow to be accessible via http://localhost:9200 in the runner
-        ports:
-          - 9200:9200
-        options: >-
-          --health-cmd "curl --silent --fail http://localhost:9200/_cluster/health"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-        env:
-          # Disabling the security to make sure we can access without tls in our tests
-          # https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#general-security-settings
-          xpack.security.enabled: "false"
-          # We run a single node for our integration tests
-          discovery.type: "single-node"
-          # Disabling to make sure we can delete indices via wildcards
-          # https://www.elastic.co/guide/en/elasticsearch/reference/current/index-management-settings.html
-          action.destructive_requires_name: "false"
-          # We need to configure ILM to run more often, to make sure data is cleaned up earlier
-          # Useful for tests where we verify history clean up
-          # Default is 10m
-          # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-settings.html
-          indices.lifecycle.poll_interval: "1s"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-build
-        with:
-          maven-cache-key-modifier: it-elasticsearch
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      # Build the platform before running the integration tests; skipping frontend
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C -Dquickly
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
-      # Run specific integration tests with ES service container
-      #
-      # To communicate to the IT what database to expect and run against:
-      # -D test.integration.camunda.database.type=es
-      #
-      - name: Run integration test with externalized ES
-        shell: bash
-        run: >
-          ./mvnw -B -T 1 --no-snapshot-updates
-          -D forkCount=4
-          -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
-          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -D test.integration.camunda.database.type=es
-          -pl 'qa/acceptance-tests'
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Analyze Test Runs
-        id: analyze-test-run
-        if: always()
-        uses: ./.github/actions/analyze-test-runs
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
-        with:
-          name: "[IT] Elasticsearch"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
-          detailed_junit_tests: true
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "elasticsearch"
+      database-image-version: "8.18.4"
+      it-database-type: "es"
 
   opensearch-integration-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    name: "Database Integration Tests / Opensearch"
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    # if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
-    name: "General / Integration / OpenSearch ITs"
-    timeout-minutes: 15
-    permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-16-default
-    outputs:
-      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
-    services:
-      # Set up an OpenSearch service container
-      # https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/about-service-containers
-      opensearch:
-        image: opensearchproject/opensearch:2.19.3
-        # Exposing the ports allow to be accessible via http://localhost:9200 in the runner
-        ports:
-          - 9200:9200
-        options: >-
-          --health-cmd "curl --silent --fail http://localhost:9200/_cluster/health"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-        env:
-          # Disabling the security to make sure we can access without tls in our tests
-          # https://opensearch.org/docs/latest/security/configuration/disable-enable-security/
-          DISABLE_SECURITY_PLUGIN: "true"
-          # We run a single node for our integration tests
-          discovery.type: "single-node"
-          # Disabling to make sure we can delete indices via wildcards
-          # https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/index-settings/
-          action.destructive_requires_name: "false"
-          # We have to specify an initial password to bootstrap OpenSearch
-          # https://opensearch.org/blog/replacing-default-admin-credentials/
-          OPENSEARCH_INITIAL_ADMIN_PASSWORD: "yourStrongPassword123!"
-          # We need to configure ISM to run more often, to make sure data is cleaned up earlier
-          # Useful for tests where we verify history clean up
-          # Default is 5 - unit is minutes
-          # https://opensearch.org/docs/latest/im-plugin/ism/settings/
-          plugins.index_state_management.job_interval: "1"
-          # A randomized delay that is added to a job’s base run time to prevent a surge of activity from all indexes at the same time.
-          plugins.index_state_management.jitter: "0"
-          knn.algo_param.index_thread_qty: 4
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-build
-        with:
-          maven-cache-key-modifier: it-elasticsearch
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      # Build the platform before running the integration tests; skipping frontend
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C -Dquickly
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
-      # Run specific integration tests with OS service container
-      #
-      # To communicate to the IT what database to expect and run against:
-      # -D test.integration.camunda.database.type=os
-      #
-      - name: Run integration test with externalized OS
-        shell: bash
-        run: >
-          ./mvnw -B -T 1 --no-snapshot-updates
-          -D forkCount=4
-          -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
-          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -D test.integration.camunda.database.type=os
-          -pl 'qa/acceptance-tests'
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Analyze Test Runs
-        id: analyze-test-run
-        if: always()
-        uses: ./.github/actions/analyze-test-runs
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
-        with:
-          name: "[IT] OpenSearch"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
-          detailed_junit_tests: true
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+    secrets: inherit
+    with:
+      database-type: "opensearch"
+      database-image-version: "2.19.3"
+      it-database-type: "os"
 
   rdbms-h2-integration-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    name: "Database Integration Tests / RDBMS H2"
+    # if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
-    name: "General / Integration / RDBMS - H2 ITs"
-    timeout-minutes: 15
-    permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-8-default
-    outputs:
-      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-build
-        with:
-          maven-cache-key-modifier: it-elasticsearch
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      # Build the platform before running the integration tests; skipping frontend
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C -PskipFrontendBuild
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
-      # Run specific integration tests with H2 inmemory database
-      #
-      # To communicate to the IT what database to expect and run against:
-      # -Dcamunda.it.database.type=rdbms
-      #
-      - name: Run integration test with InMemory H2
-        shell: bash
-        timeout-minutes: 10
-        run: >
-          ./mvnw -B -T 2 --no-snapshot-updates
-          -D forkCount=3
-          -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
-          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -D test.integration.camunda.database.type=rdbms_h2
-          -pl 'qa/acceptance-tests'
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Analyze Test Runs
-        id: analyze-test-run
-        if: always()
-        uses: ./.github/actions/analyze-test-runs
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
-        with:
-          name: "[IT] RDBMS - H2"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
-          detailed_junit_tests: true
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "h2"
+      it-database-type: "rdbms_h2"
 
   rdbms-postgres-integration-tests:
-    if: github.event_name == 'schedule'
+    name: "Database Integration Tests / RDBMS Postgres"
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "postgres"
+      database-image-version: "18-alpine"
+      it-database-type: "rdbms_postgres"
+
+    #    if: github.event_name == 'schedule'
     needs: [ detect-changes ]
-    name: "General / Integration / RDBMS - Postgres ITs"
-    timeout-minutes: 15
-    permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-8-default
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
-    services:
-      # Set up a postgres service container
-      postgres:
-        image: postgres:18-alpine
-        # Provide the password for postgres
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
-        env:
-          POSTGRES_USER: camunda
-          POSTGRES_DB: camunda
-          POSTGRES_PASSWORD: camunda
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd "pg_isready"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-build
-        with:
-          maven-cache-key-modifier: it-rdbms-postgres
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      # Build the platform before running the integration tests; skipping frontend
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C -PskipFrontendBuild
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
-      # Run specific integration tests with H2 inmemory database
-      #
-      # To communicate to the IT what database to expect and run against:
-      # -Dcamunda.it.database.type=rdbms
-      #
-      - name: Run integration test with Postgres RDBMS
-        shell: bash
-        timeout-minutes: 10
-        run: >
-          ./mvnw -B -T 2 --no-snapshot-updates
-          -D forkCount=3
-          -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
-          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -D test.integration.camunda.database.type=rdbms_postgres
-          -D camunda.secondary-storage.rdbms.url=rdbms
-          -pl 'qa/acceptance-tests'
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Analyze Test Runs
-        id: analyze-test-run
-        if: always()
-        uses: ./.github/actions/analyze-test-runs
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
-        with:
-          name: "[IT] RDBMS - Postgres"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
-          detailed_junit_tests: true
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   rdbms-mysql-integration-tests:
-    if: github.event_name == 'schedule'
+    name: "Database Integration Tests / RDBMS MySQL"
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "mysql"
+      database-image-version: "9.4"
+      it-database-type: "rdbms_mysql"
+
+    #    if: github.event_name == 'schedule'
     needs: [ detect-changes ]
-    name: "General / Integration / RDBMS - MySQL ITs"
-    timeout-minutes: 15
-    permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-8-default
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
-    services:
-      # Set up a mysql service container
-      mysql:
-        image: mysql:9.4
-        # Provide the password for mysql
-        ports:
-          # Maps tcp port 3306 on service container to the host
-          - 3306:3306
-        env:
-          MYSQL_USER: camunda
-          MYSQL_PASSWORD: camunda
-          MYSQL_DATABASE: camunda
-          MYSQL_RANDOM_ROOT_PASSWORD: 1
-        # Set health checks to wait until mysql has started
-        options: >-
-          --health-cmd "mysqladmin ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-build
-        with:
-          maven-cache-key-modifier: it-rdbms-mysql
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      # Build the platform before running the integration tests; skipping frontend
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C -PskipFrontendBuild
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
-      - name: Run integration test with MySQL RDBMS
-        shell: bash
-        timeout-minutes: 10
-        run: >
-          ./mvnw -B -T 2 --no-snapshot-updates
-          -D forkCount=3
-          -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
-          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -D test.integration.camunda.database.type=rdbms_mysql
-          -D camunda.secondary-storage.rdbms.url=rdbms
-          -pl 'qa/acceptance-tests'
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Analyze Test Runs
-        id: analyze-test-run
-        if: always()
-        uses: ./.github/actions/analyze-test-runs
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
-        with:
-          name: "[IT] RDBMS - MySQL"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
-          detailed_junit_tests: true
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   rdbms-mariadb-integration-tests:
-    if: github.event_name == 'schedule'
+    name: "Database Integration Tests / RDBMS MariaDB"
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "mariadb"
+      database-image-version: "12.0"
+      it-database-type: "rdbms_mariadb"
+
+    #    if: github.event_name == 'schedule'
     needs: [ detect-changes ]
-    name: "General / Integration / RDBMS - MariaDB ITs"
-    timeout-minutes: 15
-    permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-8-default
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
-    services:
-      # Set up a mariadb service container
-      mariadb:
-        image: mariadb:12.0
-        # Provide the password for mariadb
-        ports:
-          # Maps tcp port 3306 on service container to the host
-          - 3306:3306
-        env:
-          MARIADB_USER: camunda
-          MARIADB_PASSWORD: camunda
-          MARIADB_DATABASE: camunda
-          MARIADB_RANDOM_ROOT_PASSWORD: 1
-        # Set health checks to wait until mariadb has started
-        options: >-
-          --health-cmd "healthcheck.sh --connect --innodb_initialized"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-build
-        with:
-          maven-cache-key-modifier: it-rdbms-mariadb
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      # Build the platform before running the integration tests; skipping frontend
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C -PskipFrontendBuild
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
-      - name: Run integration test with MariaDB RDBMS
-        shell: bash
-        timeout-minutes: 10
-        run: >
-          ./mvnw -B -T 2 --no-snapshot-updates
-          -D forkCount=3
-          -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
-          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -D test.integration.camunda.database.type=rdbms_mariadb
-          -D camunda.secondary-storage.rdbms.url=rdbms
-          -pl 'qa/acceptance-tests'
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Analyze Test Runs
-        id: analyze-test-run
-        if: always()
-        uses: ./.github/actions/analyze-test-runs
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
-        with:
-          name: "[IT] RDBMS - MariaDB"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
-          detailed_junit_tests: true
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   rdbms-mssql-integration-tests:
-    if: github.event_name == 'schedule'
+    name: "Database Integration Tests / RDBMS MSSQL"
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "mssql"
+      database-image-version: "2022-latest"
+      it-database-type: "rdbms_mssql"
+
+    #    if: github.event_name == 'schedule'
     needs: [ detect-changes ]
-    name: "General / Integration / RDBMS - MSSQL ITs"
-    timeout-minutes: 15
-    permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-8-default
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
-    services:
-      # Set up a mssql service container
-      mssql:
-        image: mcr.microsoft.com/mssql/server:2022-latest
-        # Provide the password for mssql
-        ports:
-          # Maps tcp port 1433 on service container to the host
-          - 1433:1433
-        env:
-          ACCEPT_EULA: y
-          MSSQL_SA_PASSWORD: Camunda#8_demo
-        # Set health checks to wait until mssql has started
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-build
-        with:
-          maven-cache-key-modifier: it-rdbms-mssql
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      # Build the platform before running the integration tests; skipping frontend
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C -PskipFrontendBuild
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
-      - name: Run integration test with MSSQL RDBMS
-        shell: bash
-        timeout-minutes: 10
-        run: >
-          ./mvnw -B -T 2 --no-snapshot-updates
-          -D forkCount=3
-          -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
-          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -D test.integration.camunda.database.type=rdbms_mssql
-          -D camunda.secondary-storage.rdbms.url=rdbms
-          -pl 'qa/acceptance-tests'
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Analyze Test Runs
-        id: analyze-test-run
-        if: always()
-        uses: ./.github/actions/analyze-test-runs
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
-        with:
-          name: "[IT] RDBMS - MSSQL"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
-          detailed_junit_tests: true
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   rdbms-oracle-integration-tests:
-    if: github.event_name == 'schedule'
+    name: "Database Integration Tests / RDBMS Oracle"
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "oracle"
+      database-image-version: "23-slim-faststart"
+      it-database-type: "rdbms_oracle"
+
+    #    if: github.event_name == 'schedule'
     needs: [ detect-changes ]
-    name: "General / Integration / RDBMS - Oracle ITs"
-    timeout-minutes: 15
-    permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-8-default
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
-    services:
-      # Set up a oracle service container
-      oracle:
-        image: gvenzl/oracle-free:23-slim-faststart
-        ports:
-          # Maps database port on service container to the host
-          - 1521:1521
-        env:
-          ORACLE_PASSWORD: sys_user_password
-          APP_USER: camunda
-          APP_USER_PASSWORD: camunda
-        # Set health checks to wait until db has started
-        options: >-
-          --health-cmd "healthcheck.sh"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-build
-        with:
-          maven-cache-key-modifier: it-rdbms-oracle
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      # Build the platform before running the integration tests; skipping frontend
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C -PskipFrontendBuild
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
-      - name: Run integration test with Oracle RDBMS
-        shell: bash
-        timeout-minutes: 10
-        run: >
-          ./mvnw -B -T 2 --no-snapshot-updates
-          -D forkCount=3
-          -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
-          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -D test.integration.camunda.database.type=rdbms_oracle
-          -D camunda.secondary-storage.rdbms.url=rdbms
-          -pl 'qa/acceptance-tests'
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Analyze Test Runs
-        id: analyze-test-run
-        if: always()
-        uses: ./.github/actions/analyze-test-runs
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
-        with:
-          name: "[IT] RDBMS - Oracle"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "General"
-          detailed_junit_tests: true
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   rdbms-integration-tests:
     if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,7 @@ jobs:
 
   elasticsearch-integration-tests:
     name: "Database Integration Tests / Elasticsearch"
-    # if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
@@ -434,7 +434,7 @@ jobs:
   opensearch-integration-tests:
     name: "Database Integration Tests / Opensearch"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
-    # if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
     secrets: inherit
     with:
@@ -444,7 +444,7 @@ jobs:
 
   rdbms-h2-integration-tests:
     name: "Database Integration Tests / RDBMS H2"
-    # if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
@@ -455,62 +455,62 @@ jobs:
   rdbms-postgres-integration-tests:
     name: "Database Integration Tests / RDBMS Postgres"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    if: github.event_name == 'schedule'
+    needs: [ detect-changes ]
     secrets: inherit
     with:
       database-type: "postgres"
       database-image-version: "18-alpine"
       it-database-type: "rdbms_postgres"
 
-    #    if: github.event_name == 'schedule'
-    needs: [ detect-changes ]
 
   rdbms-mysql-integration-tests:
     name: "Database Integration Tests / RDBMS MySQL"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    if: github.event_name == 'schedule'
+    needs: [ detect-changes ]
     secrets: inherit
     with:
       database-type: "mysql"
       database-image-version: "9.4"
       it-database-type: "rdbms_mysql"
 
-    #    if: github.event_name == 'schedule'
-    needs: [ detect-changes ]
 
   rdbms-mariadb-integration-tests:
     name: "Database Integration Tests / RDBMS MariaDB"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    if: github.event_name == 'schedule'
+    needs: [ detect-changes ]
     secrets: inherit
     with:
       database-type: "mariadb"
       database-image-version: "12.0"
       it-database-type: "rdbms_mariadb"
 
-    #    if: github.event_name == 'schedule'
-    needs: [ detect-changes ]
 
   rdbms-mssql-integration-tests:
     name: "Database Integration Tests / RDBMS MSSQL"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    if: github.event_name == 'schedule'
+    needs: [ detect-changes ]
     secrets: inherit
     with:
       database-type: "mssql"
       database-image-version: "2022-latest"
       it-database-type: "rdbms_mssql"
 
-    #    if: github.event_name == 'schedule'
-    needs: [ detect-changes ]
 
   rdbms-oracle-integration-tests:
     name: "Database Integration Tests / RDBMS Oracle"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    if: github.event_name == 'schedule'
+    needs: [ detect-changes ]
     secrets: inherit
     with:
       database-type: "oracle"
       database-image-version: "23-slim-faststart"
       it-database-type: "rdbms_oracle"
 
-    #    if: github.event_name == 'schedule'
-    needs: [ detect-changes ]
 
   rdbms-integration-tests:
     if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     #      size: 134217728 # 128*2^20 bytes = 128Mb
     environment:
       POSTGRES_USER: camunda
-      POSTGRES_PASSWORD: demo
+      POSTGRES_PASSWORD: camunda
     ports:
       - "5432:5432"
 
@@ -38,7 +38,7 @@ services:
       MARIADB_ROOT_PASSWORD: example
       MARIADB_DATABASE: camunda
       MARIADB_USER: camunda
-      MARIADB_PASSWORD: demo
+      MARIADB_PASSWORD: camunda
     ports:
       - "3306:3306"
 
@@ -49,7 +49,7 @@ services:
       MYSQL_ROOT_PASSWORD: example
       MYSQL_DATABASE: camunda
       MYSQL_USER: camunda
-      MYSQL_PASSWORD: demo
+      MYSQL_PASSWORD: camunda
     ports:
       - "3306:3306"
 
@@ -64,7 +64,7 @@ services:
     environment:
       ORACLE_PASSWORD: sys_user_password
       APP_USER: camunda
-      APP_USER_PASSWORD: demo
+      APP_USER_PASSWORD: camunda
     # Customize healthcheck script options for startup
     healthcheck:
       test: [ "CMD", "healthcheck.sh" ]

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -84,6 +84,11 @@ services:
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
       - path.repo=/usr/local/els-snapshots
       - action.destructive_requires_name=false
+        # We need to configure ILM to run more often, to make sure data is cleaned up earlier
+        # Useful for tests where we verify history clean up
+        # Default is 10m
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-settings.html
+      - indices.lifecycle.poll_interval=1s
     ulimits:
       memlock:
         soft: -1
@@ -108,6 +113,16 @@ services:
       - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!
       - action.destructive_requires_name=false
+        # Disabling the security to make sure we can access without tls in our tests
+        # https://opensearch.org/docs/latest/security/configuration/disable-enable-security/
+        # We need to configure ISM to run more often, to make sure data is cleaned up earlier
+        # Useful for tests where we verify history clean up
+        # Default is 5 - unit is minutes
+        # https://opensearch.org/docs/latest/im-plugin/ism/settings/
+      - plugins.index_state_management.job_interval=1
+        # A randomized delay that is added to a job’s base run time to prevent a surge of activity from all indexes at the same time.
+      - plugins.index_state_management.jitter=0
+      - knn.algo_param.index_thread_qty=4
     ulimits:
       memlock:
         soft: -1

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserTaskDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserTaskDbReader.java
@@ -59,7 +59,6 @@ public class UserTaskDbReader extends AbstractEntityReader<UserTaskEntity>
 
     LOG.trace("[RDBMS DB] Search for users with filter {}", dbQuery);
     final var totalHits = userTaskMapper.count(dbQuery);
-
     if (shouldReturnEmptyPage(dbPage, totalHits)) {
       return buildSearchQueryResult(totalHits, List.of(), dbSort);
     }

--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -48,7 +48,7 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
     ) t
     JOIN ${prefix}AUTHORIZATIONS a ON t.AUTHORIZATION_KEY = a.AUTHORIZATION_KEY AND t.OWNER_ID = a.OWNER_ID AND t.OWNER_TYPE = a.OWNER_TYPE AND
-    t.RESOURCE_TYPE = a.RESOURCE_TYPE AND t.RESOURCE_ID = a.RESOURCE_ID AND t.RESOURCE_PROPERTY_NAME = a.RESOURCE_PROPERTY_NAME
+    t.RESOURCE_TYPE = a.RESOURCE_TYPE AND t.RESOURCE_ID = a.RESOURCE_ID
     <!-- outer orderBy for actual sorting -->
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
   </select>

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -199,7 +199,7 @@
   </insert>
 
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel">
-    UPDATE FLOW_NODE_INSTANCE
+    UPDATE ${prefix}FLOW_NODE_INSTANCE
     SET FLOW_NODE_ID             = #{flowNodeId},
         FLOW_NODE_NAME           = #{flowNodeName},
         FLOW_NODE_SCOPE_KEY      = #{flowNodeScopeKey},

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -184,16 +184,16 @@
         </foreach>
       </if>
       <if test="filter.hasFailedWithRetriesLeft == true">
-        AND HAS_FAILED_WITH_RETRIES_LEFT = TRUE
+        AND HAS_FAILED_WITH_RETRIES_LEFT = ${true}
       </if>
       <if test="filter.hasFailedWithRetriesLeft == false">
-        AND HAS_FAILED_WITH_RETRIES_LEFT = FALSE
+        AND HAS_FAILED_WITH_RETRIES_LEFT = ${false}
       </if>
       <if test="filter.isDenied == true">
-        AND IS_DENIED = TRUE
+        AND IS_DENIED = ${true}
       </if>
       <if test="filter.isDenied == false">
-        AND IS_DENIED = FALSE
+        AND IS_DENIED = ${false}
       </if>
       <if test="filter.retriesOperations != null and !filter.retriesOperations.isEmpty()">
         <foreach collection="filter.retriesOperations" item="operation">
@@ -270,14 +270,14 @@
         WORKER = #{worker},
         ERROR_MESSAGE = #{errorMessage},
         ERROR_CODE = #{errorCode},
-        END_TIME = #{endTime},
+        END_TIME = #{endTime, jdbcType=TIMESTAMP},
         CUSTOM_HEADERS = #{serializedCustomHeaders},
         KIND = #{kind},
         ELEMENT_ID = #{elementId},
         IS_DENIED = #{isDenied},
         DENIED_REASON = #{deniedReason},
         LISTENER_EVENT_TYPE = #{listenerEventType},
-        DEADLINE = #{deadline},
+        DEADLINE = #{deadline, jdbcType=TIMESTAMP},
         HAS_FAILED_WITH_RETRIES_LEFT = #{hasFailedWithRetriesLeft},
         LAST_UPDATE_TIME = #{lastUpdateTime, jdbcType=TIMESTAMP}
     WHERE JOB_KEY = #{jobKey}

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -252,8 +252,8 @@
     TENANT_ID, TYPE, WORKER, STATE, RETRIES, ERROR_MESSAGE, ERROR_CODE, END_TIME, CUSTOM_HEADERS, KIND, ELEMENT_ID, IS_DENIED, DENIED_REASON, LISTENER_EVENT_TYPE,
     DEADLINE, HAS_FAILED_WITH_RETRIES_LEFT, HISTORY_CLEANUP_DATE, CREATION_TIME, LAST_UPDATE_TIME)
     VALUES (#{jobKey}, #{partitionId}, #{processInstanceKey}, #{elementInstanceKey}, #{processDefinitionId},
-    #{processDefinitionKey}, #{tenantId}, #{type}, #{worker}, #{state}, #{retries}, #{errorMessage}, #{errorCode}, #{endTime}, #{serializedCustomHeaders}, #{kind}, #{elementId}, #{isDenied},
-    #{deniedReason}, #{listenerEventType}, #{deadline}, #{hasFailedWithRetriesLeft}, #{historyCleanupDate, jdbcType=TIMESTAMP}, #{creationTime, jdbcType=TIMESTAMP}, #{lastUpdateTime, jdbcType=TIMESTAMP})
+    #{processDefinitionKey}, #{tenantId}, #{type}, #{worker}, #{state}, #{retries}, #{errorMessage}, #{errorCode}, #{endTime, jdbcType=TIMESTAMP}, #{serializedCustomHeaders}, #{kind}, #{elementId}, #{isDenied},
+    #{deniedReason}, #{listenerEventType}, #{deadline, jdbcType=TIMESTAMP}, #{hasFailedWithRetriesLeft}, #{historyCleanupDate, jdbcType=TIMESTAMP}, #{creationTime, jdbcType=TIMESTAMP}, #{lastUpdateTime, jdbcType=TIMESTAMP})
   </insert>
 
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.JobDbModel">

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -295,7 +295,7 @@
         <foreach collection="filter.errorMessageOperations" item="operation">
           AND EXISTS (
           SELECT 1
-          FROM INCIDENT i
+          FROM ${prefix}INCIDENT i
           WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
           AND i.ERROR_MESSAGE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
           )
@@ -305,7 +305,7 @@
         <foreach collection="filter.incidentErrorHashCodeOperations" item="operation">
           AND EXISTS (
           SELECT 1
-          FROM INCIDENT i
+          FROM ${prefix}INCIDENT i
           WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
           AND i.ERROR_MESSAGE_HASH <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition" />
         )

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -298,7 +298,7 @@
       <foreach collection="filter.errorMessageOperations" item="operation">
         AND EXISTS (
         SELECT 1
-        FROM INCIDENT i
+        FROM ${prefix}INCIDENT i
         WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
         AND i.ERROR_MESSAGE
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
@@ -310,7 +310,7 @@
       <foreach collection="filter.incidentErrorHashCodeOperations" item="operation">
         AND EXISTS (
         SELECT 1
-        FROM INCIDENT i
+        FROM ${prefix}INCIDENT i
         WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
         AND i.ERROR_MESSAGE_HASH
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
@@ -403,7 +403,7 @@
   </insert>
 
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel">
-    UPDATE PROCESS_INSTANCE
+    UPDATE ${prefix}PROCESS_INSTANCE
     SET PROCESS_DEFINITION_ID       = #{processDefinitionId},
         PROCESS_DEFINITION_KEY      = #{processDefinitionKey},
         STATE                       = #{state},
@@ -421,7 +421,7 @@
 
   <update id="updateStateAndEndDate"
     parameterType="io.camunda.db.rdbms.sql.ProcessInstanceMapper$EndProcessInstanceDto">
-    UPDATE ${prefix}PROCESS_INSTANCE p
+    UPDATE ${prefix}PROCESS_INSTANCE
     SET STATE    = #{state},
         END_DATE = #{endDate}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/StandaloneCamundaTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/StandaloneCamundaTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class StandaloneCamundaTest {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * on RDBMS.
  */
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class ApplicationAuthorizationIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchTest.java
@@ -8,6 +8,7 @@
 package io.camunda.it.client;
 
 import static io.camunda.it.util.TestHelper.assertSorted;
+import static io.camunda.it.util.TestHelper.assertSortedFlexible;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
@@ -97,7 +98,11 @@ public class ElementInstanceSearchTest {
             .send()
             .join()
             .items();
-    elementInstance = allElementInstances.getFirst();
+    elementInstance =
+        allElementInstances.stream()
+            .filter(e -> e.getElementId().equals("Event_1p0nsc7"))
+            .findFirst()
+            .get();
     elementInstanceWithIncident =
         allElementInstances.stream()
             .filter(f -> f.getIncidentKey() != null)
@@ -385,7 +390,10 @@ public class ElementInstanceSearchTest {
             .sort(s -> s.elementId().desc())
             .send()
             .join();
-    assertSorted(resultAsc, resultDesc, ElementInstance::getElementId);
+
+    // depending on the database vendor, we have two different sort algorithms here... either
+    // case-insensitive or normal ascending/descending
+    assertSortedFlexible(resultAsc, resultDesc, ElementInstance::getElementId);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
@@ -25,6 +25,7 @@ import io.camunda.client.api.response.Process;
 import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.it.util.TestHelper;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.webapps.schema.entities.incident.ErrorType;
 import java.util.ArrayList;
@@ -468,14 +469,7 @@ class IncidentSearchTest {
     final var resultDesc =
         camundaClient.newIncidentSearchRequest().sort(s -> s.elementId().desc()).send().join();
 
-    final var all = resultAsc.items().stream().map(Incident::getElementId).toList();
-    final var sortedAsc = all.stream().sorted().toList();
-    final var sortedDesc = all.stream().sorted(Comparator.reverseOrder()).toList();
-
-    assertThat(resultAsc.items().stream().map(Incident::getElementId).toList())
-        .containsExactlyElementsOf(sortedAsc);
-    assertThat(resultDesc.items().stream().map(Incident::getElementId).toList())
-        .containsExactlyElementsOf(sortedDesc);
+    TestHelper.assertSortedFlexible(resultAsc, resultDesc, Incident::getElementId);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
@@ -651,12 +651,15 @@ public class JobSearchTest {
         camundaClient.newJobSearchRequest().sort(s -> s.worker().desc()).send().join();
 
     // then
+    // note: For OracleDB empty strings are treated as NULLs, so we need to handle nulls in sorting
     assertThat(resultAsc.items())
         .extracting(Job::getWorker)
-        .containsExactlyElementsOf(all.stream().sorted(Comparator.naturalOrder()).toList());
+        .containsExactlyElementsOf(
+            all.stream().sorted(Comparator.nullsLast(Comparator.naturalOrder())).toList());
     assertThat(resultDesc.items())
         .extracting(Job::getWorker)
-        .containsExactlyElementsOf(all.stream().sorted(Comparator.reverseOrder()).toList());
+        .containsExactlyElementsOf(
+            all.stream().sorted(Comparator.nullsFirst(Comparator.reverseOrder())).toList());
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchMultiTenantsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchMultiTenantsTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class ProcessDefinitionSearchMultiTenantsTest {
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.client;
 
+import static io.camunda.it.util.TestHelper.assertSortedFlexible;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitForStartFormsBeingExported;
@@ -706,15 +707,9 @@ public class ProcessDefinitionSearchTest {
             .send()
             .join();
 
-    final var all = resultAsc.items().stream().map(ProcessDefinition::getResourceName).toList();
-    final var sortedAsc = all.stream().sorted(Comparator.naturalOrder()).toList();
-    final var sortedDesc = all.stream().sorted(Comparator.reverseOrder()).toList();
-
-    // then
-    assertThat(resultAsc.items().stream().map(ProcessDefinition::getResourceName).toList())
-        .containsExactlyElementsOf(sortedAsc);
-    assertThat(resultDesc.items().stream().map(ProcessDefinition::getResourceName).toList())
-        .containsExactlyElementsOf(sortedDesc);
+    // depending on the database vendor, we have two different sort algorithms here... either
+    // case-insensitive or normal ascending/descending
+    assertSortedFlexible(resultAsc, resultDesc, ProcessDefinition::getResourceName);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIntegrationTest.java
@@ -106,8 +106,8 @@ public class UsersUpdateIntegrationTest {
                       .send()
                       .join();
               assertThat(response.items().getFirst().getUsername()).isEqualTo(username);
-              assertThat(response.items().getFirst().getName()).isEmpty();
-              assertThat(response.items().getFirst().getEmail()).isEmpty();
+              assertThat(response.items().getFirst().getName()).isNullOrEmpty();
+              assertThat(response.items().getFirst().getEmail()).isNullOrEmpty();
             });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/csrf/CsrfTokenIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/csrf/CsrfTokenIT.java
@@ -33,7 +33,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class CsrfTokenIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/logout/BasicAuthLogoutIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/logout/BasicAuthLogoutIT.java
@@ -31,7 +31,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class BasicAuthLogoutIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/oidc/OverlappingUsernameAndClientIdClaimTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/oidc/OverlappingUsernameAndClientIdClaimTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.io.TempDir;
  * user or a client.
  */
 @MultiDbTest(setupKeycloak = true)
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class OverlappingUsernameAndClientIdClaimTest {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateApiAnonymousUserIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateApiAnonymousUserIT.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class OperateApiAnonymousUserIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateApiOidcClientIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateApiOidcClientIT.java
@@ -40,7 +40,7 @@ import org.springframework.http.HttpStatus;
  * internal API (as one class, to save time on Keycloak setup).
  */
 @MultiDbTest(setupKeycloak = true)
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class OperateApiOidcClientIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
@@ -51,7 +51,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class OperateInternalApiGroupPermissionsIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiPermissionsIT.java
@@ -59,7 +59,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class OperateInternalApiPermissionsIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
@@ -51,7 +51,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class OperateInternalApiRolePermissionsIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1ApiPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1ApiPermissionsIT.java
@@ -54,7 +54,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class OperateV1ApiPermissionsIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/CompatibilityModeOperateZeebeAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/CompatibilityModeOperateZeebeAuthorizationIT.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class CompatibilityModeOperateZeebeAuthorizationIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/NoCompatibilityModeOperateZeebeAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/NoCompatibilityModeOperateZeebeAuthorizationIT.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class NoCompatibilityModeOperateZeebeAuthorizationIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentNotifierIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentNotifierIT.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class IncidentNotifierIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/VariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/VariableIT.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @MultiDbTest
 public class VariableIT {
@@ -66,7 +68,26 @@ public class VariableIT {
   }
 
   @Test
+  @DisabledIfSystemProperty(
+      named = "test.integration.camunda.database.type",
+      matches = "rdbms_oracle")
   void shouldTruncateVariable() {
+    shouldTruncateVariable(DEFAULT_VARIABLE_SIZE_THRESHOLD);
+  }
+
+  /**
+   * Oracle has different limits for VARCHAR2 fields depending on the database settings. In most
+   * common configurations, the limit is 4000 bytes for VARCHAR2 fields.
+   */
+  @Test
+  @EnabledIfSystemProperty(
+      named = "test.integration.camunda.database.type",
+      matches = "rdbms_oracle")
+  void shouldTruncateVariableOracle() {
+    shouldTruncateVariable(4000);
+  }
+
+  void shouldTruncateVariable(final int variableSizeThreshold) {
     // given
     final var deployment =
         client
@@ -75,7 +96,7 @@ public class VariableIT {
             .send()
             .join();
 
-    final String largeValue = "b".repeat(DEFAULT_VARIABLE_SIZE_THRESHOLD + 1);
+    final String largeValue = "b".repeat(variableSizeThreshold + 1);
 
     final var processInstanceKey =
         client
@@ -110,7 +131,7 @@ public class VariableIT {
     assertThat(largeVariable).isPresent();
     assertThat(largeVariable.get().isTruncated()).isTrue();
     assertThat(largeVariable.get().getValue())
-        .isEqualTo("\"" + largeValue.substring(0, DEFAULT_VARIABLE_SIZE_THRESHOLD - 1));
+        .isEqualTo("\"" + largeValue.substring(0, variableSizeThreshold - 1));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/spring/CamundaApplicationSpringDependenciesTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/spring/CamundaApplicationSpringDependenciesTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 final class CamundaApplicationSpringDependenciesTest extends AbstractSpringDependenciesTest {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/spring/StandaloneBrokerSpringDependenciesTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/spring/StandaloneBrokerSpringDependenciesTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 final class StandaloneBrokerSpringDependenciesTest extends AbstractSpringDependenciesTest {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java
@@ -203,6 +203,9 @@ public class UserTaskIT {
 
   @Test
   void shouldExportUserTaskVariable() {
+    // oracles limit of 4000 minus 2 for the ""
+    final int bigVariableSize = 3998;
+
     // when
     createAndDeployUserTaskProcess(
         client, "test-process-id", "zeebe-task", AbstractUserTaskBuilder::zeebeUserTask);
@@ -219,7 +222,7 @@ public class UserTaskIT {
                 "boolVariable",
                 true,
                 "bigVariable",
-                "a".repeat(8188)));
+                "a".repeat(bigVariableSize)));
 
     waitForProcessTasks(client, processInstanceId);
 
@@ -260,7 +263,7 @@ public class UserTaskIT {
             .filter(
                 f ->
                     f.processInstanceVariables(
-                        Map.of("bigVariable", "\"" + "a".repeat(8188) + "\"")))
+                        Map.of("bigVariable", "\"" + "a".repeat(bigVariableSize) + "\"")))
             .send()
             .join()
             .items();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskRestrictionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskRestrictionsIT.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class UserTaskRestrictionsIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/TasklistCreateProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/TasklistCreateProcessInstanceIT.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class TasklistCreateProcessInstanceIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUserTaskAuthorizationIT.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class CompatibilityTasklistUserTaskAuthorizationIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/compatibility/NoCompatibilityModeTasklistUserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/compatibility/NoCompatibilityModeTasklistUserTaskAuthorizationIT.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/TasklistV1ApiAnonymousUserIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/TasklistV1ApiAnonymousUserIT.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class TasklistV1ApiAnonymousUserIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/TasklistV1ApiOidcClientIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/TasklistV1ApiOidcClientIT.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest(setupKeycloak = true)
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class TasklistV1ApiOidcClientIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/form/TasklistV1ApiFormPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/form/TasklistV1ApiFormPermissionsIT.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class TasklistV1ApiFormPermissionsIT {
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/groups/TasklistV1ApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/groups/TasklistV1ApiGroupPermissionsIT.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class TasklistV1ApiGroupPermissionsIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/internal/TasklistV1ApiInternalProcessPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/internal/TasklistV1ApiInternalProcessPermissionsIT.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class TasklistV1ApiInternalProcessPermissionsIT {
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/roles/TasklistV1ApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/roles/TasklistV1ApiRolePermissionsIT.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class TasklistV1ApiRolePermissionsIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/task/TasklistV1ApiUserTaskPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/task/TasklistV1ApiUserTaskPermissionsIT.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class TasklistV1ApiUserTaskPermissionsIT {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -8,6 +8,7 @@
 package io.camunda.it.util;
 
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -1053,6 +1054,27 @@ public final class TestHelper {
       final Function<T, U> propertyExtractor) {
     assertThatIsAscSorted(resultAsc.items(), propertyExtractor);
     assertThatIsDescSorted(resultDesc.items(), propertyExtractor);
+  }
+
+  /**
+   * Asserts that the given search responses are sorted either in a case insensitive way or in a
+   * Java natural order way.
+   */
+  public static <T> void assertSortedFlexible(
+      final SearchResponse<T> resultAsc,
+      final SearchResponse<T> resultDesc,
+      final Function<T, String> propertyExtractor) {
+    assertThat(resultAsc)
+        .satisfiesAnyOf(
+            result ->
+                assertThatIsSortedBy(result.items(), propertyExtractor, CASE_INSENSITIVE_ORDER),
+            result -> assertThatIsAscSorted(result.items(), propertyExtractor));
+    assertThat(resultDesc)
+        .satisfiesAnyOf(
+            result ->
+                assertThatIsSortedBy(
+                    result.items(), propertyExtractor, CASE_INSENSITIVE_ORDER.reversed()),
+            result -> assertThatIsDescSorted(result.items(), propertyExtractor));
   }
 
   public static <T, U extends Comparable<U>> void assertThatIsAscSorted(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -1057,8 +1057,10 @@ public final class TestHelper {
   }
 
   /**
-   * Asserts that the given search responses are sorted either in a case insensitive way or in a
-   * Java natural order way.
+   * Asserts that the given search responses are sorted either in a case-insensitive way or in a
+   * Java natural order way. This flexibility is needed because different databases might sort
+   * strings differently. To not make the assertion depend on a specific database behavior, we allow
+   * both sorting methods.
    */
   public static <T> void assertSortedFlexible(
       final SearchResponse<T> resultAsc,

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -310,7 +310,8 @@ public class CamundaMultiDBExtension
         final var expectedDescriptors = new IndexDescriptors(testPrefix, false).all();
         setupHelper = new ElasticOpenSearchSetupHelper(DEFAULT_OS_URL, expectedDescriptors);
       }
-      case RDBMS -> multiDbConfigurator.configureRDBMSSupport(isHistoryRelatedTest);
+      case RDBMS_H2, RDBMS_MARIADB, RDBMS_MSSQL, RDBMS_MYSQL, RDBMS_ORACLE, RDBMS_POSTGRES ->
+          multiDbConfigurator.configureRDBMSSupport(databaseType, testPrefix, isHistoryRelatedTest);
       case AWS_OS -> {
         final var awsOSUrl = System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL);
         multiDbConfigurator.configureAWSOpenSearchSupport(
@@ -668,7 +669,12 @@ public class CamundaMultiDBExtension
     LOCAL,
     ES,
     OS,
-    RDBMS,
+    RDBMS_H2,
+    RDBMS_MARIADB,
+    RDBMS_MSSQL,
+    RDBMS_MYSQL,
+    RDBMS_ORACLE,
+    RDBMS_POSTGRES,
     AWS_OS
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -311,7 +311,7 @@ public class CamundaMultiDBExtension
         setupHelper = new ElasticOpenSearchSetupHelper(DEFAULT_OS_URL, expectedDescriptors);
       }
       case RDBMS_H2, RDBMS_MARIADB, RDBMS_MSSQL, RDBMS_MYSQL, RDBMS_ORACLE, RDBMS_POSTGRES ->
-          multiDbConfigurator.configureRDBMSSupport(databaseType, testPrefix, isHistoryRelatedTest);
+          multiDbConfigurator.configureRDBMSSupport(databaseType, isHistoryRelatedTest);
       case AWS_OS -> {
         final var awsOSUrl = System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL);
         multiDbConfigurator.configureAWSOpenSearchSupport(

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -12,6 +12,7 @@ import static io.camunda.spring.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABAS
 import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 
 import io.camunda.exporter.CamundaExporter;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
@@ -277,20 +278,51 @@ public class MultiDbConfigurator {
         });
   }
 
-  public void configureRDBMSSupport(final boolean retentionEnabled) {
+  public void configureRDBMSSupport(
+      final DatabaseType databaseType, final String prefix, final boolean retentionEnabled) {
+    final String shortPrefix = generateTablePrefix(prefix);
     // db type
     testApplication.withProperty(PROPERTY_CAMUNDA_DATABASE_TYPE, DB_TYPE_RDBMS);
     testApplication.withProperty(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, DB_TYPE_RDBMS);
     testApplication.withProperty("camunda.operate.database", DB_TYPE_RDBMS); // compatibility
     testApplication.withProperty("camunda.tasklist.database", DB_TYPE_RDBMS); // compatibility
+
+    testApplication.withProperty("camunda.data.secondary-storage.rdbms.prefix", shortPrefix);
     // --
 
-    testApplication.withProperty(
-        "spring.datasource.url",
-        "jdbc:h2:mem:testdb+" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
-    testApplication.withProperty("spring.datasource.driver-class-name", "org.h2.Driver");
-    testApplication.withProperty("spring.datasource.username", "sa");
-    testApplication.withProperty("spring.datasource.password", "");
+    if (databaseType == DatabaseType.RDBMS_H2) {
+      testApplication.withProperty(
+          "spring.datasource.url",
+          "jdbc:h2:mem:testdb+" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
+      testApplication.withProperty("spring.datasource.username", "sa");
+      testApplication.withProperty("spring.datasource.password", "");
+    } else if (databaseType == DatabaseType.RDBMS_MARIADB) {
+      testApplication.withProperty(
+          "spring.datasource.url", "jdbc:mariadb://localhost:3306/camunda");
+      testApplication.withProperty("spring.datasource.username", "camunda");
+      testApplication.withProperty("spring.datasource.password", "camunda");
+    } else if (databaseType == DatabaseType.RDBMS_MYSQL) {
+      testApplication.withProperty("spring.datasource.url", "jdbc:mysql://localhost:3306/camunda");
+      testApplication.withProperty("spring.datasource.username", "camunda");
+      testApplication.withProperty("spring.datasource.password", "camunda");
+    } else if (databaseType == DatabaseType.RDBMS_MSSQL) {
+      testApplication.withProperty(
+          "spring.datasource.url", "jdbc:sqlserver://localhost:1433;Encrypt=false");
+      testApplication.withProperty("spring.datasource.username", "sa");
+      testApplication.withProperty("spring.datasource.password", "Camunda#8_demo");
+    } else if (databaseType == DatabaseType.RDBMS_ORACLE) {
+      testApplication.withProperty(
+          "spring.datasource.url", "jdbc:oracle:thin:@localhost:1521/FREEPDB1");
+      testApplication.withProperty("spring.datasource.username", "camunda");
+      testApplication.withProperty("spring.datasource.password", "camunda");
+    } else if (databaseType == DatabaseType.RDBMS_POSTGRES) {
+      testApplication.withProperty("spring.datasource.url", "jdbc:postgresql:camunda");
+      testApplication.withProperty("spring.datasource.username", "camunda");
+      testApplication.withProperty("spring.datasource.password", "camunda");
+    } else {
+      throw new IllegalArgumentException("RDBMS Database type not supported: " + databaseType);
+    }
+
     testApplication.withProperty("logging.level.io.camunda.db.rdbms", "DEBUG");
     testApplication.withProperty("logging.level.org.mybatis", "DEBUG");
 
@@ -345,5 +377,22 @@ public class MultiDbConfigurator {
                   "aws",
                   Map.of("enabled", true)));
         });
+  }
+
+  /**
+   * Generates a pseudorandom table prefix based on the given prefix by creating a deterministic
+   * random string.
+   *
+   * @param prefix test prefix
+   * @return
+   */
+  private static String generateTablePrefix(final String prefix) {
+    final String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    final StringBuilder sb = new StringBuilder(10);
+    final java.util.Random random = new java.util.Random();
+    for (int i = 0; i < 10; i++) {
+      sb.append(chars.charAt(random.nextInt(chars.length())));
+    }
+    return sb.toString();
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -279,8 +279,8 @@ public class MultiDbConfigurator {
   }
 
   public void configureRDBMSSupport(
-      final DatabaseType databaseType, final String prefix, final boolean retentionEnabled) {
-    final String shortPrefix = generateTablePrefix(prefix);
+      final DatabaseType databaseType, final boolean retentionEnabled) {
+    final String shortPrefix = generateTablePrefix();
     // db type
     testApplication.withProperty(PROPERTY_CAMUNDA_DATABASE_TYPE, DB_TYPE_RDBMS);
     testApplication.withProperty(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, DB_TYPE_RDBMS);
@@ -380,13 +380,11 @@ public class MultiDbConfigurator {
   }
 
   /**
-   * Generates a pseudorandom table prefix based on the given prefix by creating a deterministic
-   * random string.
+   * Generates a random table prefix based on the given prefix by creating a random string.
    *
-   * @param prefix test prefix
-   * @return
+   * @return the table prefix
    */
-  private static String generateTablePrefix(final String prefix) {
+  private static String generateTablePrefix() {
     final String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     final StringBuilder sb = new StringBuilder(10);
     final java.util.Random random = new java.util.Random();

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
@@ -95,5 +95,5 @@ public @interface MultiDbTest {
    * @return the database type to run the test with. By default, the test will run with the local
    *     database type as defined in the test configuration.
    */
-  DatabaseType value() default DatabaseType.LOCAL;
+  DatabaseType value() default DatabaseType.RDBMS_MYSQL;
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
@@ -95,5 +95,5 @@ public @interface MultiDbTest {
    * @return the database type to run the test with. By default, the test will run with the local
    *     database type as defined in the test configuration.
    */
-  DatabaseType value() default DatabaseType.RDBMS_MYSQL;
+  DatabaseType value() default DatabaseType.LOCAL;
 }


### PR DESCRIPTION
## Description

This PR adds integration test steps against additional RDBMS databases: MySQL, MariaDB, Oracle, MSSQL
- the tests for these vendors are executed every day in the scheduled morning CI build 

Additional changes needed for this:
- refactored the RDBMS exclusion pattern for integration tests
- added random DDL prefix for rdbms ITs (for inmemory H2 was that was not needed so far)
- fixed various smaller bugs in the SQL statements for the additional vendors
  - datatype mappings regarding datetype / timestamp
  - SQL syntax errors
  - added missing DDL prefixes
- adjusted integration tests to match some very special database behavior:
  - MySQL and MariaDB have different sorting collations for UTF8 (they sort case-insensitive) => discussion ongoing of that's a problem
  - Oracle treats and `UPDATE table SET col = ''` as `UPDATE table SET col = NULL` (that can't be changed!)

## Related issues

closes #36365

Follow-Ups:
- https://github.com/camunda/camunda/issues/39888 