### PR TITLE
[Backport release-8.8.1] fix: override react-is to fix Carbon tabs

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -3436,12 +3436,6 @@
         "react": ">=16.12.0"
       }
     },
-    "node_modules/downshift/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "license": "MIT"
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.237",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.237.tgz",
@@ -5889,11 +5883,10 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
-      "license": "MIT",
-      "peer": true
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "8.0.7",
@@ -5925,12 +5918,6 @@
         "@types/react": ">=16",
         "react": ">=16"
       }
-    },
-    "node_modules/react-markdown/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -61,5 +61,10 @@
     "vite": "7.0.7",
     "vite-plugin-svgr": "^4.3.0"
   },
-  "stableVersion": "8.8.0-SNAPSHOT"
+  "stableVersion": "8.8.0-SNAPSHOT",
+  "overrides": {
+    "@carbon/react": {
+      "react-is": "18.3.1"
+    }
+  }
 }


### PR DESCRIPTION
# Description
Backport of #39827 to `release-8.8.1`.

relates to 