### PR TITLE
Introduce update mapping rule command

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1788,7 +1788,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * @return a builder for the command
    */
-  UpdateMappingRuleCommandStep1 newUpdateMappingRule(String mappingRuleId);
+  UpdateMappingRuleCommandStep1 newUpdateMappingRuleCommand(String mappingRuleId);
 
   /*
    * Retrieves the XML representation of a decision requirements.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -85,6 +85,7 @@ import io.camunda.client.api.command.UnassignUserTaskCommandStep1;
 import io.camunda.client.api.command.UpdateAuthorizationCommandStep1;
 import io.camunda.client.api.command.UpdateGroupCommandStep1;
 import io.camunda.client.api.command.UpdateJobCommandStep1;
+import io.camunda.client.api.command.UpdateMappingRuleCommandStep1;
 import io.camunda.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.client.api.command.UpdateRoleCommandStep1;
 import io.camunda.client.api.command.UpdateTenantCommandStep1;
@@ -1770,6 +1771,24 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   CreateMappingRuleCommandStep1 newCreateMappingRuleCommand();
+
+  /**
+   * Command to update a mapping rule.
+   *
+   * <pre>
+   * camundaClient
+   *  .newUpdateMappingRule("mappingRuleId")
+   *  .name("name")
+   *  .claimName("claim name")
+   *  .claimValue("claim value")
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   *
+   * @return a builder for the command
+   */
+  UpdateMappingRuleCommandStep1 newUpdateMappingRule(String mappingRuleId);
 
   /*
    * Retrieves the XML representation of a decision requirements.

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateMappingRuleCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateMappingRuleCommandStep1.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.UpdateMappingRuleResponse;
+
+public interface UpdateMappingRuleCommandStep1 {
+
+  /**
+   * Set the name for the mapping rule to be updated.
+   *
+   * @param name the new name for this mapping rule
+   * @return the builder for this command.
+   */
+  public UpdateMappingRuleCommandStep2 name(final String name);
+
+  public interface UpdateMappingRuleCommandStep2 {
+    /**
+     * Set the claim name for the mapping rule to be updated.
+     *
+     * @param claimName the new claim name for this mapping rule
+     * @return the builder for this command.
+     */
+    public UpdateMappingRuleCommandStep3 claimName(final String claimName);
+  }
+
+  public interface UpdateMappingRuleCommandStep3 {
+    /**
+     * Set the claim value for the mapping rule to be updated.
+     *
+     * @param claimValue the new claim value for this mapping rule
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it.
+     */
+    public UpdateMappingRuleCommandStep4 claimValue(final String claimValue);
+  }
+
+  public interface UpdateMappingRuleCommandStep4
+      extends FinalCommandStep<UpdateMappingRuleResponse> {}
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/UpdateMappingRuleResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UpdateMappingRuleResponse.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface UpdateMappingRuleResponse {
+
+  /** Returns the mapping rule ID of the updated mapping rule. */
+  String getMappingRuleId();
+
+  /** Returns the updated name of the mapping rule. */
+  String getName();
+
+  /** Returns the updated claim name of the mapping rule. */
+  String getClaimName();
+
+  /** Returns the updated claim value of the mapping rule. */
+  String getClaimValue();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -1071,7 +1071,7 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public UpdateMappingRuleCommandStep1 newUpdateMappingRule(final String mappingRuleId) {
+  public UpdateMappingRuleCommandStep1 newUpdateMappingRuleCommand(final String mappingRuleId) {
     return new UpdateMappingRuleCommandImpl(httpClient, mappingRuleId, jsonMapper);
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -96,6 +96,7 @@ import io.camunda.client.api.command.UnassignUserTaskCommandStep1;
 import io.camunda.client.api.command.UpdateAuthorizationCommandStep1;
 import io.camunda.client.api.command.UpdateGroupCommandStep1;
 import io.camunda.client.api.command.UpdateJobCommandStep1;
+import io.camunda.client.api.command.UpdateMappingRuleCommandStep1;
 import io.camunda.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.client.api.command.UpdateRoleCommandStep1;
 import io.camunda.client.api.command.UpdateTenantCommandStep1;
@@ -239,6 +240,7 @@ import io.camunda.client.impl.command.UnassignUserTaskCommandImpl;
 import io.camunda.client.impl.command.UpdateAuthorizationCommandImpl;
 import io.camunda.client.impl.command.UpdateGroupCommandImpl;
 import io.camunda.client.impl.command.UpdateJobCommandImpl;
+import io.camunda.client.impl.command.UpdateMappingRuleCommandImpl;
 import io.camunda.client.impl.command.UpdateRoleCommandImpl;
 import io.camunda.client.impl.command.UpdateTenantCommandImpl;
 import io.camunda.client.impl.command.UpdateUserCommandImpl;
@@ -1066,6 +1068,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public CreateMappingRuleCommandStep1 newCreateMappingRuleCommand() {
     return new CreateMappingRuleCommandImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public UpdateMappingRuleCommandStep1 newUpdateMappingRule(final String mappingRuleId) {
+    return new UpdateMappingRuleCommandImpl(httpClient, mappingRuleId, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateMappingRuleCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateMappingRuleCommandImpl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.UpdateMappingRuleCommandStep1;
+import io.camunda.client.api.command.UpdateMappingRuleCommandStep1.UpdateMappingRuleCommandStep2;
+import io.camunda.client.api.command.UpdateMappingRuleCommandStep1.UpdateMappingRuleCommandStep3;
+import io.camunda.client.api.command.UpdateMappingRuleCommandStep1.UpdateMappingRuleCommandStep4;
+import io.camunda.client.api.response.UpdateMappingRuleResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UpdateMappingRuleResponseImpl;
+import io.camunda.client.protocol.rest.MappingRuleUpdateRequest;
+import io.camunda.client.protocol.rest.MappingRuleUpdateResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class UpdateMappingRuleCommandImpl
+    implements UpdateMappingRuleCommandStep1,
+        UpdateMappingRuleCommandStep2,
+        UpdateMappingRuleCommandStep3,
+        UpdateMappingRuleCommandStep4 {
+  private final String mappingRuleId;
+  private final MappingRuleUpdateRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public UpdateMappingRuleCommandImpl(
+      final HttpClient httpClient, final String mappingRuleId, final JsonMapper jsonMapper) {
+    this.mappingRuleId = mappingRuleId;
+    request = new MappingRuleUpdateRequest();
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public UpdateMappingRuleCommandStep2 name(final String name) {
+    request.setName(name);
+    return this;
+  }
+
+  @Override
+  public UpdateMappingRuleCommandStep3 claimName(final String claimName) {
+    request.setClaimName(claimName);
+    return this;
+  }
+
+  @Override
+  public UpdateMappingRuleCommandStep4 claimValue(final String claimValue) {
+    request.setClaimValue(claimValue);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<UpdateMappingRuleResponse> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<UpdateMappingRuleResponse> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("name", request.getName());
+    ArgumentUtil.ensureNotNullNorEmpty("claimName", request.getClaimName());
+    ArgumentUtil.ensureNotNullNorEmpty("claimValue", request.getClaimValue());
+    final HttpCamundaFuture<UpdateMappingRuleResponse> result = new HttpCamundaFuture<>();
+    final UpdateMappingRuleResponseImpl response = new UpdateMappingRuleResponseImpl();
+
+    httpClient.put(
+        "/mapping-rules/" + mappingRuleId,
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        MappingRuleUpdateResult.class,
+        response::setResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateMappingRuleResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateMappingRuleResponseImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.UpdateMappingRuleResponse;
+import io.camunda.client.protocol.rest.MappingRuleUpdateResult;
+
+public class UpdateMappingRuleResponseImpl implements UpdateMappingRuleResponse {
+  private String mappingRuleId;
+  private String name;
+  private String claimName;
+  private String claimValue;
+
+  @Override
+  public String getMappingRuleId() {
+    return mappingRuleId;
+  }
+
+  @Override
+  public String getClaimName() {
+    return claimName;
+  }
+
+  @Override
+  public String getClaimValue() {
+    return claimValue;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  public UpdateMappingRuleResponseImpl setResponse(final MappingRuleUpdateResult result) {
+    this.mappingRuleId = result.getMappingRuleId();
+    this.name = result.getName();
+    this.claimName = result.getClaimName();
+    this.claimValue = result.getClaimValue();
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/mappingrule/UpdateMappingRuleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/mappingrule/UpdateMappingRuleTest.java
@@ -40,7 +40,7 @@ public class UpdateMappingRuleTest extends ClientRestTest {
 
     // when
     client
-        .newUpdateMappingRule(MAPPING_RULE_ID)
+        .newUpdateMappingRuleCommand(MAPPING_RULE_ID)
         .name(UPDATED_NAME)
         .claimName(UPDATED_CLAIM_NAME)
         .claimValue(UPDATED_CLAIM_VALUE)
@@ -62,7 +62,7 @@ public class UpdateMappingRuleTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUpdateMappingRule(MAPPING_RULE_ID)
+                    .newUpdateMappingRuleCommand(MAPPING_RULE_ID)
                     .name(invalidName)
                     .claimName(UPDATED_CLAIM_NAME)
                     .claimValue(UPDATED_CLAIM_VALUE)
@@ -78,7 +78,7 @@ public class UpdateMappingRuleTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUpdateMappingRule(MAPPING_RULE_ID)
+                    .newUpdateMappingRuleCommand(MAPPING_RULE_ID)
                     .name(UPDATED_NAME)
                     .claimName(invalidClaimName)
                     .claimValue(UPDATED_CLAIM_VALUE)
@@ -94,7 +94,7 @@ public class UpdateMappingRuleTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUpdateMappingRule(MAPPING_RULE_ID)
+                    .newUpdateMappingRuleCommand(MAPPING_RULE_ID)
                     .name(UPDATED_NAME)
                     .claimName(UPDATED_CLAIM_NAME)
                     .claimValue(invalidClaimValue)

--- a/clients/java/src/test/java/io/camunda/client/mappingrule/UpdateMappingRuleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/mappingrule/UpdateMappingRuleTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.mappingrule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.protocol.rest.MappingRuleUpdateRequest;
+import io.camunda.client.protocol.rest.MappingRuleUpdateResult;
+import io.camunda.client.util.ClientRestTest;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+public class UpdateMappingRuleTest extends ClientRestTest {
+  private static final String MAPPING_RULE_ID = "mappingRuleId";
+  private static final String UPDATED_NAME = "Updated Mapping Rule Name";
+  private static final String UPDATED_CLAIM_NAME = "Updated Claim Name";
+  private static final String UPDATED_CLAIM_VALUE = "Updated Claim Name";
+
+  @Test
+  void shouldUpdateMappingRule() {
+    // given
+    gatewayService.onUpdateMappingRuleRequest(
+        MAPPING_RULE_ID, Instancio.create(MappingRuleUpdateResult.class));
+
+    // when
+    client
+        .newUpdateMappingRule(MAPPING_RULE_ID)
+        .name(UPDATED_NAME)
+        .claimName(UPDATED_CLAIM_NAME)
+        .claimValue(UPDATED_CLAIM_VALUE)
+        .send()
+        .join();
+
+    // then
+    final MappingRuleUpdateRequest request =
+        gatewayService.getLastRequest(MappingRuleUpdateRequest.class);
+    assertThat(request.getName()).isEqualTo(UPDATED_NAME);
+    assertThat(request.getClaimName()).isEqualTo(UPDATED_CLAIM_NAME);
+    assertThat(request.getClaimValue()).isEqualTo(UPDATED_CLAIM_VALUE);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldRaiseExceptionInvalidName(final String invalidName) {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateMappingRule(MAPPING_RULE_ID)
+                    .name(invalidName)
+                    .claimName(UPDATED_CLAIM_NAME)
+                    .claimValue(UPDATED_CLAIM_VALUE)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldRaiseExceptionInvalidClaimName(final String invalidClaimName) {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateMappingRule(MAPPING_RULE_ID)
+                    .name(UPDATED_NAME)
+                    .claimName(invalidClaimName)
+                    .claimValue(UPDATED_CLAIM_VALUE)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldRaiseExceptionInvalidClaimValue(final String invalidClaimValue) {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateMappingRule(MAPPING_RULE_ID)
+                    .name(UPDATED_NAME)
+                    .claimName(UPDATED_CLAIM_NAME)
+                    .claimValue(invalidClaimValue)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -37,8 +37,8 @@ public class RestGatewayPaths {
   private static final String URL_INCIDENT = REST_API_PATH + "/incidents/%s";
   private static final String URL_INCIDENT_RESOLUTION = REST_API_PATH + "/incidents/%s/resolution";
   private static final String URL_JOB_ACTIVATION = REST_API_PATH + "/jobs/activation";
-  private static final String URL_MAPPING_RULE = REST_API_PATH + "/mapping-rules/%s";
   private static final String URL_MAPPING_RULES = REST_API_PATH + "/mapping-rules";
+  private static final String URL_MAPPING_RULE = URL_MAPPING_RULES + "/%s";
   private static final String URL_MESSAGE_PUBLICATION = REST_API_PATH + "/messages/publication";
   private static final String URL_MESSAGE_CORRELATION = REST_API_PATH + "/messages/correlation";
   private static final String URL_PROCESS_DEFINITION = REST_API_PATH + "/process-definitions/%s";

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -39,6 +39,7 @@ import io.camunda.client.protocol.rest.IncidentResult;
 import io.camunda.client.protocol.rest.JobActivationResult;
 import io.camunda.client.protocol.rest.MappingRuleCreateResult;
 import io.camunda.client.protocol.rest.MappingRuleResult;
+import io.camunda.client.protocol.rest.MappingRuleUpdateResult;
 import io.camunda.client.protocol.rest.MessageCorrelationResult;
 import io.camunda.client.protocol.rest.MessagePublicationResult;
 import io.camunda.client.protocol.rest.ProblemDetail;
@@ -274,6 +275,11 @@ public class RestGatewayService {
 
   public void onUpdateRoleRequest(final String roleId, final RoleUpdateResult response) {
     registerPut(RestGatewayPaths.getRoleUrl(roleId), response);
+  }
+
+  public void onUpdateMappingRuleRequest(
+      final String mappingRuleId, final MappingRuleUpdateResult response) {
+    registerPut(RestGatewayPaths.getMappingRuleUrl(mappingRuleId), response);
   }
 
   public void onDecisionRequirementsRequest(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MappingRuleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MappingRuleAuthorizationIT.java
@@ -204,7 +204,7 @@ class MappingRuleAuthorizationIT {
     assertThatThrownBy(
             () ->
                 camundaClient
-                    .newUpdateMappingRule(MAPPING_RULE_1.id())
+                    .newUpdateMappingRuleCommand(MAPPING_RULE_1.id())
                     .name("name")
                     .claimName("claim")
                     .claimValue("value")
@@ -225,7 +225,7 @@ class MappingRuleAuthorizationIT {
     // when
     final Future<UpdateMappingRuleResponse> result =
         camundaClient
-            .newUpdateMappingRule(MAPPING_RULE_1.id())
+            .newUpdateMappingRuleCommand(MAPPING_RULE_1.id())
             .name(name)
             .claimName(claimName)
             .claimValue(claimValue)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRuleIT.java
@@ -68,7 +68,7 @@ public class MappingRuleIT {
 
     // when
     client
-        .newUpdateMappingRule(EXISTING_RULE_ID)
+        .newUpdateMappingRuleCommand(EXISTING_RULE_ID)
         .name(name)
         .claimName(claimName)
         .claimValue(claimValue)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRuleIT.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import java.net.http.HttpClient;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class MappingRuleIT {
+  private static CamundaClient client;
+
+  private static final String EXISTING_RULE_ID = Strings.newRandomValidIdentityId();
+  private static final String EXISTING_NAME = "MappingRuleName";
+  private static final String EXISTING_CLAIM_NAME = "ClaimName";
+  private static final String EXISTING_CLAIM_VALUE = "ClaimValue";
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  @BeforeAll
+  static void setup() {
+    createMappingRule(EXISTING_RULE_ID, EXISTING_NAME, EXISTING_CLAIM_NAME, EXISTING_CLAIM_VALUE);
+    assertMappingRuleExists(
+        EXISTING_RULE_ID, EXISTING_NAME, EXISTING_CLAIM_NAME, EXISTING_CLAIM_VALUE);
+  }
+
+  @Test
+  void shouldCreateAndGetMappingRuleById() {
+    // given
+    final var mappingRuleId = Strings.newRandomValidIdentityId();
+    final var name = UUID.randomUUID().toString();
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+
+    // when
+    createMappingRule(mappingRuleId, name, claimName, claimValue);
+    // then
+    assertMappingRuleExists(mappingRuleId, name, claimName, claimValue);
+  }
+
+  @Test
+  void shouldUpdateMappingRule() {
+    // given
+    final var name = UUID.randomUUID().toString();
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+
+    // when
+    client
+        .newUpdateMappingRule(EXISTING_RULE_ID)
+        .name(name)
+        .claimName(claimName)
+        .claimValue(claimValue)
+        .send()
+        .join();
+
+    // then
+    assertMappingRuleExists(EXISTING_RULE_ID, name, claimName, claimValue);
+  }
+
+  private static void createMappingRule(
+      final String mappingRuleId,
+      final String name,
+      final String claimName,
+      final String claimValue) {
+    client
+        .newCreateMappingRuleCommand()
+        .mappingRuleId(mappingRuleId)
+        .name(name)
+        .claimName(claimName)
+        .claimValue(claimValue)
+        .send()
+        .join();
+  }
+
+  private static void assertMappingRuleExists(
+      final String mappingRuleId,
+      final String name,
+      final String claimName,
+      final String claimValue) {
+    Awaitility.await("Mapping rule exists in both storage systems")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var mappingRule = client.newMappingRuleGetRequest(mappingRuleId).send().join();
+              assertThat(mappingRule).isNotNull();
+              assertThat(mappingRule.getMappingRuleId()).isEqualTo(mappingRuleId);
+              assertThat(mappingRule.getName()).isEqualTo(name);
+              assertThat(mappingRule.getClaimName()).isEqualTo(claimName);
+              assertThat(mappingRule.getClaimValue()).isEqualTo(claimValue);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRuleIT.java
@@ -21,6 +21,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 public class MappingRuleIT {
@@ -56,7 +57,9 @@ public class MappingRuleIT {
     assertMappingRuleExists(mappingRuleId, name, claimName, claimValue);
   }
 
+  // TODO: enable when update is supported for rdbms
   @Test
+  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
   void shouldUpdateMappingRule() {
     // given
     final var name = UUID.randomUUID().toString();


### PR DESCRIPTION
## Description

This PR adds the update mapping rule command to the Camunda Java Client, including unit, acceptance, and authorization tests.

The endpoint was already there as well, so this is purely client side + the final acceptance tests.

## Related issues

closes #35819 
