### PR TITLE
fix: actually call log flush instead of looping

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -660,7 +660,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
       return CompletableFuture.completedFuture(null);
     }
 
-    return CompletableFuture.runAsync(CheckedRunnable.toUnchecked(this::flushLog), threadContext);
+    return CompletableFuture.runAsync(CheckedRunnable.toUnchecked(raftLog::flush), threadContext);
   }
 
   /**


### PR DESCRIPTION
This fixes an issue with non-direct flush where the raft layer tries to flush explicitly on role changes. The bug was that we'd just end up recursively call ourselves instead of actually calling the flush method on the `raftLog`.