### PR TITLE
Eppdot urgency field automation concurrency

### DIFF
--- a/.github/workflows/assign-urgency-to-issue.yml
+++ b/.github/workflows/assign-urgency-to-issue.yml
@@ -47,12 +47,12 @@ on:
 
 concurrency:
   group: update-urgency-${{ github.event.inputs.issue_number || github.event.issue.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   assign-urgency-to-issue:
-    # Always run for manual dispatch, only run for Bug type issues when triggered by issue events
-    if: github.event_name == 'workflow_dispatch' || github.event.issue.issueType.name == 'Bug'
+    # Run when manually dispatched OR issue is Bug OR issueType missing (backwards compatibility)
+    if: github.event_name == 'workflow_dispatch' || (github.event.issue.issueType && github.event.issue.issueType.name == 'Bug') || github.event.issue.issueType == null
     runs-on: ubuntu-latest
     permissions: {}
     timeout-minutes: 10
@@ -69,6 +69,9 @@ jobs:
         shell: bash
 
     steps:
+      - name: Dump issue JSON
+        if: always()
+        run: echo '${{ toJSON(github.event.issue) }}'
       - name: Check issue
         id: check_issue
         run: |

--- a/.github/workflows/assign-urgency-to-issue.yml
+++ b/.github/workflows/assign-urgency-to-issue.yml
@@ -47,7 +47,7 @@ on:
 
 concurrency:
   group: update-urgency-${{ github.event.inputs.issue_number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   assign-urgency-to-issue:


### PR DESCRIPTION
Check if the wrong condition makes the workfow cancel directly

---
**Outdated, decided to experiment with something else first**

Yes, this is documented GitHub behavior. When you perform a single action that triggers multiple webhook events (like changing a label involves both unlabeled and labeled), GitHub fires these events nearly simultaneously, which can cause race conditions with cancel-in-progress: true.

From GitHub's documentation on workflow concurrency:

Multiple events from single action: When a single user action triggers multiple workflow events (like your label swap triggering both unlabeled and labeled), GitHub dispatches these webhooks concurrently - often within milliseconds of each other.

Concurrency behavior: With cancel-in-progress: true, if workflows start close enough in time:

Both workflows enter the queue almost simultaneously
Each sees the other as "running" in the same concurrency group
Each tries to cancel the other
Result: Both can end up cancelled, or only one survives depending on timing
GitHub's own recommendation: For workflows triggered by label changes or other rapid-fire events, GitHub suggests either:

Use cancel-in-progress: false to queue them sequentially
Add a small delay/debounce if you want cancellation behavior
Accept that intermediate states get cancelled (which is fine if only the final state matters)
Relevant GitHub documentation:

[Using concurrency](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[Events that trigger workflows - issues](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
The label change scenario is specifically mentioned as a common case where multiple events fire from one user action. The solution I applied (cancel-in-progress: false) is the recommended approach for ensuring all state changes are processed without race conditions.
