### PR TITLE
ci: build identity with npm for benchmark tests

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -132,7 +132,7 @@ runs:
       if: ${{ inputs.source-build == 'true' }}
       working-directory: ./identity/client
       shell: bash
-      run: yarn
+      run: npm ci
 
     - uses: ./.github/actions/build-zeebe
       if: ${{ inputs.source-build == 'true' }}

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -152,6 +152,7 @@ jobs:
         id: build-identity-fe
         with:
           directory: ./identity/client
+          package-manager: "npm"
       - uses: ./.github/actions/build-zeebe
         name: Build Camunda Platform
         id: build-camunda

--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -112,6 +112,7 @@ jobs:
         id: build-identity-fe
         with:
           directory: ./identity/client
+          package-manager: "npm"
       - uses: ./.github/actions/build-zeebe
         name: Build Zeebe
         id: build-zeebe

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -358,7 +358,7 @@ jobs:
   run-backup-restore-tests:
     if: inputs.runBeTests
     name: "Integration / Backup Restore ITs"
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1466,6 +1466,7 @@ jobs:
         id: build-identity-fe
         with:
           directory: ./identity/client
+          package-manager: "npm"
       # compile and generate-sources to ensure that the Javadoc can be properly generated; compile is
       # necessary when using annotation preprocessors for code generation, as otherwise the symbols are
       # not resolve-able by the Javadoc generator
@@ -1524,6 +1525,7 @@ jobs:
         id: build-identity-fe
         with:
           directory: ./identity/client
+          package-manager: "npm"
       - uses: ./.github/actions/build-zeebe
         id: build-camunda
         with:

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -145,6 +145,7 @@ jobs:
         id: build-identity-fe
         with:
           directory: ./identity/client
+          package-manager: "npm"
       - uses: ./.github/actions/build-zeebe
         name: Build Zeebe
         id: build-zeebe


### PR DESCRIPTION
## Description

This pull request makes a minor update to the workflow configuration for building the identity frontend. The change explicitly sets the package manager to `npm` for the build step, ensuring consistency and clarity in the build process.

([.github/workflows/zeebe-benchmark.ymlR148](diffhunk://#diff-4546845324597d9802d983f9a1a32d9b91fd5b9980c5ad8444a042d12f886c1dR148))

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
