### PR TITLE
ci: skip generate changelog when dryrun

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -297,6 +297,7 @@ jobs:
           verbose: 'false'
       - name: Generate Changelog
         id: gen-changelog
+        if: ${{ !inputs.dryRun }}
         run: |
           # We set some bash properties to better fail/debug this script
           #


### PR DESCRIPTION
## Description

This pull request introduces a small change to the Camunda Platform release workflow. The change ensures that the "Generate Changelog" step is only executed when the workflow is not running in dry run mode.

Reasoning:
Current issue is related to [comparing the fake dry-run version to an existing tag](https://github.com/camunda/camunda/actions/runs/18909852141/job/53980723308):
```
0s
Run # We set some bash properties to better fail/debug this script
+ changelog='Release 0.0.0-dryrun-88'
+ ZCL_FROM_REV=
+ ZCL_TARGET_REV=0.0.0-dryrun-88
+ ./zcl add-labels --token=*** --from= --target=0.0.0-dryrun-88 --label=version:0.0.0-dryrun-88 --org camunda --repo camunda
2025/10/29 14:11:49 Fetching git history in dir . for  .. 0.0.0-dryrun-88
2025/10/29 14:11:49 /usr/bin/git -C . log -1 --format=%ai 
2025/10/29 14:11:49 fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
exit status 128
Error: Process completed with exit code 1.
```

After a quick review of what this step does, and reviewing this [document](https://docs.google.com/document/d/1h-NCavkat0plZehcHviRdXSKBV8vlmrn/edit#heading=h.pyluvfbz6lhi). We should skip the Generate Changelog step in dry runs because it depends on resolved release tags and interacts with labeling, both of which we avoid or fake during dry runs to prevent side effects. The dry-run design explicitly skips steps that either cause external side effects or rely on published artifacts (e.g., Maven Central publishing, post-release flows), and advises caution around tags due to unintended workflow triggers. In this context, Generate Changelog’s dependencies and side effects are not required for dry-run verification and can fail or be misleading when tags are stubbed.

Related to: https://github.com/camunda/camunda/pull/40040

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
