### PR TITLE
fix: update ConnectorsCmd to accept custom Camunda port

### DIFF
--- a/c8run/internal/processmanagement/processhandler_test.go
+++ b/c8run/internal/processmanagement/processhandler_test.go
@@ -26,7 +26,7 @@ func (m *mockC8) ElasticsearchCmd(ctx context.Context, elasticsearchVersion stri
 	return nil
 }
 
-func (m *mockC8) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string) *exec.Cmd {
+func (m *mockC8) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd {
 	return nil
 }
 

--- a/c8run/internal/start/startuphandler.go
+++ b/c8run/internal/start/startuphandler.go
@@ -269,7 +269,7 @@ func (s *StartupHandler) StartCommand(wg *sync.WaitGroup, ctx context.Context, s
 	}
 
 	s.ProcessHandler.AttemptToStartProcess(processInfo.Connectors.PidPath, "Connectors", func() {
-		connectorsCmd := c8.ConnectorsCmd(ctx, javaBinary, parentDir, processInfo.Camunda.Version)
+		connectorsCmd := c8.ConnectorsCmd(ctx, javaBinary, parentDir, processInfo.Camunda.Version, state.Settings.Port)
 		connectorsLogPath := filepath.Join(parentDir, "log", "connectors.log")
 		err := s.startApplication(connectorsCmd, processInfo.Connectors.PidPath, connectorsLogPath, stop)
 		if err != nil {

--- a/c8run/internal/types/types.go
+++ b/c8run/internal/types/types.go
@@ -11,7 +11,7 @@ type C8Run interface {
 	ProcessTree(commandPid int) []*os.Process
 	VersionCmd(ctx context.Context, javaBinaryPath string) *exec.Cmd
 	ElasticsearchCmd(ctx context.Context, elasticsearchVersion string, parentDir string) *exec.Cmd
-	ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string) *exec.Cmd
+	ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd
 	CamundaCmd(ctx context.Context, camundaVersion string, parentDir string, extraArgs string, javaOpts string) *exec.Cmd
 }
 

--- a/c8run/internal/unix/stub.go
+++ b/c8run/internal/unix/stub.go
@@ -24,7 +24,7 @@ func (w *UnixC8Run) ElasticsearchCmd(ctx context.Context, elasticsearchVersion s
 	panic("Platform was not built for unix")
 }
 
-func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string) *exec.Cmd {
+func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd {
 	panic("Platform was not built for unix")
 }
 

--- a/c8run/internal/unix/unix.go
+++ b/c8run/internal/unix/unix.go
@@ -50,12 +50,17 @@ func (w *UnixC8Run) ElasticsearchCmd(ctx context.Context, elasticsearchVersion s
 	return elasticsearchCmd
 }
 
-func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string) *exec.Cmd {
+func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd {
 	classPath := parentDir + "/*:" + parentDir + "/custom_connectors/*"
 	mainClass := "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 	springConfigLocation := "--spring.config.additional-location=" + parentDir + "/connectors-application.properties"
 	connectorsCmd := exec.CommandContext(ctx, javaBinary, "-cp", classPath, mainClass, springConfigLocation)
 	connectorsCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// Set the CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS environment variable with the custom port
+	zeebeRestAddress := fmt.Sprintf("http://localhost:%d", camundaPort)
+	connectorsCmd.Env = append(os.Environ(), fmt.Sprintf("CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=%s", zeebeRestAddress))
+
 	return connectorsCmd
 }
 

--- a/c8run/internal/unix/unix.go
+++ b/c8run/internal/unix/unix.go
@@ -57,9 +57,11 @@ func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parent
 	connectorsCmd := exec.CommandContext(ctx, javaBinary, "-cp", classPath, mainClass, springConfigLocation)
 	connectorsCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	// Set the CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS environment variable with the custom port
-	zeebeRestAddress := fmt.Sprintf("http://localhost:%d", camundaPort)
-	connectorsCmd.Env = append(os.Environ(), fmt.Sprintf("CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=%s", zeebeRestAddress))
+	// Set default Zeebe REST address if the user has not provided one already.
+	if _, exists := os.LookupEnv("CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS"); !exists {
+		zeebeRestAddress := fmt.Sprintf("http://localhost:%d", camundaPort)
+		connectorsCmd.Env = append(os.Environ(), fmt.Sprintf("CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=%s", zeebeRestAddress))
+	}
 
 	return connectorsCmd
 }

--- a/c8run/internal/unix/unix_test.go
+++ b/c8run/internal/unix/unix_test.go
@@ -103,3 +103,27 @@ func TestConnectorsCmdPortNotInArgs(t *testing.T) {
 		t.Errorf("Port should not be in command arguments, only in environment variable. Args: %s", args)
 	}
 }
+
+func TestConnectorsCmdRespectsExistingZeebeRestEnv(t *testing.T) {
+	ctx := context.Background()
+	unixC8Run := &UnixC8Run{}
+
+	customAddress := "https://external-host:9443"
+	t.Setenv("CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS", customAddress)
+
+	cmd := unixC8Run.ConnectorsCmd(
+		ctx,
+		"java",
+		"/test/parent/dir",
+		"8.8.1",
+		9000,
+	)
+
+	if cmd.Env != nil {
+		for _, env := range cmd.Env {
+			if strings.Contains(env, "CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=") {
+				t.Fatalf("expected existing CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS to be preserved, but command overrides it: %s", env)
+			}
+		}
+	}
+}

--- a/c8run/internal/unix/unix_test.go
+++ b/c8run/internal/unix/unix_test.go
@@ -1,0 +1,105 @@
+//go:build linux || darwin
+
+package unix
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestConnectorsCmdWithCustomPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		camundaPort  int
+		expectedAddr string
+	}{
+		{
+			name:         "default port",
+			camundaPort:  8080,
+			expectedAddr: "CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=http://localhost:8080",
+		},
+		{
+			name:         "custom port 9000",
+			camundaPort:  9000,
+			expectedAddr: "CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=http://localhost:9000",
+		},
+		{
+			name:         "custom port 8888",
+			camundaPort:  8888,
+			expectedAddr: "CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=http://localhost:8888",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			unixC8Run := &UnixC8Run{}
+
+			cmd := unixC8Run.ConnectorsCmd(
+				ctx,
+				"java",
+				"/test/parent/dir",
+				"8.8.1",
+				tt.camundaPort,
+			)
+
+			// Check that the environment variable is set correctly
+			found := false
+			for _, env := range cmd.Env {
+				if strings.Contains(env, "CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=") {
+					if env != tt.expectedAddr {
+						t.Errorf("Expected environment variable %q, got %q", tt.expectedAddr, env)
+					}
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS environment variable not found in command environment")
+			}
+
+			// Verify the command structure - cmd.Path will be resolved by exec.CommandContext
+			// so we check cmd.Args[0] instead which is the actual command
+			if !strings.Contains(cmd.Args[0], "java") {
+				t.Errorf("Expected command to contain 'java', got %q", cmd.Args[0])
+			}
+
+			// Check that the classpath includes custom_connectors
+			args := strings.Join(cmd.Args, " ")
+			if !strings.Contains(args, "custom_connectors") {
+				t.Errorf("Expected classpath to include 'custom_connectors', got: %s", args)
+			}
+
+			// Check that the main class is correct
+			if !strings.Contains(args, "io.camunda.connector.runtime.app.ConnectorRuntimeApplication") {
+				t.Errorf("Expected main class 'io.camunda.connector.runtime.app.ConnectorRuntimeApplication', got: %s", args)
+			}
+
+			// Check that the spring config location is included
+			if !strings.Contains(args, "--spring.config.additional-location=") {
+				t.Errorf("Expected spring config location argument, got: %s", args)
+			}
+		})
+	}
+}
+
+func TestConnectorsCmdPortNotInArgs(t *testing.T) {
+	ctx := context.Background()
+	unixC8Run := &UnixC8Run{}
+
+	cmd := unixC8Run.ConnectorsCmd(
+		ctx,
+		"java",
+		"/test/parent/dir",
+		"8.8.1",
+		9000,
+	)
+
+	// The port should be in the environment variable, not in the command arguments
+	args := strings.Join(cmd.Args, " ")
+	if strings.Contains(args, "9000") {
+		t.Errorf("Port should not be in command arguments, only in environment variable. Args: %s", args)
+	}
+}

