### PR TITLE
Validate global user task listeners configuration

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -510,7 +510,20 @@ public final class SystemContext {
         continue;
       }
 
-      listener.setEventTypes(eventTypes);
+      // Check if retries actually contains a number
+      try {
+        if (Integer.parseInt(listener.getRetries()) <= 0) {
+          throw new NumberFormatException();
+        }
+      } catch (final NumberFormatException e) {
+        LOG.warn(
+            String.format(
+                "Invalid retries for global listener: '%s'; listener will be ignored [%s.retries]",
+                listener.getRetries(), propertyPrefix));
+        continue;
+      }
+
+      listener.setEventTypes(validEventTypes);
       validListeners.add(listener);
     }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -501,14 +501,31 @@ public final class SystemContext {
                     return true;
                   })
               .toList();
+
+      // Remove duplicates
+      final List<String> uniqueEventTypes = new ArrayList<>();
+      validEventTypes.forEach(
+          eventType -> {
+            if (uniqueEventTypes.contains(eventType)) {
+              LOG.warn(
+                  String.format(
+                      "Duplicated event type will be considered only once: '%s' [%s.eventTypes]",
+                      eventType, propertyPrefix));
+            } else {
+              uniqueEventTypes.add(eventType);
+            }
+          });
+
       // Check if valid event types have been provided
-      if (validEventTypes.isEmpty()) {
+      if (uniqueEventTypes.isEmpty()) {
         LOG.warn(
             String.format(
                 "Missing event types for global listener; listener will be ignored [%s.eventTypes]",
                 propertyPrefix));
         continue;
       }
+
+      listener.setEventTypes(uniqueEventTypes);
 
       // Check if retries actually contains a number
       try {
@@ -522,8 +539,6 @@ public final class SystemContext {
                 listener.getRetries(), propertyPrefix));
         continue;
       }
