### PR TITLE
Refactor 415 Doc API Tests According To Expected Behaviour - 8.9 Tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
@@ -18,6 +18,7 @@ import {
   assertBadRequest,
   assertNotFoundRequest,
   assertForbiddenRequest,
+  assertStatusCode
 } from '../../../utils/http';
 import {
   CREATE_DOC_INVALID_REQUEST,
@@ -76,14 +77,15 @@ test.describe.parallel('Document API Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  //Skipped due to bug 38510: https://github.com/camunda/camunda/issues/38510
-  test.skip('Create Document Invalid Header 415', async ({request}) => {
+  test('Create Document Invalid Header 415', async ({request}) => {
     const res = await request.post(buildUrl('/documents'), {
       headers: jsonHeaders(),
       multipart: CREATE_TXT_DOCUMENT_REQUEST(),
     });
 
-    await assertUnsupportedMediaTypeRequest(res);
+    await assertStatusCode(res, 415);
+    const json = await res.json();
+    assertRequiredFields(json, ['error']);
   });
 
   test('Create Document Invalid Body 400', async ({request}) => {
@@ -320,8 +322,7 @@ test.describe.parallel('Document API Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  //Skipped due to bug 38510: https://github.com/camunda/camunda/issues/38510
-  test.skip('Create Multiple Documents Invalid Header 415', async ({request}) => {
+  test('Create Multiple Documents Invalid Header 415', async ({request}) => {
     const name = generateUniqueId();
     const payload = CREATE_ON_FLY_MULTIPLE_DOCUMENTS_REQUEST_BODY(name, 2);
 
@@ -330,7 +331,9 @@ test.describe.parallel('Document API Tests', () => {
       multipart: payload,
     });
 
-    await assertUnsupportedMediaTypeRequest(res);
+    await assertStatusCode(res, 415);
+    const json = await res.json();
+    assertRequiredFields(json, ['error']);
   });
 
   test('Create Multiple Documents Invalid Body 400', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
@@ -17,8 +17,7 @@ import {
   assertUnsupportedMediaTypeRequest,
   assertBadRequest,
   assertNotFoundRequest,
-  assertForbiddenRequest,
-  assertStatusCode
+  assertForbiddenRequest
 } from '../../../utils/http';
 import {
   CREATE_DOC_INVALID_REQUEST,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
@@ -83,9 +83,7 @@ test.describe.parallel('Document API Tests', () => {
       multipart: CREATE_TXT_DOCUMENT_REQUEST(),
     });
 
-    await assertStatusCode(res, 415);
-    const json = await res.json();
-    assertRequiredFields(json, ['error']);
+    await assertUnsupportedMediaTypeRequest(res);
   });
 
   test('Create Document Invalid Body 400', async ({request}) => {
@@ -331,9 +329,7 @@ test.describe.parallel('Document API Tests', () => {
       multipart: payload,
     });
 
-    await assertStatusCode(res, 415);
-    const json = await res.json();
-    assertRequiredFields(json, ['error']);
+    await assertUnsupportedMediaTypeRequest(res);
   });
 
   test('Create Multiple Documents Invalid Body 400', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -71,7 +71,6 @@ export async function assertUnauthorizedRequest(response: APIResponse) {
 export async function assertUnsupportedMediaTypeRequest(response: APIResponse) {
   await assertStatusCode(response, 415);
   const json = await response.json();
-  assertRequiredFields(json, ['error']);
   expect(json.error).toContain('Unsupported Media Type');
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -71,7 +71,7 @@ export async function assertUnauthorizedRequest(response: APIResponse) {
 export async function assertUnsupportedMediaTypeRequest(response: APIResponse) {
   await assertStatusCode(response, 415);
   const json = await response.json();
-  expect(json.error).toContain('Unsupported Media Type');
+  expect(json.title).toContain('Unsupported Media Type');
 }
 
 export async function assertBadRequest(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

According to the following [GitHub issue comment](https://github.com/camunda/camunda/issues/38510#issuecomment-3456373258), the Document 415 API tests need to be adjusted as they were previously asserting the wrong behaviour. This PR unskips the tests and adjusts the assertions accordingly. 

Successful test run [here](https://github.com/camunda/camunda/actions/runs/18902343031). Note the failing test is due to the following [bug](https://github.com/camunda/camunda/issues/39819), which has been addressed in the following [PR](https://github.com/camunda/camunda/pull/40144).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
