### PR TITLE
fix: in MigrationSnapshotDirector call onHealthReport when listener subscribes

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
@@ -98,7 +98,7 @@ public class MigrationSnapshotDirector implements HealthMonitorable, CloseableSi
   public void addFailureListener(final FailureListener failureListener) {
     LOG.trace("Added failure listener {}", failureListener);
     listeners.put(failureListener, Boolean.TRUE);
-    failureListener.onFailure(healthReport);
+    failureListener.onHealthReport(healthReport);
   }
 
   @Override


### PR DESCRIPTION
## Description
When a listener is added, `onHealthReport` should be called not `onFailure`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #39751
