### PR TITLE
build: add now required charset config to mvn-javadoc-plugin

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -54,6 +54,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${plugin.version.javadoc}</version>
           <configuration>
+            <charset>UTF-8</charset>
             <source>${version.java}</source>
             <quiet>true</quiet>
             <additionalOptions>-Xdoclint:none</additionalOptions>


### PR DESCRIPTION
## Description
Backport of https://github.com/camunda/camunda/pull/39698 to release-8.8.1.

relates to
