### PR TITLE
fix: clean up serializer mixins

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -39,6 +39,7 @@ final class BulkIndexRequest implements ContentProducer {
 
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
       new ObjectMapper()
+          .addMixIn(Record.class, RecordSequenceMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -15,11 +15,6 @@ import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
-import io.camunda.zeebe.protocol.record.value.JobRecordValue;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
-import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
@@ -45,12 +40,6 @@ final class BulkIndexRequest implements ContentProducer {
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
       new ObjectMapper()
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
-          .addMixIn(Record.class, RecordMetadata87Mixin.class)
-          .addMixIn(ProcessInstanceCreationRecordValue.class, ProcessInstanceCreation87Mixin.class)
-          .addMixIn(ProcessInstanceRecordValue.class, ProcessInstance87Mixin.class)
-          .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResult87Mixin.class)
-          .addMixIn(UserTaskRecordValue.class, UserTask87Mixin.class)
-          .addMixIn(JobRecordValue.class, Job87Mixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
@@ -59,14 +48,6 @@ final class BulkIndexRequest implements ContentProducer {
   private static final String RECORD_AUTHORIZATIONS_PROPERTY = "authorizations";
   private static final String RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY =
       "decisionEvaluationInstanceKey";
-  private static final String BATCH_OPERATION_REFERENCE_PROPERTY = "batchOperationReference";
-  private static final String TAGS_PROPERTY = "tags";
-  private static final String RESULT_PROPERTY = "result";
-  private static final String DENIED_REASON_PROPERTY = "deniedReason";
-  private static final String RUNTIME_INSTRUCTIONS_PROPERTY = "runtimeInstructions";
-  private static final String ELEMENT_INSTANCE_PATH_PROPERTY = "elementInstancePath";
-  private static final String PROCESS_DEFINITION_PATH_PROPERTY = "processDefinitionPath";
-  private static final String CALLING_ELEMENT_PATH_PROPERTY = "callingElementPath";
   private static final String AUTH_INFO_PROPERTY = "authInfo";
   private final List<BulkOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
@@ -192,30 +173,6 @@ final class BulkIndexRequest implements ContentProducer {
 
   @JsonIgnoreProperties({RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY})
   private static final class EvaluatedDecisionMixin {}
-
-  @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
-  @JsonIgnoreProperties({BATCH_OPERATION_REFERENCE_PROPERTY, RECORD_AUTHORIZATIONS_PROPERTY})
-  private static final class RecordMetadata87Mixin {}
-
-  @JsonIgnoreProperties({
-    TAGS_PROPERTY,
-    ELEMENT_INSTANCE_PATH_PROPERTY,
-    PROCESS_DEFINITION_PATH_PROPERTY,
-    CALLING_ELEMENT_PATH_PROPERTY,
-  })
-  private static final class ProcessInstance87Mixin {}
-
-  @JsonIgnoreProperties({TAGS_PROPERTY, RUNTIME_INSTRUCTIONS_PROPERTY})
-  private static final class ProcessInstanceCreation87Mixin {}
-
-  @JsonIgnoreProperties({TAGS_PROPERTY})
-  private static final class ProcessInstanceResult87Mixin {}
-
-  @JsonIgnoreProperties({DENIED_REASON_PROPERTY})
-  private static final class UserTask87Mixin {}
-
-  @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY})
-  private static final class Job87Mixin {}
 
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
   private static final class CommandDistributionMixin {}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -39,6 +39,7 @@ final class BulkIndexRequest implements ContentProducer {
       new ObjectMapper()
           .addMixIn(Record.class, RecordSequenceMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
+          .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
@@ -50,8 +51,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResult87Mixin.class)
           .addMixIn(UserTaskRecordValue.class, UserTask87Mixin.class)
           .addMixIn(JobRecordValue.class, Job87Mixin.class)
-          .addMixIn(
-              CommandDistributionRecordValue.class, CommandDistributionPreviousVersionMixin.class)
+          .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -218,5 +218,5 @@ final class BulkIndexRequest implements ContentProducer {
   private static final class Job87Mixin {}
 
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
-  private static final class CommandDistributionPreviousVersionMixin {}
+  private static final class CommandDistributionMixin {}
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -269,32 +269,6 @@ final class ElasticsearchExporterIT {
     }
   }
 
-  @ParameterizedTest(name = "{0}")
-  @MethodSource("io.camunda.zeebe.exporter.TestSupport#provideValueTypes")
-  void shouldExportRecordsOnPreviousVersion(final ValueType valueType) {
-    // given
-    config.setIncludeEnabledRecords(false);
-    exporter.configure(exporterTestContext);
-    exporter.open(controller);
-
-    final var record =
-        factory.generateRecord(
-            valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion().toLowerCase()));
-
-    // when
-    export(record);
-
-    // then
-    final var response = testClient.getExportedDocumentFor(record);
-    assertThat(response)
-        .extracting(GetResponse::index, GetResponse::id, GetResponse::routing, GetResponse::source)
-        .containsExactly(
-            indexRouter.indexFor(record),
-            indexRouter.idFor(record),
-            String.valueOf(record.getPartitionId()),
-            record);
-  }
-
   private boolean export(final Record<?> record) {
     exporter.export(record);
     return true;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -15,11 +15,6 @@ import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
-import io.camunda.zeebe.protocol.record.value.JobRecordValue;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
-import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
@@ -45,12 +40,6 @@ final class BulkIndexRequest implements ContentProducer {
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
       new ObjectMapper()
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
-          .addMixIn(Record.class, RecordMetadata87Mixin.class)
-          .addMixIn(ProcessInstanceCreationRecordValue.class, ProcessInstanceCreation87Mixin.class)
-          .addMixIn(ProcessInstanceRecordValue.class, ProcessInstance87Mixin.class)
-          .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResult87Mixin.class)
-          .addMixIn(UserTaskRecordValue.class, UserTask87Mixin.class)
-          .addMixIn(JobRecordValue.class, Job87Mixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
@@ -59,14 +48,6 @@ final class BulkIndexRequest implements ContentProducer {
   private static final String RECORD_AUTHORIZATIONS_PROPERTY = "authorizations";
   private static final String RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY =
       "decisionEvaluationInstanceKey";
-  private static final String BATCH_OPERATION_REFERENCE_PROPERTY = "batchOperationReference";
-  private static final String TAGS_PROPERTY = "tags";
-  private static final String RESULT_PROPERTY = "result";
-  private static final String DENIED_REASON_PROPERTY = "deniedReason";
-  private static final String RUNTIME_INSTRUCTIONS_PROPERTY = "runtimeInstructions";
-  private static final String ELEMENT_INSTANCE_PATH_PROPERTY = "elementInstancePath";
-  private static final String PROCESS_DEFINITION_PATH_PROPERTY = "processDefinitionPath";
-  private static final String CALLING_ELEMENT_PATH_PROPERTY = "callingElementPath";
   private static final String AUTH_INFO_PROPERTY = "authInfo";
 
   private final List<BulkOperation> operations = new ArrayList<>();
@@ -193,30 +174,6 @@ final class BulkIndexRequest implements ContentProducer {
 
   @JsonIgnoreProperties({RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY})
   private static final class EvaluatedDecisionMixin {}
-
-  @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
-  @JsonIgnoreProperties({BATCH_OPERATION_REFERENCE_PROPERTY, RECORD_AUTHORIZATIONS_PROPERTY})
-  private static final class RecordMetadata87Mixin {}
-
-  @JsonIgnoreProperties({
-    TAGS_PROPERTY,
-    ELEMENT_INSTANCE_PATH_PROPERTY,
-    PROCESS_DEFINITION_PATH_PROPERTY,
-    CALLING_ELEMENT_PATH_PROPERTY,
-  })
-  private static final class ProcessInstance87Mixin {}
-
-  @JsonIgnoreProperties({TAGS_PROPERTY, RUNTIME_INSTRUCTIONS_PROPERTY})
-  private static final class ProcessInstanceCreation87Mixin {}
-
-  @JsonIgnoreProperties({TAGS_PROPERTY})
-  private static final class ProcessInstanceResult87Mixin {}
-
-  @JsonIgnoreProperties({DENIED_REASON_PROPERTY})
-  private static final class UserTask87Mixin {}
-
-  @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY})
-  private static final class Job87Mixin {}
 
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
   private static final class CommandDistributionMixin {}

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -39,6 +39,7 @@ final class BulkIndexRequest implements ContentProducer {
 
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
       new ObjectMapper()
+          .addMixIn(Record.class, RecordSequenceMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -39,6 +39,7 @@ final class BulkIndexRequest implements ContentProducer {
       new ObjectMapper()
           .addMixIn(Record.class, RecordSequenceMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
+          .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
@@ -50,8 +51,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResult87Mixin.class)
           .addMixIn(UserTaskRecordValue.class, UserTask87Mixin.class)
           .addMixIn(JobRecordValue.class, Job87Mixin.class)
-          .addMixIn(
-              CommandDistributionRecordValue.class, CommandDistributionPreviousVersionMixin.class)
+          .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -219,5 +219,5 @@ final class BulkIndexRequest implements ContentProducer {
   private static final class Job87Mixin {}
 
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
-  private static final class CommandDistributionPreviousVersionMixin {}
+  private static final class CommandDistributionMixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -13,15 +13,13 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.opensearch.BulkIndexRequest.BulkOperation;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
-import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceCreationRecordValue;
-import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceCreationRuntimeInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceResultRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
@@ -41,9 +39,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 @Execution(ExecutionMode.CONCURRENT)
 final class BulkIndexRequestTest {
@@ -288,144 +284,16 @@ final class BulkIndexRequestTest {
     }
 
     @Test
-    void shouldIndexRecordWithoutBatchOperationReference() {
-      // given
-      final var record =
-          recordFactory.generateRecord(
-              r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
-                      .withBatchOperationReference(10L));
-
-      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
-
-      // when
-      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
-
-      // then
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("batchOperationReference"))
-          .describedAs("Expect that the records are NOT serialized with batchOperationReference")
-          .containsExactly(new Object[] {null});
-    }
-
-    @Test
-    void shouldIndexRecordWithBatchOperationReference() {
-      // given
-      final var record =
-          recordFactory.generateRecord(
-              r -> r.withBrokerVersion(VersionUtil.getVersion()).withBatchOperationReference(10L));
-
-      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
-
-      // when
-      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
-
-      // then
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("batchOperationReference"))
-          .describedAs("Expect that the records are serialized with batchOperationReference")
-          .containsExactly(10);
-    }
-
-    @Test
-    void shouldIndexRecordWithoutDeniedReason() {
-      // given
-      final var record =
-          recordFactory.generateRecord(
-              r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
-                      .withValue(new UserTaskRecord().setDeniedReason("denied")));
-
-      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
-
-      // when
-      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
-
-      // then
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("deniedReason"))
-          .describedAs("Expect that the records are NOT serialized with deniedReason")
-          .containsExactly(new Object[] {null});
-    }
-
-    @Test
-    void shouldIndexRecordWithDeniedReason() {
-      // given
-      final var record =
-          recordFactory.generateRecord(
-              r ->
-                  r.withBrokerVersion(VersionUtil.getVersion())
-                      .withValue(new UserTaskRecord().setDeniedReason("denied")));
-
-      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
-
-      // when
-      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
-
-      // then
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("deniedReason"))
-          .describedAs("Expect that the records are serialized with deniedReason")
-          .containsExactly("denied");
-    }
-
-    @ParameterizedTest
-    @MethodSource("recordsSupportingTags")
-    void shouldIndexRecordWithTags(final Record record) {
-      // given
-      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
-
-      // when
-      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
-
-      // then
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("tags"))
-          .describedAs("Expect that the records are serialized with tags")
-          .containsExactly(List.of("t1", "t2"));
-    }
-
-    @ParameterizedTest
-    @MethodSource("recordsSupportingTagsPreviousVersion")
-    void shouldIndexRecordWithoutTags(final Record record) {
-      // given
-      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
-
-      // when
-      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
-
-      // then
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("tags"))
-          .describedAs("Expect that the records are NOT serialized with tags")
-          .containsExactly(new Object[] {null});
-    }
-
-    @Test
-    void shouldIndexRecordWithoutResult() {
+    void shouldIndexCommandDistributionRecordWithoutAuthInfoOnPreviousVersion() {
       // given
       final var record =
           recordFactory.generateRecord(
               r ->
                   r.withBrokerVersion(VersionUtil.getPreviousVersion())
                       .withValue(
-                          new JobRecord().setResult(new JobResult().setDeniedReason("denied"))));
+                          new CommandDistributionRecord()
+                              .setPartitionId(1)
+                              .setAuthInfo(new AuthInfo().setAuthData("test-data"))));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
 
@@ -437,20 +305,22 @@ final class BulkIndexRequestTest {
           .hasSize(1)
           .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
           .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("result"))
-          .describedAs("Expect that the records are NOT serialized with deniedReason")
+          .extracting(source -> ((Map<String, Object>) source).get("authInfo"))
+          .describedAs("Expect that the records are NOT serialized with authInfo")
           .containsExactly(new Object[] {null});
     }
 
     @Test
-    void shouldIndexRecordWithResult() {
+    void shouldIndexCommandDistributionRecordWithoutAuthInfo() {
       // given
       final var record =
           recordFactory.generateRecord(
               r ->
                   r.withBrokerVersion(VersionUtil.getVersion())
                       .withValue(
-                          new JobRecord().setResult(new JobResult().setDeniedReason("denied"))));
+                          new CommandDistributionRecord()
+                              .setPartitionId(1)
+                              .setAuthInfo(new AuthInfo().setAuthData("test-data"))));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
 
@@ -462,166 +332,9 @@ final class BulkIndexRequestTest {
           .hasSize(1)
           .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
           .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("result"))
-          .extracting(source -> ((Map<String, Object>) source).get("deniedReason"))
-          .describedAs("Expect that the records are NOT serialized with deniedReason")
-          .containsExactly("denied");
-    }
-
-    @Test
-    void shouldIndexProcessInstanceCreationRecordWithoutRuntimeInstructions() {
-      // given
-      final var record =
-          recordFactory.generateRecord(
-              r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
-                      .withValue(
-                          ImmutableProcessInstanceCreationRecordValue.builder()
-                              .withRuntimeInstructions(
-                                  List.of(
-                                      ImmutableProcessInstanceCreationRuntimeInstructionValue
-                                          .builder()
-                                          .withAfterElementId("afterElementId")
-                                          .build()))
-                              .build()));
-
-      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
-
-      // when
-      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
-
-      // then
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("runtimeInstructions"))
-          .describedAs("Expect that the records are NOT serialized with runtimeInstructions")
+          .extracting(source -> ((Map<String, Object>) source).get("authInfo"))
+          .describedAs("Expect that the records are NOT serialized with authInfo")
           .containsExactly(new Object[] {null});
-    }
-
-    @Test
-    void shouldIndexProcessInstanceCreationRecordWithRuntimeInstructions() {
-      // given
-      final var record =
-          recordFactory.generateRecord(
-              r ->
-                  r.withBrokerVersion(VersionUtil.getVersion())
-                      .withValue(
-                          ImmutableProcessInstanceCreationRecordValue.builder()
-                              .withRuntimeInstructions(
-                                  List.of(
-                                      ImmutableProcessInstanceCreationRuntimeInstructionValue
-                                          .builder()
-                                          .withAfterElementId("afterElementId")
-                                          .build()))
-                              .build()));
-
-      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
-
-      // when
-      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
-
-      // then
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("runtimeInstructions"))
-          .extracting(source -> ((List) source).getFirst())
-          .extracting(source -> ((Map<String, Object>) source).get("afterElementId"))
-          .describedAs("Expect that the records are serialized with runtimeInstructions")
-          .containsExactly("afterElementId");
-    }
-
-    @Test
-    void shouldIndexProcessInstanceRecordWithoutNewFields() {
-      // given
-      final var record =
-          recordFactory.generateRecord(
-              r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
-                      .withValue(
-                          ImmutableProcessInstanceRecordValue.builder()
-                              .withElementInstancePath(List.of(List.of(1L, 2L, 3L)))
-                              .withProcessDefinitionPath(List.of(1L, 2L, 3L))
-                              .withCallingElementPath(List.of(3, 4, 5))
-                              .build()));
-
-      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
-
-      // when
-      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
-
-      // then
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("elementInstancePath"))
-          .describedAs("Expect that the records are NOT serialized with elementInstancePath")
-          .containsExactly(new Object[] {null});
-
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionPath"))
-          .describedAs("Expect that the records are NOT serialized with processDefinitionPath")
-          .containsExactly(new Object[] {null});
-
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("callingElementPath"))
-          .describedAs("Expect that the records are NOT serialized with callingElementPath")
-          .containsExactly(new Object[] {null});
-    }
-
-    @Test
-    void shouldIndexProcessInstanceRecordWithNewFields() {
-      // given
-      final var record =
-          recordFactory.generateRecord(
-              r ->
-                  r.withBrokerVersion(VersionUtil.getVersion())
-                      .withValue(
-                          ImmutableProcessInstanceRecordValue.builder()
-                              .withElementInstancePath(List.of(List.of(1L, 2L, 3L)))
-                              .withProcessDefinitionPath(List.of(1L, 2L, 3L))
-                              .withCallingElementPath(List.of(3, 4, 5))
-                              .build()));
-
-      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
-
-      // when
-      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
-
-      // then
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("elementInstancePath"))
-          .describedAs("Expect that the records are serialized with elementInstancePath")
-          .containsExactly(List.of(List.of(1, 2, 3)));
-
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("processDefinitionPath"))
-          .describedAs("Expect that the records are serialized with processDefinitionPath")
-          .containsExactly(List.of(1, 2, 3));
-
-      assertThat(request.bulkOperations())
-          .hasSize(1)
-          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
-          .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("callingElementPath"))
-          .describedAs("Expect that the records are serialized with callingElementPath")
-          .containsExactly(List.of(3, 4, 5));
     }
 
     private Record<?> deserializeSource(final BulkOperation operation) {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -22,8 +22,6 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
-import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceCreationRecordValue;
-import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
@@ -339,9 +337,7 @@ final class OpensearchExporterIT {
               indexRouter.indexFor(record),
               indexRouter.idFor(record),
               String.valueOf(record.getPartitionId()),
-              VersionUtil.getVersionLowerCase().equals(version)
-                  ? record
-                  : modifyExpectedRecordForPreviousVersion(valueType, record));
+              record);
     } else {
       assertThatThrownBy(() -> testClient.getExportedDocumentFor(record))
           .isInstanceOf(OpenSearchException.class)
@@ -349,56 +345,30 @@ final class OpensearchExporterIT {
     }
   }
 
