### PR TITLE
fix: fix mvn commands in load-tester README.md after project was moved

### DIFF
--- a/load-tests/load-tester/README.md
+++ b/load-tests/load-tester/README.md
@@ -7,8 +7,8 @@ This project contains code for the starter and worker, which are used during our
 To build the docker images for the load test application, run the following command:
 
 ```bash
-./mvnw -am -pl zeebe/load-tests/load-tester package -DskipTests -DskipChecks
-./mvnw -pl zeebe/load-tests/load-tester jib:build -Pstarter
-./mvnw -pl zeebe/load-tests/load-tester jib:build -Pworker
+./mvnw -am -pl load-tests/load-tester package -DskipTests -DskipChecks
+./mvnw -pl load-tests/load-tester jib:build -Pstarter
+./mvnw -pl load-tests/load-tester jib:build -Pworker
 ```
 


### PR DESCRIPTION
## Description
fix mvn commands in load-tester README.md after project was moved
`zeebe` prefix is not valid anymore, now that the project is in the root.
