### PR TITLE
test: add timeout to fail fast

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/FailOverReplicationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/FailOverReplicationTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
 import org.springframework.util.unit.DataSize;
 
 public class FailOverReplicationTest {
@@ -44,7 +45,12 @@ public class FailOverReplicationTest {
   private final ClusteringRule clusteringRule =
       new ClusteringRule(PARTITION_COUNT, 3, 3, FailOverReplicationTest::configureBroker);
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
-  @Rule public RuleChain ruleChain = RuleChain.outerRule(clusteringRule).around(clientRule);
+  private final Timeout testTimeout = Timeout.seconds(120);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(testTimeout).around(clusteringRule).around(clientRule);
+
   private CamundaClient client;
 
   @Before


### PR DESCRIPTION
## Description

Add a timeout to the test so that the test fails fast instead of CI job timing out.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related #39856
