### PR TITLE
Export mapping rule updates to RDBMS

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MappingRuleWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MappingRuleWriter.java
@@ -40,4 +40,14 @@ public class MappingRuleWriter {
             "io.camunda.db.rdbms.sql.MappingRuleMapper.delete",
             mappingRuleId));
   }
+
+  public void update(final MappingRuleDbModel mappingRule) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.MAPPING_RULE,
+            WriteStatementType.UPDATE,
+            mappingRule.mappingRuleId(),
+            "io.camunda.db.rdbms.sql.MappingRuleMapper.update",
+            mappingRule));
+  }
 }

--- a/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
@@ -27,6 +27,14 @@
     VALUES (#{mappingRuleId}, #{mappingRuleKey}, #{claimName}, #{claimValue}, #{name})
   </insert>
 
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.MappingRuleDbModel">
+    UPDATE ${prefix}MAPPING_RULES
+    SET NAME = #{name},
+        CLAIM_NAME = #{claimName},
+        CLAIM_VALUE = #{claimValue}
+    WHERE MAPPING_RULE_ID = #{mappingRuleId}
+  </update>
+
   <delete id="delete" parameterType="string">
     DELETE
     FROM ${prefix}MAPPING_RULES

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRuleIT.java
@@ -96,7 +96,7 @@ public class MappingRuleIT {
       final String name,
       final String claimName,
       final String claimValue) {
-    Awaitility.await("Mapping rule exists in both storage systems")
+    Awaitility.await("Mapping rule exists in the secondary storage system")
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRuleIT.java
@@ -21,7 +21,6 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 public class MappingRuleIT {
@@ -57,9 +56,7 @@ public class MappingRuleIT {
     assertMappingRuleExists(mappingRuleId, name, claimName, claimValue);
   }
 
-  // TODO: enable when update is supported for rdbms
   @Test
-  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
   void shouldUpdateMappingRule() {
     // given
     final var name = UUID.randomUUID().toString();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleIT.java
@@ -277,11 +277,14 @@ public class MappingRuleIT {
     writer.flush();
 
     // then
-    final var mappingRule = rdbmsService.getMappingRuleReader().findOne(mappingRuleId).orElse(null);
-    assertThat(mappingRule.mappingRuleKey()).isEqualTo(randomizedMappingRule.mappingRuleKey());
-    assertThat(mappingRule.mappingRuleId()).isEqualTo(randomizedMappingRule.mappingRuleId());
-    assertThat(mappingRule.name()).isEqualTo("Updated Name");
-    assertThat(mappingRule.claimName()).isEqualTo("Updated Claim Name");
-    assertThat(mappingRule.claimValue()).isEqualTo("Updated Claim Value");
+    final var mappingRule = rdbmsService.getMappingRuleReader().findOne(mappingRuleId);
+    assertThat(mappingRule)
+        .isPresent()
+        .get()
+        .returns(randomizedMappingRule.mappingRuleKey(), m -> m.mappingRuleKey())
+        .returns(randomizedMappingRule.mappingRuleId(), m -> m.mappingRuleId())
+        .returns("Updated Name", m -> m.name())
+        .returns("Updated Claim Name", m -> m.claimName())
+        .returns("Updated Claim Value", m -> m.claimValue());
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/MappingRuleExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/MappingRuleExportHandlerTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.camunda.db.rdbms.write.domain.MappingRuleDbModel;
+import io.camunda.db.rdbms.write.service.MappingRuleWriter;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
+import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class MappingRuleExportHandlerTest {
+  private static final Set<MappingRuleIntent> TEST_EXPORTABLE_INTENTS =
+      EnumSet.of(MappingRuleIntent.CREATED, MappingRuleIntent.DELETED, MappingRuleIntent.UPDATED);
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+
+  @Mock private MappingRuleWriter writer;
+
+  @Captor private ArgumentCaptor<MappingRuleDbModel> dbModelCaptor;
+
+  private MappingRuleExportHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new MappingRuleExportHandler(writer);
+  }
+
+  private static Stream<MappingRuleIntent> exportableIntents() {
+    return TEST_EXPORTABLE_INTENTS.stream();
+  }
+
+  @ParameterizedTest(name = "Should be able to export record with intent: {0}")
+  @MethodSource("exportableIntents")
+  void shouldExportRecord(final MappingRuleIntent intent) {
+    // given
+    final Record<MappingRuleRecordValue> record =
+        factory.generateRecord(ValueType.MAPPING_RULE, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(handler.canExport(record))
+        .as("Handler should be able to export record with intent: %s", intent)
+        .isTrue();
+  }
+
+  private static Stream<MappingRuleIntent> nonExportableIntents() {
+    return Stream.of(MappingRuleIntent.values())
+        .filter(Predicate.not(TEST_EXPORTABLE_INTENTS::contains));
+  }
+
+  @ParameterizedTest(name = "Should not export record with unsupported intent: {0}")
+  @MethodSource("nonExportableIntents")
+  void shouldNotExportRecord(final MappingRuleIntent intent) {
+    // given
+    final Record<MappingRuleRecordValue> record =
+        factory.generateRecord(ValueType.MAPPING_RULE, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(handler.canExport(record))
+        .as("Handler should not be able to export record with unsupported intent: %s", intent)
+        // If this assertion fails, it means that the given intent was recently added to
+        // `MappingRuleExporterHandleTest#EXPORTABLE_INTENTS`.
+        // In that case:
+        // - Add it to `MappingRuleExporterHandleTest#TEST_EXPORTABLE_INTENTS` set
+        // - Review whether it needs custom handling in `MappingRuleExporterHandle#export`:
+        //   - If so, add a dedicated handling in `MappingRuleExporterHandler#export`
+        //   - Add a dedicated test for the new intent in this class
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("Should handle record with DELETED intent")
+  void shouldHandleDeletedMappingRuleRecord() {
+    // given
+    final Record<MappingRuleRecordValue> record =
+        factory.generateRecord(
+            ValueType.MAPPING_RULE, r -> r.withIntent(MappingRuleIntent.DELETED));
+    final var recordValue = record.getValue();
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).delete(eq(recordValue.getMappingRuleId()));
+
+    // ensure no other methods are called
+    verifyNoMoreInteractions(writer);
+  }
+
+  @Test
+  @DisplayName("Should handle record with CREATED intent")
+  void shouldHandleCreatedMappingRuleRecord() {
+    // given
+    final Record<MappingRuleRecordValue> record =
+        factory.generateRecord(
+            ValueType.MAPPING_RULE, r -> r.withIntent(MappingRuleIntent.CREATED));
+    final var recordValue = record.getValue();
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(dbModelCaptor.capture());
+    assertThat(dbModelCaptor.getValue())
+        .satisfies(model -> assertMappingRuleModelEqualsRecord(model, record));
+
+    // ensure no other methods are called
+    verifyNoMoreInteractions(writer);
+  }
+
+  @Test
+  @DisplayName("Should handle record with UPDATED intent")
+  void shouldHandleUpdatedMappingRuleRecord() {
+    // given
+    final Record<MappingRuleRecordValue> record =
+        factory.generateRecord(
+            ValueType.MAPPING_RULE, r -> r.withIntent(MappingRuleIntent.UPDATED));
+    final var recordValue = record.getValue();
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).update(dbModelCaptor.capture());
+    assertThat(dbModelCaptor.getValue())
+        .satisfies(model -> assertMappingRuleModelEqualsRecord(model, record));
+
+    // ensure no other methods are called
+    verifyNoMoreInteractions(writer);
+  }
+
+  private void assertMappingRuleModelEqualsRecord(
+      final MappingRuleDbModel model, final Record<MappingRuleRecordValue> record) {
+    final var recordValue = record.getValue();
+    assertThat(model.mappingRuleId()).isEqualTo(recordValue.getMappingRuleId());
+    assertThat(model.mappingRuleKey()).isEqualTo(recordValue.getMappingRuleKey());
+    assertThat(model.name()).isEqualTo(recordValue.getName());
+    assertThat(model.claimName()).isEqualTo(recordValue.getClaimName());
+    assertThat(model.claimValue()).isEqualTo(recordValue.getClaimValue());
+  }
+}


### PR DESCRIPTION
## Description

This PR adds support update mapping rules with RDBMS. I wasn't if or where to add unit tests, so please let me know. Tentatively I would prefer some, so happy to discuss that.
