### PR TITLE
Allow ordering global task listeners with respect to local ones

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ListenerCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ListenerCfg.java
@@ -19,6 +19,7 @@ public class ListenerCfg implements ConfigurationEntry {
   private List<String> eventTypes = new ArrayList<>();
   private String type;
   private String retries = DEFAULT_RETRIES;
+  private boolean afterLocal = false;
 
   public List<String> getEventTypes() {
     return eventTypes;
@@ -44,7 +45,15 @@ public class ListenerCfg implements ConfigurationEntry {
     this.retries = retries;
   }
 
+  public boolean isAfterLocal() {
+    return afterLocal;
+  }
+
+  public void setAfterLocal(final boolean afterLocal) {
+    this.afterLocal = afterLocal;
+  }
+
   public ListenerConfiguration createListenerConfiguration() {
-    return new ListenerConfiguration(eventTypes, type, retries);
+    return new ListenerConfiguration(eventTypes, type, retries, afterLocal);
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.ListenerConfiguration;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -69,10 +70,23 @@ final class EngineCfgTest {
     assertThat(configuration.getCommandRedistributionInterval()).isEqualTo(Duration.ofSeconds(60));
     assertThat(configuration.getCommandRedistributionMaxBackoff())
         .isEqualTo(Duration.ofMinutes(20));
-    assertThat(configuration.getListeners().task()).hasSize(1);
-    final var listener = configuration.getListeners().task().getFirst();
-    assertThat(listener.type()).isEqualTo("test");
-    assertThat(listener.eventTypes()).containsExactly("creating", "canceling");
-    assertThat(listener.retries()).isEqualTo("5");
+    assertThat(configuration.getListeners().task()).hasSize(2);
+    final var taskListeners = configuration.getListeners().task();
+    assertListenerCfg(
+        taskListeners.get(0), "test1", new String[] {"creating", "canceling"}, "5", false);
+    assertListenerCfg(
+        taskListeners.get(1), "test2", new String[] {"assigning", "canceling"}, "2", true);
+  }
+
+  void assertListenerCfg(
+      final ListenerConfiguration config,
+      final String type,
+      final String[] eventTypes,
+      final String retries,
+      final boolean afterLocal) {
+    assertThat(config.type()).isEqualTo(type);
+    assertThat(config.eventTypes()).containsExactly(eventTypes);
+    assertThat(config.retries()).isEqualTo(retries);
+    assertThat(config.afterLocal()).isEqualTo(afterLocal);
   }
 }

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -20,8 +20,14 @@ zeebe:
         maxProcessDepth: 2000
         listeners:
           task:
-            - type: test
+            - type: test1
               eventTypes:
                 - creating
                 - canceling
               retries: 5
+            - type: test2
+              eventTypes:
+                - assigning
+                - canceling
+              retries: 2
+              afterLocal: true

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenerConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenerConfiguration.java
@@ -9,4 +9,5 @@ package io.camunda.zeebe.engine;
 
 import java.util.List;
 
-public record ListenerConfiguration(List<String> eventTypes, String type, String retries) {}
+public record ListenerConfiguration(
+    List<String> eventTypes, String type, String retries, boolean afterLocal) {}


### PR DESCRIPTION
## Description

It should be possible to configure Global User Task Listeners to be run either before of after the ones defined at process-level.
This PR accomplishes this by adding a new configuration property to the global listeners configuration:
- afterLocal: If true, the listener is executed after local ones (defined at the definition level). The default behaviour is to run global listeners before the ones defined at the process definition level.

This flag is then used to add the global listeners either to the beginning or the end of the task listeners list for each user task.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39925
