### PR TITLE
[Backport stable/8.6] fix: use snapshot position in recovery failure message

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -575,7 +575,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     final boolean failedToRecoverReader = !logStreamReader.seekToNextEvent(snapshotPosition);
     if (failedToRecoverReader) {
       throw new IllegalStateException(
-          String.format(ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED, -1, getName()));
+          String.format(ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED, snapshotPosition, getName()));
     }
     logStream.registerRecordAvailableListener(this);
     if (!exporterPhase.equals(ExporterPhase.PAUSED)) {


### PR DESCRIPTION
# Description
Backport of #40077 to `stable/8.6`.

relates to 