### PR TITLE
map RESOLVE incident intent to ACTIVE incident state

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/incident/IncidentState.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/incident/IncidentState.java
@@ -7,34 +7,34 @@
  */
 package io.camunda.webapps.schema.entities.incident;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 public enum IncidentState {
-  ACTIVE("CREATED"),
+  ACTIVE("CREATED", "RESOLVE"),
   MIGRATED("MIGRATED"),
   RESOLVED("RESOLVED"),
-  RESOLVE("RESOLVE"),
   PENDING(null);
 
   private static final Map<String, IncidentState> INTENT_MAP = new HashMap<>();
 
   static {
-    Arrays.stream(IncidentState.values()).forEach(is -> INTENT_MAP.put(is.getZeebeIntent(), is));
+    for (final IncidentState state : IncidentState.values()) {
+      for (final String intent : state.zeebeIntents) {
+        if (intent != null) {
+          INTENT_MAP.put(intent, state);
+        }
+      }
+    }
   }
 
-  private final String zeebeIntent;
+  private final String[] zeebeIntents;
 
-  IncidentState(final String zeebeIntent) {
-    this.zeebeIntent = zeebeIntent;
+  IncidentState(final String... zeebeIntents) {
+    this.zeebeIntents = zeebeIntents != null ? zeebeIntents : new String[0];
   }
 
   public static IncidentState createFrom(final String zeebeIntent) {
     return INTENT_MAP.get(zeebeIntent);
-  }
-
-  public String getZeebeIntent() {
-    return zeebeIntent;
   }
 }

--- a/webapps-schema/src/test/java/io/camunda/webapps/schema/IncidentStateTest.java
+++ b/webapps-schema/src/test/java/io/camunda/webapps/schema/IncidentStateTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.camunda.webapps.schema.entities.incident.IncidentState;
+import org.junit.jupiter.api.Test;
+
+public class IncidentStateTest {
+
+  @Test
+  void shouldCreateValidIncidentStateFromAllPossibleValues() {
+    assertThat(IncidentState.createFrom("CREATED")).isEqualTo(IncidentState.ACTIVE);
+    assertThat(IncidentState.createFrom("RESOLVE")).isEqualTo(IncidentState.ACTIVE);
+    assertThat(IncidentState.createFrom("MIGRATED")).isEqualTo(IncidentState.MIGRATED);
+    assertThat(IncidentState.createFrom("RESOLVED")).isEqualTo(IncidentState.RESOLVED);
+  }
+
+  @Test
+  void shouldFailCreatingIncidentIntentWithNullSource() {
+    assertThat(IncidentState.createFrom(null)).isNull();
+  }
+
+  @Test
+  void shouldFailCreatingIncidentIntentWithInvalidSource() {
+    assertThat(IncidentState.createFrom("UNKNOWN_INTENT")).isNull();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
@@ -17,10 +17,13 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Set;
 
 public class PostImporterQueueFromIncidentHandler
     implements ExportHandler<PostImporterQueueEntity, IncidentRecordValue> {
 
+  private static final Set<IncidentIntent> SUPPORTED_INTENTS =
+      Set.of(IncidentIntent.CREATED, IncidentIntent.MIGRATED, IncidentIntent.RESOLVED);
   private final String indexName;
 
   public PostImporterQueueFromIncidentHandler(final String indexName) {
@@ -39,7 +42,7 @@ public class PostImporterQueueFromIncidentHandler
 
   @Override
   public boolean handlesRecord(final Record<IncidentRecordValue> record) {
-    return true;
+    return SUPPORTED_INTENTS.contains((IncidentIntent) record.getIntent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
@@ -51,6 +51,16 @@ public class PostImporterQueueFromIncidentHandlerTest {
   }
 
   @Test
+  void shouldNotHandleResolveIntentRecords() {
+    // given
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(IncidentIntent.RESOLVE));
+
+    // when - then
+    assertThat(underTest.handlesRecord(incidentRecord)).isFalse();
+  }
+
+  @Test
   void shouldGenerateIdsForCreated() {
     // given
     final long expectedId = 123;


### PR DESCRIPTION
## Description

The client side does not know of any incident status `RESOLVE`, therefore it should instead map a `RESOLVE` incident intent to an `ACTIVE` incident status.

## Related issues

closes #37288 
