### PR TITLE
fix: add missing READ_PROCESS_INSTANCE permission

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -204,6 +204,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             .setResourceId(WILDCARD.getResourceId())
             .setPermissionTypes(
                 Set.of(
+                    PermissionType.READ_PROCESS_INSTANCE,
                     PermissionType.READ_PROCESS_DEFINITION,
                     PermissionType.CREATE_PROCESS_INSTANCE,
                     PermissionType.UPDATE_PROCESS_INSTANCE)));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeDefaultsTest.java
@@ -291,6 +291,7 @@ public class IdentitySetupInitializeDefaultsTest {
                 Assertions.assertThat(auth)
                     .hasResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
                     .hasOnlyPermissionTypes(
+                        PermissionType.READ_PROCESS_INSTANCE,
                         PermissionType.READ_PROCESS_DEFINITION,
                         PermissionType.CREATE_PROCESS_INSTANCE,
                         PermissionType.UPDATE_PROCESS_INSTANCE),


### PR DESCRIPTION
## Description

Fresh installations of Camunda 8.8+gen1 on SaaS or Camunda 8.8.0 SM have an issue with the polling connector. The connectors pod is unable to fetch active process instances, so any active instance with a polling connector will be stuck.

We root-caused this down to a missing permission. The Connectors role needs an additional permission: READ_PROCESS_INSTANCE for all process definitions.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39757 
