### PR TITLE
test: flaky PostImporterNullTreePathIT

### DIFF
--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/PostImporterNullTreePathIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/PostImporterNullTreePathIT.java
@@ -127,8 +127,8 @@ public class PostImporterNullTreePathIT {
               // we cannot reliably assert the treePath, see
               // https://github.com/camunda/camunda/issues/39653
               // assertThat(incident.getTreePath()).matches(TREE_PATH_REGEX);
-              final String piKey = incident.getTreePath().split("/")[0].substring(3);
-              assertThat(processInstanceKeys.contains(Long.parseLong(piKey))).isTrue();
+              // final String piKey = incident.getTreePath().split("/")[0].substring(3);
+              // assertThat(processInstanceKeys.contains(Long.parseLong(piKey))).isTrue();
             });
   }
 }


### PR DESCRIPTION
processInstanceKeys contains the root PI keys only, because https://github.com/camunda/camunda/issues/39653, the first PI in the path may not be the root PI key

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
