### PR TITLE
feat: add exporting state to dynamic configuration

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -73,8 +73,8 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.SortedMap;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -247,7 +247,8 @@ final class ClusterApiUtils {
     };
   }
 
-  private static List<BrokerState> mapBrokerStates(final Map<MemberId, MemberState> topology) {
+  private static List<BrokerState> mapBrokerStates(
+      final SortedMap<MemberId, MemberState> topology) {
     return topology.entrySet().stream()
         .map(
             entry ->
@@ -280,7 +281,7 @@ final class ClusterApiUtils {
   }
 
   private static List<PartitionState> mapPartitionStates(
-      final Map<Integer, io.camunda.zeebe.dynamic.config.state.PartitionState> partitions) {
+      final SortedMap<Integer, io.camunda.zeebe.dynamic.config.state.PartitionState> partitions) {
     return partitions.entrySet().stream()
         .map(
             entry ->

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
@@ -239,6 +240,7 @@ final class ClusterApiUtilsTest {
     final DynamicPartitionConfig partitionConfig =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of(
                     "exporter-1",
                     new ExporterState(0, exporterState, Optional.empty()),

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -42,7 +42,6 @@ import io.camunda.zeebe.management.cluster.ExporterStatus.StatusEnum;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.management.cluster.TopologyChangeCompletedInner;
 import java.time.Instant;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -286,7 +285,7 @@ final class ClusterApiUtilsTest {
     final MemberId memberId1 = member(1);
     final MemberId memberId2 = member(2);
     final SortedSet<Integer> partitionSet = new TreeSet<>(Set.of(1, 2, 3));
-    final Collection<MemberId> memberCollection = List.of(memberId1, memberId2);
+    final Set<MemberId> memberCollection = Set.of(memberId1, memberId2);
     final Optional<RoutingState> emptyRoutingState = Optional.empty();
     final Optional<String> emptyExporterId = Optional.empty();
     final Optional<DynamicPartitionConfig> emptyConfig = Optional.empty();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import java.util.HashMap;
 import java.util.List;
@@ -108,6 +109,7 @@ public final class StaticConfigurationGenerator {
         .forEach(
             (exporterId, ignore) ->
                 exporters.put(exporterId, new ExporterState(0, State.ENABLED, Optional.empty())));
-    return new DynamicPartitionConfig(new ExportingConfig(Map.copyOf(exporters)));
+    return new DynamicPartitionConfig(
+        new ExportingConfig(ExportingState.EXPORTING, Map.copyOf(exporters)));
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/PartitionConfigurationManagerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/PartitionConfigurationManagerTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
@@ -51,6 +52,7 @@ final class PartitionConfigurationManagerTest {
     private final DynamicPartitionConfig partitionConfig =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of(exporterId, new ExporterState(0, State.ENABLED, Optional.empty()))));
 
     @BeforeEach
@@ -133,6 +135,7 @@ final class PartitionConfigurationManagerTest {
     private final DynamicPartitionConfig partitionConfig =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of(
                     exporterId, new ExporterState(0, State.CONFIG_NOT_FOUND, Optional.empty()))));
 
@@ -214,6 +217,7 @@ final class PartitionConfigurationManagerTest {
     private final DynamicPartitionConfig partitionConfig =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of(
                     validExporterToInitialize,
                     new ExporterState(0, State.ENABLED, Optional.empty()))));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
@@ -238,6 +239,7 @@ class ExporterDirectorPartitionTransitionStepTest {
     final var updatedConfig =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of(enabledExporterId, new ExporterState(0, State.ENABLED, Optional.empty()))));
     transitionContext.setDynamicPartitionConfig(updatedConfig);
     startingFuture.complete(null);
@@ -313,6 +315,7 @@ class ExporterDirectorPartitionTransitionStepTest {
       final State exporterTwoState) {
     return new DynamicPartitionConfig(
         new ExportingConfig(
+            ExportingState.EXPORTING,
             Map.of(
                 exporterOne,
                 new ExporterState(0, exporterOneState, Optional.empty()),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationChangeResponse.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationChangeResponse.java
@@ -7,14 +7,29 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import com.google.common.collect.ImmutableSortedMap;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
 
 public record ClusterConfigurationChangeResponse(
     long changeId,
-    Map<MemberId, MemberState> currentConfiguration,
-    Map<MemberId, MemberState> expectedConfiguration,
-    List<ClusterConfigurationChangeOperation> plannedChanges) {}
+    SortedMap<MemberId, MemberState> currentConfiguration,
+    SortedMap<MemberId, MemberState> expectedConfiguration,
+    List<ClusterConfigurationChangeOperation> plannedChanges) {
+
+  public ClusterConfigurationChangeResponse(
+      final long changeId,
+      final Map<MemberId, MemberState> currentConfiguration,
+      final Map<MemberId, MemberState> expectedConfiguration,
+      final List<ClusterConfigurationChangeOperation> plannedChanges) {
+    this(
+        changeId,
+        ImmutableSortedMap.copyOf(currentConfiguration),
+        ImmutableSortedMap.copyOf(expectedConfiguration),
+        plannedChanges);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -230,7 +230,7 @@ public class ProtoBufSerializer
     return new DynamicPartitionConfig(decodeExportingConfig(config.getExporting()));
   }
 
-  private ExportingConfig decodeExportingConfig(final Topology.ExportingConfig exporting) {
+  ExportingConfig decodeExportingConfig(final Topology.ExportingConfig exporting) {
     return new ExportingConfig(
         decodeExportingState(exporting.getState()),
         exporting.getExportersMap().entrySet().stream()

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -240,7 +240,7 @@ public class ProtoBufSerializer
 
   private ExportingState decodeExportingState(final Topology.ExportingStateEnum exportingState) {
     return switch (exportingState) {
-      case EXPORTING_STATE_UNKNOWN -> null;
+      case EXPORTING_STATE_UNKNOWN -> ExportingState.UNKNOWN;
       case EXPORTING -> ExportingState.EXPORTING;
       case SOFT_PAUSED -> ExportingState.SOFT_PAUSED;
       case PAUSED -> ExportingState.PAUSED;
@@ -317,8 +317,7 @@ public class ProtoBufSerializer
 
   private Topology.ExportingStateEnum encodeExportingState(final ExportingState state) {
     return switch (state) {
-      // TODO: no need to handle null as soon as we have a proper initializer.
-      case null -> Topology.ExportingStateEnum.EXPORTING_STATE_UNKNOWN;
+      case UNKNOWN -> Topology.ExportingStateEnum.EXPORTING_STATE_UNKNOWN;
       case EXPORTING -> Topology.ExportingStateEnum.EXPORTING;
       case SOFT_PAUSED -> Topology.ExportingStateEnum.SOFT_PAUSED;
       case PAUSED -> Topology.ExportingStateEnum.PAUSED;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -693,7 +693,7 @@ public class ProtoBufSerializer
           topologyChangeOperation.getPartitionForceReconfigure().getPartitionId(),
           topologyChangeOperation.getPartitionForceReconfigure().getMembersList().stream()
               .map(MemberId::from)
-              .toList());
+              .collect(Collectors.toSet()));
     } else if (topologyChangeOperation.hasMemberRemove()) {
       return new MemberRemoveOperation(
           memberId, MemberId.from(topologyChangeOperation.getMemberRemove().getMemberToRemove()));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterChangePlan.java
@@ -30,6 +30,11 @@ public record ClusterChangePlan(
     List<CompletedOperation> completedOperations,
     List<ClusterConfigurationChangeOperation> pendingOperations) {
 
+  public ClusterChangePlan {
+    completedOperations = List.copyOf(completedOperations);
+    pendingOperations = List.copyOf(pendingOperations);
+  }
+
   public static ClusterChangePlan init(
       final long id, final List<ClusterConfigurationChangeOperation> operations) {
     return new ClusterChangePlan(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -47,6 +47,19 @@ public record ClusterConfiguration(
     members = Map.copyOf(members);
   }
 
+  public ClusterConfiguration {
+    if (version < UNINITIALIZED_VERSION) {
+      throw new IllegalArgumentException(
+          String.format("Version must be >= %d", UNINITIALIZED_VERSION));
+    }
+
+    Objects.requireNonNull(members);
+    Objects.requireNonNull(lastChange);
+    Objects.requireNonNull(pendingChanges);
+    Objects.requireNonNull(routingState);
+    Objects.requireNonNull(clusterId);
+  }
+
   public static ClusterConfiguration uninitialized() {
     return new ClusterConfiguration(
         UNINITIALIZED_VERSION,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.state;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.SortedMap;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -34,7 +36,7 @@ import java.util.stream.Stream;
  */
 public record ClusterConfiguration(
     long version,
-    Map<MemberId, MemberState> members,
+    SortedMap<MemberId, MemberState> members,
     Optional<CompletedChange> lastChange,
     Optional<ClusterChangePlan> pendingChanges,
     Optional<RoutingState> routingState,
@@ -43,8 +45,21 @@ public record ClusterConfiguration(
   public static final int INITIAL_VERSION = 1;
   private static final int UNINITIALIZED_VERSION = -1;
 
-  public ClusterConfiguration {
-    members = Map.copyOf(members);
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  public ClusterConfiguration(
+      final long version,
+      final Map<MemberId, MemberState> members,
+      final Optional<CompletedChange> lastChange,
+      final Optional<ClusterChangePlan> pendingChanges,
+      final Optional<RoutingState> routingState,
+      final Optional<String> clusterId) {
+    this(
+        version,
+        ImmutableSortedMap.copyOf(members),
+        lastChange,
+        pendingChanges,
+        routingState,
+        clusterId);
   }
 
   public ClusterConfiguration {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
  * @param version - represents the current version of the configuration. It is incremented only by
  *     the coordinator when a new configuration change is triggered.
  * @param members - represents the state of each member
- * @param pendingChanges- keeps track of the ongoing configuration changes
+ * @param pendingChanges - keeps track of the ongoing configuration changes
  *     <p>This class is immutable. Each mutable methods returns a new instance with the updated
  *     state.
  */
@@ -42,6 +42,10 @@ public record ClusterConfiguration(
 
   public static final int INITIAL_VERSION = 1;
   private static final int UNINITIALIZED_VERSION = -1;
+
+  public ClusterConfiguration {
+    members = Map.copyOf(members);
+  }
 
   public static ClusterConfiguration uninitialized() {
     return new ClusterConfiguration(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -8,9 +8,8 @@
 package io.camunda.zeebe.dynamic.config.state;
 
 import io.atomix.cluster.MemberId;
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -143,10 +142,10 @@ public sealed interface ClusterConfigurationChangeOperation {
      * @param members the members of the partition's replication group after the reconfiguration
      */
     record PartitionForceReconfigureOperation(
-        MemberId memberId, int partitionId, Collection<MemberId> members)
+        MemberId memberId, int partitionId, Set<MemberId> members)
         implements PartitionChangeOperation {
       public PartitionForceReconfigureOperation {
-        members = List.copyOf(members);
+        members = Set.copyOf(members);
       }
     }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+import com.google.common.collect.ImmutableSortedSet;
 import io.atomix.cluster.MemberId;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.TreeSet;
 
 /**
  * An operation that changes the configuration. The operation could be a member join or leave a
@@ -83,7 +83,7 @@ public sealed interface ClusterConfigurationChangeOperation {
         MemberId memberId, int desiredPartitionCount, SortedSet<Integer> partitionsToRedistribute)
         implements ScaleUpOperation {
       public AwaitRedistributionCompletion {
-        partitionsToRedistribute = new TreeSet<>(partitionsToRedistribute);
+        partitionsToRedistribute = ImmutableSortedSet.copyOf(partitionsToRedistribute);
       }
     }
 
@@ -96,7 +96,7 @@ public sealed interface ClusterConfigurationChangeOperation {
         MemberId memberId, int desiredPartitionCount, SortedSet<Integer> partitionsToRelocate)
         implements ScaleUpOperation {
       public AwaitRelocationCompletion {
-        partitionsToRelocate = new TreeSet<>(partitionsToRelocate);
+        partitionsToRelocate = ImmutableSortedSet.copyOf(partitionsToRelocate);
       }
     }
   }
@@ -142,10 +142,12 @@ public sealed interface ClusterConfigurationChangeOperation {
      * @param members the members of the partition's replication group after the reconfiguration
      */
     record PartitionForceReconfigureOperation(
-        MemberId memberId, int partitionId, Set<MemberId> members)
+        MemberId memberId, int partitionId, SortedSet<MemberId> members)
         implements PartitionChangeOperation {
-      public PartitionForceReconfigureOperation {
-        members = Set.copyOf(members);
+
+      public PartitionForceReconfigureOperation(
+          final MemberId memberId, final int partitionId, final Set<MemberId> members) {
+        this(memberId, partitionId, ImmutableSortedSet.copyOf(members));
       }
     }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -9,8 +9,10 @@ package io.camunda.zeebe.dynamic.config.state;
 
 import io.atomix.cluster.MemberId;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * An operation that changes the configuration. The operation could be a member join or leave a
@@ -80,7 +82,11 @@ public sealed interface ClusterConfigurationChangeOperation {
      */
     record AwaitRedistributionCompletion(
         MemberId memberId, int desiredPartitionCount, SortedSet<Integer> partitionsToRedistribute)
-        implements ScaleUpOperation {}
+        implements ScaleUpOperation {
+      public AwaitRedistributionCompletion {
+        partitionsToRedistribute = new TreeSet<>(partitionsToRedistribute);
+      }
+    }
 
     /**
      * @param memberId the id of the member that initiated the scale up
@@ -89,7 +95,11 @@ public sealed interface ClusterConfigurationChangeOperation {
      */
     record AwaitRelocationCompletion(
         MemberId memberId, int desiredPartitionCount, SortedSet<Integer> partitionsToRelocate)
-        implements ScaleUpOperation {}
+        implements ScaleUpOperation {
+      public AwaitRelocationCompletion {
+        partitionsToRelocate = new TreeSet<>(partitionsToRelocate);
+      }
+    }
   }
 
   sealed interface PartitionChangeOperation extends ClusterConfigurationChangeOperation {
@@ -134,7 +144,11 @@ public sealed interface ClusterConfigurationChangeOperation {
      */
     record PartitionForceReconfigureOperation(
         MemberId memberId, int partitionId, Collection<MemberId> members)
-        implements PartitionChangeOperation {}
+        implements PartitionChangeOperation {
+      public PartitionForceReconfigureOperation {
+        members = List.copyOf(members);
+      }
+    }
 
     /**
      * Operation to disable an exporter on a partition in the given member.

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
@@ -13,15 +13,10 @@ import java.util.function.UnaryOperator;
 public record DynamicPartitionConfig(ExportingConfig exporting) {
 
   public static DynamicPartitionConfig uninitialized() {
-    // This is temporary until we have a way to initialize this during bootstrap or first update to
-    // the version that added this
     return new DynamicPartitionConfig(null);
   }
 
-  // Only used in tests. May be removed.
   public static DynamicPartitionConfig init() {
-    // This is temporary until we have a way to initialize this during bootstrap or first update to
-    // the version that added this
     return new DynamicPartitionConfig(ExportingConfig.empty());
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
@@ -17,7 +17,7 @@ public record DynamicPartitionConfig(ExportingConfig exporting) {
   }
 
   public static DynamicPartitionConfig init() {
-    return new DynamicPartitionConfig(ExportingConfig.empty());
+    return new DynamicPartitionConfig(ExportingConfig.init());
   }
 
   public boolean isInitialized() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
@@ -20,6 +20,10 @@ import java.util.Optional;
  */
 public record ExportingConfig(ExportingState state, Map<String, ExporterState> exporters) {
 
+  public ExportingConfig {
+    exporters = Map.copyOf(exporters);
+  }
+
   public static ExportingConfig init() {
     return new ExportingConfig(null, Map.of());
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
@@ -8,20 +8,22 @@
 package io.camunda.zeebe.dynamic.config.state;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SortedMap;
 
 /**
  * Represents configuration or state of exporting in a partition that can be updated during runtime.
  *
  * @param exporters the state of each exporter in this partition
  */
-public record ExportingConfig(ExportingState state, Map<String, ExporterState> exporters) {
+public record ExportingConfig(ExportingState state, SortedMap<String, ExporterState> exporters) {
 
-  public ExportingConfig {
-    exporters = Map.copyOf(exporters);
+  public ExportingConfig(final ExportingState state, final Map<String, ExporterState> exporters) {
+    this(state, ImmutableSortedMap.copyOf(exporters));
   }
 
   public static ExportingConfig init() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
@@ -12,6 +12,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
 
@@ -26,8 +27,13 @@ public record ExportingConfig(ExportingState state, SortedMap<String, ExporterSt
     this(state, ImmutableSortedMap.copyOf(exporters));
   }
 
+  public ExportingConfig {
+    Objects.requireNonNull(state);
+    Objects.requireNonNull(exporters);
+  }
+
   public static ExportingConfig init() {
-    return new ExportingConfig(null, Map.of());
+    return new ExportingConfig(ExportingState.UNKNOWN, Map.of());
   }
 
   private ExportingConfig updateExporter(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
@@ -18,10 +18,10 @@ import java.util.Optional;
  *
  * @param exporters the state of each exporter in this partition
  */
-public record ExportingConfig(Map<String, ExporterState> exporters) {
+public record ExportingConfig(ExportingState state, Map<String, ExporterState> exporters) {
 
-  public static ExportingConfig empty() {
-    return new ExportingConfig(Map.of());
+  public static ExportingConfig init() {
+    return new ExportingConfig(null, Map.of());
   }
 
   private ExportingConfig updateExporter(
@@ -31,7 +31,7 @@ public record ExportingConfig(Map<String, ExporterState> exporters) {
             .putAll(exporters)
             .put(exporterName, exporterState)
             .buildKeepingLast(); // choose last one if there are duplicate keys
-    return new ExportingConfig(newExporters);
+    return new ExportingConfig(state, newExporters);
   }
 
   public ExportingConfig disableExporter(final String exporterName) {
@@ -48,7 +48,7 @@ public record ExportingConfig(Map<String, ExporterState> exporters) {
         exporters.entrySet().stream()
             .filter(entry -> !entry.getKey().equals(exporterName))
             .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
-    return new ExportingConfig(newExporters);
+    return new ExportingConfig(state, newExporters);
   }
 
   public ExportingConfig disableExporters(final Collection<String> exporterNames) {
@@ -65,7 +65,7 @@ public record ExportingConfig(Map<String, ExporterState> exporters) {
 
     final var newExporters =
         builder.buildKeepingLast(); // choose last one if there are duplicate keys
-    return new ExportingConfig(newExporters);
+    return new ExportingConfig(state, newExporters);
   }
 
   public ExportingConfig enableExporter(final String exporterName, final long metadataVersion) {
@@ -96,7 +96,7 @@ public record ExportingConfig(Map<String, ExporterState> exporters) {
 
     final var newExporters =
         builder.buildKeepingLast(); // choose last one if there are duplicate keys
-    return new ExportingConfig(newExporters);
+    return new ExportingConfig(state, newExporters);
   }
 
   /**
@@ -119,6 +119,6 @@ public record ExportingConfig(Map<String, ExporterState> exporters) {
 
     final var newExporters =
         builder.buildKeepingLast(); // choose last one if there are duplicate keys
-    return new ExportingConfig(newExporters);
+    return new ExportingConfig(state, newExporters);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingState.java
@@ -9,6 +9,11 @@ package io.camunda.zeebe.dynamic.config.state;
 
 /** Controls the overall state of exporting across all exporters. */
 public enum ExportingState {
+  /**
+   * The exporting state is not yet controlled through {@link DynamicPartitionConfig}, we don't know
+   * whether we are exporting or not.
+   */
+  UNKNOWN,
   /** All enabled exporters are actively exporting records. */
   EXPORTING,
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingState.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+/** Controls the overall state of exporting across all exporters. */
+public enum ExportingState {
+  /** All enabled exporters are actively exporting records. */
+  EXPORTING,
+  /**
+   * All enabled exporters are actively exporting records but progress updates are not persisted.
+   */
+  SOFT_PAUSED,
+  /** Nothing is being exported. */
+  PAUSED,
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/MemberState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/MemberState.java
@@ -8,10 +8,12 @@
 package io.camunda.zeebe.dynamic.config.state;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.SortedMap;
 import java.util.function.UnaryOperator;
 
 /**
@@ -26,10 +28,13 @@ import java.util.function.UnaryOperator;
  * @param partitions state of all partitions that the member is replicating
  */
 public record MemberState(
-    long version, Instant lastUpdated, State state, Map<Integer, PartitionState> partitions) {
-
-  public MemberState {
-    partitions = Map.copyOf(partitions);
+    long version, Instant lastUpdated, State state, SortedMap<Integer, PartitionState> partitions) {
+  public MemberState(
+      final long version,
+      final Instant lastUpdated,
+      final State state,
+      final Map<Integer, PartitionState> partitions) {
+    this(version, lastUpdated, state, ImmutableSortedMap.copyOf(partitions));
   }
 
   public static MemberState initializeAsActive(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/MemberState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/MemberState.java
@@ -27,6 +27,11 @@ import java.util.function.UnaryOperator;
  */
 public record MemberState(
     long version, Instant lastUpdated, State state, Map<Integer, PartitionState> partitions) {
+
+  public MemberState {
+    partitions = Map.copyOf(partitions);
+  }
+
   public static MemberState initializeAsActive(
       final Map<Integer, PartitionState> initialPartitions) {
     return new MemberState(0, Instant.MIN, State.ACTIVE, Map.copyOf(initialPartitions));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+import com.google.common.collect.ImmutableSortedSet;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.protocol.Protocol;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -121,9 +123,19 @@ public record RoutingState(
      */
     record ActivePartitions(
         int basePartitionCount,
-        Set<Integer> additionalActivePartitions,
-        Set<Integer> inactivePartitions)
+        SortedSet<Integer> additionalActivePartitions,
+        SortedSet<Integer> inactivePartitions)
         implements RequestHandling {
+      public ActivePartitions(
+          final int basePartitionCount,
+          final Set<Integer> additionalActivePartitions,
+          final Set<Integer> inactivePartitions) {
+        this(
+            basePartitionCount,
+            ImmutableSortedSet.copyOf(additionalActivePartitions),
+            ImmutableSortedSet.copyOf(inactivePartitions));
+      }
+
       public ActivePartitions {
         Objects.requireNonNull(additionalActivePartitions);
         Objects.requireNonNull(inactivePartitions);

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -58,7 +58,10 @@ message PartitionState {
 
 message PartitionConfig { ExportingConfig exporting = 1; }
 
-message ExportingConfig { map<string, ExporterState> exporters = 1; }
+message ExportingConfig {
+  map<string, ExporterState> exporters = 1;
+  ExportingStateEnum state = 2;
+}
 
 message ExporterState {
   ExporterStateEnum state = 1;
@@ -198,4 +201,11 @@ enum ExporterStateEnum {
   ENABLED = 1;
   DISABLED = 2;
   CONFIG_NOT_FOUND = 3;
+}
+
+enum ExportingStateEnum {
+  EXPORTING_STATE_UNKNOWN = 0;
+  EXPORTING = 1;
+  SOFT_PAUSED = 2;
+  PAUSED = 3;
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -46,7 +47,9 @@ final class ClusterConfigurationModifierTest {
                     Map.of(
                         1,
                         PartitionState.active(
-                            1, new DynamicPartitionConfig(new ExportingConfig(Map.of()))))));
+                            1,
+                            new DynamicPartitionConfig(
+                                new ExportingConfig(ExportingState.EXPORTING, Map.of()))))));
 
     @Test
     void shouldInitializeRoutingStateIfPartitionScalingIsEnabled() {
@@ -111,6 +114,7 @@ final class ClusterConfigurationModifierTest {
       final var expectedConfig =
           new DynamicPartitionConfig(
               new ExportingConfig(
+                  null,
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -157,6 +161,7 @@ final class ClusterConfigurationModifierTest {
       final var expectedConfig =
           new DynamicPartitionConfig(
               new ExportingConfig(
+                  ExportingState.EXPORTING,
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -180,6 +185,7 @@ final class ClusterConfigurationModifierTest {
       final var expectedConfig =
           new DynamicPartitionConfig(
               new ExportingConfig(
+                  ExportingState.EXPORTING,
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -196,6 +202,7 @@ final class ClusterConfigurationModifierTest {
       final var expectedConfig =
           new DynamicPartitionConfig(
               new ExportingConfig(
+                  ExportingState.EXPORTING,
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -218,6 +225,7 @@ final class ClusterConfigurationModifierTest {
       final var initialConfig =
           new DynamicPartitionConfig(
               new ExportingConfig(
+                  ExportingState.EXPORTING,
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -238,6 +246,7 @@ final class ClusterConfigurationModifierTest {
       final var expectedConfig =
           new DynamicPartitionConfig(
               new ExportingConfig(
+                  ExportingState.EXPORTING,
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -254,6 +263,7 @@ final class ClusterConfigurationModifierTest {
       final var initialConfig =
           new DynamicPartitionConfig(
               new ExportingConfig(
+                  ExportingState.EXPORTING,
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),
@@ -282,6 +292,7 @@ final class ClusterConfigurationModifierTest {
       final DynamicPartitionConfig config =
           new DynamicPartitionConfig(
               new ExportingConfig(
+                  ExportingState.EXPORTING,
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
@@ -114,7 +114,7 @@ final class ClusterConfigurationModifierTest {
       final var expectedConfig =
           new DynamicPartitionConfig(
               new ExportingConfig(
-                  null,
+                  ExportingState.UNKNOWN,
                   Map.of(
                       "expA",
                       new ExporterState(0, State.ENABLED, Optional.empty()),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
@@ -42,7 +42,6 @@ final class PersistedClusterConfigurationRandomizedPropertyTest {
     // then
     assertThat(updatedTopology).isEqualTo(persistedClusterTopology.getConfiguration());
     assertThat(PersistedClusterConfiguration.ofFile(topologyFile, serializer).getConfiguration())
-        .usingRecursiveComparison()
         .isEqualTo(updatedTopology);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -41,6 +41,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
@@ -442,6 +443,7 @@ final class ClusterConfigurationManagementApiTest {
     final var partitionConfigWithExporter =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var configurationWithExporter =
         initialTopology.updateMember(
@@ -465,6 +467,7 @@ final class ClusterConfigurationManagementApiTest {
     final var partitionConfigWithExporter =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var configurationWithExporter =
         initialTopology.updateMember(
@@ -489,6 +492,7 @@ final class ClusterConfigurationManagementApiTest {
     final var partitionConfigWithExporter =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of(exporterId, new ExporterState(1, State.DISABLED, Optional.empty()))));
     final var configurationWithExporter =
         initialTopology.updateMember(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -346,8 +346,8 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactlyInAnyOrder(
-            new PartitionForceReconfigureOperation(id0, 1, List.of(id0)),
-            new PartitionForceReconfigureOperation(id2, 2, List.of(id2)),
+            new PartitionForceReconfigureOperation(id0, 1, Set.of(id0)),
+            new PartitionForceReconfigureOperation(id2, 2, Set.of(id2)),
             new MemberRemoveOperation(id0, id1),
             new MemberRemoveOperation(id0, id3));
   }
@@ -428,8 +428,8 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactlyInAnyOrder(
-            new PartitionForceReconfigureOperation(id0, 1, List.of(id0)),
-            new PartitionForceReconfigureOperation(id2, 2, List.of(id2)),
+            new PartitionForceReconfigureOperation(id0, 1, Set.of(id0)),
+            new PartitionForceReconfigureOperation(id2, 2, Set.of(id2)),
             new MemberRemoveOperation(id0, id1),
             new MemberRemoveOperation(id0, id3));
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import java.util.Map;
@@ -125,6 +126,7 @@ final class ClusterPurgeRequestTransformerTest {
     final var transformer = new PurgeRequestTransformer();
     final ExportingConfig exportingConfig =
         new ExportingConfig(
+            ExportingState.EXPORTING,
             Map.of(
                 "exporter",
                 new ExporterState(1, ExporterState.State.ENABLED, Optional.of("config"))));
@@ -161,6 +163,7 @@ final class ClusterPurgeRequestTransformerTest {
         DynamicPartitionConfig.init()
             .updateExporting(
                 new ExportingConfig(
+                    ExportingState.EXPORTING,
                     Map.of(
                         "exporter",
                         new ExporterState(1, ExporterState.State.ENABLED, Optional.of("config")))));
@@ -168,6 +171,7 @@ final class ClusterPurgeRequestTransformerTest {
         DynamicPartitionConfig.init()
             .updateExporting(
                 new ExportingConfig(
+                    ExportingState.EXPORTING,
                     Map.of(
                         "exporter", new ExporterState(1, State.DISABLED, Optional.of("config")))));
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDeleteRequestTransformerTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -31,6 +32,7 @@ final class ExporterDeleteRequestTransformerTest {
   private final DynamicPartitionConfig config =
       new DynamicPartitionConfig(
           new ExportingConfig(
+              ExportingState.EXPORTING,
               Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -31,6 +32,7 @@ final class ExporterDisableRequestTransformerTest {
   private final DynamicPartitionConfig config =
       new DynamicPartitionConfig(
           new ExportingConfig(
+              ExportingState.EXPORTING,
               Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformerTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -31,6 +32,7 @@ final class ExporterEnableRequestTransformerTest {
   private final DynamicPartitionConfig config =
       new DynamicPartitionConfig(
           new ExportingConfig(
+              ExportingState.EXPORTING,
               Map.of(exporterId, new ExporterState(1, State.DISABLED, Optional.empty()))));
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformerTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -57,8 +56,8 @@ class ForceScaleDownRequestTransformerTest {
     assertThat(result.get())
         .hasSize(4)
         .containsExactlyInAnyOrder(
-            new PartitionForceReconfigureOperation(id0, 1, List.of(id0)),
-            new PartitionForceReconfigureOperation(id2, 2, List.of(id2)),
+            new PartitionForceReconfigureOperation(id0, 1, Set.of(id0)),
+            new PartitionForceReconfigureOperation(id2, 2, Set.of(id2)),
             new MemberRemoveOperation(id0, id1),
             new MemberRemoveOperation(id0, id3));
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
@@ -21,8 +21,8 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -56,7 +56,7 @@ final class ConfigurationChangeAppliersImplTest {
             new PartitionReconfigurePriorityOperation(localMemberId, 1, 1),
             PartitionReconfigurePriorityApplier.class),
         Arguments.of(
-            new PartitionForceReconfigureOperation(localMemberId, 1, List.of()),
+            new PartitionForceReconfigureOperation(localMemberId, 1, Set.of()),
             PartitionForceReconfigureApplier.class),
         Arguments.of(
             new PartitionDisableExporterOperation(localMemberId, 1, "expId"),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/DeleteHistoryApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/DeleteHistoryApplierTest.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.ClusterConfigurationAssert;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -57,7 +58,9 @@ public class DeleteHistoryApplierTest {
                     m.addPartition(
                         partitionId,
                         PartitionState.active(
-                            1, new DynamicPartitionConfig(new ExportingConfig(Map.of())))));
+                            1,
+                            new DynamicPartitionConfig(
+                                new ExportingConfig(ExportingState.EXPORTING, Map.of())))));
     // when
     final var result = deleteHistoryApplier.init(clusterConfigWithPartition);
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplierTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
@@ -168,6 +169,7 @@ final class PartitionBootstrapApplierTest {
           DynamicPartitionConfig.init()
               .updateExporting(
                   new ExportingConfig(
+                      ExportingState.EXPORTING,
                       Map.of(
                           "exporter",
                           new ExporterState(
@@ -203,6 +205,7 @@ final class PartitionBootstrapApplierTest {
           DynamicPartitionConfig.init()
               .updateExporting(
                   new ExportingConfig(
+                      ExportingState.EXPORTING,
                       Map.of(
                           "exporter",
                           new ExporterState(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplierTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -98,6 +99,7 @@ final class PartitionDeleteExporterApplierTest {
     final var configWithExporter =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var clusterConfiguration =
         ClusterConfiguration.init()
@@ -123,6 +125,7 @@ final class PartitionDeleteExporterApplierTest {
     final var configWithExporter =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of(
                     exporterId, new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty()))));
     final var clusterConfiguration =
@@ -162,7 +165,8 @@ final class PartitionDeleteExporterApplierTest {
   void shouldCompleteFutureAndUpdateStateIfApplySucceeds() {
     // given
     final var exporterState = new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty());
-    final var exporterConfig = new ExportingConfig(Map.of(exporterId, exporterState));
+    final var exporterConfig =
+        new ExportingConfig(ExportingState.EXPORTING, Map.of(exporterId, exporterState));
     final var partitionConfig = new DynamicPartitionConfig(exporterConfig);
     final var memberState =
         MemberState.initializeAsActive(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplierTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -98,6 +99,7 @@ final class PartitionDisableExporterApplierTest {
     final var configWithExporter =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var clusterConfiguration =
         ClusterConfiguration.init()
@@ -136,7 +138,8 @@ final class PartitionDisableExporterApplierTest {
   void shouldCompleteFutureAndUpdateStateIfApplySucceeds() {
     // given
     final var exporterState = new ExporterState(1, State.ENABLED, Optional.empty());
-    final var exporterConfig = new ExportingConfig(Map.of(exporterId, exporterState));
+    final var exporterConfig =
+        new ExportingConfig(ExportingState.EXPORTING, Map.of(exporterId, exporterState));
     final var partitionConfig = new DynamicPartitionConfig(exporterConfig);
     final var memberState =
         MemberState.initializeAsActive(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionEnableExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionEnableExporterApplierTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -48,7 +49,9 @@ final class PartitionEnableExporterApplierTest {
                   m.addPartition(
                       partitionId,
                       PartitionState.active(
-                          1, new DynamicPartitionConfig(new ExportingConfig(Map.of())))));
+                          1,
+                          new DynamicPartitionConfig(
+                              new ExportingConfig(ExportingState.EXPORTING, Map.of())))));
 
   @Test
   void shouldRejectWhenMemberDoesNotExist() {
@@ -100,6 +103,7 @@ final class PartitionEnableExporterApplierTest {
     final var configWithDisabledExporter =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of("other", new ExporterState(0, State.DISABLED, Optional.empty()))));
     final var clusterConfiguration =
         clusterConfigWithPartition.updateMember(
@@ -122,6 +126,7 @@ final class PartitionEnableExporterApplierTest {
     final var configWithOtherExporter =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of("other", new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var clusterConfiguration =
         ClusterConfiguration.init()
@@ -164,6 +169,7 @@ final class PartitionEnableExporterApplierTest {
     final var configWithOtherExporter =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of("other", new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var clusterConfiguration =
         ClusterConfiguration.init()

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplierTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
@@ -224,6 +225,7 @@ final class PartitionJoinApplierTest {
     final var config =
         new DynamicPartitionConfig(
             new ExportingConfig(
+                ExportingState.EXPORTING,
                 Map.of(
                     "expA",
                     new ExporterState(1, ExporterState.State.ENABLED, Optional.of("expB")))));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
@@ -32,8 +32,11 @@ final class ProtoBufSerializerPropertyTest {
 
     // then
     assertThat(decodedState.getClusterConfiguration())
-        .describedAs("Decoded clusterTopology must be equal to initial one")
-        .usingRecursiveComparison()
+        .describedAs(
+            """
+            Decoded clusterTopology must be equal to initial one.
+            If this fails even though both objects look the same, make sure to take defensive copies of collections in the ClusterTopology and its nested types.
+            jqwik tends to generate sorted sets and maps which are not equal to the unsorted collections created on deserialization.""")
         .isEqualTo(clusterConfiguration);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.dynamic.config.protocol.Topology.MessageCorrelation.Hash
 import io.camunda.zeebe.dynamic.config.protocol.Topology.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import java.util.List;
@@ -282,6 +283,6 @@ final class ProtoBufSerializerTest {
         protoBufSerializer.decodeExportingConfig(Topology.ExportingConfig.parseFrom(serialized));
 
     // then
-    assertThat(deserialized.state()).isNull();
+    assertThat(deserialized.state()).isEqualTo(ExportingState.UNKNOWN);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
 import io.camunda.zeebe.dynamic.config.protocol.Topology;
+import io.camunda.zeebe.dynamic.config.protocol.Topology.ExporterStateEnum;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.RoutingState;
@@ -260,5 +261,27 @@ final class ProtoBufSerializerTest {
             state -> {
               assertThat(state.requestHandling()).isEqualTo(new RequestHandling.AllPartitions(3));
             });
+  }
+
+  @Test
+  void shouldDecodeExportingConfigWithoutStateCorrectly() throws InvalidProtocolBufferException {
+    // given
+    final var serialized =
+        Topology.ExportingConfig.newBuilder()
+            .putAllExporters(
+                Map.of(
+                    "exporter-1",
+                    Topology.ExporterState.newBuilder()
+                        .setState(ExporterStateEnum.ENABLED)
+                        .build()))
+            .build()
+            .toByteArray();
+
+    // when
+    final var deserialized =
+        protoBufSerializer.decodeExportingConfig(Topology.ExportingConfig.parseFrom(serialized));
+
+    // then
+    assertThat(deserialized.state()).isNull();
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -267,6 +267,7 @@ class ClusterConfigurationTest {
     final String exporterName = "exporter";
     final var exportersConfig =
         new ExportingConfig(
+            ExportingState.EXPORTING,
             Map.of(exporterName, new ExporterState(1, ENABLED, Optional.of("other"))));
     final var config = new DynamicPartitionConfig(exportersConfig);
 
@@ -312,7 +313,9 @@ class ClusterConfigurationTest {
 
     final DynamicPartitionConfig validConfig =
         new DynamicPartitionConfig(
-            new ExportingConfig(Map.of("expA", new ExporterState(1, ENABLED, Optional.empty()))));
+            new ExportingConfig(
+                ExportingState.EXPORTING,
+                Map.of("expA", new ExporterState(1, ENABLED, Optional.empty()))));
     final var topologyWithValidConfig =
         new ClusterConfiguration(
             0,

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
-import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
@@ -117,11 +116,6 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   @Provide
   Arbitrary<MemberId> memberIds() {
     return Arbitraries.integers().greaterOrEqual(0).map(id -> MemberId.from(id.toString()));
-  }
-
-  @Provide
-  Arbitrary<ExportingState> exportingStates() {
-    return Arbitraries.of(ExportingState.values()).injectNull(0.1);
   }
 
   @Provide

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -118,8 +118,13 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   }
 
   @Provide
-  Arbitrary<ExportingConfig> exportersConfigs() {
+  Arbitrary<ExportingConfig> exportingConfigs() {
     return Arbitraries.forType(ExportingConfig.class).enableRecursion();
+  }
+
+  @Provide
+  Arbitrary<ExportingState> exportingStates() {
+    return Arbitraries.of(ExportingState.values()).injectNull(0.1);
   }
 
   @Provide

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -22,13 +22,19 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.util.ReflectUtil;
+import java.util.Set;
+import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Combinators;
 import net.jqwik.api.Provide;
 import net.jqwik.api.domains.DomainContextBase;
+import net.jqwik.api.providers.ArbitraryProvider;
+import net.jqwik.api.providers.TypeUsage;
+import net.jqwik.api.support.CollectorsSupport;
 
 /**
  * Contains all arbitraries needed to generate a {@link ClusterConfiguration}. The topology is not
@@ -109,18 +115,8 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   }
 
   @Provide
-  Arbitrary<SortedSet<Integer>> sortedIntegerSets() {
-    return Arbitraries.integers().list().map(TreeSet::new);
-  }
-
-  @Provide
   Arbitrary<MemberId> memberIds() {
     return Arbitraries.integers().greaterOrEqual(0).map(id -> MemberId.from(id.toString()));
-  }
-
-  @Provide
-  Arbitrary<ExportingConfig> exportingConfigs() {
-    return Arbitraries.forType(ExportingConfig.class).enableRecursion();
   }
 
   @Provide
@@ -134,5 +130,48 @@ public final class ClusterTopologyDomain extends DomainContextBase {
         .enableRecursion()
         .map(DynamicPartitionConfig::new)
         .filter(DynamicPartitionConfig::isInitialized);
+  }
+
+  @SuppressWarnings("unused")
+  static class SortedMapArbitraryProvider implements ArbitraryProvider {
+    @Override
+    public boolean canProvideFor(final TypeUsage targetType) {
+      return targetType.isAssignableFrom(SortedMap.class);
+    }
+
+    @Override
+    public Set<Arbitrary<?>> provideFor(
+        final TypeUsage targetType, final SubtypeProvider subtypeProvider) {
+      final TypeUsage keyType = targetType.getTypeArgument(0);
+      final TypeUsage valueType = targetType.getTypeArgument(1);
+
+      return subtypeProvider
+          .resolveAndCombine(keyType, valueType)
+          .map(
+              arbitraries -> {
+                final Arbitrary<?> keyArbitrary = arbitraries.get(0);
+                final Arbitrary<?> valueArbitrary = arbitraries.get(1);
+                return Arbitraries.maps(keyArbitrary, valueArbitrary).map(TreeMap::new);
+              })
+          .collect(CollectorsSupport.toLinkedHashSet());
+    }
+  }
+
+  @SuppressWarnings("unused")
+  static class SortedSetArbitraryProvider implements ArbitraryProvider {
+    @Override
+    public boolean canProvideFor(final TypeUsage targetType) {
+      return targetType.isAssignableFrom(SortedSet.class);
+    }
+
+    @Override
+    public Set<Arbitrary<?>> provideFor(
+        final TypeUsage targetType, final SubtypeProvider subtypeProvider) {
+      final TypeUsage elementType = targetType.getTypeArgument(0);
+      final Set<Arbitrary<?>> elementArbitraries = subtypeProvider.apply(elementType);
+      return elementArbitraries.stream()
+          .map(arbitrary -> arbitrary.set().map(TreeSet::new))
+          .collect(CollectorsSupport.toLinkedHashSet());
+    }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
@@ -32,6 +33,7 @@ class ConfigurationUtilTest {
   private final DynamicPartitionConfig partitionConfig =
       new DynamicPartitionConfig(
           new ExportingConfig(
+              ExportingState.EXPORTING,
               Map.of("expA", new ExporterState(1, ExporterState.State.ENABLED, Optional.empty()))));
 
   @Test


### PR DESCRIPTION
This adds a new field to dynamic partition configuration that controls the exporting state: Exporting, Soft Paused or Paused.

For now, this has no function, but it's at least (de-)serialized to the protobuf representation and thus persisted. When this field is missing from the serialized state, for example after update from a previous version, we will use `null` as a placeholder and re-encode it as `EXPORTING_STATE_UNKNOWN`. We also use `null` when initializing dynamic configuration for the first time. Eventually, this will be initialized based on the actual state of exporting as it was set by `PartitionAdminControl`.

I've included a couple of other refactors and fixes that are related and added the motivation in each commit message.

relates to #39743