### PR TITLE
fix: snapshot for bootstrap should not always be reserved 

### DIFF
--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -151,9 +151,7 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
 
   @Override
   public boolean isReserved() {
-    // bootstrap snapshots are not deleted following the normal procedure, they are deleted when the
-    // scaling operation has been terminated
-    return !reservations.isEmpty() || (metadata != null && metadata.isBootstrap());
+    return !reservations.isEmpty();
   }
 
   void delete() {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotTest.java
@@ -110,7 +110,7 @@ public final class FileBasedSnapshotTest {
   }
 
   @Test
-  public void shouldMarkAsReservedBootstrappedSnapshots() throws IOException {
+  public void shoulNotdMarkAsReservedBootstrappedSnapshots() throws IOException {
     // given
     final var metadata = new FileBasedSnapshotMetadata(1, 1L, 1L, 0, true);
     final var snapshotPath = snapshotDir.resolve("snapshot");
@@ -120,7 +120,7 @@ public final class FileBasedSnapshotTest {
     final var snapshot = createSnapshot(snapshotPath, checksumPath, metadata);
 
     // then
-    assertThat(snapshot.isReserved()).isTrue();
+    assertThat(snapshot.isReserved()).isFalse();
     assertThat(snapshot.isBootstrap()).isTrue();
   }
 


### PR DESCRIPTION

## Description
When a snapshot for bootstrap is restored into the `snapshots/` folder, it's flag `isBootstrap` in the metadata file is still set as "true", because we just copy all files from the snapshot without modifying the metadata.
Once it's been restored, it's included in the `availableSnapshots` field of `FileBaseSnapshotStore` as a regular snapshot.
Method `isReserved()` is used only when deleting snapshots from the available snapshot list, therefore we do not need to take into account that flag.
Snapshot for bootstrap saved in the folder `bootstrap-snapshots/` are deleted anyway within the transition steps of the partition.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
closes #39967 
