### PR TITLE
fix: exclude authinfo 8.8

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -39,6 +39,7 @@ final class BulkIndexRequest implements ContentProducer {
       new ObjectMapper()
           .addMixIn(Record.class, RecordSequenceMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
+          .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
@@ -50,7 +51,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResult87Mixin.class)
           .addMixIn(UserTaskRecordValue.class, UserTask87Mixin.class)
           .addMixIn(JobRecordValue.class, Job87Mixin.class)
-          .addMixIn(CommandDistributionRecordValue.class, CommandDistribution87Mixin.class)
+          .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -217,5 +218,5 @@ final class BulkIndexRequest implements ContentProducer {
   private static final class Job87Mixin {}
 
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
-  private static final class CommandDistribution87Mixin {}
+  private static final class CommandDistributionMixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -39,6 +39,7 @@ final class BulkIndexRequest implements ContentProducer {
       new ObjectMapper()
           .addMixIn(Record.class, RecordSequenceMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
+          .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
@@ -50,7 +51,7 @@ final class BulkIndexRequest implements ContentProducer {
           .addMixIn(ProcessInstanceResultRecordValue.class, ProcessInstanceResult87Mixin.class)
           .addMixIn(UserTaskRecordValue.class, UserTask87Mixin.class)
           .addMixIn(JobRecordValue.class, Job87Mixin.class)
-          .addMixIn(CommandDistributionRecordValue.class, CommandDistribution87Mixin.class)
+          .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -218,5 +219,5 @@ final class BulkIndexRequest implements ContentProducer {
   private static final class Job87Mixin {}
 
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
-  private static final class CommandDistribution87Mixin {}
+  private static final class CommandDistributionMixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.opensearch.BulkIndexRequest.BulkOperation;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
@@ -625,6 +627,60 @@ final class BulkIndexRequestTest {
           .extracting(source -> ((Map<String, Object>) source).get("callingElementPath"))
           .describedAs("Expect that the records are serialized with callingElementPath")
           .containsExactly(List.of(3, 4, 5));
+    }
+
+    @Test
+    void shouldIndexCommandDistributionRecordWithoutAuthInfoOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new CommandDistributionRecord()
+                              .setPartitionId(1)
+                              .setAuthInfo(new AuthInfo().setAuthData("test-data"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("authInfo"))
+          .describedAs("Expect that the records are NOT serialized with authInfo")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexCommandDistributionRecordWithoutAuthInfo() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new CommandDistributionRecord()
+                              .setPartitionId(1)
+                              .setAuthInfo(new AuthInfo().setAuthData("test-data"))));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.get(0), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("authInfo"))
+          .describedAs("Expect that the records are NOT serialized with authInfo")
+          .containsExactly(new Object[] {null});
     }
 
     private Record<?> deserializeSource(final BulkOperation operation) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Exclude `CommandDistributionRecord#authInfo` from being serialized in the ES/OS exported records in 8.8 version as well since it's not part of the index mapping schema.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #39805
