### PR TITLE
fix: flaky nightly tasklist test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/usertask_with_variables2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/usertask_with_variables2.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_190h7pv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111">
+  <bpmn:process id="usertask_with_variables2" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0u665te</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u665te" sourceRef="StartEvent_1" targetRef="Activity_0awbj0c" />
+    <bpmn:endEvent id="Event_0gtkwhz" name="End">
+      <bpmn:incoming>Flow_1mtspc2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1mtspc2" sourceRef="Activity_0awbj0c" targetRef="Event_0gtkwhz" />
+    <bpmn:userTask id="Activity_0awbj0c" name="Some user activity">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u665te</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mtspc2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_with_variables2">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gtkwhz_di" bpmnElement="Event_0gtkwhz">
+        <dc:Bounds x="482" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1svyo8o_di" bpmnElement="Activity_0awbj0c">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u665te_di" bpmnElement="Flow_0u665te">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mtspc2_di" bpmnElement="Flow_1mtspc2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="482" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
@@ -15,10 +15,14 @@ import {navigateToApp} from '@pages/UtilitiesPage';
 test.beforeAll(async () => {
   await deploy([
     './resources/usertask_with_variables.bpmn',
+    './resources/usertask_with_variables2.bpmn',
     './resources/usertask_without_variables.bpmn',
   ]);
   await createInstances('usertask_without_variables', 1, 1);
-  await createInstances('usertask_with_variables', 1, 4, {
+  await createInstances('usertask_with_variables', 1, 3, {
+    testData: 'something',
+  });
+  await createInstances('usertask_with_variables2', 1, 1, {
     testData: 'something',
   });
 });
@@ -40,7 +44,9 @@ test.describe('variables page', () => {
     taskDetailsPage,
   }) => {
     await taskPanelPage.openTask('usertask_without_variables');
-    await expect(taskDetailsPage.emptyTaskMessage).toBeVisible({timeout: 30000});
+    await expect(taskDetailsPage.emptyTaskMessage).toBeVisible({
+      timeout: 30000,
+    });
   });
 
   test('display variables when task has variables', async ({
@@ -168,10 +174,12 @@ test.describe('variables page', () => {
   }) => {
     test.slow();
     await taskPanelPage.filterBy('Unassigned');
-    await taskPanelPage.openTask('usertask_with_variables');
+    await taskPanelPage.openTask('usertask_with_variables2');
 
     await expect(taskDetailsPage.addVariableButton).toBeHidden();
-    await expect(taskDetailsPage.assignToMeButton).toBeVisible({timeout: 60000});
+    await expect(taskDetailsPage.assignToMeButton).toBeVisible({
+      timeout: 60000,
+    });
     await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
     await taskDetailsPage.clickAssignToMeButton();
 
@@ -191,9 +199,11 @@ test.describe('variables page', () => {
     await page.reload();
 
     await taskPanelPage.filterBy('Completed');
-    await taskPanelPage.openTask('usertask_with_variables');
+    await taskPanelPage.openTask('usertask_with_variables2');
 
-    await expect(page.getByText('newVariableName')).toBeVisible({timeout: 60000});
+    await expect(page.getByText('newVariableName')).toBeVisible({
+      timeout: 60000,
+    });
     await expect(page.getByText('newVariableValue')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Because tests run in parallel the test data was interfering, this PR separate the test data

Successful test run [here](https://github.com/camunda/camunda/actions/runs/18743136509)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
