### PR TITLE
fix:harden github issue json dump

### DIFF
--- a/.github/workflows/assign-urgency-to-issue.yml
+++ b/.github/workflows/assign-urgency-to-issue.yml
@@ -71,7 +71,10 @@ jobs:
     steps:
       - name: Dump issue JSON
         if: always()
-        run: echo '${{ toJSON(github.event.issue) }}'
+        run: |
+          ISSUE_JSON='${{ toJSON(github.event.issue) }}'
+          echo 'Github Issue Context JSON:'
+          printf '%s\n' "$ISSUE_JSON"
       - name: Check issue
         id: check_issue
         run: |


### PR DESCRIPTION
[here](https://github.com/camunda/camunda/actions/runs/18842056775/job/53756528585) echo'ing the JSON failed, but it's just meta data, thus the job shouldn't fail 
