### PR TITLE
feat: increase COMMIT_TRESHOLD

### DIFF
--- a/.ci/scripts/outdated-pr-scripts/process-pr.sh
+++ b/.ci/scripts/outdated-pr-scripts/process-pr.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # Configuration
-COMMIT_THRESHOLD="${COMMIT_THRESHOLD:-50}"
+COMMIT_THRESHOLD="${COMMIT_THRESHOLD:-100}"
 STALE_DAYS_THRESHOLD="${STALE_DAYS_THRESHOLD:-7}"
 
 # Get the script directory and source our library functions


### PR DESCRIPTION
Based on [developer feedback](https://camunda.slack.com/archives/C071KP5BTHB/p1761745879159199), the treshold is increased to 100. Based on the number of commits in the last 30 days

camunda git:(main) git log --oneline --since="30 days ago" --format="%cd" --date=short origin/main | sort | uniq -c
  22 2025-09-29
  47 2025-09-30
  47 2025-10-01
  64 2025-10-02
   8 2025-10-03
   1 2025-10-05
  31 2025-10-06
  40 2025-10-07
  45 2025-10-08
  19 2025-10-09
  59 2025-10-10
  40 2025-10-13
  39 2025-10-14
  52 2025-10-15
  37 2025-10-16
  57 2025-10-17
   9 2025-10-18
   4 2025-10-19
  34 2025-10-20
  49 2025-10-21
  60 2025-10-22
  66 2025-10-23
  39 2025-10-24
   2 2025-10-25
  99 2025-10-27
  37 2025-10-28
  16 2025-10-29
