### PR TITLE
Refactor 415 Doc API Tests According To Expected Behaviour - 8.8 Tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
@@ -76,8 +76,7 @@ test.describe.parallel('Document API Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  //Skipped due to bug 38510: https://github.com/camunda/camunda/issues/38510
-  test.skip('Create Document Invalid Header 415', async ({request}) => {
+  test('Create Document Invalid Header 415', async ({request}) => {
     const res = await request.post(buildUrl('/documents'), {
       headers: jsonHeaders(),
       multipart: CREATE_TXT_DOCUMENT_REQUEST(),
@@ -320,8 +319,7 @@ test.describe.parallel('Document API Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  //Skipped due to bug 38510: https://github.com/camunda/camunda/issues/38510
-  test.skip('Create Multiple Documents Invalid Header 415', async ({request}) => {
+  test('Create Multiple Documents Invalid Header 415', async ({request}) => {
     const name = generateUniqueId();
     const payload = CREATE_ON_FLY_MULTIPLE_DOCUMENTS_REQUEST_BODY(name, 2);
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -67,8 +67,7 @@ export async function assertUnauthorizedRequest(response: APIResponse) {
 export async function assertUnsupportedMediaTypeRequest(response: APIResponse) {
   await assertStatusCode(response, 415);
   const json = await response.json();
-  assertRequiredFields(json, ['error']);
-  expect(json.error).toContain('Unsupported Media Type');
+  expect(json.title).toContain('Unsupported Media Type');
 }
 
 export async function assertBadRequest(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

According to the following [GitHub issue comment](https://github.com/camunda/camunda/issues/38510#issuecomment-3456373258), the Document 415 API tests need to be adjusted as they were previously asserting the wrong behaviour. This PR unskips the tests and adjusts the assertions accordingly. 

Successful test run [here](https://github.com/camunda/camunda/actions/runs/18902791578).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
