### PR TITLE
feat: add property enable exporter execution metrics to uc

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Metrics.java
+++ b/configuration/src/main/java/io/camunda/configuration/Metrics.java
@@ -16,8 +16,14 @@ public class Metrics {
   private static final Set<String> LEGACY_ENABLE_ACTOR_METRICS_PPROPERTIES =
       Set.of("zeebe.broker.experimental.features.enableActorMetrics");
 
+  private static final Set<String> LEGACY_ENABLE_EXPORTER_EXECUTION_METRICS_PPROPERTIES =
+      Set.of("zeebe.broker.executionMetricsExporterEnabled");
+
   /** Controls whether to collect metrics about actor usage such as actor job execution latencies */
   private boolean actor = true;
+
+  /** Enable exporter execution metrics */
+  private boolean enableExporterExecutionMetrics;
 
   public boolean isActor() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
@@ -30,5 +36,18 @@ public class Metrics {
 
   public void setActor(final boolean actor) {
     this.actor = actor;
+  }
+
+  public boolean isEnableExporterExecutionMetrics() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".enable-exporter-execution-metrics",
+        enableExporterExecutionMetrics,
+        Boolean.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_ENABLE_EXPORTER_EXECUTION_METRICS_PPROPERTIES);
+  }
+
+  public void setEnableExporterExecutionMetrics(final boolean enableExporterExecutionMetrics) {
+    this.enableExporterExecutionMetrics = enableExporterExecutionMetrics;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -814,6 +814,7 @@ public class BrokerBasedPropertiesOverride {
   private void populateFromMetrics(final BrokerBasedProperties override) {
     final Metrics metrics = unifiedConfiguration.getCamunda().getMonitoring().getMetrics();
     override.getExperimental().getFeatures().setEnableActorMetrics(metrics.isActor());
+    override.setExecutionMetricsExporterEnabled(metrics.isEnableExporterExecutionMetrics());
   }
 
   private void setArgIfNotNull(

--- a/configuration/src/test/java/io/camunda/configuration/MetricsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/MetricsTest.java
@@ -27,11 +27,14 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 public class MetricsTest {
 
   private static final boolean EXPECTED_ACTOR = true;
+  private static final boolean EXPECTED_ENABLE_EXPORTER_EXECUTION_METRICS = true;
 
   @Nested
   @TestPropertySource(
       properties = {
         "camunda.monitoring.metrics.actor=" + EXPECTED_ACTOR,
+        "camunda.monitoring.metrics.enable-exporter-execution-metrics="
+            + EXPECTED_ENABLE_EXPORTER_EXECUTION_METRICS,
       })
   class WithOnlyUnifiedConfigSet {
     final BrokerBasedProperties brokerCfg;
@@ -44,6 +47,8 @@ public class MetricsTest {
     void shouldSetMetrics() {
       assertThat(brokerCfg.getExperimental().getFeatures().isEnableActorMetrics())
           .isEqualTo(EXPECTED_ACTOR);
+      assertThat(brokerCfg.isExecutionMetricsExporterEnabled())
+          .isEqualTo(EXPECTED_ENABLE_EXPORTER_EXECUTION_METRICS);
     }
   }
 
@@ -51,6 +56,8 @@ public class MetricsTest {
   @TestPropertySource(
       properties = {
         "zeebe.broker.experimental.features.enableActorMetrics=" + EXPECTED_ACTOR,
+        "zeebe.broker.executionMetricsExporterEnabled="
+            + EXPECTED_ENABLE_EXPORTER_EXECUTION_METRICS,
       })
   class WithOnlyLegacySet {
     final BrokerBasedProperties brokerCfg;
@@ -63,6 +70,8 @@ public class MetricsTest {
     void shouldSetMetricsFromLegacy() {
       assertThat(brokerCfg.getExperimental().getFeatures().isEnableActorMetrics())
           .isEqualTo(EXPECTED_ACTOR);
+      assertThat(brokerCfg.isExecutionMetricsExporterEnabled())
+          .isEqualTo(EXPECTED_ENABLE_EXPORTER_EXECUTION_METRICS);
     }
   }
 
@@ -71,8 +80,11 @@ public class MetricsTest {
       properties = {
         // new
         "camunda.monitoring.metrics.actor=" + EXPECTED_ACTOR,
+        "camunda.monitoring.metrics.enable-exporter-execution-metrics="
+            + EXPECTED_ENABLE_EXPORTER_EXECUTION_METRICS,
         // legacy
-        "zeebe.broker.experimental.features.enableActorMetrics=false"
+        "zeebe.broker.experimental.features.enableActorMetrics=false",
+        "zeebe.broker.executionMetricsExporterEnabled=false"
       })
   class WithNewAndLegacySet {
     final BrokerBasedProperties brokerCfg;
@@ -85,6 +97,8 @@ public class MetricsTest {
     void shouldSetMetrics() {
       assertThat(brokerCfg.getExperimental().getFeatures().isEnableActorMetrics())
           .isEqualTo(EXPECTED_ACTOR);
+      assertThat(brokerCfg.isExecutionMetricsExporterEnabled())
+          .isEqualTo(EXPECTED_ENABLE_EXPORTER_EXECUTION_METRICS);
     }
   }
 }


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.monitoring.metrics to unified config.

The legacy properties are:
zeebe.broker.executionMetricsExporterEnabled

The new properties are:
camunda.monitoring.metrics.enable-exporter-execution-metrics

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.

## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to 