### PR TITLE
[Backport main] fix: do not wrap parse exceptions as problems

### DIFF
--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
@@ -17,7 +17,6 @@ package io.camunda.zeebe.client.impl.http;
 
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
-import io.camunda.zeebe.client.api.command.ProblemException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -85,12 +84,12 @@ public class HttpZeebeFuture<RespT> extends CompletableFuture<RespT> implements 
     }
   }
 
-  private ProblemException unwrapExecutionException(final ExecutionException e) {
+  private ClientException unwrapExecutionException(final ExecutionException e) {
     final Throwable cause = e.getCause();
-    if (cause instanceof ProblemException) {
-      throw (ProblemException) cause;
+    if (cause instanceof ClientException) {
+      return (ClientException) cause;
     } else {
-      throw new ClientException(cause);
+      return new ClientException(cause);
     }
   }
 }

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
@@ -100,17 +100,10 @@ public interface TypedApiEntityConsumer<T> {
 
     @Override
     public ApiEntity<T> generateContent() throws IOException {
-      try {
-        if (isResponse) {
-          return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), type));
-        }
-        return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
-      } catch (final IOException ioe) {
-        // write the original JSON response into an error response
-        final String jsonString = getJsonString();
-        return ApiEntity.of(
-            new ProblemDetail().title("Unexpected server response").status(500).detail(jsonString));
+      if (isResponse) {
+        return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), type));
       }
+      return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
     }
 
     @Override

--- a/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumerTest.java
+++ b/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumerTest.java
@@ -16,8 +16,10 @@
 package io.camunda.zeebe.client.impl.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import io.camunda.zeebe.client.impl.http.ApiEntity.Error;
 import io.camunda.zeebe.client.impl.http.ApiEntity.Response;
 import io.camunda.zeebe.client.impl.http.ApiEntity.Unknown;
@@ -68,15 +70,9 @@ class ApiEntityConsumerTest {
     consumer.streamStart(ContentType.APPLICATION_JSON);
     // Feed the data
     consumer.data(byteBuffer, true);
-    // Generate the content
-    final ApiEntity<TestEntity> entity = consumer.generateContent();
 
-    // then
-    assertThat(entity).isInstanceOf(Error.class);
-    final ProblemDetail response = entity.problem();
-    assertThat(response).isNotNull();
-    assertThat(response.getTitle()).isEqualTo("Unexpected server response");
-    assertThat(response.getDetail()).isEqualTo(jsonResponse);
+    // when-then Generate the content
+    assertThatThrownBy(consumer::generateContent).isInstanceOf(UnrecognizedPropertyException.class);
   }
 
   @Test
@@ -92,15 +88,9 @@ class ApiEntityConsumerTest {
     consumer.streamStart(ContentType.APPLICATION_PROBLEM_JSON);
     // Feed the data
     consumer.data(byteBuffer, true);
-    // Generate the content
-    final ApiEntity<TestEntity> entity = consumer.generateContent();
 
-    // then
-    assertThat(entity).isInstanceOf(Error.class);
-    final ProblemDetail response = entity.problem();
-    assertThat(response).isNotNull();
-    assertThat(response.getTitle()).isEqualTo("Unexpected server response");
-    assertThat(response.getDetail()).isEqualTo(jsonResponse);
+    // when-then Generate the content
+    assertThatThrownBy(consumer::generateContent).isInstanceOf(UnrecognizedPropertyException.class);
   }
 
   @Test

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpCamundaFuture.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpCamundaFuture.java
@@ -17,7 +17,6 @@ package io.camunda.client.impl.http;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.ClientException;
-import io.camunda.client.api.command.ProblemException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -79,14 +78,12 @@ public class HttpCamundaFuture<RespT> extends CompletableFuture<RespT>
     }
   }
 
-  private ProblemException unwrapExecutionException(final ExecutionException e) {
+  private ClientException unwrapExecutionException(final ExecutionException e) {
     final Throwable cause = e.getCause();
-    if (cause instanceof ProblemException) {
-      throw (ProblemException) cause;
-    } else if (cause instanceof ClientException) {
-      throw (ClientException) cause;
+    if (cause instanceof ClientException) {
+      return (ClientException) cause;
     } else {
-      throw new ClientException(cause);
+      return new ClientException(cause);
     }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/TypedApiEntityConsumer.java
@@ -93,25 +93,10 @@ public interface TypedApiEntityConsumer<T> {
 
     @Override
     public ApiEntity<T> generateContent() throws IOException {
-      try {
-        if (isResponse) {
-          return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), type));
-        }
-        return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
-      } catch (final IOException ioe) {
-        LOGGER.warn("Could not read JSON content", ioe);
-        // write the original JSON response into an error response
-        final String jsonString = getJsonString();
-        return ApiEntity.of(
-            new ProblemDetail()
-                .title("Cannot parse the server JSON response")
-                .status(500)
-                .detail(
-                    "The client failed to parse the JSON response: "
-                        + ioe.getMessage()
-                        + ". The received JSON payload is: "
-                        + jsonString));
+      if (isResponse) {
+        return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), type));
       }
+      return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
     }
 
     @Override


### PR DESCRIPTION
# Description
Backport of #39673 to `main`.

relates to 