### PR TITLE
feat: uc: added request/limit config

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Aimd.java
+++ b/configuration/src/main/java/io/camunda/configuration/Aimd.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import java.time.Duration;
+
+// AIMD backpressure algorithm configs
+public class Aimd {
+
+  private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMillis(200);
+  private static final int DEFAULT_INITIAL_LIMIT = 100;
+  private static final int DEFAULT_MIN_LIMIT = 1;
+  private static final int DEFAULT_MAX_LIMIT = 1000;
+  private static final double DEFAULT_BACKOFF_RATIO = 0.9;
+
+  /** The request timeout */
+  private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+
+  /** The initial limit */
+  private int initialLimit = DEFAULT_INITIAL_LIMIT;
+
+  /** The minimum limit */
+  private int minLimit = DEFAULT_MIN_LIMIT;
+
+  /** The maximum limit */
+  private int maxLimit = DEFAULT_MAX_LIMIT;
+
+  /** The backoff ratio */
+  private double backoffRatio = DEFAULT_BACKOFF_RATIO;
+
+  public Duration getRequestTimeout() {
+    return requestTimeout;
+  }
+
+  public void setRequestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+  }
+
+  public int getInitialLimit() {
+    return initialLimit;
+  }
+
+  public void setInitialLimit(final int initialLimit) {
+    this.initialLimit = initialLimit;
+  }
+
+  public int getMinLimit() {
+    return minLimit;
+  }
+
+  public void setMinLimit(final int minLimit) {
+    this.minLimit = minLimit;
+  }
+
+  public int getMaxLimit() {
+    return maxLimit;
+  }
+
+  public void setMaxLimit(final int maxLimit) {
+    this.maxLimit = maxLimit;
+  }
+
+  public double getBackoffRatio() {
+    return backoffRatio;
+  }
+
+  public void setBackoffRatio(final double backoffRatio) {
+    this.backoffRatio = backoffRatio;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Fixed.java
+++ b/configuration/src/main/java/io/camunda/configuration/Fixed.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+// Fixed backpressure algorithm config
+public class Fixed {
+
+  private static final int DEFAULT_LIMIT = 20;
+
+  /** The limit */
+  private int limit = DEFAULT_LIMIT;
+
+  public int getLimit() {
+    return limit;
+  }
+
+  public void setLimit(final int limit) {
+    this.limit = limit;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/FlowControl.java
+++ b/configuration/src/main/java/io/camunda/configuration/FlowControl.java
@@ -11,8 +11,19 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class FlowControl {
 
+  /** Configure request limit */
+  @NestedConfigurationProperty private Limit request = null;
+
   /** Configure rate limit */
   @NestedConfigurationProperty private Write write = null;
+
+  public Limit getRequest() {
+    return request;
+  }
+
+  public void setRequest(final Limit request) {
+    this.request = request;
+  }
 
   public Write getWrite() {
     return write;

--- a/configuration/src/main/java/io/camunda/configuration/Gradient.java
+++ b/configuration/src/main/java/io/camunda/configuration/Gradient.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+// Gradient backpressure algorithm configs
+public class Gradient {
+
+  private static final int DEFAULT_MIN_LIMIT = 10;
+  private static final int DEFAULT_INITIAL_LIMIT = 20;
+  private static final double DEFAULT_RTT_TOLERANCE = 2.0;
+
+  /** The minimum limit */
+  private int minLimit = DEFAULT_MIN_LIMIT;
+
+  /** The initial limit */
+  private int initialLimit = DEFAULT_INITIAL_LIMIT;
+
+  /** The RTT tolerance */
+  private double rttTolerance = DEFAULT_RTT_TOLERANCE;
+
+  public int getMinLimit() {
+    return minLimit;
+  }
+
+  public void setMinLimit(final int minLimit) {
+    this.minLimit = minLimit;
+  }
+
+  public int getInitialLimit() {
+    return initialLimit;
+  }
+
+  public void setInitialLimit(final int initialLimit) {
+    this.initialLimit = initialLimit;
+  }
+
+  public double getRttTolerance() {
+    return rttTolerance;
+  }
+
+  public void setRttTolerance(final double rttTolerance) {
+    this.rttTolerance = rttTolerance;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Gradient2.java
+++ b/configuration/src/main/java/io/camunda/configuration/Gradient2.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+// Gradient2 backpressure algorithm configs
+public class Gradient2 {
+
+  private static final int DEFAULT_MIN_LIMIT = 10;
+  private static final int DEFAULT_INITIAL_LIMIT = 20;
+  private static final double DEFAULT_RTT_TOLERANCE = 2.0;
+  private static final int DEFAULT_LONG_WINDOW = 600;
+
+  /** The minimum limit */
+  private int minLimit = DEFAULT_MIN_LIMIT;
+
+  /** The initial limit */
+  private int initialLimit = DEFAULT_INITIAL_LIMIT;
+
+  /** The RTT tolerance */
+  private double rttTolerance = DEFAULT_RTT_TOLERANCE;
+
+  /** The long window */
+  private int longWindow = DEFAULT_LONG_WINDOW;
+
+  public int getMinLimit() {
+    return minLimit;
+  }
+
+  public void setMinLimit(final int minLimit) {
+    this.minLimit = minLimit;
+  }
+
+  public int getInitialLimit() {
+    return initialLimit;
+  }
+
+  public void setInitialLimit(final int initialLimit) {
+    this.initialLimit = initialLimit;
+  }
+
+  public double getRttTolerance() {
+    return rttTolerance;
+  }
+
+  public void setRttTolerance(final double rttTolerance) {
+    this.rttTolerance = rttTolerance;
+  }
+
+  public int getLongWindow() {
+    return longWindow;
+  }
+
+  public void setLongWindow(final int longWindow) {
+    this.longWindow = longWindow;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/LegacyVegas.java
+++ b/configuration/src/main/java/io/camunda/configuration/LegacyVegas.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+// Legacy vegas backpressure algorithm configs
+public class LegacyVegas {
+
+  private static final int DEFAULT_INITIAL_LIMIT = 1024;
+  private static final int DEFAULT_MAX_CONCURRENCY = 1024 * 32;
+  private static final double DEFAULT_ALPHA_LIMIT = 0.7;
+  private static final double DEFAULT_BETA_LIMIT = 0.95;
+
+  /** The initial limit */
+  private int initialLimit = DEFAULT_INITIAL_LIMIT;
+
+  /** The max concurrency */
+  private int maxConcurrency = DEFAULT_MAX_CONCURRENCY;
+
+  /** The alpha limit */
+  private double alphaLimit = DEFAULT_ALPHA_LIMIT;
+
+  /** The beta limit */
+  private double betaLimit = DEFAULT_BETA_LIMIT;
+
+  public int getInitialLimit() {
+    return initialLimit;
+  }
+
+  public void setInitialLimit(final int initialLimit) {
+    this.initialLimit = initialLimit;
+  }
+
+  public int getMaxConcurrency() {
+    return maxConcurrency;
+  }
+
+  public void setMaxConcurrency(final int maxConcurrency) {
+    this.maxConcurrency = maxConcurrency;
+  }
+
+  public double getAlphaLimit() {
+    return alphaLimit;
+  }
+
+  public void setAlphaLimit(final double alphaLimit) {
+    this.alphaLimit = alphaLimit;
+  }
+
+  public double getBetaLimit() {
+    return betaLimit;
+  }
+
+  public void setBetaLimit(final double betaLimit) {
+    this.betaLimit = betaLimit;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Limit.java
+++ b/configuration/src/main/java/io/camunda/configuration/Limit.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+public class Limit {
+
+  private static final String PREFIX = "camunda.processing.flow-control.request";
+
+  private static final boolean DEFAULT_ENABLED = true;
+  private static final boolean DEFAULT_USE_WINDOWED = true;
+  private static final String DEFAULT_ALGORITHM = "aimd";
+
+  private static final Set<String> LEGACY_ENABLED_PROPERTIES =
+      Set.of("zeebe.broker.flowControl.request.enabled", "zeebe.broker.backpressure.enabled");
+  private static final Set<String> LEGACY_USE_WINDOWED_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.useWindowed", "zeebe.broker.backpressure.useWindowed");
+  private static final Set<String> LEGACY_ALGORITHM_PROPERTIES =
+      Set.of("zeebe.broker.flowControl.request.algorithm", "zeebe.broker.backpressure.algorithm");
+  private static final Set<String> LEGACY_AIMD_REQUEST_TIMEOUT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.aimd.requestTimeout",
+          "zeebe.broker.backpressure.aimd.requestTimeout");
+  private static final Set<String> LEGACY_AIMD_INITIAL_LIMIT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.aimd.initialLimit",
+          "zeebe.broker.backpressure.aimd.initialLimit");
+  private static final Set<String> LEGACY_AIMD_MIN_LIMIT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.aimd.minLimit",
+          "zeebe.broker.backpressure.aimd.minLimit");
+  private static final Set<String> LEGACY_AIMD_MAX_LIMIT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.aimd.maxLimit",
+          "zeebe.broker.backpressure.aimd.maxLimit");
+  private static final Set<String> LEGACY_AIMD_BACKOFF_RATIO_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.aimd.backoffRatio",
+          "zeebe.broker.backpressure.aimd.backoffRatio");
+  private static final Set<String> LEGACY_FIXED_LIMIT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.fixed.limit", "zeebe.broker.backpressure.fixed.limit");
+  private static final Set<String> LEGACY_VEGAS_ALPHA_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.vegas.alpha", "zeebe.broker.backpressure.vegas.alpha");
+  private static final Set<String> LEGACY_VEGAS_BETA_PROPERTIES =
+      Set.of("zeebe.broker.flowControl.request.vegas.beta", "zeebe.broker.backpressure.vegas.beta");
+  private static final Set<String> LEGACY_VEGAS_INITIAL_LIMIT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.vegas.initialLimit",
+          "zeebe.broker.backpressure.vegas.initialLimit");
+  private static final Set<String> LEGACY_GRADIENT_MIN_LIMIT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.gradient.minLimit",
+          "zeebe.broker.backpressure.gradient.minLimit");
+  private static final Set<String> LEGACY_GRADIENT_INITIAL_LIMIT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.gradient.initialLimit",
+          "zeebe.broker.backpressure.gradient.initialLimit");
+  private static final Set<String> LEGACY_GRADIENT_RTT_TOLERANCE_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.gradient.rttTolerance",
+          "zeebe.broker.backpressure.gradient.rttTolerance");
+  private static final Set<String> LEGACY_GRADIENT2_MIN_LIMIT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.gradient2.minLimit",
+          "zeebe.broker.backpressure.gradient2.minLimit");
+  private static final Set<String> LEGACY_GRADIENT2_INITIAL_LIMIT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.gradient2.initialLimit",
+          "zeebe.broker.backpressure.gradient2.initialLimit");
+  private static final Set<String> LEGACY_GRADIENT2_RTT_TOLERANCE_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.gradient2.rttTolerance",
+          "zeebe.broker.backpressure.gradient2.rttTolerance");
+  private static final Set<String> LEGACY_GRADIENT2_LONG_WINDOW_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.gradient2.longWindow",
+          "zeebe.broker.backpressure.gradient2.longWindow");
+  private static final Set<String> LEGACY_LEGACY_VEGAS_INITIAL_LIMIT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.legacyVegas.initialLimit",
+          "zeebe.broker.backpressure.legacyVegas.initialLimit");
+  private static final Set<String> LEGACY_LEGACY_VEGAS_MAX_CONCURRENCY_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.legacyVegas.maxConcurrency",
+          "zeebe.broker.backpressure.legacyVegas.maxConcurrency");
+  private static final Set<String> LEGACY_LEGACY_VEGAS_ALPHA_LIMIT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.legacyVegas.alphaLimit",
+          "zeebe.broker.backpressure.legacyVegas.alphaLimit");
+  private static final Set<String> LEGACY_LEGACY_VEGAS_BETA_LIMIT_PROPERTIES =
+      Set.of(
+          "zeebe.broker.flowControl.request.legacyVegas.betaLimit",
+          "zeebe.broker.backpressure.legacyVegas.betaLimit");
+
+  /** Enable request limit */
+  private boolean enabled = DEFAULT_ENABLED;
+
+  /** Use windowed limit */
+  private boolean windowed = DEFAULT_USE_WINDOWED;
+
+  /** The algorithm to use for limiting (aimd, fixed, vegas, gradient, gradient2, legacy-vegas) */
+  private String algorithm = DEFAULT_ALGORITHM;
+
+  // Algorithm-specific configurations
+  @NestedConfigurationProperty private final Aimd aimd = new Aimd();
+  @NestedConfigurationProperty private final Fixed fixed = new Fixed();
+  @NestedConfigurationProperty private final Vegas vegas = new Vegas();
+  @NestedConfigurationProperty private final Gradient gradient = new Gradient();
+  @NestedConfigurationProperty private final Gradient2 gradient2 = new Gradient2();
+  @NestedConfigurationProperty private final LegacyVegas legacyVegas = new LegacyVegas();
+
+  public boolean isEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enabled",
+        enabled,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_ENABLED_PROPERTIES);
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public boolean isWindowed() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".windowed",
+        windowed,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_USE_WINDOWED_PROPERTIES);
+  }
+
+  public void setWindowed(final boolean windowed) {
+    this.windowed = windowed;
+  }
+
+  public String getAlgorithm() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".algorithm",
+        algorithm,
+        String.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_ALGORITHM_PROPERTIES);
+  }
+
+  public void setAlgorithm(final String algorithm) {
+    this.algorithm = algorithm;
+  }
+
+  public Aimd getAimd() {
+    return aimd;
+  }
+
+  public Fixed getFixed() {
+    return fixed;
+  }
+
+  public Vegas getVegas() {
+    return vegas;
+  }
+
+  public Gradient getGradient() {
+    return gradient;
+  }
+
+  public Gradient2 getGradient2() {
+    return gradient2;
+  }
+
+  public LegacyVegas getLegacyVegas() {
+    return legacyVegas;
+  }
+
+  // Legacy property getters for backward compatibility validation
+  public Duration getAimdRequestTimeout() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".aimd.request-timeout",
+        aimd.getRequestTimeout(),
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_AIMD_REQUEST_TIMEOUT_PROPERTIES);
+  }
+
+  public int getAimdInitialLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".aimd.initial-limit",
+        aimd.getInitialLimit(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_AIMD_INITIAL_LIMIT_PROPERTIES);
+  }
+
+  public int getAimdMinLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".aimd.min-limit",
+        aimd.getMinLimit(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_AIMD_MIN_LIMIT_PROPERTIES);
+  }
+
+  public int getAimdMaxLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".aimd.max-limit",
+        aimd.getMaxLimit(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_AIMD_MAX_LIMIT_PROPERTIES);
+  }
+
+  public double getAimdBackoffRatio() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".aimd.backoff-ratio",
+        aimd.getBackoffRatio(),
+        Double.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_AIMD_BACKOFF_RATIO_PROPERTIES);
+  }
+
+  public int getFixedLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".fixed.limit",
+        fixed.getLimit(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_FIXED_LIMIT_PROPERTIES);
+  }
+
+  public int getVegasAlpha() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".vegas.alpha",
+        vegas.getAlpha(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_VEGAS_ALPHA_PROPERTIES);
+  }
+
+  public int getVegasBeta() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".vegas.beta",
+        vegas.getBeta(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_VEGAS_BETA_PROPERTIES);
+  }
+
+  public int getVegasInitialLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".vegas.initial-limit",
+        vegas.getInitialLimit(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_VEGAS_INITIAL_LIMIT_PROPERTIES);
+  }
+
+  public int getGradientMinLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".gradient.min-limit",
+        gradient.getMinLimit(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_GRADIENT_MIN_LIMIT_PROPERTIES);
+  }
+
+  public int getGradientInitialLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".gradient.initial-limit",
+        gradient.getInitialLimit(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_GRADIENT_INITIAL_LIMIT_PROPERTIES);
+  }
+
+  public double getGradientRttTolerance() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".gradient.rtt-tolerance",
+        gradient.getRttTolerance(),
+        Double.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_GRADIENT_RTT_TOLERANCE_PROPERTIES);
+  }
+
+  public int getGradient2MinLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".gradient2.min-limit",
+        gradient2.getMinLimit(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_GRADIENT2_MIN_LIMIT_PROPERTIES);
+  }
+
+  public int getGradient2InitialLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".gradient2.initial-limit",
+        gradient2.getInitialLimit(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_GRADIENT2_INITIAL_LIMIT_PROPERTIES);
+  }
+
+  public double getGradient2RttTolerance() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".gradient2.rtt-tolerance",
+        gradient2.getRttTolerance(),
+        Double.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_GRADIENT2_RTT_TOLERANCE_PROPERTIES);
+  }
+
+  public int getGradient2LongWindow() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".gradient2.long-window",
+        gradient2.getLongWindow(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_GRADIENT2_LONG_WINDOW_PROPERTIES);
+  }
+
+  public int getLegacyVegasInitialLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".legacy-vegas.initial-limit",
+        legacyVegas.getInitialLimit(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_LEGACY_VEGAS_INITIAL_LIMIT_PROPERTIES);
+  }
+
+  public int getLegacyVegasMaxConcurrency() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".legacy-vegas.max-concurrency",
+        legacyVegas.getMaxConcurrency(),
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_LEGACY_VEGAS_MAX_CONCURRENCY_PROPERTIES);
+  }
+
+  public double getLegacyVegasAlphaLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".legacy-vegas.alpha-limit",
+        legacyVegas.getAlphaLimit(),
+        Double.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_LEGACY_VEGAS_ALPHA_LIMIT_PROPERTIES);
+  }
+
+  public double getLegacyVegasBetaLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".legacy-vegas.beta-limit",
+        legacyVegas.getBetaLimit(),
+        Double.class,
+        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        LEGACY_LEGACY_VEGAS_BETA_LIMIT_PROPERTIES);
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Vegas.java
+++ b/configuration/src/main/java/io/camunda/configuration/Vegas.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+// Vegas backpressure algorithm configs
+public class Vegas {
+
+  private static final int DEFAULT_ALPHA = 3;
+  private static final int DEFAULT_BETA = 6;
+  private static final int DEFAULT_INITIAL_LIMIT = 20;
+
+  /** The alpha value */
+  private int alpha = DEFAULT_ALPHA;
+
+  /** The beta value */
+  private int beta = DEFAULT_BETA;
+
+  /** The initial limit */
+  private int initialLimit = DEFAULT_INITIAL_LIMIT;
+
+  public int getAlpha() {
+    return alpha;
+  }
+
+  public void setAlpha(final int alpha) {
+    this.alpha = alpha;
+  }
+
+  public int getBeta() {
+    return beta;
+  }
+
+  public void setBeta(final int beta) {
+    this.beta = beta;
+  }
+
+  public int getInitialLimit() {
+    return initialLimit;
+  }
+
+  public void setInitialLimit(final int initialLimit) {
+    this.initialLimit = initialLimit;
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/LimitPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/LimitPropertiesTest.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.backpressure.AIMDCfg;
+import io.camunda.zeebe.broker.system.configuration.backpressure.FixedCfg;
+import io.camunda.zeebe.broker.system.configuration.backpressure.Gradient2Cfg;
+import io.camunda.zeebe.broker.system.configuration.backpressure.GradientCfg;
+import io.camunda.zeebe.broker.system.configuration.backpressure.LegacyVegasCfg;
+import io.camunda.zeebe.broker.system.configuration.backpressure.LimitCfg;
+import io.camunda.zeebe.broker.system.configuration.backpressure.VegasCfg;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class LimitPropertiesTest {
+
+  private static final boolean EXPECTED_ENABLED = false;
+  private static final boolean EXPECTED_WINDOWED = false;
+  private static final String EXPECTED_ALGORITHM = "fixed";
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.flow-control.request.enabled=" + EXPECTED_ENABLED,
+        "camunda.processing.flow-control.request.windowed=" + EXPECTED_WINDOWED,
+        "camunda.processing.flow-control.request.algorithm=" + EXPECTED_ALGORITHM,
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetLimitProperties() {
+      assertThat(brokerBasedProperties.getFlowControl().getRequest())
+          .returns(EXPECTED_ENABLED, LimitCfg::isEnabled)
+          .returns(EXPECTED_WINDOWED, LimitCfg::useWindowed)
+          .returns(EXPECTED_ALGORITHM.toUpperCase(), cfg -> cfg.getAlgorithm().name());
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.flowControl.request.enabled=" + EXPECTED_ENABLED,
+        "zeebe.broker.flowControl.request.useWindowed=" + EXPECTED_WINDOWED,
+        "zeebe.broker.flowControl.request.algorithm=" + EXPECTED_ALGORITHM,
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetLimitPropertiesFromLegacy() {
+      assertThat(brokerBasedProperties.getFlowControl().getRequest())
+          .returns(EXPECTED_ENABLED, LimitCfg::isEnabled)
+          .returns(EXPECTED_WINDOWED, LimitCfg::useWindowed)
+          .returns(EXPECTED_ALGORITHM.toUpperCase(), cfg -> cfg.getAlgorithm().name());
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.flow-control.request.enabled=true",
+        "camunda.processing.flow-control.request.algorithm=aimd",
+        "camunda.processing.flow-control.request.aimd.request-timeout=500ms",
+        "camunda.processing.flow-control.request.aimd.initial-limit=150",
+        "camunda.processing.flow-control.request.aimd.min-limit=5",
+        "camunda.processing.flow-control.request.aimd.max-limit=2000",
+        "camunda.processing.flow-control.request.aimd.backoff-ratio=0.85",
+      })
+  class WithAimdAlgorithm {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithAimdAlgorithm(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetAimdProperties() {
+      final var request = brokerBasedProperties.getFlowControl().getRequest();
+      assertThat(request).isNotNull();
+      assertThat(request.getAlgorithm().name()).isEqualTo("AIMD");
+      assertThat(request.getAimd())
+          .returns(Duration.ofMillis(500), AIMDCfg::getRequestTimeout)
+          .returns(150, AIMDCfg::getInitialLimit)
+          .returns(5, AIMDCfg::getMinLimit)
+          .returns(2000, AIMDCfg::getMaxLimit)
+          .returns(0.85, AIMDCfg::getBackoffRatio);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.flowControl.request.enabled=true",
+        "zeebe.broker.flowControl.request.algorithm=aimd",
+        "zeebe.broker.flowControl.request.aimd.requestTimeout=500ms",
+        "zeebe.broker.flowControl.request.aimd.initialLimit=150",
+        "zeebe.broker.flowControl.request.aimd.minLimit=5",
+        "zeebe.broker.flowControl.request.aimd.maxLimit=2000",
+        "zeebe.broker.flowControl.request.aimd.backoffRatio=0.85",
+      })
+  class WithAimdAlgorithmLegacy {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithAimdAlgorithmLegacy(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetAimdPropertiesFromLegacy() {
+      final var request = brokerBasedProperties.getFlowControl().getRequest();
+      assertThat(request).isNotNull();
+      assertThat(request.getAlgorithm().name()).isEqualTo("AIMD");
+      assertThat(request.getAimd())
+          .returns(Duration.ofMillis(500), AIMDCfg::getRequestTimeout)
+          .returns(150, AIMDCfg::getInitialLimit)
+          .returns(5, AIMDCfg::getMinLimit)
+          .returns(2000, AIMDCfg::getMaxLimit)
+          .returns(0.85, AIMDCfg::getBackoffRatio);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.flow-control.request.enabled=true",
+        "camunda.processing.flow-control.request.algorithm=fixed",
+        "camunda.processing.flow-control.request.fixed.limit=50",
+      })
+  class WithFixedAlgorithm {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithFixedAlgorithm(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetFixedProperties() {
+      final var request = brokerBasedProperties.getFlowControl().getRequest();
+      assertThat(request).isNotNull();
+      assertThat(request.getAlgorithm().name()).isEqualTo("FIXED");
+      assertThat(request.getFixed()).returns(50, FixedCfg::getLimit);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.flowControl.request.enabled=true",
+        "zeebe.broker.flowControl.request.algorithm=fixed",
+        "zeebe.broker.flowControl.request.fixed.limit=50",
+      })
+  class WithFixedAlgorithmLegacy {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithFixedAlgorithmLegacy(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetFixedPropertiesFromLegacy() {
+      final var request = brokerBasedProperties.getFlowControl().getRequest();
+      assertThat(request).isNotNull();
+      assertThat(request.getAlgorithm().name()).isEqualTo("FIXED");
+      assertThat(request.getFixed()).returns(50, FixedCfg::getLimit);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.flow-control.request.enabled=true",
+        "camunda.processing.flow-control.request.algorithm=vegas",
+        "camunda.processing.flow-control.request.vegas.alpha=5",
+        "camunda.processing.flow-control.request.vegas.beta=10",
+        "camunda.processing.flow-control.request.vegas.initial-limit=30",
+      })
+  class WithVegasAlgorithm {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithVegasAlgorithm(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetVegasProperties() {
+      final var request = brokerBasedProperties.getFlowControl().getRequest();
+      assertThat(request).isNotNull();
+      assertThat(request.getAlgorithm().name()).isEqualTo("VEGAS");
+      assertThat(request.getVegas())
+          .returns(5, VegasCfg::getAlpha)
+          .returns(10, VegasCfg::getBeta)
+          .returns(30, VegasCfg::getInitialLimit);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.flowControl.request.enabled=true",
+        "zeebe.broker.flowControl.request.algorithm=vegas",
+        "zeebe.broker.flowControl.request.vegas.alpha=5",
+        "zeebe.broker.flowControl.request.vegas.beta=10",
+        "zeebe.broker.flowControl.request.vegas.initialLimit=30",
+      })
+  class WithVegasAlgorithmLegacy {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithVegasAlgorithmLegacy(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetVegasPropertiesFromLegacy() {
+      final var request = brokerBasedProperties.getFlowControl().getRequest();
+      assertThat(request).isNotNull();
+      assertThat(request.getAlgorithm().name()).isEqualTo("VEGAS");
+      assertThat(request.getVegas())
+          .returns(5, VegasCfg::getAlpha)
+          .returns(10, VegasCfg::getBeta)
+          .returns(30, VegasCfg::getInitialLimit);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.flow-control.request.enabled=true",
+        "camunda.processing.flow-control.request.algorithm=gradient",
+        "camunda.processing.flow-control.request.gradient.min-limit=15",
+        "camunda.processing.flow-control.request.gradient.initial-limit=25",
+        "camunda.processing.flow-control.request.gradient.rtt-tolerance=3.0",
+      })
+  class WithGradientAlgorithm {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithGradientAlgorithm(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetGradientProperties() {
+      final var request = brokerBasedProperties.getFlowControl().getRequest();
+      assertThat(request).isNotNull();
+      assertThat(request.getAlgorithm().name()).isEqualTo("GRADIENT");
+      assertThat(request.getGradient())
+          .returns(15, GradientCfg::getMinLimit)
+          .returns(25, GradientCfg::getInitialLimit)
+          .returns(3.0, GradientCfg::getRttTolerance);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.flowControl.request.enabled=true",
+        "zeebe.broker.flowControl.request.algorithm=gradient",
+        "zeebe.broker.flowControl.request.gradient.minLimit=15",
+        "zeebe.broker.flowControl.request.gradient.initialLimit=25",
+        "zeebe.broker.flowControl.request.gradient.rttTolerance=3.0",
+      })
+  class WithGradientAlgorithmLegacy {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithGradientAlgorithmLegacy(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetGradientPropertiesFromLegacy() {
+      final var request = brokerBasedProperties.getFlowControl().getRequest();
+      assertThat(request).isNotNull();
+      assertThat(request.getAlgorithm().name()).isEqualTo("GRADIENT");
+      assertThat(request.getGradient())
+          .returns(15, GradientCfg::getMinLimit)
+          .returns(25, GradientCfg::getInitialLimit)
+          .returns(3.0, GradientCfg::getRttTolerance);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.flow-control.request.enabled=true",
+        "camunda.processing.flow-control.request.algorithm=gradient2",
+        "camunda.processing.flow-control.request.gradient2.min-limit=12",
+        "camunda.processing.flow-control.request.gradient2.initial-limit=22",
+        "camunda.processing.flow-control.request.gradient2.rtt-tolerance=2.5",
+        "camunda.processing.flow-control.request.gradient2.long-window=700",
+      })
+  class WithGradient2Algorithm {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithGradient2Algorithm(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetGradient2Properties() {
+      final var request = brokerBasedProperties.getFlowControl().getRequest();
+      assertThat(request).isNotNull();
+      assertThat(request.getAlgorithm().name()).isEqualTo("GRADIENT2");
+      assertThat(request.getGradient2())
+          .returns(12, Gradient2Cfg::getMinLimit)
+          .returns(22, Gradient2Cfg::getInitialLimit)
+          .returns(2.5, Gradient2Cfg::getRttTolerance)
+          .returns(700, Gradient2Cfg::getLongWindow);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.flowControl.request.enabled=true",
+        "zeebe.broker.flowControl.request.algorithm=gradient2",
+        "zeebe.broker.flowControl.request.gradient2.minLimit=12",
+        "zeebe.broker.flowControl.request.gradient2.initialLimit=22",
+        "zeebe.broker.flowControl.request.gradient2.rttTolerance=2.5",
+        "zeebe.broker.flowControl.request.gradient2.longWindow=700",
+      })
+  class WithGradient2AlgorithmLegacy {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithGradient2AlgorithmLegacy(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetGradient2PropertiesFromLegacy() {
+      final var request = brokerBasedProperties.getFlowControl().getRequest();
+      assertThat(request).isNotNull();
+      assertThat(request.getAlgorithm().name()).isEqualTo("GRADIENT2");
+      assertThat(request.getGradient2())
+          .returns(12, Gradient2Cfg::getMinLimit)
+          .returns(22, Gradient2Cfg::getInitialLimit)
+          .returns(2.5, Gradient2Cfg::getRttTolerance)
+          .returns(700, Gradient2Cfg::getLongWindow);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.flow-control.request.enabled=true",
+        "camunda.processing.flow-control.request.algorithm=legacy-vegas",
+        "camunda.processing.flow-control.request.legacy-vegas.initial-limit=2048",
+        "camunda.processing.flow-control.request.legacy-vegas.max-concurrency=65536",
+        "camunda.processing.flow-control.request.legacy-vegas.alpha-limit=0.8",
+        "camunda.processing.flow-control.request.legacy-vegas.beta-limit=0.98",
+      })
+  class WithLegacyVegasAlgorithm {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithLegacyVegasAlgorithm(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetLegacyVegasProperties() {
+      final var request = brokerBasedProperties.getFlowControl().getRequest();
+      assertThat(request).isNotNull();
+      assertThat(request.getAlgorithm().name()).isEqualTo("LEGACY_VEGAS");
+      assertThat(request.getLegacyVegas())
+          .returns(2048, LegacyVegasCfg::initialLimit)
+          .returns(65536, LegacyVegasCfg::getMaxConcurrency)
+          .returns(0.8, LegacyVegasCfg::alphaLimit)
+          .returns(0.98, LegacyVegasCfg::betaLimit);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.flowControl.request.enabled=true",
+        "zeebe.broker.flowControl.request.algorithm=legacy_vegas",
+        "zeebe.broker.flowControl.request.legacyVegas.initialLimit=2048",
+        "zeebe.broker.flowControl.request.legacyVegas.maxConcurrency=65536",
+        "zeebe.broker.flowControl.request.legacyVegas.alphaLimit=0.8",
+        "zeebe.broker.flowControl.request.legacyVegas.betaLimit=0.98",
+      })
+  class WithLegacyVegasAlgorithmLegacy {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithLegacyVegasAlgorithmLegacy(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldSetLegacyVegasPropertiesFromLegacy() {
+      final var request = brokerBasedProperties.getFlowControl().getRequest();
+      assertThat(request).isNotNull();
+      assertThat(request.getAlgorithm().name()).isEqualTo("LEGACY_VEGAS");
+      assertThat(request.getLegacyVegas())
+          .returns(2048, LegacyVegasCfg::initialLimit)
+          .returns(65536, LegacyVegasCfg::getMaxConcurrency)
+          .returns(0.8, LegacyVegasCfg::alphaLimit)
+          .returns(0.98, LegacyVegasCfg::betaLimit);
+    }
+  }
+
+  @Nested
+  class WithoutNewAndLegacySet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithoutNewAndLegacySet(@Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldNotSetRequest() {
+      assertThat(brokerBasedProperties.getFlowControl().getRequest()).isNull();
+    }
+  }
+}


### PR DESCRIPTION
## Description
feat: uc: added request/limit config

⚠️  Should be merged with wave 2 migration.

## General Request Properties (3 properties)
- `zeebe.broker.flowControl.request.enabled`, `zeebe.broker.backpressure.enabled` → `camunda.processing.flow-control.request.enabled`
- `zeebe.broker.flowControl.request.useWindowed`, `zeebe.broker.backpressure.useWindowed` → `camunda.processing.flow-control.request.windowed`
- `zeebe.broker.flowControl.request.algorithm`, `zeebe.broker.backpressure.algorithm` → `camunda.processing.flow-control.request.algorithm`

## AIMD Algorithm Properties (5 properties)
- `zeebe.broker.flowControl.request.aimd.requestTimeout`, `zeebe.broker.backpressure.aimd.requestTimeout` → `camunda.processing.flow-control.request.aimd.request-timeout`
- `zeebe.broker.flowControl.request.aimd.initialLimit`, `zeebe.broker.backpressure.aimd.initialLimit` → `camunda.processing.flow-control.request.aimd.initial-limit`
- `zeebe.broker.flowControl.request.aimd.minLimit`, `zeebe.broker.backpressure.aimd.minLimit` → `camunda.processing.flow-control.request.aimd.min-limit`
- `zeebe.broker.flowControl.request.aimd.maxLimit`, `zeebe.broker.backpressure.aimd.maxLimit` → `camunda.processing.flow-control.request.aimd.max-limit`
- `zeebe.broker.flowControl.request.aimd.backoffRatio`, `zeebe.broker.backpressure.aimd.backoffRatio` → `camunda.processing.flow-control.request.aimd.backoff-ratio`

## Fixed Algorithm Properties (1 property)
- `zeebe.broker.flowControl.request.fixed.limit`, `zeebe.broker.backpressure.fixed.limit` → `camunda.processing.flow-control.request.fixed.limit`

## Vegas Algorithm Properties (3 properties)
- `zeebe.broker.flowControl.request.vegas.alpha`, `zeebe.broker.backpressure.vegas.alpha` → `camunda.processing.flow-control.request.vegas.alpha`
- `zeebe.broker.flowControl.request.vegas.beta`, `zeebe.broker.backpressure.vegas.beta` → `camunda.processing.flow-control.request.vegas.beta`
- `zeebe.broker.flowControl.request.vegas.initialLimit`, `zeebe.broker.backpressure.vegas.initialLimit` → `camunda.processing.flow-control.request.vegas.initial-limit`

## Gradient Algorithm Properties (3 properties)
- `zeebe.broker.flowControl.request.gradient.minLimit`, `zeebe.broker.backpressure.gradient.minLimit` → `camunda.processing.flow-control.request.gradient.min-limit`
- `zeebe.broker.flowControl.request.gradient.initialLimit`, `zeebe.broker.backpressure.gradient.initialLimit` → `camunda.processing.flow-control.request.gradient.initial-limit`
- `zeebe.broker.flowControl.request.gradient.rttTolerance`, `zeebe.broker.backpressure.gradient.rttTolerance` → `camunda.processing.flow-control.request.gradient.rtt-tolerance`

## Gradient2 Algorithm Properties (4 properties)
- `zeebe.broker.flowControl.request.gradient2.minLimit`, `zeebe.broker.backpressure.gradient2.minLimit` → `camunda.processing.flow-control.request.gradient2.min-limit`
- `zeebe.broker.flowControl.request.gradient2.initialLimit`, `zeebe.broker.backpressure.gradient2.initialLimit` → `camunda.processing.flow-control.request.gradient2.initial-limit`
- `zeebe.broker.flowControl.request.gradient2.rttTolerance`, `zeebe.broker.backpressure.gradient2.rttTolerance` → `camunda.processing.flow-control.request.gradient2.rtt-tolerance`
- `zeebe.broker.flowControl.request.gradient2.longWindow`, `zeebe.broker.backpressure.gradient2.longWindow` → `camunda.processing.flow-control.request.gradient2.long-window`

## Legacy Vegas Algorithm Properties (4 properties)
- `zeebe.broker.flowControl.request.legacyVegas.initialLimit`, `zeebe.broker.backpressure.legacyVegas.initialLimit` → `camunda.processing.flow-control.request.legacy-vegas.initial-limit`
- `zeebe.broker.flowControl.request.legacyVegas.maxConcurrency`, `zeebe.broker.backpressure.legacyVegas.maxConcurrency` → `camunda.processing.flow-control.request.legacy-vegas.max-concurrency`
- `zeebe.broker.flowControl.request.legacyVegas.alphaLimit`, `zeebe.broker.backpressure.legacyVegas.alphaLimit` → `camunda.processing.flow-control.request.legacy-vegas.alpha-limit`
- `zeebe.broker.flowControl.request.legacyVegas.betaLimit`, `zeebe.broker.backpressure.legacyVegas.betaLimit` → `camunda.processing.flow-control.request.legacy-vegas.beta-limit`

## Checklist
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
closes #40028
