### PR TITLE
Expand logging on element instance not found in element tree path builder

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -128,7 +128,7 @@ public class ElementTreePathBuilder {
   private ElementInstance getElementInstance(final long elementInstanceKey) {
     final ElementInstance instance = elementInstanceProvider.getInstance(elementInstanceKey);
     if (instance == null) {
-      throw new IllegalStateException(
+      throw new ElementInstanceNotFoundException(
           String.format(
               "Expected to find element instance for given key '%d', but didn't exist.",
               elementInstanceKey));
@@ -145,4 +145,11 @@ public class ElementTreePathBuilder {
       Long elementInstanceKey,
       Long parentElementInstanceKey,
       ProcessInstanceRecordValue processInstanceRecord) {}
+
+  private static class ElementInstanceNotFoundException extends IllegalStateException {
+
+    ElementInstanceNotFoundException(final String message) {
+      super(message);
+    }
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -91,7 +91,18 @@ public class ElementTreePathBuilder {
       elementInstancePath.add(curr.elementInstanceKey);
       long currParent = curr.parentElementInstanceKey;
       while (currParent != -1) {
-        final var instance = getElementInstance(currParent);
+        final ElementInstance instance;
+        try {
+          instance = getElementInstance(currParent);
+        } catch (final ElementInstanceNotFoundException exception) {
+          throw new IllegalStateException(
+              """
+              Expected to build element tree path, but couldn't find element instance '%d'. \
+              Element tree path created so far: '%s'. \
+              Currently adding parent process instance's element instance path: '%s'."""
+                  .formatted(currParent, properties, elementInstancePath),
+              exception);
+        }
         elementInstancePath.addFirst(currParent);
         currParent = instance.getParentKey();
       }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We regularly see an `IllegalStateException` in `ElementTreePathBuilder`, but we lack information to root cause it. This PR adds more details to the exception.

Note that the `getElementInstance` method is called from three places in this class, but this only adds additional data to the call site we see in the relevant stack-traces.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #26755 