-  private Record modifyExpectedRecordForPreviousVersion(
-      final ValueType valueType, final Record record) {
-    final var copyFactory = new ProtocolFactory(factory.getSeed());
-    final RecordValue recordValue =
-        (RecordValue)
-            switch (valueType) {
-              case JOB ->
-                  ImmutableJobRecordValue.builder()
-                      .from(((ImmutableJobRecordValue) record.getValue()))
-                      .withTags(List.of())
-                      .resultBuilder(null)
-                      .build();
-              case PROCESS_INSTANCE ->
-                  ImmutableProcessInstanceRecordValue.builder()
-                      .from(((ImmutableProcessInstanceRecordValue) record.getValue()))
-                      .withCallingElementPath(List.of())
-                      .withProcessDefinitionPath(List.of())
-                      .withTags(List.of())
-                      .withElementInstancePath(List.of())
-                      .build();
-              case JOB_BATCH ->
-                  ImmutableJobBatchRecordValue.builder()
-                      .from(((ImmutableJobBatchRecordValue) record.getValue()))
-                      .withJobs(
-                          ((ImmutableJobBatchRecordValue) record.getValue())
-                              .getJobs().stream()
-                                  .map(
-                                      job ->
-                                          ImmutableJobRecordValue.builder()
-                                              .from(job)
-                                              .withTags(List.of())
-                                              .resultBuilder(null)
-                                              .build())
-                                  .toList())
-                      .build();
-              case PROCESS_INSTANCE_CREATION ->
-                  ImmutableProcessInstanceCreationRecordValue.builder()
-                      .from(((ImmutableProcessInstanceCreationRecordValue) record.getValue()))
-                      .withTags(List.of())
-                      .withRuntimeInstructions(List.of())
-                      .build();
-              default -> record.getValue();
-            };
-    return copyFactory.generateRecord(
-        valueType,
-        r ->
-            r.withValue(recordValue)
-                .withAuthorizations(record.getAuthorizations())
-                .withBrokerVersion(record.getBrokerVersion())
-                .withBatchOperationReference(-1L));
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("io.camunda.zeebe.exporter.opensearch.TestSupport#provideValueTypes")
+  void shouldExportRecordsOnPreviousVersion(final ValueType valueType) {
+    // given
+    config.setIncludeEnabledRecords(false);
+    exporter.configure(exporterTestContext);
+    exporter.open(controller);
+
+    final var record =
+        factory.generateRecord(
+            valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion().toLowerCase()));
+
+    // when
+    export(record);
+
+    // then
+    final var response = testClient.getExportedDocumentFor(record);
+    assertThat(response)
+        .extracting(GetResponse::index, GetResponse::id, GetResponse::routing, GetResponse::source)
+        .containsExactly(
+            indexRouter.indexFor(record),
+            indexRouter.idFor(record),
+            String.valueOf(record.getPartitionId()),
+            record);
   }
 
   private boolean export(final Record<?> record) {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -345,32 +345,6 @@ final class OpensearchExporterIT {
     }
   }
 
