### PR TITLE
[Backport main] ci: skip Identify previous release version if dry-run

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -291,6 +291,7 @@ jobs:
           chmod +x zcl
       - name: Identify previous release version
         id: prev_version
+        if: ${{ !inputs.dryRun }}
         uses: camunda/infra-global-github-actions/previous-version@main
         with:
           version: "${{ inputs.releaseVersion }}"


### PR DESCRIPTION
# Description
Backport of #40133 to `main`.

relates to 