### PR TITLE
[Backport stable/8.8] fix: add usage metrics rollover interval validation and configuration

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1040,6 +1040,7 @@
         #   history:
         #     elsRolloverDateFormat: "date"
         #     rolloverInterval: "1d"
+        #     usageMetricsRolloverInterval: "1M"
         #     rolloverBatchSize: 100
         #     waitPeriodBeforeArchiving: "1h"
         #     delayBetweenRuns: 2000

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ConfigValidator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ConfigValidator.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 public final class ConfigValidator {
   private static final String PATTERN_DATE_INTERVAL_FORMAT = "^(?:[1-9]\\d*)" + "([smhdwMy])$";
   private static final String PATTERN_ROLLOVER_INTERVAL_FORMAT = "^(?:[1-9]\\d*)([hdwMy])$";
+  private static final String PATTERN_USAGE_METRICS_ROLLOVER_INTERVAL_FORMAT = "^(?:[1-4]w|1M)$";
 
   /**
    * Supported pattern for min_age property of ILM, we only support: days, hours, minutes and
@@ -33,6 +34,8 @@ public final class ConfigValidator {
       Pattern.compile(PATTERN_DATE_INTERVAL_FORMAT).asPredicate();
   private static final Predicate<String> CHECK_ROLLOVER_INTERVAL =
       Pattern.compile(PATTERN_ROLLOVER_INTERVAL_FORMAT).asPredicate();
+  private static final Predicate<String> CHECK_USAGE_METRICS_ROLLOVER_INTERVAL =
+      Pattern.compile(PATTERN_USAGE_METRICS_ROLLOVER_INTERVAL_FORMAT).asPredicate();
   private static final Pattern INVALID_INDEX_PREFIX_CHARS = Pattern.compile("[\\\\/*?\"<>| _]");
 
   private ConfigValidator() {}
@@ -90,6 +93,16 @@ public final class ConfigValidator {
           String.format(
               "CamundaExporter archiver.rolloverInterval '%s' must match pattern '%s', but didn't.",
               rolloverInterval, PATTERN_ROLLOVER_INTERVAL_FORMAT));
+    }
+
+    final String usageMetricsRolloverInterval =
+        configuration.getHistory().getUsageMetricsRolloverInterval();
+    if (usageMetricsRolloverInterval != null
+        && !CHECK_USAGE_METRICS_ROLLOVER_INTERVAL.test(usageMetricsRolloverInterval)) {
+      throw new ExporterException(
+          String.format(
+              "CamundaExporter archiver.usageMetricsRolloverInterval '%s' must match pattern '%s', but didn't.",
+              usageMetricsRolloverInterval, PATTERN_USAGE_METRICS_ROLLOVER_INTERVAL_FORMAT));
     }
 
     final String waitPeriodBeforeArchiving =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -188,7 +188,7 @@ public class ExporterConfiguration {
     private boolean processInstanceEnabled = true;
     private String elsRolloverDateFormat = "date";
     private String rolloverInterval = "1d";
-    private String usageMetricsRolloverInterval = "1w";
+    private String usageMetricsRolloverInterval = "1M";
     private int rolloverBatchSize = 100;
     private String waitPeriodBeforeArchiving = "1h";
     private int delayBetweenRuns = 2000;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -188,6 +188,7 @@ public class ExporterConfiguration {
     private boolean processInstanceEnabled = true;
     private String elsRolloverDateFormat = "date";
     private String rolloverInterval = "1d";
+    private String usageMetricsRolloverInterval = "1w";
     private int rolloverBatchSize = 100;
     private String waitPeriodBeforeArchiving = "1h";
     private int delayBetweenRuns = 2000;
@@ -217,6 +218,14 @@ public class ExporterConfiguration {
 
     public void setRolloverInterval(final String rolloverInterval) {
       this.rolloverInterval = rolloverInterval;
+    }
+
+    public String getUsageMetricsRolloverInterval() {
+      return usageMetricsRolloverInterval;
+    }
+
+    public void setUsageMetricsRolloverInterval(final String usageMetricsRolloverInterval) {
+      this.usageMetricsRolloverInterval = usageMetricsRolloverInterval;
     }
 
     public String getArchivingTimePoint() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -177,7 +177,10 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .thenComposeAsync(
             response ->
                 createArchiveBatch(
-                    response, UsageMetricTUTemplate.END_TIME, usageMetricTUTemplateDescriptor),
+                    response,
+                    UsageMetricTUTemplate.END_TIME,
+                    usageMetricTUTemplateDescriptor,
+                    config.getUsageMetricsRolloverInterval()),
             executor);
   }
 
@@ -196,7 +199,10 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .thenComposeAsync(
             response ->
                 createArchiveBatch(
-                    response, UsageMetricTemplate.END_TIME, usageMetricTemplateDescriptor),
+                    response,
+                    UsageMetricTemplate.END_TIME,
+                    usageMetricTemplateDescriptor,
+                    config.getUsageMetricsRolloverInterval()),
             executor);
   }
 
@@ -391,6 +397,14 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       final SearchResponse<?> response,
       final String field,
       final IndexTemplateDescriptor templateDescriptor) {
+    return createArchiveBatch(response, field, templateDescriptor, config.getRolloverInterval());
+  }
+
+  private CompletableFuture<ArchiveBatch> createArchiveBatch(
+      final SearchResponse<?> response,
+      final String field,
+      final IndexTemplateDescriptor templateDescriptor,
+      final String rolloverInterval) {
     final var hits = response.hits().hits();
     if (hits.isEmpty()) {
       return CompletableFuture.completedFuture(new ArchiveBatch(null, List.of()));
@@ -408,7 +422,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         date -> {
           lastHistoricalArchiverDate =
               DateOfArchivedDocumentsUtil.calculateDateOfArchiveIndexForBatch(
-                  endDate, date, config.getRolloverInterval(), config.getElsRolloverDateFormat());
+                  endDate, date, rolloverInterval, config.getElsRolloverDateFormat());
 
           final var ids =
               hits.stream()

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/ConfigValidatorTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/ConfigValidatorTest.java
@@ -180,6 +180,60 @@ public class ConfigValidatorTest {
             "CamundaExporter archiver.rolloverInterval '1s' must match pattern '^(?:[1-9]\\d*)([hdwMy])$', but didn't.");
   }
 
+  @Test
+  void shouldAssureUsageMetricsRolloverIntervalToBeValid() {
+    // given
+    config.getHistory().setUsageMetricsRolloverInterval("1day");
+
+    // when - then
+    assertThatCode(() -> ConfigValidator.validate(config))
+        .isInstanceOf(ExporterException.class)
+        .hasMessageContaining(
+            "CamundaExporter archiver.usageMetricsRolloverInterval '1day' must match pattern '^(?:[1-4]w|1M)$', but didn't.");
+  }
+
+  @Test
+  void shouldAssureUsageMetricsRolloverIsInAllowedRange() {
+    // given
+    config.getHistory().setUsageMetricsRolloverInterval("7d");
+    // when - then
+    assertThatCode(() -> ConfigValidator.validate(config))
+        .isInstanceOf(ExporterException.class)
+        .hasMessageContaining(
+            "CamundaExporter archiver.usageMetricsRolloverInterval '7d' must match pattern '^(?:[1-4]w|1M)$', but didn't.");
+
+    // given
+    config.getHistory().setUsageMetricsRolloverInterval("5w");
+    // when - then
+    assertThatCode(() -> ConfigValidator.validate(config))
+        .isInstanceOf(ExporterException.class)
+        .hasMessageContaining(
+            "CamundaExporter archiver.usageMetricsRolloverInterval '5w' must match pattern '^(?:[1-4]w|1M)$', but didn't.");
+
+    // given
+    config.getHistory().setUsageMetricsRolloverInterval("2M");
+    // when - then
+    assertThatCode(() -> ConfigValidator.validate(config))
+        .isInstanceOf(ExporterException.class)
+        .hasMessageContaining(
+            "CamundaExporter archiver.usageMetricsRolloverInterval '2M' must match pattern '^(?:[1-4]w|1M)$', but didn't.");
+
+    // given
+    config.getHistory().setUsageMetricsRolloverInterval("1w");
+    // when - then
+    ConfigValidator.validate(config);
+
+    // given
+    config.getHistory().setUsageMetricsRolloverInterval("4w");
+    // when - then
+    ConfigValidator.validate(config);
+
+    // given
+    config.getHistory().setUsageMetricsRolloverInterval("1M");
+    // when - then
+    ConfigValidator.validate(config);
+  }
+
   @ParameterizedTest(name = "{0}")
   @ValueSource(ints = {-1, 0})
   void shouldForbidNonPositiveMaxCacheSize(final int maxCacheSize) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/DateOfArchivedDocumentsUtilIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/DateOfArchivedDocumentsUtilIT.java
@@ -21,6 +21,14 @@ public class DateOfArchivedDocumentsUtilIT {
             DateOfArchivedDocumentsUtil.calculateDateOfArchiveIndexForBatch(
                 "2023-09-01", "", "1d", "yyyy-MM-dd"))
         .isEqualTo("2023-09-01");
+    assertThat(
+            DateOfArchivedDocumentsUtil.calculateDateOfArchiveIndexForBatch(
+                "2023-09-05", "2023-08-01", "1M", "yyyy-MM-dd"))
+        .isEqualTo("2023-09-05");
+    assertThat(
+            DateOfArchivedDocumentsUtil.calculateDateOfArchiveIndexForBatch(
+                "2023-09-05", "2023-08-28", "1M", "yyyy-MM-dd"))
+        .isEqualTo("2023-08-28");
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #39556 to `stable/8.8`.

relates to camunda/camunda#39357