### PR TITLE
ci: use zeebe docker version for optimize release job

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -375,7 +375,7 @@ jobs:
         env:
           OPTIMIZE_IMAGE_TAG: ${{ env.RELEASE_VERSION }}
           ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
-          ZEEBE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_version }}
+          ZEEBE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_docker_version }}
           IDENTITY_VERSION: ${{ steps.pom-info.outputs.x_identity_version }}
 
       - name: Wait for Optimize to start


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
It seems with [this change](https://github.com/camunda/camunda/pull/36881) optimize started using zeebe snapshot versions in the pom.
This caused the optimize release job to fail as the smoke test steps runs zeebe from docker with 8.x.x-SNAPSHOT version which we do not push to docker. So i got [this error](https://github.com/camunda/camunda/actions/runs/18913498596/job/53990477172) on the release job:
`Error manifest for camunda/zeebe:8.9.0-SNAPSHOT`


In this PR, i changed the optimize release workflow to use the zeebe docker version instead. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
