### PR TITLE
[Backport release-8.8.1] build: bump javadoc version

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -42,7 +42,7 @@
     <license.header.file>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header.file>
 
     <plugin.version.flatten>1.7.2</plugin.version.flatten>
-    <plugin.version.javadoc>3.11.3</plugin.version.javadoc>
+    <plugin.version.javadoc>3.12.0</plugin.version.javadoc>
     <plugin.version.license>5.0.0</plugin.version.license>
     <plugin.version.spotless>2.44.5</plugin.version.spotless>
 


### PR DESCRIPTION
# Description
Backport of #39713 to `release-8.8.1`.

relates to 