### PR TITLE
ci: fix OC on demand workflow

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -207,21 +207,23 @@ jobs:
             TEST_ARGS=(--project=chromium)
             
             if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
-              echo "Running all tests in V2 mode"
-              TEST_ARGS+=(
-                tests/api/
-                tests/operate/
-                tests/identity/
-                tests/tasklist/
-                tests/common-flows/
-                --grep-invert="v1/"
-              )
+              echo "Running V2 mode tests"
+              if [[ "${{ needs.validate-branch.outputs.base }}" == "stable/8.8" ]]; then
+                # stable/8.8: run all tests excluding @v1-only tagged tests
+                TEST_ARGS+=(tests/ --grep-invert '@v1-only')
+              else
+                # main: run all tests excluding v1/ directories
+                TEST_ARGS+=(tests/ --grep-invert 'v1/')
+              fi
             else
-              echo "Running V1 mode tests from specific directories"
-              TEST_ARGS+=(
-                tests/tasklist/v1/
-                tests/common-flows/v1/
-              )
+              echo "Running V1 mode tests"
+              if [[ "${{ needs.validate-branch.outputs.base }}" == "stable/8.8" ]]; then
+                # stable/8.8: no v1/ directories, run regular directories for V1 mode
+                TEST_ARGS+=(tests/tasklist/ tests/common-flows/)
+              else
+                # main: has v1/ directories for V1 mode
+                TEST_ARGS+=(tests/tasklist/v1/ tests/common-flows/v1/)
+              fi
             fi
           fi
           echo "Running tests with args: ${TEST_ARGS[*]}"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
After the restructure of OC test suite on `main`, the on-demand workflow stopped triggering all V1 tasklist tests on `stable/8.8`.
This PR fixes the issue by updating the behavior so that in **V2 mode**, all tests are triggered, while in **V1 mode**, only the tasklist and common flow tests are executed.

[main](https://github.com/camunda/camunda/actions/runs/18776518923/job/53572441093)
[stable/8.8](https://github.com/camunda/camunda/actions/runs/18776351384/job/53571900776)
[stable/8.7](https://github.com/camunda/camunda/actions/runs/18776683413/job/53572958937)
[stable/8.6](https://github.com/camunda/camunda/actions/runs/18776788408/job/53573281497)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
