### PR TITLE
[Backport stable/8.6] feat: store schema version metadata in 8.7

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
@@ -7,9 +7,14 @@
  */
 package io.camunda.operate.schema;
 
+import static io.camunda.operate.store.MetadataStore.SCHEMA_VERSION_METADATA_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.conditions.DatabaseInfo;
@@ -20,6 +25,7 @@ import io.camunda.operate.property.MigrationProperties;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager;
+import io.camunda.operate.schema.indices.MetadataIndex;
 import io.camunda.operate.schema.indices.MigrationRepositoryIndex;
 import io.camunda.operate.schema.migration.Migrator;
 import io.camunda.operate.schema.migration.elasticsearch.ElasticsearchMigrationPlanFactory;
@@ -37,17 +43,25 @@ import io.camunda.operate.schema.util.elasticsearch.ElasticsearchSchemaTestHelpe
 import io.camunda.operate.schema.util.elasticsearch.TestElasticsearchConnector;
 import io.camunda.operate.schema.util.opensearch.OpenSearchSchemaTestHelper;
 import io.camunda.operate.schema.util.opensearch.TestOpenSearchConnector;
+import io.camunda.operate.store.MetadataStore;
+import io.camunda.operate.store.elasticsearch.ElasticsearchMetadataStore;
 import io.camunda.operate.store.elasticsearch.ElasticsearchTaskStore;
+import io.camunda.operate.store.opensearch.OpensearchMetadataStore;
 import io.camunda.operate.store.opensearch.OpensearchTaskStore;
