### PR TITLE
[Backport stable/8.8] fix: snapshot for bootstrap should not always be reserved 

### DIFF
--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -151,9 +151,7 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
 
   @Override
   public boolean isReserved() {
-    // bootstrap snapshots are not deleted following the normal procedure, they are deleted when the
-    // scaling operation has been terminated
-    return !reservations.isEmpty() || (metadata != null && metadata.isBootstrap());
+    return !reservations.isEmpty();
   }
 
   void delete() {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotTest.java
@@ -110,7 +110,7 @@ public final class FileBasedSnapshotTest {
   }
 
   @Test
-  public void shouldMarkAsReservedBootstrappedSnapshots() throws IOException {
+  public void shoulNotdMarkAsReservedBootstrappedSnapshots() throws IOException {
     // given
     final var metadata = new FileBasedSnapshotMetadata(1, 1L, 1L, 0, true);
     final var snapshotPath = snapshotDir.resolve("snapshot");
@@ -120,7 +120,7 @@ public final class FileBasedSnapshotTest {
     final var snapshot = createSnapshot(snapshotPath, checksumPath, metadata);
 
     // then
-    assertThat(snapshot.isReserved()).isTrue();
+    assertThat(snapshot.isReserved()).isFalse();
     assertThat(snapshot.isBootstrap()).isTrue();
   }
 


### PR DESCRIPTION
# Description
Backport of #40147 to `stable/8.8`.

relates to #39967