### PR TITLE
[Backport stable/8.8] perf: test cluster scales thread count to match replicas

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -352,6 +352,12 @@ public final class TestClusterBuilder {
                   cluster.setClusterSize(brokersCount);
                   cluster.setClusterName(name);
                 })
+            .withBrokerConfig(
+                cfg -> {
+                  final var replicas = (partitionsCount * replicationFactor) / brokersCount;
+                  cfg.getThreads().setIoThreadCount(replicas);
+                  cfg.getThreads().setCpuThreadCount(replicas);
+                })
             .withBrokerConfig(cfg -> cfg.getGateway().setEnable(useEmbeddedGateway))
             .withRecordingExporter(useRecordingExporter);
     return broker;


### PR DESCRIPTION
# Description
Backport of #40193 to `stable/8.8`.

relates to 