### PR TITLE
fix: set uc repository-name fallback mode to SUPPORTED_ONLY_IF_VALUES_MATCH

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Backup.java
+++ b/configuration/src/main/java/io/camunda/configuration/Backup.java
@@ -9,29 +9,19 @@ package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import java.time.Duration;
-import java.util.Map;
 import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class Backup implements Cloneable {
   private static final String PREFIX = "camunda.data.backup";
 
-  private static final Map<String, String> LEGACY_OPERATE_BACKUP_PROPERTIES =
-      Map.of(
-          "repositoryName",
-          "camunda.operate.backup.repositoryName",
-          "snapshotTimeout",
-          "camunda.operate.backup.snapshotTimeout",
-          "incompleteCheckTimeoutInSeconds",
-          "camunda.operate.backup.incompleteCheckTimeoutInSeconds");
-
-  private static final Map<String, String> LEGACY_TASKLIST_BACKUP_PROPERTIES =
-      Map.of("repositoryName", "camunda.tasklist.backup.repositoryName");
-
-  private static final Map<String, String> LEGACY_BROKER_BACKUP_PROPERTIES =
-      Map.of("store", "zeebe.broker.data.backup.store");
-
-  private Map<String, String> legacyPropertyMap = LEGACY_OPERATE_BACKUP_PROPERTIES;
+  private static final String LEGACY_OPERATE_SNAPSHOT_TIMEOUT =
+      "camunda.operate.backup.snapshotTimeout";
+  private static final String LEGACY_OPERATE_INCOMPLETE_CHECK_TIMEOUT_IN_SECONDS =
+      "camunda.operate.backup.incompleteCheckTimeoutInSeconds";
+  private static final Set<String> LEGACY_REPOSITORY_NAME_PROPERTIES =
+      Set.of("camunda.tasklist.backup.repositoryName", "camunda.operate.backup.repositoryName");
+  private static final String LEGACY_BROKER_STORE = "zeebe.broker.data.backup.store";
 
   /**
    * Set the ES / OS snapshot repository name.
@@ -93,8 +83,8 @@ public class Backup implements Cloneable {
         PREFIX + ".repository-name",
         repositoryName,
         String.class,
-        BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(legacyPropertyMap.get("repositoryName")));
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_REPOSITORY_NAME_PROPERTIES);
   }
 
   public void setRepositoryName(final String repositoryName) {
@@ -107,7 +97,7 @@ public class Backup implements Cloneable {
         snapshotTimeout,
         Integer.class,
         BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(legacyPropertyMap.get("snapshotTimeout")));
+        Set.of(LEGACY_OPERATE_SNAPSHOT_TIMEOUT));
   }
 
   public void setSnapshotTimeout(final int snapshotTimeout) {
@@ -121,7 +111,7 @@ public class Backup implements Cloneable {
             incompleteCheckTimeout.getSeconds(),
             Long.class,
             BackwardsCompatibilityMode.SUPPORTED,
-            Set.of(legacyPropertyMap.get("incompleteCheckTimeoutInSeconds")));
+            Set.of(LEGACY_OPERATE_INCOMPLETE_CHECK_TIMEOUT_IN_SECONDS));
 
     return Duration.ofSeconds(incompleteCheckTimeoutInSeconds);
   }
@@ -168,38 +158,11 @@ public class Backup implements Cloneable {
         store,
         BackupStoreType.class,
         BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(legacyPropertyMap.get("store")));
+        Set.of(LEGACY_BROKER_STORE));
   }
 
   public void setStore(final BackupStoreType store) {
     this.store = store;
-  }
-
-  @Override
-  public Object clone() {
-    try {
-      return super.clone();
-    } catch (final CloneNotSupportedException e) {
-      throw new AssertionError("Unexpected: Class must implement Cloneable", e);
-    }
-  }
-
-  public Backup withOperateBackupProperties() {
-    final var copy = (Backup) clone();
-    copy.legacyPropertyMap = LEGACY_OPERATE_BACKUP_PROPERTIES;
-    return copy;
-  }
-
-  public Backup withTasklistBackupProperties() {
-    final var copy = (Backup) clone();
-    copy.legacyPropertyMap = LEGACY_TASKLIST_BACKUP_PROPERTIES;
-    return copy;
-  }
-
-  public Backup withBrokerBackupProperties() {
-    final var copy = (Backup) clone();
-    copy.legacyPropertyMap = LEGACY_BROKER_BACKUP_PROPERTIES;
-    return copy;
   }
 
   public enum BackupStoreType {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -478,8 +478,7 @@ public class BrokerBasedPropertiesOverride {
   }
 
   private void populateFromBackup(final BrokerBasedProperties override) {
-    final Backup backup =
-        unifiedConfiguration.getCamunda().getData().getBackup().withBrokerBackupProperties();
+    final Backup backup = unifiedConfiguration.getCamunda().getData().getBackup();
     final BackupStoreCfg backupStoreCfg = override.getData().getBackup();
     backupStoreCfg.setStore(BackupStoreType.valueOf(backup.getStore().name()));
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -70,8 +70,7 @@ public class OperatePropertiesOverride {
   }
 
   private void pouplateFromBackup(final OperateProperties override) {
-    final Backup operateBackup =
-        unifiedConfiguration.getCamunda().getData().getBackup().withOperateBackupProperties();
+    final Backup operateBackup = unifiedConfiguration.getCamunda().getData().getBackup();
     final BackupProperties backupProperties = override.getBackup();
     backupProperties.setRepositoryName(operateBackup.getRepositoryName());
     backupProperties.setSnapshotTimeout(operateBackup.getSnapshotTimeout());

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -15,7 +15,6 @@ import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.Security;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.search.connect.plugin.PluginConfiguration;
-import io.camunda.tasklist.property.BackupProperties;
 import io.camunda.tasklist.property.SslProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import java.util.List;
@@ -70,10 +69,8 @@ public class TasklistPropertiesOverride {
   }
 
   private void populateFromBackup(final TasklistProperties override) {
-    final Backup backup =
-        unifiedConfiguration.getCamunda().getData().getBackup().withTasklistBackupProperties();
-    final BackupProperties backupProperties = override.getBackup();
-    backupProperties.setRepositoryName(backup.getRepositoryName());
+    final Backup backup = unifiedConfiguration.getCamunda().getData().getBackup();
+    override.getBackup().setRepositoryName(backup.getRepositoryName());
   }
 
   private void populateFromElasticsearch(

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupOperatePropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupOperatePropertiesTest.java
@@ -56,39 +56,40 @@ public class DataBackupOperatePropertiesTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.tasklist.backup.repositoryName=repositoryNameLegacyTasklist",
+        "camunda.data.backup.repository-name=repositoryName",
+        "camunda.tasklist.backup.repositoryName=repositoryName",
       })
-  class WithOnlyTasklistLegacySet {
+  class WithTasklistLegacySet {
     final OperateProperties operateProperties;
 
-    WithOnlyTasklistLegacySet(@Autowired final OperateProperties operateProperties) {
+    WithTasklistLegacySet(@Autowired final OperateProperties operateProperties) {
       this.operateProperties = operateProperties;
     }
 
     @Test
-    void shouldNotSetRepositoryNameFromLegacyTasklist() {
-      assertThat(operateProperties.getBackup().getRepositoryName()).isNull();
+    void shouldSetRepositoryNameIfNewAndTasklistMatch() {
+      assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
     }
   }
 
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.operate.backup.repositoryName=repositoryNameLegacyOperate",
+        "camunda.data.backup.repository-name=repositoryName",
+        "camunda.operate.backup.repositoryName=repositoryName",
         "camunda.operate.backup.snapshotTimeout=5",
         "camunda.operate.backup.incompleteCheckTimeoutInSeconds=180",
       })
-  class WithOnlyOperateLegacySet {
+  class WithOperateLegacySet {
     final OperateProperties operateProperties;
 
-    WithOnlyOperateLegacySet(@Autowired final OperateProperties operateProperties) {
+    WithOperateLegacySet(@Autowired final OperateProperties operateProperties) {
       this.operateProperties = operateProperties;
     }
 
     @Test
-    void shouldSetRepositoryNameFromLegacyOperate() {
-      assertThat(operateProperties.getBackup().getRepositoryName())
-          .isEqualTo("repositoryNameLegacyOperate");
+    void shouldSetRepositoryNameIfNewAndOperateMatch() {
+      assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
     }
 
     @Test
@@ -106,13 +107,13 @@ public class DataBackupOperatePropertiesTest {
   @TestPropertySource(
       properties = {
         // new
-        "camunda.data.backup.repository-name=repositoryNameNew",
+        "camunda.data.backup.repository-name=repositoryName",
         "camunda.data.backup.snapshot-timeout=5",
         "camunda.data.backup.incomplete-check-timeout=3m",
         // legacy configuration tasklist
-        "camunda.tasklist.backup.repositoryName=repositoryNameLegacyTasklist",
+        "camunda.tasklist.backup.repositoryName=repositoryName",
         // legacy configuration operate
-        "camunda.operate.backup.repositoryName=repositoryNameLegacyOperate",
+        "camunda.operate.backup.repositoryName=repositoryName",
         "camunda.operate.backup.snapshotTimeout=2",
         "camunda.operate.backup.incompleteCheckTimeoutInSeconds=90",
       })
@@ -124,8 +125,8 @@ public class DataBackupOperatePropertiesTest {
     }
 
     @Test
-    void shouldSetRepositoryNameFromNew() {
-      assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryNameNew");
+    void shouldSetRepositoryNameIfNewAndLegacyMatch() {
+      assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupTasklistPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupTasklistPropertiesTest.java
@@ -44,37 +44,38 @@ public class DataBackupTasklistPropertiesTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.operate.backup.repositoryName=repositoryNameLegacyOperate",
+        "camunda.data.backup.repository-name=repositoryName",
+        "camunda.operate.backup.repositoryName=repositoryName",
       })
-  class WithOnlyOperateLegacySet {
+  class WithOperateLegacySet {
     final TasklistProperties tasklistProperties;
 
-    WithOnlyOperateLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+    WithOperateLegacySet(@Autowired final TasklistProperties tasklistProperties) {
       this.tasklistProperties = tasklistProperties;
     }
 
     @Test
-    void shouldNotSetRepositoryNameFromLegacyOperate() {
-      assertThat(tasklistProperties.getBackup().getRepositoryName()).isNull();
+    void shouldSetRepositoryNameIfNewAndOperateMatch() {
+      assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
     }
   }
 
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.tasklist.backup.repositoryName=repositoryNameLegacyTasklist",
+        "camunda.data.backup.repository-name=repositoryName",
+        "camunda.tasklist.backup.repositoryName=repositoryName",
       })
-  class WithOnlyTasklistLegacySet {
+  class WithTasklistLegacySet {
     final TasklistProperties tasklistProperties;
 
-    WithOnlyTasklistLegacySet(@Autowired final TasklistProperties tasklistProperties) {
+    WithTasklistLegacySet(@Autowired final TasklistProperties tasklistProperties) {
       this.tasklistProperties = tasklistProperties;
     }
 
     @Test
-    void shouldSetRepositoryNameFromLegacyTasklist() {
-      assertThat(tasklistProperties.getBackup().getRepositoryName())
-          .isEqualTo("repositoryNameLegacyTasklist");
+    void shouldSetRepositoryNameIfNewAndTasklistMatch() {
+      assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
     }
   }
 
@@ -82,11 +83,11 @@ public class DataBackupTasklistPropertiesTest {
   @TestPropertySource(
       properties = {
         // new
-        "camunda.data.backup.repository-name=repositoryNameNew",
+        "camunda.data.backup.repository-name=repositoryName",
         // legacy configuration operate
-        "camunda.operate.backup.repositoryName=repositoryNameLegacyOperate",
+        "camunda.operate.backup.repositoryName=repositoryName",
         // legacy configuration tasklist
-        "camunda.tasklist.backup.repositoryName=repositoryNameLegacyTasklist",
+        "camunda.tasklist.backup.repositoryName=repositoryName",
       })
   class WithNewAndLegacySet {
     final TasklistProperties tasklistProperties;
@@ -96,8 +97,8 @@ public class DataBackupTasklistPropertiesTest {
     }
 
     @Test
-    void shouldSetRepositoryNameFromNew() {
-      assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryNameNew");
+    void shouldSetRepositoryNameIfNewAndLegacyMatch() {
+      assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
     }
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -160,10 +160,7 @@ public class BackupRestoreIT {
                   "Unsupported database type: " + config.databaseType);
         };
 
-    testStandaloneApplication.withProperty(
-        "camunda.tasklist.backup.repositoryName", REPOSITORY_NAME);
-    testStandaloneApplication.withProperty(
-        "camunda.operate.backup.repositoryName", REPOSITORY_NAME);
+    testStandaloneApplication.withProperty("camunda.data.backup.repository-name", REPOSITORY_NAME);
 
     testStandaloneApplication.start().awaitCompleteTopology();
 


### PR DESCRIPTION
## Description

This PR sets the unified configuration property repository-name backward compatibility mode to SUPPORTED_ONY_IF_VALUES_MATCH as requested in thread https://camunda.slack.com/archives/C08E56YUUMS/p1761051426497999 

## Related issues

closes #
