### PR TITLE
ci: merge optimize into the platform release process

### DIFF
--- a/.github/optimize/scripts/update-zeebe-identity.sh
+++ b/.github/optimize/scripts/update-zeebe-identity.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# === Configuration ===
+# Expected environment variables:
+# - RELEASE_VERSION (e.g., "8.6.1")
+# - IS_PATCH ("true" or "false")
+
+echo "Updating zeebe.version and identity.version in optimize/pom.xml"
+cd optimize
+
+# --- Log current versions ---
+CURRENT_ZEEBE=$(./mvnw help:evaluate -Dexpression=zeebe.version -q -DforceStdout)
+CURRENT_IDENTITY=$(./mvnw help:evaluate -Dexpression=identity.version -q -DforceStdout)
+echo "Current zeebe.version: ${CURRENT_ZEEBE}"
+echo "Current identity.version: ${CURRENT_IDENTITY}"
+
+# --- Determine Identity version ---
+if [ "${IS_PATCH:-false}" = "true" ]; then
+  echo "PATCH release detected - fetching latest Identity patch version from Docker Hub"
+
+  # Extract major.minor (e.g., 8.6.1 -> 8.6)
+  MAJOR_MINOR=$(echo "${RELEASE_VERSION}" | sed -E 's/^([0-9]+\.[0-9]+)\.[0-9]+.*$/\1/')
+
+  echo "Fetching latest Identity patch version for ${MAJOR_MINOR}.x from Docker Hub"
+  IDENTITY_LATEST_PATCH=$(curl -s "https://registry.hub.docker.com/v2/repositories/camunda/identity/tags/?page_size=1000" \
+    | jq -r '.results[].name' \
+    | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+    | sort -V \
+    | tail -1)
+
+  if [ -n "${IDENTITY_LATEST_PATCH}" ] && [ "${IDENTITY_LATEST_PATCH}" != "null" ]; then
+    echo "Found latest Identity patch version: ${IDENTITY_LATEST_PATCH}"
+    IDENTITY_VERSION="${IDENTITY_LATEST_PATCH}"
+  else
+    echo "No Identity patch version found on Docker Hub, using RELEASE_VERSION"
+    IDENTITY_VERSION="${RELEASE_VERSION}"
+  fi
+else
+  echo "Non-patch release - using same version as release"
+  IDENTITY_VERSION="${RELEASE_VERSION}"
+fi
+
+# --- Update Zeebe and identity versions ---
+./mvnw versions:set-property \
+  -Dproperty=zeebe.version \
+  -DnewVersion="${RELEASE_VERSION}" \
+  -DgenerateBackupPoms=false \
+  -q
+./mvnw versions:set-property \
+  -Dproperty=identity.version \
+  -DnewVersion="${IDENTITY_VERSION}" \
+  -DgenerateBackupPoms=false \
+  -q
+
+# --- Log updated versions ---
+echo "Updated zeebe.version: $(./mvnw help:evaluate -Dexpression=zeebe.version -q -DforceStdout)"
+echo "Updated identity.version: $(./mvnw help:evaluate -Dexpression=identity.version -q -DforceStdout)"
+
+# --- Commit if changed ---
+git add pom.xml
+if ! git diff --staged --quiet; then
+  git commit -m "chore: update zeebe.version to ${RELEASE_VERSION} and identity.version to ${IDENTITY_VERSION}"
+  echo "Dependency versions updated and committed."
+else
+  echo "No version changes needed."
+fi

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -32,6 +32,11 @@ on:
         description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven Central, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
         type: boolean
         default: false
+      includeOptimize:
+        description: 'Whether to include Optimize in the release'
+        type: boolean
+        required: false
+        default: false
   workflow_dispatch:
     inputs:
       releaseBranch:
@@ -59,6 +64,11 @@ on:
       releaseProcessDryRun:
         description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven Central, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
         type: boolean
+        default: false
+      includeOptimize:
+        description: 'Whether to include Optimize in the release'
+        type: boolean
+        required: false
         default: false
 defaults:
   run:
