### PR TITLE
test: add automatic tests for global task listeners

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerEventType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerEventType.java
@@ -62,5 +62,5 @@ public enum ZeebeTaskListenerEventType {
   assigning,
   updating,
   completing,
-  canceling
+  canceling;
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -21,6 +21,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private UsageMetricsCfg usageMetrics = new UsageMetricsCfg();
   private DistributionCfg distribution = new DistributionCfg();
   private int maxProcessDepth = EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH;
+  private ListenersCfg listeners = new ListenersCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -31,6 +32,7 @@ public final class EngineCfg implements ConfigurationEntry {
     validators.init(globalConfig, brokerBase);
     distribution.init(globalConfig, brokerBase);
     usageMetrics.init(globalConfig, brokerBase);
+    listeners.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -97,6 +99,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.maxProcessDepth = maxProcessDepth;
   }
 
+  public ListenersCfg getListeners() {
+    return listeners;
+  }
+
+  public void setListeners(final ListenersCfg listeners) {
+    this.listeners = listeners;
+  }
+
   @Override
   public String toString() {
     return "EngineCfg{"
@@ -144,6 +154,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setCommandDistributionPaused(distribution.isPauseCommandDistribution())
         .setCommandRedistributionInterval(distribution.getRedistributionInterval())
         .setCommandRedistributionMaxBackoff(distribution.getMaxBackoffDuration())
-        .setMaxProcessDepth(getMaxProcessDepth());
+        .setMaxProcessDepth(getMaxProcessDepth())
+        .setListeners(listeners.createListenersConfiguration());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ListenerCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ListenerCfg.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.ListenerConfiguration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListenerCfg implements ConfigurationEntry {
+
+  private static final String DEFAULT_RETRIES = "3";
+
+  private List<String> eventTypes = new ArrayList<>();
+  private String type;
+  private String retries = DEFAULT_RETRIES;
+
+  public List<String> getEventTypes() {
+    return eventTypes;
+  }
+
+  public void setEventTypes(final List<String> eventTypes) {
+    this.eventTypes = eventTypes;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
+  }
+
+  public String getRetries() {
+    return retries;
+  }
+
+  public void setRetries(final String retries) {
+    this.retries = retries;
+  }
+
+  public ListenerConfiguration createListenerConfiguration() {
+    return new ListenerConfiguration(eventTypes, type, retries);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ListenerCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ListenerCfg.java
@@ -19,6 +19,7 @@ public class ListenerCfg implements ConfigurationEntry {
   private List<String> eventTypes = new ArrayList<>();
   private String type;
   private String retries = DEFAULT_RETRIES;
+  private boolean afterLocal = false;
 
   public List<String> getEventTypes() {
     return eventTypes;
@@ -44,7 +45,15 @@ public class ListenerCfg implements ConfigurationEntry {
     this.retries = retries;
   }
 
+  public boolean isAfterLocal() {
+    return afterLocal;
+  }
+
+  public void setAfterLocal(final boolean afterLocal) {
+    this.afterLocal = afterLocal;
+  }
+
   public ListenerConfiguration createListenerConfiguration() {
-    return new ListenerConfiguration(eventTypes, type, retries);
+    return new ListenerConfiguration(eventTypes, type, retries, afterLocal);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ListenersCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ListenersCfg.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.ListenersConfiguration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListenersCfg implements ConfigurationEntry {
+
+  private List<ListenerCfg> task = new ArrayList<>();
+
+  public List<ListenerCfg> getTask() {
+    return task;
+  }
+
+  public void setTask(final List<ListenerCfg> task) {
+    this.task = task;
+  }
+
+  public ListenersConfiguration createListenersConfiguration() {
+    return new ListenersConfiguration(
+        task.stream().map(ListenerCfg::createListenerConfiguration).toList());
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -46,6 +46,7 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL);
     assertThat(configuration.getCommandRedistributionMaxBackoff())
         .isEqualTo(EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION);
+    assertThat(configuration.getListeners().task()).isEmpty();
   }
 
   @Test
@@ -68,5 +69,10 @@ final class EngineCfgTest {
     assertThat(configuration.getCommandRedistributionInterval()).isEqualTo(Duration.ofSeconds(60));
     assertThat(configuration.getCommandRedistributionMaxBackoff())
         .isEqualTo(Duration.ofMinutes(20));
+    assertThat(configuration.getListeners().task()).hasSize(1);
+    final var listener = configuration.getListeners().task().getFirst();
+    assertThat(listener.type()).isEqualTo("test");
+    assertThat(listener.eventTypes()).containsExactly("creating", "canceling");
+    assertThat(listener.retries()).isEqualTo("5");
   }
 }

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -18,3 +18,10 @@ zeebe:
           redistributionInterval: 60s
           maxBackoffDuration: 20m
         maxProcessDepth: 2000
+        listeners:
+          task:
+            - type: test
+              eventTypes:
+                - creating
+                - canceling
+              retries: 5

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -90,6 +90,7 @@ public final class EngineConfiguration {
       DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION;
 
   private boolean enableIdentitySetup = DEFAULT_ENABLE_IDENTITY_SETUP;
+  private ListenersConfiguration listeners = ListenersConfiguration.empty();
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -334,6 +335,15 @@ public final class EngineConfiguration {
 
   public EngineConfiguration setEnableIdentitySetup(final boolean enableIdentitySetup) {
     this.enableIdentitySetup = enableIdentitySetup;
+    return this;
+  }
+
+  public ListenersConfiguration getListeners() {
+    return listeners;
+  }
+
+  public EngineConfiguration setListeners(final ListenersConfiguration listeners) {
+    this.listeners = listeners;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenerConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenerConfiguration.java
@@ -10,4 +10,6 @@ package io.camunda.zeebe.engine;
 import java.util.List;
 
 public record ListenerConfiguration(
-    List<String> eventTypes, String type, String retries, boolean afterLocal) {}
+    List<String> eventTypes, String type, String retries, boolean afterLocal) {
+  public static final String ALL_EVENT_TYPES = "all";
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenerConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenerConfiguration.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine;
+
+import java.util.List;
+
+public record ListenerConfiguration(List<String> eventTypes, String type, String retries) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenerConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenerConfiguration.java
@@ -9,4 +9,5 @@ package io.camunda.zeebe.engine;
 
 import java.util.List;
 
-public record ListenerConfiguration(List<String> eventTypes, String type, String retries) {}
+public record ListenerConfiguration(
+    List<String> eventTypes, String type, String retries, boolean afterLocal) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenersConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenersConfiguration.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine;
+
+import java.util.Collections;
+import java.util.List;
+
+public record ListenersConfiguration(List<ListenerConfiguration> task) {
+  public static ListenersConfiguration empty() {
+    return new ListenersConfiguration(Collections.emptyList());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
@@ -9,16 +9,30 @@ package io.camunda.zeebe.engine.processing.deployment.model;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.ListenersConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
 import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidator;
 import java.time.InstantSource;
+import java.util.Objects;
 
 public final class BpmnFactory {
 
-  public static BpmnTransformer createTransformer(final InstantSource clock) {
-    return new BpmnTransformer(createExpressionLanguage(new ZeebeFeelEngineClock(clock)));
+  public BpmnFactory() {}
+
+  public static BpmnTransformer createTransformer(
+      final InstantSource clock, final EngineConfiguration configuration) {
+    final ListenersConfiguration listenerConfig;
+    if (configuration != null) {
+      listenerConfig =
+          Objects.requireNonNullElse(configuration.getListeners(), ListenersConfiguration.empty());
+    } else {
+      listenerConfig = ListenersConfiguration.empty();
+    }
+    return new BpmnTransformer(
+        createExpressionLanguage(new ZeebeFeelEngineClock(clock)), listenerConfig);
   }
 
   public static BpmnValidator createValidator(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.deployment.model.transformation;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.engine.ListenersConfiguration;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.AdHocSubProcessTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.BoundaryEventTransformer;
@@ -71,7 +72,9 @@ public final class BpmnTransformer {
 
   private final ExpressionLanguage expressionLanguage;
 
-  public BpmnTransformer(final ExpressionLanguage expressionLanguage) {
+  public BpmnTransformer(
+      final ExpressionLanguage expressionLanguage,
+      final ListenersConfiguration listenersConfiguration) {
     this.expressionLanguage = expressionLanguage;
 
     step1Visitor = new TransformationVisitor();
@@ -96,7 +99,8 @@ public final class BpmnTransformer {
     step2Visitor.registerHandler(new ScriptTaskTransformer());
     step2Visitor.registerHandler(new SequenceFlowTransformer());
     step2Visitor.registerHandler(new StartEventTransformer());
-    step2Visitor.registerHandler(new UserTaskTransformer(expressionLanguage));
+    step2Visitor.registerHandler(
+        new UserTaskTransformer(expressionLanguage, listenersConfiguration));
 
     step3Visitor = new TransformationVisitor();
     step3Visitor.registerHandler(new ContextProcessTransformer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.impl.StaticExpression;
+import io.camunda.zeebe.engine.ListenerConfiguration;
+import io.camunda.zeebe.engine.ListenersConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
@@ -30,6 +32,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListeners;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskSchedule;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTask;
 import io.camunda.zeebe.protocol.Protocol;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,9 +45,13 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
   private static final Logger LOG = Loggers.STREAM_PROCESSING;
 
   private final ExpressionLanguage expressionLanguage;
+  private final ListenersConfiguration listenersConfiguration;
 
-  public UserTaskTransformer(final ExpressionLanguage expressionLanguage) {
+  public UserTaskTransformer(
+      final ExpressionLanguage expressionLanguage,
+      final ListenersConfiguration listenersConfiguration) {
     this.expressionLanguage = expressionLanguage;
+    this.listenersConfiguration = listenersConfiguration;
   }
 
   @Override
@@ -298,33 +305,80 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
       final FlowNode element,
       final ExecutableUserTask userTask,
       final UserTaskProperties userTaskProperties) {
+
+    final var taskListeners = new ArrayList<TaskListener>();
+
+    // Add global listeners
+    Optional.ofNullable(listenersConfiguration)
+        .map(ListenersConfiguration::task)
+        .ifPresent(
+            listeners ->
+                listeners.stream()
+                    .map(l -> toTaskListenerModel(l, userTaskProperties))
+                    .forEach(taskListeners::addAll));
+
+    // Add listeners defined directly on the model
     Optional.ofNullable(element.getSingleExtensionElement(ZeebeTaskListeners.class))
         .map(
             listeners ->
                 listeners.getTaskListeners().stream()
                     .map(listener -> toTaskListenerModel(listener, userTaskProperties))
                     .toList())
-        .ifPresent(userTask::setTaskListeners);
+        .ifPresent(taskListeners::addAll);
+
+    if (!taskListeners.isEmpty()) {
+      userTask.setTaskListeners(taskListeners);
+    }
   }
 
   private TaskListener toTaskListenerModel(
-      final ZeebeTaskListener zeebeTaskListener, final UserTaskProperties userTaskProperties) {
+      final ZeebeTaskListenerEventType eventType,
+      final String jobType,
+      final String jobRetries,
+      final UserTaskProperties userTaskProperties) {
     final TaskListener listener = new TaskListener();
-    final var eventType = getZeebeTaskListenerEventType(zeebeTaskListener);
-    listener.setEventType(eventType);
+    listener.setEventType(getZeebeTaskListenerEventType(eventType));
 
     final JobWorkerProperties jobProperties = new JobWorkerProperties();
     jobProperties.wrap(userTaskProperties);
-    jobProperties.setType(expressionLanguage.parseExpression(zeebeTaskListener.getType()));
-    jobProperties.setRetries(expressionLanguage.parseExpression(zeebeTaskListener.getRetries()));
+    jobProperties.setType(expressionLanguage.parseExpression(jobType));
+    jobProperties.setRetries(expressionLanguage.parseExpression(jobRetries));
     listener.setJobWorkerProperties(jobProperties);
     return listener;
   }
 
+  private TaskListener toTaskListenerModel(
+      final ZeebeTaskListener zeebeTaskListener, final UserTaskProperties userTaskProperties) {
+    return toTaskListenerModel(
+        zeebeTaskListener.getEventType(),
+        zeebeTaskListener.getType(),
+        zeebeTaskListener.getRetries(),
+        userTaskProperties);
+  }
+
+  private List<TaskListener> toTaskListenerModel(
+      final ListenerConfiguration globalTaskListener, final UserTaskProperties userTaskProperties) {
+
+    final var eventTypes =
+        globalTaskListener.eventTypes().stream().map(ZeebeTaskListenerEventType::valueOf).toList();
+    final var jobType = globalTaskListener.type();
+    final var jobRetries = globalTaskListener.retries();
+
+    final List<TaskListener> taskListeners = new ArrayList<>();
+    eventTypes.forEach(
+        eventType -> {
+          final TaskListener listener =
+              toTaskListenerModel(eventType, jobType, jobRetries, userTaskProperties);
+          taskListeners.add(listener);
+        });
+    return taskListeners;
+  }
+
   @SuppressWarnings("deprecation")
   private static ZeebeTaskListenerEventType getZeebeTaskListenerEventType(
-      final ZeebeTaskListener zeebeTaskListener) {
-    return switch (zeebeTaskListener.getEventType()) {
+      final ZeebeTaskListenerEventType eventType) {
+    // convert deprecated event types to their non-deprecated counterparts
+    return switch (eventType) {
       case create, creating -> ZeebeTaskListenerEventType.creating;
       case assignment, assigning -> ZeebeTaskListenerEventType.assigning;
       case update, updating -> ZeebeTaskListenerEventType.updating;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -60,7 +60,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
       final boolean enableStraightThroughProcessingLoopDetector,
       final EngineConfiguration config,
       final InstantSource clock) {
-    bpmnTransformer = BpmnFactory.createTransformer(clock);
+    bpmnTransformer = BpmnFactory.createTransformer(clock, config);
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
     this.checksumGenerator = checksumGenerator;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -114,7 +114,7 @@ public final class DbProcessState implements MutableProcessState {
       final TransactionContext transactionContext,
       final EngineConfiguration config,
       final InstantSource clock) {
-    transformer = BpmnFactory.createTransformer(clock);
+    transformer = BpmnFactory.createTransformer(clock, config);
     processDefinitionKey = new DbLong();
     persistedProcess = new PersistedProcess();
     tenantIdKey = new DbString();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.ListenersConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
@@ -42,7 +43,8 @@ class UserTaskTransformerTest {
   private final ExpressionLanguage expressionLanguage =
       ExpressionLanguageFactory.createExpressionLanguage(
           new ZeebeFeelEngineClock(InstantSource.system()));
-  private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
+  private final BpmnTransformer transformer =
+      new BpmnTransformer(expressionLanguage, ListenersConfiguration.empty());
 
   private BpmnModelInstance processWithUserTask(final Consumer<UserTaskBuilder> userTaskModifier) {
     return Bpmn.createExecutableProcess().startEvent().userTask(TASK_ID, userTaskModifier).done();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.ListenerConfiguration;
 import io.camunda.zeebe.engine.ListenersConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerTask;
@@ -20,14 +21,17 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.TaskListener;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import io.camunda.zeebe.model.bpmn.builder.TaskListenerBuilder;
 import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import java.time.InstantSource;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -43,8 +47,10 @@ class UserTaskTransformerTest {
   private final ExpressionLanguage expressionLanguage =
       ExpressionLanguageFactory.createExpressionLanguage(
           new ZeebeFeelEngineClock(InstantSource.system()));
+  private final ListenersConfiguration listenersConfiguration =
+      new ListenersConfiguration(new ArrayList<>());
   private final BpmnTransformer transformer =
-      new BpmnTransformer(expressionLanguage, ListenersConfiguration.empty());
+      new BpmnTransformer(expressionLanguage, listenersConfiguration);
 
   private BpmnModelInstance processWithUserTask(final Consumer<UserTaskBuilder> userTaskModifier) {
     return Bpmn.createExecutableProcess().startEvent().userTask(TASK_ID, userTaskModifier).done();
@@ -279,6 +285,11 @@ class UserTaskTransformerTest {
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
   class ZeebeTaskListenerTests {
 
+    @BeforeEach
+    public void resetGlobalListeners() {
+      listenersConfiguration.task().clear();
+    }
+
     Stream<Arguments> taskListeners() {
       return Stream.of(
           Arguments.of(
@@ -401,6 +412,128 @@ class UserTaskTransformerTest {
       assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.canceling))
           .extracting(this::type)
           .containsExactly("cancel");
+    }
+
+    @DisplayName(
+        "Should transform user task with globally-defined task listener including locally-defined task headers")
+    @Test
+    void shouldTransformGlobalListenersWithTaskHeaders() {
+      // given
+      listenersConfiguration
+          .task()
+          .add(new ListenerConfiguration(List.of("creating"), "global", "3", false));
+
+      // when
+      final var userTask =
+          transformZeebeUserTask(
+              processWithUserTask(b -> b.zeebeTaskHeader("key", "value").zeebeUserTask()));
+
+      // then
+      assertThat(userTask.getTaskListeners())
+          .hasSize(1)
+          .first()
+          .satisfies(
+              listener -> {
+                assertThat(listener.getJobWorkerProperties().getTaskHeaders())
+                    .isEqualTo(Map.of("key", "value"));
+              });
+    }
+
+    @DisplayName(
+        "Should transform user task with globally-defined \"generic\" task listener creating a new listener for each event type")
+    @Test
+    void shouldTransformGenericGlobalListenerWithMultipleIndividualListeners() {
+      // given
+      listenersConfiguration
+          .task()
+          .add(new ListenerConfiguration(List.of("all"), "global", "3", false));
+
+      // when
+      final var userTask =
+          transformZeebeUserTask(processWithUserTask(AbstractUserTaskBuilder::zeebeUserTask));
+
+      // then
+      assertThat(userTask.getTaskListeners()).hasSize(5);
+      assertThat(userTask.getTaskListeners())
+          .extracting(TaskListener::getEventType)
+          .containsExactly(
+              ZeebeTaskListenerEventType.creating,
+              ZeebeTaskListenerEventType.assigning,
+              ZeebeTaskListenerEventType.updating,
+              ZeebeTaskListenerEventType.completing,
+              ZeebeTaskListenerEventType.canceling);
+      assertThat(userTask.getTaskListeners()).extracting(this::type).containsOnly("global");
+    }
+
+    @DisplayName(
+        "Should transform user task with globally and locally defined task listeners and preserve listener definition order, considering configuration flags")
+    @Test
+    void shouldTransformGlobalListenersAndPreserveListenersDefinitionOrderPerEventType() {
+      // given
+      listenersConfiguration
+          .task()
+          .add(new ListenerConfiguration(List.of("creating"), "globalCreateBefore", "3", false));
+      listenersConfiguration
+          .task()
+          .add(new ListenerConfiguration(List.of("all"), "globalGenericBefore", "3", false));
+      listenersConfiguration
+          .task()
+          .add(new ListenerConfiguration(List.of("creating"), "globalCreateAfter", "3", true));
+      listenersConfiguration
+          .task()
+          .add(new ListenerConfiguration(List.of("updating"), "globalUpdateAfter", "3", true));
+
+      // when
+      final var userTask =
+          transformZeebeUserTask(
+              processWithUserTask(
+                  b ->
+                      b.zeebeTaskListener(tl -> tl.creating().type("localCreate"))
+                          .zeebeTaskListener(tl -> tl.assigning().type("localAssign"))
+                          .zeebeUserTask()));
+
+      // then
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.creating))
+          .extracting(this::type)
+          .containsExactly(
+              "globalCreateBefore", "globalGenericBefore", "localCreate", "globalCreateAfter");
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.assigning))
+          .extracting(this::type)
+          .containsExactly("globalGenericBefore", "localAssign");
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.updating))
+          .extracting(this::type)
+          .containsExactly("globalGenericBefore", "globalUpdateAfter");
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.canceling))
+          .extracting(this::type)
+          .containsExactly("globalGenericBefore");
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.completing))
+          .extracting(this::type)
+          .containsExactly("globalGenericBefore");
+    }
+
+    @DisplayName(
+        "Should transform user task with globally and locally defined task listeners and preserve listener definition order, considering configuration flags")
+    @Test
+    void shouldTransformDeprecatedGlobalListenersWhileAvoidingDuplicates() {
+      // given
+      listenersConfiguration
+          .task()
+          .add(
+              new ListenerConfiguration(
+                  List.of("creating", "create"), "globalCreateBefore", "3", false));
+
+      // when
+      final var userTask =
+          transformZeebeUserTask(processWithUserTask(AbstractUserTaskBuilder::zeebeUserTask));
+
+      // then
+      assertThat(userTask.getTaskListeners())
+          .hasSize(1)
+          .first()
+          .satisfies(
+              listener -> {
+                assertThat(listener.getEventType()).isEqualTo(ZeebeTaskListenerEventType.creating);
+              });
     }
 
     private String type(final TaskListener listener) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyProcessState.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyProcessState.java
@@ -83,7 +83,7 @@ public final class LegacyProcessState {
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
       final InstantSource clock) {
-    transformer = BpmnFactory.createTransformer(clock);
+    transformer = BpmnFactory.createTransformer(clock, null);
     processDefinitionKey = new DbLong();
     persistedProcess = new PersistedProcess();
     processColumnFamily =


### PR DESCRIPTION
## Description

Automatic tests are needed to validate the correct functionality of global user tasks.

This PR includes tests to check that the configuration is read correctly and that global listeners are correctly included in user tasks when transforming them.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39929
