### PR TITLE
Add since version annotation to all entities

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/BeforeVersion880.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/BeforeVersion880.java
@@ -14,5 +14,5 @@ import java.lang.annotation.Target;
 
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
-@SinceVersion(value = "8.8.0", nullable = true)
-public @interface SinceVersion880 {}
+@SinceVersion(value = "before-8.8.0", requireDefault = false)
+public @interface BeforeVersion880 {}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/CorrelatedMessageSubscriptionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/CorrelatedMessageSubscriptionEntity.java
@@ -16,22 +16,22 @@ public class CorrelatedMessageSubscriptionEntity
         PartitionedEntity<CorrelatedMessageSubscriptionEntity>,
         TenantOwned {
 
-  private String id;
+  @SinceVersion880 private String id;
 
-  private String bpmnProcessId;
-  private String correlationKey;
-  private OffsetDateTime correlationTime;
-  private String flowNodeId;
-  private Long flowNodeInstanceKey;
-  private long messageKey;
-  private String messageName;
-  private int partitionId;
-  private Long position;
-  private Long processDefinitionKey;
-  private Long processInstanceKey;
-  private long subscriptionKey;
-  private String subscriptionType;
-  private String tenantId;
+  @SinceVersion880 private String bpmnProcessId;
+  @SinceVersion880 private String correlationKey;
+  @SinceVersion880 private OffsetDateTime correlationTime;
+  @SinceVersion880 private String flowNodeId;
+  @SinceVersion880 private Long flowNodeInstanceKey;
+  @SinceVersion880 private long messageKey;
+  @SinceVersion880 private String messageName;
+  @SinceVersion880 private int partitionId;
+  @SinceVersion880 private Long position;
+  @SinceVersion880 private Long processDefinitionKey;
+  @SinceVersion880 private Long processInstanceKey;
+  @SinceVersion880 private long subscriptionKey;
+  @SinceVersion880 private String subscriptionType;
+  @SinceVersion880 private String tenantId;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/CorrelatedMessageSubscriptionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/CorrelatedMessageSubscriptionEntity.java
@@ -16,22 +16,22 @@ public class CorrelatedMessageSubscriptionEntity
         PartitionedEntity<CorrelatedMessageSubscriptionEntity>,
         TenantOwned {
 
-  @SinceVersion880 private String id;
+  @BeforeVersion880 private String id;
 
-  @SinceVersion880 private String bpmnProcessId;
-  @SinceVersion880 private String correlationKey;
-  @SinceVersion880 private OffsetDateTime correlationTime;
-  @SinceVersion880 private String flowNodeId;
-  @SinceVersion880 private Long flowNodeInstanceKey;
-  @SinceVersion880 private long messageKey;
-  @SinceVersion880 private String messageName;
-  @SinceVersion880 private int partitionId;
-  @SinceVersion880 private Long position;
-  @SinceVersion880 private Long processDefinitionKey;
-  @SinceVersion880 private Long processInstanceKey;
-  @SinceVersion880 private long subscriptionKey;
-  @SinceVersion880 private String subscriptionType;
-  @SinceVersion880 private String tenantId;
+  @BeforeVersion880 private String bpmnProcessId;
+  @BeforeVersion880 private String correlationKey;
+  @BeforeVersion880 private OffsetDateTime correlationTime;
+  @BeforeVersion880 private String flowNodeId;
+  @BeforeVersion880 private Long flowNodeInstanceKey;
+  @BeforeVersion880 private long messageKey;
+  @BeforeVersion880 private String messageName;
+  @BeforeVersion880 private int partitionId;
+  @BeforeVersion880 private Long position;
+  @BeforeVersion880 private Long processDefinitionKey;
+  @BeforeVersion880 private Long processInstanceKey;
+  @BeforeVersion880 private long subscriptionKey;
+  @BeforeVersion880 private String subscriptionType;
+  @BeforeVersion880 private String tenantId;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JobEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JobEntity.java
@@ -15,18 +15,18 @@ import java.util.Objects;
 public class JobEntity
     implements ExporterEntity<JobEntity>, PartitionedEntity<JobEntity>, TenantOwned {
 
-  private String id;
-  private long key;
-  private int partitionId;
-  private Long processInstanceKey;
-  private Long flowNodeInstanceId;
-  private String flowNodeId;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private long key;
+  @SinceVersion880 private int partitionId;
+  @SinceVersion880 private Long processInstanceKey;
+  @SinceVersion880 private Long flowNodeInstanceId;
+  @SinceVersion880 private String flowNodeId;
 
   /** Attention! This field will be filled in only for data imported after v. 8.7.0. */
-  private Long processDefinitionKey;
+  @SinceVersion880 private Long processDefinitionKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.7.0. */
-  private String bpmnProcessId;
+  @SinceVersion880 private String bpmnProcessId;
 
   /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
   private OffsetDateTime creationTime;
@@ -34,25 +34,25 @@ public class JobEntity
   /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
   private OffsetDateTime lastUpdateTime;
 
-  private String tenantId;
-  private String type;
-  private String worker;
-  private Integer retries;
-  private String state;
-  private String errorMessage;
-  private String errorCode;
-  private OffsetDateTime deadline;
-  private OffsetDateTime endTime;
-  private Map<String, String> customHeaders;
-  private boolean jobFailedWithRetriesLeft;
-  private String jobKind;
+  @SinceVersion880 private String tenantId;
+  @SinceVersion880 private String type;
+  @SinceVersion880 private String worker;
+  @SinceVersion880 private Integer retries;
+  @SinceVersion880 private String state;
+  @SinceVersion880 private String errorMessage;
+  @SinceVersion880 private String errorCode;
+  @SinceVersion880 private OffsetDateTime deadline;
+  @SinceVersion880 private OffsetDateTime endTime;
+  @SinceVersion880 private Map<String, String> customHeaders;
+  @SinceVersion880 private boolean jobFailedWithRetriesLeft;
+  @SinceVersion880 private String jobKind;
 
-  private String listenerEventType;
+  @SinceVersion880 private String listenerEventType;
 
-  private Long position;
+  @SinceVersion880 private Long position;
 
-  private Boolean denied;
-  private String deniedReason;
+  @SinceVersion880 private Boolean denied;
+  @SinceVersion880 private String deniedReason;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JobEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JobEntity.java
@@ -15,44 +15,46 @@ import java.util.Objects;
 public class JobEntity
     implements ExporterEntity<JobEntity>, PartitionedEntity<JobEntity>, TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private long key;
-  @SinceVersion880 private int partitionId;
-  @SinceVersion880 private Long processInstanceKey;
-  @SinceVersion880 private Long flowNodeInstanceId;
-  @SinceVersion880 private String flowNodeId;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private int partitionId;
+  @BeforeVersion880 private Long processInstanceKey;
+  @BeforeVersion880 private Long flowNodeInstanceId;
+  @BeforeVersion880 private String flowNodeId;
 
   /** Attention! This field will be filled in only for data imported after v. 8.7.0. */
-  @SinceVersion880 private Long processDefinitionKey;
+  @BeforeVersion880 private Long processDefinitionKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.7.0. */
-  @SinceVersion880 private String bpmnProcessId;
+  @BeforeVersion880 private String bpmnProcessId;
 
   /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private OffsetDateTime creationTime;
 
   /** Attention! This field will be filled in only for data imported after v. 8.9.0. */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private OffsetDateTime lastUpdateTime;
 
-  @SinceVersion880 private String tenantId;
-  @SinceVersion880 private String type;
-  @SinceVersion880 private String worker;
-  @SinceVersion880 private Integer retries;
-  @SinceVersion880 private String state;
-  @SinceVersion880 private String errorMessage;
-  @SinceVersion880 private String errorCode;
-  @SinceVersion880 private OffsetDateTime deadline;
-  @SinceVersion880 private OffsetDateTime endTime;
-  @SinceVersion880 private Map<String, String> customHeaders;
-  @SinceVersion880 private boolean jobFailedWithRetriesLeft;
-  @SinceVersion880 private String jobKind;
+  @BeforeVersion880 private String tenantId;
+  @BeforeVersion880 private String type;
+  @BeforeVersion880 private String worker;
+  @BeforeVersion880 private Integer retries;
+  @BeforeVersion880 private String state;
+  @BeforeVersion880 private String errorMessage;
+  @BeforeVersion880 private String errorCode;
+  @BeforeVersion880 private OffsetDateTime deadline;
+  @BeforeVersion880 private OffsetDateTime endTime;
+  @BeforeVersion880 private Map<String, String> customHeaders;
+  @BeforeVersion880 private boolean jobFailedWithRetriesLeft;
+  @BeforeVersion880 private String jobKind;
 
-  @SinceVersion880 private String listenerEventType;
+  @BeforeVersion880 private String listenerEventType;
 
-  @SinceVersion880 private Long position;
+  @BeforeVersion880 private Long position;
 
-  @SinceVersion880 private Boolean denied;
-  @SinceVersion880 private String deniedReason;
+  @BeforeVersion880 private Boolean denied;
+  @BeforeVersion880 private String deniedReason;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/MessageEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/MessageEntity.java
@@ -13,16 +13,16 @@ import java.util.Objects;
 
 public class MessageEntity implements ExporterEntity<MessageEntity>, TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private String messageName;
-  @SinceVersion880 private String correlationKey;
-  @SinceVersion880 private OffsetDateTime publishDate;
-  @SinceVersion880 private OffsetDateTime expireDate;
-  @SinceVersion880 private OffsetDateTime deadline;
-  @SinceVersion880 private Long timeToLive;
-  @SinceVersion880 private String messageId;
-  @SinceVersion880 private String variables;
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private String messageName;
+  @BeforeVersion880 private String correlationKey;
+  @BeforeVersion880 private OffsetDateTime publishDate;
+  @BeforeVersion880 private OffsetDateTime expireDate;
+  @BeforeVersion880 private OffsetDateTime deadline;
+  @BeforeVersion880 private Long timeToLive;
+  @BeforeVersion880 private String messageId;
+  @BeforeVersion880 private String variables;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/MessageEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/MessageEntity.java
@@ -13,16 +13,16 @@ import java.util.Objects;
 
 public class MessageEntity implements ExporterEntity<MessageEntity>, TenantOwned {
 
-  private String id;
-  private String messageName;
-  private String correlationKey;
-  private OffsetDateTime publishDate;
-  private OffsetDateTime expireDate;
-  private OffsetDateTime deadline;
-  private Long timeToLive;
-  private String messageId;
-  private String variables;
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private String messageName;
+  @SinceVersion880 private String correlationKey;
+  @SinceVersion880 private OffsetDateTime publishDate;
+  @SinceVersion880 private OffsetDateTime expireDate;
+  @SinceVersion880 private OffsetDateTime deadline;
+  @SinceVersion880 private Long timeToLive;
+  @SinceVersion880 private String messageId;
+  @SinceVersion880 private String variables;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/MetricEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/MetricEntity.java
@@ -13,11 +13,11 @@ import java.util.Objects;
 
 public class MetricEntity implements ExporterEntity<MetricEntity>, TenantOwned {
 
-  private String id;
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  private String event;
-  private String value;
-  private OffsetDateTime eventTime;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private String event;
+  @SinceVersion880 private String value;
+  @SinceVersion880 private OffsetDateTime eventTime;
 
   public MetricEntity() {}
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/MetricEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/MetricEntity.java
@@ -13,11 +13,11 @@ import java.util.Objects;
 
 public class MetricEntity implements ExporterEntity<MetricEntity>, TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  @SinceVersion880 private String event;
-  @SinceVersion880 private String value;
-  @SinceVersion880 private OffsetDateTime eventTime;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private String event;
+  @BeforeVersion880 private String value;
+  @BeforeVersion880 private OffsetDateTime eventTime;
 
   public MetricEntity() {}
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ProcessEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ProcessEntity.java
@@ -15,21 +15,21 @@ import java.util.Objects;
 
 public class ProcessEntity implements ExporterEntity<ProcessEntity>, TenantOwned {
 
-  private String id;
-  private long key;
-  private String name;
-  private int version;
-  private String versionTag;
-  private String bpmnProcessId;
-  private String bpmnXml;
-  private String resourceName;
-  private List<ProcessFlowNodeEntity> flowNodes = new ArrayList<>();
-  @JsonIgnore private List<String> callActivityIds = new ArrayList<>();
-  private String formId;
-  private String formKey;
-  private Boolean isFormEmbedded;
-  private Boolean isPublic;
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private long key;
+  @SinceVersion880 private String name;
+  @SinceVersion880 private int version;
+  @SinceVersion880 private String versionTag;
+  @SinceVersion880 private String bpmnProcessId;
+  @SinceVersion880 private String bpmnXml;
+  @SinceVersion880 private String resourceName;
+  @SinceVersion880 private List<ProcessFlowNodeEntity> flowNodes = new ArrayList<>();
+  @SinceVersion880 @JsonIgnore private List<String> callActivityIds = new ArrayList<>();
+  @SinceVersion880 private String formId;
+  @SinceVersion880 private String formKey;
+  @SinceVersion880 private Boolean isFormEmbedded;
+  @SinceVersion880 private Boolean isPublic;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   public String getName() {
     return name;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ProcessEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ProcessEntity.java
@@ -15,21 +15,21 @@ import java.util.Objects;
 
 public class ProcessEntity implements ExporterEntity<ProcessEntity>, TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private long key;
-  @SinceVersion880 private String name;
-  @SinceVersion880 private int version;
-  @SinceVersion880 private String versionTag;
-  @SinceVersion880 private String bpmnProcessId;
-  @SinceVersion880 private String bpmnXml;
-  @SinceVersion880 private String resourceName;
-  @SinceVersion880 private List<ProcessFlowNodeEntity> flowNodes = new ArrayList<>();
-  @SinceVersion880 @JsonIgnore private List<String> callActivityIds = new ArrayList<>();
-  @SinceVersion880 private String formId;
-  @SinceVersion880 private String formKey;
-  @SinceVersion880 private Boolean isFormEmbedded;
-  @SinceVersion880 private Boolean isPublic;
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private int version;
+  @BeforeVersion880 private String versionTag;
+  @BeforeVersion880 private String bpmnProcessId;
+  @BeforeVersion880 private String bpmnXml;
+  @BeforeVersion880 private String resourceName;
+  @BeforeVersion880 private List<ProcessFlowNodeEntity> flowNodes = new ArrayList<>();
+  @JsonIgnore private List<String> callActivityIds = new ArrayList<>();
+  @BeforeVersion880 private String formId;
+  @BeforeVersion880 private String formKey;
+  @BeforeVersion880 private Boolean isFormEmbedded;
+  @BeforeVersion880 private Boolean isPublic;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   public String getName() {
     return name;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ProcessFlowNodeEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ProcessFlowNodeEntity.java
@@ -11,8 +11,8 @@ import java.util.Objects;
 
 public class ProcessFlowNodeEntity {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private String name;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private String name;
 
   public ProcessFlowNodeEntity() {}
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ProcessFlowNodeEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ProcessFlowNodeEntity.java
@@ -11,8 +11,8 @@ import java.util.Objects;
 
 public class ProcessFlowNodeEntity {
 
-  private String id;
-  private String name;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private String name;
 
   public ProcessFlowNodeEntity() {}
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SequenceFlowEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SequenceFlowEntity.java
@@ -12,18 +12,18 @@ import java.util.Objects;
 
 public class SequenceFlowEntity implements ExporterEntity<SequenceFlowEntity>, TenantOwned {
 
-  @SinceVersion880 private String id;
+  @BeforeVersion880 private String id;
 
-  @SinceVersion880 private Long processInstanceKey;
-
-  /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  @SinceVersion880 private Long processDefinitionKey;
+  @BeforeVersion880 private Long processInstanceKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  @SinceVersion880 private String bpmnProcessId;
+  @BeforeVersion880 private Long processDefinitionKey;
 
-  @SinceVersion880 private String activityId;
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
+  @BeforeVersion880 private String bpmnProcessId;
+
+  @BeforeVersion880 private String activityId;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SequenceFlowEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SequenceFlowEntity.java
@@ -12,18 +12,18 @@ import java.util.Objects;
 
 public class SequenceFlowEntity implements ExporterEntity<SequenceFlowEntity>, TenantOwned {
 
-  private String id;
+  @SinceVersion880 private String id;
 
-  private Long processInstanceKey;
-
-  /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  private Long processDefinitionKey;
+  @SinceVersion880 private Long processInstanceKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  private String bpmnProcessId;
+  @SinceVersion880 private Long processDefinitionKey;
 
-  private String activityId;
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
+  @SinceVersion880 private String bpmnProcessId;
+
+  @SinceVersion880 private String activityId;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  *    {@literal @SinceVersion("8.8.0")}
  *     private String newField = "bar" // This will pass
  *
- *    {@literal @SinceVersion(value = "8.8.0", nullable = true)}
+ *    {@literal @SinceVersion(value = "8.8.0", requireDefault = true)}
  *     private String newField; // This will pass
  *   }
  * </code></pre>
@@ -40,5 +40,5 @@ import java.lang.annotation.Target;
 public @interface SinceVersion {
   String value();
 
-  boolean nullable() default false;
+  boolean requireDefault() default true;
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  *   }
  * </code></pre>
  */
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SinceVersion {
   String value();

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion880.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/SinceVersion880.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@SinceVersion(value = "8.8.0", nullable = true)
+public @interface SinceVersion880 {}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/VariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/VariableEntity.java
@@ -15,27 +15,27 @@ import java.util.Objects;
 public class VariableEntity
     implements ExporterEntity<VariableEntity>, PartitionedEntity<VariableEntity>, TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private long key;
-  @SinceVersion880 private int partitionId;
-  @SinceVersion880 private String name;
-  @SinceVersion880 private String value;
-  @SinceVersion880 private String fullValue;
-  @SinceVersion880 private boolean isPreview;
-  @SinceVersion880 private Long scopeKey;
-  @SinceVersion880 private Long processInstanceKey;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private int partitionId;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private String value;
+  @BeforeVersion880 private String fullValue;
+  @BeforeVersion880 private boolean isPreview;
+  @BeforeVersion880 private Long scopeKey;
+  @BeforeVersion880 private Long processInstanceKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  @SinceVersion880 private Long processDefinitionKey;
+  @BeforeVersion880 private Long processDefinitionKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  @SinceVersion880 private String bpmnProcessId;
+  @BeforeVersion880 private String bpmnProcessId;
 
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
-  @SinceVersion880 private Long position;
+  @BeforeVersion880 private Long position;
 
-  @SinceVersion880 @JsonIgnore private Object[] sortValues;
+  @JsonIgnore private Object[] sortValues;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/VariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/VariableEntity.java
@@ -15,27 +15,27 @@ import java.util.Objects;
 public class VariableEntity
     implements ExporterEntity<VariableEntity>, PartitionedEntity<VariableEntity>, TenantOwned {
 
-  private String id;
-  private long key;
-  private int partitionId;
-  private String name;
-  private String value;
-  private String fullValue;
-  private boolean isPreview;
-  private Long scopeKey;
-  private Long processInstanceKey;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private long key;
+  @SinceVersion880 private int partitionId;
+  @SinceVersion880 private String name;
+  @SinceVersion880 private String value;
+  @SinceVersion880 private String fullValue;
+  @SinceVersion880 private boolean isPreview;
+  @SinceVersion880 private Long scopeKey;
+  @SinceVersion880 private Long processInstanceKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  private Long processDefinitionKey;
+  @SinceVersion880 private Long processDefinitionKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  private String bpmnProcessId;
+  @SinceVersion880 private String bpmnProcessId;
 
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
-  private Long position;
+  @SinceVersion880 private Long position;
 
-  @JsonIgnore private Object[] sortValues;
+  @SinceVersion880 @JsonIgnore private Object[] sortValues;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntity.java
@@ -8,6 +8,7 @@
 package io.camunda.webapps.schema.entities.auditlog;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
@@ -15,57 +16,118 @@ import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 public class AuditLogEntity extends AbstractExporterEntity<AuditLogEntity> {
 
   // the key of the affected entity
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long entityKey;
+
   // the id of the affected entity, if applicable (ex. Identity-related entities)
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String entityId;
+
   // the type of the affected entity
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private AuditLogEntityType entityType;
+
   // the type of operation that was performed, i.e. the Zeebe record intent
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private AuditLogOperationType operationType;
+
   // the version of the affected entity, i.e. the Zeebe record version
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Integer entityVersion;
+
   // the value type of the affected entity, i.e. the Zeebe record value type
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Short entityValueType;
+
   // the intent of the affected entity, i.e. the Zeebe record intent
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Short entityOperationIntent;
+
   // the key of the batch operation, if applicable
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long batchOperationKey;
+
   // the type of the batch operation, if applicable
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private BatchOperationType batchOperationType;
+
   // the creation timestamp of the Zeebe event that triggered the audit log entry
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long timestamp;
+
   // the type of the actor that performed the operation, (USER or CLIENT)
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private AuditLogActorType actorType;
+
   // the id of the actor that performed the operation
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String actorId;
+
   // the id of the tenant the operation was performed in
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String tenantId;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private ClusterVariableScope tenantScope;
+
   // marks if the operations was successful or failed
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private AuditLogOperationResult result;
+
   // details
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String details;
+
   // the explanation on why the operation was performed
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String annotation;
+
   // the category of the operation (ADMIN, OPERATOR, USER_TASK)
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private AuditLogOperationCategory category;
 
   // searchable fields dependent on the entity type
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String bpmnProcessId;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String decisionRequirementsId;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String decisionId;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long deploymentKey;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long formKey;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long resourceKey;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long processDefinitionKey;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long processInstanceKey;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long elementInstanceKey;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long jobKey;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long userTaskKey;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long decisionRequirementsKey;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long decisionKey;
 
   // join relation for batch operation parent and items
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private EntityJoinRelation join;
 
   public Long getEntityKey() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
@@ -8,16 +8,30 @@
 package io.camunda.webapps.schema.entities.clustervariable;
 
 import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import java.util.Objects;
 
 public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEntity> {
 
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String id;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String name;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String value;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String fullValue;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private boolean isPreview;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private ClusterVariableScope scope;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String tenantId;
 
   public boolean getIsPreview() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceEntity.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.schema.entities.dmn;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -22,39 +23,50 @@ public class DecisionInstanceEntity
         PartitionedEntity<DecisionInstanceEntity>,
         TenantOwned {
 
-  private String id;
-  private long key;
-  private int partitionId;
-  private Integer executionIndex;
-  private DecisionInstanceState state;
-  private OffsetDateTime evaluationDate;
-  @Deprecated private String evaluationFailure;
-  private String evaluationFailureMessage;
-  private Long position;
-  private long decisionRequirementsKey;
-  private String decisionRequirementsId;
-  private long processDefinitionKey;
-  private long processInstanceKey;
+  @SinceVersion880 private String id;
+
+  @SinceVersion880 private long key;
+
+  @SinceVersion880 private int partitionId;
+
+  @SinceVersion880 private Integer executionIndex;
+
+  @SinceVersion880 private DecisionInstanceState state;
+
+  @SinceVersion880 private OffsetDateTime evaluationDate;
+  @SinceVersion880 @Deprecated private String evaluationFailure;
+
+  @SinceVersion880 private String evaluationFailureMessage;
+
+  @SinceVersion880 private Long position;
+
+  @SinceVersion880 private long decisionRequirementsKey;
+
+  @SinceVersion880 private String decisionRequirementsId;
+
+  @SinceVersion880 private long processDefinitionKey;
+
+  @SinceVersion880 private long processInstanceKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  private String bpmnProcessId;
+  @SinceVersion880 private String bpmnProcessId;
 
-  private long elementInstanceKey;
-  private String elementId;
-  private String decisionId;
-  private String decisionDefinitionId;
-  private String decisionName;
-  private int decisionVersion;
-  private String rootDecisionName;
-  private String rootDecisionId;
-  private String rootDecisionDefinitionId;
-  private DecisionType decisionType;
-  private String result;
-  private List<DecisionInstanceInputEntity> evaluatedInputs = new ArrayList<>();
-  private List<DecisionInstanceOutputEntity> evaluatedOutputs = new ArrayList<>();
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private long elementInstanceKey;
+  @SinceVersion880 private String elementId;
+  @SinceVersion880 private String decisionId;
+  @SinceVersion880 private String decisionDefinitionId;
+  @SinceVersion880 private String decisionName;
+  @SinceVersion880 private int decisionVersion;
+  @SinceVersion880 private String rootDecisionName;
+  @SinceVersion880 private String rootDecisionId;
+  @SinceVersion880 private String rootDecisionDefinitionId;
+  @SinceVersion880 private DecisionType decisionType;
+  @SinceVersion880 private String result;
+  @SinceVersion880 private List<DecisionInstanceInputEntity> evaluatedInputs = new ArrayList<>();
+  @SinceVersion880 private List<DecisionInstanceOutputEntity> evaluatedOutputs = new ArrayList<>();
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
-  @JsonIgnore private Object[] sortValues;
+  @SinceVersion880 @JsonIgnore private Object[] sortValues;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceEntity.java
@@ -8,9 +8,9 @@
 package io.camunda.webapps.schema.entities.dmn;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -23,50 +23,39 @@ public class DecisionInstanceEntity
         PartitionedEntity<DecisionInstanceEntity>,
         TenantOwned {
 
-  @SinceVersion880 private String id;
-
-  @SinceVersion880 private long key;
-
-  @SinceVersion880 private int partitionId;
-
-  @SinceVersion880 private Integer executionIndex;
-
-  @SinceVersion880 private DecisionInstanceState state;
-
-  @SinceVersion880 private OffsetDateTime evaluationDate;
-  @SinceVersion880 @Deprecated private String evaluationFailure;
-
-  @SinceVersion880 private String evaluationFailureMessage;
-
-  @SinceVersion880 private Long position;
-
-  @SinceVersion880 private long decisionRequirementsKey;
-
-  @SinceVersion880 private String decisionRequirementsId;
-
-  @SinceVersion880 private long processDefinitionKey;
-
-  @SinceVersion880 private long processInstanceKey;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private int partitionId;
+  @BeforeVersion880 private Integer executionIndex;
+  @BeforeVersion880 private DecisionInstanceState state;
+  @BeforeVersion880 private OffsetDateTime evaluationDate;
+  @BeforeVersion880 @Deprecated private String evaluationFailure;
+  @BeforeVersion880 private String evaluationFailureMessage;
+  @BeforeVersion880 private Long position;
+  @BeforeVersion880 private long decisionRequirementsKey;
+  @BeforeVersion880 private String decisionRequirementsId;
+  @BeforeVersion880 private long processDefinitionKey;
+  @BeforeVersion880 private long processInstanceKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  @SinceVersion880 private String bpmnProcessId;
+  @BeforeVersion880 private String bpmnProcessId;
 
-  @SinceVersion880 private long elementInstanceKey;
-  @SinceVersion880 private String elementId;
-  @SinceVersion880 private String decisionId;
-  @SinceVersion880 private String decisionDefinitionId;
-  @SinceVersion880 private String decisionName;
-  @SinceVersion880 private int decisionVersion;
-  @SinceVersion880 private String rootDecisionName;
-  @SinceVersion880 private String rootDecisionId;
-  @SinceVersion880 private String rootDecisionDefinitionId;
-  @SinceVersion880 private DecisionType decisionType;
-  @SinceVersion880 private String result;
-  @SinceVersion880 private List<DecisionInstanceInputEntity> evaluatedInputs = new ArrayList<>();
-  @SinceVersion880 private List<DecisionInstanceOutputEntity> evaluatedOutputs = new ArrayList<>();
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private long elementInstanceKey;
+  @BeforeVersion880 private String elementId;
+  @BeforeVersion880 private String decisionId;
+  @BeforeVersion880 private String decisionDefinitionId;
+  @BeforeVersion880 private String decisionName;
+  @BeforeVersion880 private int decisionVersion;
+  @BeforeVersion880 private String rootDecisionName;
+  @BeforeVersion880 private String rootDecisionId;
+  @BeforeVersion880 private String rootDecisionDefinitionId;
+  @BeforeVersion880 private DecisionType decisionType;
+  @BeforeVersion880 private String result;
+  @BeforeVersion880 private List<DecisionInstanceInputEntity> evaluatedInputs = new ArrayList<>();
+  @BeforeVersion880 private List<DecisionInstanceOutputEntity> evaluatedOutputs = new ArrayList<>();
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
-  @SinceVersion880 @JsonIgnore private Object[] sortValues;
+  @JsonIgnore private Object[] sortValues;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceInputEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceInputEntity.java
@@ -7,14 +7,14 @@
  */
 package io.camunda.webapps.schema.entities.dmn;
 
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import java.util.Objects;
 
 public class DecisionInstanceInputEntity {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private String name;
-  @SinceVersion880 private String value;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private String value;
 
   public String getId() {
     return id;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceInputEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceInputEntity.java
@@ -7,13 +7,14 @@
  */
 package io.camunda.webapps.schema.entities.dmn;
 
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import java.util.Objects;
 
 public class DecisionInstanceInputEntity {
 
-  private String id;
-  private String name;
-  private String value;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private String name;
+  @SinceVersion880 private String value;
 
   public String getId() {
     return id;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceOutputEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceOutputEntity.java
@@ -7,16 +7,16 @@
  */
 package io.camunda.webapps.schema.entities.dmn;
 
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import java.util.Objects;
 
 public class DecisionInstanceOutputEntity {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private String name;
-  @SinceVersion880 private String value;
-  @SinceVersion880 private String ruleId;
-  @SinceVersion880 private int ruleIndex;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private String value;
+  @BeforeVersion880 private String ruleId;
+  @BeforeVersion880 private int ruleIndex;
 
   public String getId() {
     return id;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceOutputEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/DecisionInstanceOutputEntity.java
@@ -7,15 +7,16 @@
  */
 package io.camunda.webapps.schema.entities.dmn;
 
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import java.util.Objects;
 
 public class DecisionInstanceOutputEntity {
 
-  private String id;
-  private String name;
-  private String value;
-  private String ruleId;
-  private int ruleIndex;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private String name;
+  @SinceVersion880 private String value;
+  @SinceVersion880 private String ruleId;
+  @SinceVersion880 private int ruleIndex;
 
   public String getId() {
     return id;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/definition/DecisionDefinitionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/definition/DecisionDefinitionEntity.java
@@ -7,29 +7,22 @@
  */
 package io.camunda.webapps.schema.entities.dmn.definition;
 
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
 public class DecisionDefinitionEntity
     implements ExporterEntity<DecisionDefinitionEntity>, TenantOwned {
 
-  @SinceVersion880 private String id;
-
-  @SinceVersion880 private long key;
-
-  @SinceVersion880 private String decisionId;
-
-  @SinceVersion880 private String name;
-
-  @SinceVersion880 private int version;
-
-  @SinceVersion880 private String decisionRequirementsId;
-
-  @SinceVersion880 private long decisionRequirementsKey;
-
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private String decisionId;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private int version;
+  @BeforeVersion880 private String decisionRequirementsId;
+  @BeforeVersion880 private long decisionRequirementsKey;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/definition/DecisionDefinitionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/definition/DecisionDefinitionEntity.java
@@ -8,20 +8,28 @@
 package io.camunda.webapps.schema.entities.dmn.definition;
 
 import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
 public class DecisionDefinitionEntity
     implements ExporterEntity<DecisionDefinitionEntity>, TenantOwned {
 
-  private String id;
-  private long key;
-  private String decisionId;
-  private String name;
-  private int version;
-  private String decisionRequirementsId;
-  private long decisionRequirementsKey;
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private String id;
+
+  @SinceVersion880 private long key;
+
+  @SinceVersion880 private String decisionId;
+
+  @SinceVersion880 private String name;
+
+  @SinceVersion880 private int version;
+
+  @SinceVersion880 private String decisionRequirementsId;
+
+  @SinceVersion880 private long decisionRequirementsKey;
+
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/definition/DecisionRequirementsEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/definition/DecisionRequirementsEntity.java
@@ -7,29 +7,22 @@
  */
 package io.camunda.webapps.schema.entities.dmn.definition;
 
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
 public class DecisionRequirementsEntity
     implements ExporterEntity<DecisionRequirementsEntity>, TenantOwned {
 
-  @SinceVersion880 private String id;
-
-  @SinceVersion880 private long key;
-
-  @SinceVersion880 private String decisionRequirementsId;
-
-  @SinceVersion880 private String name;
-
-  @SinceVersion880 private int version;
-
-  @SinceVersion880 private String xml;
-
-  @SinceVersion880 private String resourceName;
-
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private String decisionRequirementsId;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private int version;
+  @BeforeVersion880 private String xml;
+  @BeforeVersion880 private String resourceName;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/definition/DecisionRequirementsEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/dmn/definition/DecisionRequirementsEntity.java
@@ -8,20 +8,28 @@
 package io.camunda.webapps.schema.entities.dmn.definition;
 
 import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
 public class DecisionRequirementsEntity
     implements ExporterEntity<DecisionRequirementsEntity>, TenantOwned {
 
-  private String id;
-  private long key;
-  private String decisionRequirementsId;
-  private String name;
-  private int version;
-  private String xml;
-  private String resourceName;
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private String id;
+
+  @SinceVersion880 private long key;
+
+  @SinceVersion880 private String decisionRequirementsId;
+
+  @SinceVersion880 private String name;
+
+  @SinceVersion880 private int version;
+
+  @SinceVersion880 private String xml;
+
+  @SinceVersion880 private String resourceName;
+
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/flownode/FlowNodeInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/flownode/FlowNodeInstanceEntity.java
@@ -8,9 +8,9 @@
 package io.camunda.webapps.schema.entities.flownode;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -21,32 +21,32 @@ public class FlowNodeInstanceEntity
         PartitionedEntity<FlowNodeInstanceEntity>,
         TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private long key;
-  @SinceVersion880 private int partitionId;
-  @SinceVersion880 private String flowNodeId;
-  @SinceVersion880 private String flowNodeName;
-  @SinceVersion880 private OffsetDateTime startDate;
-  @SinceVersion880 private OffsetDateTime endDate;
-  @SinceVersion880 private FlowNodeState state;
-  @SinceVersion880 private FlowNodeType type;
-  @SinceVersion880 @Deprecated private Long incidentKey;
-  @SinceVersion880 private Long processInstanceKey;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private int partitionId;
+  @BeforeVersion880 private String flowNodeId;
+  @BeforeVersion880 private String flowNodeName;
+  @BeforeVersion880 private OffsetDateTime startDate;
+  @BeforeVersion880 private OffsetDateTime endDate;
+  @BeforeVersion880 private FlowNodeState state;
+  @BeforeVersion880 private FlowNodeType type;
+  @BeforeVersion880 @Deprecated private Long incidentKey;
+  @BeforeVersion880 private Long processInstanceKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  @SinceVersion880 private Long processDefinitionKey;
+  @BeforeVersion880 private Long processDefinitionKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  @SinceVersion880 private String bpmnProcessId;
+  @BeforeVersion880 private String bpmnProcessId;
 
-  @SinceVersion880 private String treePath;
-  @SinceVersion880 private int level;
-  @SinceVersion880 private Long position;
-  @SinceVersion880 private boolean incident;
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  @SinceVersion880 private Long scopeKey;
+  @BeforeVersion880 private String treePath;
+  @BeforeVersion880 private int level;
+  @BeforeVersion880 private Long position;
+  @BeforeVersion880 private boolean incident;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private Long scopeKey;
 
-  @SinceVersion880 @JsonIgnore private Object[] sortValues;
+  @JsonIgnore private Object[] sortValues;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/flownode/FlowNodeInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/flownode/FlowNodeInstanceEntity.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.schema.entities.flownode;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -20,32 +21,32 @@ public class FlowNodeInstanceEntity
         PartitionedEntity<FlowNodeInstanceEntity>,
         TenantOwned {
 
-  private String id;
-  private long key;
-  private int partitionId;
-  private String flowNodeId;
-  private String flowNodeName;
-  private OffsetDateTime startDate;
-  private OffsetDateTime endDate;
-  private FlowNodeState state;
-  private FlowNodeType type;
-  @Deprecated private Long incidentKey;
-  private Long processInstanceKey;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private long key;
+  @SinceVersion880 private int partitionId;
+  @SinceVersion880 private String flowNodeId;
+  @SinceVersion880 private String flowNodeName;
+  @SinceVersion880 private OffsetDateTime startDate;
+  @SinceVersion880 private OffsetDateTime endDate;
+  @SinceVersion880 private FlowNodeState state;
+  @SinceVersion880 private FlowNodeType type;
+  @SinceVersion880 @Deprecated private Long incidentKey;
+  @SinceVersion880 private Long processInstanceKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  private Long processDefinitionKey;
+  @SinceVersion880 private Long processDefinitionKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  private String bpmnProcessId;
+  @SinceVersion880 private String bpmnProcessId;
 
-  private String treePath;
-  private int level;
-  private Long position;
-  private boolean incident;
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  private Long scopeKey;
+  @SinceVersion880 private String treePath;
+  @SinceVersion880 private int level;
+  @SinceVersion880 private Long position;
+  @SinceVersion880 private boolean incident;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private Long scopeKey;
 
-  @JsonIgnore private Object[] sortValues;
+  @SinceVersion880 @JsonIgnore private Object[] sortValues;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/form/EmbeddedFormBatch.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/form/EmbeddedFormBatch.java
@@ -8,12 +8,13 @@
 package io.camunda.webapps.schema.entities.form;
 
 import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import java.util.List;
 
 public class EmbeddedFormBatch implements ExporterEntity<EmbeddedFormBatch> {
 
-  private String id;
-  private List<FormEntity> forms;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private List<FormEntity> forms;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/form/EmbeddedFormBatch.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/form/EmbeddedFormBatch.java
@@ -7,14 +7,14 @@
  */
 package io.camunda.webapps.schema.entities.form;
 
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import java.util.List;
 
 public class EmbeddedFormBatch implements ExporterEntity<EmbeddedFormBatch> {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private List<FormEntity> forms;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private List<FormEntity> forms;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/form/FormEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/form/FormEntity.java
@@ -8,27 +8,27 @@
 package io.camunda.webapps.schema.entities.form;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
 public class FormEntity implements ExporterEntity<FormEntity>, TenantOwned {
 
-  @SinceVersion880 private String name;
-  @SinceVersion880 private String id;
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  @SinceVersion880 private long key;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private long key;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonProperty("bpmnId")
   private String formId;
 
-  @SinceVersion880 private String schema;
-  @SinceVersion880 private Long version;
-  @SinceVersion880 private Boolean isDeleted;
-  @SinceVersion880 private String processDefinitionId;
-  @SinceVersion880 private boolean embedded;
+  @BeforeVersion880 private String schema;
+  @BeforeVersion880 private Long version;
+  @BeforeVersion880 private Boolean isDeleted;
+  @BeforeVersion880 private String processDefinitionId;
+  @BeforeVersion880 private boolean embedded;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/form/FormEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/form/FormEntity.java
@@ -9,23 +9,26 @@ package io.camunda.webapps.schema.entities.form;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
 public class FormEntity implements ExporterEntity<FormEntity>, TenantOwned {
 
-  private String id;
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  private long key;
+  @SinceVersion880 private String name;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private long key;
 
+  @SinceVersion880
   @JsonProperty("bpmnId")
   private String formId;
 
-  private String schema;
-  private Long version;
-  private Boolean isDeleted;
-  private String processDefinitionId;
-  private boolean embedded;
+  @SinceVersion880 private String schema;
+  @SinceVersion880 private Long version;
+  @SinceVersion880 private Boolean isDeleted;
+  @SinceVersion880 private String processDefinitionId;
+  @SinceVersion880 private boolean embedded;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/incident/IncidentEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/incident/IncidentEntity.java
@@ -8,9 +8,9 @@
 package io.camunda.webapps.schema.entities.incident;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -18,42 +18,26 @@ import java.util.Objects;
 public class IncidentEntity
     implements ExporterEntity<IncidentEntity>, PartitionedEntity<IncidentEntity>, TenantOwned {
 
-  @SinceVersion880 private String id;
-
-  @SinceVersion880 private long key;
-
-  @SinceVersion880 private int partitionId;
-
-  @SinceVersion880 private ErrorType errorType;
-
-  @SinceVersion880 private String errorMessage;
-
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private int partitionId;
+  @BeforeVersion880 private ErrorType errorType;
+  @BeforeVersion880 private String errorMessage;
   // Is only used by binding to ES results
-  @SinceVersion880 private Integer errorMessageHash;
+  @BeforeVersion880 private Integer errorMessageHash;
+  @BeforeVersion880 private IncidentState state;
+  @BeforeVersion880 private String flowNodeId;
+  @BeforeVersion880 private Long flowNodeInstanceKey;
+  @BeforeVersion880 private Long jobKey;
+  @BeforeVersion880 private Long processInstanceKey;
+  @BeforeVersion880 private OffsetDateTime creationTime;
+  @BeforeVersion880 private Long processDefinitionKey;
+  @BeforeVersion880 private String bpmnProcessId;
+  @BeforeVersion880 private String treePath;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private Long position;
 
-  @SinceVersion880 private IncidentState state;
-
-  @SinceVersion880 private String flowNodeId;
-
-  @SinceVersion880 private Long flowNodeInstanceKey;
-
-  @SinceVersion880 private Long jobKey;
-
-  @SinceVersion880 private Long processInstanceKey;
-
-  @SinceVersion880 private OffsetDateTime creationTime;
-
-  @SinceVersion880 private Long processDefinitionKey;
-
-  @SinceVersion880 private String bpmnProcessId;
-
-  @SinceVersion880 private String treePath;
-
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-
-  @SinceVersion880 private Long position;
-
-  @SinceVersion880 @Deprecated @JsonIgnore private boolean pending = true;
+  @Deprecated @JsonIgnore private boolean pending = true;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/incident/IncidentEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/incident/IncidentEntity.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.schema.entities.incident;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -17,42 +18,42 @@ import java.util.Objects;
 public class IncidentEntity
     implements ExporterEntity<IncidentEntity>, PartitionedEntity<IncidentEntity>, TenantOwned {
 
-  private String id;
+  @SinceVersion880 private String id;
 
-  private long key;
+  @SinceVersion880 private long key;
 
-  private int partitionId;
+  @SinceVersion880 private int partitionId;
 
-  private ErrorType errorType;
+  @SinceVersion880 private ErrorType errorType;
 
-  private String errorMessage;
+  @SinceVersion880 private String errorMessage;
 
   // Is only used by binding to ES results
-  private Integer errorMessageHash;
+  @SinceVersion880 private Integer errorMessageHash;
 
-  private IncidentState state;
+  @SinceVersion880 private IncidentState state;
 
-  private String flowNodeId;
+  @SinceVersion880 private String flowNodeId;
 
-  private Long flowNodeInstanceKey;
+  @SinceVersion880 private Long flowNodeInstanceKey;
 
-  private Long jobKey;
+  @SinceVersion880 private Long jobKey;
 
-  private Long processInstanceKey;
+  @SinceVersion880 private Long processInstanceKey;
 
-  private OffsetDateTime creationTime;
+  @SinceVersion880 private OffsetDateTime creationTime;
 
-  private Long processDefinitionKey;
+  @SinceVersion880 private Long processDefinitionKey;
 
-  private String bpmnProcessId;
+  @SinceVersion880 private String bpmnProcessId;
 
-  private String treePath;
+  @SinceVersion880 private String treePath;
 
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
-  private Long position;
+  @SinceVersion880 private Long position;
 
-  @Deprecated @JsonIgnore private boolean pending = true;
+  @SinceVersion880 @Deprecated @JsonIgnore private boolean pending = true;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/FlowNodeInstanceForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/FlowNodeInstanceForListViewEntity.java
@@ -9,9 +9,9 @@ package io.camunda.webapps.schema.entities.listview;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -24,32 +24,32 @@ public class FlowNodeInstanceForListViewEntity
         PartitionedEntity<FlowNodeInstanceForListViewEntity>,
         TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private long key;
-  @SinceVersion880 private int partitionId;
-  @SinceVersion880 private Long processInstanceKey;
-  @SinceVersion880 private String activityId;
-  @SinceVersion880 private FlowNodeState activityState;
-  @SinceVersion880 private FlowNodeType activityType;
-  @SinceVersion880 @Deprecated @JsonIgnore private List<Long> incidentKeys = new ArrayList<>();
-  @SinceVersion880 private String errorMessage;
-  @SinceVersion880 private boolean incident;
-  @SinceVersion880 private boolean jobFailedWithRetriesLeft = false;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private int partitionId;
+  @BeforeVersion880 private Long processInstanceKey;
+  @BeforeVersion880 private String activityId;
+  @BeforeVersion880 private FlowNodeState activityState;
+  @BeforeVersion880 private FlowNodeType activityType;
+  @Deprecated @JsonIgnore private List<Long> incidentKeys = new ArrayList<>();
+  @BeforeVersion880 private String errorMessage;
+  @BeforeVersion880 private boolean incident;
+  @BeforeVersion880 private boolean jobFailedWithRetriesLeft = false;
 
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
-  @SinceVersion880 @Deprecated @JsonIgnore private boolean pendingIncident;
+  @Deprecated @JsonIgnore private boolean pendingIncident;
 
-  @SinceVersion880 private Long position;
-  @SinceVersion880 private Long positionIncident;
-  @SinceVersion880 private Long positionJob;
+  @BeforeVersion880 private Long position;
+  @BeforeVersion880 private Long positionIncident;
+  @BeforeVersion880 private Long positionJob;
 
-  @SinceVersion880
+  @BeforeVersion880
   private ListViewJoinRelation joinRelation =
       new ListViewJoinRelation(ListViewTemplate.ACTIVITIES_JOIN_RELATION);
 
-  @SinceVersion880 @JsonIgnore private Long startTime;
-  @SinceVersion880 @JsonIgnore private Long endTime;
+  @JsonIgnore private Long startTime;
+  @JsonIgnore private Long endTime;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/FlowNodeInstanceForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/FlowNodeInstanceForListViewEntity.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -23,31 +24,32 @@ public class FlowNodeInstanceForListViewEntity
         PartitionedEntity<FlowNodeInstanceForListViewEntity>,
         TenantOwned {
 
-  private String id;
-  private long key;
-  private int partitionId;
-  private Long processInstanceKey;
-  private String activityId;
-  private FlowNodeState activityState;
-  private FlowNodeType activityType;
-  @Deprecated @JsonIgnore private List<Long> incidentKeys = new ArrayList<>();
-  private String errorMessage;
-  private boolean incident;
-  private boolean jobFailedWithRetriesLeft = false;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private long key;
+  @SinceVersion880 private int partitionId;
+  @SinceVersion880 private Long processInstanceKey;
+  @SinceVersion880 private String activityId;
+  @SinceVersion880 private FlowNodeState activityState;
+  @SinceVersion880 private FlowNodeType activityType;
+  @SinceVersion880 @Deprecated @JsonIgnore private List<Long> incidentKeys = new ArrayList<>();
+  @SinceVersion880 private String errorMessage;
+  @SinceVersion880 private boolean incident;
+  @SinceVersion880 private boolean jobFailedWithRetriesLeft = false;
 
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
-  @Deprecated @JsonIgnore private boolean pendingIncident;
+  @SinceVersion880 @Deprecated @JsonIgnore private boolean pendingIncident;
 
-  private Long position;
-  private Long positionIncident;
-  private Long positionJob;
+  @SinceVersion880 private Long position;
+  @SinceVersion880 private Long positionIncident;
+  @SinceVersion880 private Long positionJob;
 
+  @SinceVersion880
   private ListViewJoinRelation joinRelation =
       new ListViewJoinRelation(ListViewTemplate.ACTIVITIES_JOIN_RELATION);
 
-  @JsonIgnore private Long startTime;
-  @JsonIgnore private Long endTime;
+  @SinceVersion880 @JsonIgnore private Long startTime;
+  @SinceVersion880 @JsonIgnore private Long endTime;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ListViewJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ListViewJoinRelation.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.webapps.schema.entities.listview;
 
+import io.camunda.webapps.schema.entities.SinceVersion880;
+
 public class ListViewJoinRelation {
 
-  private String name;
+  @SinceVersion880 private String name;
 
-  private Long parent;
+  @SinceVersion880 private Long parent;
 
   public ListViewJoinRelation() {}
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ListViewJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ListViewJoinRelation.java
@@ -7,13 +7,13 @@
  */
 package io.camunda.webapps.schema.entities.listview;
 
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 
 public class ListViewJoinRelation {
 
-  @SinceVersion880 private String name;
+  @BeforeVersion880 private String name;
 
-  @SinceVersion880 private Long parent;
+  @BeforeVersion880 private Long parent;
 
   public ListViewJoinRelation() {}
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
@@ -10,9 +10,9 @@ package io.camunda.webapps.schema.entities.listview;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -24,40 +24,40 @@ public class ProcessInstanceForListViewEntity
         PartitionedEntity<ProcessInstanceForListViewEntity>,
         TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private long key;
-  @SinceVersion880 private int partitionId;
-  @SinceVersion880 private Long processDefinitionKey;
-  @SinceVersion880 private String processName;
-  @SinceVersion880 private Integer processVersion;
-  @SinceVersion880 private String processVersionTag;
-  @SinceVersion880 private String bpmnProcessId;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private int partitionId;
+  @BeforeVersion880 private Long processDefinitionKey;
+  @BeforeVersion880 private String processName;
+  @BeforeVersion880 private Integer processVersion;
+  @BeforeVersion880 private String processVersionTag;
+  @BeforeVersion880 private String bpmnProcessId;
 
-  @SinceVersion880 private OffsetDateTime startDate;
-  @SinceVersion880 private OffsetDateTime endDate;
+  @BeforeVersion880 private OffsetDateTime startDate;
+  @BeforeVersion880 private OffsetDateTime endDate;
 
-  @SinceVersion880 private ProcessInstanceState state;
+  @BeforeVersion880 private ProcessInstanceState state;
 
-  @SinceVersion880 private List<String> batchOperationIds;
+  @BeforeVersion880 private List<String> batchOperationIds;
 
-  @SinceVersion880 private Long parentProcessInstanceKey;
+  @BeforeVersion880 private Long parentProcessInstanceKey;
 
-  @SinceVersion880 private Long parentFlowNodeInstanceKey;
+  @BeforeVersion880 private Long parentFlowNodeInstanceKey;
 
-  @SinceVersion880 private String treePath;
+  @BeforeVersion880 private String treePath;
 
-  @SinceVersion880 private boolean incident;
+  @BeforeVersion880 private boolean incident;
 
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
-  @SinceVersion880
+  @BeforeVersion880
   private ListViewJoinRelation joinRelation =
       new ListViewJoinRelation(PROCESS_INSTANCE_JOIN_RELATION);
 
-  @SinceVersion880 private Long position;
-  @SinceVersion880 private Set<String> tags;
+  @BeforeVersion880 private Long position;
+  @BeforeVersion880 private Set<String> tags;
 
-  @SinceVersion880 @JsonIgnore private Object[] sortValues;
+  @JsonIgnore private Object[] sortValues;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
@@ -12,6 +12,7 @@ import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PR
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -23,39 +24,40 @@ public class ProcessInstanceForListViewEntity
         PartitionedEntity<ProcessInstanceForListViewEntity>,
         TenantOwned {
 
-  private String id;
-  private long key;
-  private int partitionId;
-  private Long processDefinitionKey;
-  private String processName;
-  private Integer processVersion;
-  private String processVersionTag;
-  private String bpmnProcessId;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private long key;
+  @SinceVersion880 private int partitionId;
+  @SinceVersion880 private Long processDefinitionKey;
+  @SinceVersion880 private String processName;
+  @SinceVersion880 private Integer processVersion;
+  @SinceVersion880 private String processVersionTag;
+  @SinceVersion880 private String bpmnProcessId;
 
-  private OffsetDateTime startDate;
-  private OffsetDateTime endDate;
+  @SinceVersion880 private OffsetDateTime startDate;
+  @SinceVersion880 private OffsetDateTime endDate;
 
-  private ProcessInstanceState state;
+  @SinceVersion880 private ProcessInstanceState state;
 
-  private List<String> batchOperationIds;
+  @SinceVersion880 private List<String> batchOperationIds;
 
-  private Long parentProcessInstanceKey;
+  @SinceVersion880 private Long parentProcessInstanceKey;
 
-  private Long parentFlowNodeInstanceKey;
+  @SinceVersion880 private Long parentFlowNodeInstanceKey;
 
-  private String treePath;
+  @SinceVersion880 private String treePath;
 
-  private boolean incident;
+  @SinceVersion880 private boolean incident;
 
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
+  @SinceVersion880
   private ListViewJoinRelation joinRelation =
       new ListViewJoinRelation(PROCESS_INSTANCE_JOIN_RELATION);
 
-  private Long position;
-  private Set<String> tags;
+  @SinceVersion880 private Long position;
+  @SinceVersion880 private Set<String> tags;
 
-  @JsonIgnore private Object[] sortValues;
+  @SinceVersion880 @JsonIgnore private Object[] sortValues;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/VariableForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/VariableForListViewEntity.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.schema.entities.listview;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
@@ -18,16 +19,17 @@ public class VariableForListViewEntity
         PartitionedEntity<VariableForListViewEntity>,
         TenantOwned {
 
-  private String id;
-  private long key;
-  private int partitionId;
-  private Long processInstanceKey;
-  private Long scopeKey;
-  private String varName;
-  private String varValue;
-  private String tenantId;
-  private Long position;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private long key;
+  @SinceVersion880 private int partitionId;
+  @SinceVersion880 private Long processInstanceKey;
+  @SinceVersion880 private Long scopeKey;
+  @SinceVersion880 private String varName;
+  @SinceVersion880 private String varValue;
+  @SinceVersion880 private String tenantId;
+  @SinceVersion880 private Long position;
 
+  @SinceVersion880
   private ListViewJoinRelation joinRelation =
       new ListViewJoinRelation(ListViewTemplate.VARIABLES_JOIN_RELATION);
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/VariableForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/VariableForListViewEntity.java
@@ -8,9 +8,9 @@
 package io.camunda.webapps.schema.entities.listview;
 
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
@@ -19,17 +19,17 @@ public class VariableForListViewEntity
         PartitionedEntity<VariableForListViewEntity>,
         TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private long key;
-  @SinceVersion880 private int partitionId;
-  @SinceVersion880 private Long processInstanceKey;
-  @SinceVersion880 private Long scopeKey;
-  @SinceVersion880 private String varName;
-  @SinceVersion880 private String varValue;
-  @SinceVersion880 private String tenantId;
-  @SinceVersion880 private Long position;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private int partitionId;
+  @BeforeVersion880 private Long processInstanceKey;
+  @BeforeVersion880 private Long scopeKey;
+  @BeforeVersion880 private String varName;
+  @BeforeVersion880 private String varValue;
+  @BeforeVersion880 private String tenantId;
+  @BeforeVersion880 private Long position;
 
-  @SinceVersion880
+  @BeforeVersion880
   private ListViewJoinRelation joinRelation =
       new ListViewJoinRelation(ListViewTemplate.VARIABLES_JOIN_RELATION);
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.webapps.schema.entities.messagesubscription;
 
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -19,49 +19,49 @@ public class MessageSubscriptionEntity
         PartitionedEntity<MessageSubscriptionEntity>,
         TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private long key;
-  @SinceVersion880 private int partitionId;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private int partitionId;
 
   /** Process data. */
-  @SinceVersion880 private Long processDefinitionKey;
+  @BeforeVersion880 private Long processDefinitionKey;
 
-  @SinceVersion880 private Long processInstanceKey;
-  @SinceVersion880 private String bpmnProcessId;
+  @BeforeVersion880 private Long processInstanceKey;
+  @BeforeVersion880 private String bpmnProcessId;
 
   /** Activity data. */
-  @SinceVersion880 private String flowNodeId;
+  @BeforeVersion880 private String flowNodeId;
 
-  @SinceVersion880 private Long flowNodeInstanceKey;
+  @BeforeVersion880 private Long flowNodeInstanceKey;
 
-  private MessageSubscriptionState eventType;
-  private OffsetDateTime dateTime;
+  @BeforeVersion880 private MessageSubscriptionState eventType;
+  @BeforeVersion880 private OffsetDateTime dateTime;
 
-  private MessageSubscriptionMetadataEntity metadata;
+  @BeforeVersion880 private MessageSubscriptionMetadataEntity metadata;
 
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
-  private Long positionProcessMessageSubscription;
-
-  /**
-   * @deprecated since 8.9
-   */
-  @Deprecated private EventSourceType eventSourceType;
+  @BeforeVersion880 private Long positionProcessMessageSubscription;
 
   /**
    * @deprecated since 8.9
    */
-  @Deprecated private Long position;
+  @BeforeVersion880 @Deprecated private EventSourceType eventSourceType;
 
   /**
    * @deprecated since 8.9
    */
-  @Deprecated private Long positionIncident;
+  @BeforeVersion880 @Deprecated private Long position;
 
   /**
    * @deprecated since 8.9
    */
-  @Deprecated private Long positionJob;
+  @BeforeVersion880 @Deprecated private Long positionIncident;
+
+  /**
+   * @deprecated since 8.9
+   */
+  @BeforeVersion880 @Deprecated private Long positionJob;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
@@ -9,6 +9,7 @@ package io.camunda.webapps.schema.entities.messagesubscription;
 
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -18,27 +19,27 @@ public class MessageSubscriptionEntity
         PartitionedEntity<MessageSubscriptionEntity>,
         TenantOwned {
 
-  private String id;
-  private long key;
-  private int partitionId;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private long key;
+  @SinceVersion880 private int partitionId;
 
   /** Process data. */
-  private Long processDefinitionKey;
+  @SinceVersion880 private Long processDefinitionKey;
 
-  private Long processInstanceKey;
-  private String bpmnProcessId;
+  @SinceVersion880 private Long processInstanceKey;
+  @SinceVersion880 private String bpmnProcessId;
 
   /** Activity data. */
-  private String flowNodeId;
+  @SinceVersion880 private String flowNodeId;
 
-  private Long flowNodeInstanceKey;
+  @SinceVersion880 private Long flowNodeInstanceKey;
 
   private MessageSubscriptionState eventType;
   private OffsetDateTime dateTime;
 
   private MessageSubscriptionMetadataEntity metadata;
 
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   private Long positionProcessMessageSubscription;
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionMetadataEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionMetadataEntity.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.webapps.schema.entities.messagesubscription;
 
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.webapps.schema.entities.incident.ErrorType;
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -15,9 +16,9 @@ import java.util.Objects;
 public class MessageSubscriptionMetadataEntity {
 
   /** Message data. */
-  private String messageName;
+  @SinceVersion880 private String messageName;
 
-  private String correlationKey;
+  @SinceVersion880 private String correlationKey;
 
   /**
    * @deprecated since 8.9

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionMetadataEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionMetadataEntity.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.webapps.schema.entities.messagesubscription;
 
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.incident.ErrorType;
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -16,49 +16,49 @@ import java.util.Objects;
 public class MessageSubscriptionMetadataEntity {
 
   /** Message data. */
-  @SinceVersion880 private String messageName;
+  @BeforeVersion880 private String messageName;
 
-  @SinceVersion880 private String correlationKey;
-
-  /**
-   * @deprecated since 8.9
-   */
-  @Deprecated private String jobType;
+  @BeforeVersion880 private String correlationKey;
 
   /**
    * @deprecated since 8.9
    */
-  @Deprecated private Integer jobRetries;
+  @BeforeVersion880 @Deprecated private String jobType;
 
   /**
    * @deprecated since 8.9
    */
-  @Deprecated private String jobWorker;
+  @BeforeVersion880 @Deprecated private Integer jobRetries;
 
   /**
    * @deprecated since 8.9
    */
-  @Deprecated private OffsetDateTime jobDeadline;
+  @BeforeVersion880 @Deprecated private String jobWorker;
 
   /**
    * @deprecated since 8.9
    */
-  @Deprecated private Map<String, String> jobCustomHeaders;
+  @BeforeVersion880 @Deprecated private OffsetDateTime jobDeadline;
 
   /**
    * @deprecated since 8.9
    */
-  @Deprecated private Long jobKey;
+  @BeforeVersion880 @Deprecated private Map<String, String> jobCustomHeaders;
 
   /**
    * @deprecated since 8.9
    */
-  @Deprecated private ErrorType incidentErrorType;
+  @BeforeVersion880 @Deprecated private Long jobKey;
 
   /**
    * @deprecated since 8.9
    */
-  @Deprecated private String incidentErrorMessage;
+  @BeforeVersion880 @Deprecated private ErrorType incidentErrorType;
+
+  /**
+   * @deprecated since 8.9
+   */
+  @BeforeVersion880 @Deprecated private String incidentErrorMessage;
 
   public String getMessageName() {
     return messageName;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/metrics/UsageMetricsEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/metrics/UsageMetricsEntity.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.webapps.schema.entities.metrics;
 
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -19,13 +19,13 @@ public final class UsageMetricsEntity
         PartitionedEntity<UsageMetricsEntity>,
         TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private OffsetDateTime startTime;
-  @SinceVersion880 private OffsetDateTime endTime;
-  @SinceVersion880 private UsageMetricsEventType eventType;
-  @SinceVersion880 private Long eventValue;
-  @SinceVersion880 private String tenantId;
-  @SinceVersion880 private int partitionId;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private OffsetDateTime startTime;
+  @BeforeVersion880 private OffsetDateTime endTime;
+  @BeforeVersion880 private UsageMetricsEventType eventType;
+  @BeforeVersion880 private Long eventValue;
+  @BeforeVersion880 private String tenantId;
+  @BeforeVersion880 private int partitionId;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/metrics/UsageMetricsEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/metrics/UsageMetricsEntity.java
@@ -9,6 +9,7 @@ package io.camunda.webapps.schema.entities.metrics;
 
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -18,13 +19,13 @@ public final class UsageMetricsEntity
         PartitionedEntity<UsageMetricsEntity>,
         TenantOwned {
 
-  private String id;
-  private OffsetDateTime startTime;
-  private OffsetDateTime endTime;
-  private UsageMetricsEventType eventType;
-  private Long eventValue;
-  private String tenantId;
-  private int partitionId;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private OffsetDateTime startTime;
+  @SinceVersion880 private OffsetDateTime endTime;
+  @SinceVersion880 private UsageMetricsEventType eventType;
+  @SinceVersion880 private Long eventValue;
+  @SinceVersion880 private String tenantId;
+  @SinceVersion880 private int partitionId;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/metrics/UsageMetricsTUEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/metrics/UsageMetricsTUEntity.java
@@ -9,6 +9,7 @@ package io.camunda.webapps.schema.entities.metrics;
 
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -18,12 +19,12 @@ public class UsageMetricsTUEntity
         PartitionedEntity<UsageMetricsTUEntity>,
         TenantOwned {
 
-  private String id;
-  private OffsetDateTime startTime;
-  private OffsetDateTime endTime;
-  private Long assigneeHash;
-  private String tenantId;
-  private int partitionId;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private OffsetDateTime startTime;
+  @SinceVersion880 private OffsetDateTime endTime;
+  @SinceVersion880 private Long assigneeHash;
+  @SinceVersion880 private String tenantId;
+  @SinceVersion880 private int partitionId;
 
   @Override
   public int hashCode() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/metrics/UsageMetricsTUEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/metrics/UsageMetricsTUEntity.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.webapps.schema.entities.metrics;
 
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -19,12 +19,12 @@ public class UsageMetricsTUEntity
         PartitionedEntity<UsageMetricsTUEntity>,
         TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private OffsetDateTime startTime;
-  @SinceVersion880 private OffsetDateTime endTime;
-  @SinceVersion880 private Long assigneeHash;
-  @SinceVersion880 private String tenantId;
-  @SinceVersion880 private int partitionId;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private OffsetDateTime startTime;
+  @BeforeVersion880 private OffsetDateTime endTime;
+  @BeforeVersion880 private Long assigneeHash;
+  @BeforeVersion880 private String tenantId;
+  @BeforeVersion880 private int partitionId;
 
   @Override
   public int hashCode() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -9,6 +9,7 @@ package io.camunda.webapps.schema.entities.operation;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -16,24 +17,27 @@ import java.util.UUID;
 
 public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationEntity> {
 
-  private String name;
-  private OperationType type;
-  private OffsetDateTime startDate;
-  private OffsetDateTime endDate;
-  private String username;
+  @SinceVersion880 private String name;
+  @SinceVersion880 private OperationType type;
+  @SinceVersion880 private OffsetDateTime startDate;
+  @SinceVersion880 private OffsetDateTime endDate;
+  @SinceVersion880 private String username;
 
-  private Integer instancesCount = 0;
-  private Integer operationsTotalCount = 0;
+  @SinceVersion880 private Integer instancesCount = 0;
+  @SinceVersion880 private Integer operationsTotalCount = 0;
   // Legacy - Contains all operations (completed + failed)
-  private Integer operationsFinishedCount = 0;
+  @SinceVersion880 private Integer operationsFinishedCount = 0;
 
   // new fields for batch operation in zeebe engine
-  private BatchOperationState state;
-  private Integer operationsFailedCount = 0; // Just failed / rejected operations
-  private Integer operationsCompletedCount = 0; // Just successfully completed operations
-  private List<BatchOperationErrorEntity> errors = List.of();
+  @SinceVersion880 private BatchOperationState state;
+  @SinceVersion880 private Integer operationsFailedCount = 0; // Just failed / rejected operations
 
-  @JsonIgnore private Object[] sortValues;
+  @SinceVersion880
+  private Integer operationsCompletedCount = 0; // Just successfully completed operations
+
+  @SinceVersion880 private List<BatchOperationErrorEntity> errors = List.of();
+
+  @SinceVersion880 @JsonIgnore private Object[] sortValues;
 
   public String getName() {
     return name;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -9,7 +9,7 @@ package io.camunda.webapps.schema.entities.operation;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -17,27 +17,27 @@ import java.util.UUID;
 
 public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationEntity> {
 
-  @SinceVersion880 private String name;
-  @SinceVersion880 private OperationType type;
-  @SinceVersion880 private OffsetDateTime startDate;
-  @SinceVersion880 private OffsetDateTime endDate;
-  @SinceVersion880 private String username;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private OperationType type;
+  @BeforeVersion880 private OffsetDateTime startDate;
+  @BeforeVersion880 private OffsetDateTime endDate;
+  @BeforeVersion880 private String username;
 
-  @SinceVersion880 private Integer instancesCount = 0;
-  @SinceVersion880 private Integer operationsTotalCount = 0;
+  @BeforeVersion880 private Integer instancesCount = 0;
+  @BeforeVersion880 private Integer operationsTotalCount = 0;
   // Legacy - Contains all operations (completed + failed)
-  @SinceVersion880 private Integer operationsFinishedCount = 0;
+  @BeforeVersion880 private Integer operationsFinishedCount = 0;
 
   // new fields for batch operation in zeebe engine
-  @SinceVersion880 private BatchOperationState state;
-  @SinceVersion880 private Integer operationsFailedCount = 0; // Just failed / rejected operations
+  @BeforeVersion880 private BatchOperationState state;
+  @BeforeVersion880 private Integer operationsFailedCount = 0; // Just failed / rejected operations
 
-  @SinceVersion880
+  @BeforeVersion880
   private Integer operationsCompletedCount = 0; // Just successfully completed operations
 
-  @SinceVersion880 private List<BatchOperationErrorEntity> errors = List.of();
+  @BeforeVersion880 private List<BatchOperationErrorEntity> errors = List.of();
 
-  @SinceVersion880 @JsonIgnore private Object[] sortValues;
+  @JsonIgnore private Object[] sortValues;
 
   public String getName() {
     return name;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationErrorEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationErrorEntity.java
@@ -8,13 +8,14 @@
 package io.camunda.webapps.schema.entities.operation;
 
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import java.util.Objects;
 
 public class BatchOperationErrorEntity implements PartitionedEntity<BatchOperationErrorEntity> {
 
-  private int partitionId;
-  private String type;
-  private String message;
+  @SinceVersion880 private int partitionId;
+  @SinceVersion880 private String type;
+  @SinceVersion880 private String message;
 
   @Override
   public int getPartitionId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationErrorEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationErrorEntity.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.webapps.schema.entities.operation;
 
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import java.util.Objects;
 
 public class BatchOperationErrorEntity implements PartitionedEntity<BatchOperationErrorEntity> {
 
-  @SinceVersion880 private int partitionId;
-  @SinceVersion880 private String type;
-  @SinceVersion880 private String message;
+  @BeforeVersion880 private int partitionId;
+  @BeforeVersion880 private String type;
+  @BeforeVersion880 private String message;
 
   @Override
   public int getPartitionId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
@@ -8,7 +8,7 @@
 package io.camunda.webapps.schema.entities.operation;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -18,35 +18,35 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
   /**
    * Is used by batch operation engine in zeebe to identify the resource (process, incident, ...)
    */
-  @SinceVersion880 private Long itemKey;
+  @BeforeVersion880 private Long itemKey;
 
-  @SinceVersion880 private Long processInstanceKey;
-
-  /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  @SinceVersion880 private Long processDefinitionKey;
+  @BeforeVersion880 private Long processInstanceKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  @SinceVersion880 private String bpmnProcessId;
+  @BeforeVersion880 private Long processDefinitionKey;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
+  @BeforeVersion880 private String bpmnProcessId;
 
   /** Attention! This field will be filled in only for data imported after v. 8.3.0. */
-  @SinceVersion880 private Long decisionDefinitionKey;
+  @BeforeVersion880 private Long decisionDefinitionKey;
 
-  @SinceVersion880 private Long incidentKey;
-  @SinceVersion880 private Long scopeKey;
-  @SinceVersion880 private String variableName;
-  @SinceVersion880 private String variableValue;
-  @SinceVersion880 private OperationType type;
-  @SinceVersion880 private OffsetDateTime lockExpirationTime;
-  @SinceVersion880 private String lockOwner;
-  @SinceVersion880 private OperationState state;
-  @SinceVersion880 private String errorMessage;
-  @SinceVersion880 private String batchOperationId;
-  @SinceVersion880 private Long zeebeCommandKey;
-  @SinceVersion880 private String username;
-  @SinceVersion880 private String modifyInstructions;
-  @SinceVersion880 private String migrationPlan;
+  @BeforeVersion880 private Long incidentKey;
+  @BeforeVersion880 private Long scopeKey;
+  @BeforeVersion880 private String variableName;
+  @BeforeVersion880 private String variableValue;
+  @BeforeVersion880 private OperationType type;
+  @BeforeVersion880 private OffsetDateTime lockExpirationTime;
+  @BeforeVersion880 private String lockOwner;
+  @BeforeVersion880 private OperationState state;
+  @BeforeVersion880 private String errorMessage;
+  @BeforeVersion880 private String batchOperationId;
+  @BeforeVersion880 private Long zeebeCommandKey;
+  @BeforeVersion880 private String username;
+  @BeforeVersion880 private String modifyInstructions;
+  @BeforeVersion880 private String migrationPlan;
 
-  @SinceVersion880 private OffsetDateTime completedDate;
+  @BeforeVersion880 private OffsetDateTime completedDate;
 
   public Long getItemKey() {
     return itemKey;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
@@ -8,6 +8,7 @@
 package io.camunda.webapps.schema.entities.operation;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -17,35 +18,35 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
   /**
    * Is used by batch operation engine in zeebe to identify the resource (process, incident, ...)
    */
-  private Long itemKey;
+  @SinceVersion880 private Long itemKey;
 
-  private Long processInstanceKey;
-
-  /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  private Long processDefinitionKey;
+  @SinceVersion880 private Long processInstanceKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
-  private String bpmnProcessId;
+  @SinceVersion880 private Long processDefinitionKey;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
+  @SinceVersion880 private String bpmnProcessId;
 
   /** Attention! This field will be filled in only for data imported after v. 8.3.0. */
-  private Long decisionDefinitionKey;
+  @SinceVersion880 private Long decisionDefinitionKey;
 
-  private Long incidentKey;
-  private Long scopeKey;
-  private String variableName;
-  private String variableValue;
-  private OperationType type;
-  private OffsetDateTime lockExpirationTime;
-  private String lockOwner;
-  private OperationState state;
-  private String errorMessage;
-  private String batchOperationId;
-  private Long zeebeCommandKey;
-  private String username;
-  private String modifyInstructions;
-  private String migrationPlan;
+  @SinceVersion880 private Long incidentKey;
+  @SinceVersion880 private Long scopeKey;
+  @SinceVersion880 private String variableName;
+  @SinceVersion880 private String variableValue;
+  @SinceVersion880 private OperationType type;
+  @SinceVersion880 private OffsetDateTime lockExpirationTime;
+  @SinceVersion880 private String lockOwner;
+  @SinceVersion880 private OperationState state;
+  @SinceVersion880 private String errorMessage;
+  @SinceVersion880 private String batchOperationId;
+  @SinceVersion880 private Long zeebeCommandKey;
+  @SinceVersion880 private String username;
+  @SinceVersion880 private String modifyInstructions;
+  @SinceVersion880 private String migrationPlan;
 
-  private OffsetDateTime completedDate;
+  @SinceVersion880 private OffsetDateTime completedDate;
 
   public Long getItemKey() {
     return itemKey;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/post/PostImporterQueueEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/post/PostImporterQueueEntity.java
@@ -8,26 +8,27 @@
 package io.camunda.webapps.schema.entities.post;
 
 import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 
 public class PostImporterQueueEntity implements ExporterEntity<PostImporterQueueEntity> {
 
-  private String id;
+  @SinceVersion880 private String id;
 
-  private Long key;
+  @SinceVersion880 private Long key;
 
-  private PostImporterActionType actionType;
+  @SinceVersion880 private PostImporterActionType actionType;
 
-  private String intent;
+  @SinceVersion880 private String intent;
 
-  private OffsetDateTime creationTime;
+  @SinceVersion880 private OffsetDateTime creationTime;
 
-  private Integer partitionId;
+  @SinceVersion880 private Integer partitionId;
 
-  private Long processInstanceKey;
+  @SinceVersion880 private Long processInstanceKey;
 
-  private Long position;
+  @SinceVersion880 private Long position;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/post/PostImporterQueueEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/post/PostImporterQueueEntity.java
@@ -7,28 +7,28 @@
  */
 package io.camunda.webapps.schema.entities.post;
 
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 
 public class PostImporterQueueEntity implements ExporterEntity<PostImporterQueueEntity> {
 
-  @SinceVersion880 private String id;
+  @BeforeVersion880 private String id;
 
-  @SinceVersion880 private Long key;
+  @BeforeVersion880 private Long key;
 
-  @SinceVersion880 private PostImporterActionType actionType;
+  @BeforeVersion880 private PostImporterActionType actionType;
 
-  @SinceVersion880 private String intent;
+  @BeforeVersion880 private String intent;
 
-  @SinceVersion880 private OffsetDateTime creationTime;
+  @BeforeVersion880 private OffsetDateTime creationTime;
 
-  @SinceVersion880 private Integer partitionId;
+  @BeforeVersion880 private Integer partitionId;
 
-  @SinceVersion880 private Long processInstanceKey;
+  @BeforeVersion880 private Long processInstanceKey;
 
-  @SinceVersion880 private Long position;
+  @BeforeVersion880 private Long position;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
@@ -8,20 +8,21 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Set;
 
 public class AuthorizationEntity extends AbstractExporterEntity<AuthorizationEntity> {
 
-  public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
-  private Long authorizationKey;
-  private String ownerId;
-  private String ownerType;
-  private String resourceType;
-  private Short resourceMatcher;
-  private String resourceId;
+  @SinceVersion880 public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
+  @SinceVersion880 private Long authorizationKey;
+  @SinceVersion880 private String ownerId;
+  @SinceVersion880 private String ownerType;
+  @SinceVersion880 private String resourceType;
+  @SinceVersion880 private Short resourceMatcher;
+  @SinceVersion880 private String resourceId;
   private String resourcePropertyName;
-  private Set<PermissionType> permissionTypes;
+  @SinceVersion880 private Set<PermissionType> permissionTypes;
 
   public AuthorizationEntity() {}
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
@@ -8,21 +8,24 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Set;
 
 public class AuthorizationEntity extends AbstractExporterEntity<AuthorizationEntity> {
 
-  @SinceVersion880 public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
-  @SinceVersion880 private Long authorizationKey;
-  @SinceVersion880 private String ownerId;
-  @SinceVersion880 private String ownerType;
-  @SinceVersion880 private String resourceType;
-  @SinceVersion880 private Short resourceMatcher;
-  @SinceVersion880 private String resourceId;
+  public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
+  @BeforeVersion880 private Long authorizationKey;
+  @BeforeVersion880 private String ownerId;
+  @BeforeVersion880 private String ownerType;
+  @BeforeVersion880 private String resourceType;
+  @BeforeVersion880 private Short resourceMatcher;
+  @BeforeVersion880 private String resourceId;
+  @BeforeVersion880 private Set<PermissionType> permissionTypes;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
   private String resourcePropertyName;
-  @SinceVersion880 private Set<PermissionType> permissionTypes;
 
   public AuthorizationEntity() {}
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
@@ -8,10 +8,10 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.JoinRelationshipType;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 
-public record EntityJoinRelation(@SinceVersion880 String name, @SinceVersion880 String parent) {
+public record EntityJoinRelation(@BeforeVersion880 String name, @BeforeVersion880 String parent) {
 
   public static class EntityJoinRelationFactory<T extends JoinRelationshipType> {
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
@@ -8,9 +8,10 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.JoinRelationshipType;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 
-public record EntityJoinRelation(String name, String parent) {
+public record EntityJoinRelation(@SinceVersion880 String name, @SinceVersion880 String parent) {
 
   public static class EntityJoinRelationFactory<T extends JoinRelationshipType> {
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.webapps.schema.entities.usermanagement;
 
-import io.camunda.webapps.schema.entities.JoinRelationshipType;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
+import io.camunda.webapps.schema.entities.JoinRelationshipType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public record EntityJoinRelation(@BeforeVersion880 String name, @BeforeVersion880 String parent) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
@@ -8,16 +8,16 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 
 public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
 
-  @SinceVersion880 private Long key;
-  @SinceVersion880 private String groupId;
-  @SinceVersion880 private String name;
-  @SinceVersion880 private String description;
+  @BeforeVersion880 private Long key;
+  @BeforeVersion880 private String groupId;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private String description;
 
-  @SinceVersion880 private EntityJoinRelation join;
+  @BeforeVersion880 private EntityJoinRelation join;
 
   public Long getKey() {
     return key;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
@@ -8,15 +8,16 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 
 public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
 
-  private Long key;
-  private String groupId;
-  private String name;
-  private String description;
+  @SinceVersion880 private Long key;
+  @SinceVersion880 private String groupId;
+  @SinceVersion880 private String name;
+  @SinceVersion880 private String description;
 
-  private EntityJoinRelation join;
+  @SinceVersion880 private EntityJoinRelation join;
 
   public Long getKey() {
     return key;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupMemberEntity.java
@@ -8,15 +8,15 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class GroupMemberEntity extends AbstractExporterEntity<GroupMemberEntity> {
 
-  @SinceVersion880 private String memberId;
-  @SinceVersion880 private EntityType memberType;
+  @BeforeVersion880 private String memberId;
+  @BeforeVersion880 private EntityType memberType;
 
-  @SinceVersion880 private EntityJoinRelation join;
+  @BeforeVersion880 private EntityJoinRelation join;
 
   public String getMemberId() {
     return memberId;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupMemberEntity.java
@@ -8,14 +8,15 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class GroupMemberEntity extends AbstractExporterEntity<GroupMemberEntity> {
 
-  private String memberId;
-  private EntityType memberType;
+  @SinceVersion880 private String memberId;
+  @SinceVersion880 private EntityType memberType;
 
-  private EntityJoinRelation join;
+  @SinceVersion880 private EntityJoinRelation join;
 
   public String getMemberId() {
     return memberId;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/MappingRuleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/MappingRuleEntity.java
@@ -8,16 +8,16 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 
 public class MappingRuleEntity extends AbstractExporterEntity<MappingRuleEntity> {
 
-  @SinceVersion880 public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
-  @SinceVersion880 private Long key;
-  @SinceVersion880 private String mappingRuleId;
-  @SinceVersion880 private String claimName;
-  @SinceVersion880 private String claimValue;
-  @SinceVersion880 private String name;
+  public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
+  @BeforeVersion880 private Long key;
+  @BeforeVersion880 private String mappingRuleId;
+  @BeforeVersion880 private String claimName;
+  @BeforeVersion880 private String claimValue;
+  @BeforeVersion880 private String name;
 
   public MappingRuleEntity() {}
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/MappingRuleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/MappingRuleEntity.java
@@ -8,15 +8,16 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 
 public class MappingRuleEntity extends AbstractExporterEntity<MappingRuleEntity> {
 
-  public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
-  private Long key;
-  private String mappingRuleId;
-  private String claimName;
-  private String claimValue;
-  private String name;
+  @SinceVersion880 public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
+  @SinceVersion880 private Long key;
+  @SinceVersion880 private String mappingRuleId;
+  @SinceVersion880 private String claimName;
+  @SinceVersion880 private String claimValue;
+  @SinceVersion880 private String name;
 
   public MappingRuleEntity() {}
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
@@ -8,14 +8,15 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 
 public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
 
-  private Long key;
-  private String roleId;
-  private String name;
-  private String description;
-  private EntityJoinRelation join;
+  @SinceVersion880 private Long key;
+  @SinceVersion880 private String roleId;
+  @SinceVersion880 private String name;
+  @SinceVersion880 private String description;
+  @SinceVersion880 private EntityJoinRelation join;
 
   public Long getKey() {
     return key;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
@@ -8,15 +8,15 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 
 public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
 
-  @SinceVersion880 private Long key;
-  @SinceVersion880 private String roleId;
-  @SinceVersion880 private String name;
-  @SinceVersion880 private String description;
-  @SinceVersion880 private EntityJoinRelation join;
+  @BeforeVersion880 private Long key;
+  @BeforeVersion880 private String roleId;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private String description;
+  @BeforeVersion880 private EntityJoinRelation join;
 
   public Long getKey() {
     return key;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleMemberEntity.java
@@ -8,13 +8,14 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class RoleMemberEntity extends AbstractExporterEntity<RoleMemberEntity> {
-  private String memberId;
-  private EntityType memberType;
+  @SinceVersion880 private String memberId;
+  @SinceVersion880 private EntityType memberType;
 
-  private EntityJoinRelation join;
+  @SinceVersion880 private EntityJoinRelation join;
 
   public String getMemberId() {
     return memberId;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleMemberEntity.java
@@ -8,14 +8,14 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class RoleMemberEntity extends AbstractExporterEntity<RoleMemberEntity> {
-  @SinceVersion880 private String memberId;
-  @SinceVersion880 private EntityType memberType;
+  @BeforeVersion880 private String memberId;
+  @BeforeVersion880 private EntityType memberType;
 
-  @SinceVersion880 private EntityJoinRelation join;
+  @BeforeVersion880 private EntityJoinRelation join;
 
   public String getMemberId() {
     return memberId;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
@@ -8,16 +8,16 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 
 public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
 
-  @SinceVersion880 private Long key;
-  @SinceVersion880 private String tenantId;
-  @SinceVersion880 private String name;
-  @SinceVersion880 private String description;
+  @BeforeVersion880 private Long key;
+  @BeforeVersion880 private String tenantId;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private String description;
 
-  @SinceVersion880 private EntityJoinRelation join;
+  @BeforeVersion880 private EntityJoinRelation join;
 
   public Long getKey() {
     return key;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
@@ -8,15 +8,16 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 
 public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
 
-  private Long key;
-  private String tenantId;
-  private String name;
-  private String description;
+  @SinceVersion880 private Long key;
+  @SinceVersion880 private String tenantId;
+  @SinceVersion880 private String name;
+  @SinceVersion880 private String description;
 
-  private EntityJoinRelation join;
+  @SinceVersion880 private EntityJoinRelation join;
 
   public Long getKey() {
     return key;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantMemberEntity.java
@@ -8,18 +8,17 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class TenantMemberEntity extends AbstractExporterEntity<TenantMemberEntity> {
 
-  @SinceVersion(value = "8.8.0", nullable = true)
-  private String tenantId;
+  @SinceVersion880 private String tenantId;
 
-  private String memberId;
-  private EntityType memberType;
+  @SinceVersion880 private String memberId;
+  @SinceVersion880 private EntityType memberType;
 
-  private EntityJoinRelation join;
+  @SinceVersion880 private EntityJoinRelation join;
 
   public String getTenantId() {
     return tenantId;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantMemberEntity.java
@@ -8,17 +8,19 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
+import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class TenantMemberEntity extends AbstractExporterEntity<TenantMemberEntity> {
 
-  @SinceVersion880 private String tenantId;
+  @SinceVersion(value = "8.8.0", requireDefault = false)
+  private String tenantId;
 
-  @SinceVersion880 private String memberId;
-  @SinceVersion880 private EntityType memberType;
+  @BeforeVersion880 private String memberId;
+  @BeforeVersion880 private EntityType memberType;
 
-  @SinceVersion880 private EntityJoinRelation join;
+  @BeforeVersion880 private EntityJoinRelation join;
 
   public String getTenantId() {
     return tenantId;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/UserEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/UserEntity.java
@@ -8,16 +8,17 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 
 public class UserEntity extends AbstractExporterEntity<UserEntity> {
 
-  public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
-  private String id;
-  private Long key;
-  private String username;
-  private String name;
-  private String email;
-  private String password;
+  @SinceVersion880 public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
+  @SinceVersion880 private String id;
+  @SinceVersion880 private Long key;
+  @SinceVersion880 private String username;
+  @SinceVersion880 private String name;
+  @SinceVersion880 private String email;
+  @SinceVersion880 private String password;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/UserEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/UserEntity.java
@@ -8,17 +8,17 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 
 public class UserEntity extends AbstractExporterEntity<UserEntity> {
 
-  @SinceVersion880 public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
-  @SinceVersion880 private String id;
-  @SinceVersion880 private Long key;
-  @SinceVersion880 private String username;
-  @SinceVersion880 private String name;
-  @SinceVersion880 private String email;
-  @SinceVersion880 private String password;
+  public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private Long key;
+  @BeforeVersion880 private String username;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private String email;
+  @BeforeVersion880 private String password;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/DraftTaskVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/DraftTaskVariableEntity.java
@@ -8,6 +8,7 @@
 package io.camunda.webapps.schema.entities.usertask;
 
 import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
@@ -15,13 +16,13 @@ import java.util.Objects;
 public class DraftTaskVariableEntity
     implements ExporterEntity<DraftTaskVariableEntity>, TenantOwned {
 
-  private String id;
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  private String taskId;
-  private String name;
-  private String value;
-  private String fullValue;
-  private boolean isPreview;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private String taskId;
+  @SinceVersion880 private String name;
+  @SinceVersion880 private String value;
+  @SinceVersion880 private String fullValue;
+  @SinceVersion880 private boolean isPreview;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/DraftTaskVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/DraftTaskVariableEntity.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.webapps.schema.entities.usertask;
 
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
@@ -16,13 +16,13 @@ import java.util.Objects;
 public class DraftTaskVariableEntity
     implements ExporterEntity<DraftTaskVariableEntity>, TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  @SinceVersion880 private String taskId;
-  @SinceVersion880 private String name;
-  @SinceVersion880 private String value;
-  @SinceVersion880 private String fullValue;
-  @SinceVersion880 private boolean isPreview;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private String taskId;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private String value;
+  @BeforeVersion880 private String fullValue;
+  @BeforeVersion880 private boolean isPreview;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/SnapshotTaskVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/SnapshotTaskVariableEntity.java
@@ -9,6 +9,7 @@ package io.camunda.webapps.schema.entities.usertask;
 
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
@@ -18,16 +19,16 @@ public class SnapshotTaskVariableEntity
         PartitionedEntity<SnapshotTaskVariableEntity>,
         TenantOwned {
 
-  private String id;
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  private long key;
-  private int partitionId;
-  private String taskId;
-  private String name;
-  private String value;
-  private String fullValue;
-  private boolean isPreview;
-  private Long processInstanceKey;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private long key;
+  @SinceVersion880 private int partitionId;
+  @SinceVersion880 private String taskId;
+  @SinceVersion880 private String name;
+  @SinceVersion880 private String value;
+  @SinceVersion880 private String fullValue;
+  @SinceVersion880 private boolean isPreview;
+  @SinceVersion880 private Long processInstanceKey;
 
   public SnapshotTaskVariableEntity() {}
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/SnapshotTaskVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/SnapshotTaskVariableEntity.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.webapps.schema.entities.usertask;
 
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
@@ -19,16 +19,16 @@ public class SnapshotTaskVariableEntity
         PartitionedEntity<SnapshotTaskVariableEntity>,
         TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  @SinceVersion880 private long key;
-  @SinceVersion880 private int partitionId;
-  @SinceVersion880 private String taskId;
-  @SinceVersion880 private String name;
-  @SinceVersion880 private String value;
-  @SinceVersion880 private String fullValue;
-  @SinceVersion880 private boolean isPreview;
-  @SinceVersion880 private Long processInstanceKey;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private int partitionId;
+  @BeforeVersion880 private String taskId;
+  @BeforeVersion880 private String name;
+  @BeforeVersion880 private String value;
+  @BeforeVersion880 private String fullValue;
+  @BeforeVersion880 private boolean isPreview;
+  @BeforeVersion880 private Long processInstanceKey;
 
   public SnapshotTaskVariableEntity() {}
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskEntity.java
@@ -8,9 +8,9 @@
 package io.camunda.webapps.schema.entities.usertask;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -21,122 +21,122 @@ import java.util.Set;
 public class TaskEntity
     implements ExporterEntity<TaskEntity>, PartitionedEntity<TaskEntity>, TenantOwned {
 
-  @SinceVersion880 private String id;
+  @BeforeVersion880 private String id;
 
-  @SinceVersion880 private long key;
+  @BeforeVersion880 private long key;
 
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
-  @SinceVersion880 private int partitionId;
+  @BeforeVersion880 private int partitionId;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String flowNodeBpmnId;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String name;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String flowNodeInstanceId;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private OffsetDateTime completionTime;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String processInstanceId;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long position;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskState state;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private OffsetDateTime creationTime;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String bpmnProcessId;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String processDefinitionId;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String assignee;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String[] candidateGroups;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String[] candidateUsers;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String formKey;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String formId;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long formVersion;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Boolean isFormEmbedded;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private OffsetDateTime followUpDate;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private OffsetDateTime dueDate;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String externalFormReference;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Integer processDefinitionVersion;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, String> customHeaders;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Integer priority;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Set<String> tags;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String action;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private List<String> changedAttributes;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskJoinRelationship join;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskImplementation implementation;
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskEntity.java
@@ -125,6 +125,7 @@ public class TaskEntity
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Set<String> tags;
 
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String action;
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskEntity.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.schema.entities.usertask;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -20,95 +21,122 @@ import java.util.Set;
 public class TaskEntity
     implements ExporterEntity<TaskEntity>, PartitionedEntity<TaskEntity>, TenantOwned {
 
-  private String id;
+  @SinceVersion880 private String id;
 
-  private long key;
+  @SinceVersion880 private long key;
 
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
-  private int partitionId;
+  @SinceVersion880 private int partitionId;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String flowNodeBpmnId;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String name;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String flowNodeInstanceId;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private OffsetDateTime completionTime;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String processInstanceId;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long position;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskState state;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private OffsetDateTime creationTime;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String bpmnProcessId;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String processDefinitionId;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String assignee;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String[] candidateGroups;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String[] candidateUsers;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String formKey;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String formId;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long formVersion;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Boolean isFormEmbedded;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private OffsetDateTime followUpDate;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private OffsetDateTime dueDate;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String externalFormReference;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Integer processDefinitionVersion;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, String> customHeaders;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Integer priority;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Set<String> tags;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String action;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private List<String> changedAttributes;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskJoinRelationship join;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskImplementation implementation;
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskJoinRelationship.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskJoinRelationship.java
@@ -8,13 +8,13 @@
 package io.camunda.webapps.schema.entities.usertask;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.camunda.webapps.schema.entities.SinceVersion880;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import java.util.Objects;
 
 public class TaskJoinRelationship {
-  @SinceVersion880 private String name;
+  @BeforeVersion880 private String name;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long parent;
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskJoinRelationship.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskJoinRelationship.java
@@ -8,11 +8,13 @@
 package io.camunda.webapps.schema.entities.usertask;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import java.util.Objects;
 
 public class TaskJoinRelationship {
-  private String name;
+  @SinceVersion880 private String name;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long parent;
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskProcessInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskProcessInstanceEntity.java
@@ -8,9 +8,9 @@
 package io.camunda.webapps.schema.entities.usertask;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
@@ -19,15 +19,15 @@ public class TaskProcessInstanceEntity
         PartitionedEntity<TaskProcessInstanceEntity>,
         TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  @SinceVersion880 private int partitionId;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private int partitionId;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long processInstanceId;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskJoinRelationship join;
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskProcessInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskProcessInstanceEntity.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.schema.entities.usertask;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Objects;
 
@@ -18,13 +19,15 @@ public class TaskProcessInstanceEntity
         PartitionedEntity<TaskProcessInstanceEntity>,
         TenantOwned {
 
-  private String id;
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  private int partitionId;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private int partitionId;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long processInstanceId;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskJoinRelationship join;
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskVariableEntity.java
@@ -8,9 +8,9 @@
 package io.camunda.webapps.schema.entities.usertask;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.camunda.webapps.schema.entities.BeforeVersion880;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
-import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 
 public class TaskVariableEntity
@@ -18,40 +18,40 @@ public class TaskVariableEntity
         PartitionedEntity<TaskVariableEntity>,
         TenantOwned {
 
-  @SinceVersion880 private String id;
-  @SinceVersion880 private long key;
-  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  @SinceVersion880 private int partitionId;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private long key;
+  @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @BeforeVersion880 private int partitionId;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String name;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String value;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String fullValue;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Boolean isTruncated;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long scopeKey;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long processInstanceId;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long position;
 
-  @SinceVersion880
+  @BeforeVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskJoinRelationship join;
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskVariableEntity.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.schema.entities.usertask;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion880;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 
 public class TaskVariableEntity
@@ -17,32 +18,40 @@ public class TaskVariableEntity
         PartitionedEntity<TaskVariableEntity>,
         TenantOwned {
 
-  private String id;
-  private long key;
-  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
-  private int partitionId;
+  @SinceVersion880 private String id;
+  @SinceVersion880 private long key;
+  @SinceVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  @SinceVersion880 private int partitionId;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String name;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String value;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String fullValue;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Boolean isTruncated;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long scopeKey;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long processInstanceId;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Long position;
 
+  @SinceVersion880
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskJoinRelationship join;
 


### PR DESCRIPTION
## Description

To avoid a scenario where new fields are added which are nullable and don't have a default value which will result in NPE when searching through these entities. The SinceVersion annotation has been added, each entity field must have this annotation enforced by `EntityTest.java`, or an annotation composed of `SinceVersion` like `SinceVersion880` (purely for DRY purposes). 

## Related issues

closes #39569 
