### PR TITLE
feat: remove duplicated log message from fs backup store

### DIFF
--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -79,7 +79,6 @@ public final class FilesystemBackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
-    LOG.debug("Saving {}", backup.id());
     return CompletableFuture.runAsync(
         () -> {
           final var manifest = manifestManager.createInitialManifest(backup);


### PR DESCRIPTION
Should have been removed just like we removed it for Azure and GCS: https://github.com/camunda/camunda/pull/33858