### PR TITLE
ci: use fake dry-run tags

### DIFF
--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -20,7 +20,9 @@ jobs:
       fail-fast: false
     with:
       releaseBranch: stable/8.8
-      releaseVersion: 0.8.8
+      # Uses existing Camunda release tags for dry run testing without creating new ones
+      # Release version format: 1.x+1.0 chosen to reflect that each stable/x.y represents a minor release
+      releaseVersion: 1.3.0 #https://github.com/camunda/camunda/releases/tag/1.3.0 
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
@@ -32,7 +34,9 @@ jobs:
       fail-fast: false
     with:
       releaseBranch: stable/8.7
-      releaseVersion: 0.8.7
+      # Uses existing Camunda release tags for dry run testing without creating new ones
+      # Release version format: 1.x+1.0 chosen to reflect that each stable/x.y represents a minor release
+      releaseVersion: 1.2.0 #https://github.com/camunda/camunda/releases/tag/1.2.0
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
@@ -44,7 +48,9 @@ jobs:
       fail-fast: false
     with:
       releaseBranch: stable/8.6
-      releaseVersion: 0.8.6
+      # Uses existing Camunda release tags for dry run testing without creating new ones
+      # Release version format: 1.x+1.0 chosen to reflect that each stable/x.y represents a minor release
+      releaseVersion: 1.1.0 #https://github.com/camunda/camunda/releases/tag/1.1.0
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -11,46 +11,68 @@ on:
     - cron: '0 2 * * 1-5'
 
 jobs:
-  # Camunda Platform release
+  create-fake-tag:
+    name: "Create fake tag for dry runs"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Create fake tag locally
+        run: |
+          git fetch --tags
+          if ! git rev-parse 0.0.0-dryrun >/dev/null 2>&1; then 
+            git tag -a 0.0.0-dryrun -m "Dummy tag for dry run"; 
+          fi
+          echo "Created fake tag 0.0.0-dryrun locally (not pushed)"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: create-fake-tag
+          path: .git
+
   dry-run-release-88:
     name: "Release from stable/8.8"
+    needs: create-fake-tag
     uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.8
     secrets: inherit
     strategy:
       fail-fast: false
     with:
       releaseBranch: stable/8.8
-      # Uses existing Camunda release tags for dry run testing without creating new ones
-      # Release version format: 1.x+1.0 chosen to reflect that each stable/x.y represents a minor release
-      releaseVersion: 1.3.0 #https://github.com/camunda/camunda/releases/tag/1.3.0 
+      # Uses fake tag for dry run testing without affecting real releases
+      releaseVersion: 0.0.0-dryrun
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
   dry-run-release-87:
     name: "Release from stable/8.7"
+    needs: create-fake-tag
     uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.7
     secrets: inherit
     strategy:
       fail-fast: false
     with:
       releaseBranch: stable/8.7
-      # Uses existing Camunda release tags for dry run testing without creating new ones
-      # Release version format: 1.x+1.0 chosen to reflect that each stable/x.y represents a minor release
-      releaseVersion: 1.2.0 #https://github.com/camunda/camunda/releases/tag/1.2.0
+      # Uses fake tag for dry run testing without affecting real releases
+      releaseVersion: 0.0.0-dryrun
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
   dry-run-release-86:
     name: "Release from stable/8.6"
+    needs: create-fake-tag
     uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.6
     secrets: inherit
     strategy:
       fail-fast: false
     with:
       releaseBranch: stable/8.6
-      # Uses existing Camunda release tags for dry run testing without creating new ones
-      # Release version format: 1.x+1.0 chosen to reflect that each stable/x.y represents a minor release
-      releaseVersion: 1.1.0 #https://github.com/camunda/camunda/releases/tag/1.1.0
+      # Uses fake tag for dry run testing without affecting real releases
+      releaseVersion: 0.0.0-dryrun
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
@@ -58,7 +80,7 @@ jobs:
   notify-camunda:
     name: Send Slack notification for 8.6+
     runs-on: ubuntu-latest
