### PR TITLE
test: fix failing Operate and Tasklist backup CI

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -245,6 +245,7 @@ runs:
           - '**/*.md'
 
         webapps-change:
+          - 'configuration/**'
           - 'webapps-backup/**'
           - 'webapps-common/**'
           - 'webapps-schema/**'

--- a/configuration/src/main/java/io/camunda/configuration/Backup.java
+++ b/configuration/src/main/java/io/camunda/configuration/Backup.java
@@ -83,7 +83,7 @@ public class Backup implements Cloneable {
         PREFIX + ".repository-name",
         repositoryName,
         String.class,
-        BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+        BackwardsCompatibilityMode.SUPPORTED,
         LEGACY_REPOSITORY_NAME_PROPERTIES);
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupOperatePropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupOperatePropertiesTest.java
@@ -56,8 +56,7 @@ public class DataBackupOperatePropertiesTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.data.backup.repository-name=repositoryName",
-        "camunda.tasklist.backup.repositoryName=repositoryName",
+        "camunda.tasklist.backup.repositoryName=repositoryNameLegacyTasklist",
       })
   class WithTasklistLegacySet {
     final OperateProperties operateProperties;
@@ -68,15 +67,15 @@ public class DataBackupOperatePropertiesTest {
 
     @Test
     void shouldSetRepositoryNameIfNewAndTasklistMatch() {
-      assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+      assertThat(operateProperties.getBackup().getRepositoryName())
+          .isEqualTo("repositoryNameLegacyTasklist");
     }
   }
 
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.data.backup.repository-name=repositoryName",
-        "camunda.operate.backup.repositoryName=repositoryName",
+        "camunda.operate.backup.repositoryName=repositoryNameLegacyOperate",
         "camunda.operate.backup.snapshotTimeout=5",
         "camunda.operate.backup.incompleteCheckTimeoutInSeconds=180",
       })
@@ -89,7 +88,8 @@ public class DataBackupOperatePropertiesTest {
 
     @Test
     void shouldSetRepositoryNameIfNewAndOperateMatch() {
-      assertThat(operateProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+      assertThat(operateProperties.getBackup().getRepositoryName())
+          .isEqualTo("repositoryNameLegacyOperate");
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupTasklistPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupTasklistPropertiesTest.java
@@ -44,8 +44,7 @@ public class DataBackupTasklistPropertiesTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.data.backup.repository-name=repositoryName",
-        "camunda.operate.backup.repositoryName=repositoryName",
+        "camunda.operate.backup.repositoryName=repositoryNameLegacyOperate",
       })
   class WithOperateLegacySet {
     final TasklistProperties tasklistProperties;
@@ -56,15 +55,15 @@ public class DataBackupTasklistPropertiesTest {
 
     @Test
     void shouldSetRepositoryNameIfNewAndOperateMatch() {
-      assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+      assertThat(tasklistProperties.getBackup().getRepositoryName())
+          .isEqualTo("repositoryNameLegacyOperate");
     }
   }
 
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.data.backup.repository-name=repositoryName",
-        "camunda.tasklist.backup.repositoryName=repositoryName",
+        "camunda.tasklist.backup.repositoryName=repositoryNameLegacyTasklist",
       })
   class WithTasklistLegacySet {
     final TasklistProperties tasklistProperties;
@@ -75,7 +74,8 @@ public class DataBackupTasklistPropertiesTest {
 
     @Test
     void shouldSetRepositoryNameIfNewAndTasklistMatch() {
-      assertThat(tasklistProperties.getBackup().getRepositoryName()).isEqualTo("repositoryName");
+      assertThat(tasklistProperties.getBackup().getRepositoryName())
+          .isEqualTo("repositoryNameLegacyTasklist");
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The use of legacy properties without the need to provide the new property should be supported for backup repository name

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
