### PR TITLE
ci: always pull image for PrefixMigrationIT

### DIFF
--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -54,6 +54,7 @@ import org.springframework.util.StringUtils;
 import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.images.PullPolicy;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -371,6 +372,7 @@ public class PrefixMigrationIT {
   private GenericContainer<?> createCamundaContainer() {
     final var container =
         new GenericContainer<>(DockerImageName.parse("camunda/camunda:8.7-SNAPSHOT"))
+            .withImagePullPolicy(PullPolicy.alwaysPull())
             .waitingFor(
                 new HttpWaitStrategy()
                     .forPort(MONITORING.port())


### PR DESCRIPTION
## Description

To ensure integration happens with most recent state of the image tag.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Context: https://camunda.slack.com/archives/C071KP5BTHB/p1761652801647429?thread_ts=1761573821.459979&cid=C071KP5BTHB
