### PR TITLE
fix: include filters for batch operation requests

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.test.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.test.ts
@@ -169,7 +169,7 @@ describe('buildMutationRequestBody', () => {
         parentInstanceId: 'parent-456',
         retriesLeft: true,
         incidentErrorHashCode: 37136123613781,
-      } satisfies RequestFilters,
+      },
       includeIds: [],
       excludeIds: [],
     });
@@ -193,7 +193,7 @@ describe('buildMutationRequestBody', () => {
         activityId: 'taskA',
         incidents: false,
         processIds: ['p1', 'p2'],
-      } satisfies RequestFilters,
+      },
       includeIds: [],
       excludeIds: [],
     });
@@ -214,7 +214,7 @@ describe('buildMutationRequestBody', () => {
       baseFilter: {
         startDateAfter: after,
         startDateBefore: before,
-      } satisfies RequestFilters,
+      },
       includeIds: [],
       excludeIds: [],
     });
@@ -237,7 +237,7 @@ describe('buildMutationRequestBody', () => {
       baseFilter: {
         endDateAfter: after,
         endDateBefore: before,
-      } satisfies RequestFilters,
+      },
       includeIds: [],
       excludeIds: [],
     });
@@ -257,7 +257,7 @@ describe('buildMutationRequestBody', () => {
       baseFilter: {
         incidents: false,
         variable: {name: 'foo', values: ['a', 'b']},
-      } satisfies RequestFilters,
+      },
       includeIds: [],
       excludeIds: [],
     });
@@ -277,7 +277,7 @@ describe('buildMutationRequestBody', () => {
       baseFilter: {
         completed: true,
         canceled: true,
-      } satisfies RequestFilters,
+      },
       includeIds: [],
       excludeIds: [],
     });
@@ -291,7 +291,7 @@ describe('buildMutationRequestBody', () => {
     const onlyCompleted: Body = buildMutationRequestBody({
       baseFilter: {
         completed: true,
-      } satisfies RequestFilters,
+      },
       includeIds: [],
       excludeIds: [],
     });
@@ -305,7 +305,7 @@ describe('buildMutationRequestBody', () => {
     const onlyCanceled: Body = buildMutationRequestBody({
       baseFilter: {
         canceled: true,
-      } satisfies RequestFilters,
+      },
       includeIds: [],
       excludeIds: [],
     });

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.test.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.test.ts
@@ -170,7 +170,7 @@ describe('buildMutationRequestBody', () => {
         parentInstanceId: 'parent-456',
         retriesLeft: true,
         incidentErrorHashCode: 37136123613781,
-      } as RequestFilters,
+      } satisfies RequestFilters,
       includeIds: [],
       excludeIds: [],
     });
@@ -194,7 +194,7 @@ describe('buildMutationRequestBody', () => {
         activityId: 'taskA',
         incidents: false,
         processIds: ['p1', 'p2'],
-      } as RequestFilters,
+      } satisfies RequestFilters,
       includeIds: [],
       excludeIds: [],
     });
@@ -215,7 +215,7 @@ describe('buildMutationRequestBody', () => {
       baseFilter: {
         startDateAfter: after,
         startDateBefore: before,
-      } as RequestFilters,
+      } satisfies RequestFilters,
       includeIds: [],
       excludeIds: [],
     });
@@ -235,7 +235,7 @@ describe('buildMutationRequestBody', () => {
       baseFilter: {
         endDateAfter: after,
         endDateBefore: before,
-      } as RequestFilters,
+      } satisfies RequestFilters,
       includeIds: [],
       excludeIds: [],
     });
@@ -252,7 +252,7 @@ describe('buildMutationRequestBody', () => {
       baseFilter: {
         incidents: false,
         variable: {name: 'foo', values: ['a', 'b']},
-      } as RequestFilters,
+      } satisfies RequestFilters,
       includeIds: [],
       excludeIds: [],
     });
@@ -272,7 +272,7 @@ describe('buildMutationRequestBody', () => {
       baseFilter: {
         completed: true,
         canceled: true,
-      } as RequestFilters,
+      } satisfies RequestFilters,
       includeIds: [],
       excludeIds: [],
     });
