### PR TITLE
test: verify process instance modification works for multi-instance subprocesses

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ProcessModificationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ProcessModificationIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.orchestration;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startScopedProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static io.camunda.it.util.TestHelper.waitForScopedProcessInstancesToStart;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.enums.ElementInstanceType;
+import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+@MultiDbTest
+public class ProcessModificationIT {
+  private static CamundaClient camundaClient;
+  private String testScopeId;
+
+  @BeforeEach
+  public void beforeEach(final TestInfo testInfo) {
+    Objects.requireNonNull(camundaClient);
+    testScopeId =
+        testInfo.getTestMethod().map(Method::toString).orElse(UUID.randomUUID().toString());
+  }
+
+  @Test
+  public void canActivateElementInSpecificMultiInstanceBodyInstance() {
+    // given
+    // deploy process with multi-instance subprocess and start process instance
+    final String processId = "process";
+    final String multiInstanceBody = "multi_instance_subprocess";
+    final String userTaskA = "A";
+    final String userTaskB = "B";
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .subProcess(
+                multiInstanceBody,
+                sub ->
+                    sub.multiInstance(
+                        m ->
+                            m.zeebeInputCollectionExpression("[1,2,3]")
+                                .zeebeInputElement("index")
+                                .parallel()))
+            .embeddedSubProcess()
+            .startEvent()
+            .userTask(userTaskA)
+            .userTask(userTaskB)
+            .endEvent()
+            .subProcessDone()
+            .endEvent()
+            .done();
+    final var deployment =
+        deployProcessAndWaitForIt(camundaClient, process, String.format("%s.bpmn", testScopeId));
+    final var processInstanceEvent =
+        startScopedProcessInstance(camundaClient, deployment.getBpmnProcessId(), testScopeId);
+    waitForScopedProcessInstancesToStart(camundaClient, testScopeId, 1);
+
+    final long processInstanceKey = processInstanceEvent.getProcessInstanceKey();
+
+    // now select the multi-instance body instance
+    final var miBodyInstance =
+        waitForElementInstances(
+                camundaClient,
+                f ->
+                    f.processInstanceKey(processInstanceKey)
+                        .elementId(multiInstanceBody)
+                        .type(ElementInstanceType.MULTI_INSTANCE_BODY))
+            .getFirst();
+
+    // select one of the multi-instance body instances
+    final List<ElementInstance> miInstances =
+        waitForElementInstances(
+            camundaClient,
+            f ->
+                f.elementInstanceScopeKey(miBodyInstance.getElementInstanceKey())
+                    .elementId(multiInstanceBody));
+    final var miInstance = miInstances.getFirst();
+
+    final var taskAElementInstance =
+        waitForElementInstances(camundaClient, f -> f.elementId(userTaskA)).getFirst();
+
+    // when
+    // terminate task E in the selected multi-instance instance and activate task F there
+    camundaClient
+        .newModifyProcessInstanceCommand(processInstanceKey)
+        .terminateElement(taskAElementInstance.getElementInstanceKey())
+        .and()
+        .activateElement(userTaskB, miInstance.getElementInstanceKey())
+        .send()
+        .join();
+
+    // then
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId(userTaskB)
+                .state(ElementInstanceState.ACTIVE)
+                .type(ElementInstanceType.USER_TASK));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ProcessModificationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ProcessModificationIT.java
@@ -199,4 +199,124 @@ public class ProcessModificationIT {
                 .state(ElementInstanceState.ACTIVE)
                 .type(ElementInstanceType.USER_TASK));
   }
