### PR TITLE
[Backport stable/8.8] fix: remove japicmp as its breaking builds

### DIFF
--- a/webapps-schema/pom.xml
+++ b/webapps-schema/pom.xml
@@ -66,5 +66,8 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+<<<<<<< HEAD
 
+=======
+>>>>>>> fe2935a4 (fix: remove japicmp as its breaking builds)
 </project>


### PR DESCRIPTION
# Description
Backport of #40086 to `stable/8.8`.

relates to #40057