### PR TITLE
POC: input size validation

### DIFF
--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -65,7 +65,10 @@ record MockProcessingResult(List<Event> records, Response response) implements P
 
     final @Override public Either<RuntimeException, ProcessingResultBuilder>
         appendRecordReturnEither(
-            final long key, final RecordValue value, final RecordMetadata metadata) {
+            final long key,
+            final RecordValue value,
+            final RecordMetadata metadata,
+            final boolean validateKeywordFieldSize) {
 
       final var record =
           new Event(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
@@ -21,13 +21,15 @@ public final class DataCfg implements ConfigurationEntry {
   public static final String DEFAULT_DIRECTORY = "data";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private static final DataSize DEFAULT_DATA_SIZE = DataSize.ofMegabytes(128);
+  private static final DataSize DEFAULT_MAX_KEYWORD_FIELD_SIZE =
+      DataSize.ofBytes(StreamProcessorContext.DEFAULT_DATA_MAX_KEYWORD_FIELD_SIZE);
   private String directory = DEFAULT_DIRECTORY;
 
   private String runtimeDirectory = null;
 
   private DataSize logSegmentSize = DEFAULT_DATA_SIZE;
 
-  private DataSize maxKeyWordFieldSize = StreamProcessorContext.DEFAULT_DATA_MAX_KEYWORD_FIELD_SIZE;
+  private DataSize maxKeyWordFieldSize = DEFAULT_MAX_KEYWORD_FIELD_SIZE;
 
   private Duration snapshotPeriod = Duration.ofMinutes(5);
 
@@ -120,7 +122,7 @@ public final class DataCfg implements ConfigurationEntry {
 
   public long getMaxKeyWordFieldSizeInBytes() {
     return Optional.ofNullable(maxKeyWordFieldSize)
-        .orElse(StreamProcessorContext.DEFAULT_DATA_MAX_KEYWORD_FIELD_SIZE)
+        .orElse(DEFAULT_MAX_KEYWORD_FIELD_SIZE)
         .toBytes();
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.configuration;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.stream.impl.StreamProcessorContext;
 import java.io.File;
 import java.time.Duration;
 import java.util.Optional;
@@ -20,12 +21,13 @@ public final class DataCfg implements ConfigurationEntry {
   public static final String DEFAULT_DIRECTORY = "data";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private static final DataSize DEFAULT_DATA_SIZE = DataSize.ofMegabytes(128);
-
   private String directory = DEFAULT_DIRECTORY;
 
   private String runtimeDirectory = null;
 
   private DataSize logSegmentSize = DEFAULT_DATA_SIZE;
+
+  private DataSize maxKeyWordFieldSize = StreamProcessorContext.DEFAULT_DATA_MAX_KEYWORD_FIELD_SIZE;
 
   private Duration snapshotPeriod = Duration.ofMinutes(5);
 
@@ -114,6 +116,20 @@ public final class DataCfg implements ConfigurationEntry {
 
   public void setLogSegmentSize(final DataSize logSegmentSize) {
     this.logSegmentSize = logSegmentSize;
+  }
+
+  public long getMaxKeyWordFieldSizeInBytes() {
+    return Optional.ofNullable(maxKeyWordFieldSize)
+        .orElse(StreamProcessorContext.DEFAULT_DATA_MAX_KEYWORD_FIELD_SIZE)
+        .toBytes();
+  }
+
+  public DataSize getMaxKeyWordFieldSize() {
+    return maxKeyWordFieldSize;
+  }
+
+  public void setMaxKeyWordFieldSize(final DataSize maxKeyWordFieldSize) {
+    this.maxKeyWordFieldSize = maxKeyWordFieldSize;
   }
 
   public Duration getSnapshotPeriod() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -171,6 +171,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .nodeId(context.getNodeId())
         .commandResponseWriter(context.getCommandApiService().newCommandResponseWriter())
         .maxCommandsInBatch(context.getBrokerCfg().getProcessing().getMaxCommandsInBatch())
+        .maxKeywordFieldSize(context.getBrokerCfg().getData().getMaxKeyWordFieldSize())
         .setEnableAsyncScheduledTasks(
             context.getBrokerCfg().getProcessing().isEnableAsyncScheduledTasks())
         .setScheduledTaskCheckInterval(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -171,7 +171,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .nodeId(context.getNodeId())
         .commandResponseWriter(context.getCommandApiService().newCommandResponseWriter())
         .maxCommandsInBatch(context.getBrokerCfg().getProcessing().getMaxCommandsInBatch())
-        .maxKeywordFieldSize(context.getBrokerCfg().getData().getMaxKeyWordFieldSize())
+        .maxKeywordFieldSize(context.getBrokerCfg().getData().getMaxKeyWordFieldSize().toBytes())
         .setEnableAsyncScheduledTasks(
             context.getBrokerCfg().getProcessing().isEnableAsyncScheduledTasks())
         .setScheduledTaskCheckInterval(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorImpl.java
@@ -21,7 +21,6 @@ public final class TypedRecordProcessorImpl<T extends UnifiedRecordValue>
     implements TypedRecordProcessor<T> {
 
   private final TypedRecordProcessor<T> wrappedProcessor;
-  private TypedRecord<T> commandIncoming;
 
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
@@ -35,21 +34,15 @@ public final class TypedRecordProcessorImpl<T extends UnifiedRecordValue>
 
   @Override
   public void processRecord(final TypedRecord<T> command) {
-    commandIncoming = command;
     wrappedProcessor.processRecord(command);
   }
 
   @Override
   public ProcessingError tryHandleError(final TypedRecord<T> command, final Throwable error) {
     if (error instanceof MsgpackPropertySizeException) {
-      rejectionWriter.appendRejection(
-          commandIncoming != null ? commandIncoming : command,
-          RejectionType.INVALID_ARGUMENT,
-          error.getMessage());
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, error.getMessage());
       responseWriter.writeRejectionOnCommand(
-          commandIncoming != null ? commandIncoming : command,
-          RejectionType.INVALID_ARGUMENT,
-          error.getMessage());
+          command, RejectionType.INVALID_ARGUMENT, error.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     }
     return wrappedProcessor.tryHandleError(command, error);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.msgpack.MsgpackPropertySizeException;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+@ExcludeAuthorizationCheck
+public final class TypedRecordProcessorImpl<T extends UnifiedRecordValue>
+    implements TypedRecordProcessor<T> {
+
+  private final TypedRecordProcessor<T> wrappedProcessor;
+  private TypedRecord<T> commandIncoming;
+
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+
+  public TypedRecordProcessorImpl(
+      final TypedRecordProcessor<T> wrappedProcessor, final Writers writers) {
+    this.wrappedProcessor = wrappedProcessor;
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<T> command) {
+    commandIncoming = command;
+    wrappedProcessor.processRecord(command);
+  }
+
+  @Override
+  public ProcessingError tryHandleError(final TypedRecord<T> command, final Throwable error) {
+    if (error instanceof MsgpackPropertySizeException) {
+      rejectionWriter.appendRejection(
+          commandIncoming != null ? commandIncoming : command,
+          RejectionType.INVALID_ARGUMENT,
+          error.getMessage());
+      responseWriter.writeRejectionOnCommand(
+          commandIncoming != null ? commandIncoming : command,
+          RejectionType.INVALID_ARGUMENT,
+          error.getMessage());
+      return ProcessingError.EXPECTED_ERROR;
+    }
+    return wrappedProcessor.tryHandleError(command, error);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessors.java
@@ -36,7 +36,11 @@ public final class TypedRecordProcessors {
 
   public TypedRecordProcessors onCommand(
       final ValueType valueType, final Intent intent, final TypedRecordProcessor<?> processor) {
-    recordProcessorMap.put(RecordType.COMMAND, valueType, intent.value(), processor);
+    recordProcessorMap.put(
+        RecordType.COMMAND,
+        valueType,
+        intent.value(),
+        new TypedRecordProcessorImpl<>(processor, writers));
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -70,7 +70,7 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
             .operationReference(metadata.getOperationReference())
             .batchOperationReference(metadata.getBatchOperationReference());
 
-    resultBuilder().appendRecord(key, value, recordMetadata);
+    resultBuilder().appendRecord(key, value, recordMetadata, true);
     eventApplier.applyState(key, intent, value, recordVersion);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -55,7 +55,7 @@ public class DeploymentRejectionTest {
   }
 
   @Test
-  public void shouldRejectDeploymentIfIdTooLong() {
+  public void shouldRejectDeploymentIfProcessIdTooLong() {
     // given
     final BpmnModelInstance process =
         Bpmn.createExecutableProcess("x".repeat(33 * 1024)).startEvent().endEvent().done();
@@ -65,8 +65,13 @@ public class DeploymentRejectionTest {
         ENGINE.deployment().withXmlResource(process).expectRejection().deploy();
 
     // then
-    Assertions.assertThat(rejectedDeployment.getRecordType())
-        .isEqualTo(RecordType.COMMAND_REJECTION);
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(
+            "Attribute validation errors: Property bpmnProcessId exceeding max size of 32768B.");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -55,6 +55,21 @@ public class DeploymentRejectionTest {
   }
 
   @Test
+  public void shouldRejectDeploymentIfIdTooLong() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("x".repeat(33 * 1024)).startEvent().endEvent().done();
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(process).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment.getRecordType())
+        .isEqualTo(RecordType.COMMAND_REJECTION);
+  }
+
+  @Test
   public void shouldRejectDeploymentIfNotValidDesignTimeAspect() {
     // given
     final String resource = "/processes/invalid_process.bpmn";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationRejectionTest.java
@@ -114,7 +114,7 @@ public final class MessageCorrelationRejectionTest {
             .withId("x".repeat(33 * 1024))
             .withName(messageName)
             .withCorrelationKey(correlationKey)
-            .expectRejection()
+            .expectGeneralRejection()
             .publish();
     // then
     Assertions.assertThat(rejectedRecord)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/PublishMessageClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/PublishMessageClient.java
@@ -44,6 +44,14 @@ public final class PublishMessageClient {
                   .withCorrelationKey(message.correlationKey)
                   .getFirst();
 
+  private static final Function<Message, Record<MessageRecordValue>>
+      GENERAL_REJECTION_EXPECTATION_SUPPLIER =
+          (message) ->
+              RecordingExporter.messageRecords(MessageIntent.PUBLISH)
+                  .onlyCommandRejections()
+                  .withCorrelationKey(message.correlationKey)
+                  .getFirst();
+
   private final MessageRecord messageRecord;
   private final CommandWriter writer;
   private final int partitionCount;
@@ -110,6 +118,11 @@ public final class PublishMessageClient {
 
   public PublishMessageClient expectRejection() {
     expectation = REJECTION_EXPECTATION_SUPPLIER;
+    return this;
+  }
+
+  public PublishMessageClient expectGeneralRejection() {
+    expectation = GENERAL_REJECTION_EXPECTATION_SUPPLIER;
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/stream/FakeProcessingResultBuilder.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/stream/FakeProcessingResultBuilder.java
@@ -59,6 +59,15 @@ public class FakeProcessingResultBuilder<V extends UnifiedRecordValue>
   @Override
   public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
       final long key, final RecordValue value, final RecordMetadata metadata) {
+    return appendRecordReturnEither(key, value, metadata, false);
+  }
+
+  @Override
+  public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
+      final long key,
+      final RecordValue value,
+      final RecordMetadata metadata,
+      final boolean validateKeywordFieldSize) {
     final int partitionId = Protocol.decodePartitionId(key);
     final var copiedRecord = new CopiedRecord<>((V) value, metadata, key, partitionId, -1, -1, -1);
     followupRecords.add(copiedRecord.copyOf());

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/MsgpackPropertySizeException.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/MsgpackPropertySizeException.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.msgpack;
+
+public class MsgpackPropertySizeException extends RuntimeException {
+
+  public MsgpackPropertySizeException(final String message) {
+    super(message);
+  }
+}

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
@@ -64,7 +64,7 @@ public abstract class BaseProperty<T extends BaseValue> implements Recyclable {
     return key;
   }
 
-  protected T resolveValue() {
+  public T resolveValue() {
     if (isSet) {
       return value;
     } else if (defaultValue != null) {

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.msgpack.value;
 
+import io.camunda.zeebe.msgpack.MsgpackPropertySizeException;
 import io.camunda.zeebe.msgpack.property.BaseProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.property.UndeclaredProperty;
@@ -239,7 +240,7 @@ public class ObjectValue extends BaseValue {
       return Either.right(null);
     }
     return Either.left(
-        new IllegalArgumentException(
+        new MsgpackPropertySizeException(
             "Attribute validation errors: " + String.join(" ", validationErrors)));
   }
 }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import org.springframework.util.unit.DataSize;
 
 public class ObjectValue extends BaseValue {
   private final List<BaseProperty<? extends BaseValue>> declaredProperties;
@@ -225,14 +224,14 @@ public class ObjectValue extends BaseValue {
     return declaredProperties.isEmpty() && undeclaredProperties.isEmpty();
   }
 
-  public Either<RuntimeException, Void> validateKeywordFields(final DataSize maxSize) {
+  public Either<RuntimeException, Void> validateKeywordFields(final long maxSize) {
     final var validationErrors = new ArrayList<String>();
     declaredProperties.forEach(
         prop -> {
           if (prop instanceof final StringProperty stringProperty
-              && stringProperty.resolveValue().getEncodedLength() > maxSize.toBytes()) {
+              && stringProperty.resolveValue().getEncodedLength() > maxSize) {
             validationErrors.add(
-                "Property " + stringProperty.getKey() + " exceeding max size of " + maxSize + ".");
+                "Property " + stringProperty.getKey() + " exceeding max size of " + maxSize + "B.");
           }
         });
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
@@ -28,9 +28,17 @@ public interface ProcessingResultBuilder {
    *     RecordBatch
    */
   default ProcessingResultBuilder appendRecord(
-      final long key, final RecordValue value, final RecordMetadata metadata)
+      final long key, final RecordValue value, final RecordMetadata metadata) {
+    return appendRecord(key, value, metadata, false);
+  }
+
+  default ProcessingResultBuilder appendRecord(
+      final long key,
+      final RecordValue value,
+      final RecordMetadata metadata,
+      final boolean validateKeywordFieldSize)
       throws RuntimeException {
-    final var either = appendRecordReturnEither(key, value, metadata);
+    final var either = appendRecordReturnEither(key, value, metadata, validateKeywordFieldSize);
 
     if (either.isLeft()) {
       // This is how we handled too big record batches as well, except that this is now a
@@ -50,8 +58,24 @@ public interface ProcessingResultBuilder {
    *
    * @return returns either a failure or itself for chaining
    */
+  default Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
+      final long key, final RecordValue value, final RecordMetadata metadata) {
+    return appendRecordReturnEither(key, value, metadata, false);
+  }
+
+  /**
+   * Appends a record to the result, returns an {@link Either<RuntimeException,
+   * ProcessingResultBuilder>} which indicates whether the appending was successful or not. This is
+   * useful in case were potentially we could reach the record batch limit size. The return either
+   * allows to handle such error case gracefully.
+   *
+   * @return returns either a failure or itself for chaining
+   */
   Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
-      final long key, final RecordValue value, final RecordMetadata metadata);
+      final long key,
+      final RecordValue value,
+      final RecordMetadata metadata,
+      final boolean validateKeywordFieldSize);
 
   /**
    * Sets the response for the result; will be overwritten if called more than once

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -30,7 +30,6 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.StringUtil;
 import java.util.ArrayList;
 import java.util.List;
-import org.springframework.util.unit.DataSize;
 
 /**
  * Implementation of {@code ProcessingResultBuilder} that buffers the processing results. After
@@ -46,10 +45,10 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   private final long operationReference;
   private boolean processInASeparateBatch = false;
   private final long batchOperationReference;
-  private final DataSize maxKeywordFieldSize;
+  private final long maxKeywordFieldSize;
 
   BufferedProcessingResultBuilder(
-      final RecordBatchSizePredicate predicate, final DataSize maxKeywordFieldSize) {
+      final RecordBatchSizePredicate predicate, final long maxKeywordFieldSize) {
     this(
         predicate,
         operationReferenceNullValue(),
@@ -61,7 +60,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
       final RecordBatchSizePredicate predicate,
       final long operationReference,
       final long batchOperationReference,
-      final DataSize maxKeywordFieldSize) {
+      final long maxKeywordFieldSize) {
     mutableRecordBatch = new RecordBatch(predicate);
     this.operationReference = operationReference;
     this.batchOperationReference = batchOperationReference;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -70,7 +70,10 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
 
   @Override
   public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
-      final long key, final RecordValue value, final RecordMetadata metadata) {
+      final long key,
+      final RecordValue value,
+      final RecordMetadata metadata,
+      final boolean validateKeywordFieldSize) {
 
     // `operationReference` from `metadata` should have a higher precedence
     if (metadata.getOperationReference() == operationReferenceNullValue()) {
@@ -97,10 +100,12 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
     }
 
     // validate record keyword fields
-    final var validationResult =
-        ((UnifiedRecordValue) value).validateKeywordFields(maxKeywordFieldSize);
-    if (validationResult.isLeft()) {
-      return Either.left(validationResult.getLeft());
+    if (validateKeywordFieldSize) {
+      final var validationResult =
+          ((UnifiedRecordValue) value).validateKeywordFields(maxKeywordFieldSize);
+      if (validationResult.isLeft()) {
+        return Either.left(validationResult.getLeft());
+      }
     }
 
     final var metadataWithValueType = metadata.valueType(valueType);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -182,7 +182,7 @@ public final class ProcessingStateMachine {
     abortCondition = context.getAbortCondition();
     lastProcessedPositionState = context.getLastProcessedPositionState();
     maxCommandsInBatch = context.getMaxCommandsInBatch();
-    maxKeywordFieldSize = context.getMaxKeywordFieldSize().toBytes();
+    maxKeywordFieldSize = context.getMaxKeywordFieldSize();
 
     writeRetryStrategy = new AbortableRetryStrategy(actor);
     sideEffectsRetryStrategy = new AbortableRetryStrategy(actor);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -56,7 +56,6 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
-import org.springframework.util.unit.DataSize;
 
 /**
  * Represents the processing state machine, which is executed on normal processing.
@@ -160,7 +159,7 @@ public final class ProcessingStateMachine {
   private final LogStreamWriter logStreamWriter;
   private boolean inProcessing;
   private final int maxCommandsInBatch;
-  private final DataSize maxKeywordFieldSize;
+  private final long maxKeywordFieldSize;
   private int processedCommandsCount;
   private final ProcessingMetrics processingMetrics;
   private final ScheduledCommandCache scheduledCommandCache;
@@ -183,7 +182,7 @@ public final class ProcessingStateMachine {
     abortCondition = context.getAbortCondition();
     lastProcessedPositionState = context.getLastProcessedPositionState();
     maxCommandsInBatch = context.getMaxCommandsInBatch();
-    maxKeywordFieldSize = context.getMaxKeywordFieldSize();
+    maxKeywordFieldSize = context.getMaxKeywordFieldSize().toBytes();
 
     writeRetryStrategy = new AbortableRetryStrategy(actor);
     sideEffectsRetryStrategy = new AbortableRetryStrategy(actor);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import org.springframework.util.unit.DataSize;
 
 public final class StreamProcessorBuilder {
 
@@ -151,6 +152,11 @@ public final class StreamProcessorBuilder {
 
   public StreamProcessorBuilder maxCommandsInBatch(final int maxCommandsInBatch) {
     streamProcessorContext.maxCommandsInBatch(maxCommandsInBatch);
+    return this;
+  }
+
+  public StreamProcessorBuilder maxKeywordFieldSize(final DataSize maxKeywordFieldSize) {
+    streamProcessorContext.maxKeywordFieldSize(maxKeywordFieldSize);
     return this;
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import org.springframework.util.unit.DataSize;
 
 public final class StreamProcessorBuilder {
 
@@ -155,7 +154,7 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public StreamProcessorBuilder maxKeywordFieldSize(final DataSize maxKeywordFieldSize) {
+  public StreamProcessorBuilder maxKeywordFieldSize(final long maxKeywordFieldSize) {
     streamProcessorContext.maxKeywordFieldSize(maxKeywordFieldSize);
     return this;
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -26,12 +26,11 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
-import org.springframework.util.unit.DataSize;
 
 public final class StreamProcessorContext implements ReadonlyStreamProcessorContext {
 
   public static final int DEFAULT_MAX_COMMANDS_IN_BATCH = 100;
-  public static final DataSize DEFAULT_DATA_MAX_KEYWORD_FIELD_SIZE = DataSize.ofKilobytes(32);
+  public static final long DEFAULT_DATA_MAX_KEYWORD_FIELD_SIZE = 32 * 1024;
 
   private static final StreamProcessorListener NOOP_LISTENER = processedCommand -> {};
   private ActorControl actor;
@@ -55,7 +54,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private volatile StreamProcessor.Phase phase = Phase.INITIAL;
   private KeyGeneratorControls keyGeneratorControls;
   private int maxCommandsInBatch = DEFAULT_MAX_COMMANDS_IN_BATCH;
-  private DataSize maxKeywordFieldSize = DEFAULT_DATA_MAX_KEYWORD_FIELD_SIZE;
+  private long maxKeywordFieldSize = DEFAULT_DATA_MAX_KEYWORD_FIELD_SIZE;
   private boolean enableAsyncScheduledTasks = true;
   private EventFilter processingFilter = e -> true;
   private ControllableStreamClock clock;
@@ -227,11 +226,11 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
     return maxCommandsInBatch;
   }
 
-  public DataSize getMaxKeywordFieldSize() {
+  public long getMaxKeywordFieldSize() {
     return maxKeywordFieldSize;
   }
 
-  public StreamProcessorContext maxKeywordFieldSize(final DataSize maxKeywordFieldSize) {
+  public StreamProcessorContext maxKeywordFieldSize(final long maxKeywordFieldSize) {
     this.maxKeywordFieldSize = maxKeywordFieldSize;
     return this;
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -26,10 +26,13 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
+import org.springframework.util.unit.DataSize;
 
 public final class StreamProcessorContext implements ReadonlyStreamProcessorContext {
 
   public static final int DEFAULT_MAX_COMMANDS_IN_BATCH = 100;
+  public static final DataSize DEFAULT_DATA_MAX_KEYWORD_FIELD_SIZE = DataSize.ofKilobytes(32);
+
   private static final StreamProcessorListener NOOP_LISTENER = processedCommand -> {};
   private ActorControl actor;
   private LogStream logStream;
@@ -52,6 +55,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private volatile StreamProcessor.Phase phase = Phase.INITIAL;
   private KeyGeneratorControls keyGeneratorControls;
   private int maxCommandsInBatch = DEFAULT_MAX_COMMANDS_IN_BATCH;
+  private DataSize maxKeywordFieldSize = DEFAULT_DATA_MAX_KEYWORD_FIELD_SIZE;
   private boolean enableAsyncScheduledTasks = true;
   private EventFilter processingFilter = e -> true;
   private ControllableStreamClock clock;
@@ -221,6 +225,15 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public int getMaxCommandsInBatch() {
     return maxCommandsInBatch;
+  }
+
+  public DataSize getMaxKeywordFieldSize() {
+    return maxKeywordFieldSize;
+  }
+
+  public StreamProcessorContext maxKeywordFieldSize(final DataSize maxKeywordFieldSize) {
+    this.maxKeywordFieldSize = maxKeywordFieldSize;
+    return this;
   }
 
   public StreamProcessorContext setEnableAsyncScheduledTasks(final boolean enabled) {

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorErrorHandlingTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorErrorHandlingTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.stream.util.Records;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.verification.VerificationWithTimeout;
+import org.springframework.util.unit.DataSize;
 
 @ExtendWith(StreamPlatformExtension.class)
 class StreamProcessorErrorHandlingTest {
@@ -81,7 +82,8 @@ class StreamProcessorErrorHandlingTest {
   void shouldContinueProcessingEvenIfErrorHandlingFailedForUserCommand() {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
-    final var successResult = new BufferedProcessingResultBuilder((c, s) -> true);
+    final var successResult =
+        new BufferedProcessingResultBuilder((c, s) -> true, DataSize.ofKilobytes(32));
     successResult.appendRecordReturnEither(
         1,
         Records.processInstance(1),

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorErrorHandlingTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorErrorHandlingTest.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.stream.util.Records;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.verification.VerificationWithTimeout;
-import org.springframework.util.unit.DataSize;
 
 @ExtendWith(StreamPlatformExtension.class)
 class StreamProcessorErrorHandlingTest {
@@ -82,8 +81,7 @@ class StreamProcessorErrorHandlingTest {
   void shouldContinueProcessingEvenIfErrorHandlingFailedForUserCommand() {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
-    final var successResult =
-        new BufferedProcessingResultBuilder((c, s) -> true, DataSize.ofKilobytes(32));
+    final var successResult = new BufferedProcessingResultBuilder((c, s) -> true, 32 * 1024);
     successResult.appendRecordReturnEither(
         1,
         Records.processInstance(1),

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -71,14 +71,13 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.mockito.verification.VerificationWithTimeout;
-import org.springframework.util.unit.DataSize;
 
 @ExtendWith(StreamPlatformExtension.class)
 public final class StreamProcessorTest {
 
   private static final long TIMEOUT_MILLIS = 2_000L;
   private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);
-  private static final DataSize MAX_FIELD_SIZE = DataSize.ofKilobytes(32);
+  private static final long MAX_FIELD_SIZE = 32 * 1024;
 
   @SuppressWarnings("unused") // injected by the extension
   private StreamPlatform streamPlatform;


### PR DESCRIPTION
## Description

* Validates the size of user input for String properties before adding event records to the log.
* Creates proper rejections to user commands and rolls back other records and changes before the validation exception.
* Transparently handles exceeded size exceptions for all existing and future record processors.
* Tests exceeded sizes for some user commands (deployment, message correlation)

Notes:
* This doesn't fail deployments where the ID of an activity is too long. This requires BPMN validation.
* This fails, though, if that activity is supposed to be activated.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #37952 
