### PR TITLE
feat: add property jfr to unified configuration

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -133,6 +133,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-exporter</artifactId>
     </dependency>

--- a/configuration/src/main/java/io/camunda/configuration/Metrics.java
+++ b/configuration/src/main/java/io/camunda/configuration/Metrics.java
@@ -13,7 +13,7 @@ public class Metrics {
 
   private static final String PREFIX = "camunda.monitoring.metrics";
 
-  private static final Set<String> LEGACY_ENABLE_ACTOR_METRICS_PPROPERTIES =
+  private static final Set<String> LEGACY_ENABLE_ACTOR_METRICS_PROPERTIES =
       Set.of("zeebe.broker.experimental.features.enableActorMetrics");
 
   /** Controls whether to collect metrics about actor usage such as actor job execution latencies */
@@ -25,7 +25,7 @@ public class Metrics {
         actor,
         Boolean.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
-        LEGACY_ENABLE_ACTOR_METRICS_PPROPERTIES);
+        LEGACY_ENABLE_ACTOR_METRICS_PROPERTIES);
   }
 
   public void setActor(final boolean actor) {

--- a/configuration/src/main/java/io/camunda/configuration/Monitoring.java
+++ b/configuration/src/main/java/io/camunda/configuration/Monitoring.java
@@ -7,12 +7,20 @@
  */
 package io.camunda.configuration;
 
+import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class Monitoring {
 
+  private static final String PREFIX = "camunda.monitoring";
+
+  private static final Set<String> LEGACY_JFR_PROPERTIES = Set.of("camunda.flags.jfr.metrics");
+
   /** Configure metrics */
   @NestedConfigurationProperty Metrics metrics = new Metrics();
+
+  /** Allows registering and tracking metrics based on JFR events */
+  private boolean isJfr = false;
 
   public Metrics getMetrics() {
     return metrics;
@@ -20,5 +28,18 @@ public class Monitoring {
 
   public void setMetrics(final Metrics metrics) {
     this.metrics = metrics;
+  }
+
+  public boolean isJfr() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".jfr",
+        isJfr,
+        Boolean.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_JFR_PROPERTIES);
+  }
+
+  public void setJfr(final boolean jfr) {
+    isJfr = jfr;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/conditions/ConditionalOnJfr.java
+++ b/configuration/src/main/java/io/camunda/configuration/conditions/ConditionalOnJfr.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.conditions;
+
+import io.camunda.configuration.conditions.ConditionalOnJfr.OnJfrCondition;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Optional;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(OnJfrCondition.class)
+public @interface ConditionalOnJfr {
+
+  class OnJfrCondition implements Condition {
+
+    @Override
+    public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+      final var env = context.getEnvironment();
+
+      return Boolean.parseBoolean(
+          Optional.ofNullable(env.getProperty("camunda.monitoring.jfr"))
+              .orElse(env.getProperty("camunda.flags.jfr.metrics", "false")));
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/MonitoringTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/MonitoringTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({UnifiedConfiguration.class, UnifiedConfigurationHelper.class})
+public class MonitoringTest {
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.monitoring.jfr=true"})
+  class WithOnlyUnifiedConfigSet {
+    final UnifiedConfiguration unifiedConfiguration;
+
+    WithOnlyUnifiedConfigSet(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldSetJfr() {
+      assertThat(unifiedConfiguration.getCamunda().getMonitoring().isJfr()).isTrue();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.flags.jfr.metrics=true"})
+  class WithOnlyLegacySet {
+    final UnifiedConfiguration unifiedConfiguration;
+
+    WithOnlyLegacySet(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldSetJfrFromLegacy() {
+      assertThat(unifiedConfiguration.getCamunda().getMonitoring().isJfr()).isTrue();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.monitoring.jfr=true",
+        // legacy
+        "camunda.flags.jfr.metrics=false"
+      })
+  class WithNewAndLegacySet {
+    final UnifiedConfiguration unifiedConfiguration;
+
+    WithNewAndLegacySet(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldSetJfrFromNew() {
+      assertThat(unifiedConfiguration.getCamunda().getMonitoring().isJfr()).isTrue();
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/OnJfrConditionTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/OnJfrConditionTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.conditions.ConditionalOnJfr;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+class OnJfrConditionTest {
+
+  private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+
+  @ParameterizedTest(name = "camunda.monitoring.jfr={0} → bean should exist={1}")
+  @CsvSource({"true,  true", "false, false"})
+  void shouldLoadOrNotLoadBeanWhenOnlyNewPropertyIsSet(
+      final String propertyValue, final boolean shouldLoadBean) {
+    contextRunner
+        .withPropertyValues("camunda.monitoring.jfr=" + propertyValue)
+        .withUserConfiguration(TestConfig.class)
+        .run(
+            context -> {
+              if (shouldLoadBean) {
+                assertThat(context).hasSingleBean(TestBean.class);
+              } else {
+                assertThat(context).doesNotHaveBean(TestBean.class);
+              }
+            });
+  }
+
+  @ParameterizedTest(name = "camunda.flags.jfr.metrics={0} → bean should exist={1}")
+  @CsvSource({"true,  true", "false, false"})
+  void shouldLoadOrNotLoadBeanWhenOnlyLegacyPropertyIsSet(
+      final String propertyValue, final boolean shouldLoadBean) {
+    contextRunner
+        .withPropertyValues("camunda.flags.jfr.metrics=" + propertyValue)
+        .withUserConfiguration(TestConfig.class)
+        .run(
+            context -> {
+              if (shouldLoadBean) {
+                assertThat(context).hasSingleBean(TestBean.class);
+              } else {
+                assertThat(context).doesNotHaveBean(TestBean.class);
+              }
+            });
+  }
+
+  @Test
+  void shouldUseNewPropertyInFavourOfLegacy() {
+    contextRunner
+        .withPropertyValues("camunda.monitoring.jfr=true")
+        .withPropertyValues("camunda.flags.jfr.metrics=false")
+        .withUserConfiguration(TestConfig.class)
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(TestBean.class);
+            });
+  }
+
+  @Test
+  void shouldNotLoadBeanWhenNewAndLegacyAreNotSet() {
+    contextRunner
+        .withUserConfiguration(TestConfig.class)
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(TestBean.class);
+            });
+  }
+
+  @Configuration
+  static class TestConfig {
+    @Bean
+    @ConditionalOnJfr
+    TestBean testBean() {
+      return new TestBean();
+    }
+  }
+
+  static class TestBean {}
+}

--- a/dist/src/main/java/io/camunda/application/commons/metrics/JfrMetricRecorder.java
+++ b/dist/src/main/java/io/camunda/application/commons/metrics/JfrMetricRecorder.java
@@ -8,12 +8,12 @@
 package io.camunda.application.commons.metrics;
 
 import io.camunda.application.commons.metrics.jfr.NativeMemoryMetrics;
+import io.camunda.configuration.conditions.ConditionalOnJfr;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Objects;
 import jdk.jfr.consumer.RecordingStream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationStartedEvent;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.event.EventListener;
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
  * from stopping.
  */
 @Component
-@ConditionalOnProperty(prefix = "camunda.flags.jfr", name = "metrics", havingValue = "true")
+@ConditionalOnJfr
 @Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
 public final class JfrMetricRecorder {
   private final RecordingStream jfrStream;


### PR DESCRIPTION
## Description

This PR adds the properties from section camunda.monitoring to unified config.

The legacy properties are:
camunda.flags.jfr.metrics

The new properties are:
camunda.monitoring.jfr

Backwards compatibility is supported for these properties. That means, if legacy is set and new property is not set, legacy value will be used.

## Checklist

- [ ] The legacy properties and the backwards compatibility strategy are updated in [schema doc](https://docs.google.com/spreadsheets/d/1R4epsy6DWemA8_76cUE6zOGUFbrXCXlM2reXnKFuz7Y/edit?gid=818158292#gid=818158292)
- [ ] The new property fields are documented in the code
## Related issues

related to 