### PR TITLE
ci: ensure Minimus credentials in all places

### DIFF
--- a/.github/workflows/camunda-release-migration-test.yml
+++ b/.github/workflows/camunda-release-migration-test.yml
@@ -95,6 +95,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
       - uses: ./.github/actions/build-frontend
         name: Build Operate Frontend
         id: build-operate-fe

--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -18,7 +18,7 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
-jobs:  
+jobs:
   build-camunda:
     if: >
       github.event.pull_request.state != 'closed' && (
@@ -39,10 +39,11 @@ jobs:
         vault-address: ${{ secrets.VAULT_ADDR }}
         vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
         vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+        minimus: true
 
     - uses: ./.github/actions/build-zeebe
       id: build-camunda
-      with: 
+      with:
         maven-extra-args: -Dskip.fe.build=false
 
     - uses: ./.github/actions/build-platform-docker

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -128,6 +128,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
       - uses: ./.github/actions/build-frontend
         name: Build Operate Frontend
         id: build-operate-fe


### PR DESCRIPTION
## Description

Raised on [Slack](https://camunda.slack.com/archives/C08NZ7E9ZT2/p1761674113769789): https://github.com/camunda/camunda/actions/runs/18882320165/job/53888538746?pr=38687

This PR ensures all places that want to build `camunda.Dockerfile` have Minimus credentials enabled, fixing e.g. preview environment builds.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to #36903 
