### PR TITLE
[Backport stable/8.6] fix: in MigrationSnapshotDirector call onHealthReport when listener subscribes

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
@@ -98,7 +98,7 @@ public class MigrationSnapshotDirector implements HealthMonitorable, CloseableSi
   public void addFailureListener(final FailureListener failureListener) {
     LOG.trace("Added failure listener {}", failureListener);
     listeners.put(failureListener, Boolean.TRUE);
-    failureListener.onFailure(healthReport);
+    failureListener.onHealthReport(healthReport);
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #39949 to `stable/8.6`.

relates to #39751