### PR TITLE
feat: check for user/group existence before adding to tenant/role

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchMultiTenantsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchMultiTenantsTest.java
@@ -18,6 +18,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.api.search.sort.ProcessDefinitionSort;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
@@ -84,9 +86,13 @@ public class ProcessDefinitionSearchMultiTenantsTest {
 
   private static CamundaClient camundaClient;
 
+  @UserDefinition
+  private static final TestUser USER_1 = new TestUser(USERNAME_1, "password", List.of());
+
   @BeforeAll
   public static void beforeAll(@Authenticated final CamundaClient adminClient)
       throws InterruptedException {
+
     createTenant(
         adminClient,
         TENANT_ID_1,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByGroupIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByGroupIntegrationTest.java
@@ -183,20 +183,24 @@ public class RolesByGroupIntegrationTest {
   }
 
   @Test
-  void shouldAssigningRoleToGroupIfGroupDoesNotExist() {
+  void shouldRejectAssigningRoleToGroupIfGroupDoesNotExist() {
     // given
     final var groupId = Strings.newRandomValidIdentityId();
 
-    // when
-    camundaClient
-        .newAssignRoleToGroupCommand()
-        .roleId(EXISTING_ROLE_ID)
-        .groupId(groupId)
-        .send()
-        .join();
-
-    // then
-    assertRoleAssignedToGroup(EXISTING_ROLE_ID, groupId);
+    // when/then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newAssignRoleToGroupCommand()
+                    .roleId(EXISTING_ROLE_ID)
+                    .groupId(groupId)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining(
+            String.format(
+                "Expected to add an entity with ID '%s' and type 'GROUP' to role with ID '%s', but the entity doesn't exist.",
+                groupId, EXISTING_ROLE_ID));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByGroupIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByGroupIntegrationTest.java
@@ -339,6 +339,7 @@ public class RolesByGroupIntegrationTest {
   void shouldUnassigningRoleFromGroupIfGroupDoesNotExist() {
     // given
     final var groupId = Strings.newRandomValidIdentityId();
+    camundaClient.newCreateGroupCommand().groupId(groupId).name(groupId).send().join();
 
     camundaClient
         .newAssignRoleToGroupCommand()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -149,8 +149,8 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     final boolean localGroupEnabled =
         (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case GROUP -> !localGroupEnabled || groupState.get(entityId).isPresent();
-      case USER -> !localUserEnabled || userState.getUser(entityId).isPresent();
+      case GROUP -> localGroupEnabled && groupState.get(entityId).isEmpty();
+      case USER -> localUserEnabled && userState.getUser(entityId).isEmpty();
       case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       default -> false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -149,8 +149,8 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     final boolean localGroupEnabled =
         (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case GROUP -> localGroupEnabled && groupState.get(entityId).isEmpty();
-      case USER -> localUserEnabled && userState.getUser(entityId).isEmpty();
+      case GROUP -> !localGroupEnabled || groupState.get(entityId).isPresent();
+      case USER -> !localUserEnabled || userState.getUser(entityId).isPresent();
       case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       default -> false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
 import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.RoleState;
-import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
@@ -34,8 +33,6 @@ import java.util.Map;
 
 public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
 
-  public static final String IS_CAMUNDA_USERS_ENABLED = "is_camunda_users_enabled";
-  public static final String IS_CAMUNDA_GROUPS_ENABLED = "is_camunda_groups_enabled";
   public static final String ROLE_NOT_FOUND_ERROR_MESSAGE =
       "Expected to update role with ID '%s', but a role with this ID does not exist.";
   public static final String ENTITY_NOT_FOUND_ERROR_MESSAGE =
@@ -46,7 +43,6 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
   private final MappingRuleState mappingRuleState;
   private final MembershipState membershipState;
   private final GroupState groupState;
-  private final UserState userState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -64,7 +60,6 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     mappingRuleState = processingState.getMappingRuleState();
     membershipState = processingState.getMembershipState();
     groupState = processingState.getGroupState();
-    userState = processingState.getUserState();
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -144,8 +144,8 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     final boolean localGroupEnabled =
         (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case GROUP -> localGroupEnabled && groupState.get(entityId).isPresent();
-      case USER -> localUserEnabled && userState.getUser(entityId).isPresent();
+      case GROUP -> !localGroupEnabled || groupState.get(entityId).isPresent();
+      case USER -> !localUserEnabled || userState.getUser(entityId).isPresent();
       case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       default -> false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -149,8 +149,8 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     final boolean localGroupEnabled =
         (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case GROUP -> localGroupEnabled && groupState.get(entityId).isPresent();
-      case USER -> localUserEnabled && userState.getUser(entityId).isPresent();
+      case GROUP -> localGroupEnabled && groupState.get(entityId).isEmpty();
+      case USER -> localUserEnabled && userState.getUser(entityId).isEmpty();
       case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       default -> false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
 import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.RoleState;
+import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
@@ -33,6 +34,8 @@ import java.util.Map;
 
 public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
 
+  public static final String IS_CAMUNDA_USERS_ENABLED = "is_camunda_users_enabled";
+  public static final String IS_CAMUNDA_GROUPS_ENABLED = "is_camunda_groups_enabled";
   public static final String ROLE_NOT_FOUND_ERROR_MESSAGE =
       "Expected to update role with ID '%s', but a role with this ID does not exist.";
   public static final String ENTITY_NOT_FOUND_ERROR_MESSAGE =
@@ -43,6 +46,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
   private final MappingRuleState mappingRuleState;
   private final MembershipState membershipState;
   private final GroupState groupState;
+  private final UserState userState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -60,6 +64,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     mappingRuleState = processingState.getMappingRuleState();
     membershipState = processingState.getMembershipState();
     groupState = processingState.getGroupState();
+    userState = processingState.getUserState();
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
@@ -138,9 +143,15 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
       final Map<String, Object> authorizations,
       final EntityType entityType,
       final String entityId) {
+
+    final boolean localUserEnabled =
+        (boolean) authorizations.getOrDefault(IS_CAMUNDA_USERS_ENABLED, false);
+    final boolean localGroupEnabled =
+        (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case USER, CLIENT, GROUP ->
-          true; // With simple mapping rules, any username, client id or group can be assigned
+      case GROUP -> localGroupEnabled && groupState.get(entityId).isEmpty();
+      case USER -> localUserEnabled && userState.getUser(entityId).isEmpty();
+      case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       default -> false;
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -149,8 +149,8 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     final boolean localGroupEnabled =
         (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case GROUP -> localGroupEnabled && groupState.get(entityId).isEmpty();
-      case USER -> localUserEnabled && userState.getUser(entityId).isEmpty();
+      case GROUP -> localGroupEnabled && groupState.get(entityId).isPresent();
+      case USER -> localUserEnabled && userState.getUser(entityId).isPresent();
       case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       default -> false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
 import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.RoleState;
+import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
@@ -33,6 +34,8 @@ import java.util.Map;
 
 public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
 
+  public static final String IS_CAMUNDA_USERS_ENABLED = "is_camunda_users_enabled";
+  public static final String IS_CAMUNDA_GROUPS_ENABLED = "is_camunda_groups_enabled";
   public static final String ROLE_NOT_FOUND_ERROR_MESSAGE =
       "Expected to update role with ID '%s', but a role with this ID does not exist.";
   public static final String ENTITY_NOT_FOUND_ERROR_MESSAGE =
@@ -43,6 +46,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
   private final MappingRuleState mappingRuleState;
   private final MembershipState membershipState;
   private final GroupState groupState;
+  private final UserState userState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -60,6 +64,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     mappingRuleState = processingState.getMappingRuleState();
     membershipState = processingState.getMembershipState();
     groupState = processingState.getGroupState();
+    userState = processingState.getUserState();
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.RoleState;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
+import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.engine.state.tenant.PersistedTenant;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -161,8 +162,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     final boolean localGroupEnabled =
         (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case GROUP -> localGroupEnabled && groupState.get(entityId).isEmpty();
-      case USER -> localUserEnabled && userState.getUser(entityId).isEmpty();
+      case GROUP -> !localGroupEnabled || groupState.get(entityId).isPresent();
+      case USER -> !localUserEnabled || userState.getUser(entityId).isPresent();
       case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       case ROLE -> roleState.getRole(entityId).isPresent();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -162,8 +162,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     final boolean localGroupEnabled =
         (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case GROUP -> localGroupEnabled && groupState.get(entityId).isEmpty();
-      case USER -> localUserEnabled && userState.getUser(entityId).isEmpty();
+      case GROUP -> localGroupEnabled && groupState.get(entityId).isPresent();
+      case USER -> localUserEnabled && userState.getUser(entityId).isPresent();
       case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       case ROLE -> roleState.getRole(entityId).isPresent();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -162,8 +162,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     final boolean localGroupEnabled =
         (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case GROUP -> localGroupEnabled && groupState.get(entityId).isEmpty();
-      case USER -> localUserEnabled && userState.getUser(entityId).isEmpty();
+      case GROUP -> !localGroupEnabled || groupState.get(entityId).isPresent();
+      case USER -> !localUserEnabled || userState.getUser(entityId).isPresent();
       case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       case ROLE -> roleState.getRole(entityId).isPresent();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -162,8 +162,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     final boolean localGroupEnabled =
         (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case GROUP -> !localGroupEnabled || groupState.get(entityId).isPresent();
-      case USER -> !localUserEnabled || userState.getUser(entityId).isPresent();
+      case GROUP -> localGroupEnabled && groupState.get(entityId).isEmpty();
+      case USER -> localUserEnabled && userState.getUser(entityId).isEmpty();
       case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       case ROLE -> roleState.getRole(entityId).isPresent();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.RoleState;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
+import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.engine.state.tenant.PersistedTenant;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -39,11 +40,15 @@ import java.util.Map;
 
 public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor<TenantRecord> {
 
+  public static final String IS_CAMUNDA_USERS_ENABLED = "is_camunda_users_enabled";
+  public static final String IS_CAMUNDA_GROUPS_ENABLED = "is_camunda_groups_enabled";
+
   private static final String TENANT_NOT_FOUND_ERROR_MESSAGE =
       "Expected to add entity to tenant with ID '%s', but no tenant with this ID exists.";
   private final TenantState tenantState;
   private final MappingRuleState mappingRuleState;
   private final GroupState groupState;
+  private final UserState userState;
   private final RoleState roleState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
@@ -64,6 +69,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     mappingRuleState = state.getMappingRuleState();
     groupState = state.getGroupState();
     roleState = state.getRoleState();
+    userState = state.getUserState();
     membershipState = state.getMembershipState();
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;
@@ -151,9 +157,14 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       final Map<String, Object> authorizations,
       final EntityType entityType,
       final String entityId) {
+    final boolean localUserEnabled =
+        (boolean) authorizations.getOrDefault(IS_CAMUNDA_USERS_ENABLED, false);
+    final boolean localGroupEnabled =
+        (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case USER, CLIENT, GROUP ->
-          true; // With simple mapping rules, any username, client id or group can be assigned
+      case GROUP -> localGroupEnabled && groupState.get(entityId).isEmpty();
+      case USER -> localUserEnabled && userState.getUser(entityId).isEmpty();
+      case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       case ROLE -> roleState.getRole(entityId).isPresent();
       default -> false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -162,8 +162,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     final boolean localGroupEnabled =
         (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case GROUP -> localGroupEnabled && groupState.get(entityId).isPresent();
-      case USER -> localUserEnabled && userState.getUser(entityId).isPresent();
+      case GROUP -> localGroupEnabled && groupState.get(entityId).isEmpty();
+      case USER -> localUserEnabled && userState.getUser(entityId).isEmpty();
       case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       case ROLE -> roleState.getRole(entityId).isPresent();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.RoleState;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
-import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.engine.state.tenant.PersistedTenant;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -162,8 +161,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     final boolean localGroupEnabled =
         (boolean) authorizations.getOrDefault(IS_CAMUNDA_GROUPS_ENABLED, false);
     return switch (entityType) {
-      case GROUP -> localGroupEnabled && groupState.get(entityId).isPresent();
-      case USER -> localUserEnabled && userState.getUser(entityId).isPresent();
+      case GROUP -> localGroupEnabled && groupState.get(entityId).isEmpty();
+      case USER -> localUserEnabled && userState.getUser(entityId).isEmpty();
       case CLIENT -> true;
       case MAPPING_RULE -> mappingRuleState.get(entityId).isPresent();
       case ROLE -> roleState.getRole(entityId).isPresent();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/AssignGroupToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/AssignGroupToTenantTest.java
@@ -95,19 +95,20 @@ class AssignGroupToTenantTest {
     // given
     final String nonExistentGroupId = Strings.newRandomValidIdentityId();
 
-    // when
-    client
-        .newAssignGroupToTenantCommand()
-        .groupId(nonExistentGroupId)
-        .tenantId(tenantId)
-        .send()
-        .join();
-
-    // then
-    ZeebeAssertHelper.assertEntityAssignedToTenant(
-        tenantId,
-        nonExistentGroupId,
-        tenant -> assertThat(tenant.getEntityType()).isEqualTo(EntityType.GROUP));
+    // when/then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newAssignGroupToTenantCommand()
+                    .groupId(nonExistentGroupId)
+                    .tenantId(tenantId)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining(
+            "Expected to add group with ID '%s' to tenant with ID '%s', but the group doesn't exist."
+                .formatted(nonExistentGroupId, tenantId));
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UnassignGroupFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UnassignGroupFromTenantTest.java
@@ -106,12 +106,14 @@ class UnassignGroupFromTenantTest {
   void shouldUnassignIfGroupDoesNotExist() {
     // given
     final String nonExistentGroupId = Strings.newRandomValidIdentityId();
+    client.newCreateGroupCommand().groupId(nonExistentGroupId).name("group").send().join();
     client
         .newAssignGroupToTenantCommand()
         .groupId(nonExistentGroupId)
         .tenantId(tenantId)
         .send()
         .join();
+    client.newDeleteGroupCommand(nonExistentGroupId).send().join();
 
     // when
     client

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/multitenancy/MultiTenancyIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/multitenancy/MultiTenancyIT.java
@@ -138,7 +138,7 @@ public class MultiTenancyIT {
       authUtil.createUser(
           USER_TENANT_A_WITHOUT_DEFAULT_TENANT, USER_TENANT_A_WITHOUT_DEFAULT_TENANT);
       authUtil.createUser(USER_WITHOUT_TENANT, USER_WITHOUT_TENANT);
-
+      assignUsersToTenant(client, "<default>", USER_TENANT_A, USER_TENANT_B, USER_TENANT_A_AND_B);
       createTenantAndAssignUsers(
           client,
           TENANT_A,

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/multitenancy/MultiTenancyIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/multitenancy/MultiTenancyIT.java
@@ -138,6 +138,7 @@ public class MultiTenancyIT {
       authUtil.createUser(
           USER_TENANT_A_WITHOUT_DEFAULT_TENANT, USER_TENANT_A_WITHOUT_DEFAULT_TENANT);
       authUtil.createUser(USER_WITHOUT_TENANT, USER_WITHOUT_TENANT);
+
       createTenantAndAssignUsers(
           client,
           TENANT_A,

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/multitenancy/MultiTenancyIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/multitenancy/MultiTenancyIT.java
@@ -138,7 +138,6 @@ public class MultiTenancyIT {
       authUtil.createUser(
           USER_TENANT_A_WITHOUT_DEFAULT_TENANT, USER_TENANT_A_WITHOUT_DEFAULT_TENANT);
       authUtil.createUser(USER_WITHOUT_TENANT, USER_WITHOUT_TENANT);
-      assignUsersToTenant(client, "<default>", USER_TENANT_A, USER_TENANT_B, USER_TENANT_A_AND_B);
       createTenantAndAssignUsers(
           client,
           TENANT_A,


### PR DESCRIPTION
## Description

When I add a user (with internal user management enabled), group (with internal group management enabled) to tenant or role, then the workflow engine should validate that the user/group/role exists and reject the command if it does not.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #38530 
