### PR TITLE
ci: fetch all git history because of yarn

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -110,6 +110,7 @@ jobs:
           # - This token will be used for all git operations in this job
           # - This token expires after 1 hour (https://github.com/actions/create-github-app-token?tab=readme-ov-file#create-github-app-token)
           token: ${{ steps.github-token.outputs.token }}
+          fetch-depth: 0
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@v3.4.0


### PR DESCRIPTION
## Description

Trying [this proposed solution](https://github.com/yarnpkg/berry/issues/4424#issuecomment-2775525527) to this error:
```
Error: ROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.15.1:yarn (update package.json version) on project identity-webjar: Failed to run task: 'yarn version 8.8.0' failed. org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1) -> [Help 1]
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
