### PR TITLE
ci: adjust generation template for 8.6

### DIFF
--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -64,7 +64,7 @@ jobs:
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.second-last-version) }}
             generation_template: ${{ format('Camunda {0}+gen1', needs.get-versions.outputs.second-last-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.third-last-version) }}
-            generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.third-last-version) }}
+            generation_template: ${{ format('Camunda {0}+gen1', needs.get-versions.outputs.third-last-version) }}
     runs-on: ubuntu-latest
     name: Weekly E2E
     steps:


### PR DESCRIPTION
The generation template for 8.6 was wrong, leading our e2e tests to fail