### PR TITLE
Prevent `ALREADY_EXISTS` error in ITs

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
@@ -74,7 +74,7 @@ class ApplicationAuthorizationIT {
           List.of(new Permissions(COMPONENT, ACCESS, List.of("tasklist"))));
 
   @AutoClose
-  private static final HttpClient HTTP_CLIENT =
+  private final HttpClient httpClient =
       HttpClient.newBuilder().followRedirects(Redirect.NEVER).build();
 
   @ParameterizedTest
@@ -109,7 +109,7 @@ class ApplicationAuthorizationIT {
             .uri(createUri(client, componentName + PATH_OPERATE_WEBAPP_USER))
             .build();
     final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
     // then
     assertAccessAllowed(response);
@@ -126,7 +126,7 @@ class ApplicationAuthorizationIT {
             .header("Authorization", basicAuthentication(RESTRICTED))
             .build();
     final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
     // then
     assertAccessAllowed(response);
@@ -203,7 +203,7 @@ class ApplicationAuthorizationIT {
             .header("Authorization", basicAuthentication(RESTRICTED))
             .build();
     final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
     // then
     final MeResponse meResponse = OBJECT_MAPPER.readValue(response.body(), MeResponse.class);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BasicAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BasicAuthenticationIT.java
@@ -42,7 +42,7 @@ public class BasicAuthenticationIT {
   private static final String PASSWORD = "correct_password";
   @UserDefinition private static final TestUser USER = new TestUser(USERNAME, PASSWORD, List.of());
   private static CamundaClient camundaClient;
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
   @Test
   void basicAuthWithValidCredentials(@Authenticated(USERNAME) final CamundaClient userClient)
@@ -54,7 +54,7 @@ public class BasicAuthenticationIT {
             .header("Authorization", basicAuthentication(USERNAME))
             .build();
     final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
     // then
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
@@ -67,7 +67,7 @@ public class BasicAuthenticationIT {
         HttpRequest.newBuilder().uri(createUri(camundaClient, PATH_V2_AUTHENTICATION_ME)).build();
 
     final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
     // then
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
@@ -82,7 +82,7 @@ public class BasicAuthenticationIT {
             .header("Authorization", basicAuthentication("bad"))
             .build();
     final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
     // then
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MappingRuleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MappingRuleAuthorizationIT.java
@@ -83,7 +83,7 @@ class MappingRuleAuthorizationIT {
   private static final TestMappingRule MAPPING_RULE_2 =
       new TestMappingRule("mappingRule2", "test-name2", "test-value2");
 
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
   @Test
   void searchShouldReturnAuthorizedMappingRules(
@@ -165,7 +165,7 @@ class MappingRuleAuthorizationIT {
   }
 
   // TODO once available, this test should use the client to make the request
-  private static MappingRuleSearchResponse searchMappingRules(
+  private MappingRuleSearchResponse searchMappingRules(
       final String restAddress, final String username)
       throws URISyntaxException, IOException, InterruptedException {
     final var encodedCredentials =
@@ -179,7 +179,7 @@ class MappingRuleAuthorizationIT {
             .build();
 
     final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     return OBJECT_MAPPER.readValue(response.body(), MappingRuleSearchResponse.class);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
@@ -36,14 +36,12 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -90,8 +88,6 @@ class TenantAuthorizationIT {
 
   @UserDefinition
   private static final TestUser UNAUTHORIZED_USER = new TestUser(UNAUTHORIZED, PASSWORD, List.of());
-
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByTenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByTenantIntegrationTest.java
@@ -16,9 +16,7 @@ import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
-import java.net.http.HttpClient;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -27,8 +25,6 @@ public class ClientsByTenantIntegrationTest {
 
   private static CamundaClient camundaClient;
   private static final String TENANT_ID = Strings.newRandomValidIdentityId();
-
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
   @BeforeAll
   static void setup() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIntegrationTest.java
@@ -39,11 +39,9 @@ public class RoleIntegrationTest {
 
   private static final String EXISTING_ROLE_ID = Strings.newRandomValidIdentityId();
   private static final String EXISTING_ROLE_NAME = "ARoleName";
-
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
-
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
   @BeforeAll
   static void setup() {
@@ -331,7 +329,7 @@ public class RoleIntegrationTest {
   }
 
   // TODO once available, this test should use the client to make the request
-  private static AuthorizationSearchResponse searchAuthorizations(final String restAddress)
+  private AuthorizationSearchResponse searchAuthorizations(final String restAddress)
       throws URISyntaxException, IOException, InterruptedException {
     final HttpRequest request =
         HttpRequest.newBuilder()
@@ -340,7 +338,7 @@ public class RoleIntegrationTest {
             .build();
 
     final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     return OBJECT_MAPPER.readValue(response.body(), AuthorizationSearchResponse.class);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByTenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByTenantIntegrationTest.java
@@ -39,11 +39,9 @@ public class RolesByTenantIntegrationTest {
   private static final String PASSWORD = "password";
 
   private static CamundaClient camundaClient;
-
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
-
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
   @Test
   void shouldAssignRoleToTenant() {
@@ -300,7 +298,7 @@ public class RolesByTenantIntegrationTest {
         .join();
   }
 
-  private static void waitForTenantsToBeCreated(final String tenantId) {
+  private void waitForTenantsToBeCreated(final String tenantId) {
     Awaitility.await("should create tenants and import in ES")
         .atMost(Duration.ofSeconds(15))
         .ignoreExceptions() // Ignore exceptions and continue retrying
@@ -313,8 +311,8 @@ public class RolesByTenantIntegrationTest {
   }
 
   // TODO once available, this test should use the client to make the request
-  private static Either<Tuple<HttpStatus, String>, TenantResponse> getTenantById(
-      final String tenantId) throws URISyntaxException, IOException, InterruptedException {
+  private Either<Tuple<HttpStatus, String>, TenantResponse> getTenantById(final String tenantId)
+      throws URISyntaxException, IOException, InterruptedException {
     final var encodedCredentials =
         Base64.getEncoder().encodeToString("%s:%s".formatted(ADMIN_USERNAME, PASSWORD).getBytes());
     final HttpRequest request =
@@ -331,7 +329,7 @@ public class RolesByTenantIntegrationTest {
 
     // Send the request and get the response
     final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
     if (response.statusCode() == HttpStatus.OK.value()) {
       return Either.right(OBJECT_MAPPER.readValue(response.body(), TenantResponse.class));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UnassignClientFromTenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UnassignClientFromTenantIntegrationTest.java
@@ -16,9 +16,7 @@ import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
-import java.net.http.HttpClient;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -27,8 +25,6 @@ public class UnassignClientFromTenantIntegrationTest {
 
   private static CamundaClient camundaClient;
   private static final String TENANT_ID = Strings.newRandomValidIdentityId();
-
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
   @BeforeAll
   static void setup() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
@@ -67,6 +67,7 @@ public class OperateInternalApiGroupPermissionsIT {
   private static final String UNAUTHORIZED_USERNAME = "unauthorized";
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
   @UserDefinition
   private static final TestUser ADMIN =
       new TestUser(
@@ -79,12 +80,15 @@ public class OperateInternalApiGroupPermissionsIT {
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
+
   @UserDefinition
   private static final TestUser AUTHORIZED_USER =
       new TestUser(AUTHORIZED_USERNAME, AUTHORIZED_USERNAME, List.of());
+
   @UserDefinition
   private static final TestUser UNAUTHORIZED_USER =
       new TestUser(UNAUTHORIZED_USERNAME, UNAUTHORIZED_USERNAME, List.of());
+
   private static long processInstanceKey;
   @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
@@ -65,10 +65,8 @@ public class OperateInternalApiGroupPermissionsIT {
   private static final String ADMIN_USERNAME = "admin";
   private static final String AUTHORIZED_USERNAME = "authorized";
   private static final String UNAUTHORIZED_USERNAME = "unauthorized";
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
   @UserDefinition
   private static final TestUser ADMIN =
       new TestUser(
@@ -81,16 +79,14 @@ public class OperateInternalApiGroupPermissionsIT {
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
-
   @UserDefinition
   private static final TestUser AUTHORIZED_USER =
       new TestUser(AUTHORIZED_USERNAME, AUTHORIZED_USERNAME, List.of());
-
   @UserDefinition
   private static final TestUser UNAUTHORIZED_USER =
       new TestUser(UNAUTHORIZED_USERNAME, UNAUTHORIZED_USERNAME, List.of());
-
   private static long processInstanceKey;
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
   @BeforeAll
   public static void beforeAll(
@@ -227,7 +223,7 @@ public class OperateInternalApiGroupPermissionsIT {
             .build();
 
     // Send the request and get the response
-    final var response = HTTP_CLIENT.send(request, BodyHandlers.ofString());
+    final var response = httpClient.send(request, BodyHandlers.ofString());
     return OBJECT_MAPPER.readValue(response.body(), ResponseCount.class);
   }
 
@@ -247,7 +243,7 @@ public class OperateInternalApiGroupPermissionsIT {
             .build();
 
     // Send the request and get the response
-    return HTTP_CLIENT.send(request, BodyHandlers.ofString()).statusCode();
+    return httpClient.send(request, BodyHandlers.ofString()).statusCode();
   }
 
   private int addVariableToProcessInstance(
@@ -280,7 +276,7 @@ public class OperateInternalApiGroupPermissionsIT {
             .header("Content-Type", "application/json")
             .build();
     // Send the request and get the response
-    return HTTP_CLIENT.send(request, BodyHandlers.ofString()).statusCode();
+    return httpClient.send(request, BodyHandlers.ofString()).statusCode();
   }
 
   private record ResponseCount(int totalCount) {}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
@@ -67,6 +67,7 @@ public class OperateInternalApiRolePermissionsIT {
   private static final String UNAUTHORIZED_USERNAME = "unauthorized";
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
   @UserDefinition
   private static final TestUser ADMIN =
       new TestUser(
@@ -79,12 +80,15 @@ public class OperateInternalApiRolePermissionsIT {
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
+
   @UserDefinition
   private static final TestUser AUTHORIZED_USER =
       new TestUser(AUTHORIZED_USERNAME, AUTHORIZED_USERNAME, List.of());
+
   @UserDefinition
   private static final TestUser UNAUTHORIZED_USER =
       new TestUser(UNAUTHORIZED_USERNAME, UNAUTHORIZED_USERNAME, List.of());
+
   private static long processInstanceKey;
   @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
@@ -106,7 +110,12 @@ public class OperateInternalApiRolePermissionsIT {
             PermissionType.READ_PROCESS_INSTANCE, PermissionType.UPDATE_PROCESS_INSTANCE)
         .send()
         .join();
-    adminClient.newAssignRoleToUserCommand().roleId(roleId).username(AUTHORIZED_USERNAME).send().join();
+    adminClient
+        .newAssignRoleToUserCommand()
+        .roleId(roleId)
+        .username(AUTHORIZED_USERNAME)
+        .send()
+        .join();
 
     adminClient
         .newDeployResourceCommand()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
@@ -65,10 +65,8 @@ public class OperateInternalApiRolePermissionsIT {
   private static final String ADMIN_USERNAME = "admin";
   private static final String AUTHORIZED_USERNAME = "authorized";
   private static final String UNAUTHORIZED_USERNAME = "unauthorized";
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
   @UserDefinition
   private static final TestUser ADMIN =
       new TestUser(
@@ -81,16 +79,14 @@ public class OperateInternalApiRolePermissionsIT {
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
-
   @UserDefinition
   private static final TestUser AUTHORIZED_USER =
       new TestUser(AUTHORIZED_USERNAME, AUTHORIZED_USERNAME, List.of());
-
   @UserDefinition
   private static final TestUser UNAUTHORIZED_USER =
       new TestUser(UNAUTHORIZED_USERNAME, UNAUTHORIZED_USERNAME, List.of());
-
   private static long processInstanceKey;
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
   @BeforeAll
   public static void beforeAll(
@@ -110,7 +106,7 @@ public class OperateInternalApiRolePermissionsIT {
             PermissionType.READ_PROCESS_INSTANCE, PermissionType.UPDATE_PROCESS_INSTANCE)
         .send()
         .join();
-    addUserToRole(adminClient.getConfiguration().getRestAddress(), roleId, AUTHORIZED_USERNAME);
+    adminClient.newAssignRoleToUserCommand().roleId(roleId).username(AUTHORIZED_USERNAME).send().join();
 
     adminClient
         .newDeployResourceCommand()
@@ -196,22 +192,6 @@ public class OperateInternalApiRolePermissionsIT {
         .isEqualTo(HttpStatus.FORBIDDEN.value());
   }
 
-  private static void addUserToRole(final URI url, final String roleId, final String username)
-      throws Exception {
-    final var uri = URI.create(url + "v2/roles/%s/users/%s".formatted(roleId, username));
-    final var encodedCredentials =
-        Base64.getEncoder()
-            .encodeToString("%s:%s".formatted(ADMIN_USERNAME, ADMIN_USERNAME).getBytes());
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(uri)
-            .PUT(HttpRequest.BodyPublishers.noBody())
-            .header("Authorization", "Basic %s".formatted(encodedCredentials))
-            .header("Content-Type", "application/json")
-            .build();
-    HTTP_CLIENT.send(request, BodyHandlers.ofString());
-  }
-
   private ResponseCount searchRunningProcessInstances(
       final CamundaClient client, final String username)
       throws URISyntaxException, IOException, InterruptedException {
@@ -238,7 +218,7 @@ public class OperateInternalApiRolePermissionsIT {
             .build();
 
     // Send the request and get the response
-    final var response = HTTP_CLIENT.send(request, BodyHandlers.ofString());
+    final var response = httpClient.send(request, BodyHandlers.ofString());
     return OBJECT_MAPPER.readValue(response.body(), ResponseCount.class);
   }
 
@@ -258,7 +238,7 @@ public class OperateInternalApiRolePermissionsIT {
             .build();
 
     // Send the request and get the response
-    return HTTP_CLIENT.send(request, BodyHandlers.ofString()).statusCode();
+    return httpClient.send(request, BodyHandlers.ofString()).statusCode();
   }
 
   private int addVariableToProcessInstance(
@@ -291,7 +271,7 @@ public class OperateInternalApiRolePermissionsIT {
             .header("Content-Type", "application/json")
             .build();
     // Send the request and get the response
-    return HTTP_CLIENT.send(request, BodyHandlers.ofString()).statusCode();
+    return httpClient.send(request, BodyHandlers.ofString()).statusCode();
   }
 
   private record ResponseCount(int totalCount) {}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/groups/TasklistV1ApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/groups/TasklistV1ApiGroupPermissionsIT.java
@@ -59,6 +59,7 @@ public class TasklistV1ApiGroupPermissionsIT {
   private static final String ADMIN_USERNAME = "admin";
   private static final String AUTHORIZED_USERNAME = "authorized";
   private static final String UNAUTHORIZED_USERNAME = "unauthorized";
+
   @UserDefinition
   private static final TestUser ADMIN =
       new TestUser(
@@ -71,12 +72,15 @@ public class TasklistV1ApiGroupPermissionsIT {
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))));
+
   @UserDefinition
   private static final TestUser AUTHORIZED_USER =
       new TestUser(AUTHORIZED_USERNAME, AUTHORIZED_USERNAME, List.of());
+
   @UserDefinition
   private static final TestUser UNAUTHORIZED_USER =
       new TestUser(UNAUTHORIZED_USERNAME, UNAUTHORIZED_USERNAME, List.of());
+
   private static long processDefinitionKey;
   private static long taskKey;
   @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/groups/TasklistV1ApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/groups/TasklistV1ApiGroupPermissionsIT.java
@@ -59,8 +59,6 @@ public class TasklistV1ApiGroupPermissionsIT {
   private static final String ADMIN_USERNAME = "admin";
   private static final String AUTHORIZED_USERNAME = "authorized";
   private static final String UNAUTHORIZED_USERNAME = "unauthorized";
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
-
   @UserDefinition
   private static final TestUser ADMIN =
       new TestUser(
@@ -73,17 +71,15 @@ public class TasklistV1ApiGroupPermissionsIT {
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))));
-
   @UserDefinition
   private static final TestUser AUTHORIZED_USER =
       new TestUser(AUTHORIZED_USERNAME, AUTHORIZED_USERNAME, List.of());
-
   @UserDefinition
   private static final TestUser UNAUTHORIZED_USER =
       new TestUser(UNAUTHORIZED_USERNAME, UNAUTHORIZED_USERNAME, List.of());
-
   private static long processDefinitionKey;
   private static long taskKey;
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
   @BeforeAll
   public static void beforeAll(
@@ -227,7 +223,7 @@ public class TasklistV1ApiGroupPermissionsIT {
             .build();
 
     // Send the request and get the response
-    return HTTP_CLIENT.send(request, BodyHandlers.ofString()).statusCode();
+    return httpClient.send(request, BodyHandlers.ofString()).statusCode();
   }
 
   private int assignTask(final CamundaClient client, final String username, final long taskId)
@@ -255,6 +251,6 @@ public class TasklistV1ApiGroupPermissionsIT {
             .build();
 
     // Send the request and get the response
-    return HTTP_CLIENT.send(request, BodyHandlers.ofString()).statusCode();
+    return httpClient.send(request, BodyHandlers.ofString()).statusCode();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/roles/TasklistV1ApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/roles/TasklistV1ApiRolePermissionsIT.java
@@ -59,6 +59,7 @@ public class TasklistV1ApiRolePermissionsIT {
   private static final String ADMIN_USERNAME = "admin";
   private static final String AUTHORIZED_USERNAME = "authorized";
   private static final String UNAUTHORIZED_USERNAME = "unauthorized";
+
   @UserDefinition
   private static final TestUser ADMIN =
       new TestUser(
@@ -71,12 +72,15 @@ public class TasklistV1ApiRolePermissionsIT {
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))));
+
   @UserDefinition
   private static final TestUser AUTHORIZED_USER =
       new TestUser(AUTHORIZED_USERNAME, AUTHORIZED_USERNAME, List.of());
+
   @UserDefinition
   private static final TestUser UNAUTHORIZED_USER =
       new TestUser(UNAUTHORIZED_USERNAME, UNAUTHORIZED_USERNAME, List.of());
+
   private static long processDefinitionKey;
   private static long taskKey;
   @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
@@ -98,7 +102,12 @@ public class TasklistV1ApiRolePermissionsIT {
         .permissionTypes(PermissionType.READ_PROCESS_DEFINITION, PermissionType.UPDATE_USER_TASK)
         .send()
         .join();
-    adminClient.newAssignRoleToUserCommand().roleId(roleId).username(AUTHORIZED_USERNAME).send().join();
+    adminClient
+        .newAssignRoleToUserCommand()
+        .roleId(roleId)
+        .username(AUTHORIZED_USERNAME)
+        .send()
+        .join();
 
     adminClient
         .newDeployResourceCommand()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/roles/TasklistV1ApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/roles/TasklistV1ApiRolePermissionsIT.java
@@ -59,8 +59,6 @@ public class TasklistV1ApiRolePermissionsIT {
   private static final String ADMIN_USERNAME = "admin";
   private static final String AUTHORIZED_USERNAME = "authorized";
   private static final String UNAUTHORIZED_USERNAME = "unauthorized";
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
-
   @UserDefinition
   private static final TestUser ADMIN =
       new TestUser(
@@ -73,17 +71,15 @@ public class TasklistV1ApiRolePermissionsIT {
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))));
-
   @UserDefinition
   private static final TestUser AUTHORIZED_USER =
       new TestUser(AUTHORIZED_USERNAME, AUTHORIZED_USERNAME, List.of());
-
   @UserDefinition
   private static final TestUser UNAUTHORIZED_USER =
       new TestUser(UNAUTHORIZED_USERNAME, UNAUTHORIZED_USERNAME, List.of());
-
   private static long processDefinitionKey;
   private static long taskKey;
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
   @BeforeAll
   public static void beforeAll(
@@ -102,7 +98,7 @@ public class TasklistV1ApiRolePermissionsIT {
         .permissionTypes(PermissionType.READ_PROCESS_DEFINITION, PermissionType.UPDATE_USER_TASK)
         .send()
         .join();
-    addUserToRole(adminClient.getConfiguration().getRestAddress(), roleId, AUTHORIZED_USERNAME);
+    adminClient.newAssignRoleToUserCommand().roleId(roleId).username(AUTHORIZED_USERNAME).send().join();
 
     adminClient
         .newDeployResourceCommand()
@@ -204,22 +200,6 @@ public class TasklistV1ApiRolePermissionsIT {
             });
   }
 
-  private static void addUserToRole(final URI url, final String roleId, final String username)
-      throws Exception {
-    final var uri = URI.create(url + "v2/roles/%s/users/%s".formatted(roleId, username));
-    final var encodedCredentials =
-        Base64.getEncoder()
-            .encodeToString("%s:%s".formatted(ADMIN_USERNAME, ADMIN_USERNAME).getBytes());
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(uri)
-            .PUT(BodyPublishers.noBody())
-            .header("Authorization", "Basic %s".formatted(encodedCredentials))
-            .header("Content-Type", "application/json")
-            .build();
-    HTTP_CLIENT.send(request, BodyHandlers.ofString());
-  }
-
   private int getRunningProcessInstance(
       final CamundaClient client, final String username, final long processDefinitionKey)
       throws URISyntaxException, IOException, InterruptedException {
@@ -238,7 +218,7 @@ public class TasklistV1ApiRolePermissionsIT {
             .build();
 
     // Send the request and get the response
-    return HTTP_CLIENT.send(request, BodyHandlers.ofString()).statusCode();
+    return httpClient.send(request, BodyHandlers.ofString()).statusCode();
   }
 
   private int assignTask(final CamundaClient client, final String username, final long taskId)
@@ -266,6 +246,6 @@ public class TasklistV1ApiRolePermissionsIT {
             .build();
 
     // Send the request and get the response
-    return HTTP_CLIENT.send(request, BodyHandlers.ofString()).statusCode();
+    return httpClient.send(request, BodyHandlers.ofString()).statusCode();
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -23,6 +23,7 @@ import io.camunda.qa.util.auth.TestRole;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.zeebe.broker.system.configuration.DataCfg;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -256,6 +257,7 @@ public class CamundaMultiDBExtension
     final var application = applicationUnderTest.application();
     multiDbConfigurator = new MultiDbConfigurator(application);
     application
+        .withBrokerConfig(cfg -> cfg.getData().setDirectory(DataCfg.DEFAULT_DIRECTORY))
         .withBrokerConfig(cfg -> cfg.getGateway().setEnable(true))
         .withExporter(
             "recordingExporter", cfg -> cfg.setClassName(RecordingExporter.class.getName()));


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The lifecycle between the `CamundaMultiDBExtension` and the test application are slightly different. Only one test application is created per run and reruns. The `beforeAll` in the extension is triggered for each run and for each rerun. As a result the application configuration doesn't get properly reset.

This generally isn't a problem, as the configuration is setup by the test case and will always be the same. However, 
for the data folder it's different. If we reuse the same folder, it means we run into the problem that data of the primary storage is not cleared from the previous rerun. We will notice this especially in the ITs that setup Identity entities. This setup will fail as the entities already exist.

By setting the data folder to the default value we automatically create this data folder in a temporary directory. 
The rerun would notice a temporary directory is already set an reuse the same one. If we reset the data folder to the
 default value here, it will create a new temporary directory to create it in.

https://github.com/camunda/camunda/blob/289ed5aa8fdeeb3b41524210273d650b20f53535/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ConfigurationUtil.java#L19-L23

 There is one downside to this approach. This prevents us from setting the data folder to a different folder in our 
 test cases. Looking at usages we do not do this anywhere. I have accepted this limitation here, as it makes the 
 implementation much much simpler.

-------

This PR also contains another fix for a similar problem. We use the `HttpClient` in a lot of these tests (which we should get rid of!). This client is static. Making this static means it gets reused across test cases and test runs. The latter is the problem when rerunning for flaky tests. The http client will be closed, at the end of the first run. The second run will try and reuse this http client. As a result it runs into an exception as it's already closed


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39855
