### PR TITLE
fix: patch c8run to 8.8.1

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,8 +1,8 @@
 ELASTICSEARCH_VERSION=8.17.3
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.8.0
+CAMUNDA_VERSION=8.8.1
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
-CONNECTORS_VERSION=8.8.0
+CONNECTORS_VERSION=8.8.1
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.8
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.8


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Update patch version of `8.8.0` in C8run to `8.8.1`

related to https://github.com/camunda/team-distribution/issues/620

release train: [8.8.1 patch release](https://camunda.slack.com/archives/C03NFMH4KC6/p1761303096643939?thread_ts=1760614420.210439&cid=C03NFMH4KC6)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
