### PR TITLE
feat: Support for spring proxy classes in Camunda annotation processing

### DIFF
--- a/clients/camunda-spring-boot-starter/pom.xml
+++ b/clients/camunda-spring-boot-starter/pom.xml
@@ -23,6 +23,7 @@
     <version.java>17</version.java>
     <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
     <version.roaster>2.30.1.Final</version.roaster>
+    <version.aspectjweaver>1.9.24</version.aspectjweaver>
     <generated.test.sources.path>${project.build.directory}/generated-test-sources/java</generated.test.sources.path>
   </properties>
 
@@ -138,6 +139,12 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjweaver</artifactId>
+      <version>${version.aspectjweaver}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/AbstractCamundaAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/AbstractCamundaAnnotationProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.client.bean.BeanInfo;
 import io.camunda.client.lifecycle.CamundaClientLifecycleAware;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.util.ClassUtils;
 
 public abstract class AbstractCamundaAnnotationProcessor
     implements ApplicationContextAware, CamundaClientLifecycleAware {
@@ -46,7 +47,8 @@ public abstract class AbstractCamundaAnnotationProcessor
         final BeanInfo beanInfo =
             BeanInfo.builder()
                 .beanName(beanName)
-                .targetClass(beanType)
+                // use Spring's ClassUtils to get the user class in case of a proxy
+                .targetClass(ClassUtils.getUserClass(beanType))
                 .beanSupplier(() -> applicationContext.getBean(beanName))
                 .build();
         if (isApplicableFor(beanInfo)) {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/processor/CamundaAnnotationProcessorAopCompatibilityTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/processor/CamundaAnnotationProcessorAopCompatibilityTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.annotation.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.annotation.Variable;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.bean.BeanInfo;
+import io.camunda.client.spring.annotation.processor.CamundaAnnotationProcessorAopCompatibilityTest.AopBeanConfig;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@SpringBootTest(classes = AopBeanConfig.class)
+public class CamundaAnnotationProcessorAopCompatibilityTest {
+
+  @Autowired TestCamundaAnnotationProcessor processor;
+  @Autowired ExampleAspect exampleAspect;
+  @Autowired MyWorker myWorker;
+
+  @Test
+  void shouldExtractTargetClassNotSpringProxy() {
+    // given
+    processor.onStart(mock(CamundaClient.class));
+
+    // when
+    myWorker.worker(null, null);
+
+    // then
+    // verify Aspect was working as expected
+    assertThat(exampleAspect.invoked).isTrue();
+    assertThat(myWorker.wasInvoked()).isTrue();
+    // verify that processor extracted the correct target class not the CGLIB proxy class
+    assertThat(processor.beanInfo)
+        .isNotNull()
+        .extracting(BeanInfo::getTargetClass)
+        .isEqualTo(MyWorker.class);
+  }
+
+  @Configuration
+  @EnableAspectJAutoProxy
+  static class AopBeanConfig {
+    @Bean
+    public TestCamundaAnnotationProcessor processor() {
+      return new TestCamundaAnnotationProcessor();
+    }
+
+    @Bean
+    public MyWorker myWorker() {
+      return new MyWorker();
+    }
+
+    @Bean
+    public ExampleAspect exampleAspect() {
+      return new ExampleAspect();
+    }
+  }
+
+  static class MyWorker {
+    boolean invoked = false;
+
+    @JobWorker
+    public void worker(final ActivatedJob job, @Variable final String name) {
+      invoked = true;
+    }
+
+    public boolean wasInvoked() {
+      return invoked;
+    }
+  }
+
+  static class TestCamundaAnnotationProcessor extends AbstractCamundaAnnotationProcessor {
+    BeanInfo beanInfo;
+
+    @Override
+    protected boolean isApplicableFor(final BeanInfo beanInfo) {
+      return beanInfo.getTargetClass().equals(MyWorker.class);
+    }
+
+    @Override
+    protected void configureFor(final BeanInfo beanInfo) {
+      this.beanInfo = beanInfo;
+    }
+
+    @Override
+    protected void start(final CamundaClient client) {
+      // do nothing
+    }
+
+    @Override
+    protected void stop(final CamundaClient client) {
+      // do nothing
+    }
+  }
+
+  @Aspect
+  static class ExampleAspect {
+    boolean invoked = false;
+
+    @Around("@annotation(io.camunda.client.annotation.JobWorker) && args(job,..)")
+    public Object wrapJobWorker(final ProceedingJoinPoint joinPoint, final ActivatedJob job)
+        throws Throwable {
+      invoked = true;
+      return joinPoint.proceed();
+    }
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/processor/CamundaAnnotationProcessorPrototypeBeanCompatibilityTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/processor/CamundaAnnotationProcessorPrototypeBeanCompatibilityTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.mock;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.bean.BeanInfo;
-import io.camunda.client.spring.annotation.processor.AbstractCamundaAnnotationProcessorTest.PrototypeBeanConfig;
+import io.camunda.client.spring.annotation.processor.CamundaAnnotationProcessorPrototypeBeanCompatibilityTest.PrototypeBeanConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 
 @SpringBootTest(classes = PrototypeBeanConfig.class)
-public class AbstractCamundaAnnotationProcessorTest {
+public class CamundaAnnotationProcessorPrototypeBeanCompatibilityTest {
 
   @Autowired TestCamundaAnnotationProcessor processor;
 


### PR DESCRIPTION
## Description

When using Spring AOP and the usage of proxy classes, camunda annotation processing wasn't guaranteed to work, as some information just as method annotations were not picked up.

This change ensures the obtained BeanInfo.targetClass always points to the actual user defined class instead to a potential spring proxy class.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39956 
