### PR TITLE
fix: correct url is used to fetch the platform values

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -268,7 +268,7 @@ jobs:
           --set orchestration.image.registry=gcr.io
           --set orchestration.image.repository=zeebe-io/zeebe
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          -f https://raw.githubusercontent.com/camunda/camunda/refs/heads/${{ inputs.ref }}/load-tests/camunda-platform-values.yaml
+          -f https://raw.githubusercontent.com/camunda/camunda/${{ inputs.ref }}/load-tests/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && '-f load-tests/setup/default/values-stable.yaml' || '' }}
       - name: Label namespace


### PR DESCRIPTION
## Description
`input.ref` is a commit hash, not a branch name

:x: Original [link](https://raw.githubusercontent.com/camunda/camunda/refs/heads/3e6c47c5a58c7e9022ca5ecaab76975c7d355ee0/load-tests/camunda-platform-values.yaml)
:white_check_mark:  fixed [link](https://raw.githubusercontent.com/camunda/camunda/3e6c47c5a58c7e9022ca5ecaab76975c7d355ee0/load-tests/camunda-platform-values.yaml)