### PR TITLE
ci: include 88 to be notified on slack

### DIFF
--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -52,7 +52,7 @@ jobs:
   notify-camunda:
     name: Send Slack notification for 8.6+
     runs-on: ubuntu-latest
-    needs: [dry-run-release-86, dry-run-release-87]
+    needs: [dry-run-release-86, dry-run-release-87, dry-run-release-88]
     if: always()
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job


### PR DESCRIPTION
## Description

This pull request updates the workflow configuration for sending Slack notifications in the Zeebe release dry run process. The main change is to ensure that the notification job depends on the completion of the new dry run release for version 8.8.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
