### PR TITLE
[Backport stable/8.6] fix: actually call log flush instead of looping

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -621,7 +621,11 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
       return CompletableFuture.completedFuture(null);
     }
 
+<<<<<<< HEAD
     return CompletableFuture.runAsync(raftLog::forceFlush, threadContext);
+=======
+    return CompletableFuture.runAsync(CheckedRunnable.toUnchecked(raftLog::flush), threadContext);
+>>>>>>> 413eb933 (fix: actually call log flush instead of looping)
   }
 
   /**


### PR DESCRIPTION
# Description
Backport of #40198 to `stable/8.6`.

relates to 