--- a/c8run/internal/windows/stub.go
+++ b/c8run/internal/windows/stub.go
@@ -24,7 +24,7 @@ func (w *WindowsC8Run) ElasticsearchCmd(ctx context.Context, elasticsearchVersio
 	panic("Platform was not built for windows")
 }
 
-func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string) *exec.Cmd {
+func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd {
 	panic("Platform was not built for windows")
 }
 

--- a/c8run/internal/windows/windows.go
+++ b/c8run/internal/windows/windows.go
@@ -52,9 +52,11 @@ func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, par
 		// CreationFlags: 0x00000010, // CREATE_NEW_CONSOLE : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 	}
 
-	// Set the CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS environment variable with the custom port
-	zeebeRestAddress := fmt.Sprintf("http://localhost:%d", camundaPort)
-	connectorsCmd.Env = append(os.Environ(), fmt.Sprintf("CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=%s", zeebeRestAddress))
+	// Set default Zeebe REST address if the user has not provided one already.
+	if _, exists := os.LookupEnv("CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS"); !exists {
+		zeebeRestAddress := fmt.Sprintf("http://localhost:%d", camundaPort)
+		connectorsCmd.Env = append(os.Environ(), fmt.Sprintf("CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=%s", zeebeRestAddress))
+	}
 
 	return connectorsCmd
 }

--- a/c8run/internal/windows/windows.go
+++ b/c8run/internal/windows/windows.go
@@ -44,13 +44,18 @@ func (w *WindowsC8Run) ElasticsearchCmd(ctx context.Context, elasticsearchVersio
 	return elasticsearchCmd
 }
 
