### PR TITLE
[Backport stable/8.7] deps: Update dependency io.grpc:grpc to v1.76.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -55,7 +55,7 @@
     <version.docker-java-api>3.4.2</version.docker-java-api>
     <version.elasticsearch>8.13.4</version.elasticsearch>
     <version.error-prone>2.32.0</version.error-prone>
-    <version.grpc>1.68.3</version.grpc>
+    <version.grpc>1.76.0</version.grpc>
     <version.gson>2.11.0</version.gson>
     <version.guava>33.3.1-jre</version.guava>
     <version.hamcrest>3.0</version.hamcrest>


### PR DESCRIPTION
# Description
Backport of #40067 to `stable/8.7`.

relates to #40068