### PR TITLE
[Backport stable/8.8] Ensure correct element id is set when resolving old incidents

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -391,6 +391,11 @@ public final class EventAppliers implements EventApplier {
         2,
         new IncidentResolvedV2Applier(
             state.getIncidentState(), state.getJobState(), state.getElementInstanceState()));
+    register(
+        IncidentIntent.RESOLVED,
+        3,
+        new IncidentResolvedV3Applier(
+            state.getIncidentState(), state.getJobState(), state.getElementInstanceState()));
     register(IncidentIntent.MIGRATED, new IncidentMigratedApplier(state.getIncidentState()));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV3Applier.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.job.JobThrowErrorProcessor;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import java.util.EnumSet;
+import java.util.Set;
+
+final class IncidentResolvedV3Applier implements TypedEventApplier<IncidentIntent, IncidentRecord> {
+
+  private static final Set<State> RESOLVABLE_JOB_STATES =
+      EnumSet.of(State.FAILED, State.ERROR_THROWN);
+
+  private final MutableIncidentState incidentState;
+  private final MutableJobState jobState;
+  private final MutableElementInstanceState elementInstanceState;
+
+  public IncidentResolvedV3Applier(
+      final MutableIncidentState incidentState,
+      final MutableJobState jobState,
+      final MutableElementInstanceState elementInstanceState) {
+    this.incidentState = incidentState;
+    this.jobState = jobState;
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void applyState(final long incidentKey, final IncidentRecord value) {
+    if (value.getErrorType() == ErrorType.EXTRACT_VALUE_ERROR) {
+      resetListenerIndices(value);
+    }
+
+    final var jobKey = value.getJobKey();
+    final boolean isJobRelatedIncident = jobKey > 0;
+
+    if (isJobRelatedIncident) {
+      final var stateOfJob = jobState.getState(jobKey);
+      if (RESOLVABLE_JOB_STATES.contains(stateOfJob)) {
+        final var job = jobState.getJob(jobKey);
+        resetElementId(job, value.getElementId());
+        jobState.resolve(jobKey, job);
+      }
+    }
+    incidentState.deleteIncident(incidentKey);
+  }
+
+  private void resetListenerIndices(final IncidentRecord value) {
+    final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
+    if (elementInstance != null) {
+      elementInstance.resetExecutionListenerIndex();
+      elementInstance.resetTaskListenerIndices();
+      elementInstanceState.updateInstance(elementInstance);
+    }
+  }
+
+  /**
+   * {@link JobThrowErrorProcessor} sets the job's elementId to NO_CATCH_EVENT_FOUND for unhandled
+   * error incidents. In order to completely resolve the issue, the elementId must be reset.
+   */
+  private void resetElementId(final JobRecord job, final String incidentRecordElementId) {
+    if (JobThrowErrorProcessor.NO_CATCH_EVENT_FOUND.equals(job.getElementId())) {
+      // change the job object here, it will be persisted with the jobState.resolve call
+      job.setElementId(incidentRecordElementId);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV3Applier.java
@@ -73,8 +73,16 @@ final class IncidentResolvedV3Applier implements TypedEventApplier<IncidentInten
    */
   private void resetElementId(final JobRecord job, final String incidentRecordElementId) {
     if (JobThrowErrorProcessor.NO_CATCH_EVENT_FOUND.equals(job.getElementId())) {
+
       // change the job object here, it will be persisted with the jobState.resolve call
-      job.setElementId(incidentRecordElementId);
+      if (JobThrowErrorProcessor.NO_CATCH_EVENT_FOUND.equals(incidentRecordElementId)) {
+        final var elementInstance = elementInstanceState.getInstance(job.getElementInstanceKey());
+        if (elementInstance != null) {
+          job.setElementId(elementInstance.getValue().getElementId());
+        }
+      } else {
+        job.setElementId(incidentRecordElementId);
+      }
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedApplierTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.processing.job.JobThrowErrorProcessor;
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class IncidentResolvedApplierTest {
+
+  private MutableProcessingState processingState;
+  private MutableIncidentState incidentState;
+  private MutableJobState jobStateMock;
+  private MutableElementInstanceState elementInstanceStateMock;
+  private IncidentResolvedV3Applier applier;
+
+  @BeforeEach
+  public void setup() {
+    jobStateMock = mock(MutableJobState.class);
+    incidentState = processingState.getIncidentState();
+    elementInstanceStateMock = mock(MutableElementInstanceState.class);
+    applier = new IncidentResolvedV3Applier(incidentState, jobStateMock, elementInstanceStateMock);
+  }
+
+  @Test
+  void shouldRevertJobElementIdOnIncidentResolution() {
+    // given
+    final var incidentKey = 1L;
+    final var jobKey = 2L;
+    final var elementInstanceKey = 3L;
+    final var elementId = "elementId";
+    final var incidentRecord =
+        new IncidentRecord()
+            .setErrorType(ErrorType.UNHANDLED_ERROR_EVENT)
+            .setJobKey(jobKey)
+            .setElementId(BufferUtil.wrapString(elementId));
+
+    final var job =
+        new JobRecord()
+            .setElementInstanceKey(elementInstanceKey)
+            .setElementId(JobThrowErrorProcessor.NO_CATCH_EVENT_FOUND);
+    when(jobStateMock.getState(jobKey)).thenReturn(State.ERROR_THROWN);
+    when(jobStateMock.getJob(jobKey)).thenReturn(job);
+
+    // when
+    applier.applyState(incidentKey, incidentRecord);
+
+    // then
+    assertThat(job.getElementId()).isEqualTo(elementId);
+  }
+
+  @Test
+  void shouldRevertJobElementIdOnIncidentResolutionWhenIncidentContainsWrongElementId() {
+    // given
+    final var incidentKey = 1L;
+    final var jobKey = 2L;
+    final var elementInstanceKey = 3L;
+    final var oldElementId = JobThrowErrorProcessor.NO_CATCH_EVENT_FOUND;
+    final var newElementId = "elementId";
+    final var incidentRecord =
+        new IncidentRecord()
+            .setErrorType(ErrorType.UNHANDLED_ERROR_EVENT)
+            .setJobKey(jobKey)
+            .setElementId(BufferUtil.wrapString(oldElementId));
+
+    final var job =
+        new JobRecord().setElementInstanceKey(elementInstanceKey).setElementId(oldElementId);
+    when(jobStateMock.getState(jobKey)).thenReturn(State.ERROR_THROWN);
+    when(jobStateMock.getJob(jobKey)).thenReturn(job);
+
+    final var elementInstance = new ElementInstance();
+    elementInstance.getValue().setElementId(newElementId);
+    when(elementInstanceStateMock.getInstance(elementInstanceKey)).thenReturn(elementInstance);
+
+    // when
+    applier.applyState(incidentKey, incidentRecord);
+
+    // then
+    assertThat(job.getElementId()).isEqualTo(newElementId);
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Incident_RESOLVED_v3.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Incident_RESOLVED_v3.golden
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.job.JobThrowErrorProcessor;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import java.util.EnumSet;
+import java.util.Set;
+
+final class IncidentResolvedV3Applier implements TypedEventApplier<IncidentIntent, IncidentRecord> {
+
+  private static final Set<State> RESOLVABLE_JOB_STATES =
+      EnumSet.of(State.FAILED, State.ERROR_THROWN);
+
+  private final MutableIncidentState incidentState;
+  private final MutableJobState jobState;
+  private final MutableElementInstanceState elementInstanceState;
+
+  public IncidentResolvedV3Applier(
+      final MutableIncidentState incidentState,
+      final MutableJobState jobState,
+      final MutableElementInstanceState elementInstanceState) {
+    this.incidentState = incidentState;
+    this.jobState = jobState;
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void applyState(final long incidentKey, final IncidentRecord value) {
+    if (value.getErrorType() == ErrorType.EXTRACT_VALUE_ERROR) {
+      resetListenerIndices(value);
+    }
+
+    final var jobKey = value.getJobKey();
+    final boolean isJobRelatedIncident = jobKey > 0;
+
+    if (isJobRelatedIncident) {
+      final var stateOfJob = jobState.getState(jobKey);
+      if (RESOLVABLE_JOB_STATES.contains(stateOfJob)) {
+        final var job = jobState.getJob(jobKey);
+        resetElementId(job, value.getElementId());
+        jobState.resolve(jobKey, job);
+      }
+    }
+    incidentState.deleteIncident(incidentKey);
+  }
+
+  private void resetListenerIndices(final IncidentRecord value) {
+    final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
+    if (elementInstance != null) {
+      elementInstance.resetExecutionListenerIndex();
+      elementInstance.resetTaskListenerIndices();
+      elementInstanceState.updateInstance(elementInstance);
+    }
+  }
+
+  /**
+   * {@link JobThrowErrorProcessor} sets the job's elementId to NO_CATCH_EVENT_FOUND for unhandled
+   * error incidents. In order to completely resolve the issue, the elementId must be reset.
+   */
+  private void resetElementId(final JobRecord job, final String incidentRecordElementId) {
+    if (JobThrowErrorProcessor.NO_CATCH_EVENT_FOUND.equals(job.getElementId())) {
+
+      // change the job object here, it will be persisted with the jobState.resolve call
+      if (JobThrowErrorProcessor.NO_CATCH_EVENT_FOUND.equals(incidentRecordElementId)) {
+        final var elementInstance = elementInstanceState.getInstance(job.getElementInstanceKey());
+        if (elementInstance != null) {
+          job.setElementId(elementInstance.getValue().getElementId());
+        }
+      } else {
+        job.setElementId(incidentRecordElementId);
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description
Backport of #39861 to `stable/8.8`.

relates to #39853