### PR TITLE
fix: handle runtime instructions for multi-instance activities

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -485,11 +485,9 @@ public final class BpmnStateTransitionBehavior {
 
     // if an element is part of a multi-instance, we skip runtime instructions as they are applied
     // to the multi-instance container element
-
-    final var flowScopeInstance = stateBehavior.getFlowScopeInstance(context);
     final var isMultiInstanceActivity =
-        flowScopeInstance != null && flowScopeInstance.getMultiInstanceLoopCounter() > 0;
-
+        element.getFlowScope() != null
+            && element.getFlowScope().getElementType() == BpmnElementType.MULTI_INSTANCE_BODY;
     if (isMultiInstanceActivity) {
       return Either.right(context);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -483,6 +483,17 @@ public final class BpmnStateTransitionBehavior {
       return Either.right(context);
     }
 
+    // if an element is part of a multi-instance, we skip runtime instructions as they are applied
+    // to the multi-instance container element
+
+    final var flowScopeInstance = stateBehavior.getFlowScopeInstance(context);
+    final var isMultiInstanceActivity =
+        flowScopeInstance != null && flowScopeInstance.getMultiInstanceLoopCounter() > 0;
+
+    if (isMultiInstanceActivity) {
+      return Either.right(context);
+    }
+
     // We only have one runtime instruction type for now (termination), so we can directly execute
     // its logic (interrupt process instance and request termination).
     // Due to this, we also assume that only one non-duplicate instruction can be present for each

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithTerminationInstructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithTerminationInstructionTest.java
@@ -286,11 +286,7 @@ public class CreateProcessInstanceWithTerminationInstructionTest {
                 .zeebeExpression("i + 2")
                 .zeebeResultVariable("j")
                 .multiInstance(
-                    b ->
-                        b.zeebeInputCollectionExpression("[1,2,3]")
-                            .zeebeInputElement("i")
-                            .zeebeOutputCollection("out")
-                            .zeebeOutputElementExpression("j + 2"))
+                    b -> b.zeebeInputCollectionExpression("[1,2,3]").zeebeInputElement("i"))
                 .endEvent()
                 .done())
         .deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithTerminationInstructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithTerminationInstructionTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -311,15 +312,19 @@ public class CreateProcessInstanceWithTerminationInstructionTest {
                         || record.getValue().getElementId().equals(multiInstanceTaskId));
 
     assertThat(result)
-        .extracting(Record::getIntent, record -> record.getValue().getElementId())
+        .extracting(Record::getIntent, r -> r.getValue().getBpmnElementType())
         .containsSubsequence(
-            Tuple.tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, multiInstanceTaskId),
-            Tuple.tuple(ProcessInstanceIntent.ELEMENT_COMPLETED, multiInstanceTaskId),
-            Tuple.tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, multiInstanceTaskId),
-            Tuple.tuple(ProcessInstanceIntent.ELEMENT_COMPLETED, multiInstanceTaskId),
-            Tuple.tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, multiInstanceTaskId),
-            Tuple.tuple(ProcessInstanceIntent.ELEMENT_COMPLETED, multiInstanceTaskId),
-            Tuple.tuple(ProcessInstanceIntent.ELEMENT_TERMINATING, processId),
-            Tuple.tuple(ProcessInstanceIntent.ELEMENT_TERMINATED, processId));
+            Tuple.tuple(
+                ProcessInstanceIntent.ELEMENT_ACTIVATED, BpmnElementType.MULTI_INSTANCE_BODY),
+            Tuple.tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, BpmnElementType.SCRIPT_TASK),
+            Tuple.tuple(ProcessInstanceIntent.ELEMENT_COMPLETED, BpmnElementType.SCRIPT_TASK),
+            Tuple.tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, BpmnElementType.SCRIPT_TASK),
+            Tuple.tuple(ProcessInstanceIntent.ELEMENT_COMPLETED, BpmnElementType.SCRIPT_TASK),
+            Tuple.tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, BpmnElementType.SCRIPT_TASK),
+            Tuple.tuple(ProcessInstanceIntent.ELEMENT_COMPLETED, BpmnElementType.SCRIPT_TASK),
+            Tuple.tuple(
+                ProcessInstanceIntent.ELEMENT_COMPLETED, BpmnElementType.MULTI_INSTANCE_BODY),
+            Tuple.tuple(ProcessInstanceIntent.ELEMENT_TERMINATING, BpmnElementType.PROCESS),
+            Tuple.tuple(ProcessInstanceIntent.ELEMENT_TERMINATED, BpmnElementType.PROCESS));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithTerminationInstructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithTerminationInstructionTest.java
@@ -282,8 +282,7 @@ public class CreateProcessInstanceWithTerminationInstructionTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(processId)
                 .startEvent()
-                .scriptTask()
-                .id(multiInstanceTaskId)
+                .scriptTask(multiInstanceTaskId)
                 .zeebeExpression("i + 2")
                 .zeebeResultVariable("j")
                 .multiInstance(


### PR DESCRIPTION
## Description

This PR adds a check before executing the runtime instruction to determine if the element is running as part of a multi-instance activity.

If it is part of a multi-instance, we should not execute the runtime instruction for every individual instance of the activity. Instead, we should only execute it once when the whole multi-instance activity finishes (i.e. token leaves the element from the user's perspective).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39812 