-func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string) *exec.Cmd {
+func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, camundaVersion string, camundaPort int) *exec.Cmd {
 	connectorsCmd := exec.CommandContext(ctx, javaBinary, "-classpath", parentDir+"\\*;"+parentDir+"\\custom_connectors\\*", "io.camunda.connector.runtime.app.ConnectorRuntimeApplication", "--spring.config.additional-location="+parentDir+"\\connectors-application.properties")
 	connectorsCmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: 0x08000000 | 0x00000200, // CREATE_NO_WINDOW, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 		// CreationFlags: 0x00000008 | 0x00000200, // DETACHED_PROCESS, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 		// CreationFlags: 0x00000010, // CREATE_NEW_CONSOLE : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 	}
+
+	// Set the CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS environment variable with the custom port
+	zeebeRestAddress := fmt.Sprintf("http://localhost:%d", camundaPort)
+	connectorsCmd.Env = append(os.Environ(), fmt.Sprintf("CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=%s", zeebeRestAddress))
+
 	return connectorsCmd
 }
 

--- a/c8run/internal/windows/windows_test.go
+++ b/c8run/internal/windows/windows_test.go
@@ -103,3 +103,27 @@ func TestConnectorsCmdPortNotInArgs(t *testing.T) {
 		t.Errorf("Port should not be in command arguments, only in environment variable. Args: %s", args)
 	}
 }
+
+func TestConnectorsCmdRespectsExistingZeebeRestEnv(t *testing.T) {
+	ctx := context.Background()
+	windowsC8Run := &WindowsC8Run{}
+
+	customAddress := "https://external-host:9443"
+	t.Setenv("CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS", customAddress)
+
+	cmd := windowsC8Run.ConnectorsCmd(
+		ctx,
+		"java",
+		"C:\\test\\parent\\dir",
+		"8.8.1",
+		9000,
+	)
+
+	if cmd.Env != nil {
+		for _, env := range cmd.Env {
+			if strings.Contains(env, "CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=") {
+				t.Fatalf("expected existing CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS to be preserved, but command overrides it: %s", env)
+			}
+		}
+	}
+}

--- a/c8run/internal/windows/windows_test.go
+++ b/c8run/internal/windows/windows_test.go
@@ -1,0 +1,105 @@
+//go:build windows
+
+package windows
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestConnectorsCmdWithCustomPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		camundaPort  int
+		expectedAddr string
+	}{
+		{
+			name:         "default port",
+			camundaPort:  8080,
+			expectedAddr: "CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=http://localhost:8080",
+		},
+		{
+			name:         "custom port 9000",
+			camundaPort:  9000,
+			expectedAddr: "CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=http://localhost:9000",
+		},
+		{
+			name:         "custom port 8888",
+			camundaPort:  8888,
+			expectedAddr: "CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=http://localhost:8888",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			windowsC8Run := &WindowsC8Run{}
+
+			cmd := windowsC8Run.ConnectorsCmd(
+				ctx,
+				"java",
+				"C:\\test\\parent\\dir",
+				"8.8.1",
+				tt.camundaPort,
+			)
+
+			// Check that the environment variable is set correctly
+			found := false
+			for _, env := range cmd.Env {
+				if strings.Contains(env, "CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=") {
+					if env != tt.expectedAddr {
+						t.Errorf("Expected environment variable %q, got %q", tt.expectedAddr, env)
+					}
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS environment variable not found in command environment")
+			}
+
+			// Verify the command structure - cmd.Path will be resolved by exec.CommandContext
+			// so we check cmd.Args[0] instead which is the actual command
+			if !strings.Contains(cmd.Args[0], "java") {
+				t.Errorf("Expected command to contain 'java', got %q", cmd.Args[0])
+			}
+
+			// Check that the classpath includes custom_connectors (Windows uses backslash)
+			args := strings.Join(cmd.Args, " ")
+			if !strings.Contains(args, "custom_connectors") {
+				t.Errorf("Expected classpath to include 'custom_connectors', got: %s", args)
+			}
+
+			// Check that the main class is correct
+			if !strings.Contains(args, "io.camunda.connector.runtime.app.ConnectorRuntimeApplication") {
+				t.Errorf("Expected main class 'io.camunda.connector.runtime.app.ConnectorRuntimeApplication', got: %s", args)
+			}
+
+			// Check that the spring config location is included (Windows uses backslash)
+			if !strings.Contains(args, "--spring.config.additional-location=") {
+				t.Errorf("Expected spring config location argument, got: %s", args)
+			}
+		})
+	}
+}
+
+func TestConnectorsCmdPortNotInArgs(t *testing.T) {
+	ctx := context.Background()
+	windowsC8Run := &WindowsC8Run{}
+
+	cmd := windowsC8Run.ConnectorsCmd(
+		ctx,
+		"java",
+		"C:\\test\\parent\\dir",
+		"8.8.1",
+		9000,
+	)
+
+	// The port should be in the environment variable, not in the command arguments
+	args := strings.Join(cmd.Args, " ")
+	if strings.Contains(args, "9000") {
+		t.Errorf("Port should not be in command arguments, only in environment variable. Args: %s", args)
+	}
+}


### PR DESCRIPTION
## Description

start-up procedure now sets the env var `CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS` according to port switch supplied (`--port`)
which in turn makes connectors recognize the correct Zeebe REST address to connect to

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39691