@@ -731,7 +741,18 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
+  optimize-release:
+    needs: release
+    name: Optimize Release
+    if: ${{ (!inputs.dryRun || inputs.releaseProcessDryRun) && inputs.includeOptimize }}
+    uses: ./.github/workflows/optimize-release-optimize-c8-only.yml
+    with:
+      RELEASE_VERSION: ${{ inputs.releaseVersion }}
+      DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
+      BRANCH: ${{ needs.release.outputs.releaseBranch }}
+      DOCKER_LATEST: ${{ inputs.isLatest }}
+      IS_DRY_RUN: ${{ inputs.dryRun }}
+    secrets: inherit
   # Snyk security monitoring job performs vulnerability scanning on Docker images and source code.
   # Only runs for stable releases (not alpha, rc, SNAPSHOT).
   # Flags impact:
@@ -827,7 +848,7 @@ jobs:
   notify-on-success:
     name: Send Slack notification on success
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk, fossa-release]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, optimize-release, snyk, fossa-release]
     # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
     # else => send slack notification as an actual release succeeded
     if: ${{ always() && (
@@ -837,6 +858,7 @@ jobs:
       needs.operate-docker.result == 'success' &&
       needs.tasklist-docker.result == 'success' &&
       needs.camunda-docker.result == 'success' &&
+      (needs.optimize-release.result == 'success' || needs.optimize-release.result == 'skipped') &&
       (needs.snyk.result == 'success' || needs.snyk.result == 'skipped') &&
       (needs.fossa-release.result == 'success' || needs.fossa-release.result == 'skipped')
       ) && !inputs.dryRun && !inputs.releaseProcessDryRun }}
@@ -877,7 +899,7 @@ jobs:
   notify-if-failed:
     name: Send Slack notification on failure
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk, fossa-release]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, optimize-release, snyk, fossa-release]
     # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
     # else => send slack notification as an actual release failed
     if: ${{ always() && (
@@ -887,6 +909,7 @@ jobs:
         needs.operate-docker.result == 'failure' ||
         needs.tasklist-docker.result == 'failure' ||
         needs.camunda-docker.result == 'failure' ||
+        needs.optimize-release.result == 'failure' ||
         needs.snyk.result == 'failure' ||
         needs.fossa-release.result == 'failure'
         ) && !inputs.dryRun && !inputs.releaseProcessDryRun }}

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -2,6 +2,28 @@
 name: Optimize Release Camunda Optimize C8
 
 on:
+  workflow_call:
+    inputs:
+      RELEASE_VERSION:
+        required: true
+        description: "Version to release. Applied to pom.xml and Git tag"
+        type: string
+      DEVELOPMENT_VERSION:
+        required: true
+        description: "Next development version"
+        type: string
+      BRANCH:
+        required: true
+        description: "The branch used for the release checkout"
+        type: string
+      DOCKER_LATEST:
+        required: true
+        description: "Should the docker image be tagged as latest?"
+        type: boolean
+      IS_DRY_RUN:
+        required: true
+        description: "Is this a dry run?"
+        type: boolean
   schedule:
     - cron: "0 0 * * 1-5"
   workflow_dispatch:

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -250,6 +250,10 @@ jobs:
         with:
           work-dir: ./optimize
 
+      - name: Update zeebe and identity versions
+        if: ${{ env.IS_RC == 'false' }}
+        run: ./.github/optimize/scripts/update-zeebe-identity.sh
+
       - name: Clean release
         run: |
           ./mvnw release:clean


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This pull request integrates Optimize into the main platform release workflow and automates optimize dependency version updates. 

* Integrated the `optimize-release` job into the main workflow, which runs only if `includeOptimize` is set and not in dry run mode. This job calls the dedicated Optimize release workflow and passes necessary parameters.

* Introduced a script (`update-zeebe-identity.sh`) that automatically updates `zeebe.version` and `identity.version` in `optimize/pom.xml` based on the release type, fetching the latest patch version from Docker Hub for patch releases.


### 🧩 Script Overview: `update_versions.sh`

This script automates the update of `zeebe.version` and `identity.version` in `optimize/pom.xml` during the release process.
It performs the following steps:

* Skips execution for release candidates (`IS_RC=true`).
* Updates `zeebe.version` to match the current `RELEASE_VERSION` because from  the moment this PR is merged, Optimize will always be released along with zeebe so versions should be aligned.
* Determines the appropriate `identity.version`:

  * For **patch releases** (`IS_PATCH=true`), it fetches the latest patch version from Docker Hub (`camunda/identity`) matching the current major.minor line.
  * For **regular releases**, it aligns `identity.version` with `RELEASE_VERSION`.
* Commits changes to `pom.xml` only if updates were made.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40257
