### PR TITLE
perf: avoid runtime flush on shutdown

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
@@ -117,7 +117,7 @@ public final class ExporterRule implements TestRule {
       final Function<RecordExporter, RecordExporter> recordExporter) {
     final var stream = streams.getLogStream(STREAM_NAME);
     final var runtimeFolder = streams.createRuntimeFolder(stream);
-    capturedZeebeDb = spy(zeebeDbFactory.createDb(runtimeFolder.toFile()));
+    capturedZeebeDb = spy(zeebeDbFactory.createDb(runtimeFolder.toFile(), false));
 
     final var descriptorsWithInitializationInfo =
         exporterDescriptors.stream()

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTransactionErrorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTransactionErrorTest.java
@@ -99,6 +99,11 @@ final class StreamProcessorTransactionErrorTest {
     }
 
     @Override
+    public ZeebeDb<ZbColumnFamilies> createDb(final File pathName, final boolean avoidFlush) {
+      return new ErrorProneZeebeDb(delegate.createDb(pathName), commitException);
+    }
+
+    @Override
     public ZeebeDb<ZbColumnFamilies> createDb(final File pathName) {
       return new ErrorProneZeebeDb(delegate.createDb(pathName), commitException);
     }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDbFactory.java
@@ -18,13 +18,15 @@ import java.io.File;
  */
 public interface ZeebeDbFactory<ColumnFamilyNames extends Enum<? extends EnumValue> & EnumValue> {
 
+  ZeebeDb<ColumnFamilyNames> createDb(final File pathName, final boolean avoidFlush);
+
   /**
    * Creates a zeebe database in the given directory.
    *
    * @param pathName the path where the database should be created
    * @return the created zeebe database
    */
-  ZeebeDb<ColumnFamilyNames> createDb(File pathName);
+  ZeebeDb<ColumnFamilyNames> createDb(final File pathName);
 
   /**
    * Opens an existing DB in read-only mode for the sole purpose of creating snapshots from it.

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
@@ -26,7 +26,7 @@ public class RocksDBSnapshotCopy implements SnapshotCopy {
       final Path fromPath, final Path toPath, final Set<ColumnFamilyScope> scopes) {
     try (final var fromDB =
             (SnapshotOnlyDb<ZbColumnFamilies>) factory.openSnapshotOnlyDb(fromPath.toFile());
-        final var toDB = factory.createDb(toPath.toFile())) {
+        final var toDB = factory.createDb(toPath.toFile(), false)) {
       fromDB.copySnapshot(toDB, scopes);
     }
   }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -118,6 +118,9 @@ public final class ZeebeRocksDbFactory<
     props.put("file_checksum_gen_factory", "FileChecksumGenCrc32cFactory");
     //    Enables full file checksum
 
+    // No sense in flushing data that we will just discard anyway. We always recover from snapshot.
+    props.setProperty("avoid_flush_during_shutdown", "true");
+
     final var dbOptions =
         DBOptions.getDBOptionsFromProps(props)
             .setErrorIfExists(false)

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -192,7 +192,7 @@ final class ZeebeRocksDbFactoryTest {
     key.wrapString("foo");
     value.wrapString("bar");
 
-    try (final var db = factory.createDb(path)) {
+    try (final var db = factory.createDb(path, false)) {
       final var column =
           db.createColumnFamily(
               DefaultColumnFamily.DEFAULT, db.createContext(), new DbString(), new DbString());

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbTest.java
@@ -57,7 +57,7 @@ final class ZeebeRocksDbTest {
   void shouldReopenDb(final @TempDir File pathName) throws Exception {
     // given
     final ZeebeDbFactory<DefaultColumnFamily> dbFactory = DefaultZeebeDbFactory.getDefaultFactory();
-    ZeebeDb<DefaultColumnFamily> db = dbFactory.createDb(pathName);
+    ZeebeDb<DefaultColumnFamily> db = dbFactory.createDb(pathName, false);
 
     final DbString key = new DbString();
     key.wrapString("foo");


### PR DESCRIPTION
We don't need to flush unwritten data on shutdown because we never reuse a runtime and recover from snapshot instead. Some tests that still require flush on shutdown, for example because they manually use a `ZeebeDb` and circumvent the snapshot recovery, still opt-in to flush on shutdown.

relates to #39932