+
+  @Test
+  public void canModifyElementsInMultiInstanceAdHocSubprocessWithAiAgentPattern() {
+    // given
+    final String processId = "ai-agent-process";
+    final String mergeGateway = "merge_gateway";
+    final String aiAgentTask = "ai_agent_task";
+    final String shouldRunTools = "should_run_tools";
+    final String toolsSubprocess = "tools_subprocess";
+    final String toolA = "tool_a";
+    final String toolB = "tool_b";
+    final String toolC = "tool_c";
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .exclusiveGateway(mergeGateway)
+            .serviceTask(aiAgentTask)
+            .zeebeJobType("ai-agent")
+            .exclusiveGateway(shouldRunTools)
+            .defaultFlow()
+            .endEvent()
+            .moveToLastExclusiveGateway()
+            .sequenceFlowId("run_tools")
+            .condition("=is defined(agent.toolCalls)")
+            .adHocSubProcess(
+                toolsSubprocess,
+                adHocSubProcess -> {
+                  adHocSubProcess
+                      .multiInstance()
+                      .zeebeInputCollectionExpression("agent.iterations")
+                      .zeebeInputElement("iteration");
+                  adHocSubProcess.zeebeActiveElementsCollectionExpression("agent.toolCalls");
+                  adHocSubProcess.serviceTask(toolA).zeebeJobType("tool-a");
+                  adHocSubProcess.serviceTask(toolB).zeebeJobType("tool-b");
+                  adHocSubProcess.serviceTask(toolC).zeebeJobType("tool-c");
+                })
+            .connectTo(mergeGateway)
+            .done();
+    final var deployment =
+        deployProcessAndWaitForIt(
+            camundaClient, process, String.format("%s-ai-agent.bpmn", testScopeId));
+    final var processInstance =
+        startScopedProcessInstance(camundaClient, deployment.getBpmnProcessId(), testScopeId);
+    waitForProcessInstances(
+        camundaClient, p -> p.processDefinitionKey(deployment.getProcessDefinitionKey()), 1);
+
+    final long processInstanceKey = processInstance.getProcessInstanceKey();
+
+    // Complete the AI agent task to route to the tools subprocess
+    // The AI agent outputs toolCalls and iterations which activate the multi-instance ad-hoc
+    // subprocess
+    final var activateJobsResponse =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType("ai-agent")
+            .maxJobsToActivate(1)
+            .send()
+            .join();
+    final var aiAgentJob = activateJobsResponse.getJobs().getFirst();
+    camundaClient
+        .newCompleteCommand(aiAgentJob.getKey())
+        .variables(
+            Map.of("agent", Map.of("toolCalls", List.of("tool_a"), "iterations", List.of(1, 2))))
+        .send()
+        .join();
+
+    // Wait for the multi-instance ad-hoc subprocess body to be activated
+    final var toolsSubprocessBodyInstance =
+        waitForElementInstances(
+                camundaClient,
+                f ->
+                    f.processInstanceKey(processInstanceKey)
+                        .elementId(toolsSubprocess)
+                        .type(ElementInstanceType.MULTI_INSTANCE_BODY))
+            .getFirst();
+
+    // Select one of the multi-instance ad-hoc subprocess instances
+    final List<ElementInstance> miInstances =
+        waitForElementInstances(
+            camundaClient,
+            f ->
+                f.elementInstanceScopeKey(toolsSubprocessBodyInstance.getElementInstanceKey())
+                    .elementId(toolsSubprocess));
+    final var miInstance = miInstances.getFirst();
+
+    final var toolAElementInstance =
+        waitForElementInstances(
+                camundaClient, f -> f.processInstanceKey(processInstanceKey).elementId(toolA))
+            .getFirst();
+
+    // when
+    // terminate tool A and activate tools B and C in a specific instance of the multi-instance
+    // ad-hoc subprocess
+    camundaClient
+        .newModifyProcessInstanceCommand(processInstanceKey)
+        .terminateElement(toolAElementInstance.getElementInstanceKey())
+        .and()
+        .activateElement(toolB, miInstance.getElementInstanceKey())
+        .and()
+        .activateElement(toolC, miInstance.getElementInstanceKey())
+        .send()
+        .join();
+
+    // then
+    // verify both tool B and tool C are now active in the specified instance
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId(toolB)
+                .state(ElementInstanceState.ACTIVE)
+                .type(ElementInstanceType.SERVICE_TASK));
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId(toolC)
+                .state(ElementInstanceState.ACTIVE)
+                .type(ElementInstanceType.SERVICE_TASK));
+  }
 }


### PR DESCRIPTION
## UPDATE:
**This PR will be closed in favor of https://github.com/camunda/camunda/pull/40453**

## Description

Adds acceptance tests to verify that process instance modification works correctly when modifying elements within specific instances of multi-instance subprocesses.

### Changes

This PR adds three test cases to `ProcessModificationIT`:

#### 1. `canActivateElementInSpecificMultiInstanceBodyInstance()`
Tests process modification in a **regular multi-instance subprocess**:
- Creates a multi-instance subprocess with 3 iterations
- Selects a specific instance from the multi-instance body
- Terminates one task and activates another task within that specific instance
- Verifies the modification is scoped correctly to the selected instance

#### 2. `canActivateElementInSpecificMultiInstanceAdhocSubprocessInstance()`
Tests process modification in a **multi-instance ad-hoc subprocess**:
- Creates a multi-instance ad-hoc subprocess with dynamic element activation
- Each iteration activates different tasks based on input collection
- Modifies elements within a specific instance of the multi-instance body
- Verifies tasks can be terminated and activated in the selected instance

#### 3. `canModifyElementsInMultiInstanceAdHocSubprocessWithAiAgentPattern()`
Tests process modification in a **multi-instance ad-hoc subprocess following the AI Agent Task connector pattern**:
- Models the full AI agent feedback loop with merge gateway, AI agent task, routing gateway, and tools subprocess
- AI agent task completes and outputs `toolCalls` to activate tools dynamically
- Modifies multiple tools within a specific instance of the multi-instance ad-hoc subprocess
- Validates the AI agent use case where tools are dynamically activated/terminated across iterations

### Motivation

These tests ensure that the `ancestorElementInstanceKey` parameter in process modification commands can be used to select a certain multi-instance subprocess instance to allow modification for multi-instance subprocesses, including:
- Regular multi-instance subprocesses
- Ad-hoc multi-instance subprocesses
- Complex patterns like the AI Agent Task connector that rely on dynamic tool activation

This is critical for supporting agentic AI workflows where an AI agent controls tool execution within multi-instance ad-hoc subprocesses.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40226
