### PR TITLE
ci: change alpha version to 8.7.0-alpha2

### DIFF
--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -27,11 +27,11 @@ jobs:
         # which requires webapps-schema artifact (introduced Sep 13, 2024).
         # Earlier versions from 2021 predate this dependency and cause build failures.
         # See discussion at: https://camunda.slack.com/archives/C06UWQNCU7M/p1760468857576009?thread_ts=1760406101.424439&cid=C06UWQNCU7M
-        version: [ 8.6.1, 8.8.0-alpha8 ]
+        version: [ 8.6.1, 8.7.0-alpha2 ]
         include:
           - version: 8.6.1
             latest: true
-          - version: 8.8.0-alpha8
+          - version: 8.7.0-alpha2
             latest: false
     with:
       releaseBranch: ${{ inputs.branch || 'main' }}


### PR DESCRIPTION
## Description

This pull request updates the Camunda platform versions used in the dry-run workflow configuration. The main change is swapping out a pre-release version for a different, earlier alpha version to address build dependency issues.

Version update in workflow configuration:

* [`.github/workflows/camunda-platform-release-main-dry-run.yml`](diffhunk://#diff-6435569638e89471eb604f5f02638ffb7163b0f832dd0771a405c52485bdddb2L30-R34): Changed the tested Camunda platform version from `8.8.0-alpha8` to `8.7.0-alpha2` in both the `version` array and the `include` section, ensuring compatibility with the required `webapps-schema` artifact.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