+import io.camunda.zeebe.util.VersionUtil;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @ContextConfiguration(
     classes = {
@@ -69,6 +83,9 @@ import org.springframework.test.context.ContextConfiguration;
       ListViewTemplate.class,
       IncidentTemplate.class,
       PostImporterQueueTemplate.class,
+      MetadataIndex.class,
+      ElasticsearchMetadataStore.class,
+      OpensearchMetadataStore.class,
       TestTemplate.class,
       TestIndex.class,
       MigrationProperties.class,
@@ -88,6 +105,9 @@ public class SchemaStartupIT extends AbstractSchemaIT {
   @Autowired private OperateProperties operateProperties;
 
   @Autowired private MigrationProperties migrationProperties;
+
+  @MockitoSpyBean private MetadataStore metadataStore;
+  @Autowired private MetadataIndex metadataIndex;
 
   @Test
   public void shouldAddMissingFieldToExistingIndex() throws MigrationException {
@@ -220,6 +240,71 @@ public class SchemaStartupIT extends AbstractSchemaIT {
         schemaManager.getIndexSettingsFor(indexName, SchemaManager.NUMBERS_OF_REPLICA);
     assertThat(unchangedSettings.get(SchemaManager.NUMBERS_OF_REPLICA))
         .isEqualTo(String.valueOf(initialReplicas));
+  }
+
+  @Test
+  void shouldStoreSchemaVersionWhenMetadataIsMissing() throws MigrationException {
+    // given
+    assertThat(metadataStore.getSchemaVersion()).isNull();
+
+    // when
+    schemaStartup.initializeSchemaOnDemand();
+
+    // then
+    final var metadata = metadataStore.getSchemaVersion();
+    assertThat(metadata).isEqualTo(VersionUtil.getVersion());
+  }
+
+  @Test
+  void shouldStoreSchemaVersionWhenSchemaVersionMetadataIsMissing() throws MigrationException {
+    // given
+    schemaHelper.createIndex(
+        metadataIndex, metadataIndex.getIndexName(), metadataIndex.getSchemaClasspathFilename());
+    assertThat(metadataStore.getSchemaVersion()).isNull();
+
+    // when
+    schemaStartup.initializeSchemaOnDemand();
+
+    // then
+    final var metadata = metadataStore.getSchemaVersion();
+    assertThat(metadata).isEqualTo(VersionUtil.getVersion());
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSchemaVersions")
+  void shouldStoreSchemaVersionOnlyWhenSchemaVersionIsOutdated(
+      final String schemaVersion, final boolean shouldUpdate) throws MigrationException {
+    // given
+    schemaHelper.createIndex(
+        metadataIndex, metadataIndex.getIndexName(), metadataIndex.getSchemaClasspathFilename());
+    clientTestHelper.createDocument(
+        metadataIndex.getFullQualifiedName(),
+        SCHEMA_VERSION_METADATA_ID,
+        Map.of(
+            MetadataIndex.ID, SCHEMA_VERSION_METADATA_ID,
+            MetadataIndex.VALUE, schemaVersion));
+
+    // when
+    schemaStartup.initializeSchemaOnDemand();
+
+    // then
+    final var updatedVersion = metadataStore.getSchemaVersion();
+    assertThat(updatedVersion).isEqualTo(shouldUpdate ? VersionUtil.getVersion() : schemaVersion);
+    if (shouldUpdate) {
+      verify(metadataStore, times(1)).storeSchemaVersion(VersionUtil.getVersion());
+    } else {
+      verify(metadataStore, never()).storeSchemaVersion(any());
+    }
+  }
+
+  private static Stream<Arguments> provideSchemaVersions() {
+    return Stream.of(
+        Arguments.of("8.7.0", true),
+        Arguments.of("8.7.0-SNAPSHOT", true),
+        Arguments.of("UNKNOWN", true),
+        Arguments.of(VersionUtil.getVersion(), false),
+        Arguments.of("8.8.0", false),
+        Arguments.of("8.7.99", false));
   }
 
   private void setNumberOfReplicas(final int numberOfReplicas) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
@@ -299,12 +299,12 @@ public class SchemaStartupIT extends AbstractSchemaIT {
 
   private static Stream<Arguments> provideSchemaVersions() {
     return Stream.of(
-        Arguments.of("8.7.0", true),
-        Arguments.of("8.7.0-SNAPSHOT", true),
+        Arguments.of("8.6.0", true),
+        Arguments.of("8.6.0-SNAPSHOT", true),
         Arguments.of("UNKNOWN", true),
         Arguments.of(VersionUtil.getVersion(), false),
-        Arguments.of("8.8.0", false),
-        Arguments.of("8.7.99", false));
+        Arguments.of("8.7.0", false),
+        Arguments.of("8.6.99", false));
   }
 
   private void setNumberOfReplicas(final int numberOfReplicas) {

--- a/operate/schema/pom.xml
+++ b/operate/schema/pom.xml
@@ -20,6 +20,11 @@
       <artifactId>operate-common</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
     <!-- SPRING -->
 
     <dependency>

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
@@ -14,6 +14,9 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.operate.schema.indices.IndexDescriptor;
 import io.camunda.operate.schema.migration.Migrator;
+import io.camunda.operate.store.MetadataStore;
+import io.camunda.zeebe.util.SemanticVersion;
+import io.camunda.zeebe.util.VersionUtil;
 import jakarta.annotation.PostConstruct;
 import java.util.Map;
 import java.util.Set;
@@ -40,6 +43,8 @@ public class SchemaStartup {
   @Autowired private OperateProperties operateProperties;
 
   @Autowired private MigrationProperties migrationProperties;
+
+  @Autowired private MetadataStore metadataStore;
 
   @PostConstruct
   public void initializeSchema() throws MigrationException {
@@ -75,6 +80,9 @@ public class SchemaStartup {
               "SchemaStartup: schema won't be updated as schema creation is disabled in configuration.");
         }
       }
+      if (createSchema) {
+        storeSchemaVersion();
+      }
       if (createSchema && updateSchemaSettings) {
         schemaManager.updateIndexSettings();
       }
@@ -86,6 +94,17 @@ public class SchemaStartup {
     } catch (final Exception ex) {
       LOGGER.error("Schema startup failed: " + ex.getMessage(), ex);
       throw ex;
+    }
+  }
+
+  private void storeSchemaVersion() {
+    if (VersionUtil.getSemanticVersion()
+        .flatMap(
+            appVersion ->
+                SemanticVersion.parse(metadataStore.getSchemaVersion())
+                    .map(schemaVersion -> schemaVersion.compareTo(appVersion) < 0))
+        .orElse(true)) {
+      metadataStore.storeSchemaVersion(VersionUtil.getVersion());
     }
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
@@ -98,12 +98,17 @@ public class SchemaStartup {
   }
 
   private void storeSchemaVersion() {
-    if (VersionUtil.getSemanticVersion()
-        .flatMap(
-            appVersion ->
-                SemanticVersion.parse(metadataStore.getSchemaVersion())
-                    .map(schemaVersion -> schemaVersion.compareTo(appVersion) < 0))
-        .orElse(true)) {
+    // Check if the current schema version in the metadata store is older than the application
+    // version. Returns true if the schema version should be updated, or if either version cannot be
+    // parsed into a SemanticVersion.
+    final boolean shouldUpdateSchemaVersion =
+        VersionUtil.getSemanticVersion()
+            .flatMap(
+                appVersion ->
+                    SemanticVersion.parse(metadataStore.getSchemaVersion())
+                        .map(schemaVersion -> schemaVersion.compareTo(appVersion) < 0))
+            .orElse(true);
+    if (shouldUpdateSchemaVersion) {
       metadataStore.storeSchemaVersion(VersionUtil.getVersion());
     }
   }

--- a/operate/schema/src/main/java/io/camunda/operate/schema/indices/MetadataIndex.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/indices/MetadataIndex.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.schema.indices;
+
+import io.camunda.operate.schema.backup.Prio1Backup;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class MetadataIndex extends AbstractIndexDescriptor implements Prio1Backup {
+
+  public static final String INDEX_NAME = "metadata";
+
+  public static final String ID = "id";
+
+  public static final String VALUE = "value";
+
+  @Override
+  public String getIndexName() {
+    return INDEX_NAME;
+  }
+
+  @Override
+  public String getVersion() {
+    return "8.8.0";
+  }
+}

--- a/operate/schema/src/main/java/io/camunda/operate/store/MetadataStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/MetadataStore.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.store;
+
+public interface MetadataStore {
+  // Schema version metadata constants
+  String SCHEMA_VERSION_METADATA_ID = "schema-version";
+
+  /**
+   * Retrieves the schema version from metadata storage. Returns null if no version is stored
+   * (indicating a fresh installation).
+   */
+  String getSchemaVersion();
+
+  /**
+   * Stores the current application version as the schema version in metadata storage. This should
+   * be called after a successful schema upgrade.
+   */
+  void storeSchemaVersion(final String version);
+}

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchMetadataStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchMetadataStore.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.store.elasticsearch;
+
+import io.camunda.operate.conditions.ElasticsearchCondition;
+import io.camunda.operate.schema.indices.MetadataIndex;
+import io.camunda.operate.store.MetadataStore;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Conditional(ElasticsearchCondition.class)
+@Component
+public class ElasticsearchMetadataStore implements MetadataStore {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchMetadataStore.class);
+
+  @Autowired private RetryElasticsearchClient retryElasticsearchClient;
+  @Autowired private MetadataIndex metadataIndex;
+
+  @Override
+  public String getSchemaVersion() {
+    // Check if metadata index exists
+    if (!retryElasticsearchClient.indexExists(metadataIndex.getFullQualifiedName())) {
+      LOG.debug("Metadata index does not exist");
+      return null;
+    }
+    final var schemaVersionDoc =
+        retryElasticsearchClient.getDocument(
+            metadataIndex.getFullQualifiedName(), SCHEMA_VERSION_METADATA_ID);
+    if (schemaVersionDoc == null) {
+      LOG.debug("Schema version metadata document cannot be found");
+      return null;
+    }
+    return schemaVersionDoc.get(MetadataIndex.VALUE).toString();
+  }
+
+  @Override
+  public void storeSchemaVersion(final String version) {
+    retryElasticsearchClient.createOrUpdateDocument(
+        metadataIndex.getFullQualifiedName(),
+        SCHEMA_VERSION_METADATA_ID,
+        Map.of(
+            MetadataIndex.ID, SCHEMA_VERSION_METADATA_ID,
+            MetadataIndex.VALUE, version));
+    LOG.debug("Stored schema version: {}", version);
+  }
+}

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/RetryElasticsearchClient.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/RetryElasticsearchClient.java
@@ -862,4 +862,10 @@ public class RetryElasticsearchClient {
                 .getSettings(new GetSettingsRequest().indices(indexPattern), requestOptions)
                 .getIndexToSettings());
   }
+
+  public boolean indexExists(final String indexName) {
+    return executeWithRetries(
+        "IndexExists " + indexName,
+        () -> esClient.indices().exists(new GetIndexRequest(indexName), requestOptions));
+  }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchMetadataStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchMetadataStore.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.store.opensearch;
+
+import static io.camunda.operate.store.opensearch.dsl.RequestDSL.indexRequestBuilder;
+
+import io.camunda.operate.conditions.OpensearchCondition;
+import io.camunda.operate.schema.indices.MetadataIndex;
+import io.camunda.operate.store.MetadataStore;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Conditional(OpensearchCondition.class)
+@Component
+public class OpensearchMetadataStore implements MetadataStore {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OpensearchMetadataStore.class);
+
+  @Autowired private RichOpenSearchClient richOpenSearchClient;
+  @Autowired private MetadataIndex metadataIndex;
+
+  @Override
+  public String getSchemaVersion() {
+    // Check if metadata index exists
+    if (!richOpenSearchClient.index().indexExists(metadataIndex.getFullQualifiedName())) {
+      LOG.debug("Metadata index does not exist");
+      return null;
+    }
+    final var schemaVersionDoc =
+        richOpenSearchClient
+            .doc()
+            .getWithRetries(
+                metadataIndex.getFullQualifiedName(), SCHEMA_VERSION_METADATA_ID, Map.class);
+    if (schemaVersionDoc.isEmpty()) {
+      LOG.debug("Schema version metadata document cannot be found");
+      return null;
+    }
+    return schemaVersionDoc.get().get(MetadataIndex.VALUE).toString();
+  }
+
+  @Override
+  public void storeSchemaVersion(final String version) {
+    richOpenSearchClient
+        .doc()
+        .indexWithRetries(
+            indexRequestBuilder(metadataIndex.getFullQualifiedName())
+                .id(SCHEMA_VERSION_METADATA_ID)
+                .document(
+                    Map.of(
+                        MetadataIndex.ID, SCHEMA_VERSION_METADATA_ID,
+                        MetadataIndex.VALUE, version)));
+    LOG.debug("Stored schema version: {}", version);
+  }
+}

--- a/operate/schema/src/main/resources/schema/elasticsearch/create/index/operate-metadata.json
+++ b/operate/schema/src/main/resources/schema/elasticsearch/create/index/operate-metadata.json
@@ -1,0 +1,13 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/operate/schema/src/main/resources/schema/opensearch/create/index/operate-metadata.json
+++ b/operate/schema/src/main/resources/schema/opensearch/create/index/operate-metadata.json
@@ -1,0 +1,13 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "value": {
+        "type": "keyword"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description
Backport of #39769 to `stable/8.6`.

relates to #38985