### PR TITLE
fix: reset exporter to isolate tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/CompatibilityModeOperateZeebeAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/CompatibilityModeOperateZeebeAuthorizationIT.java
@@ -36,7 +36,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -155,7 +154,6 @@ public class CompatibilityModeOperateZeebeAuthorizationIT {
       @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
       @Authenticated(TEST_USER_NAME_WITH_PERMISSION) final CamundaClient testClientWithPermissions,
       @Authenticated(TEST_USER_NAME_NO_PERMISSION) final CamundaClient testClientNoPermissions) {
-    RecordingExporter.reset();
     // given
     // deployed decision definitions
     decisionDeploymentEvent = deployResource(adminClient, DECISION_RESOURCE);
@@ -177,11 +175,6 @@ public class CompatibilityModeOperateZeebeAuthorizationIT {
 
     // wait for operate to catch up
     waitForProcessesToBeDeployed(adminClient, 5);
-  }
-
-  @AfterAll
-  public static void afterAll(@Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
-    RecordingExporter.reset();
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/CompatibilityModeOperateZeebeAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/CompatibilityModeOperateZeebeAuthorizationIT.java
@@ -281,11 +281,7 @@ public class CompatibilityModeOperateZeebeAuthorizationIT {
       assertThat(responseBody.statusCode()).isEqualTo(expectedResponseCode);
       if (expectedResponseCode == 200) {
         // if the request is successful, we expect the process instance to be modified
-        RecordingExporter.processInstanceModificationRecords()
-            .withIntent(ProcessInstanceModificationIntent.MODIFIED)
-            .withProcessInstanceKey(processInstanceKey)
-            .exists();
-
+        RecordingExporter.setMaximumWaitTime(25_000L);
         final var count =
             RecordingExporter.processInstanceModificationRecords()
                 .withIntent(ProcessInstanceModificationIntent.MODIFIED)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/NoCompatibilityModeOperateZeebeAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/NoCompatibilityModeOperateZeebeAuthorizationIT.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -149,6 +150,7 @@ public class NoCompatibilityModeOperateZeebeAuthorizationIT {
   @BeforeAll
   public static void beforeAll(@Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given
+    RecordingExporter.reset();
     // deployed decision definitions
     decisionDeploymentEvent = deployResource(adminClient, DECISION_RESOURCE);
     // wait for Operate to catch up
@@ -169,6 +171,11 @@ public class NoCompatibilityModeOperateZeebeAuthorizationIT {
 
     // wait for operate to catch up
     waitForProcessesToBeDeployed(adminClient, 5);
+  }
+
+  @AfterAll
+  public static void afterAll(@Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
+    RecordingExporter.reset();
   }
 
   @ParameterizedTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/NoCompatibilityModeOperateZeebeAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/compatibility/NoCompatibilityModeOperateZeebeAuthorizationIT.java
@@ -36,7 +36,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -150,7 +149,6 @@ public class NoCompatibilityModeOperateZeebeAuthorizationIT {
   @BeforeAll
   public static void beforeAll(@Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given
-    RecordingExporter.reset();
     // deployed decision definitions
     decisionDeploymentEvent = deployResource(adminClient, DECISION_RESOURCE);
     // wait for Operate to catch up
@@ -171,11 +169,6 @@ public class NoCompatibilityModeOperateZeebeAuthorizationIT {
 
     // wait for operate to catch up
     waitForProcessesToBeDeployed(adminClient, 5);
-  }
-
-  @AfterAll
-  public static void afterAll(@Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
-    RecordingExporter.reset();
   }
 
   @ParameterizedTest

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -267,7 +267,7 @@ public class CamundaMultiDBExtension
     final Class<?> testClass = context.getRequiredTestClass();
     final var isHistoryRelatedTest = testClass.isAnnotationPresent(HistoryMultiDbTest.class);
     testPrefix = testClass.getSimpleName().toLowerCase();
-
+    RecordingExporter.reset();
     setupTestApplication(testClass);
     switch (databaseType) {
       case LOCAL -> {
@@ -604,6 +604,7 @@ public class CamundaMultiDBExtension
   public void afterAll(final ExtensionContext context) throws Exception {
     CloseHelper.quietCloseAll(closeables);
     authenticatedClientFactory.close();
+    RecordingExporter.reset();
   }
 
   @Override


### PR DESCRIPTION
## Description

The [ci](https://github.com/camunda/camunda/actions/runs/18708073884/job/53349969069) is failing but tests are ok individually. Running all tests in `qa/acceptance-tests/src/test/java/io/camunda/it/operate` shows that `NoneCompatibilityModeOperateZeebeAuthorizationIT` has affect on `CompatibilityModeOperateZeebeAuthorizationIT` and cause the RecordExporter queries to return wrong numbers.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
[#39855 CI: opensearch-integration-tests job is unstable](https://github.com/camunda/camunda/issues/39855)

closes #
