### PR TITLE
C8Run RDBMS support regression tests

### DIFF
--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -64,6 +64,18 @@ jobs:
         with:
           go-version: '>=1.23.1'
 
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/qa/ci/common NEXUS_USERNAME;
+            secret/data/products/qa/ci/common NEXUS_PASSWORD;
+
       - name: Build c8run
         working-directory: ./c8run
         run: go build -o c8run ./cmd/c8run
@@ -71,6 +83,9 @@ jobs:
       - name: Package c8run
         run: ./package.sh
         working-directory: ./c8run
+        env:
+          JAVA_ARTIFACTS_USER: ${{ steps.secrets.outputs.NEXUS_USERNAME }}
+          JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
 
       - name: Run c8run
         run: |

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -127,5 +127,5 @@ jobs:
         if: always()
         with:
           name: logs-${{ matrix.config }}
-          path: ./camunda/c8run/log/*.log
+          path: ./c8run/log/*.log
           retention-days: 10

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -65,11 +65,12 @@ jobs:
           go-version: '>=1.23.1'
 
       - name: Build c8run
-        run: go build -o c8run ./c8run/cmd/c8run
+        working-directory: ./c8run
+        run: go build -o c8run ./cmd/c8run
 
       - name: Package c8run
         run: ./package.sh
-        working-directory: ./camunda/c8run
+        working-directory: ./c8run
 
       - name: Run c8run
         run: |

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -123,8 +123,12 @@ jobs:
         working-directory: ./c8run
         run: ./shutdown.sh
 
-      - name: Sanitize matrix name
-        run: echo "ARTIFACT_NAME=logs-${MATRIX_CONFIG//\//-}" >> $GITHUB_ENV
+      - name: Sanitize matrix name for artifact
+        shell: bash
+        run: |
+          SANITIZED_NAME="logs-${MATRIX_CONFIG//\//-}"
+          echo "ARTIFACT_NAME=$SANITIZED_NAME" >> $GITHUB_ENV
+          echo "Artifact name will be: $SANITIZED_NAME"
         env:
           MATRIX_CONFIG: ${{ matrix.config }}
 

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -92,12 +92,12 @@ jobs:
           echo "Matrix config: $CONFIG"
           if [[ "$CONFIG" == *"application-h2.yaml" ]]; then
             echo "Using H2 configuration..."
-            cp "$CONFIG" ./camunda/c8run/application.yaml
+            cp "../$CONFIG" ./configuration/application.yaml
           else
             echo "Using default configuration (no override)"
           fi
           nohup ./start.sh --detached &
-        working-directory: ./camunda/c8run
+        working-directory: ./c8run
         env:
           CONFIG: ${{ matrix.config }}
 

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -37,7 +37,6 @@ permissions:
 
 jobs:
   build_and_test_c8run:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: macos-latest
     strategy:
       max-parallel: 1

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -72,14 +72,17 @@ jobs:
 
       - name: Run c8run
         run: |
-          if [[ "${{ matrix.config }}" == *"application-h2.yaml" ]]; then
+          echo "Matrix config: $CONFIG"
+          if [[ "$CONFIG" == *"application-h2.yaml" ]]; then
             echo "Using H2 configuration..."
-            cp ${{ matrix.config }} ./camunda/c8run/application.yaml
+            cp "$CONFIG" ./camunda/c8run/application.yaml
           else
             echo "Using default configuration (no override)"
           fi
           nohup ./start.sh --detached &
         working-directory: ./camunda/c8run
+        env:
+          CONFIG: ${{ matrix.config }}
 
       - name: Wait for app to start
         run: bash -c 'while ! curl -s -f "http://localhost:9600/actuator/health"; do sleep 5; done'

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   build_and_test_c8run:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 1
       fail-fast: false

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -65,8 +65,7 @@ jobs:
           go-version: '>=1.23.1'
 
       - name: Build c8run
-        run: go build -o c8run ./cmd/c8run
-        working-directory: ./camunda/c8run
+        run: go build -o c8run ./c8run/cmd/c8run
 
       - name: Package c8run
         run: ./package.sh

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           curl -f -L -o ijhttp.zip "https://jb.gg/ijhttp/latest"
           unzip ijhttp.zip
-          ijhttp/ijhttp qa/http/c8run-tests.http --private-env-file qa/http/http-client.private.env.json --env ${{ matrix.env }} --report -t 60000
+          ijhttp/ijhttp qa/http/c8run-tests/c8run-tests.http --private-env-file qa/http/http-client.private.env.json --env ${{ matrix.env }} --report -t 60000
 
       - name: Cleanup
         shell: bash

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -123,21 +123,21 @@ jobs:
         working-directory: ./c8run
         run: ./shutdown.sh
 
-      - name: Set artifact name
+      - name: Prepare artifact name
         id: set-artifact-name
-        shell: bash
         run: |
           MATRIX_NAME="${{ matrix.config }}"
           if [ -z "$MATRIX_NAME" ]; then
             MATRIX_NAME="default"
           fi
           SANITIZED_NAME="logs-${MATRIX_NAME//\//-}"
-          echo "ARTIFACT_NAME=$SANITIZED_NAME" >> "$GITHUB_ENV"
           echo "Artifact name set to: $SANITIZED_NAME"
+          echo "ARTIFACT_NAME=$SANITIZED_NAME" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ steps.set-artifact-name.outputs.ARTIFACT_NAME }}
           path: ./c8run/log/*.log
           retention-days: 10
+      

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -123,22 +123,9 @@ jobs:
         working-directory: ./c8run
         run: ./shutdown.sh
 
-      - name: Prepare artifact name
-        id: set-artifact-name
-        env:
-          MATRIX_CONFIG: ${{ matrix.config }}
-        run: |
-          MATRIX_NAME="$MATRIX_CONFIG"
-          if [ -z "$MATRIX_NAME" ]; then
-            MATRIX_NAME="default"
-          fi
-          SANITIZED_NAME="logs-${MATRIX_NAME//\//-}"
-          echo "Artifact name set to: $SANITIZED_NAME"
-          echo "ARTIFACT_NAME=$SANITIZED_NAME" >> $GITHUB_OUTPUT
-
-      - uses: actions/upload-artifact@v4
+      - name: Publish Test Report
         if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          name: ${{ steps.set-artifact-name.outputs.ARTIFACT_NAME }}
-          path: ./c8run/log/*.log
-          retention-days: 10
+          files: '**/reports/report.xml'
+          comment_mode: off

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -1,0 +1,110 @@
+# description: Runs regression tests on Identity. Tests are defined as .http files
+# test location: /qa/http/c8run-tests
+# type: CI
+# owner: @camunda/identity
+name: C8Run RDBMS Regression Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run tests on'
+        required: true
+        default: 'main'
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
+
+permissions:
+  actions: write
+  attestations: none
+  checks: write
+  contents: read
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: write
+
+jobs:
+  build_and_test_c8run:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        env: [ 'local' ]
+        config:
+          - 'config/application.yaml'
+          - 'qa/http/c8run-tests/application-h2.yaml'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.23.1'
+
+      - name: Build c8run
+        run: go build -o c8run ./cmd/c8run
+        working-directory: ./camunda/c8run
+
+      - name: Package c8run
+        run: ./package.sh
+        working-directory: ./camunda/c8run
+
+      - name: Run c8run
+        run: |
+          if [[ "${{ matrix.config }}" == *"application-h2.yaml" ]]; then
+            echo "Using H2 configuration..."
+            cp ${{ matrix.config }} ./camunda/c8run/application.yaml
+          else
+            echo "Using default configuration (no override)"
+          fi
+          nohup ./start.sh --detached &
+        working-directory: ./camunda/c8run
+
+      - name: Wait for app to start
+        run: bash -c 'while ! curl -s -f "http://localhost:9600/actuator/health"; do sleep 5; done'
+        timeout-minutes: 5
+
+      - name: Install IntelliJ HTTP Client
+        shell: bash
+        run: |
+          curl -f -L -o ijhttp.zip "https://jb.gg/ijhttp/latest"
+          unzip ijhttp.zip
+          ijhttp/ijhttp qa/http/c8run-tests.http --private-env-file qa/http/http-client.private.env.json --env ${{ matrix.env }} --report -t 60000
+
+      - name: Cleanup
+        shell: bash
+        if: always()
+        run: |
+          rm qa/http/http-client.private.env.json
+
+      - name: Shut down Docker Compose
+        if: always()
+        run: ./shutdown.sh
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: logs-${{ matrix.config }}
+          path: ./camunda/c8run/log/*.log
+          retention-days: 10

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -1,7 +1,7 @@
 # description: Runs regression tests on C8Run. Tests are defined as .http files
 # test location: /qa/http/c8run-tests
 # type: CI
-# owner: @camunda/identity
+# owner: @camunda/qa-engineering
 name: C8Run RDBMS Regression Tests
 
 on:
@@ -39,7 +39,7 @@ jobs:
   build_and_test_c8run:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      max-parallel: 2
       fail-fast: false
       matrix:
         env: [ 'local' ]

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -123,9 +123,14 @@ jobs:
         working-directory: ./c8run
         run: ./shutdown.sh
 
+      - name: Sanitize matrix name
+        run: echo "ARTIFACT_NAME=logs-${MATRIX_CONFIG//\//-}" >> $GITHUB_ENV
+        env:
+          MATRIX_CONFIG: ${{ matrix.config }}
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logs-${{ join(split(matrix.config, '/'), '-') }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: ./c8run/log/*.log
           retention-days: 10

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -123,14 +123,17 @@ jobs:
         working-directory: ./c8run
         run: ./shutdown.sh
 
-      - name: Sanitize matrix name for artifact
+      - name: Set artifact name
+        id: set-artifact-name
         shell: bash
         run: |
-          SANITIZED_NAME="logs-${MATRIX_CONFIG//\//-}"
-          echo "ARTIFACT_NAME=$SANITIZED_NAME" >> $GITHUB_ENV
-          echo "Artifact name will be: $SANITIZED_NAME"
-        env:
-          MATRIX_CONFIG: ${{ matrix.config }}
+          MATRIX_NAME="${{ matrix.config }}"
+          if [ -z "$MATRIX_NAME" ]; then
+            MATRIX_NAME="default"
+          fi
+          SANITIZED_NAME="logs-${MATRIX_NAME//\//-}"
+          echo "ARTIFACT_NAME=$SANITIZED_NAME" >> "$GITHUB_ENV"
+          echo "Artifact name set to: $SANITIZED_NAME"
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -125,8 +125,10 @@ jobs:
 
       - name: Prepare artifact name
         id: set-artifact-name
+        env:
+          MATRIX_CONFIG: ${{ matrix.config }}
         run: |
-          MATRIX_NAME="${{ matrix.config }}"
+          MATRIX_NAME="$MATRIX_CONFIG"
           if [ -z "$MATRIX_NAME" ]; then
             MATRIX_NAME="default"
           fi
@@ -140,4 +142,3 @@ jobs:
           name: ${{ steps.set-artifact-name.outputs.ARTIFACT_NAME }}
           path: ./c8run/log/*.log
           retention-days: 10
-      

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -126,6 +126,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logs-${{ matrix.config }}
+          name: logs-${{ join(split(matrix.config, '/'), '-') }}
           path: ./c8run/log/*.log
           retention-days: 10

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -120,6 +120,7 @@ jobs:
 
       - name: Shut down Docker Compose
         if: always()
+        working-directory: ./c8run
         run: ./shutdown.sh
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -1,10 +1,13 @@
-# description: Runs regression tests on Identity. Tests are defined as .http files
+# description: Runs regression tests on C8Run. Tests are defined as .http files
 # test location: /qa/http/c8run-tests
 # type: CI
 # owner: @camunda/identity
 name: C8Run RDBMS Regression Tests
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       branch:

--- a/qa/http/c8run-tests/User Task Processes/New form A.form
+++ b/qa/http/c8run-tests/User Task Processes/New form A.form
@@ -1,0 +1,96 @@
+{
+  "components": [
+    {
+      "label": "proceed?",
+      "type": "textfield",
+      "layout": {
+        "row": "Row_15sclyt",
+        "columns": null
+      },
+      "id": "Field_0pzgltd",
+      "key": "textfield"
+    },
+    {
+      "subtype": "datetime",
+      "dateLabel": "Date",
+      "type": "datetime",
+      "layout": {
+        "row": "Row_15sclyt",
+        "columns": null
+      },
+      "id": "Field_1lfoywk",
+      "key": "datetime",
+      "timeLabel": "Time",
+      "timeSerializingFormat": "utc_offset",
+      "timeInterval": 15
+    },
+    {
+      "label": "Dynamic list",
+      "components": [
+        {
+          "text": "Test",
+          "type": "text",
+          "layout": {
+            "row": "Row_0c4hray",
+            "columns": null
+          },
+          "id": "Field_1wes0a8"
+        },
+        {
+          "type": "table",
+          "layout": {
+            "row": "Row_157t90f",
+            "columns": null
+          },
+          "label": "Table",
+          "dataSource": "=Field_1f4668z",
+          "rowCount": 10,
+          "id": "Field_1f4668z",
+          "columns": [
+            {
+              "label": "ID",
+              "key": "id"
+            },
+            {
+              "label": "Name",
+              "key": "name"
+            },
+            {
+              "label": "Date",
+              "key": "date"
+            }
+          ]
+        },
+        {
+          "type": "image",
+          "layout": {
+            "row": "Row_157t90f",
+            "columns": 7
+          },
+          "id": "Field_1ayf72j",
+          "source": "https://camunda.com/wp-content/uploads/2024/06/adapt-icon.svg"
+        }
+      ],
+      "showOutline": true,
+      "isRepeating": true,
+      "allowAddRemove": true,
+      "defaultRepetitions": 1,
+      "type": "dynamiclist",
+      "layout": {
+        "row": "Row_0esqa63",
+        "columns": null
+      },
+      "id": "Field_1w76z2c",
+      "path": "dynamiclist_bpyuq0m"
+    }
+  ],
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.6.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.38.1"
+  },
+  "schemaVersion": 19,
+  "id": "Form_1viy2x4",
+  "type": "default"
+}

--- a/qa/http/c8run-tests/User Task Processes/New form B.form
+++ b/qa/http/c8run-tests/User Task Processes/New form B.form
@@ -1,0 +1,83 @@
+{
+  "components": [
+    {
+      "label": "Select",
+      "values": [
+        {
+          "label": "Value 1",
+          "value": "value1"
+        },
+        {
+          "label": "Value 2",
+          "value": "value2"
+        },
+        {
+          "label": "Value 3",
+          "value": "value3"
+        }
+      ],
+      "type": "select",
+      "layout": {
+        "row": "Row_13swedd",
+        "columns": null
+      },
+      "id": "Field_1etvuxb",
+      "key": "select"
+    },
+    {
+      "label": "Group 1",
+      "components": [
+        {
+          "label": "Checkbox group",
+          "values": [
+            {
+              "label": "Test 1",
+              "value": "test1"
+            },
+            {
+              "label": "Test 2",
+              "value": "test2"
+            },
+            {
+              "label": "Test 3",
+              "value": "test3"
+            }
+          ],
+          "type": "checklist",
+          "layout": {
+            "row": "Row_1dinjhp",
+            "columns": null
+          },
+          "id": "Field_054qo2s",
+          "key": "checklist_oswe2"
+        },
+        {
+          "label": "Signal?",
+          "type": "checkbox",
+          "layout": {
+            "row": "Row_1txz84e",
+            "columns": null
+          },
+          "id": "Field_0ju7eus",
+          "key": "proceed"
+        }
+      ],
+      "showOutline": true,
+      "type": "group",
+      "layout": {
+        "row": "Row_1mnd9nw",
+        "columns": null
+      },
+      "id": "Field_0wq7yrz"
+    }
+  ],
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.6.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.38.1"
+  },
+  "schemaVersion": 19,
+  "id": "Form_1dl8p3y",
+  "type": "default"
+}

--- a/qa/http/c8run-tests/User Task Processes/New form C.form
+++ b/qa/http/c8run-tests/User Task Processes/New form C.form
@@ -1,0 +1,116 @@
+{
+  "components": [
+    {
+      "text": "### Yes or No Questionnaire",
+      "type": "text",
+      "id": "Heading_0"
+    },
+    {
+      "text": "##### Section 1",
+      "type": "text",
+      "id": "Subheading_1"
+    },
+    {
+      "label": "Are you over 18 years old?",
+      "type": "checkbox",
+      "id": "Checkbox_2",
+      "defaultValue": false,
+      "validate": {
+        "required": true
+      },
+      "key": "over18"
+    },
+    {
+      "label": "Do you have any allergies?",
+      "type": "checkbox",
+      "id": "Checkbox_3",
+      "defaultValue": false,
+      "validate": {
+        "required": true
+      },
+      "key": "allergies"
+    },
+    {
+      "label": "Have you ever been convicted of a felony?",
+      "type": "checkbox",
+      "id": "Checkbox_4",
+      "defaultValue": false,
+      "validate": {
+        "required": true
+      },
+      "key": "felonyConviction"
+    },
+    {
+      "text": "##### Section 2",
+      "type": "text",
+      "id": "Subheading_5"
+    },
+    {
+      "label": "Are you a student?",
+      "values": [
+        {
+          "value": "Yes",
+          "label": "Yes"
+        },
+        {
+          "value": "No",
+          "label": "No"
+        }
+      ],
+      "type": "radio",
+      "id": "Radio_6",
+      "validate": {
+        "required": false
+      },
+      "key": "studentStatus"
+    },
+    {
+      "label": "Do you have a valid driver's license?",
+      "values": [
+        {
+          "value": "Yes",
+          "label": "Yes"
+        },
+        {
+          "value": "No",
+          "label": "No"
+        }
+      ],
+      "type": "radio",
+      "id": "Radio_7",
+      "validate": {
+        "required": false
+      },
+      "key": "driverLicense"
+    },
+    {
+      "label": "Have you ever traveled outside your home country?",
+      "values": [
+        {
+          "value": "Yes",
+          "label": "Yes"
+        },
+        {
+          "value": "No",
+          "label": "No"
+        }
+      ],
+      "type": "radio",
+      "id": "Radio_8",
+      "validate": {
+        "required": false
+      },
+      "key": "travelHistory"
+    }
+  ],
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.6.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.38.1"
+  },
+  "schemaVersion": 19,
+  "id": "Form_wjdlwtt",
+  "generated": true,
+  "type": "default"
+}

--- a/qa/http/c8run-tests/User Task Processes/User Task Test Process Incident.bpmn
+++ b/qa/http/c8run-tests/User Task Processes/User Task Test Process Incident.bpmn
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.38.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:collaboration id="pricsdv" name="HTO">
+    <bpmn:participant id="Participant_0pi84e6" processRef="Process_0uj1r9h" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_0uj1r9h" name="User Task Test Process" isExecutable="true">
+    <bpmn:laneSet id="LaneSet_0wz0i02">
+      <bpmn:lane id="Lane_1kxukl2" name="event">
+        <bpmn:flowNodeRef>Gateway_1jebry1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_0fsc6mp</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1tj3t2w</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1vdiktu</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_17vhv3u</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1iaguca</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1s61blt</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0766jw8</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1mr7vew</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_101fdfc</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1gs9ubg</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_0hh1z36</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_0dn7hwq</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:subProcess id="Activity_0dn7hwq">
+      <bpmn:incoming>Flow_0nsgv8j</bpmn:incoming>
+      <bpmn:outgoing>Flow_0efki0l</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[0,1]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="Event_1302fp8">
+        <bpmn:outgoing>Flow_1kw0wg8</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1kw0wg8" sourceRef="Event_1302fp8" targetRef="Activity_1pbqhut" />
+      <bpmn:userTask id="Activity_1pbqhut" name="Form A">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+          <zeebe:formDefinition formId="Form_1viy2x4" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1kw0wg8</bpmn:incoming>
+        <bpmn:outgoing>Flow_1xvb4m3</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:endEvent id="Event_1prjh4v">
+        <bpmn:incoming>Flow_1xvb4m3</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1xvb4m3" sourceRef="Activity_1pbqhut" targetRef="Event_1prjh4v" />
+    </bpmn:subProcess>
+    <bpmn:exclusiveGateway id="Gateway_1jebry1" name="Signal?" default="Flow_1vc2dw1">
+      <bpmn:incoming>Flow_1h2qmr7</bpmn:incoming>
+      <bpmn:outgoing>Flow_0elpvfi</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1vc2dw1</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_0fsc6mp">
+      <bpmn:incoming>Flow_0dkpvcy</bpmn:incoming>
+      <bpmn:outgoing>Flow_0nsgv8j</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1i7jyld</bpmn:outgoing>
+      <bpmn:outgoing>Flow_130lm61</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0dkpvcy</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="Activity_1tj3t2w" name="Form B">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="404" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_130lm61</bpmn:incoming>
+      <bpmn:outgoing>Flow_1h2qmr7</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_1vdiktu">
+      <bpmn:incoming>Flow_0sj8w39</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:eventBasedGateway id="Gateway_17vhv3u">
+      <bpmn:incoming>Flow_1i7jyld</bpmn:incoming>
+      <bpmn:outgoing>Flow_15hp95n</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10f7pmj</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:userTask id="Activity_1iaguca" name="Form C">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="Form_wjdlwtt" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0m1zh3p</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uc0d9v</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:intermediateCatchEvent id="Event_1s61blt" name="1min">
+      <bpmn:incoming>Flow_15hp95n</bpmn:incoming>
+      <bpmn:outgoing>Flow_0m1zh3p</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0g4qpq1">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1M</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="Event_0766jw8">
+      <bpmn:incoming>Flow_0elpvfi</bpmn:incoming>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_16ctki0" signalRef="Signal_2mku8rr" />
+    </bpmn:endEvent>
+    <bpmn:userTask id="Activity_1mr7vew" name="Form C">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="Form_wjdlwtt" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_10k93uu</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qhvk9n</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:intermediateCatchEvent id="Event_101fdfc">
+      <bpmn:incoming>Flow_10f7pmj</bpmn:incoming>
+      <bpmn:outgoing>Flow_10k93uu</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1cq09a7" signalRef="Signal_2mku8rr" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:inclusiveGateway id="Gateway_1gs9ubg">
+      <bpmn:incoming>Flow_0uc0d9v</bpmn:incoming>
+      <bpmn:incoming>Flow_0qhvk9n</bpmn:incoming>
+      <bpmn:incoming>Flow_1vc2dw1</bpmn:incoming>
+      <bpmn:outgoing>Flow_03f50eq</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_0hh1z36">
+      <bpmn:incoming>Flow_03f50eq</bpmn:incoming>
+      <bpmn:incoming>Flow_0efki0l</bpmn:incoming>
+      <bpmn:outgoing>Flow_0sj8w39</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0nsgv8j" sourceRef="Gateway_0fsc6mp" targetRef="Activity_0dn7hwq" />
+    <bpmn:sequenceFlow id="Flow_0efki0l" sourceRef="Activity_0dn7hwq" targetRef="Gateway_0hh1z36" />
+    <bpmn:sequenceFlow id="Flow_1h2qmr7" sourceRef="Activity_1tj3t2w" targetRef="Gateway_1jebry1" />
+    <bpmn:sequenceFlow id="Flow_0elpvfi" name="yes" sourceRef="Gateway_1jebry1" targetRef="Event_0766jw8">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=proceed</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1vc2dw1" sourceRef="Gateway_1jebry1" targetRef="Gateway_1gs9ubg" />
+    <bpmn:sequenceFlow id="Flow_0dkpvcy" sourceRef="StartEvent_1" targetRef="Gateway_0fsc6mp" />
+    <bpmn:sequenceFlow id="Flow_1i7jyld" sourceRef="Gateway_0fsc6mp" targetRef="Gateway_17vhv3u" />
+    <bpmn:sequenceFlow id="Flow_130lm61" sourceRef="Gateway_0fsc6mp" targetRef="Activity_1tj3t2w" />
+    <bpmn:sequenceFlow id="Flow_0sj8w39" sourceRef="Gateway_0hh1z36" targetRef="Event_1vdiktu" />
+    <bpmn:sequenceFlow id="Flow_15hp95n" sourceRef="Gateway_17vhv3u" targetRef="Event_1s61blt" />
+    <bpmn:sequenceFlow id="Flow_10f7pmj" sourceRef="Gateway_17vhv3u" targetRef="Event_101fdfc" />
+    <bpmn:sequenceFlow id="Flow_0m1zh3p" sourceRef="Event_1s61blt" targetRef="Activity_1iaguca" />
+    <bpmn:sequenceFlow id="Flow_0uc0d9v" sourceRef="Activity_1iaguca" targetRef="Gateway_1gs9ubg" />
+    <bpmn:sequenceFlow id="Flow_10k93uu" sourceRef="Event_101fdfc" targetRef="Activity_1mr7vew" />
+    <bpmn:sequenceFlow id="Flow_0qhvk9n" sourceRef="Activity_1mr7vew" targetRef="Gateway_1gs9ubg" />
+    <bpmn:sequenceFlow id="Flow_03f50eq" sourceRef="Gateway_1gs9ubg" targetRef="Gateway_0hh1z36" />
+  </bpmn:process>
+  <bpmn:signal id="Signal_2mku8rr" name="Signal1" />
+  <bpmn:message id="Message_058e0et" name="Message_058e0et">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=1" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_0kwdci8" name="Error1" errorCode="&#34;001&#34;" />
+  <bpmn:escalation id="Escalation_3j23ajg" name="Escalation1" escalationCode="001" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="pricsdv">
+      <bpmndi:BPMNShape id="Participant_0pi84e6_di" bpmnElement="Participant_0pi84e6" isHorizontal="true">
+        <dc:Bounds x="159" y="120" width="961" height="890" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1kxukl2_di" bpmnElement="Lane_1kxukl2" isHorizontal="true">
+        <dc:Bounds x="189" y="120" width="931" height="890" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0dn7hwq_di" bpmnElement="Activity_0dn7hwq" isExpanded="true">
+        <dc:Bounds x="390" y="190" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1302fp8_di" bpmnElement="Event_1302fp8">
+        <dc:Bounds x="432" y="272" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02zuu2v_di" bpmnElement="Activity_1pbqhut">
+        <dc:Bounds x="520" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1prjh4v_di" bpmnElement="Event_1prjh4v">
+        <dc:Bounds x="672" y="272" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1kw0wg8_di" bpmnElement="Flow_1kw0wg8">
+        <di:waypoint x="468" y="290" />
+        <di:waypoint x="520" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xvb4m3_di" bpmnElement="Flow_1xvb4m3">
+        <di:waypoint x="620" y="290" />
+        <di:waypoint x="672" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Gateway_0dy5o0s_di" bpmnElement="Gateway_1jebry1" isMarkerVisible="true">
+        <dc:Bounds x="615" y="465" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="622" y="435" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0p69akl_di" bpmnElement="Gateway_0fsc6mp">
+        <dc:Bounds x="325" y="465" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="222" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13dq95m_di" bpmnElement="Activity_1tj3t2w">
+        <dc:Bounds x="450" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vdiktu_di" bpmnElement="Event_1vdiktu">
+        <dc:Bounds x="952" y="682" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ur3iux_di" bpmnElement="Gateway_17vhv3u">
+        <dc:Bounds x="325" y="675" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_117c4x7" bpmnElement="Activity_1iaguca">
+        <dc:Bounds x="590" y="660" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1s61blt_di" bpmnElement="Event_1s61blt">
+        <dc:Bounds x="462" y="682" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="469" y="725" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1tpbbhr" bpmnElement="Event_0766jw8">
+        <dc:Bounds x="622" y="582" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_07nnib1_di" bpmnElement="Activity_1mr7vew">
+        <dc:Bounds x="590" y="860" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_101fdfc_di" bpmnElement="Event_101fdfc">
+        <dc:Bounds x="452" y="882" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_00ntpob_di" bpmnElement="Gateway_1gs9ubg">
+        <dc:Bounds x="735" y="675" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0k6jztm_di" bpmnElement="Gateway_0hh1z36">
+        <dc:Bounds x="845" y="675" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0nsgv8j_di" bpmnElement="Flow_0nsgv8j">
+        <di:waypoint x="350" y="465" />
+        <di:waypoint x="350" y="290" />
+        <di:waypoint x="390" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0efki0l_di" bpmnElement="Flow_0efki0l">
+        <di:waypoint x="740" y="290" />
+        <di:waypoint x="870" y="290" />
+        <di:waypoint x="870" y="675" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1h2qmr7_di" bpmnElement="Flow_1h2qmr7">
+        <di:waypoint x="550" y="490" />
+        <di:waypoint x="615" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0elpvfi_di" bpmnElement="Flow_0elpvfi">
+        <di:waypoint x="640" y="515" />
+        <di:waypoint x="640" y="582" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="651" y="537" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vc2dw1_di" bpmnElement="Flow_1vc2dw1">
+        <di:waypoint x="665" y="490" />
+        <di:waypoint x="760" y="490" />
+        <di:waypoint x="760" y="675" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dkpvcy_di" bpmnElement="Flow_0dkpvcy">
+        <di:waypoint x="258" y="490" />
+        <di:waypoint x="325" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i7jyld_di" bpmnElement="Flow_1i7jyld">
+        <di:waypoint x="350" y="515" />
+        <di:waypoint x="350" y="675" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_130lm61_di" bpmnElement="Flow_130lm61">
+        <di:waypoint x="375" y="490" />
+        <di:waypoint x="450" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0sj8w39_di" bpmnElement="Flow_0sj8w39">
+        <di:waypoint x="895" y="700" />
+        <di:waypoint x="952" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15hp95n_di" bpmnElement="Flow_15hp95n">
+        <di:waypoint x="375" y="700" />
+        <di:waypoint x="462" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10f7pmj_di" bpmnElement="Flow_10f7pmj">
+        <di:waypoint x="350" y="725" />
+        <di:waypoint x="350" y="900" />
+        <di:waypoint x="452" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m1zh3p_di" bpmnElement="Flow_0m1zh3p">
+        <di:waypoint x="498" y="700" />
+        <di:waypoint x="590" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uc0d9v_di" bpmnElement="Flow_0uc0d9v">
+        <di:waypoint x="690" y="700" />
+        <di:waypoint x="735" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10k93uu_di" bpmnElement="Flow_10k93uu">
+        <di:waypoint x="488" y="900" />
+        <di:waypoint x="590" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qhvk9n_di" bpmnElement="Flow_0qhvk9n">
+        <di:waypoint x="690" y="900" />
+        <di:waypoint x="760" y="900" />
+        <di:waypoint x="760" y="725" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03f50eq_di" bpmnElement="Flow_03f50eq">
+        <di:waypoint x="785" y="700" />
+        <di:waypoint x="845" y="700" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/http/c8run-tests/User Task Processes/User Task Test Process.bpmn
+++ b/qa/http/c8run-tests/User Task Processes/User Task Test Process.bpmn
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.38.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:collaboration id="pricsdv" name="HTO">
+    <bpmn:participant id="Participant_0pi84e6" processRef="Process_0uj1r9h" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_0uj1r9h" name="User Task Test Process" isExecutable="true">
+    <bpmn:laneSet id="LaneSet_0wz0i02">
+      <bpmn:lane id="Lane_1kxukl2" name="event">
+        <bpmn:flowNodeRef>Gateway_1jebry1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_0fsc6mp</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1tj3t2w</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1vdiktu</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_17vhv3u</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1iaguca</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1s61blt</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0766jw8</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1mr7vew</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_101fdfc</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1gs9ubg</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_0hh1z36</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_0dn7hwq</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:subProcess id="Activity_0dn7hwq">
+      <bpmn:incoming>Flow_0nsgv8j</bpmn:incoming>
+      <bpmn:outgoing>Flow_0efki0l</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[0,1]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="Event_1302fp8">
+        <bpmn:outgoing>Flow_1kw0wg8</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1kw0wg8" sourceRef="Event_1302fp8" targetRef="Activity_1pbqhut" />
+      <bpmn:userTask id="Activity_1pbqhut" name="Form A">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+          <zeebe:formDefinition formId="Form_1viy2x4" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1kw0wg8</bpmn:incoming>
+        <bpmn:outgoing>Flow_1xvb4m3</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:endEvent id="Event_1prjh4v">
+        <bpmn:incoming>Flow_1xvb4m3</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1xvb4m3" sourceRef="Activity_1pbqhut" targetRef="Event_1prjh4v" />
+    </bpmn:subProcess>
+    <bpmn:exclusiveGateway id="Gateway_1jebry1" name="Signal?" default="Flow_1vc2dw1">
+      <bpmn:incoming>Flow_1h2qmr7</bpmn:incoming>
+      <bpmn:outgoing>Flow_0elpvfi</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1vc2dw1</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_0fsc6mp">
+      <bpmn:incoming>Flow_0dkpvcy</bpmn:incoming>
+      <bpmn:outgoing>Flow_0nsgv8j</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1i7jyld</bpmn:outgoing>
+      <bpmn:outgoing>Flow_130lm61</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0dkpvcy</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="Activity_1tj3t2w" name="Form B">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="Form_1dl8p3y" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_130lm61</bpmn:incoming>
+      <bpmn:outgoing>Flow_1h2qmr7</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_1vdiktu">
+      <bpmn:incoming>Flow_0sj8w39</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:eventBasedGateway id="Gateway_17vhv3u">
+      <bpmn:incoming>Flow_1i7jyld</bpmn:incoming>
+      <bpmn:outgoing>Flow_15hp95n</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10f7pmj</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:userTask id="Activity_1iaguca" name="Form C">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="Form_wjdlwtt" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0m1zh3p</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uc0d9v</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:intermediateCatchEvent id="Event_1s61blt" name="1min">
+      <bpmn:incoming>Flow_15hp95n</bpmn:incoming>
+      <bpmn:outgoing>Flow_0m1zh3p</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0g4qpq1">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1M</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="Event_0766jw8">
+      <bpmn:incoming>Flow_0elpvfi</bpmn:incoming>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_16ctki0" signalRef="Signal_2mku8rr" />
+    </bpmn:endEvent>
+    <bpmn:userTask id="Activity_1mr7vew" name="Form C">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="Form_wjdlwtt" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_10k93uu</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qhvk9n</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:intermediateCatchEvent id="Event_101fdfc">
+      <bpmn:incoming>Flow_10f7pmj</bpmn:incoming>
+      <bpmn:outgoing>Flow_10k93uu</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1cq09a7" signalRef="Signal_2mku8rr" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:inclusiveGateway id="Gateway_1gs9ubg">
+      <bpmn:incoming>Flow_0uc0d9v</bpmn:incoming>
+      <bpmn:incoming>Flow_0qhvk9n</bpmn:incoming>
+      <bpmn:incoming>Flow_1vc2dw1</bpmn:incoming>
+      <bpmn:outgoing>Flow_03f50eq</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:parallelGateway id="Gateway_0hh1z36">
+      <bpmn:incoming>Flow_03f50eq</bpmn:incoming>
+      <bpmn:incoming>Flow_0efki0l</bpmn:incoming>
+      <bpmn:outgoing>Flow_0sj8w39</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0nsgv8j" sourceRef="Gateway_0fsc6mp" targetRef="Activity_0dn7hwq" />
+    <bpmn:sequenceFlow id="Flow_0efki0l" sourceRef="Activity_0dn7hwq" targetRef="Gateway_0hh1z36" />
+    <bpmn:sequenceFlow id="Flow_1h2qmr7" sourceRef="Activity_1tj3t2w" targetRef="Gateway_1jebry1" />
+    <bpmn:sequenceFlow id="Flow_0elpvfi" name="yes" sourceRef="Gateway_1jebry1" targetRef="Event_0766jw8">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=proceed</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1vc2dw1" sourceRef="Gateway_1jebry1" targetRef="Gateway_1gs9ubg" />
+    <bpmn:sequenceFlow id="Flow_0dkpvcy" sourceRef="StartEvent_1" targetRef="Gateway_0fsc6mp" />
+    <bpmn:sequenceFlow id="Flow_1i7jyld" sourceRef="Gateway_0fsc6mp" targetRef="Gateway_17vhv3u" />
+    <bpmn:sequenceFlow id="Flow_130lm61" sourceRef="Gateway_0fsc6mp" targetRef="Activity_1tj3t2w" />
+    <bpmn:sequenceFlow id="Flow_0sj8w39" sourceRef="Gateway_0hh1z36" targetRef="Event_1vdiktu" />
+    <bpmn:sequenceFlow id="Flow_15hp95n" sourceRef="Gateway_17vhv3u" targetRef="Event_1s61blt" />
+    <bpmn:sequenceFlow id="Flow_10f7pmj" sourceRef="Gateway_17vhv3u" targetRef="Event_101fdfc" />
+    <bpmn:sequenceFlow id="Flow_0m1zh3p" sourceRef="Event_1s61blt" targetRef="Activity_1iaguca" />
+    <bpmn:sequenceFlow id="Flow_0uc0d9v" sourceRef="Activity_1iaguca" targetRef="Gateway_1gs9ubg" />
+    <bpmn:sequenceFlow id="Flow_10k93uu" sourceRef="Event_101fdfc" targetRef="Activity_1mr7vew" />
+    <bpmn:sequenceFlow id="Flow_0qhvk9n" sourceRef="Activity_1mr7vew" targetRef="Gateway_1gs9ubg" />
+    <bpmn:sequenceFlow id="Flow_03f50eq" sourceRef="Gateway_1gs9ubg" targetRef="Gateway_0hh1z36" />
+  </bpmn:process>
+  <bpmn:signal id="Signal_2mku8rr" name="Signal1" />
+  <bpmn:message id="Message_058e0et" name="Message_058e0et">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=1" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:error id="Error_0kwdci8" name="Error1" errorCode="&#34;001&#34;" />
+  <bpmn:escalation id="Escalation_3j23ajg" name="Escalation1" escalationCode="001" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="pricsdv">
+      <bpmndi:BPMNShape id="Participant_0pi84e6_di" bpmnElement="Participant_0pi84e6" isHorizontal="true">
+        <dc:Bounds x="159" y="120" width="961" height="890" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1kxukl2_di" bpmnElement="Lane_1kxukl2" isHorizontal="true">
+        <dc:Bounds x="189" y="120" width="931" height="890" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0dn7hwq_di" bpmnElement="Activity_0dn7hwq" isExpanded="true">
+        <dc:Bounds x="390" y="190" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1302fp8_di" bpmnElement="Event_1302fp8">
+        <dc:Bounds x="432" y="272" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02zuu2v_di" bpmnElement="Activity_1pbqhut">
+        <dc:Bounds x="520" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1prjh4v_di" bpmnElement="Event_1prjh4v">
+        <dc:Bounds x="672" y="272" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1kw0wg8_di" bpmnElement="Flow_1kw0wg8">
+        <di:waypoint x="468" y="290" />
+        <di:waypoint x="520" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xvb4m3_di" bpmnElement="Flow_1xvb4m3">
+        <di:waypoint x="620" y="290" />
+        <di:waypoint x="672" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Gateway_0dy5o0s_di" bpmnElement="Gateway_1jebry1" isMarkerVisible="true">
+        <dc:Bounds x="615" y="465" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="622" y="435" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0p69akl_di" bpmnElement="Gateway_0fsc6mp">
+        <dc:Bounds x="325" y="465" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="222" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13dq95m_di" bpmnElement="Activity_1tj3t2w">
+        <dc:Bounds x="450" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vdiktu_di" bpmnElement="Event_1vdiktu">
+        <dc:Bounds x="952" y="682" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ur3iux_di" bpmnElement="Gateway_17vhv3u">
+        <dc:Bounds x="325" y="675" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_117c4x7" bpmnElement="Activity_1iaguca">
+        <dc:Bounds x="590" y="660" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1s61blt_di" bpmnElement="Event_1s61blt">
+        <dc:Bounds x="462" y="682" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="469" y="725" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1tpbbhr" bpmnElement="Event_0766jw8">
+        <dc:Bounds x="622" y="582" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_07nnib1_di" bpmnElement="Activity_1mr7vew">
+        <dc:Bounds x="590" y="860" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_101fdfc_di" bpmnElement="Event_101fdfc">
+        <dc:Bounds x="452" y="882" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_00ntpob_di" bpmnElement="Gateway_1gs9ubg">
+        <dc:Bounds x="735" y="675" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0k6jztm_di" bpmnElement="Gateway_0hh1z36">
+        <dc:Bounds x="845" y="675" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0nsgv8j_di" bpmnElement="Flow_0nsgv8j">
+        <di:waypoint x="350" y="465" />
+        <di:waypoint x="350" y="290" />
+        <di:waypoint x="390" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0efki0l_di" bpmnElement="Flow_0efki0l">
+        <di:waypoint x="740" y="290" />
+        <di:waypoint x="870" y="290" />
+        <di:waypoint x="870" y="675" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1h2qmr7_di" bpmnElement="Flow_1h2qmr7">
+        <di:waypoint x="550" y="490" />
+        <di:waypoint x="615" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0elpvfi_di" bpmnElement="Flow_0elpvfi">
+        <di:waypoint x="640" y="515" />
+        <di:waypoint x="640" y="582" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="651" y="537" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vc2dw1_di" bpmnElement="Flow_1vc2dw1">
+        <di:waypoint x="665" y="490" />
+        <di:waypoint x="760" y="490" />
+        <di:waypoint x="760" y="675" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dkpvcy_di" bpmnElement="Flow_0dkpvcy">
+        <di:waypoint x="258" y="490" />
+        <di:waypoint x="325" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i7jyld_di" bpmnElement="Flow_1i7jyld">
+        <di:waypoint x="350" y="515" />
+        <di:waypoint x="350" y="675" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_130lm61_di" bpmnElement="Flow_130lm61">
+        <di:waypoint x="375" y="490" />
+        <di:waypoint x="450" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0sj8w39_di" bpmnElement="Flow_0sj8w39">
+        <di:waypoint x="895" y="700" />
+        <di:waypoint x="952" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15hp95n_di" bpmnElement="Flow_15hp95n">
+        <di:waypoint x="375" y="700" />
+        <di:waypoint x="462" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10f7pmj_di" bpmnElement="Flow_10f7pmj">
+        <di:waypoint x="350" y="725" />
+        <di:waypoint x="350" y="900" />
+        <di:waypoint x="452" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m1zh3p_di" bpmnElement="Flow_0m1zh3p">
+        <di:waypoint x="498" y="700" />
+        <di:waypoint x="590" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uc0d9v_di" bpmnElement="Flow_0uc0d9v">
+        <di:waypoint x="690" y="700" />
+        <di:waypoint x="735" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10k93uu_di" bpmnElement="Flow_10k93uu">
+        <di:waypoint x="488" y="900" />
+        <di:waypoint x="590" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qhvk9n_di" bpmnElement="Flow_0qhvk9n">
+        <di:waypoint x="690" y="900" />
+        <di:waypoint x="760" y="900" />
+        <di:waypoint x="760" y="725" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03f50eq_di" bpmnElement="Flow_03f50eq">
+        <di:waypoint x="785" y="700" />
+        <di:waypoint x="845" y="700" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/http/c8run-tests/application-h2.yaml
+++ b/qa/http/c8run-tests/application-h2.yaml
@@ -16,14 +16,14 @@ camunda:
       users:
         - username: demo
           password: demo
-          name: demo
+          name: Demo
           email: demo@example.com
       defaultRoles:
         admin:
           users:
             - demo
-    # By default authorization and api protection is disabled
     authentication:
+      method: BASIC
       unprotected-api: true
     authorizations:
       enabled: false
@@ -33,6 +33,11 @@ zeebe:
     network:
       host: localhost
       advertisedHost: localhost
+  gateway:
+    cluster:
+      initialContactPoints: zeebe:26502
+      memberId: identity
+
 spring:
   profiles:
-    active: "broker,consolidated-auth,identity,tasklist,operate"
+    active: "broker,consolidated-auth,identity,tasklist"

--- a/qa/http/c8run-tests/application-h2.yaml
+++ b/qa/http/c8run-tests/application-h2.yaml
@@ -1,0 +1,38 @@
+camunda:
+  backup:
+    webapps:
+      enabled: false
+  data:
+    secondary-storage:
+      type: rdbms
+      rdbms:
+        url: jdbc:h2:mem:camunda
+        username: sa
+        password:
+        flushInterval: PT0.5S
+        queueSize: 1000
+  security:
+    initialization:
+      users:
+        - username: demo
+          password: demo
+          name: demo
+          email: demo@example.com
+      defaultRoles:
+        admin:
+          users:
+            - demo
+    # By default authorization and api protection is disabled
+    authentication:
+      unprotected-api: true
+    authorizations:
+      enabled: false
+
+zeebe:
+  broker:
+    network:
+      host: localhost
+      advertisedHost: localhost
+spring:
+  profiles:
+    active: "broker,consolidated-auth,identity,tasklist,operate"

--- a/qa/http/c8run-tests/c8run-tests.http
+++ b/qa/http/c8run-tests/c8run-tests.http
@@ -96,11 +96,11 @@ Content-Type: application/octet-stream
 %}
 
 ###
+# @name process-definition-search-authorized
 < {%
   import {wait} from "../js/wait"
   wait(1)
 %}
-# @name process-definition-search-authorized
 POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/search
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
@@ -127,10 +127,6 @@ Accept: application/json
 %}
 
 ###
-< {%
-  import {wait} from "../js/wait"
-  wait(4)
-%}
 # @name get-process-definition-authorized
 GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/{{PROCESS_DEFINITION_KEY}}
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
@@ -173,28 +169,6 @@ Accept: application/json
 %}
 
 ###
-# @name get-process-definition-statistics-authorized
-< {%
-  import {wait} from "../js/wait"
-  wait(2)
-%}
-POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/{{PROCESS_DEFINITION_KEY}}/statistics/element-instances
-Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
-X-CSRF-TOKEN: {{csrf_token}}
-Content-Type: application/json
-Accept: application/json
-
-{}
-
-> {%
-  client.test("Process definition retrieval is successful", function () {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-    client.assert(Array.isArray(response.body.items), "items must be array");
-    client.assert(response.body.items.length > 0, "Expect at least one element");
-  });
-%}
-
-###
 # @name create-process-instance
 POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
@@ -223,11 +197,29 @@ let expectedDefinitionKey = client.global.get("PROCESS_DEFINITION_KEY");
 %}
 
 ###
-# @name get-process-instance
+# @name get-process-definition-statistics-authorized
 < {%
   import {wait} from "../js/wait"
   wait(4)
 %}
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/{{PROCESS_DEFINITION_KEY}}/statistics/element-instances
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{}
+
+> {%
+  client.test("Process definition retrieval is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    client.assert(Array.isArray(response.body.items), "items must be array");
+    client.assert(response.body.items.length > 0, "Expect at least one element");
+  });
+%}
+
+###
+# @name get-process-instance
 GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY}}
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
@@ -297,10 +289,6 @@ Accept: application/json
 
 ###
 # @name get-process-instance-call-hierarchy
-< {%
-  import {wait} from "../js/wait"
-  wait(1)
-%}
 GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY}}/call-hierarchy
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
@@ -527,104 +515,11 @@ Accept: application/json
 %}
 
 ###
-# @name get-process-instance-with-incident
+# @name user-task-search-authorized
 < {%
   import {wait} from "../js/wait"
   wait(4)
 %}
-GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY_INCIDENT}}
-Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
-X-CSRF-TOKEN: {{csrf_token}}
-Content-Type: application/json
-Accept: application/json
-
-> {%
-  client.test("Process instance is successful returned", function () {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
-
-  client.test("Response should be JSON", function () {
-    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
-  });
-
-  let expectedInstanceKey = client.global.get("PROCESS_INSTANCE_KEY");
-  client.test("Response should not be empty", function () {
-    client.assert(response.body.processInstanceKey === expectedInstanceKey, "Process instances wasn't returned");
-    client.assert(response.body.state === "INCIDENT", "Process instance is not ACTIVE");
-    client.assert(response.body.hasIncident === true, "Process instance is healthy");
-  });
-%}
-
-###
-# @name process-incident-search-authorized
-POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/incidents/search
-Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
-X-CSRF-TOKEN: {{csrf_token}}
-Content-Type: application/json
-Accept: application/json
-
-{
-  "sort": [
-    {
-      "field": "processInstanceKey",
-      "order": "ASC"
-    }
-  ],
-  "page": {
-    "from": 0,
-    "limit": 100
-  }
-}
-
-> {%
-  client.test("Process instance search is successful", function () {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
-
-  client.test("Response should be JSON", function () {
-    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
-  });
-
-  client.test("Response should not be empty", function () {
-    client.assert(response.body.items.length > 0, "Process instances were not returned");
-    client.global.set("INCIDENT_KEY", response.body.items[0].incidentKey);
-  });
-%}
-
-###
-# @name get-process-incident-authorized
-GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/incidents/{{INCIDENT_KEY}}
-Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
-X-CSRF-TOKEN: {{csrf_token}}
-Content-Type: application/json
-Accept: application/json
-
-> {%
-  client.test("Process incident retrieval is successful", function () {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-  });
-%}
-
-###
-# @name process-incident-resolution-authorized
-POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/incidents/{{INCIDENT_KEY}}/resolution
-Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
-X-CSRF-TOKEN: {{csrf_token}}
-Content-Type: application/json
-Accept: application/json
-
-{
-  "operationReference": 1
-}
-
-> {%
-  client.test("Process incident resolution is successful", function () {
-    client.assert(response.status === 204, "Expected 204, got " + response.status);
-  });
-%}
-
-###
-# @name user-task-search-authorized
 POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/user-tasks/search
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
@@ -871,7 +766,7 @@ Accept: application/json
 # @name get-updated-assigned-user-task-authorized
 < {%
   import {wait} from "../js/wait"
-  wait(2)
+  wait(4)
 %}
 GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/user-tasks/{{USER_TASK_KEY}}
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
@@ -984,6 +879,103 @@ Accept: application/json
 
   client.test("Variables should be returned", function () {
     client.assert(response.body.variableKey !== undefined, "Variable was not returned");
+  });
+%}
+
+###
+# @name get-process-instance-with-incident
+< {%
+  import {wait} from "../js/wait"
+  wait(4)
+%}
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY_INCIDENT}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Process instance is successful returned", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  let expectedInstanceKey = client.global.get("PROCESS_INSTANCE_KEY_INCIDENT");
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.processInstanceKey === expectedInstanceKey, "Process instances wasn't returned");
+    client.assert(response.body.state === "ACTIVE", "Process instance is not ACTIVE");
+    client.assert(response.body.hasIncident === true, "Process instance is healthy");
+  });
+%}
+
+###
+# @name process-incident-search-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/incidents/search
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "sort": [
+    {
+      "field": "processInstanceKey",
+      "order": "ASC"
+    }
+  ],
+  "page": {
+    "from": 0,
+    "limit": 100
+  }
+}
+
+> {%
+  client.test("Process instance search is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.items.length > 0, "Process instances were not returned");
+    client.global.set("INCIDENT_KEY", response.body.items[0].incidentKey);
+  });
+%}
+
+###
+# @name get-process-incident-authorized
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/incidents/{{INCIDENT_KEY}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Process incident retrieval is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+%}
+
+###
+# @name process-incident-resolution-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/incidents/{{INCIDENT_KEY}}/resolution
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "operationReference": 1
+}
+
+> {%
+  client.test("Process incident resolution is successful", function () {
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
   });
 %}
 

--- a/qa/http/c8run-tests/c8run-tests.http
+++ b/qa/http/c8run-tests/c8run-tests.http
@@ -1,0 +1,312 @@
+###
+# @no-cookie-jar
+# @name login
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/login?username=demo&password=demo
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Login should succeed and set cookies", function () {
+    client.assert(response.status === 204, "Login should succeed");
+
+    const setCookieHeaders = response.headers.valuesOf("Set-Cookie");
+    if (setCookieHeaders && setCookieHeaders.length > 0) {
+      let sessionCookie = null;
+      let csrfCookie = null;
+
+      setCookieHeaders.forEach(cookie => {
+        if (cookie.includes("camunda-session")) {
+          sessionCookie = cookie.split(';')[0].split('=')[1];
+        }
+        if (cookie.includes("X-CSRF-TOKEN")) {
+          csrfCookie = cookie.split(';')[0].split('=')[1];
+        }
+      });
+
+      if (sessionCookie) {
+        client.global.set("session_cookie", sessionCookie);
+        console.log("Session cookie: " + sessionCookie);
+      }
+      if (csrfCookie) {
+        client.global.set("csrf_cookie", csrfCookie);
+        console.log("CSRF cookie: " + csrfCookie);
+      }
+    }
+  });
+%}
+
+###
+# @name test-get-x-csrf-token-header
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/authentication/me
+Accept: application/json
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+
+> {%
+  client.test("Authentication request should succeed and return CSRF token", function () {
+    client.assert(response.status === 200, "Response status is not 200");
+    client.assert(response.headers.valueOf("x-csrf-token"), "CSRF token header is missing");
+    client.global.set("csrf_token", response.headers.valueOf("x-csrf-token"));
+    console.log("CSRF Token from header: " + client.global.get("csrf_token"));
+  });
+%}
+
+###
+# @name deploy-process-diagram
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/deployments
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Accept: application/json
+Content-Type: multipart/form-data; boundary=boundary123
+
+--boundary123
+Content-Disposition: form-data; name="resources"; filename="User Task Test Process.bpmn"
+Content-Type: application/octet-stream
+
+< ./User Task Processes/User Task Test Process.bpmn
+--boundary123
+Content-Disposition: form-data; name="resources"; filename="New form A.form"
+Content-Type: application/octet-stream
+
+< ./User Task Processes/New form A.form
+--boundary123
+Content-Disposition: form-data; name="resources"; filename="New form B.form"
+Content-Type: application/octet-stream
+
+< ./User Task Processes/New form B.form
+--boundary123
+Content-Disposition: form-data; name="resources"; filename="New form C.form"
+Content-Type: application/octet-stream
+
+< ./User Task Processes/New form C.form
+--boundary123--
+
+
+> {%
+  client.test("Process deployment is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    const processKey = response.body.deployments[0].processDefinition.processDefinitionKey;
+    client.global.set("PROCESS_DEFINITION_KEY", processKey);
+    client.log("Deployed process key: " + processKey);
+  });
+%}
+
+###
+# @name start-process-instance
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "processDefinitionKey": "{{PROCESS_DEFINITION_KEY}}",
+  "variables": {},
+  "tenantId": ""
+}
+
+> {%
+  client.test("Process instance started successfully", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    client.assert(response.body.processInstanceKey, "Process instance key should exist");
+    client.log("Started process instance with key: " + response.body.processInstanceKey);
+  });
+%}
+
+###
+# @name process-definition-search-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/search
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "sort": [
+    {
+      "field": "processDefinitionKey",
+      "order": "ASC"
+    }
+  ],
+  "page": {
+    "from": 0,
+    "limit": 100
+  }
+}
+
+> {%
+  client.test("Process definition search is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    //client.global.set("PROCESS_DEFINITION_KEY", response.body.items[0].processDefinitionKey);
+  });
+%}
+
+###
+# @name create-process-instance
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "processDefinitionKey": "{{PROCESS_DEFINITION_KEY}}",
+  "variables": {}
+}
+
+> {%
+  client.test("Create process instance is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+let expectedDefinitionKey = client.global.get("PROCESS_DEFINITION_KEY");
+  client.test("Response should contain process key", function () {
+    client.assert(response.body.processDefinitionKey === expectedDefinitionKey, "Process definition key was not returned");
+    client.global.set("PROCESS_INSTANCE_KEY", response.body.processInstanceKey);
+  });
+%}
+
+###
+# @name get-process-instance
+< {%
+  import {wait} from "../js/wait"
+  wait(3)
+%}
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY}}
+Cookie: {{COOKIE_HEADER}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Process instance is successful returned", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  let expectedInstanceKey = client.global.get("PROCESS_INSTANCE_KEY");
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.processInstanceKey === expectedInstanceKey, "Process instances wasn't returned");
+  });
+%}
+
+###
+# @name process-instance-search-authorized
+< {%
+  import {wait} from "../js/wait"
+  wait(3)
+%}
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/search
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "sort": [
+    {
+      "field": "processInstanceKey",
+      "order": "ASC"
+    }
+  ],
+  "page": {
+    "from": 0,
+    "limit": 100
+  }
+}
+
+> {%
+  client.test("Process instance search is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.items.length > 0, "Process instances were not returned");
+  });
+%}
+
+###
+# @name upload-document-authorized
+POST http://localhost:8080/v2/documents
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Accept: application/json
+Content-Type: multipart/form-data; boundary=boundary123
+
+--boundary123
+Content-Disposition: form-data; name="file"; filename="test.pdf"
+X-Document-Metadata: {"fileName": "test.pdf", "size": 1234567}
+Content-Type: application/pdf
+
+< ../test.pdf
+--boundary123
+
+> {%
+  client.test("Document upload should be successful", function () {
+    client.assert(response.status === 201, "Expected 201, got " + response.status);
+    client.global.set("DOCUMENT_ID", response.body.documentId);
+    client.global.set("CONTENT_HASH", response.body.contentHash);
+  });
+
+  client.test("Response should be JSON", function () {
+    const contentType = response.headers.valueOf("Content-Type") || "";
+    client.assert(
+        contentType.toLowerCase().includes("application/json"),
+        `Response is not JSON, Content-Type was: ${contentType}`
+    );
+  });
+
+  client.test("Response body should include document ID", function () {
+    client.assert(response.body.documentId, "Document ID not found in the response");
+  });
+%}
+
+###
+# @name download-document-authorized
+GET http://localhost:8080/v2/documents/{{DOCUMENT_ID}}?contentHash={{CONTENT_HASH}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Accept: application/octet-stream
+
+> {%
+  client.test("Document download should be successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+%}
+
+###
+# @name delete-and-verify-document
+DELETE http://localhost:8080/v2/documents/{{DOCUMENT_ID}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+
+> {%
+  client.test("Document deletion should succeed", function () {
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
+  });
+
+  client.global.set("DOCUMENT_DELETED", "true");
+%}
+
+###
+# @name verify-deleted-document
+GET http://localhost:8080/v2/documents/{{DOCUMENT_ID}}?contentHash={{CONTENT_HASH}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Accept: application/octet-stream
+
+> {%
+  if (client.global.get("DOCUMENT_DELETED") === "true") {
+    client.test("Document download after deletion should fail", function () {
+      client.assert(response.status === 404, "Expected 404, got " + response.status);
+    });
+  }
+%}

--- a/qa/http/c8run-tests/c8run-tests.http
+++ b/qa/http/c8run-tests/c8run-tests.http
@@ -129,7 +129,7 @@ Accept: application/json
 ###
 < {%
   import {wait} from "../js/wait"
-  wait(2)
+  wait(4)
 %}
 # @name get-process-definition-authorized
 GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/{{PROCESS_DEFINITION_KEY}}
@@ -530,7 +530,7 @@ Accept: application/json
 # @name get-process-instance-with-incident
 < {%
   import {wait} from "../js/wait"
-  wait(2)
+  wait(4)
 %}
 GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY_INCIDENT}}
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}

--- a/qa/http/c8run-tests/c8run-tests.http
+++ b/qa/http/c8run-tests/c8run-tests.http
@@ -52,6 +52,10 @@ Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 
 ###
 # @name deploy-process-diagram
+< {%
+  import {wait} from "../js/wait"
+  wait(1)
+%}
 POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/deployments
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
@@ -85,34 +89,17 @@ Content-Type: application/octet-stream
   client.test("Process deployment is successful", function () {
     client.assert(response.status === 200, "Expected 200, got " + response.status);
     const processKey = response.body.deployments[0].processDefinition.processDefinitionKey;
+    const formKey = response.body.deployments[1].form.formKey;
     client.global.set("PROCESS_DEFINITION_KEY", processKey);
-    client.log("Deployed process key: " + processKey);
+    client.global.set("FORM_KEY", formKey);
   });
 %}
 
 ###
-# @name start-process-instance
-POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances
-Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
-X-CSRF-TOKEN: {{csrf_token}}
-Content-Type: application/json
-Accept: application/json
-
-{
-  "processDefinitionKey": "{{PROCESS_DEFINITION_KEY}}",
-  "variables": {},
-  "tenantId": ""
-}
-
-> {%
-  client.test("Process instance started successfully", function () {
-    client.assert(response.status === 200, "Expected 200, got " + response.status);
-    client.assert(response.body.processInstanceKey, "Process instance key should exist");
-    client.log("Started process instance with key: " + response.body.processInstanceKey);
-  });
+< {%
+  import {wait} from "../js/wait"
+  wait(1)
 %}
-
-###
 # @name process-definition-search-authorized
 POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/search
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
@@ -136,6 +123,74 @@ Accept: application/json
 > {%
   client.test("Process definition search is successful", function () {
     client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+%}
+
+###
+< {%
+  import {wait} from "../js/wait"
+  wait(2)
+%}
+# @name get-process-definition-authorized
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/{{PROCESS_DEFINITION_KEY}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Process definition retrieval is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+%}
+
+###
+# @name get-process-definition-xml-authorized
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/{{PROCESS_DEFINITION_KEY}}/xml
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: text/xml
+
+> {%
+  client.test("Process definition retrieval is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+%}
+
+###
+# @name get-process-definition-start-form-with-no-form-attached-authorized
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/{{PROCESS_DEFINITION_KEY}}/form
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Process definition start form retrieval is successful, but no form is attached", function () {
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
+  });
+%}
+
+###
+# @name get-process-definition-statistics-authorized
+< {%
+  import {wait} from "../js/wait"
+  wait(2)
+%}
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/{{PROCESS_DEFINITION_KEY}}/statistics/element-instances
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{}
+
+> {%
+  client.test("Process definition retrieval is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    client.assert(Array.isArray(response.body.items), "items must be array");
+    client.assert(response.body.items.length > 0, "Expect at least one element");
   });
 %}
 
@@ -174,7 +229,8 @@ let expectedDefinitionKey = client.global.get("PROCESS_DEFINITION_KEY");
   wait(4)
 %}
 GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY}}
-Cookie: {{COOKIE_HEADER}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
 Content-Type: application/json
 Accept: application/json
 
@@ -194,11 +250,80 @@ Accept: application/json
 %}
 
 ###
-# @name process-instance-search-authorized
+# @name get-process-instance-sequence-flows
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY}}/sequence-flows
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Process instance is successful returned", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should not be empty", function () {
+    client.assert(Array.isArray(response.body.items), "items must be array");
+    client.assert(response.body.items.length > 0, "Expect at least one element");
+  });
+%}
+
+###
+# @name get-process-instance-elements-statistics
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY}}/statistics/element-instances
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Process instance elements statistics are successful returned", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should not be empty", function () {
+    client.assert(Array.isArray(response.body.items), "items must be array");
+    client.assert(response.body.items.length > 0, "Expect at least one element");
+  });
+%}
+
+###
+# @name get-process-instance-call-hierarchy
 < {%
   import {wait} from "../js/wait"
-  wait(3)
+  wait(1)
 %}
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY}}/call-hierarchy
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Process instance hierarchy is successful returned", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should not be empty", function () {
+    client.assert(Array.isArray(response.body), "items must be array");
+    client.assert(response.body.length == 0, "Expect no elements in hierarchy");
+  });
+%}
+
+###
+# @name process-instance-search-authorized
 POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/search
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
@@ -229,6 +354,636 @@ Accept: application/json
 
   client.test("Response should not be empty", function () {
     client.assert(response.body.items.length > 0, "Process instances were not returned");
+  });
+%}
+
+###
+# @name process-instance-search-for-incidents-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY}}/incidents/search
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "sort": [
+    {
+      "field": "processInstanceKey",
+      "order": "ASC"
+    }
+  ],
+  "page": {
+    "from": 0,
+    "limit": 100
+  }
+}
+
+> {%
+  client.test("Process instance search for incidents is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should be empty", function () {
+    client.assert(response.body.items.length == 0, "Process instances were not returned");
+  });
+%}
+
+###
+# @name process-instance-cancellation-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY}}/cancellation
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "operationReference": 1
+}
+
+> {%
+  client.test("Process instance cancellation is successful", function () {
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
+  });
+%}
+
+###
+# @name get-cancelled-process-instance
+< {%
+  import {wait} from "../js/wait"
+  wait(4)
+%}
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Process instance is successful returned", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  let expectedInstanceKey = client.global.get("PROCESS_INSTANCE_KEY");
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.processInstanceKey === expectedInstanceKey, "Process instances wasn't returned");
+    client.assert(response.body.state === "TERMINATED", "Process instance is not canceled");
+  });
+%}
+
+###
+# @name process-definition-resource-deletion-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/resources/{{FORM_KEY}}/deletion
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "operationReference": 1
+}
+
+> {%
+  client.test("Process definition search is successful", function () {
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
+  });
+%}
+
+###
+# @name get-deleted-process-definition-resource-authorized
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/resources/{{FORM_KEY}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Resource retrieval is unsuccessful", function () {
+    client.assert(response.status === 404, "Expected 404, got " + response.status);
+  });
+%}
+
+###
+# @name deploy-process-diagram-with-incident
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/deployments
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Accept: application/json
+Content-Type: multipart/form-data; boundary=boundary123
+
+--boundary123
+Content-Disposition: form-data; name="resources"; filename="User Task Test Process Incident.bpmn"
+Content-Type: application/octet-stream
+
+< ./User Task Processes/User Task Test Process Incident.bpmn
+--boundary123--
+
+
+> {%
+  client.test("Process deployment is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+    const processKey = response.body.deployments[0].processDefinition.processDefinitionKey;
+    client.global.set("PROCESS_DEFINITION_KEY_INCIDENT", processKey);
+  });
+%}
+
+###
+# @name create-process-instance-with-incident
+< {%
+  import {wait} from "../js/wait"
+  wait(1)
+%}
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "processDefinitionKey": "{{PROCESS_DEFINITION_KEY_INCIDENT}}",
+  "variables": {}
+}
+
+> {%
+  client.test("Create process instance is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+  let expectedDefinitionKey = client.global.get("PROCESS_DEFINITION_KEY_INCIDENT");
+  client.test("Response should contain process key", function () {
+    client.assert(response.body.processDefinitionKey === expectedDefinitionKey, "Process definition key was not returned");
+    client.global.set("PROCESS_INSTANCE_KEY_INCIDENT", response.body.processInstanceKey);
+  });
+%}
+
+###
+# @name get-process-instance-with-incident
+< {%
+  import {wait} from "../js/wait"
+  wait(2)
+%}
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY_INCIDENT}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Process instance is successful returned", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  let expectedInstanceKey = client.global.get("PROCESS_INSTANCE_KEY");
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.processInstanceKey === expectedInstanceKey, "Process instances wasn't returned");
+    client.assert(response.body.state === "INCIDENT", "Process instance is not ACTIVE");
+    client.assert(response.body.hasIncident === true, "Process instance is healthy");
+  });
+%}
+
+###
+# @name process-incident-search-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/incidents/search
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "sort": [
+    {
+      "field": "processInstanceKey",
+      "order": "ASC"
+    }
+  ],
+  "page": {
+    "from": 0,
+    "limit": 100
+  }
+}
+
+> {%
+  client.test("Process instance search is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.items.length > 0, "Process instances were not returned");
+    client.global.set("INCIDENT_KEY", response.body.items[0].incidentKey);
+  });
+%}
+
+###
+# @name get-process-incident-authorized
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/incidents/{{INCIDENT_KEY}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Process incident retrieval is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+%}
+
+###
+# @name process-incident-resolution-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/incidents/{{INCIDENT_KEY}}/resolution
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "operationReference": 1
+}
+
+> {%
+  client.test("Process incident resolution is successful", function () {
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
+  });
+%}
+
+###
+# @name user-task-search-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/user-tasks/search
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "sort": [
+    {
+      "field": "creationDate",
+      "order": "ASC"
+    }
+  ],
+  "filter": {
+    "state": "CREATED"
+  },
+  "page": {
+    "from": 0,
+    "limit": 100
+  }
+}
+
+> {%
+  client.test("User tasks search is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.items.length > 0, "User task key were not returned");
+    client.global.set("USER_TASK_KEY", response.body.items[0].userTaskKey);
+    client.global.set("ELEMENT_INSTANCE_KEY", response.body.items[0].elementInstanceKey);
+  });
+%}
+
+###
+# @name element-instance-search-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/element-instances/search
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "sort": [
+    {
+      "field": "startDate",
+      "order": "ASC"
+    }
+  ],
+  "filter": {
+    "type": "USER_TASK",
+    "state": "ACTIVE",
+    "elementInstanceKey": "{{ELEMENT_INSTANCE_KEY}}"
+  },
+  "page": {
+    "from": 0,
+    "limit": 100
+  }
+}
+
+> {%
+  client.test("User tasks search is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.items.length > 0, "Element instance key were not returned");
+  });
+%}
+
+###
+# @name update-element-instance-variables-authorized
+PUT {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/element-instances/{{ELEMENT_INSTANCE_KEY}}/variables
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "variables": {"testVariable": "testValue"},
+  "local": false
+}
+
+> {%
+  client.test("User tasks search is successful", function () {
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
+  });
+%}
+
+###
+# @name get-element-instance-authorized
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/element-instances/{{ELEMENT_INSTANCE_KEY}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("User tasks search is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.elementInstanceKey !==undefined, "Element instance key were not returned");
+  });
+%}
+
+###
+# @name user-task-variables-search-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/user-tasks/{{USER_TASK_KEY}}/variables/search
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "sort": [
+    {
+      "field": "name",
+      "order": "ASC"
+    }
+  ],
+  "page": {
+    "from": 0,
+    "limit": 100
+  }
+}
+
+> {%
+  client.test("User tasks variables search is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.items.length > 0, "User task key were not returned");
+  });
+%}
+
+###
+# @name get-user-task-authorized
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/user-tasks/{{USER_TASK_KEY}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("User tasks retrieval is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.userTaskKey !== undefined, "User task key were not returned");
+  });
+%}
+
+###
+# @name get-user-task-form-authorized
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/user-tasks/{{USER_TASK_KEY}}/form
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("User tasks form retrieval is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Response should not be empty", function () {
+    client.assert(response.body.formId !== undefined, "Form ID was not returned");
+  });
+%}
+
+###
+# @name update-user-task-authorized
+PATCH {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/user-tasks/{{USER_TASK_KEY}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "changeset": {
+    "candidateUsers": [
+      "demo"
+    ],
+    "priority": 100
+  },
+  "action": "update"
+}
+
+> {%
+  client.test("Update user tasks is successful", function () {
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
+  });
+%}
+
+###
+# @name assign-user-task-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/user-tasks/{{USER_TASK_KEY}}/assignment
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "assignee": "demo",
+  "allowOverride": true,
+  "action": "assign"
+}
+
+> {%
+  client.test("Assign user tasks is successful", function () {
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
+  });
+%}
+
+###
+# @name get-updated-assigned-user-task-authorized
+< {%
+  import {wait} from "../js/wait"
+  wait(2)
+%}
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/user-tasks/{{USER_TASK_KEY}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("User tasks retrieval is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("User task should be updated and assigned", function () {
+    client.assert(response.body.userTaskKey !== undefined, "User task key were not returned");
+    client.assert(response.body.assignee == "demo", "User task was not assigned");
+    client.assert(response.body.priority == 100, "Priority was not updated");
+    client.assert(response.body.candidateUsers[0] == "demo", "User task key were not returned");
+  });
+%}
+
+###
+# @name unassign-user-task-authorized
+DELETE {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/user-tasks/{{USER_TASK_KEY}}/assignee
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Unassign user tasks is successful", function () {
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
+  });
+%}
+
+###
+# @name complete-user-task-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/user-tasks/{{USER_TASK_KEY}}/completion
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "variables": {},
+  "action": "complete"
+}
+
+> {%
+  client.test("Complete user tasks is successful", function () {
+    client.assert(response.status === 204, "Expected 204, got " + response.status);
+  });
+%}
+
+###
+# @name search-variables-authorized
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/variables/search
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "sort": [
+    {
+      "field": "name",
+      "order": "ASC"
+    }
+  ],
+  "page": {
+    "from": 0,
+    "limit": 100
+  }
+}
+
+> {%
+  client.test("Search variables is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Variables should be returned", function () {
+    client.assert(response.body.items.length > 0, "Variables were not returned");
+    client.global.set("VARIABLE_KEY", response.body.items[0].variableKey);
+  });
+%}
+
+###
+# @name get-variable-by-key-authorized
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/variables/{{VARIABLE_KEY}}
+Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
+X-CSRF-TOKEN: {{csrf_token}}
+Content-Type: application/json
+Accept: application/json
+
+> {%
+  client.test("Search variables is successful", function () {
+    client.assert(response.status === 200, "Expected 200, got " + response.status);
+  });
+
+  client.test("Response should be JSON", function () {
+    client.assert(response.headers.valueOf("Content-Type").includes("application/json"), "Response is not JSON");
+  });
+
+  client.test("Variables should be returned", function () {
+    client.assert(response.body.variableKey !== undefined, "Variable was not returned");
   });
 %}
 

--- a/qa/http/c8run-tests/c8run-tests.http
+++ b/qa/http/c8run-tests/c8run-tests.http
@@ -318,7 +318,7 @@ Accept: application/json
 
   client.test("Response should not be empty", function () {
     client.assert(Array.isArray(response.body), "items must be array");
-    client.assert(response.body.length == 0, "Expect no elements in hierarchy");
+    client.assert(response.body.length === 0, "Expect no elements in hierarchy");
   });
 %}
 
@@ -388,7 +388,7 @@ Accept: application/json
   });
 
   client.test("Response should be empty", function () {
-    client.assert(response.body.items.length == 0, "Process instances were not returned");
+    client.assert(response.body.items.length === 0, "Process instances were not returned");
   });
 %}
 
@@ -647,7 +647,7 @@ Accept: application/json
   });
 
   client.test("Response should not be empty", function () {
-    client.assert(response.body.elementInstanceKey !==undefined, "Element instance key were not returned");
+    client.assert(response.body.elementInstanceKey !== undefined, "Element instance key were not returned");
   });
 %}
 
@@ -797,9 +797,9 @@ Accept: application/json
 
   client.test("User task should be updated and assigned", function () {
     client.assert(response.body.userTaskKey !== undefined, "User task key were not returned");
-    client.assert(response.body.assignee == "demo", "User task was not assigned");
-    client.assert(response.body.priority == 100, "Priority was not updated");
-    client.assert(response.body.candidateUsers[0] == "demo", "User task key were not returned");
+    client.assert(response.body.assignee === "demo", "User task was not assigned");
+    client.assert(response.body.priority === 100, "Priority was not updated");
+    client.assert(response.body.candidateUsers[0] === "demo", "User task key were not returned");
   });
 %}
 
@@ -993,7 +993,7 @@ Accept: application/json
 
 ###
 # @name upload-document-authorized
-POST http://localhost:8080/v2/documents
+POST {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/documents
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
 Accept: application/json
@@ -1029,7 +1029,7 @@ Content-Type: application/pdf
 
 ###
 # @name download-document-authorized
-GET http://localhost:8080/v2/documents/{{DOCUMENT_ID}}?contentHash={{CONTENT_HASH}}
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/documents/{{DOCUMENT_ID}}?contentHash={{CONTENT_HASH}}
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
 Accept: application/octet-stream
@@ -1042,7 +1042,7 @@ Accept: application/octet-stream
 
 ###
 # @name delete-and-verify-document
-DELETE http://localhost:8080/v2/documents/{{DOCUMENT_ID}}
+DELETE {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/documents/{{DOCUMENT_ID}}
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
 
@@ -1056,7 +1056,7 @@ X-CSRF-TOKEN: {{csrf_token}}
 
 ###
 # @name verify-deleted-document
-GET http://localhost:8080/v2/documents/{{DOCUMENT_ID}}?contentHash={{CONTENT_HASH}}
+GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/documents/{{DOCUMENT_ID}}?contentHash={{CONTENT_HASH}}
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
 Accept: application/octet-stream

--- a/qa/http/c8run-tests/c8run-tests.http
+++ b/qa/http/c8run-tests/c8run-tests.http
@@ -136,7 +136,6 @@ Accept: application/json
 > {%
   client.test("Process definition search is successful", function () {
     client.assert(response.status === 200, "Expected 200, got " + response.status);
-    //client.global.set("PROCESS_DEFINITION_KEY", response.body.items[0].processDefinitionKey);
   });
 %}
 
@@ -172,7 +171,7 @@ let expectedDefinitionKey = client.global.get("PROCESS_DEFINITION_KEY");
 # @name get-process-instance
 < {%
   import {wait} from "../js/wait"
-  wait(3)
+  wait(4)
 %}
 GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-instances/{{PROCESS_INSTANCE_KEY}}
 Cookie: {{COOKIE_HEADER}}

--- a/qa/http/c8run-tests/c8run-tests.http
+++ b/qa/http/c8run-tests/c8run-tests.http
@@ -128,6 +128,10 @@ Accept: application/json
 
 ###
 # @name get-process-definition-authorized
+< {%
+  import {wait} from "../js/wait"
+  wait(2)
+%}
 GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/{{PROCESS_DEFINITION_KEY}}
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
@@ -142,6 +146,10 @@ Accept: application/json
 
 ###
 # @name get-process-definition-xml-authorized
+< {%
+  import {wait} from "../js/wait"
+  wait(2)
+%}
 GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/{{PROCESS_DEFINITION_KEY}}/xml
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}
@@ -156,6 +164,10 @@ Accept: text/xml
 
 ###
 # @name get-process-definition-start-form-with-no-form-attached-authorized
+< {%
+  import {wait} from "../js/wait"
+  wait(2)
+%}
 GET {{ZEEBE_REST_ADDRESS_LOCAL}}/v2/process-definitions/{{PROCESS_DEFINITION_KEY}}/form
 Cookie: camunda-session={{session_cookie}}; X-CSRF-TOKEN={{csrf_cookie}}
 X-CSRF-TOKEN: {{csrf_token}}


### PR DESCRIPTION
This pull request introduces a new CI workflow for running regression tests on C8Run and adds three new user task form definitions used in these tests. The workflow automates building, packaging, running, and testing C8Run using IntelliJ HTTP Client, and publishes the test results. The new forms provide varied test coverage for user task processes, including text fields, dynamic lists, selection controls, and questionnaires.

### CI Workflow Automation

* Added `.github/workflows/c8run-rdbms-regression-test.yml` to automate regression testing for C8Run on pull requests and manual triggers, including build, secrets import, test execution, cleanup, and report publishing.

### Test Form Definitions

* Added `qa/http/c8run-tests/User Task Processes/New form A.form` with components such as text fields, datetime, dynamic lists, tables, and images for comprehensive UI testing.
* Added `qa/http/c8run-tests/User Task Processes/New form B.form` featuring select, checklist, and checkbox group controls to test user selection and grouping interactions.
* Added `qa/http/c8run-tests/User Task Processes/New form C.form` containing a multi-section yes/no questionnaire with required and optional fields for validation and logic testing.