### PR TITLE
[Backport stable/8.8] ci: build identity with npm for benchmark tests

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -132,7 +132,7 @@ runs:
       if: ${{ inputs.source-build == 'true' }}
       working-directory: ./identity/client
       shell: bash
-      run: yarn
+      run: npm ci
 
     - uses: ./.github/actions/build-zeebe
       if: ${{ inputs.source-build == 'true' }}

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -394,7 +394,7 @@ jobs:
   run-backup-restore-tests:
     if: inputs.runBeTests
     name: "Integration / Backup Restore ITs"
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1394,6 +1394,7 @@ jobs:
         id: build-identity-fe
         with:
           directory: ./identity/client
+          package-manager: "npm"
       # compile and generate-sources to ensure that the Javadoc can be properly generated; compile is
       # necessary when using annotation preprocessors for code generation, as otherwise the symbols are
       # not resolve-able by the Javadoc generator
@@ -1452,6 +1453,7 @@ jobs:
         id: build-identity-fe
         with:
           directory: ./identity/client
+          package-manager: "npm"
       - uses: ./.github/actions/build-zeebe
         id: build-camunda
         with:

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -145,6 +145,7 @@ jobs:
         id: build-identity-fe
         with:
           directory: ./identity/client
+          package-manager: "npm"
       - uses: ./.github/actions/build-zeebe
         name: Build Zeebe
         id: build-zeebe


### PR DESCRIPTION
# Description
Backport of #39934 to `stable/8.8`.

relates to 