### PR TITLE
ci: bump node version to 20.19.5

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -154,7 +154,7 @@
     <version.springdoc>2.7.0</version.springdoc>
     <version.jakarta.json>2.0.1</version.jakarta.json>
 
-    <version.node>v20.12.2</version.node>
+    <version.node>v20.19.5</version.node>
     <version.yarn>v1.22.21</version.yarn>
 
     <version.elasticsearch-test-container>1.20.6</version.elasticsearch-test-container>


### PR DESCRIPTION
## Description

This pull request updates the Node.js version used in the project to ensure compatibility with newer features and security updates.
Should fix, found at [8.6 dry run](https://github.com/camunda/camunda/actions/runs/18671014326/job/53231677003):
```
    [INFO] Running 'yarn install --mutex file:/tmp/.yarn-mutex' in /home/runner/_work/camunda/camunda/target/checkout/tasklist/client
    [INFO] yarn install v1.22.21
    [INFO] [1/4] Resolving packages...
    [INFO] [2/4] Fetching packages...
    [INFO] error vite@7.1.11: The engine "node" is incompatible with this module. Expected version "^20.19.0 || >=22.12.0". Got "20.12.2"
    [INFO] error Found incompatible module.
    [INFO] info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Ref: https://nodejs.org/en/download/archive/v22.21.0

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
