### PR TITLE
ci: fix OC e2e release workflow

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -260,21 +260,23 @@ jobs:
             TEST_ARGS=(--project=chromium)
             
             if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
-              echo "Running All tests in V2 mode, excluding V1 specific tests"
-              TEST_ARGS+=(
-                tests/api/
-                tests/operate/
-                tests/identity/
-                tests/tasklist/
-                tests/common-flows/
-                --grep-invert="v1/"
-              )
+              echo "Running V2 mode tests"
+              if [[ "${{ needs.validate-release.outputs.base }}" == "stable/8.8" ]]; then
+                # stable/8.8: run all tests excluding @v1-only tagged tests
+                TEST_ARGS+=(tests/ --grep-invert '@v1-only')
+              else
+                # main: run all tests excluding v1/ directories
+                TEST_ARGS+=(tests/ --grep-invert 'v1/')
+              fi
             else
-              echo "Running V1 mode tests from specific V1 directories only"
-              TEST_ARGS+=(
-                tests/tasklist/v1/
-                tests/common-flows/v1/
-              )
+              echo "Running V1 mode tests"
+              if [[ "${{ needs.validate-release.outputs.base }}" == "stable/8.8" ]]; then
+                # stable/8.8: no v1/ directories, run regular directories for V1 mode
+                TEST_ARGS+=(tests/tasklist/ tests/common-flows/)
+              else
+                # main: has v1/ directories for V1 mode
+                TEST_ARGS+=(tests/tasklist/v1/ tests/common-flows/v1/)
+              fi
             fi
           fi
           echo "Running tests with args: ${TEST_ARGS[*]}"


### PR DESCRIPTION
## Description
After the restructure on `main`, the release workflow stopped triggering all V1 tasklist tests on `stable/8.8`.
This PR fixes the issue by updating the behavior so that in **V2 mode**, all tests are triggered, while in **V1 mode**, only the tasklist and common flow tests are executed.
<!-- Describe the goal and purpose of this PR. -->
[main](https://github.com/camunda/camunda/actions/runs/18777823538/job/53576573766)
[8.8.0](https://github.com/camunda/camunda/actions/runs/18777478060/job/53575440447)
[8.7.0](https://github.com/camunda/camunda/actions/runs/18777547833/job/53575662666)
[8.6.0](https://github.com/camunda/camunda/actions/runs/18777609201/job/53575856607)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