-  @ParameterizedTest(name = "{0}")
-  @MethodSource("io.camunda.zeebe.exporter.opensearch.TestSupport#provideValueTypes")
-  void shouldExportRecordsOnPreviousVersion(final ValueType valueType) {
-    // given
-    config.setIncludeEnabledRecords(false);
-    exporter.configure(exporterTestContext);
-    exporter.open(controller);
-
-    final var record =
-        factory.generateRecord(
-            valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion().toLowerCase()));
-
-    // when
-    export(record);
-
-    // then
-    final var response = testClient.getExportedDocumentFor(record);
-    assertThat(response)
-        .extracting(GetResponse::index, GetResponse::id, GetResponse::routing, GetResponse::source)
-        .containsExactly(
-            indexRouter.indexFor(record),
-            indexRouter.idFor(record),
-            String.valueOf(record.getPartitionId()),
-            record);
-  }
-
   private boolean export(final Record<?> record) {
     exporter.export(record);
     return true;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Removed obsolete compatibility mixins from 8.7
- Align serializer tests for current/previous serialization
- Exclude `CommandDistributionRecord#authInfo` from both 8.8 and 8.9 record serialization

For the time being schemas between 8.8 and 8.9 are the same. We only exclude the `AuthInfo` field since it may contain PII and is not required for exported record consumers. The field is not part of the `CommandDistributionRecord` index mapping schema.

Keeping the previous & current version mappers distinction for future proofing.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39805
