### PR TITLE
test: allow specifying DB directly in test

### DIFF
--- a/docs/testing/acceptance.md
+++ b/docs/testing/acceptance.md
@@ -196,9 +196,12 @@ will [spin up an Elasticsearch test container for local execution](https://githu
 
 Sometimes, we need to validate different secondary storages locally, for example, to reproduce a failure. For that, we can configure the test execution.
 
-In Intellij, you can edit the `Run/Debug configuration` (see this [guide](https://www.jetbrains.com/help/idea/run-debug-configuration-junit.html)) and pass in additional properties and environment variables.
+If you simply want to test with a specific database, you can just edit the annotation in your IDE, e.g. `@MultiDbTest(DatabaseType.OS)`. Then
+run the test as usual, e.g. from the IDE or via Maven.
 
-To specify the database type, use the following property: `test.integration.camunda.database.type`. We also provide specific Maven profiles to make this easier.
+Alternatively, you can specify the System property `test.integration.camunda.database.type`, which is what the CI jobs do.
+In Intellij, you can edit the `Run/Debug configuration` (see this [guide](https://www.jetbrains.com/help/idea/run-debug-configuration-junit.html)) and pass in additional properties and environment variables.
+We also provide specific Maven profiles to make this easier.
 
 * For available maven profiles, take a look at the `qa/integration-test/pom.xml`.
 * For available database types, look at `io.camunda.qa.util.multidb.CamundaMultiDBExtension#DatabaseType`
@@ -206,7 +209,14 @@ To specify the database type, use the following property: `test.integration.camu
 > [!Important]
 >
 > If you want to run against a different secondary storage, you need to spin it up manually, for example, via docker.
-> Ensure the container is available under `:9200` for ES or OS.
+> Ensure the container is available under `:9200` for ES or OS. RDBMS uses an embedded H2 database, so no setup is necessary.
+>
+> [!Note]
+> Setting an explicit database type in the `@MultiDbTest` annotation is for local testing only. There is an ArchUnit test which runs in the
+> acceptance test module that ensures no test class is annotated with an explicit database type.
+>
+> Note that setting the system property `test.integration.camunda.database.type` will override the
+> database type defined in the annotation.
 
 ### Example to run against OpenSearch
 
@@ -222,13 +232,22 @@ docker run -d -p 9200:9200 \
               opensearchproject/opensearch:latest
 ```
 
-Define the following property in your run configuration
+To run with OpenSearch from your IDE, you have two options:
 
-`-Dtest.integration.camunda.database.type=os`
+1. Edit the annotation directly in your IDE, e.g. `@MultiDbTest(DatabaseType.OS)`.
+2. Define the following property in your run configuration: `-Dtest.integration.camunda.database.type=os`
 
-Alternatively, you can also specify the respective maven profile `-Pe2e-opensearch-test`
+Alternatively, if you're running the test via Maven, you can also specify the respective maven
+profile `-Pe2e-opensearch-test`.
 
-Run the test.
+### Example to run against RDBMS
+
+Our RDBMS set up uses a local H2 database, so there is no database to set up.
+
+To run with RDBMS from your IDE, you have two options:
+
+1. Edit the annotation directly in your IDE, e.g. `@MultiDbTest(DatabaseType.RDBMS)`.
+2. Define the following property in your run configuration: `-Dtest.integration.camunda.database.type=rdbms`
 
 ## Update tests
 

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -492,6 +492,24 @@
       <artifactId>configuration</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/MultiDbTestArchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/MultiDbTestArchTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import io.camunda.qa.util.multidb.MultiDbTest;
+
+@AnalyzeClasses(packages = "io.camunda", importOptions = ImportOption.OnlyIncludeTests.class)
+final class MultiDbTestArchTest {
+
+  /**
+   * This test ensures that PRs cannot be merged if you have committed a {@link MultiDbTest} with
+   * explicit database types specified. Specifying an explicit database type is only intended for
+   * local testing purposes, but should not be part of the code base.
+   */
+  @ArchTest
+  static final ArchRule FORBID_MULTI_DB_SPECIFIED_DB =
+      classes()
+          .that()
+          .areAnnotatedWith(MultiDbTest.class)
+          .should()
+          .beAnnotatedWith(
+              DescribedPredicate.describe(
+                  "@MultiDbTest(value = ...)",
+                  annotation -> !annotation.hasExplicitlyDeclaredProperty("value")))
+          .as(
+              """
+          @MultiDbTest should not specify explicit databases; that's only for local testing \
+          purposes, please remove it before checking the code in""");
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.qa.util.multidb;
 
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -84,4 +85,15 @@ public @interface MultiDbTest {
    *     require OIDC authentication.
    */
   boolean setupKeycloak() default false;
+
+  /**
+   * Setting this is only for local testing purposes; setting the property {@link
+   * CamundaMultiDBExtension#PROP_CAMUNDA_IT_DATABASE_TYPE} will override this. This is NOT a way to
+   * limit which DB a test or class should run with; for that, use JUnit's {@code @DisabledIf}
+   * matching on the property.
+   *
+   * @return the database type to run the test with. By default, the test will run with the local
+   *     database type as defined in the test configuration.
+   */
+  DatabaseType value() default DatabaseType.LOCAL;
 }


### PR DESCRIPTION
## Description

This PR extends the `MultiDbTest` extension, allowing you to specify which DB you want to use directly via the annotation, instead of only via properties.

This simplifies reproducing tests directly in your IDE. Note that you still need to launch an  OS container if you need to test with OS, but it's a first step towards making it smoother.

Essentially it means, if you're trying to reproduce something in your IDE, you can quickly edit the annotation to say `MultiDbTest(DatabaseType.RDBMS)` for example, and test it out immediately in IDE, without fiddling with run configurations.

Note that if you specify the system property it will override the annotation, so even if you check it in, it won't really do anything in CI.

Also note that this does not extend support to annotations meta-annotated by `MultiDbTest`. Feel free to add that later.