### PR TITLE
feat: add history properties to uc

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -8,21 +8,59 @@
 package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 
 public class DocumentBasedHistory {
 
+  public static final Duration DEFAULT_HISTORY_MAX_DELAY_BETWEEN_RUNS = Duration.ofMillis(60000);
+  private static final Duration DEFAULT_HISTORY_DELAY_BETWEEN_RUNS = Duration.ofMillis(2000);
   private static final boolean DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED = true;
-
+  private static final String DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "date";
+  private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
+  private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
+  private static final String DEFAULT_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING = "1h";
   private static final Map<String, String> LEGACY_BROKER_PROPERTIES =
       Map.of(
           "process-instance-enabled",
-          "zeebe.broker.exporters.camundaexporter.args.history.process-instance-enabled");
-
+          "zeebe.broker.exporters.camundaexporter.args.history.process-instance-enabled",
+          "els-rollover-date-format",
+          "zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat",
+          "rollover-interval",
+          "zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval",
+          "rollover-batch-size",
+          "zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize",
+          "wait-period-before-archiving",
+          "zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving",
+          "delay-between-runs",
+          "zeebe.broker.exporters.camundaexporter.args.history.delayBetweenRuns",
+          "max-delay-between-runs",
+          "zeebe.broker.exporters.camundaexporter.args.history.maxDelayBetweenRuns");
   private final String prefix;
 
   private boolean processInstanceEnabled = DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED;
