### PR TITLE
ci: fix nightly tests after tasklist e2e tests restructure

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -172,11 +172,21 @@ jobs:
           fi
 
           if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
-            echo "Running all tests in V2 mode, excluding V1-specific tests"
-            npm run test -- --project=chromium --ignore="tests/common-flows/v1/**" --ignore="tests/tasklist/v1/**""
+            if [[ "${{ matrix.branch }}" == "main" ]]; then
+              echo "Running all tests in V2 mode on main branch, excluding V1-specific tests"
+              npm run test -- --project=chromium --grep-invert "tests/(common-flows/v1|tasklist/v1)/"
+            else
+              echo "Running focused tests in V2 mode: Tasklist + HTO flows (excluding @v1-only tests)"
+              npm run test -- --project=chromium tests/tasklist/ tests/common-flows/hto-user-flows.spec.ts --grep-invert "@v1-only"
+            fi
           else
-            echo "Running V1 specific tests only: common-flows/v1/ and tests/tasklist/v1/"
-            npm run test -- --project=chromium tests/common-flows/v1/ tests/tasklist/v1/"
+            if [[ "${{ matrix.branch }}" == "main" ]]; then
+              echo "Running V1 specific tests only: common-flows/v1/ and tests/tasklist/v1/"
+              npm run test -- --project=chromium tests/common-flows/v1/ tests/tasklist/v1/
+            else
+              echo "Running all tests in V1 mode"
+              npm run test -- --project=chromium
+            fi
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
After restructure of test suite in main, the nighty test run was broken. This PR fixes the workflow.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