-
-      listener.setEventTypes(validEventTypes);
       validListeners.add(listener);
     }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -55,7 +55,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -460,7 +459,7 @@ public final class SystemContext {
       final String propertyPrefix = String.format("%s.%d", propertyLocation, i);
 
       // Check if type is present
-      if (listener.getType() == null || StringUtils.isBlank(listener.getType())) {
+      if (listener.getType() == null || listener.getType().isBlank()) {
         LOG.warn(
             String.format(
                 "Missing job type for global listener; listener will be ignored [%s.type]",

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.engine.ListenerCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
@@ -617,5 +618,106 @@ final class SystemContextTest {
         .isInstanceOf(InvalidConfigurationException.class)
         .hasMessageContaining(
             "experimental.engine.batchOperation.queryRetryMaxDelay must be greater than or equal to the experimental.engine.batchOperation.queryRetryInitialDelay");
+  }
+
+  @Test
+  void shouldIgnoreInvalidEventTypesForGlobalTaskListeners() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getExperimental()
+        .getEngine()
+        .getListeners()
+        .setTask(
+            List.of(
+                createListenerCfg("test", List.of("creating", "non-existing-type", "assigning"))));
+
+    // when
+    initSystemContext(brokerCfg);
+
+    // then
+    assertThat(brokerCfg.getExperimental().getEngine().getListeners().getTask()).hasSize(1);
+    final var listenerConfig =
+        brokerCfg.getExperimental().getEngine().getListeners().getTask().getFirst();
+    assertThat(listenerConfig.getEventTypes()).containsExactly("creating", "assigning");
+  }
+
+  @Test
+  void shouldIgnoreGlobalTaskListenerWithoutJobType() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getExperimental()
+        .getEngine()
+        .getListeners()
+        .setTask(
+            List.of(
+                createListenerCfg("test", List.of("creating")),
+                createListenerCfg(null, List.of("assigning"))));
+
+    // when
+    initSystemContext(brokerCfg);
+
+    // then
+    assertThat(brokerCfg.getExperimental().getEngine().getListeners().getTask()).hasSize(1);
+    final var listenerConfig =
+        brokerCfg.getExperimental().getEngine().getListeners().getTask().getFirst();
+    assertThat(listenerConfig.getType()).isEqualTo("test");
+    assertThat(listenerConfig.getEventTypes()).containsExactly("creating");
+  }
+
+  @Test
+  void shouldIgnoreGlobalTaskListenerWithoutEventTypes() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getExperimental()
+        .getEngine()
+        .getListeners()
+        .setTask(
+            List.of(
+                createListenerCfg("test1", List.of("creating")),
+                createListenerCfg(
+                    "test2",
+                    List.of("non-existing-type")), // only invalid event type, should be ignored
+                createListenerCfg("test3", List.of())));
+
+    // when
+    initSystemContext(brokerCfg);
+
+    // then
+    assertThat(brokerCfg.getExperimental().getEngine().getListeners().getTask()).hasSize(1);
+    final var listenerConfig =
+        brokerCfg.getExperimental().getEngine().getListeners().getTask().getFirst();
+    assertThat(listenerConfig.getType()).isEqualTo("test1");
+    assertThat(listenerConfig.getEventTypes()).containsExactly("creating");
+  }
+
+  @Test
+  void shouldIgnoreExtraEventTypesWhenConfiguringGenericGlobalTaskListener() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getExperimental()
+        .getEngine()
+        .getListeners()
+        .setTask(List.of(createListenerCfg("test", List.of("creating", "all", "updating"))));
+
+    // when
+    initSystemContext(brokerCfg);
+
+    // then
+    assertThat(brokerCfg.getExperimental().getEngine().getListeners().getTask()).hasSize(1);
+    final var listenerConfig =
+        brokerCfg.getExperimental().getEngine().getListeners().getTask().getFirst();
+    assertThat(listenerConfig.getType()).isEqualTo("test");
+    assertThat(listenerConfig.getEventTypes()).containsExactly("all");
+  }
+
+  private ListenerCfg createListenerCfg(final String type, final List<String> eventTypes) {
+    final ListenerCfg listenerCfg = new ListenerCfg();
+    listenerCfg.setType(type);
+    listenerCfg.setEventTypes(eventTypes);
+    return listenerCfg;
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -734,10 +734,30 @@ final class SystemContextTest {
 
     // then
     assertThat(brokerCfg.getExperimental().getEngine().getListeners().getTask()).hasSize(2);
-    final var listenersConfig =
-        brokerCfg.getExperimental().getEngine().getListeners().getTask();
+    final var listenersConfig = brokerCfg.getExperimental().getEngine().getListeners().getTask();
     assertThat(listenersConfig.get(0).getType()).isEqualTo("test1");
     assertThat(listenersConfig.get(1).getType()).isEqualTo("test4");
+  }
+
+  @Test
+  void shouldIgnoreDuplicatedEventTypesWhenConfiguringGenericGlobalTaskListener() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getExperimental()
+        .getEngine()
+        .getListeners()
+        .setTask(List.of(createListenerCfg("test", List.of("creating", "creating", "updating"))));
+
+    // when
+    initSystemContext(brokerCfg);
+
+    // then
+    assertThat(brokerCfg.getExperimental().getEngine().getListeners().getTask()).hasSize(1);
+    final var listenerConfig =
+        brokerCfg.getExperimental().getEngine().getListeners().getTask().getFirst();
+    assertThat(listenerConfig.getType()).isEqualTo("test");
+    assertThat(listenerConfig.getEventTypes()).containsExactly("creating", "updating");
   }
 
   private ListenerCfg createListenerCfg(final String type, final List<String> eventTypes) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenerConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/ListenerConfiguration.java
@@ -7,9 +7,17 @@
  */
 package io.camunda.zeebe.engine;
 
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import java.util.List;
+import java.util.stream.Stream;
 
 public record ListenerConfiguration(
     List<String> eventTypes, String type, String retries, boolean afterLocal) {
+
   public static final String ALL_EVENT_TYPES = "all";
+
+  // List of all possible task listener event types as strings, to be used while validating
+  // the configuration (ZeebeTaskListenerEventType is not accessible from the broker module)
+  public static final List<String> TASK_LISTENER_EVENT_TYPES =
+      Stream.of(ZeebeTaskListenerEventType.values()).map(Enum::name).toList();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -373,13 +373,13 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
     final var jobType = globalTaskListener.type();
     final var jobRetries = globalTaskListener.retries();
 
-    // Extract the list of supported listener event types
-    final var evenTypeStrings =
-        globalTaskListener.eventTypes().stream().map(String::toLowerCase).toList();
+    // Extract the list of supported listener event typese
     var eventTypes =
-        evenTypeStrings.contains(ListenerConfiguration.ALL_EVENT_TYPES)
+        globalTaskListener.eventTypes().contains(ListenerConfiguration.ALL_EVENT_TYPES)
             ? List.of(ZeebeTaskListenerEventType.values())
-            : evenTypeStrings.stream().map(ZeebeTaskListenerEventType::valueOf).toList();
+            : globalTaskListener.eventTypes().stream()
+                .map(ZeebeTaskListenerEventType::valueOf)
+                .toList();
     // Remove duplicates (considering deprecated event types as equivalent to their non-deprecated
     // counterparts)
     eventTypes =


### PR DESCRIPTION
## Description

This PR introduces startup-time validation for the Global User Task Listeners configuration.

The validation has been added to `SystemContext` as with other configuration validations, but instead of throwing an exception only a warning is issued and the configuration is automatically corrected in order to let the system work correctly:
- invalid event types are removed and ignored
- listeners with missing information about event types or job type are removed and ignored
  - this also includes listeners for which only invalid event types have been defined
 - if a listener defines both the special "all" value and a normal event type for the "eventTypes" property, the configuration is corrected to only include the "all" value
 - listeners with invalid information about retries (i.e. non-numeric or negative values) are removed and ignored

In all the above cases, a suitable warning is logged, identifying the problem and its location in the configuration.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39931 