+
+  /** Date format for historical indices in Java DateTimeFormatter syntax */
+  private String elsRolloverDateFormat = DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT;
+
+  /** Time range for creating dated indices (e.g., 1d creates daily indices). */
+  private String rolloverInterval = DEFAULT_HISTORY_ROLLOVER_INTERVAL;
+
+  /** Maximum number of process instances per archiving batch */
+  private int rolloverBatchSize = DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE;
+
+  /**
+   * Grace period before archiving completed processes. Processes finished within this window are
+   * not yet archived.
+   */
+  private String waitPeriodBeforeArchiving = DEFAULT_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING;
+
+  /** Millisecond interval between archiver runs */
+  private Duration delayBetweenRuns = DEFAULT_HISTORY_DELAY_BETWEEN_RUNS;
+
+  /** Maximum millisecond interval between archiver runs due to failure backoffs */
+  private Duration maxDelayBetweenRuns = DEFAULT_HISTORY_MAX_DELAY_BETWEEN_RUNS;
 
   public DocumentBasedHistory(final String databaseName) {
     prefix = "camunda.data.secondary-storage.%s.history".formatted(databaseName);
@@ -39,5 +77,87 @@ public class DocumentBasedHistory {
 
   public void setProcessInstanceEnabled(final boolean processInstanceEnabled) {
     this.processInstanceEnabled = processInstanceEnabled;
+  }
+
+  public String getPrefix() {
+    return prefix;
+  }
+
+  public String getElsRolloverDateFormat() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix + ".els-rollover-date-format",
+        elsRolloverDateFormat,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_BROKER_PROPERTIES.get("els-rollover-date-format")));
+  }
+
+  public void setElsRolloverDateFormat(final String elsRolloverDateFormat) {
+    this.elsRolloverDateFormat = elsRolloverDateFormat;
+  }
+
+  public String getRolloverInterval() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix + ".rollover-interval",
+        rolloverInterval,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_BROKER_PROPERTIES.get("rollover-interval")));
+  }
+
+  public void setRolloverInterval(final String rolloverInterval) {
+    this.rolloverInterval = rolloverInterval;
+  }
+
+  public int getRolloverBatchSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix + ".rollover-batch-size",
+        rolloverBatchSize,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_BROKER_PROPERTIES.get("rollover-batch-size")));
+  }
+
+  public void setRolloverBatchSize(final int rolloverBatchSize) {
+    this.rolloverBatchSize = rolloverBatchSize;
+  }
+
+  public String getWaitPeriodBeforeArchiving() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix + ".wait-period-before-archiving",
+        waitPeriodBeforeArchiving,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_BROKER_PROPERTIES.get("wait-period-before-archiving")));
+  }
+
+  public void setWaitPeriodBeforeArchiving(final String waitPeriodBeforeArchiving) {
+    this.waitPeriodBeforeArchiving = waitPeriodBeforeArchiving;
+  }
+
+  public Duration getDelayBetweenRuns() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix + ".delay-between-runs",
+        delayBetweenRuns,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_BROKER_PROPERTIES.get("delay-between-runs")));
+  }
+
+  public void setDelayBetweenRuns(final Duration delayBetweenRuns) {
+    this.delayBetweenRuns = delayBetweenRuns;
+  }
+
+  public Duration getMaxDelayBetweenRuns() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix + ".max-delay-between-runs",
+        maxDelayBetweenRuns,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_BROKER_PROPERTIES.get("max-delay-between-runs")));
+  }
+
+  public void setMaxDelayBetweenRuns(final Duration maxDelayBetweenRuns) {
+    this.maxDelayBetweenRuns = maxDelayBetweenRuns;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -672,6 +672,19 @@ public class BrokerBasedPropertiesOverride {
 
     setArg(
         args, "history.processInstanceEnabled", database.getHistory().isProcessInstanceEnabled());
+    setArg(args, "history.elsRolloverDateFormat", database.getHistory().getElsRolloverDateFormat());
+    setArg(args, "history.rolloverInterval", database.getHistory().getRolloverInterval());
+    setArg(args, "history.rolloverBatchSize", database.getHistory().getRolloverBatchSize());
+    setArg(
+        args,
+        "history.waitPeriodBeforeArchiving",
+        database.getHistory().getWaitPeriodBeforeArchiving());
+    setArg(
+        args, "history.delayBetweenRuns", database.getHistory().getDelayBetweenRuns().toMillis());
+    setArg(
+        args,
+        "history.maxDelayBetweenRuns",
+        database.getHistory().getMaxDelayBetweenRuns().toMillis());
 
     setArg(args, "createSchema", database.isCreateSchema());
 

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -50,6 +50,12 @@ public class SecondaryStorageElasticsearchTest {
   private static final int EXPECTED_NUMBER_OF_SHARDS = 3;
 
   private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
+  private static final String EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "foo";
+  private static final String EXPECTED_HISTORY_ROLLOVER_INTERVAL = "5d";
+  private static final int EXPECTED_HISTORY_ROLLOVER_BATCH_SIZE = 200;
+  private static final String EXPECTED_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING = "5h";
+  private static final int EXPECTED_HISTORY_DELAY_BETWEEN_RUNS = 4000;
+  private static final int EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS = 12000;
 
   private static final boolean EXPECTED_CREATE_SCHEMA = false;
 
@@ -89,6 +95,20 @@ public class SecondaryStorageElasticsearchTest {
             + EXPECTED_NUMBER_OF_SHARDS,
         "camunda.data.secondary-storage.elasticsearch.history.process-instance-enabled="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
+        "camunda.data.secondary-storage.elasticsearch.history.els-rollover-date-format="
+            + EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT,
+        "camunda.data.secondary-storage.elasticsearch.history.rollover-interval="
+            + EXPECTED_HISTORY_ROLLOVER_INTERVAL,
+        "camunda.data.secondary-storage.elasticsearch.history.rollover-batch-size="
+            + EXPECTED_HISTORY_ROLLOVER_BATCH_SIZE,
+        "camunda.data.secondary-storage.elasticsearch.history.wait-period-before-archiving="
+            + EXPECTED_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING,
+        "camunda.data.secondary-storage.elasticsearch.history.delay-between-runs="
+            + EXPECTED_HISTORY_DELAY_BETWEEN_RUNS
+            + "ms",
+        "camunda.data.secondary-storage.elasticsearch.history.max-delay-between-runs="
+            + EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS
+            + "ms",
         "camunda.data.secondary-storage.elasticsearch.create-schema=" + EXPECTED_CREATE_SCHEMA,
         "camunda.data.secondary-storage.elasticsearch.incident-notifier.webhook="
             + EXPECTED_INCIDENT_NOTIFIER_WEBHOOK,
@@ -186,6 +206,18 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
       assertThat(exporterConfiguration.getHistory().isProcessInstanceEnabled())
           .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
+      assertThat(exporterConfiguration.getHistory().getElsRolloverDateFormat())
+          .isEqualTo(EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT);
+      assertThat(exporterConfiguration.getHistory().getRolloverInterval())
+          .isEqualTo(EXPECTED_HISTORY_ROLLOVER_INTERVAL);
+      assertThat(exporterConfiguration.getHistory().getRolloverBatchSize())
+          .isEqualTo(EXPECTED_HISTORY_ROLLOVER_BATCH_SIZE);
+      assertThat(exporterConfiguration.getHistory().getWaitPeriodBeforeArchiving())
+          .isEqualTo(EXPECTED_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING);
+      assertThat(exporterConfiguration.getHistory().getDelayBetweenRuns())
+          .isEqualTo(EXPECTED_HISTORY_DELAY_BETWEEN_RUNS);
+      assertThat(exporterConfiguration.getHistory().getMaxDelayBetweenRuns())
+          .isEqualTo(EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS);
       assertThat(exporterConfiguration.isCreateSchema()).isEqualTo(EXPECTED_CREATE_SCHEMA);
       assertThat(exporterConfiguration.getNotifier().getWebhook())
           .isEqualTo(EXPECTED_INCIDENT_NOTIFIER_WEBHOOK);
@@ -226,6 +258,62 @@ public class SecondaryStorageElasticsearchTest {
     void testCamundaSearchEngineIndexProperties() {
       assertThat(searchEngineIndexProperties.getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat="
+            + EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT,
+        "zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval="
+            + EXPECTED_HISTORY_ROLLOVER_INTERVAL,
+        "zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize="
+            + EXPECTED_HISTORY_ROLLOVER_BATCH_SIZE,
+        "zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving="
+            + EXPECTED_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING,
+        "zeebe.broker.exporters.camundaexporter.args.history.delayBetweenRuns="
+            + EXPECTED_HISTORY_DELAY_BETWEEN_RUNS
+            + "ms",
+        "zeebe.broker.exporters.camundaexporter.args.history.maxDelayBetweenRuns="
+            + EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS
+            + "ms",
+        "zeebe.broker.exporters.camundaexporter.args.bulk.delay=10s",
+        "zeebe.broker.exporters.camundaexporter.args.bulk.size=" + EXPECTED_BULK_SIZE,
+        "zeebe.broker.exporters.camundaexporter.args.bulk.memoryLimit=50MB"
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void testCamundaDataSecondaryStorageCamundaExporterProperties() {
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNotNull();
+
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToCamundaExporterConfiguration(args);
+      assertThat(exporterConfiguration.getHistory().getElsRolloverDateFormat())
+          .isEqualTo(EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT);
+      assertThat(exporterConfiguration.getHistory().getRolloverInterval())
+          .isEqualTo(EXPECTED_HISTORY_ROLLOVER_INTERVAL);
+      assertThat(exporterConfiguration.getHistory().getRolloverBatchSize())
+          .isEqualTo(EXPECTED_HISTORY_ROLLOVER_BATCH_SIZE);
+      assertThat(exporterConfiguration.getHistory().getWaitPeriodBeforeArchiving())
+          .isEqualTo(EXPECTED_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING);
+      assertThat(exporterConfiguration.getHistory().getDelayBetweenRuns())
+          .isEqualTo(EXPECTED_HISTORY_DELAY_BETWEEN_RUNS);
+      assertThat(exporterConfiguration.getHistory().getMaxDelayBetweenRuns())
+          .isEqualTo(EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS);
+      assertThat(exporterConfiguration.getBulk().getDelay()).isEqualTo(EXPECTED_BULK_DELAY);
+      assertThat(exporterConfiguration.getBulk().getSize()).isEqualTo(EXPECTED_BULK_SIZE);
+      assertThat(exporterConfiguration.getBulk().getMemoryLimit())
+          .isEqualTo(EXPECTED_BULK_MEMORY_LIMIT);
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -50,6 +50,12 @@ public class SecondaryStorageOpensearchTest {
   private static final int EXPECTED_NUMBER_OF_SHARDS = 3;
 
   private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
+  private static final String EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "foo";
+  private static final String EXPECTED_HISTORY_ROLLOVER_INTERVAL = "5d";
+  private static final int EXPECTED_HISTORY_ROLLOVER_BATCH_SIZE = 200;
+  private static final String EXPECTED_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING = "5h";
+  private static final int EXPECTED_HISTORY_DELAY_BETWEEN_RUNS = 4000;
+  private static final int EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS = 12000;
 
   private static final boolean EXPECTED_CREATE_SCHEMA = false;
 
@@ -88,6 +94,20 @@ public class SecondaryStorageOpensearchTest {
         "camunda.data.secondary-storage.opensearch.number-of-shards=" + EXPECTED_NUMBER_OF_SHARDS,
         "camunda.data.secondary-storage.opensearch.history.process-instance-enabled="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
+        "camunda.data.secondary-storage.opensearch.history.els-rollover-date-format="
+            + EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT,
+        "camunda.data.secondary-storage.opensearch.history.rollover-interval="
+            + EXPECTED_HISTORY_ROLLOVER_INTERVAL,
+        "camunda.data.secondary-storage.opensearch.history.rollover-batch-size="
+            + EXPECTED_HISTORY_ROLLOVER_BATCH_SIZE,
+        "camunda.data.secondary-storage.opensearch.history.wait-period-before-archiving="
+            + EXPECTED_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING,
+        "camunda.data.secondary-storage.opensearch.history.delay-between-runs="
+            + EXPECTED_HISTORY_DELAY_BETWEEN_RUNS
+            + "ms",
+        "camunda.data.secondary-storage.opensearch.history.max-delay-between-runs="
+            + EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS
+            + "ms",
         "camunda.data.secondary-storage.opensearch.create-schema=" + EXPECTED_CREATE_SCHEMA,
         "camunda.data.secondary-storage.opensearch.incident-notifier.webhook="
             + EXPECTED_INCIDENT_NOTIFIER_WEBHOOK,
@@ -183,6 +203,18 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
       assertThat(exporterConfiguration.getHistory().isProcessInstanceEnabled())
           .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
+      assertThat(exporterConfiguration.getHistory().getElsRolloverDateFormat())
+          .isEqualTo(EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT);
+      assertThat(exporterConfiguration.getHistory().getRolloverInterval())
+          .isEqualTo(EXPECTED_HISTORY_ROLLOVER_INTERVAL);
+      assertThat(exporterConfiguration.getHistory().getRolloverBatchSize())
+          .isEqualTo(EXPECTED_HISTORY_ROLLOVER_BATCH_SIZE);
+      assertThat(exporterConfiguration.getHistory().getWaitPeriodBeforeArchiving())
+          .isEqualTo(EXPECTED_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING);
+      assertThat(exporterConfiguration.getHistory().getDelayBetweenRuns())
+          .isEqualTo(EXPECTED_HISTORY_DELAY_BETWEEN_RUNS);
+      assertThat(exporterConfiguration.getHistory().getMaxDelayBetweenRuns())
+          .isEqualTo(EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS);
       assertThat(exporterConfiguration.isCreateSchema()).isEqualTo(EXPECTED_CREATE_SCHEMA);
       assertThat(exporterConfiguration.getNotifier().getWebhook())
           .isEqualTo(EXPECTED_INCIDENT_NOTIFIER_WEBHOOK);
@@ -225,6 +257,61 @@ public class SecondaryStorageOpensearchTest {
     void testCamundaSearchEngineIndexProperties() {
       assertThat(searchEngineIndexProperties.getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat="
+            + EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT,
+        "zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval="
+            + EXPECTED_HISTORY_ROLLOVER_INTERVAL,
+        "zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize="
+            + EXPECTED_HISTORY_ROLLOVER_BATCH_SIZE,
+        "zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving="
+            + EXPECTED_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING,
+        "zeebe.broker.exporters.camundaexporter.args.history.delayBetweenRuns="
+            + EXPECTED_HISTORY_DELAY_BETWEEN_RUNS
+            + "ms",
+        "zeebe.broker.exporters.camundaexporter.args.history.maxDelayBetweenRuns="
+            + EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS,
+        "zeebe.broker.exporters.camundaexporter.args.bulk.delay=10s",
+        "zeebe.broker.exporters.camundaexporter.args.bulk.size=" + EXPECTED_BULK_SIZE,
+        "zeebe.broker.exporters.camundaexporter.args.bulk.memoryLimit=50MB"
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void testCamundaDataSecondaryStorageCamundaExporterProperties() {
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNotNull();
+
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToCamundaExporterConfiguration(args);
+      assertThat(exporterConfiguration.getHistory().getElsRolloverDateFormat())
+          .isEqualTo(EXPECTED_HISTORY_ELS_ROLLOVER_DATE_FORMAT);
+      assertThat(exporterConfiguration.getHistory().getRolloverInterval())
+          .isEqualTo(EXPECTED_HISTORY_ROLLOVER_INTERVAL);
+      assertThat(exporterConfiguration.getHistory().getRolloverBatchSize())
+          .isEqualTo(EXPECTED_HISTORY_ROLLOVER_BATCH_SIZE);
+      assertThat(exporterConfiguration.getHistory().getWaitPeriodBeforeArchiving())
+          .isEqualTo(EXPECTED_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING);
+      assertThat(exporterConfiguration.getHistory().getDelayBetweenRuns())
+          .isEqualTo(EXPECTED_HISTORY_DELAY_BETWEEN_RUNS);
+      assertThat(exporterConfiguration.getHistory().getMaxDelayBetweenRuns())
+          .isEqualTo(EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS);
+      assertThat(exporterConfiguration.getBulk().getDelay()).isEqualTo(EXPECTED_BULK_DELAY);
+      assertThat(exporterConfiguration.getBulk().getSize()).isEqualTo(EXPECTED_BULK_SIZE);
+      assertThat(exporterConfiguration.getBulk().getMemoryLimit())
+          .isEqualTo(EXPECTED_BULK_MEMORY_LIMIT);
     }
   }
 


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.data.secondary-storage.elasticsearch/opensearch.history in unified config.

The legacy properties are:
zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat
zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval
zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize
zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving
zeebe.broker.exporters.camundaexporter.args.history.delayBetweenRuns
zeebe.broker.exporters.camundaexporter.args.history.maxDelayBetweenRuns

The new properties are:
camunda.data.secondary-storage.elasticsearch.history.els-rollover-date-format
camunda.data.secondary-storage.elasticsearch.history.rollover-interval
camunda.data.secondary-storage.elasticsearch.history.rollover-batch-size
camunda.data.secondary-storage.elasticsearch.history.wait-period-before-archiving
camunda.data.secondary-storage.elasticsearch.history.delay-between-runs
camunda.data.secondary-storage.elasticsearch.history.max-delay-between-runs

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.

## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to #34902 