### PR TITLE
Migrate global user task listeners configuration to Unified Configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CONTACT_POINT_PORT;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenersCfg;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -103,6 +104,13 @@ public class Cluster implements Cloneable {
    * <p>Note: When there is no latency enabling this may have a performance impact.
    */
   private CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.NONE;
+
+  /**
+   * Configuration for global listeners defined at cluster-level instead of directly in the BPMN
+   * model.
+   */
+  @NestedConfigurationProperty
+  private GlobalListenersCfg globalListeners = new GlobalListenersCfg();
 
   public Metadata getMetadata() {
     return metadata;
@@ -225,6 +233,14 @@ public class Cluster implements Cloneable {
 
   public void setCompressionAlgorithm(final CompressionAlgorithm compressionAlgorithm) {
     this.compressionAlgorithm = compressionAlgorithm;
+  }
+
+  public GlobalListenersCfg getGlobalListeners() {
+    return globalListeners;
+  }
+
+  public void setGlobalListeners(final GlobalListenersCfg globalListeners) {
+    this.globalListeners = globalListeners;
   }
 
   @Override

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -301,6 +301,8 @@ public class BrokerBasedPropertiesOverride {
         .getCluster()
         .setMessageCompression(
             CompressionAlgorithm.valueOf(cluster.getCompressionAlgorithm().name()));
+
+    populateFromGlobalListeners(override);
   }
 
   private void populateFromLongPolling(final BrokerBasedProperties override) {
@@ -879,5 +881,12 @@ public class BrokerBasedPropertiesOverride {
 
     exporters.forEach(
         (name, exporter) -> override.getExporters().put(name, exporter.toExporterCfg()));
+  }
+
+  private void populateFromGlobalListeners(final BrokerBasedProperties override) {
+    override
+        .getExperimental()
+        .getEngine()
+        .setGlobalListeners(unifiedConfiguration.getCamunda().getCluster().getGlobalListeners());
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/ClusterGlobalListenersTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterGlobalListenersTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenerCfg;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class ClusterGlobalListenersTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.global-listeners.user-task.0.type=my-type",
+        "camunda.cluster.global-listeners.user-task.0.event-types.0=creating",
+        "camunda.cluster.global-listeners.user-task.0.event-types.1=assigning",
+        "camunda.cluster.global-listeners.user-task.0.retries=5",
+        "camunda.cluster.global-listeners.user-task.0.after-non-global=true"
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetTaskListenerType() {
+      final List<GlobalListenerCfg> taskListeners =
+          brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask();
+      assertThat(taskListeners).hasSize(1);
+      assertThat(taskListeners.getFirst().getType()).isEqualTo("my-type");
+    }
+
+    @Test
+    void shouldSetTaskListenerEventTypes() {
+      final List<GlobalListenerCfg> taskListeners =
+          brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask();
+      assertThat(taskListeners).hasSize(1);
+      assertThat(taskListeners.getFirst().getEventTypes()).containsExactly("creating", "assigning");
+    }
+
+    @Test
+    void shouldSetTaskListenerRetries() {
+      final List<GlobalListenerCfg> taskListeners =
+          brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask();
+      assertThat(taskListeners).hasSize(1);
+      assertThat(taskListeners.getFirst().getRetries()).isEqualTo("5");
+    }
+
+    @Test
+    void shouldSetTaskListenerAfterNonGlobalFlag() {
+      final List<GlobalListenerCfg> taskListeners =
+          brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask();
+      assertThat(taskListeners).hasSize(1);
+      assertThat(taskListeners.getFirst().isAfterNonGlobal()).isEqualTo(true);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.engine.globalListeners.userTask.0.type=my-type",
+        "zeebe.broker.experimental.engine.globalListeners.userTask.0.eventTypes.0=creating",
+        "zeebe.broker.experimental.engine.globalListeners.userTask.0.eventTypes.1=assigning",
+        "zeebe.broker.experimental.engine.globalListeners.userTask.0.retries=5",
+        "zeebe.broker.experimental.engine.globalListeners.userTask.0.afterNonGlobal=true"
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldIgnoreLegacyConfiguration() {
+      final List<GlobalListenerCfg> taskListeners =
+          brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask();
+      assertThat(taskListeners).hasSize(0);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.global-listeners.user-task.0.type=my-type",
+        "camunda.cluster.global-listeners.user-task.0.event-types.0=creating",
+        "camunda.cluster.global-listeners.user-task.0.event-types.1=assigning",
+        "camunda.cluster.global-listeners.user-task.0.retries=5",
+        "camunda.cluster.global-listeners.user-task.0.after-non-global=true",
+        "zeebe.broker.experimental.engine.globalListeners.userTask.0.type=my-other-type",
+        "zeebe.broker.experimental.engine.globalListeners.userTask.0.eventTypes.0=updating",
+        "zeebe.broker.experimental.engine.globalListeners.userTask.0.retries=4",
+        "zeebe.broker.experimental.engine.globalListeners.userTask.0.afterNonGlobal=false"
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetTaskListenerTypeFromNew() {
+      final List<GlobalListenerCfg> taskListeners =
+          brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask();
+      assertThat(taskListeners).hasSize(1);
+      assertThat(taskListeners.getFirst().getType()).isEqualTo("my-type");
+    }
+
+    @Test
+    void shouldSetTaskListenerEventTypesFromNew() {
+      final List<GlobalListenerCfg> taskListeners =
+          brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask();
+      assertThat(taskListeners).hasSize(1);
+      assertThat(taskListeners.getFirst().getEventTypes()).containsExactly("creating", "assigning");
+    }
+
+    @Test
+    void shouldSetTaskListenerRetriesFromNew() {
+      final List<GlobalListenerCfg> taskListeners =
+          brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask();
+      assertThat(taskListeners).hasSize(1);
+      assertThat(taskListeners.getFirst().getRetries()).isEqualTo("5");
+    }
+
+    @Test
+    void shouldSetTaskListenerAfterNonGlobalFlagFromNew() {
+      final List<GlobalListenerCfg> taskListeners =
+          brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask();
+      assertThat(taskListeners).hasSize(1);
+      assertThat(taskListeners.getFirst().isAfterNonGlobal()).isEqualTo(true);
+    }
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -448,7 +448,7 @@ public final class SystemContext {
   }
 
   private void validateListenersConfig(final GlobalListenersCfg listeners) {
-    final String propertyLocation = "experimental.engine.globalListeners.userTask";
+    final String propertyLocation = "camunda.cluster.global-listeners.user-task";
     final List<String> supportedEventTypes = GlobalListenerConfiguration.TASK_LISTENER_EVENT_TYPES;
     final List<GlobalListenerCfg> taskListeners = listeners.getUserTask();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -21,7 +21,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private UsageMetricsCfg usageMetrics = new UsageMetricsCfg();
   private DistributionCfg distribution = new DistributionCfg();
   private int maxProcessDepth = EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH;
-  private ListenersCfg listeners = new ListenersCfg();
+  private GlobalListenersCfg globalListeners = new GlobalListenersCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -32,7 +32,7 @@ public final class EngineCfg implements ConfigurationEntry {
     validators.init(globalConfig, brokerBase);
     distribution.init(globalConfig, brokerBase);
     usageMetrics.init(globalConfig, brokerBase);
-    listeners.init(globalConfig, brokerBase);
+    globalListeners.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -99,12 +99,12 @@ public final class EngineCfg implements ConfigurationEntry {
     this.maxProcessDepth = maxProcessDepth;
   }
 
-  public ListenersCfg getListeners() {
-    return listeners;
+  public GlobalListenersCfg getGlobalListeners() {
+    return globalListeners;
   }
 
-  public void setListeners(final ListenersCfg listeners) {
-    this.listeners = listeners;
+  public void setGlobalListeners(final GlobalListenersCfg globalListeners) {
+    this.globalListeners = globalListeners;
   }
 
   @Override
@@ -155,6 +155,6 @@ public final class EngineCfg implements ConfigurationEntry {
         .setCommandRedistributionInterval(distribution.getRedistributionInterval())
         .setCommandRedistributionMaxBackoff(distribution.getMaxBackoffDuration())
         .setMaxProcessDepth(getMaxProcessDepth())
-        .setListeners(listeners.createListenersConfiguration());
+        .setListeners(globalListeners.createGlobalListenersConfiguration());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/GlobalListenerCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/GlobalListenerCfg.java
@@ -8,18 +8,18 @@
 package io.camunda.zeebe.broker.system.configuration.engine;
 
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
-import io.camunda.zeebe.engine.ListenerConfiguration;
+import io.camunda.zeebe.engine.GlobalListenerConfiguration;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ListenerCfg implements ConfigurationEntry {
+public class GlobalListenerCfg implements ConfigurationEntry {
 
   private static final String DEFAULT_RETRIES = "3";
 
   private List<String> eventTypes = new ArrayList<>();
   private String type;
   private String retries = DEFAULT_RETRIES;
-  private boolean afterLocal = false;
+  private boolean afterNonGlobal = false;
 
   public List<String> getEventTypes() {
     return eventTypes;
@@ -45,15 +45,15 @@ public class ListenerCfg implements ConfigurationEntry {
     this.retries = retries;
   }
 
-  public boolean isAfterLocal() {
-    return afterLocal;
+  public boolean isAfterNonGlobal() {
+    return afterNonGlobal;
   }
 
-  public void setAfterLocal(final boolean afterLocal) {
-    this.afterLocal = afterLocal;
+  public void setAfterNonGlobal(final boolean afterNonGlobal) {
+    this.afterNonGlobal = afterNonGlobal;
   }
 
-  public ListenerConfiguration createListenerConfiguration() {
-    return new ListenerConfiguration(eventTypes, type, retries, afterLocal);
+  public GlobalListenerConfiguration createGlobalListenerConfiguration() {
+    return new GlobalListenerConfiguration(eventTypes, type, retries, afterNonGlobal);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/GlobalListenersCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/GlobalListenersCfg.java
@@ -8,28 +8,28 @@
 package io.camunda.zeebe.broker.system.configuration.engine;
 
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
-import io.camunda.zeebe.engine.ListenersConfiguration;
+import io.camunda.zeebe.engine.GlobalListenersConfiguration;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ListenersCfg implements ConfigurationEntry {
+public class GlobalListenersCfg implements ConfigurationEntry {
 
   /**
    * Configures global listeners that will be applied to all user tasks within the process and will
    * be triggered during task processing.
    */
-  private List<ListenerCfg> task = new ArrayList<>();
+  private List<GlobalListenerCfg> userTask = new ArrayList<>();
 
-  public List<ListenerCfg> getTask() {
-    return task;
+  public List<GlobalListenerCfg> getUserTask() {
+    return userTask;
   }
 
-  public void setTask(final List<ListenerCfg> task) {
-    this.task = task;
+  public void setUserTask(final List<GlobalListenerCfg> userTask) {
+    this.userTask = userTask;
   }
 
-  public ListenersConfiguration createListenersConfiguration() {
-    return new ListenersConfiguration(
-        task.stream().map(ListenerCfg::createListenerConfiguration).toList());
+  public GlobalListenersConfiguration createGlobalListenersConfiguration() {
+    return new GlobalListenersConfiguration(
+        userTask.stream().map(GlobalListenerCfg::createGlobalListenerConfiguration).toList());
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
-import io.camunda.zeebe.broker.system.configuration.engine.ListenerCfg;
+import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenerCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
@@ -627,8 +627,8 @@ final class SystemContextTest {
     brokerCfg
         .getExperimental()
         .getEngine()
-        .getListeners()
-        .setTask(
+        .getGlobalListeners()
+        .setUserTask(
             List.of(
                 createListenerCfg("test", List.of("creating", "non-existing-type", "assigning"))));
 
@@ -636,9 +636,10 @@ final class SystemContextTest {
     initSystemContext(brokerCfg);
 
     // then
-    assertThat(brokerCfg.getExperimental().getEngine().getListeners().getTask()).hasSize(1);
+    assertThat(brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask())
+        .hasSize(1);
     final var listenerConfig =
-        brokerCfg.getExperimental().getEngine().getListeners().getTask().getFirst();
+        brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask().getFirst();
     assertThat(listenerConfig.getEventTypes()).containsExactly("creating", "assigning");
   }
 
@@ -649,8 +650,8 @@ final class SystemContextTest {
     brokerCfg
         .getExperimental()
         .getEngine()
-        .getListeners()
-        .setTask(
+        .getGlobalListeners()
+        .setUserTask(
             List.of(
                 createListenerCfg("test", List.of("creating")),
                 createListenerCfg(null, List.of("assigning"))));
@@ -659,9 +660,10 @@ final class SystemContextTest {
     initSystemContext(brokerCfg);
 
     // then
-    assertThat(brokerCfg.getExperimental().getEngine().getListeners().getTask()).hasSize(1);
+    assertThat(brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask())
+        .hasSize(1);
     final var listenerConfig =
-        brokerCfg.getExperimental().getEngine().getListeners().getTask().getFirst();
+        brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask().getFirst();
     assertThat(listenerConfig.getType()).isEqualTo("test");
     assertThat(listenerConfig.getEventTypes()).containsExactly("creating");
   }
@@ -673,8 +675,8 @@ final class SystemContextTest {
     brokerCfg
         .getExperimental()
         .getEngine()
-        .getListeners()
-        .setTask(
+        .getGlobalListeners()
+        .setUserTask(
             List.of(
                 createListenerCfg("test1", List.of("creating")),
                 createListenerCfg(
@@ -686,9 +688,10 @@ final class SystemContextTest {
     initSystemContext(brokerCfg);
 
     // then
-    assertThat(brokerCfg.getExperimental().getEngine().getListeners().getTask()).hasSize(1);
+    assertThat(brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask())
+        .hasSize(1);
     final var listenerConfig =
-        brokerCfg.getExperimental().getEngine().getListeners().getTask().getFirst();
+        brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask().getFirst();
     assertThat(listenerConfig.getType()).isEqualTo("test1");
     assertThat(listenerConfig.getEventTypes()).containsExactly("creating");
   }
@@ -700,16 +703,17 @@ final class SystemContextTest {
     brokerCfg
         .getExperimental()
         .getEngine()
-        .getListeners()
-        .setTask(List.of(createListenerCfg("test", List.of("creating", "all", "updating"))));
+        .getGlobalListeners()
+        .setUserTask(List.of(createListenerCfg("test", List.of("creating", "all", "updating"))));
 
     // when
     initSystemContext(brokerCfg);
 
     // then
-    assertThat(brokerCfg.getExperimental().getEngine().getListeners().getTask()).hasSize(1);
+    assertThat(brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask())
+        .hasSize(1);
     final var listenerConfig =
-        brokerCfg.getExperimental().getEngine().getListeners().getTask().getFirst();
+        brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask().getFirst();
     assertThat(listenerConfig.getType()).isEqualTo("test");
     assertThat(listenerConfig.getEventTypes()).containsExactly("all");
   }
@@ -721,8 +725,8 @@ final class SystemContextTest {
     brokerCfg
         .getExperimental()
         .getEngine()
-        .getListeners()
-        .setTask(
+        .getGlobalListeners()
+        .setUserTask(
             List.of(
                 createListenerCfg("test1", List.of("creating")), // missing retries
                 createListenerCfg("test2", List.of("creating"), "not-a-number"), // invalid retries
@@ -733,8 +737,10 @@ final class SystemContextTest {
     initSystemContext(brokerCfg);
 
     // then
-    assertThat(brokerCfg.getExperimental().getEngine().getListeners().getTask()).hasSize(2);
-    final var listenersConfig = brokerCfg.getExperimental().getEngine().getListeners().getTask();
+    assertThat(brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask())
+        .hasSize(2);
+    final var listenersConfig =
+        brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask();
     assertThat(listenersConfig.get(0).getType()).isEqualTo("test1");
     assertThat(listenersConfig.get(1).getType()).isEqualTo("test4");
   }
@@ -746,30 +752,32 @@ final class SystemContextTest {
     brokerCfg
         .getExperimental()
         .getEngine()
-        .getListeners()
-        .setTask(List.of(createListenerCfg("test", List.of("creating", "creating", "updating"))));
+        .getGlobalListeners()
+        .setUserTask(
+            List.of(createListenerCfg("test", List.of("creating", "creating", "updating"))));
 
     // when
     initSystemContext(brokerCfg);
 
     // then
-    assertThat(brokerCfg.getExperimental().getEngine().getListeners().getTask()).hasSize(1);
+    assertThat(brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask())
+        .hasSize(1);
     final var listenerConfig =
-        brokerCfg.getExperimental().getEngine().getListeners().getTask().getFirst();
+        brokerCfg.getExperimental().getEngine().getGlobalListeners().getUserTask().getFirst();
     assertThat(listenerConfig.getType()).isEqualTo("test");
     assertThat(listenerConfig.getEventTypes()).containsExactly("creating", "updating");
   }
 
-  private ListenerCfg createListenerCfg(final String type, final List<String> eventTypes) {
-    final ListenerCfg listenerCfg = new ListenerCfg();
+  private GlobalListenerCfg createListenerCfg(final String type, final List<String> eventTypes) {
+    final GlobalListenerCfg listenerCfg = new GlobalListenerCfg();
     listenerCfg.setType(type);
     listenerCfg.setEventTypes(eventTypes);
     return listenerCfg;
   }
 
-  private ListenerCfg createListenerCfg(
+  private GlobalListenerCfg createListenerCfg(
       final String type, final List<String> eventTypes, final String retries) {
-    final ListenerCfg listenerCfg = createListenerCfg(type, eventTypes);
+    final GlobalListenerCfg listenerCfg = createListenerCfg(type, eventTypes);
     listenerCfg.setRetries(retries);
     return listenerCfg;
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.broker.system.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
-import io.camunda.zeebe.engine.ListenerConfiguration;
+import io.camunda.zeebe.engine.GlobalListenerConfiguration;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +47,7 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL);
     assertThat(configuration.getCommandRedistributionMaxBackoff())
         .isEqualTo(EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION);
-    assertThat(configuration.getListeners().task()).isEmpty();
+    assertThat(configuration.getListeners().userTask()).isEmpty();
   }
 
   @Test
@@ -70,8 +70,8 @@ final class EngineCfgTest {
     assertThat(configuration.getCommandRedistributionInterval()).isEqualTo(Duration.ofSeconds(60));
     assertThat(configuration.getCommandRedistributionMaxBackoff())
         .isEqualTo(Duration.ofMinutes(20));
-    assertThat(configuration.getListeners().task()).hasSize(2);
-    final var taskListeners = configuration.getListeners().task();
+    assertThat(configuration.getListeners().userTask()).hasSize(2);
+    final var taskListeners = configuration.getListeners().userTask();
     assertListenerCfg(
         taskListeners.get(0), "test1", new String[] {"creating", "canceling"}, "5", false);
     assertListenerCfg(
@@ -79,14 +79,14 @@ final class EngineCfgTest {
   }
 
   void assertListenerCfg(
-      final ListenerConfiguration config,
+      final GlobalListenerConfiguration config,
       final String type,
       final String[] eventTypes,
       final String retries,
-      final boolean afterLocal) {
+      final boolean afterNonGlobal) {
     assertThat(config.type()).isEqualTo(type);
     assertThat(config.eventTypes()).containsExactly(eventTypes);
     assertThat(config.retries()).isEqualTo(retries);
-    assertThat(config.afterLocal()).isEqualTo(afterLocal);
+    assertThat(config.afterNonGlobal()).isEqualTo(afterNonGlobal);
   }
 }

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -18,8 +18,8 @@ zeebe:
           redistributionInterval: 60s
           maxBackoffDuration: 20m
         maxProcessDepth: 2000
-        listeners:
-          task:
+        globalListeners:
+          userTask:
             - type: test1
               eventTypes:
                 - creating
@@ -30,4 +30,4 @@ zeebe:
                 - assigning
                 - canceling
               retries: 2
-              afterLocal: true
+              afterNonGlobal: true

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -90,7 +90,7 @@ public final class EngineConfiguration {
       DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION;
 
   private boolean enableIdentitySetup = DEFAULT_ENABLE_IDENTITY_SETUP;
-  private ListenersConfiguration listeners = ListenersConfiguration.empty();
+  private GlobalListenersConfiguration listeners = GlobalListenersConfiguration.empty();
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -338,11 +338,11 @@ public final class EngineConfiguration {
     return this;
   }
 
-  public ListenersConfiguration getListeners() {
+  public GlobalListenersConfiguration getListeners() {
     return listeners;
   }
 
-  public EngineConfiguration setListeners(final ListenersConfiguration listeners) {
+  public EngineConfiguration setListeners(final GlobalListenersConfiguration listeners) {
     this.listeners = listeners;
     return this;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/GlobalListenerConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/GlobalListenerConfiguration.java
@@ -11,8 +11,8 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import java.util.List;
 import java.util.stream.Stream;
 
-public record ListenerConfiguration(
-    List<String> eventTypes, String type, String retries, boolean afterLocal) {
+public record GlobalListenerConfiguration(
+    List<String> eventTypes, String type, String retries, boolean afterNonGlobal) {
 
   public static final String ALL_EVENT_TYPES = "all";
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/GlobalListenersConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/GlobalListenersConfiguration.java
@@ -10,8 +10,8 @@ package io.camunda.zeebe.engine;
 import java.util.Collections;
 import java.util.List;
 
-public record ListenersConfiguration(List<ListenerConfiguration> task) {
-  public static ListenersConfiguration empty() {
-    return new ListenersConfiguration(Collections.emptyList());
+public record GlobalListenersConfiguration(List<GlobalListenerConfiguration> userTask) {
+  public static GlobalListenersConfiguration empty() {
+    return new GlobalListenersConfiguration(Collections.emptyList());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.deployment.model;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.EngineConfiguration;
-import io.camunda.zeebe.engine.ListenersConfiguration;
+import io.camunda.zeebe.engine.GlobalListenersConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
@@ -26,12 +26,13 @@ public final class BpmnFactory {
 
   public static BpmnTransformer createTransformer(
       final InstantSource clock, final EngineConfiguration configuration) {
-    final ListenersConfiguration listenerConfig;
+    final GlobalListenersConfiguration listenerConfig;
     if (configuration != null) {
       listenerConfig =
-          Objects.requireNonNullElse(configuration.getListeners(), ListenersConfiguration.empty());
+          Objects.requireNonNullElse(
+              configuration.getListeners(), GlobalListenersConfiguration.empty());
     } else {
-      listenerConfig = ListenersConfiguration.empty();
+      listenerConfig = GlobalListenersConfiguration.empty();
     }
     return new BpmnTransformer(
         createExpressionLanguage(new ZeebeFeelEngineClock(clock)), listenerConfig);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.engine.processing.deployment.model.transformation;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
-import io.camunda.zeebe.engine.ListenersConfiguration;
+import io.camunda.zeebe.engine.GlobalListenersConfiguration;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.AdHocSubProcessTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.BoundaryEventTransformer;
@@ -74,7 +74,7 @@ public final class BpmnTransformer {
 
   public BpmnTransformer(
       final ExpressionLanguage expressionLanguage,
-      final ListenersConfiguration listenersConfiguration) {
+      final GlobalListenersConfiguration globalListenersConfiguration) {
     this.expressionLanguage = expressionLanguage;
 
     step1Visitor = new TransformationVisitor();
@@ -100,7 +100,7 @@ public final class BpmnTransformer {
     step2Visitor.registerHandler(new SequenceFlowTransformer());
     step2Visitor.registerHandler(new StartEventTransformer());
     step2Visitor.registerHandler(
-        new UserTaskTransformer(expressionLanguage, listenersConfiguration));
+        new UserTaskTransformer(expressionLanguage, globalListenersConfiguration));
 
     step3Visitor = new TransformationVisitor();
     step3Visitor.registerHandler(new ContextProcessTransformer());


### PR DESCRIPTION
## Description

The global user task listeners configuration has been introduced as an experimental legacy-style configuration property: `zeebe.broker.experimental.engine.listeners.task`. Considering this is a new configuration, it should be part of the Unified Configuration instead of the deprecated legacy broker configuration properties.

This PR changes the configuration schema in order to improve clarity and integrate this feature in the Unified Configuration.

### Improve on clarity of properties purpose
#### Rename `afterLocal` flag -> `afterNonGlobal`
Listeners defined in the BPMN model are not generally called "local", so the flag name could cause confusion.

#### Rename `listeners` entry -> `globalListeners`
The configuration is specifically about global listeners (i.e. lifecycle listeners defined at cluster-level), it is important to avoid confusion with other possibly unrelated listeners.

#### Rename `task` entry -> `userTask`
The configuration is specifically about global "user task" listeners, we should avoid confusion with other kind of tasks (e.g. service tasks)

### Migrate to unified configuration
Move `zeebe.broker.experimental.engine.listeners.task` to `camunda.cluster.global-listeners.user-task`.

The current implementation is still based on the legacy configuration which is mapped to the new one, but without providing backwards compatibility (the legacy configuration should only exist in code and not be visible to users).
This speeds up the delivery of this feature without compromising the functionality. In a future PR the legacy configuration will be completely removed from the code too.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #40130
