### PR TITLE
[Backport stable/8.7] fix: `MigrationSnapshotDirector` health status is propagated correctly  

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
@@ -33,7 +33,7 @@ public class MigrationSnapshotDirector implements HealthMonitorable, CloseableSi
   private static final Logger LOG = LoggerFactory.getLogger(MigrationSnapshotDirector.class);
 
   private volatile boolean snapshotTaken = false;
-  private ScheduledTimer runningSnapshot = null;
+  private volatile ScheduledTimer runningSnapshot = null;
   private final ConcurrentMap<FailureListener, Boolean> listeners = new ConcurrentHashMap<>();
   private final AsyncSnapshotDirector snapshotDirector;
 
@@ -96,7 +96,9 @@ public class MigrationSnapshotDirector implements HealthMonitorable, CloseableSi
 
   @Override
   public void addFailureListener(final FailureListener failureListener) {
+    LOG.trace("Added failure listener {}", failureListener);
     listeners.put(failureListener, Boolean.TRUE);
+    failureListener.onFailure(healthReport);
   }
 
   @Override

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
@@ -101,7 +101,8 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
             monitoredComponent.component.removeFailureListener(monitoredComponent);
             graphListener.unregisterRelationship(name, componentName);
             graphListener.unregisterNode(monitoredComponent.component);
-            log.info("Unregistered edge {}:{}", name, componentName);
+            log.trace("Unregistered edge {}:{}", name, componentName);
+            calculateHealth();
           }
         });
   }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/startup/StartupProcess.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/startup/StartupProcess.java
@@ -159,11 +159,18 @@ public final class StartupProcess<CONTEXT> {
 
       logCurrentStepSynchronized("Startup", stepToStart);
 
+      final var before = System.nanoTime();
       final var stepStartupFuture = stepToStart.startup(context);
 
       concurrencyControl.runOnCompletion(
           stepStartupFuture,
           (contextReturnedByStep, error) -> {
+            final var completedAt = System.nanoTime();
+            logger.debug(
+                "StartupStep {} completed (error={}) took {} millis ",
+                stepToStart.getName(),
+                error != null,
+                (completedAt - before) / 1e6);
             if (error != null) {
               completeStartupFutureExceptionallySynchronized(startupFuture, stepToStart, error);
             } else {

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
@@ -175,7 +175,9 @@ public class CriticalComponentsHealthMonitorTest {
     waitUntilAllDone();
 
     // then
-    assertThat(monitor.getHealthReport().getStatus()).isEqualTo(HealthStatus.HEALTHY);
+    final var report = monitor.getHealthReport();
+    assertThat(report.getStatus()).isEqualTo(HealthStatus.UNHEALTHY);
+    assertThat(report.children()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #39790 to `stable/8.7`.

relates to #39751