@@ -286,7 +286,7 @@ describe('buildMutationRequestBody', () => {
     const onlyCompleted: Body = buildMutationRequestBody({
       baseFilter: {
         completed: true,
-      } as RequestFilters,
+      } satisfies RequestFilters,
       includeIds: [],
       excludeIds: [],
     });
@@ -300,7 +300,7 @@ describe('buildMutationRequestBody', () => {
     const onlyCanceled: Body = buildMutationRequestBody({
       baseFilter: {
         canceled: true,
-      } as RequestFilters,
+      } satisfies RequestFilters,
       includeIds: [],
       excludeIds: [],
     });

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.test.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.test.ts
@@ -210,19 +210,51 @@ describe('buildMutationRequestBody', () => {
     const after = '2020-01-01T00:00:00Z';
     const before = '2020-01-02T00:00:00Z';
 
-    const body: Body = buildMutationRequestBody({
-      baseFilter: {
-        startDateAfter: after,
-        startDateBefore: before,
-      },
-      includeIds: [],
-      excludeIds: [],
-    });
-
-    expect(body).toEqual({
+    expect(
+      buildMutationRequestBody({
+        baseFilter: {
+          startDateAfter: after,
+          startDateBefore: before,
+        },
+        includeIds: [],
+        excludeIds: [],
+      }),
+    ).toEqual({
       filter: {
         startDate: {
           $gt: '2020-01-01T00:00:00.000Z',
+          $lt: '2020-01-02T00:00:00.000Z',
+        },
+      },
+    });
+
+    expect(
+      buildMutationRequestBody({
+        baseFilter: {
+          startDateAfter: after,
+        },
+        includeIds: [],
+        excludeIds: [],
+      }),
+    ).toEqual({
+      filter: {
+        startDate: {
+          $gt: '2020-01-01T00:00:00.000Z',
+        },
+      },
+    });
+
+    expect(
+      buildMutationRequestBody({
+        baseFilter: {
+          startDateBefore: before,
+        },
+        includeIds: [],
+        excludeIds: [],
+      }),
+    ).toEqual({
+      filter: {
+        startDate: {
           $lt: '2020-01-02T00:00:00.000Z',
         },
       },
@@ -233,19 +265,51 @@ describe('buildMutationRequestBody', () => {
     const after = '2020-01-01T00:00:00Z';
     const before = '2020-01-02T00:00:00Z';
 
-    const body: Body = buildMutationRequestBody({
-      baseFilter: {
-        endDateAfter: after,
-        endDateBefore: before,
-      },
-      includeIds: [],
-      excludeIds: [],
-    });
-
-    expect(body).toEqual({
+    expect(
+      buildMutationRequestBody({
+        baseFilter: {
+          endDateAfter: after,
+          endDateBefore: before,
+        },
+        includeIds: [],
+        excludeIds: [],
+      }),
+    ).toEqual({
       filter: {
         endDate: {
           $gt: '2020-01-01T00:00:00.000Z',
+          $lt: '2020-01-02T00:00:00.000Z',
+        },
+      },
+    });
+
+    expect(
+      buildMutationRequestBody({
+        baseFilter: {
+          endDateAfter: after,
+        },
+        includeIds: [],
+        excludeIds: [],
+      }),
+    ).toEqual({
+      filter: {
+        endDate: {
+          $gt: '2020-01-01T00:00:00.000Z',
+        },
+      },
+    });
+
+    expect(
+      buildMutationRequestBody({
+        baseFilter: {
+          endDateBefore: before,
+        },
+        includeIds: [],
+        excludeIds: [],
+      }),
+    ).toEqual({
+      filter: {
+        endDate: {
           $lt: '2020-01-02T00:00:00.000Z',
         },
       },

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.test.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.test.ts
@@ -12,7 +12,6 @@ import type {
   CreateCancellationBatchOperationRequestBody,
   CreateIncidentResolutionBatchOperationRequestBody,
 } from '@camunda/camunda-api-zod-schemas/8.8';
-import {formatToISO} from 'modules/utils/date/formatDate';
 
 type Body =
   | CreateIncidentResolutionBatchOperationRequestBody
@@ -222,7 +221,10 @@ describe('buildMutationRequestBody', () => {
 
     expect(body).toEqual({
       filter: {
-        startDate: {$gt: formatToISO(after), $lt: formatToISO(before)},
+        startDate: {
+          $gt: '2020-01-01T00:00:00.000Z',
+          $lt: '2020-01-02T00:00:00.000Z',
+        },
       },
     });
   });
@@ -242,7 +244,10 @@ describe('buildMutationRequestBody', () => {
 
     expect(body).toEqual({
       filter: {
-        endDate: {$gt: formatToISO(after), $lt: formatToISO(before)},
+        endDate: {
+          $gt: '2020-01-01T00:00:00.000Z',
+          $lt: '2020-01-02T00:00:00.000Z',
+        },
       },
     });
   });

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.ts
@@ -55,35 +55,52 @@ const buildMutationRequestBody = ({
     requestBody.filter.state = {$eq: 'TERMINATED'};
   }
 
-  if (baseFilter.processIds && baseFilter.processIds.length > 0) {
+  if (
+    Array.isArray(baseFilter.processIds) &&
+    baseFilter.processIds.length > 0
+  ) {
     requestBody.filter.processDefinitionKey = {
       $in: baseFilter.processIds,
     };
   }
 
   if (baseFilter.startDateAfter || baseFilter.startDateBefore) {
-    requestBody.filter.startDate = {
-      ...(baseFilter.startDateAfter && {
-        $gt: formatToISO(baseFilter.startDateAfter),
-      }),
-      ...(baseFilter.startDateBefore && {
-        $lt: formatToISO(baseFilter.startDateBefore),
-      }),
-    };
+    const startDate: {
+      $gt?: string;
+      $lt?: string;
+    } = {};
+
+    if (baseFilter.startDateAfter) {
+      startDate.$gt = formatToISO(baseFilter.startDateAfter);
+    }
+    if (baseFilter.startDateBefore) {
+      startDate.$lt = formatToISO(baseFilter.startDateBefore);
+    }
+
+    requestBody.filter.startDate = startDate;
   }
 
   if (baseFilter.endDateAfter || baseFilter.endDateBefore) {
-    requestBody.filter.endDate = {
-      ...(baseFilter.endDateAfter && {
-        $gt: formatToISO(baseFilter.endDateAfter),
-      }),
-      ...(baseFilter.endDateBefore && {
-        $lt: formatToISO(baseFilter.endDateBefore),
-      }),
-    };
+    const endDate: {
+      $gt?: string;
+      $lt?: string;
+    } = {};
+
+    if (baseFilter.endDateAfter) {
+      endDate.$gt = formatToISO(baseFilter.endDateAfter);
+    }
+    if (baseFilter.endDateBefore) {
+      endDate.$lt = formatToISO(baseFilter.endDateBefore);
+    }
+
+    requestBody.filter.endDate = endDate;
   }
 
-  if (baseFilter.variable?.name && baseFilter.variable.values) {
+  if (
+    baseFilter.variable?.name &&
+    Array.isArray(baseFilter.variable.values) &&
+    baseFilter.variable.values.length > 0
+  ) {
     requestBody.filter.variables = baseFilter.variable.values.map((value) => {
       return {
         name: baseFilter.variable!.name,

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.ts
@@ -12,25 +12,30 @@ import type {
   CreateIncidentResolutionBatchOperationRequestBody,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import {buildProcessInstanceKeyCriterion} from 'modules/mutations/processes/buildProcessInstanceKeyCriterion';
+import {formatToISO} from 'modules/utils/date/formatDate';
 
 type BuildMutationRequestBodyParams = {
   baseFilter: RequestFilters;
   includeIds: string[];
   excludeIds: string[];
-  processDefinitionKey?: string;
 };
 
 const buildMutationRequestBody = ({
   baseFilter,
   includeIds,
   excludeIds,
-  processDefinitionKey,
 }: BuildMutationRequestBodyParams) => {
   const requestBody:
     | CreateIncidentResolutionBatchOperationRequestBody
     | CreateCancellationBatchOperationRequestBody = {
     filter: {
       elementId: baseFilter.activityId,
+      errorMessage: baseFilter.errorMessage,
+      tenantId: baseFilter.tenantId,
+      batchOperationKey: baseFilter.batchOperationId,
+      parentProcessInstanceKey: baseFilter.parentInstanceId,
+      hasRetriesLeft: baseFilter.retriesLeft,
+      incidentErrorHashCode: baseFilter.incidentErrorHashCode,
     },
   };
 
@@ -42,13 +47,54 @@ const buildMutationRequestBody = ({
     requestBody.filter.state = {$eq: 'ACTIVE'};
   }
 
+  if (baseFilter.completed && baseFilter.canceled) {
+    requestBody.filter.state = {$in: ['COMPLETED', 'TERMINATED']};
+  } else if (baseFilter.completed) {
+    requestBody.filter.state = {$eq: 'COMPLETED'};
+  } else if (baseFilter.canceled) {
+    requestBody.filter.state = {$eq: 'TERMINATED'};
+  }
+
+  if (baseFilter.processIds && baseFilter.processIds.length > 0) {
+    requestBody.filter.processDefinitionKey = {
+      $in: baseFilter.processIds,
+    };
+  }
+
+  if (baseFilter.startDateAfter || baseFilter.startDateBefore) {
+    requestBody.filter.startDate = {
+      ...(baseFilter.startDateAfter && {
+        $gt: formatToISO(baseFilter.startDateAfter),
+      }),
+      ...(baseFilter.startDateBefore && {
+        $lt: formatToISO(baseFilter.startDateBefore),
+      }),
+    };
+  }
+
+  if (baseFilter.endDateAfter || baseFilter.endDateBefore) {
+    requestBody.filter.endDate = {
+      ...(baseFilter.endDateAfter && {
+        $gt: formatToISO(baseFilter.endDateAfter),
+      }),
+      ...(baseFilter.endDateBefore && {
+        $lt: formatToISO(baseFilter.endDateBefore),
+      }),
+    };
+  }
+
+  if (baseFilter.variable?.name && baseFilter.variable.values) {
+    requestBody.filter.variables = baseFilter.variable.values.map((value) => {
+      return {
+        name: baseFilter.variable!.name,
+        value,
+      };
+    });
+  }
+
   const keyCriterion = buildProcessInstanceKeyCriterion(includeIds, excludeIds);
   if (keyCriterion) {
     requestBody.filter.processInstanceKey = keyCriterion;
-  }
-
-  if (processDefinitionKey) {
-    requestBody.filter.processDefinitionKey = processDefinitionKey;
   }
 
   return requestBody;

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -23,7 +23,6 @@ import {tracking} from 'modules/tracking';
 import {getProcessInstancesRequestFilters} from 'modules/utils/filter';
 import {processInstancesStore} from 'modules/stores/processInstances';
 import {notificationsStore} from 'modules/stores/notifications';
-import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {buildMutationRequestBody} from './buildMutationRequestBody';
 
 type Props = {
@@ -41,8 +40,6 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
   const [modalMode, setModalMode] = useState<
     'RESOLVE_INCIDENT' | 'CANCEL_PROCESS_INSTANCE' | null
   >(null);
-  const processDefinitionKey = useProcessDefinitionKeyContext();
-
   const closeModal = () => {
     setModalMode(null);
   };
@@ -112,7 +109,6 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
       baseFilter,
       includeIds,
       excludeIds: excludedProcessInstanceIds,
-      processDefinitionKey,
     });
 
     if (selectedProcessInstanceIds.length > 0) {

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -12,14 +12,7 @@ import {
   type GetProcessDefinitionStatisticsRequestBody,
   type ProcessInstanceState,
 } from '@camunda/camunda-api-zod-schemas/8.8';
-
-const formatToISO = (dateString: string | undefined): string | undefined => {
-  if (!dateString) {
-    return undefined;
-  }
-  const date = new Date(dateString);
-  return date.toISOString();
-};
+import {formatToISO} from 'modules/utils/date/formatDate';
 
 function mapFiltersToRequest(
   filters: ProcessInstanceFilters,

--- a/operate/client/src/modules/utils/date/formatDate.ts
+++ b/operate/client/src/modules/utils/date/formatDate.ts
@@ -21,4 +21,12 @@ function formatDate(
     : placeholder;
 }
 
-export {parseDate, formatDate};
+const formatToISO = (dateString: string | undefined): string | undefined => {
+  if (!dateString) {
+    return undefined;
+  }
+  const date = new Date(dateString);
+  return date.toISOString();
+};
+
+export {parseDate, formatDate, formatToISO};


### PR DESCRIPTION
## Description

- added missing filters to the batch operation mutation
- add test coverage

Note: processDefinitionKey does not always needs to be the selected process version. In case "all versions" is selected, it is a list containing keys of every version of the selected process definition.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39848
