### PR TITLE
test: improve performances of Zeebe QA test

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/startup/StartupProcess.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/startup/StartupProcess.java
@@ -195,7 +195,7 @@ public final class StartupProcess<CONTEXT> {
           (contextReturnedByStep, error) -> {
             final var completedAt = System.nanoTime();
             logger.debug(
-                "StartupStep {} completed (error={}) took {} millis ",
+                "StartupStep {} startup completed (error={}) took {} millis ",
                 stepToStart.getName(),
                 error != null,
                 (completedAt - before) / 1e6);
@@ -272,6 +272,7 @@ public final class StartupProcess<CONTEXT> {
       completeShutdownFutureSynchronized(context, shutdownFuture, collectedExceptions);
     } else {
       final var stepToShutdown = startedSteps.pop();
+      final var before = System.nanoTime();
 
       logCurrentStepSynchronized("Shutdown", stepToShutdown);
 
@@ -281,6 +282,7 @@ public final class StartupProcess<CONTEXT> {
           shutdownStepFuture,
           (contextReturnedByShutdown, error) -> {
             final CONTEXT contextToUse;
+            final var completedAt = System.nanoTime();
             if (error != null) {
               collectedExceptions.add(
                   new StartupProcessStepException(stepToShutdown.getName(), error));
@@ -288,7 +290,11 @@ public final class StartupProcess<CONTEXT> {
             } else {
               contextToUse = contextReturnedByShutdown;
             }
-
+            logger.debug(
+                "StartupStep {} shutdown completed (error={}) took {} millis ",
+                stepToShutdown.getName(),
+                error != null,
+                (completedAt - before) / 1e6);
             proceedWithShutdownSynchronized(
                 concurrencyControl, contextToUse, shutdownFuture, collectedExceptions);
           });


### PR DESCRIPTION
## Description
In this PR we drastically decrease the test duration of Zeebe QA tests that involve shutting down brokers. 
In particular, I tested the time it took for a single test case of `ScaleUpPartitionsTest` going down from 35-40s to 20-25s.

I identified another potential improvement related to the initial SYNC initialization of the dynamic config that can be made configurable to a lower value (now it's 5s), but it will be addressed in another PR.

The major factor to the slowdown was fixed in this [commit](https://github.com/camunda/camunda/commit/0b15e34e106935734c986b0cf29dc24872f29cb7):

The `ZeebeIntegrationExtension` was deleting the broker folder before the broker even started shutting down.
This created problems, particularly in RocksDB, that for some reason not yet identified, it was taking a **linear** time to close the DB. What's really strange is that it was taking around ~1 second for each `OptimisticTransactionDB` that was open:

```
Closed clsoeable org.rocksdb.OptimisticTransactionDB@2f310c67 took 14 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@2598df1e took 1026 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@3cd65a1f took 2025 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@784a86d3 took 3013 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@2c3ff74c took 4011 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@37d37ba took 5003 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@3a12a6fe took 6011 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@17e658a6 took 7000 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@e2675e3 took 8001 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@737a0a2e took 8998 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@75d4f085 took 9989 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@23c6ee2c took 10927 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@30b4acfd took 11917 
```

After that fix, the time taken is around 80millis:
```
Closeable org.rocksdb.OptimisticTransactionDB@693fa70b took 70 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@79d724a took 84 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@3f9172c7 took 78 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@4c863558 took 25 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@6087eaa3 took 26 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@5c86a5e9 took 54 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@7703548c took 55 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@3dc28bca took 76 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@7b4de589 took 93 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@4e38985 took 80 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@1dd584ab took 55 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@738fe9d0 took 81 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@44ea40 took 76 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@693fa70b took 70 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@79d724a took 84 
Closed clsoeable org.rocksdb.OptimisticTransactionDB@3f9172c7 took 78 
```

## Checklist

## Related issues
relates  #39858 
