### PR TITLE
[Backport stable/8.6] fix: ordered distribution of resource deployment and deletion

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.engine.state.immutable.FormState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
@@ -179,7 +180,10 @@ public final class DeploymentCreateProcessor
         key, DeploymentIntent.CREATED, recordWithoutResource, command);
     stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, recordWithoutResource);
 
-    distributionBehavior.withKey(key).unordered().distribute(command);
+    distributionBehavior
+        .withKey(key)
+        .inQueue(DistributionQueue.DEPLOYMENT.getQueueId())
+        .distribute(command);
   }
 
   private void processDistributedRecord(final TypedRecord<DeploymentRecord> command) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -180,10 +180,7 @@ public final class DeploymentCreateProcessor
         key, DeploymentIntent.CREATED, recordWithoutResource, command);
     stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, recordWithoutResource);
 
-    distributionBehavior
-        .withKey(key)
-        .inQueue(DistributionQueue.DEPLOYMENT.getQueueId())
-        .distribute(command);
+    distributionBehavior.withKey(key).inQueue(DistributionQueue.DEPLOYMENT).distribute(command);
   }
 
   private void processDistributedRecord(final TypedRecord<DeploymentRecord> command) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWrit
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.Protocol;
@@ -293,6 +294,10 @@ public final class CommandDistributionBehavior {
     DistributionRequestBuilder unordered();
 
     DistributionRequestBuilder inQueue(String queue);
+
+    default DistributionRequestBuilder inQueue(final DistributionQueue queue) {
+      return inQueue(queue.getQueueId());
+    }
 
     ContinuationRequestBuilder afterQueue(String queue);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -106,7 +106,7 @@ public class ResourceDeletionDeleteProcessor
     stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETED, value);
     commandDistributionBehavior
         .withKey(eventKey)
-        .inQueue(DistributionQueue.DEPLOYMENT.getQueueId())
+        .inQueue(DistributionQueue.DEPLOYMENT)
         .distribute(command);
     responseWriter.writeEventOnCommand(eventKey, ResourceDeletionIntent.DELETING, value, command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
 import io.camunda.zeebe.engine.state.deployment.PersistedForm;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
@@ -103,7 +104,10 @@ public class ResourceDeletionDeleteProcessor
     tryDeleteResources(command);
 
     stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETED, value);
-    commandDistributionBehavior.withKey(eventKey).unordered().distribute(command);
+    commandDistributionBehavior
+        .withKey(eventKey)
+        .inQueue(DistributionQueue.DEPLOYMENT.getQueueId())
+        .distribute(command);
     responseWriter.writeEventOnCommand(eventKey, ResourceDeletionIntent.DELETING, value, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DistributionQueue.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DistributionQueue.java
@@ -8,7 +8,8 @@
 package io.camunda.zeebe.engine.state.distribution;
 
 public enum DistributionQueue {
-  IDENTITY("IDENTITY");
+  IDENTITY("IDENTITY"),
+  DEPLOYMENT("DEPLOYMENT");
 
   private final String queueId;
 


### PR DESCRIPTION
# Description
Backport of #24099 to `stable/8.6`.

relates to camunda/camunda#21357 camunda/camunda#24013