### PR TITLE
[Backport stable/8.7] feat: stackless `MessagingException` to reduce noise

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingException.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingException.java
@@ -30,6 +30,12 @@ public class MessagingException extends IOException {
     super(message, cause);
   }
 
+  @Override
+  public Throwable fillInStackTrace() {
+    // Stack traces aren't useful here, all the information is in the message.
+    return this;
+  }
+
   /** Exception indicating no remote registered remote handler. */
   public static class NoRemoteHandler extends MessagingException {
     public NoRemoteHandler(final String subject) {


### PR DESCRIPTION
# Description
Backport of #40084 to `stable/8.7`.

relates to 