### PR TITLE
ci: skip Identify previous release version if dry-run

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -290,6 +290,7 @@ jobs:
           chmod +x zcl
       - name: Identify previous release version
         id: prev_version
+        if: ${{ !inputs.dryRun }}
         uses: camunda/infra-global-github-actions/previous-version@main
         with:
           version: "${{ inputs.releaseVersion }}"


### PR DESCRIPTION
## Description

This pull request makes a minor update to the Camunda platform release workflow. The main change is to ensure that the "Identify previous release version" step only runs when not in dry run mode.

* Added a condition to the "Identify previous release version" step in `.github/workflows/camunda-platform-release.yml` so it only executes when `dryRun` is not set.

Related to https://github.com/camunda/camunda/pull/40040 -> currently the dry run is [failing](https://github.com/camunda/camunda/actions/runs/18883944903/job/53894356230) during GH release because it wants to compare existing version with new one, which doesn't fit current dry-run strategy.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ x ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
