### PR TITLE
[Backport stable/8.7] fix: return 429 on job activation resource exhaustion

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/job/JobHandlerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/job/JobHandlerConfiguration.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.controller.JobActivationRequestResponseObserver;
 import io.camunda.zeebe.gateway.rest.controller.ResponseObserverProvider;
 import io.camunda.zeebe.scheduler.Actor;
@@ -89,8 +90,9 @@ public class JobHandlerConfiguration {
         .setProbeTimeoutMillis(config.longPolling().getProbeTimeout())
         .setMinEmptyResponses(config.longPolling().getMinEmptyResponses())
         .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
-        .setNoJobsReceivedExceptionProvider(RuntimeException::new)
-        .setRequestCanceledExceptionProvider(RuntimeException::new)
+        .setResourceExhaustedExceptionProvider(
+            RestErrorMapper.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
+        .setRequestCanceledExceptionProvider(RestErrorMapper.REQUEST_CANCELED_EXCEPTION_PROVIDER)
         .setMetrics(
             new LongPollingMetrics(meterRegistry, LongPollingMetricsDoc.GatewayProtocol.REST))
         .build();

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -77,7 +77,7 @@ import org.slf4j.Logger;
 
 public final class Gateway implements CloseableSilently {
 
-  public static final Function<String, Exception> NO_JOBS_RECEIVED_EXCEPTION_PROVIDER =
+  public static final Function<String, Exception> RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER =
       msg -> grpcStatusException(Code.RESOURCE_EXHAUSTED_VALUE, msg);
   public static final Function<String, Throwable> REQUEST_CANCELED_EXCEPTION_PROVIDER =
       msg -> grpcStatusException(Code.CANCELLED_VALUE, msg);
@@ -376,7 +376,7 @@ public final class Gateway implements CloseableSilently {
         .setProbeTimeoutMillis(gatewayCfg.getLongPolling().getProbeTimeout())
         .setMinEmptyResponses(gatewayCfg.getLongPolling().getMinEmptyResponses())
         .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
-        .setNoJobsReceivedExceptionProvider(NO_JOBS_RECEIVED_EXCEPTION_PROVIDER)
+        .setResourceExhaustedExceptionProvider(RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
         .setRequestCanceledExceptionProvider(REQUEST_CANCELED_EXCEPTION_PROVIDER)
         .setMetrics(
             new LongPollingMetrics(meterRegistry, LongPollingMetricsDoc.GatewayProtocol.GRPC))

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -158,7 +158,7 @@ public final class StubbedGateway {
         .setBrokerClient(brokerClient)
         .setMaxMessageSize(config.getNetwork().getMaxMessageSize().toBytes())
         .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
-        .setNoJobsReceivedExceptionProvider(Gateway.NO_JOBS_RECEIVED_EXCEPTION_PROVIDER)
+        .setResourceExhaustedExceptionProvider(Gateway.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
         .setRequestCanceledExceptionProvider(Gateway.REQUEST_CANCELED_EXCEPTION_PROVIDER)
         .setMetrics(LongPollingMetrics.noop())
         .build();

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
@@ -96,7 +96,7 @@ public final class LongPollingActivateJobsTest {
             .setProbeTimeoutMillis(PROBE_TIMEOUT)
             .setMinEmptyResponses(FAILED_RESPONSE_THRESHOLD)
             .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
-            .setNoJobsReceivedExceptionProvider(Gateway.NO_JOBS_RECEIVED_EXCEPTION_PROVIDER)
+            .setResourceExhaustedExceptionProvider(Gateway.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(Gateway.REQUEST_CANCELED_EXCEPTION_PROVIDER)
             .setMetrics(LongPollingMetrics.noop())
             .build();
@@ -263,7 +263,7 @@ public final class LongPollingActivateJobsTest {
             .setLongPollingTimeout(20000)
             .setProbeTimeoutMillis(probeTimeout)
             .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
-            .setNoJobsReceivedExceptionProvider(Gateway.NO_JOBS_RECEIVED_EXCEPTION_PROVIDER)
+            .setResourceExhaustedExceptionProvider(Gateway.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(Gateway.REQUEST_CANCELED_EXCEPTION_PROVIDER)
             .setMetrics(LongPollingMetrics.noop())
             .build();
@@ -293,7 +293,7 @@ public final class LongPollingActivateJobsTest {
             .setLongPollingTimeout(longPollingTimeout)
             .setProbeTimeoutMillis(probeTimeout)
             .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
-            .setNoJobsReceivedExceptionProvider(Gateway.NO_JOBS_RECEIVED_EXCEPTION_PROVIDER)
+            .setResourceExhaustedExceptionProvider(Gateway.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(Gateway.REQUEST_CANCELED_EXCEPTION_PROVIDER)
             .setMetrics(LongPollingMetrics.noop())
             .build();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.gateway.cmd.ConcurrentRequestException;
 import io.camunda.zeebe.msgpack.spec.MsgpackException;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.netty.channel.ConnectTimeoutException;
 import java.net.ConnectException;
 import java.util.Optional;
@@ -43,6 +44,10 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 
 public class RestErrorMapper {
+  public static final Function<String, Exception> RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER =
+      msg -> new BrokerErrorException(new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, msg));
+  public static final Function<String, Throwable> REQUEST_CANCELED_EXCEPTION_PROVIDER =
+      RuntimeException::new;
 
   public static final Function<BrokerRejection, ProblemDetail> DEFAULT_REJECTION_MAPPER =
       rejection -> {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.service.JobServices.ActivateJobsRequest;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerErrorResponse;
@@ -40,6 +41,7 @@ import io.camunda.zeebe.gateway.protocol.rest.JobActivationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.TenantAttributeHolder;
 import io.camunda.zeebe.gateway.rest.controller.JobActivationRequestResponseObserver;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
@@ -67,10 +69,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.unit.DataSize;
-import org.springframework.web.server.ResponseStatusException;
 
 public class LongPollingActivateJobsRestTest {
 
@@ -112,10 +113,10 @@ public class LongPollingActivateJobsRestTest {
             .setProbeTimeoutMillis(PROBE_TIMEOUT)
             .setMinEmptyResponses(FAILED_RESPONSE_THRESHOLD)
             .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
-            .setNoJobsReceivedExceptionProvider(
-                msg -> new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, msg))
+            .setResourceExhaustedExceptionProvider(
+                RestErrorMapper.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(
-                msg -> new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, msg))
+                RestErrorMapper.REQUEST_CANCELED_EXCEPTION_PROVIDER)
             .setMetrics(LongPollingMetrics.noop())
             .build();
     submitActorToActivateJobs(handler);
@@ -310,8 +311,10 @@ public class LongPollingActivateJobsRestTest {
             .setLongPollingTimeout(20000)
             .setProbeTimeoutMillis(probeTimeout)
             .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
-            .setNoJobsReceivedExceptionProvider(RuntimeException::new)
-            .setRequestCanceledExceptionProvider(RuntimeException::new)
+            .setResourceExhaustedExceptionProvider(
+                RestErrorMapper.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
+            .setRequestCanceledExceptionProvider(
+                RestErrorMapper.REQUEST_CANCELED_EXCEPTION_PROVIDER)
             .setMetrics(LongPollingMetrics.noop())
             .build();
     submitActorToActivateJobs(handler);
@@ -340,8 +343,10 @@ public class LongPollingActivateJobsRestTest {
             .setLongPollingTimeout(longPollingTimeout)
             .setProbeTimeoutMillis(probeTimeout)
             .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
-            .setNoJobsReceivedExceptionProvider(RuntimeException::new)
-            .setRequestCanceledExceptionProvider(RuntimeException::new)
+            .setResourceExhaustedExceptionProvider(
+                RestErrorMapper.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
+            .setRequestCanceledExceptionProvider(
+                RestErrorMapper.REQUEST_CANCELED_EXCEPTION_PROVIDER)
             .setMetrics(LongPollingMetrics.noop())
             .build();
     submitActorToActivateJobs(handler);
@@ -551,9 +556,26 @@ public class LongPollingActivateJobsRestTest {
     verify(request.getResponseObserver(), never()).onNext(any());
     verify(request.getResponseObserver(), never()).onCompleted();
 
-    assertThat(throwableCaptor.getValue()).isInstanceOf(ResponseStatusException.class);
-    final ResponseStatusException exception = (ResponseStatusException) throwableCaptor.getValue();
-    assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+    assertThat(throwableCaptor.getValue()).isInstanceOf(BrokerErrorException.class);
+    final BrokerErrorException exception = (BrokerErrorException) throwableCaptor.getValue();
+    assertThat(exception.getError())
+        .extracting(BrokerError::getCode)
+        .isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
+
+    final CompletableFuture<ResponseEntity<Object>> result =
+        ((InspectableJobActivationRequestResponseObserver) request.getResponseObserver())
+            .getResult();
+    assertThat(result.join().getBody())
+        .isInstanceOf(ProblemDetail.class)
+        .satisfies(
+            obj -> {
+              final var problemDetail = (ProblemDetail) obj;
+              assertThat(problemDetail.getStatus()).isEqualTo(429);
+              assertThat(problemDetail.getTitle()).isEqualTo("RESOURCE_EXHAUSTED");
+              assertThat(problemDetail.getDetail())
+                  .isEqualTo(
+                      "Expected to activate jobs of type 'test', but no jobs available and at least one broker returned 'RESOURCE_EXHAUSTED'. Please try again later.");
+            });
   }
 
   @Test
@@ -687,7 +709,10 @@ public class LongPollingActivateJobsRestTest {
     // then
     final ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
     verify(request.getResponseObserver(), times(1)).onError(throwableCaptor.capture());
-    assertThat(throwableCaptor.getValue()).isInstanceOf(ResponseStatusException.class);
+    final BrokerErrorException exception = (BrokerErrorException) throwableCaptor.getValue();
+    assertThat(exception.getError())
+        .extracting(BrokerError::getCode)
+        .isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
 
     assertThat(request.hasScheduledTimer()).isFalse();
   }
@@ -1095,6 +1120,10 @@ public class LongPollingActivateJobsRestTest {
 
     public JobActivationResponse getResponse() {
       return response;
+    }
+
+    public CompletableFuture<ResponseEntity<Object>> getResult() {
+      return result;
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.controller.util.ResettableJobActivationRequestResponseObserver;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -440,8 +441,10 @@ public class JobControllerLongPollingTest extends RestControllerTest {
               .setBrokerClient(brokerClient)
               .setMaxMessageSize(DataSize.ofMegabytes(4L).toBytes())
               .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
-              .setNoJobsReceivedExceptionProvider(RuntimeException::new)
-              .setRequestCanceledExceptionProvider(reason -> new RuntimeException(reason))
+              .setResourceExhaustedExceptionProvider(
+                  RestErrorMapper.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
+              .setRequestCanceledExceptionProvider(
+                  RestErrorMapper.REQUEST_CANCELED_EXCEPTION_PROVIDER)
               .setMetrics(LongPollingMetrics.noop())
               .build();
       final var future = new CompletableFuture<>();


### PR DESCRIPTION
# Description
Backport of #39985 to `stable/8.7`.

relates to #25806