### PR TITLE
[Backport stable/8.8] fix: allow editing users in frontend without setting name or email

### DIFF
--- a/identity/client/src/pages/users/modals/AddModal.tsx
+++ b/identity/client/src/pages/users/modals/AddModal.tsx
@@ -95,7 +95,6 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
       <Controller
         name="name"
         control={control}
-        rules={{ required: t("nameRequired") }}
         render={({ field, fieldState }) => (
           <TextField
             {...field}
@@ -109,9 +108,8 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
         name="email"
         control={control}
         rules={{
-          required: t("emailRequired"),
           validate: (value) =>
-            isValidEmail(value) || t("pleaseEnterValidEmail"),
+            !value || isValidEmail(value) || t("pleaseEnterValidEmail"),
         }}
         render={({ field, fieldState }) => (
           <TextField

--- a/identity/client/src/pages/users/modals/EditModal.tsx
+++ b/identity/client/src/pages/users/modals/EditModal.tsx
@@ -79,7 +79,6 @@ const EditModal: FC<UseEntityModalProps<User>> = ({
       <Controller
         name="name"
         control={control}
-        rules={{ required: t("nameRequired") }}
         render={({ field, fieldState }) => (
           <TextField
             {...field}
@@ -94,9 +93,8 @@ const EditModal: FC<UseEntityModalProps<User>> = ({
         name="email"
         control={control}
         rules={{
-          required: t("emailRequired"),
           validate: (value) =>
-            isValidEmail(value) || t("pleaseEnterValidEmail"),
+            !value || isValidEmail(value) || t("pleaseEnterValidEmail"),
         }}
         render={({ field, fieldState }) => (
           <TextField

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
@@ -189,14 +189,14 @@ export class IdentityUsersPage {
   }
 
   async editUser(
-    currentUser: {email: string},
+    currentUser: {username: string, email: string},
     updatedUser: {name: string; email: string},
   ) {
-    await waitForItemInList(this.page, this.userCell(currentUser.email), {
+    await waitForItemInList(this.page, this.userCell(currentUser.username), {
       clickNext: true,
       timeout: 30000,
     });
-    await this.editUserButton(currentUser.email).click();
+    await this.editUserButton(currentUser.username).click();
     await expect(this.editUserModal).toBeVisible();
     await this.editNameField.fill(updatedUser.name);
     await this.editEmailField.fill(updatedUser.email);
@@ -205,7 +205,7 @@ export class IdentityUsersPage {
   }
 
   async deleteUser(user: {username: string; email: string}) {
-    await waitForItemInList(this.page, this.userCell(user.email), {
+    await waitForItemInList(this.page, this.userCell(user.username), {
       clickNext: true,
       timeout: 30000,
     });
@@ -221,7 +221,7 @@ export class IdentityUsersPage {
     await expect(this.deleteUserModal).toBeHidden();
 
     const item = this.usersList.getByRole('cell', {
-      name: user.email,
+      name: user.username,
     });
     await waitForItemInList(this.page, item, {
       shouldBeVisible: false,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
@@ -179,7 +179,7 @@ export class IdentityUsersPage {
     await expect(this.createUserModal).toBeHidden();
 
     const item = this.usersList.getByRole('cell', {
-      name: user.email,
+      name: user.username,
     });
 
     await waitForItemInList(this.page, item, {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
@@ -22,6 +22,7 @@ test.beforeEach(async ({page, loginPage}) => {
 
 test.describe.serial('users CRUD', () => {
   let NEW_USER: NonNullable<ReturnType<typeof createTestData>['user']>;
+  let NEW_MINIMUM_USER: typeof NEW_USER;
   let EDITED_USER: typeof NEW_USER;
   let EDITED_MINIMUM_USER: typeof NEW_USER;
 
@@ -30,6 +31,12 @@ test.describe.serial('users CRUD', () => {
       user: true,
     });
     NEW_USER = testData.user!;
+    NEW_MINIMUM_USER = {
+      ...NEW_USER,
+      username: `minimum${NEW_USER.username}`,
+      name: '',
+      email: '',
+    };
     EDITED_USER = {
       ...NEW_USER,
       name: `Edited ${NEW_USER.name}`,
@@ -87,5 +94,21 @@ test.describe.serial('users CRUD', () => {
       clickNext: true,
       timeout: 30000,
     });
+  });
+
+  test('create a user with minimum properties', async ({
+    identityUsersPage,
+    page,
+  }) => {
+    await expect(identityUsersPage.userCell('demo@example.com')).toBeVisible();
+    await identityUsersPage.createUser(NEW_MINIMUM_USER);
+    await waitForItemInList(
+      page,
+      identityUsersPage.userCell(NEW_MINIMUM_USER.username),
+      {
+        clickNext: true,
+        timeout: 30000,
+      },
+    );
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
@@ -23,6 +23,7 @@ test.beforeEach(async ({page, loginPage}) => {
 test.describe.serial('users CRUD', () => {
   let NEW_USER: NonNullable<ReturnType<typeof createTestData>['user']>;
   let EDITED_USER: typeof NEW_USER;
+  let EDITED_MINIMUM_USER: typeof NEW_USER;
 
   test.beforeAll(() => {
     const testData = createTestData({
@@ -34,6 +35,11 @@ test.describe.serial('users CRUD', () => {
       name: `Edited ${NEW_USER.name}`,
       email: `edited.${NEW_USER.email}`,
       password: `edited${NEW_USER.password}`,
+    };
+    EDITED_MINIMUM_USER = {
+      ...EDITED_USER,
+      name: '',
+      email: '',
     };
   });
 
@@ -54,6 +60,18 @@ test.describe.serial('users CRUD', () => {
   test('edit a user', async ({identityUsersPage, page}) => {
     await identityUsersPage.editUser(NEW_USER, EDITED_USER);
     const item = identityUsersPage.userCell(EDITED_USER.email);
+    await waitForItemInList(page, item, {
+      clickNext: true,
+      timeout: 30000,
+    });
+  });
+
+  test('edit a user with minimum properties', async ({
+    identityUsersPage,
+    page,
+  }) => {
+    await identityUsersPage.editUser(EDITED_USER, EDITED_MINIMUM_USER);
+    const item = identityUsersPage.userCell(EDITED_MINIMUM_USER.username);
     await waitForItemInList(page, item, {
       clickNext: true,
       timeout: 30000,


### PR DESCRIPTION
# Description
Backport of #40032 to `stable/8.8`.

relates to #38847