### PR TITLE
perf: avoid blocking IO for RocksDB

### DIFF
--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -120,6 +120,7 @@ public final class ZeebeRocksDbFactory<
 
     final var dbOptions =
         DBOptions.getDBOptionsFromProps(props)
+            .setAvoidUnnecessaryBlockingIO(true)
             .setErrorIfExists(false)
             .setCreateIfMissing(true)
             .setParanoidChecks(true)


### PR DESCRIPTION
Enables a RocksDB config option that tries to push blocking IO to a background thread if possible. They recommend that option for latency sensitive workloads.

relates to #39932