-    needs: [dry-run-release-86, dry-run-release-87, dry-run-release-88]
+    needs: [create-fake-tag, dry-run-release-86, dry-run-release-87, dry-run-release-88]
     if: always()
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
@@ -77,7 +99,7 @@ jobs:
 
       - name: Send failure Slack notification
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        if: ${{ always() && (needs.dry-run-release-86.result != 'success' || needs.dry-run-release-87.result != 'success') && github.event_name == 'schedule' }}
+        if: ${{ always() && (needs.dry-run-release-86.result != 'success' || needs.dry-run-release-87.result != 'success' || needs.dry-run-release-88.result != 'success') && github.event_name == 'schedule' }}
         with:
           webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -28,8 +28,10 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Create fake tag locally
         run: |
-          git fetch origin tag 0.0.0-dryrun --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun -m "Dummy tag for dry run"
-          echo "Created fake tag 0.0.0-dryrun locally (not pushed)"
+          git fetch origin tag 0.0.0-dryrun-86 --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-86 -m "Dummy tag for dry run 8.6"
+          git fetch origin tag 0.0.0-dryrun-87 --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-87 -m "Dummy tag for dry run 8.7"  
+          git fetch origin tag 0.0.0-dryrun-88 --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-88 -m "Dummy tag for dry run 8.8"
+          echo "Created fake tags for all dry runs locally (not pushed)"
       - uses: actions/upload-artifact@v4
         with:
           name: create-fake-tag
@@ -45,7 +47,7 @@ jobs:
     with:
       releaseBranch: stable/8.8
       # Uses fake tag for dry run testing without affecting real releases
-      releaseVersion: 0.0.0-dryrun
+      releaseVersion: 0.0.0-dryrun-88
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
@@ -59,7 +61,7 @@ jobs:
     with:
       releaseBranch: stable/8.7
       # Uses fake tag for dry run testing without affecting real releases
-      releaseVersion: 0.0.0-dryrun
+      releaseVersion: 0.0.0-dryrun-87
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
@@ -73,7 +75,7 @@ jobs:
     with:
       releaseBranch: stable/8.6
       # Uses fake tag for dry run testing without affecting real releases
-      releaseVersion: 0.0.0-dryrun
+      releaseVersion: 0.0.0-dryrun-86
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -22,12 +22,13 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - name: Git User Setup
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Create fake tag locally
         run: |
-          git fetch --tags
-          if ! git rev-parse 0.0.0-dryrun >/dev/null 2>&1; then 
-            git tag -a 0.0.0-dryrun -m "Dummy tag for dry run"; 
-          fi
+          git fetch origin tag 0.0.0-dryrun --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun -m "Dummy tag for dry run"
           echo "Created fake tag 0.0.0-dryrun locally (not pushed)"
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Description

This pull request updates the `.github/workflows/zeebe-release-stable-dry-run.yml` workflow to improve the dry run process for releases. The main changes introduce a dedicated job to create fake tags for dry runs, ensure all dry-run release jobs depend on this new job, and update the notification logic to account for the new release branch.

**Workflow improvements for dry run releases:**

* Added a new `create-fake-tag` job that generates local fake tags (`0.0.0-dryrun-86`, `0.0.0-dryrun-87`, `0.0.0-dryrun-88`) for each supported release branch, ensuring dry runs do not affect real releases. All dry-run release jobs now depend on this job. (`.github/workflows/zeebe-release-stable-dry-run.yml`)
* Updated `dry-run-release-86`, `dry-run-release-87`, and `dry-run-release-88` jobs to use the fake tags as their `releaseVersion` and to depend on the `create-fake-tag` job. (`.github/workflows/zeebe-release-stable-dry-run.yml`)
* Modified the `notify-camunda` job to depend on the new `create-fake-tag` job in addition to the dry-run release jobs. (`.github/workflows/zeebe-release-stable-dry-run.yml`)

**Notification logic update:**

* Adjusted the Slack notification logic to include the result of the new `dry-run-release-88` job when determining if a failure notification should be sent. (`.github/workflows/zeebe-release-stable-dry-run.yml`)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
