### PR TITLE
deps: Update dependency io.grpc:grpc to v1.76.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -55,7 +55,7 @@
     <version.docker-java-api>3.5.3</version.docker-java-api>
     <version.elasticsearch>8.16.6</version.elasticsearch>
     <version.error-prone>2.41.0</version.error-prone>
-    <version.grpc>1.73.0</version.grpc>
+    <version.grpc>1.76.0</version.grpc>
     <version.gson>2.13.1</version.gson>
     <version.guava>33.4.8-jre</version.guava>
     <version.hamcrest>3.0</version.hamcrest>


### PR DESCRIPTION
## Description

Bump grpc to resolve transitive netty deps potentially vulnerable to:
* CVE-2025-58056
* CVE-2025-58057
* CVE-2025-55163

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40068
