### PR TITLE
fix: use snapshot position in recovery failure message

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -597,7 +597,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     final boolean failedToRecoverReader = !logStreamReader.seekToNextEvent(snapshotPosition);
     if (failedToRecoverReader) {
       throw new IllegalStateException(
-          String.format(ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED, -1, getName()));
+          String.format(ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED, snapshotPosition, getName()));
     }
     logStream.registerRecordAvailableListener(this);
     if (!exporterPhase.equals(ExporterPhase.PAUSED)) {


### PR DESCRIPTION
We should use the position that we actually tried to seek to, not -1, especially because seeking to -1 always succeeds because it just seeks to the first event, regardless of position.