### PR TITLE
fix: fix api-key input parameter for fossa checks

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -788,7 +788,7 @@ jobs:
       - name: Wait for FOSSA scan completion
         uses: camunda/infra-global-github-actions/fossa/wait-for-scan@3be9c0625ab9879b87b483d48d1bddfde496c70b
         with:
-          fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+          api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
           branch: ${{ steps.fossa-context.outputs.head-ref }}
           project-id: "custom+50756/camunda/camunda@single-app"
           revision-id: ${{ steps.fossa-context.outputs.head-revision }}
@@ -796,7 +796,7 @@ jobs:
       - name: Create FOSSA releases and generate reports
         uses: camunda/infra-global-github-actions/fossa/release@3be9c0625ab9879b87b483d48d1bddfde496c70b
         with:
-          fossa-api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+          api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
           branch: ${{ steps.fossa-context.outputs.head-ref }}
           project-id: "custom+50756/camunda/camunda@single-app"
           attribution-release-group-id: "4904" # https://app.fossa.com/projects/group/4904


### PR DESCRIPTION
## Description

Fix FOSSA failing checks on release workflows

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues
- https://github.com/camunda/camunda/actions/runs/18905343129/job/53966473193
- https://camunda.slack.com/archives/C06UWQNCU7M/p1761738111556209