### PR TITLE
36963 external configuration via cluster variables

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
@@ -47,6 +47,7 @@ public class ClusterVariableCreateProcessor
 
     clusterVariableRecordValidator
         .validateName(clusterVariableRecord)
+        .flatMap(clusterVariableRecordValidator::ensureValidScope)
         .flatMap(clusterVariableRecordValidator::validateUniqueness)
         .ifRightOrLeft(
             record -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
@@ -44,12 +44,11 @@ public class ClusterVariableDeleteProcessor
   @Override
   public void processNewCommand(final TypedRecord<ClusterVariableRecord> command) {
     final ClusterVariableRecord clusterVariableRecord = command.getValue();
-    final long key = keyGenerator.nextKey();
-
     clusterVariableRecordValidator
         .validateExistence(clusterVariableRecord)
         .ifRightOrLeft(
             record -> {
+              final long key = keyGenerator.nextKey();
               writers
                   .state()
                   .appendFollowUpEvent(key, ClusterVariableIntent.DELETED, clusterVariableRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clustervariable;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+@ExcludeAuthorizationCheck
+public class ClusterVariableDeleteProcessor
+    implements DistributedTypedRecordProcessor<ClusterVariableRecord> {
+
+  private final KeyGenerator keyGenerator;
+  private final Writers writers;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final CommandDistributionBehavior commandDistributionBehavior;
+  private final ClusterVariableRecordValidator clusterVariableRecordValidator;
+
+  public ClusterVariableDeleteProcessor(
+      final KeyGenerator keyGenerator,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final CommandDistributionBehavior commandDistributionBehavior,
+      final ClusterVariableState clusterVariableState) {
+    this.keyGenerator = keyGenerator;
+    this.writers = writers;
+    this.authCheckBehavior = authCheckBehavior;
+    this.commandDistributionBehavior = commandDistributionBehavior;
+    clusterVariableRecordValidator = new ClusterVariableRecordValidator(clusterVariableState);
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<ClusterVariableRecord> command) {
+    final ClusterVariableRecord clusterVariableRecord = command.getValue();
+    final long key = keyGenerator.nextKey();
+
+    clusterVariableRecordValidator
+        .validateExistence(clusterVariableRecord)
+        .ifRightOrLeft(
+            record -> {
+              writers
+                  .state()
+                  .appendFollowUpEvent(key, ClusterVariableIntent.DELETED, clusterVariableRecord);
+              writers
+                  .response()
+                  .writeEventOnCommand(
+                      key, ClusterVariableIntent.DELETED, clusterVariableRecord, command);
+              commandDistributionBehavior
+                  .withKey(key)
+                  .inQueue(clusterVariableRecord.getName())
+                  .distribute(command);
+            },
+            rejection -> {
+              writers.rejection().appendRejection(command, rejection.type(), rejection.reason());
+              writers
+                  .response()
+                  .writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+            });
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<ClusterVariableRecord> command) {
+    final var clusterVariableRecord = command.getValue();
+    clusterVariableRecordValidator
+        .validateExistence(clusterVariableRecord)
+        .ifRightOrLeft(
+            record ->
+                writers
+                    .state()
+                    .appendFollowUpEvent(command.getKey(), ClusterVariableIntent.DELETED, record),
+            rejection ->
+                writers.rejection().appendRejection(command, rejection.type(), rejection.reason()));
+    commandDistributionBehavior.acknowledgeCommand(command);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
@@ -45,7 +45,8 @@ public class ClusterVariableDeleteProcessor
   public void processNewCommand(final TypedRecord<ClusterVariableRecord> command) {
     final ClusterVariableRecord clusterVariableRecord = command.getValue();
     clusterVariableRecordValidator
-        .validateExistence(clusterVariableRecord)
+        .ensureValidScope(clusterVariableRecord)
+        .flatMap(clusterVariableRecordValidator::validateExistence)
         .ifRightOrLeft(
             record -> {
               final long key = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableProcessors.java
@@ -29,5 +29,10 @@ public class ClusterVariableProcessors {
         ClusterVariableIntent.CREATE,
         new ClusterVariableCreateProcessor(
             keyGenerator, writers, authCheckBehavior, distributionBehavior, clusterVariableState));
+    typedRecordProcessors.onCommand(
+        ValueType.CLUSTER_VARIABLE,
+        ClusterVariableIntent.DELETE,
+        new ClusterVariableDeleteProcessor(
+            keyGenerator, writers, authCheckBehavior, distributionBehavior, clusterVariableState));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
@@ -56,6 +56,22 @@ public class ClusterVariableRecordValidator {
     return Either.right(record);
   }
 
+  public Either<Rejection, ClusterVariableRecord> validateExistence(
+      final ClusterVariableRecord record) {
+    if (globallyScopedVariableExists(record) || tenantScopedVariableExists(record)) {
+      return Either.right(record);
+    }
+    return Either.left(
+        new Rejection(
+            RejectionType.NOT_FOUND,
+            "Invalid cluster variable name: '%s'. The variable does not exist in the scope '%s'"
+                .formatted(
+                    record.getName(),
+                    record.getTenantId().isBlank()
+                        ? "GLOBAL"
+                        : "tenant: '%s'".formatted(record.getTenantId()))));
+  }
+
   private boolean tenantScopedVariableExists(final ClusterVariableRecord clusterVariableRecord) {
     return !clusterVariableRecord.getTenantId().isBlank()
         && clusterVariableState.existsAtTenantScope(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
@@ -73,13 +73,13 @@ public class ClusterVariableRecordValidator {
   }
 
   private boolean tenantScopedVariableExists(final ClusterVariableRecord clusterVariableRecord) {
-    return !clusterVariableRecord.getTenantId().isBlank()
+    return clusterVariableRecord.isTenantScoped()
         && clusterVariableState.existsAtTenantScope(
             clusterVariableRecord.getNameBuffer(), clusterVariableRecord.getTenantId());
   }
 
   private boolean globallyScopedVariableExists(final ClusterVariableRecord clusterVariableRecord) {
-    return clusterVariableRecord.getTenantId().isBlank()
+    return clusterVariableRecord.isGloballyScoped()
         && clusterVariableState.existsAtGlobalScope(clusterVariableRecord.getNameBuffer());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
@@ -82,4 +82,16 @@ public class ClusterVariableRecordValidator {
     return clusterVariableRecord.isGloballyScoped()
         && clusterVariableState.existsAtGlobalScope(clusterVariableRecord.getNameBuffer());
   }
+
+  public Either<Rejection, ClusterVariableRecord> ensureValidScope(
+      final ClusterVariableRecord clusterVariableRecord) {
+    if (clusterVariableRecord.isTenantScoped() || clusterVariableRecord.isGloballyScoped()) {
+      return Either.right(clusterVariableRecord);
+    } else {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              "Invalid cluster variable scope. The scope must be either 'GLOBAL' or 'TENANT'."));
+    }
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClusterVariableCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClusterVariableCreatedApplier.java
@@ -23,6 +23,10 @@ public class ClusterVariableCreatedApplier
 
   @Override
   public void applyState(final long key, final ClusterVariableRecord clusterVariableRecord) {
-    clusterVariableState.create(clusterVariableRecord);
+    if (clusterVariableRecord.isTenantScoped()) {
+      clusterVariableState.createTenantScopedClusterVariable(clusterVariableRecord);
+    } else if (clusterVariableRecord.isGloballyScoped()) {
+      clusterVariableState.createGloballyScopedClusterVariable(clusterVariableRecord);
+    } // if ever no scope is given, it is better not to do anything for safety
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClusterVariableDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClusterVariableDeletedApplier.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableClusterVariableState;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 
 public class ClusterVariableDeletedApplier

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClusterVariableDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClusterVariableDeletedApplier.java
@@ -23,6 +23,12 @@ public class ClusterVariableDeletedApplier
 
   @Override
   public void applyState(final long key, final ClusterVariableRecord clusterVariableRecord) {
-    clusterVariableState.deleteClusterVariable(clusterVariableRecord);
+    if (clusterVariableRecord.isTenantScoped()) {
+      clusterVariableState.deleteTenantScopedClusterVariable(
+          clusterVariableRecord.getNameBuffer(), clusterVariableRecord.getTenantId());
+    } else if (clusterVariableRecord.isGloballyScoped()) {
+      clusterVariableState.deleteGloballyScopedClusterVariable(
+          clusterVariableRecord.getNameBuffer());
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -156,7 +156,9 @@ public final class EventAppliers implements EventApplier {
         ClusterVariableIntent.CREATED,
         new ClusterVariableCreatedApplier(state.getClusterVariableState()));
     register(ClusterVariableIntent.UPDATED, NOOP_EVENT_APPLIER);
-    register(ClusterVariableIntent.DELETED, NOOP_EVENT_APPLIER);
+    register(
+        ClusterVariableIntent.DELETED,
+        new ClusterVariableDeletedApplier(state.getClusterVariableState()));
   }
 
   private void registerMultiInstanceAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/DbClusterVariableScopeKey.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/DbClusterVariableScopeKey.java
@@ -10,17 +10,19 @@ package io.camunda.zeebe.engine.state.clustervariable;
 import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.impl.DbEnumValue;
 import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public class DbClusterVariableScopeKey implements DbKey {
 
-  private final DbEnumValue<Scope> scope;
+  private final DbEnumValue<ClusterVariableScope> scope;
   private final DbString scopeKey;
   private final DirectBuffer emptyScopeKey = new UnsafeBuffer(0, 0);
 
-  public DbClusterVariableScopeKey(final DbEnumValue<Scope> scope, final DbString scopeKey) {
+  public DbClusterVariableScopeKey(
+      final DbEnumValue<ClusterVariableScope> scope, final DbString scopeKey) {
     this.scope = scope;
     this.scopeKey = scopeKey;
   }
@@ -29,7 +31,7 @@ public class DbClusterVariableScopeKey implements DbKey {
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     scope.wrap(buffer, offset, length);
 
-    if (scope.getValue() != Scope.GLOBAL) {
+    if (scope.getValue() != ClusterVariableScope.GLOBAL) {
       final var scopeLength = scope.getLength();
       scopeKey.wrap(buffer, offset + scopeLength, length - scopeLength);
     } else {
@@ -39,7 +41,8 @@ public class DbClusterVariableScopeKey implements DbKey {
 
   @Override
   public int getLength() {
-    final var tenantLength = scope.getValue() == Scope.GLOBAL ? 0 : scopeKey.getLength();
+    final var tenantLength =
+        scope.getValue() == ClusterVariableScope.GLOBAL ? 0 : scopeKey.getLength();
     return scope.getLength() + tenantLength;
   }
 
@@ -47,14 +50,9 @@ public class DbClusterVariableScopeKey implements DbKey {
   public void write(final MutableDirectBuffer buffer, final int offset) {
     scope.write(buffer, offset);
 
-    if (scope.getValue() != Scope.GLOBAL) {
+    if (scope.getValue() != ClusterVariableScope.GLOBAL) {
       final var scopeLength = scope.getLength();
       scopeKey.write(buffer, offset + scopeLength);
     } // else don't write scopeKey as part of the key
-  }
-
-  public enum Scope {
-    GLOBAL,
-    TENANT
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/DbClusterVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/DbClusterVariableState.java
@@ -7,26 +7,23 @@
  */
 package io.camunda.zeebe.engine.state.clustervariable;
 
-import static io.camunda.zeebe.engine.state.clustervariable.DbClusterVariableScopeKey.Scope.GLOBAL;
-import static io.camunda.zeebe.engine.state.clustervariable.DbClusterVariableScopeKey.Scope.TENANT;
-
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbEnumValue;
 import io.camunda.zeebe.db.impl.DbString;
-import io.camunda.zeebe.engine.state.clustervariable.DbClusterVariableScopeKey.Scope;
 import io.camunda.zeebe.engine.state.mutable.MutableClusterVariableState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 
 public class DbClusterVariableState implements MutableClusterVariableState {
 
   private final DbString clusterVariableName;
-  private final DbEnumValue<Scope> clusterVariableScope;
+  private final DbEnumValue<ClusterVariableScope> clusterVariableScope;
   private final DbString clusterVariableTenantId;
   private final DbCompositeKey<DbString, DbClusterVariableScopeKey> clusterVariableKey;
 
@@ -38,7 +35,7 @@ public class DbClusterVariableState implements MutableClusterVariableState {
   public DbClusterVariableState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
     clusterVariableName = new DbString();
-    clusterVariableScope = new DbEnumValue<>(Scope.class);
+    clusterVariableScope = new DbEnumValue<>(ClusterVariableScope.class);
     clusterVariableTenantId = new DbString();
     clusterVariableKey =
         new DbCompositeKey<>(
@@ -57,7 +54,7 @@ public class DbClusterVariableState implements MutableClusterVariableState {
   @Override
   public void createTenantScopedClusterVariable(final ClusterVariableRecord clusterVariableRecord) {
     clusterVariableName.wrapBuffer(clusterVariableRecord.getNameBuffer());
-    clusterVariableScope.setValue(TENANT);
+    clusterVariableScope.setValue(ClusterVariableScope.TENANT);
     clusterVariableTenantId.wrapString(clusterVariableRecord.getTenantId());
     clusterVariableInstance.setRecord(clusterVariableRecord);
     clusterVariablesColumnFamily.insert(clusterVariableKey, clusterVariableInstance);
@@ -67,7 +64,7 @@ public class DbClusterVariableState implements MutableClusterVariableState {
   public void createGloballyScopedClusterVariable(
       final ClusterVariableRecord clusterVariableRecord) {
     clusterVariableName.wrapBuffer(clusterVariableRecord.getNameBuffer());
-    clusterVariableScope.setValue(GLOBAL);
+    clusterVariableScope.setValue(ClusterVariableScope.GLOBAL);
     clusterVariableInstance.setRecord(clusterVariableRecord);
     clusterVariablesColumnFamily.insert(clusterVariableKey, clusterVariableInstance);
   }
@@ -76,7 +73,7 @@ public class DbClusterVariableState implements MutableClusterVariableState {
   public void deleteTenantScopedClusterVariable(
       final DirectBuffer variableNameBuffer, final String tenantId) {
     clusterVariableName.wrapBuffer(variableNameBuffer);
-    clusterVariableScope.setValue(TENANT);
+    clusterVariableScope.setValue(ClusterVariableScope.TENANT);
     clusterVariableTenantId.wrapString(tenantId);
     clusterVariablesColumnFamily.deleteExisting(clusterVariableKey);
   }
@@ -84,7 +81,7 @@ public class DbClusterVariableState implements MutableClusterVariableState {
   @Override
   public void deleteGloballyScopedClusterVariable(final DirectBuffer variableNameBuffer) {
     clusterVariableName.wrapBuffer(variableNameBuffer);
-    clusterVariableScope.setValue(GLOBAL);
+    clusterVariableScope.setValue(ClusterVariableScope.GLOBAL);
     clusterVariablesColumnFamily.deleteExisting(clusterVariableKey);
   }
 
@@ -92,7 +89,7 @@ public class DbClusterVariableState implements MutableClusterVariableState {
   public Optional<ClusterVariableInstance> getTenantScopedClusterVariable(
       final DirectBuffer variableNameBuffer, final String tenantId) {
     clusterVariableName.wrapBuffer(variableNameBuffer);
-    clusterVariableScope.setValue(TENANT);
+    clusterVariableScope.setValue(ClusterVariableScope.TENANT);
     clusterVariableTenantId.wrapString(tenantId);
     return Optional.ofNullable(
         clusterVariablesColumnFamily.get(clusterVariableKey, ClusterVariableInstance::new));
@@ -102,7 +99,7 @@ public class DbClusterVariableState implements MutableClusterVariableState {
   public Optional<ClusterVariableInstance> getGloballyScopedClusterVariable(
       final DirectBuffer variableNameBuffer) {
     clusterVariableName.wrapBuffer(variableNameBuffer);
-    clusterVariableScope.setValue(GLOBAL);
+    clusterVariableScope.setValue(ClusterVariableScope.GLOBAL);
     return Optional.ofNullable(
         clusterVariablesColumnFamily.get(clusterVariableKey, ClusterVariableInstance::new));
   }
@@ -110,7 +107,7 @@ public class DbClusterVariableState implements MutableClusterVariableState {
   @Override
   public boolean existsAtTenantScope(final DirectBuffer variableNameBuffer, final String tenantId) {
     clusterVariableName.wrapBuffer(variableNameBuffer);
-    clusterVariableScope.setValue(TENANT);
+    clusterVariableScope.setValue(ClusterVariableScope.TENANT);
     clusterVariableTenantId.wrapString(tenantId);
     return clusterVariablesColumnFamily.exists(clusterVariableKey);
   }
@@ -118,7 +115,7 @@ public class DbClusterVariableState implements MutableClusterVariableState {
   @Override
   public boolean existsAtGlobalScope(final DirectBuffer variableNameBuffer) {
     clusterVariableName.wrapBuffer(variableNameBuffer);
-    clusterVariableScope.setValue(GLOBAL);
+    clusterVariableScope.setValue(ClusterVariableScope.GLOBAL);
     return clusterVariablesColumnFamily.exists(clusterVariableKey);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/DbClusterVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/DbClusterVariableState.java
@@ -55,16 +55,19 @@ public class DbClusterVariableState implements MutableClusterVariableState {
   }
 
   @Override
-  public void create(final ClusterVariableRecord clusterVariableRecord) {
-    if (clusterVariableRecord.getTenantId() == null
-        || clusterVariableRecord.getTenantId().isBlank()) {
-      clusterVariableName.wrapBuffer(clusterVariableRecord.getNameBuffer());
-      clusterVariableScope.setValue(GLOBAL);
-    } else {
-      clusterVariableName.wrapBuffer(clusterVariableRecord.getNameBuffer());
-      clusterVariableScope.setValue(TENANT);
-      clusterVariableTenantId.wrapString(clusterVariableRecord.getTenantId());
-    }
+  public void createTenantScopedClusterVariable(final ClusterVariableRecord clusterVariableRecord) {
+    clusterVariableName.wrapBuffer(clusterVariableRecord.getNameBuffer());
+    clusterVariableScope.setValue(TENANT);
+    clusterVariableTenantId.wrapString(clusterVariableRecord.getTenantId());
+    clusterVariableInstance.setRecord(clusterVariableRecord);
+    clusterVariablesColumnFamily.insert(clusterVariableKey, clusterVariableInstance);
+  }
+
+  @Override
+  public void createGloballyScopedClusterVariable(
+      final ClusterVariableRecord clusterVariableRecord) {
+    clusterVariableName.wrapBuffer(clusterVariableRecord.getNameBuffer());
+    clusterVariableScope.setValue(GLOBAL);
     clusterVariableInstance.setRecord(clusterVariableRecord);
     clusterVariablesColumnFamily.insert(clusterVariableKey, clusterVariableInstance);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableClusterVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableClusterVariableState.java
@@ -17,4 +17,13 @@ public interface MutableClusterVariableState extends ClusterVariableState {
   void deleteTenantScopedClusterVariable(DirectBuffer variableNameBuffer, String tenantId);
 
   void deleteGloballyScopedClusterVariable(DirectBuffer variableNameBuffer);
+
+  default void deleteClusterVariable(final ClusterVariableRecord clusterVariableRecord) {
+    if (clusterVariableRecord.getTenantId().isBlank()) {
+      deleteGloballyScopedClusterVariable(clusterVariableRecord.getNameBuffer());
+    } else {
+      deleteTenantScopedClusterVariable(
+          clusterVariableRecord.getNameBuffer(), clusterVariableRecord.getTenantId());
+    }
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableClusterVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableClusterVariableState.java
@@ -12,18 +12,12 @@ import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariab
 import org.agrona.DirectBuffer;
 
 public interface MutableClusterVariableState extends ClusterVariableState {
-  void create(ClusterVariableRecord clusterVariableRecord);
+
+  void createTenantScopedClusterVariable(ClusterVariableRecord clusterVariableRecord);
+
+  void createGloballyScopedClusterVariable(ClusterVariableRecord clusterVariableRecord);
 
   void deleteTenantScopedClusterVariable(DirectBuffer variableNameBuffer, String tenantId);
 
   void deleteGloballyScopedClusterVariable(DirectBuffer variableNameBuffer);
-
-  default void deleteClusterVariable(final ClusterVariableRecord clusterVariableRecord) {
-    if (clusterVariableRecord.getTenantId().isBlank()) {
-      deleteGloballyScopedClusterVariable(clusterVariableRecord.getNameBuffer());
-    } else {
-      deleteTenantScopedClusterVariable(
-          clusterVariableRecord.getNameBuffer(), clusterVariableRecord.getTenantId());
-    }
-  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableMultiPartitionTest.java
@@ -38,7 +38,12 @@ public final class CreateClusterVariableMultiPartitionTest {
   @Test
   public void createGlobalScopedClusterVariableMultiPartition() {
     // when
-    ENGINE_RULE.clusterVariables().withName("KEY_1").withValue("\"VALUE\"").create();
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_1")
+        .setGlobalScope()
+        .withValue("\"VALUE\"")
+        .create();
 
     // then
     assertThat(
@@ -90,6 +95,7 @@ public final class CreateClusterVariableMultiPartitionTest {
     ENGINE_RULE
         .clusterVariables()
         .withName("KEY_2")
+        .setTenantScope()
         .withValue("\"VALUE\"")
         .withTenantId("tenant_1")
         .create();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
@@ -69,6 +69,25 @@ public final class CreateClusterVariableTest {
   }
 
   @Test
+  public void createClusterVariableWithoutScope() {
+    // when
+    final var record =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_1")
+            .withValue("\"VALUE\"")
+            .expectRejection()
+            .create();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Invalid cluster variable scope. The scope must be either 'GLOBAL' or 'TENANT'.");
+  }
+
+  @Test
   public void createGlobalScopedClusterVariableAlreadyExists() {
     // given
     ENGINE_RULE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
@@ -38,7 +38,12 @@ public final class CreateClusterVariableTest {
   public void createGlobalScopedClusterVariable() {
     // when
     final var record =
-        ENGINE_RULE.clusterVariables().withName("KEY_1").withValue("\"VALUE\"").create();
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_1")
+            .setGlobalScope()
+            .withValue("\"VALUE\"")
+            .create();
 
     // then
     Assertions.assertThat(record)
@@ -54,6 +59,7 @@ public final class CreateClusterVariableTest {
             .clusterVariables()
             .withName("KEY_2")
             .withValue("\"VALUE\"")
+            .setTenantScope()
             .withTenantId("tenant_1")
             .create();
     // then
@@ -65,12 +71,18 @@ public final class CreateClusterVariableTest {
   @Test
   public void createGlobalScopedClusterVariableAlreadyExists() {
     // given
-    ENGINE_RULE.clusterVariables().withName("KEY_3").withValue("\"VALUE\"").create();
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_3")
+        .setGlobalScope()
+        .withValue("\"VALUE\"")
+        .create();
     // when
     final var record =
         ENGINE_RULE
             .clusterVariables()
             .withName("KEY_3")
+            .setGlobalScope()
             .withValue("\"VALUE_2\"")
             .expectRejection()
             .create();
@@ -86,12 +98,18 @@ public final class CreateClusterVariableTest {
   public void globalScopedAndTenantScopedClusterVariableDoNotOverlap() {
     // given
     final var recordGlobal =
-        ENGINE_RULE.clusterVariables().withName("KEY_5").withValue("\"VALUE\"").create();
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_5")
+            .setGlobalScope()
+            .withValue("\"VALUE\"")
+            .create();
     // when
     final var recordTenant =
         ENGINE_RULE
             .clusterVariables()
             .withName("KEY_5")
+            .setTenantScope()
             .withValue("\"VALUE\"")
             .withTenantId("tenant-1")
             .create();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableMultiPartitionTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clustervariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.stream.Collectors;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class DeleteClusterVariableMultiPartitionTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  @ClassRule
+  public static final EngineRule ENGINE_RULE = EngineRule.multiplePartition(PARTITION_COUNT);
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void deleteGlobalScopedClusterVariableMultiPartition() {
+    // given
+    ENGINE_RULE.clusterVariables().withName("KEY_1").withValue("\"VALUE\"").create();
+
+    RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+        .withDistributionIntent(ClusterVariableIntent.CREATE)
+        .await();
+
+    // when
+    ENGINE_RULE.clusterVariables().withName("KEY_1").delete();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(1)
+                .limitByCount(
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.CLUSTER_VARIABLE
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == ClusterVariableIntent.DELETE)))
+        .extracting(
+            Record::getIntent,
+            Record::getRecordType,
+            r ->
+                r.getValue() instanceof CommandDistributionRecordValue
+                    ? ((CommandDistributionRecordValue) r.getValue()).getPartitionId()
+                    : r.getPartitionId())
+        .containsSubsequence(
+            tuple(ClusterVariableIntent.DELETE, RecordType.COMMAND, 1),
+            tuple(ClusterVariableIntent.DELETED, RecordType.EVENT, 1),
+            tuple(CommandDistributionIntent.STARTED, RecordType.EVENT, 1))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 2))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
+        .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
+
+    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+      assertThat(
+              RecordingExporter.records()
+                  .withPartitionId(partitionId)
+                  .limit(record -> record.getIntent().equals(ClusterVariableIntent.DELETED))
+                  .collect(Collectors.toList()))
+          .extracting(Record::getIntent)
+          .containsSubsequence(ClusterVariableIntent.DELETE, ClusterVariableIntent.DELETED);
+    }
+  }
+
+  @Test
+  public void deleteTenantScopedClusterVariableMultiPartition() {
+    // given
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_1")
+        .withTenantId("tenant_2")
+        .withValue("\"VALUE\"")
+        .create();
+
+    RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+        .withDistributionIntent(ClusterVariableIntent.CREATE)
+        .await();
+
+    // when
+    ENGINE_RULE.clusterVariables().withName("KEY_1").withTenantId("tenant_2").delete();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(1)
+                .limitByCount(
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.CLUSTER_VARIABLE
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == ClusterVariableIntent.DELETE)))
+        .extracting(
+            Record::getIntent,
+            Record::getRecordType,
+            r ->
+                r.getValue() instanceof CommandDistributionRecordValue
+                    ? ((CommandDistributionRecordValue) r.getValue()).getPartitionId()
+                    : r.getPartitionId())
+        .containsSubsequence(
+            tuple(ClusterVariableIntent.DELETE, RecordType.COMMAND, 1),
+            tuple(ClusterVariableIntent.DELETED, RecordType.EVENT, 1),
+            tuple(CommandDistributionIntent.STARTED, RecordType.EVENT, 1))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 2))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
+        .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
+
+    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+      assertThat(
+              RecordingExporter.records()
+                  .withPartitionId(partitionId)
+                  .limit(record -> record.getIntent().equals(ClusterVariableIntent.DELETED))
+                  .collect(Collectors.toList()))
+          .extracting(Record::getIntent)
+          .containsSubsequence(ClusterVariableIntent.DELETE, ClusterVariableIntent.DELETED);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableMultiPartitionTest.java
@@ -38,14 +38,19 @@ public final class DeleteClusterVariableMultiPartitionTest {
   @Test
   public void deleteGlobalScopedClusterVariableMultiPartition() {
     // given
-    ENGINE_RULE.clusterVariables().withName("KEY_1").withValue("\"VALUE\"").create();
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_1")
+        .setGlobalScope()
+        .withValue("\"VALUE\"")
+        .create();
 
     RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
         .withDistributionIntent(ClusterVariableIntent.CREATE)
         .await();
 
     // when
-    ENGINE_RULE.clusterVariables().withName("KEY_1").delete();
+    ENGINE_RULE.clusterVariables().setGlobalScope().withName("KEY_1").delete();
 
     // then
     assertThat(
@@ -97,6 +102,7 @@ public final class DeleteClusterVariableMultiPartitionTest {
     ENGINE_RULE
         .clusterVariables()
         .withName("KEY_1")
+        .setTenantScope()
         .withTenantId("tenant_2")
         .withValue("\"VALUE\"")
         .create();
@@ -106,7 +112,12 @@ public final class DeleteClusterVariableMultiPartitionTest {
         .await();
 
     // when
-    ENGINE_RULE.clusterVariables().withName("KEY_1").withTenantId("tenant_2").delete();
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_1")
+        .setTenantScope()
+        .withTenantId("tenant_2")
+        .delete();
 
     // then
     assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableTest.java
@@ -90,6 +90,6 @@ public final class DeleteClusterVariableTest {
         .hasIntent(ClusterVariableIntent.DELETE)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Invalid cluster variable name: 'KEY_4'. The variable does not exist in the scope 'tenant': 'tenant-1'");
+            "Invalid cluster variable name: 'KEY_4'. The variable does not exist in the scope 'tenant: 'tenant-1''");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clustervariable;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class DeleteClusterVariableTest {
+
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void deleteGlobalScopedClusterVariable() {
+    // given
+    ENGINE_RULE.clusterVariables().withName("KEY_1").withValue("\"VALUE\"").create();
+
+    // when
+    final var record = ENGINE_RULE.clusterVariables().withName("KEY_1").delete();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.DELETED)
+        .hasRecordType(RecordType.EVENT);
+  }
+
+  @Test
+  public void createTenantScopedClusterVariable() {
+    // given
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_2")
+        .withValue("\"VALUE\"")
+        .withTenantId("tenant_1")
+        .create();
+
+    // when
+    final var record =
+        ENGINE_RULE.clusterVariables().withName("KEY_2").withTenantId("tenant_1").delete();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.DELETED)
+        .hasRecordType(RecordType.EVENT);
+  }
+
+  @Test
+  public void deleteNonExistingGlobalScopedClusterVariable() {
+    // when
+    final var record = ENGINE_RULE.clusterVariables().withName("KEY_3").expectRejection().delete();
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.DELETE)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Invalid cluster variable name: 'KEY_3'. The variable does not exist in the scope 'GLOBAL'");
+  }
+
+  @Test
+  public void globalScopedAndTenantScopedClusterVariableDoNotOverlapForDeletion() {
+    // given
+
+    ENGINE_RULE.clusterVariables().withName("KEY_4").withValue("\"VALUE\"").create();
+    // when
+    final var recordTenant =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_4")
+            .withTenantId("tenant-1")
+            .expectRejection()
+            .delete();
+    // then
+
+    Assertions.assertThat(recordTenant)
+        .hasIntent(ClusterVariableIntent.DELETE)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Invalid cluster variable name: 'KEY_4'. The variable does not exist in the scope 'tenant': 'tenant-1'");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableTest.java
@@ -71,6 +71,51 @@ public final class DeleteClusterVariableTest {
   }
 
   @Test
+  public void deleteWithoutScopeTenantScopedClusterVariable() {
+    // given
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_TO_DELETE_1")
+        .setTenantScope()
+        .withValue("\"VALUE\"")
+        .withTenantId("tenant_1")
+        .create();
+
+    // when
+    final var record =
+        ENGINE_RULE.clusterVariables().withName("KEY_TO_DELETE_1").expectRejection().delete();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.DELETE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Invalid cluster variable scope. The scope must be either 'GLOBAL' or 'TENANT'.");
+  }
+
+  @Test
+  public void deleteWithoutScopeGloballyScopedClusterVariable() {
+    // given
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_TO_DELETE_2")
+        .setTenantScope()
+        .withValue("\"VALUE\"")
+        .create();
+
+    // when
+    final var record =
+        ENGINE_RULE.clusterVariables().withName("KEY_TO_DELETE_2").expectRejection().delete();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.DELETE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Invalid cluster variable scope. The scope must be either 'GLOBAL' or 'TENANT'.");
+  }
+
+  @Test
   public void deleteNonExistingGlobalScopedClusterVariable() {
     // when
     final var record =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -682,7 +682,13 @@ public class CommandDistributionIdempotencyTest {
             new Scenario(
                 ValueType.CLUSTER_VARIABLE,
                 ClusterVariableIntent.CREATE,
-                () -> ENGINE.clusterVariables().withName("KEY_1").withValue("\"VALUE\"").create()),
+                () ->
+                    ENGINE
+                        .clusterVariables()
+                        .withName("KEY_1")
+                        .setGlobalScope()
+                        .withValue("\"VALUE\"")
+                        .create()),
             ClusterVariableCreateProcessor.class
           },
           {
@@ -691,8 +697,13 @@ public class CommandDistributionIdempotencyTest {
                 ValueType.CLUSTER_VARIABLE,
                 ClusterVariableIntent.DELETE,
                 () -> {
-                  ENGINE.clusterVariables().withName("KEY_2").withValue("\"VALUE\"").create();
-                  return ENGINE.clusterVariables().withName("KEY_2").delete();
+                  ENGINE
+                      .clusterVariables()
+                      .withName("KEY_2")
+                      .setGlobalScope()
+                      .withValue("\"VALUE\"")
+                      .create();
+                  return ENGINE.clusterVariables().setGlobalScope().withName("KEY_2").delete();
                 }),
             ClusterVariableDeleteProcessor.class
           },

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationResumePro
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationSuspendProcessor;
 import io.camunda.zeebe.engine.processing.clock.ClockProcessor;
 import io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableCreateProcessor;
+import io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableDeleteProcessor;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCreateProcessor;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationDeleteProcessor;
@@ -683,6 +684,17 @@ public class CommandDistributionIdempotencyTest {
                 ClusterVariableIntent.CREATE,
                 () -> ENGINE.clusterVariables().withName("KEY_1").withValue("\"VALUE\"").create()),
             ClusterVariableCreateProcessor.class
+          },
+          {
+            "ClusterVariable.DELETE is idempotent",
+            new Scenario(
+                ValueType.CLUSTER_VARIABLE,
+                ClusterVariableIntent.DELETE,
+                () -> {
+                  ENGINE.clusterVariables().withName("KEY_2").withValue("\"VALUE\"").create();
+                  return ENGINE.clusterVariables().withName("KEY_2").delete();
+                }),
+            ClusterVariableDeleteProcessor.class
           },
           {
             "MessageSubscription.MIGRATE is idempotent",

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClusterVariableClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClusterVariableClient.java
@@ -66,6 +66,16 @@ public final class ClusterVariableClient {
     return this;
   }
 
+  public ClusterVariableClient setTenantScope() {
+    clusterVariableRecord.setTenantScope();
+    return this;
+  }
+
+  public ClusterVariableClient setGlobalScope() {
+    clusterVariableRecord.setGlobalScope();
+    return this;
+  }
+
   public ClusterVariableClient expectRejection() {
     expectation = REJECTION_SUPPLIER;
     return this;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClusterVariableClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClusterVariableClient.java
@@ -81,4 +81,15 @@ public final class ClusterVariableClient {
             clusterVariableRecord);
     return expectation.apply(position);
   }
+
+  public Record<ClusterVariableRecordValue> delete() {
+    final long position =
+        writer.writeCommand(
+            DEFAULT_KEY,
+            requestStreamId,
+            requestId,
+            ClusterVariableIntent.DELETE,
+            clusterVariableRecord);
+    return expectation.apply(position);
+  }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ClusterVariable_CREATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ClusterVariable_CREATED_v1.golden
@@ -23,6 +23,10 @@ public class ClusterVariableCreatedApplier
 
   @Override
   public void applyState(final long key, final ClusterVariableRecord clusterVariableRecord) {
-    clusterVariableState.create(clusterVariableRecord);
+    if (clusterVariableRecord.isTenantScoped()) {
+      clusterVariableState.createTenantScopedClusterVariable(clusterVariableRecord);
+    } else if (clusterVariableRecord.isGloballyScoped()) {
+      clusterVariableState.createGloballyScopedClusterVariable(clusterVariableRecord);
+    } // if ever no scope is given, it is better not to do anything for safety
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ClusterVariable_DELETED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ClusterVariable_DELETED_v1.golden
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableClusterVariableState;
-import io.camunda.zeebe.protocol.impl.record.value.variable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 
 public class ClusterVariableDeletedApplier

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ClusterVariable_DELETED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ClusterVariable_DELETED_v1.golden
@@ -23,6 +23,12 @@ public class ClusterVariableDeletedApplier
 
   @Override
   public void applyState(final long key, final ClusterVariableRecord clusterVariableRecord) {
-    clusterVariableState.deleteClusterVariable(clusterVariableRecord);
+    if (clusterVariableRecord.isTenantScoped()) {
+      clusterVariableState.deleteTenantScopedClusterVariable(
+          clusterVariableRecord.getNameBuffer(), clusterVariableRecord.getTenantId());
+    } else if (clusterVariableRecord.isGloballyScoped()) {
+      clusterVariableState.deleteGloballyScopedClusterVariable(
+          clusterVariableRecord.getNameBuffer());
+    }
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-cluster-variable-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-cluster-variable-template.json
@@ -28,6 +28,9 @@
               "type": "keyword",
               "ignore_above": 8191
             },
+            "scope": {
+              "type": "keyword"
+            },
             "tenantId": {
               "type": "keyword"
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-cluster-variable-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-cluster-variable-template.json
@@ -2,7 +2,9 @@
   "index_patterns": [
     "zeebe-record_cluster-variable_*"
   ],
-  "composed_of": ["zeebe-record"],
+  "composed_of": [
+    "zeebe-record"
+  ],
   "priority": 20,
   "version": 1,
   "template": {
@@ -25,6 +27,9 @@
             "value": {
               "type": "keyword",
               "ignore_above": 8191
+            },
+            "scope": {
+              "type": "keyword"
             },
             "tenantId": {
               "type": "keyword"

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
@@ -16,16 +16,19 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public class ClusterVariableRecord extends UnifiedRecordValue
     implements ClusterVariableRecordValue {
+
+  private static final UnsafeBuffer SERIALIZABLE_EMPTY_BUFFER = new UnsafeBuffer(new byte[] {0});
 
   private static final StringValue NAME_KEY = new StringValue("name");
   private static final StringValue VALUE_KEY = new StringValue("value");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
-  private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
+  private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY, SERIALIZABLE_EMPTY_BUFFER);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
 
   public ClusterVariableRecord() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
@@ -32,7 +32,7 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private final BinaryProperty valueProp =
       new BinaryProperty(VALUE_KEY, new UnsafeBuffer(new byte[] {0}));
   private final EnumProperty<ClusterVariableScope> scopeProp =
-      new EnumProperty<>(SCOPE_KEY, ClusterVariableScope.class);
+      new EnumProperty<>(SCOPE_KEY, ClusterVariableScope.class, ClusterVariableScope.UNSPECIFIED);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
 
   public ClusterVariableRecord() {
@@ -63,19 +63,22 @@ public class ClusterVariableRecord extends UnifiedRecordValue
     return scopeProp.getValue();
   }
 
+  public ClusterVariableRecord setScope(final ClusterVariableScope scope) {
+    scopeProp.setValue(scope);
+    return this;
+  }
+
   public ClusterVariableRecord setName(final String name) {
     nameProp.setValue(name);
     return this;
   }
 
   public ClusterVariableRecord setTenantScope() {
-    scopeProp.setValue(ClusterVariableScope.TENANT);
-    return this;
+    return setScope(ClusterVariableScope.TENANT);
   }
 
   public ClusterVariableRecord setGlobalScope() {
-    scopeProp.setValue(ClusterVariableScope.GLOBAL);
-    return this;
+    return setScope(ClusterVariableScope.GLOBAL);
   }
 
   @JsonIgnore
@@ -98,10 +101,12 @@ public class ClusterVariableRecord extends UnifiedRecordValue
     return this;
   }
 
+  @JsonIgnore
   public boolean isTenantScoped() {
     return ClusterVariableScope.TENANT.equals(scopeProp.getValue());
   }
 
+  @JsonIgnore
   public boolean isGloballyScoped() {
     return ClusterVariableScope.GLOBAL.equals(scopeProp.getValue());
   }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
@@ -16,16 +16,19 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public class ClusterVariableRecord extends UnifiedRecordValue
     implements ClusterVariableRecordValue {
+
+  private static final UnsafeBuffer SERIALIZABLE_EMPTY_BUFFER = new UnsafeBuffer(new byte[] {0});
 
   private static final StringValue NAME_KEY = new StringValue("name");
   private static final StringValue VALUE_KEY = new StringValue("value");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
-  private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
+  private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY, SERIALIZABLE_EMPTY_BUFFER);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
 
   public ClusterVariableRecord() {

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
@@ -32,7 +32,7 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private final BinaryProperty valueProp =
       new BinaryProperty(VALUE_KEY, new UnsafeBuffer(new byte[] {0}));
   private final EnumProperty<ClusterVariableScope> scopeProp =
-      new EnumProperty<>(SCOPE_KEY, ClusterVariableScope.class);
+      new EnumProperty<>(SCOPE_KEY, ClusterVariableScope.class, ClusterVariableScope.UNSPECIFIED);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
 
   public ClusterVariableRecord() {
@@ -63,19 +63,22 @@ public class ClusterVariableRecord extends UnifiedRecordValue
     return scopeProp.getValue();
   }
 
+  public ClusterVariableRecord setScope(final ClusterVariableScope scope) {
+    scopeProp.setValue(scope);
+    return this;
+  }
+
   public ClusterVariableRecord setName(final String name) {
     nameProp.setValue(name);
     return this;
   }
 
   public ClusterVariableRecord setTenantScope() {
-    scopeProp.setValue(ClusterVariableScope.TENANT);
-    return this;
+    return setScope(ClusterVariableScope.TENANT);
   }
 
   public ClusterVariableRecord setGlobalScope() {
-    scopeProp.setValue(ClusterVariableScope.GLOBAL);
-    return this;
+    return setScope(ClusterVariableScope.GLOBAL);
   }
 
   @JsonIgnore
@@ -98,10 +101,12 @@ public class ClusterVariableRecord extends UnifiedRecordValue
     return this;
   }
 
+  @JsonIgnore
   public boolean isTenantScoped() {
     return ClusterVariableScope.TENANT.equals(scopeProp.getValue());
   }
 
+  @JsonIgnore
   public boolean isGloballyScoped() {
     return ClusterVariableScope.GLOBAL.equals(scopeProp.getValue());
   }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
@@ -30,7 +30,7 @@ import org.immutables.value.Value;
  * <ul>
  *   <li>{@link #getName()} – the unique name of the cluster variable.
  *   <li>{@link #getValue()} – the current value of the cluster variable, as a deserialized object.
- *   <li>{@link #getKey()} – the unique key identifying the cluster variable
+ *   <li>{@link #getScope()} – the current scope of the cluster variable.
  * </ul>
  *
  * @see RecordValue;
@@ -57,4 +57,14 @@ public interface ClusterVariableRecordValue extends RecordValue, TenantOwned {
    * @return the variable value
    */
   Object getValue();
+
+  /**
+   * Returns the scope in which this variable is defined.
+   *
+   * <p>The scope determines the visibility and lifecycle of the variable, for example, whether it
+   * is global across all tenants or specific to a single tenant.
+   *
+   * @return the variable scope (never {@code null})
+   */
+  ClusterVariableScope getScope();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableScope.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableScope.java
@@ -17,7 +17,8 @@ package io.camunda.zeebe.protocol.record.value;
 
 public enum ClusterVariableScope {
   GLOBAL("global"),
-  TENANT("tenant");
+  TENANT("tenant"),
+  UNSPECIFIED("unspecified");
 
   private final String scope;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableScope.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableScope.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public enum ClusterVariableScope {
+  GLOBAL("global"),
+  TENANT("tenant");
+
+  private final String scope;
+
+  ClusterVariableScope(final String scope) {
+    this.scope = scope;
+  }
+
+  public String getScope() {
+    return scope;
+  }
+}


### PR DESCRIPTION
## Description

In this PR I implemented cluster variable deletion support and integrated it into the RocksDB / state

- Added a new processor: ClusterVariableDeleteProcessor, which handles commands to delete cluster variables
- Wrote state applier: ClusterVariableDeletedApplier which updates the internal mutable cluster variable state when a deletion event is applied
- Introduced MutableClusterVariableState new generic delete method
- Modified event applier registration (in EventAppliers) to wire in the new applier for cluster variable “DELETED” intent
- Updated processor wiring (in EngineProcessors) so cluster variable DELETE commands are registered in the processor pipeline
- Added tests (integration / unit) for the new behavior:
- DeleteClusterVariableTest exercising correct success and failure cases
- Test utilities / client support (ClusterVariableClient)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/39056
