### PR TITLE
Initial implementation of global user task listeners

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -21,6 +21,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private UsageMetricsCfg usageMetrics = new UsageMetricsCfg();
   private DistributionCfg distribution = new DistributionCfg();
   private int maxProcessDepth = EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH;
+  private ListenersCfg listeners = new ListenersCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -31,6 +32,7 @@ public final class EngineCfg implements ConfigurationEntry {
     validators.init(globalConfig, brokerBase);
     distribution.init(globalConfig, brokerBase);
     usageMetrics.init(globalConfig, brokerBase);
+    listeners.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -97,6 +99,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.maxProcessDepth = maxProcessDepth;
   }
 
+  public ListenersCfg getListeners() {
+    return listeners;
+  }
+
+  public void setListeners(final ListenersCfg listeners) {
+    this.listeners = listeners;
+  }
+
   @Override
   public String toString() {
     return "EngineCfg{"
@@ -144,6 +154,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setCommandDistributionPaused(distribution.isPauseCommandDistribution())
         .setCommandRedistributionInterval(distribution.getRedistributionInterval())
         .setCommandRedistributionMaxBackoff(distribution.getMaxBackoffDuration())
-        .setMaxProcessDepth(getMaxProcessDepth());
+        .setMaxProcessDepth(getMaxProcessDepth())
+        .setListeners(listeners.createListenersConfiguration());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ListenerCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ListenerCfg.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.ListenerConfiguration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListenerCfg implements ConfigurationEntry {
+
+  private static final String DEFAULT_RETRIES = "3";
+
+  private List<String> eventTypes = new ArrayList<>();
+  private String type;
+  private String retries = DEFAULT_RETRIES;
+
+  public List<String> getEventTypes() {
+    return eventTypes;
+  }
+
+  public void setEventTypes(final List<String> eventTypes) {
+    this.eventTypes = eventTypes;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
+  }
+
+  public String getRetries() {
+    return retries;
+  }
+
+  public void setRetries(final String retries) {
+    this.retries = retries;
+  }
+
+  public ListenerConfiguration createListenerConfiguration() {
+    return new ListenerConfiguration(eventTypes, type, retries);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ListenersCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ListenersCfg.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.ListenersConfiguration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListenersCfg implements ConfigurationEntry {
+
+  /**
+   * Configures global listeners that will be applied to all user tasks within the process and will
+   * be triggered during task processing.
+   */
+  private List<ListenerCfg> task = new ArrayList<>();
+
+  public List<ListenerCfg> getTask() {
+    return task;
+  }
+
+  public void setTask(final List<ListenerCfg> task) {
+    this.task = task;
+  }
+
+  public ListenersConfiguration createListenersConfiguration() {
+    return new ListenersConfiguration(
+        task.stream().map(ListenerCfg::createListenerConfiguration).toList());
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -46,6 +46,7 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL);
     assertThat(configuration.getCommandRedistributionMaxBackoff())
         .isEqualTo(EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION);
+    assertThat(configuration.getListeners().task()).isEmpty();
   }
 
   @Test
@@ -68,5 +69,10 @@ final class EngineCfgTest {
     assertThat(configuration.getCommandRedistributionInterval()).isEqualTo(Duration.ofSeconds(60));
     assertThat(configuration.getCommandRedistributionMaxBackoff())
         .isEqualTo(Duration.ofMinutes(20));
+    assertThat(configuration.getListeners().task()).hasSize(1);
+    final var listener = configuration.getListeners().task().getFirst();
+    assertThat(listener.type()).isEqualTo("test");
+    assertThat(listener.eventTypes()).containsExactly("creating", "canceling");
+    assertThat(listener.retries()).isEqualTo("5");
   }
 }

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -18,3 +18,10 @@ zeebe:
           redistributionInterval: 60s
           maxBackoffDuration: 20m
         maxProcessDepth: 2000
+        listeners:
+          task:
+            - type: test
+              eventTypes:
+                - creating
+                - canceling
+              retries: 5

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -90,6 +90,7 @@ public final class EngineConfiguration {
       DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION;
 
   private boolean enableIdentitySetup = DEFAULT_ENABLE_IDENTITY_SETUP;
+  private ListenersConfiguration listeners = ListenersConfiguration.empty();
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -334,6 +335,15 @@ public final class EngineConfiguration {
 
   public EngineConfiguration setEnableIdentitySetup(final boolean enableIdentitySetup) {
     this.enableIdentitySetup = enableIdentitySetup;
+    return this;
+  }
+
+  public ListenersConfiguration getListeners() {
+    return listeners;
+  }
+
+  public EngineConfiguration setListeners(final ListenersConfiguration listeners) {
+    this.listeners = listeners;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenerConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenerConfiguration.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine;
+
+import java.util.List;
+
+public record ListenerConfiguration(List<String> eventTypes, String type, String retries) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenersConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenersConfiguration.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine;
+
+import java.util.Collections;
+import java.util.List;
+
+public record ListenersConfiguration(List<ListenerConfiguration> task) {
+  public static ListenersConfiguration empty() {
+    return new ListenersConfiguration(Collections.emptyList());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
@@ -9,16 +9,32 @@ package io.camunda.zeebe.engine.processing.deployment.model;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.ListenersConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
 import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidator;
 import java.time.InstantSource;
+import java.util.Objects;
 
 public final class BpmnFactory {
 
-  public static BpmnTransformer createTransformer(final InstantSource clock) {
-    return new BpmnTransformer(createExpressionLanguage(new ZeebeFeelEngineClock(clock)));
+  public BpmnFactory() {
+    /* utility class */
+  }
+
+  public static BpmnTransformer createTransformer(
+      final InstantSource clock, final EngineConfiguration configuration) {
+    final ListenersConfiguration listenerConfig;
+    if (configuration != null) {
+      listenerConfig =
+          Objects.requireNonNullElse(configuration.getListeners(), ListenersConfiguration.empty());
+    } else {
+      listenerConfig = ListenersConfiguration.empty();
+    }
+    return new BpmnTransformer(
+        createExpressionLanguage(new ZeebeFeelEngineClock(clock)), listenerConfig);
   }
 
   public static BpmnValidator createValidator(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.deployment.model.transformation;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.engine.ListenersConfiguration;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.AdHocSubProcessTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.BoundaryEventTransformer;
@@ -71,7 +72,9 @@ public final class BpmnTransformer {
 
   private final ExpressionLanguage expressionLanguage;
 
-  public BpmnTransformer(final ExpressionLanguage expressionLanguage) {
+  public BpmnTransformer(
+      final ExpressionLanguage expressionLanguage,
+      final ListenersConfiguration listenersConfiguration) {
     this.expressionLanguage = expressionLanguage;
 
     step1Visitor = new TransformationVisitor();
@@ -96,7 +99,8 @@ public final class BpmnTransformer {
     step2Visitor.registerHandler(new ScriptTaskTransformer());
     step2Visitor.registerHandler(new SequenceFlowTransformer());
     step2Visitor.registerHandler(new StartEventTransformer());
-    step2Visitor.registerHandler(new UserTaskTransformer(expressionLanguage));
+    step2Visitor.registerHandler(
+        new UserTaskTransformer(expressionLanguage, listenersConfiguration));
 
     step3Visitor = new TransformationVisitor();
     step3Visitor.registerHandler(new ContextProcessTransformer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -60,7 +60,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
       final boolean enableStraightThroughProcessingLoopDetector,
       final EngineConfiguration config,
       final InstantSource clock) {
-    bpmnTransformer = BpmnFactory.createTransformer(clock);
+    bpmnTransformer = BpmnFactory.createTransformer(clock, config);
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
     this.checksumGenerator = checksumGenerator;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -114,7 +114,7 @@ public final class DbProcessState implements MutableProcessState {
       final TransactionContext transactionContext,
       final EngineConfiguration config,
       final InstantSource clock) {
-    transformer = BpmnFactory.createTransformer(clock);
+    transformer = BpmnFactory.createTransformer(clock, config);
     processDefinitionKey = new DbLong();
     persistedProcess = new PersistedProcess();
     tenantIdKey = new DbString();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.ListenersConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
@@ -42,7 +43,8 @@ class UserTaskTransformerTest {
   private final ExpressionLanguage expressionLanguage =
       ExpressionLanguageFactory.createExpressionLanguage(
           new ZeebeFeelEngineClock(InstantSource.system()));
-  private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
+  private final BpmnTransformer transformer =
+      new BpmnTransformer(expressionLanguage, ListenersConfiguration.empty());
 
   private BpmnModelInstance processWithUserTask(final Consumer<UserTaskBuilder> userTaskModifier) {
     return Bpmn.createExecutableProcess().startEvent().userTask(TASK_ID, userTaskModifier).done();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyProcessState.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyProcessState.java
@@ -83,7 +83,7 @@ public final class LegacyProcessState {
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
       final InstantSource clock) {
-    transformer = BpmnFactory.createTransformer(clock);
+    transformer = BpmnFactory.createTransformer(clock, null);
     processDefinitionKey = new DbLong();
     persistedProcess = new PersistedProcess();
     processColumnFamily =


### PR DESCRIPTION
## Description

In https://github.com/camunda/camunda/pull/38418 a Proof of Concept was created for implementing global listeners (both task and execution) with a configuration file approach. This PR is related only to global task listeners (excluding global execution listeners).
With respect with the original PoC, this PR:
- aligns the configuration syntax considering the configuration properties below
- ensures that there are no CI failures

#### Configuration properties for global task listeners

- eventTypes: Specifies a list of user task event types that trigger the listener. Supported values are creating, assigning, updating, completing, and canceling
- type: The name of the job type. Used as a reference to specify which job workers request the respective task listener job.
- retries: The number of retries for the user task listener job (defaults to 3 if omitted).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39924
