### PR TITLE
[Backport main] ci: skip generate changelog when dryrun

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -297,6 +297,7 @@ jobs:
           verbose: 'false'
       - name: Generate Changelog
         id: gen-changelog
+        if: ${{ !inputs.dryRun }}
         run: |
           # We set some bash properties to better fail/debug this script
           #


### PR DESCRIPTION
# Description
Backport of #40194 to `main`.

relates to 