### PR TITLE
ci: use fake tags for dry-run

### DIFF
--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -16,33 +16,8 @@ on:
     - cron: '0 1 * * 1-5'
 
 jobs:
-  # create-fake-tag:
-  #   name: "Create fake tag for dry runs"
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 5
-  #   permissions:
-  #     contents: read
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v5
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Git User Setup
-  #       run: |
-  #         git config user.name "github-actions[bot]"
-  #         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-  #     - name: Create fake tag locally
-  #       run: |
-  #         git fetch origin tag 0.0.0-dryrun-minor --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-minor -m "Dummy tag for dry run minor"
-  #         git fetch origin tag 0.0.0-dryrun-alpha --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-alpha -m "Dummy tag for dry run alpha"
-  #         echo "Created fake tags for all dry runs locally (not pushed)"
-  #     - uses: actions/upload-artifact@v4
-  #       with:
-  #         name: create-fake-tag
-  #         path: .git
   dry-run-release:
     name: "${{ matrix.version }} from ${{ inputs.branch || 'main' }}"
-    # needs: [create-fake-tag]
     uses: ./.github/workflows/camunda-platform-release.yml
     secrets: inherit
     strategy:

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -16,33 +16,33 @@ on:
     - cron: '0 1 * * 1-5'
 
 jobs:
-  create-fake-tag:
-    name: "Create fake tag for dry runs"
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Git User Setup
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Create fake tag locally
-        run: |
-          git fetch origin tag 0.0.0-dryrun-minor --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-minor -m "Dummy tag for dry run minor"
-          git fetch origin tag 0.0.0-dryrun-alpha --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-alpha -m "Dummy tag for dry run alpha"
-          echo "Created fake tags for all dry runs locally (not pushed)"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: create-fake-tag
-          path: .git
+  # create-fake-tag:
+  #   name: "Create fake tag for dry runs"
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 5
+  #   permissions:
+  #     contents: read
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v5
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Git User Setup
+  #       run: |
+  #         git config user.name "github-actions[bot]"
+  #         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  #     - name: Create fake tag locally
+  #       run: |
+  #         git fetch origin tag 0.0.0-dryrun-minor --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-minor -m "Dummy tag for dry run minor"
+  #         git fetch origin tag 0.0.0-dryrun-alpha --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-alpha -m "Dummy tag for dry run alpha"
+  #         echo "Created fake tags for all dry runs locally (not pushed)"
+  #     - uses: actions/upload-artifact@v4
+  #       with:
+  #         name: create-fake-tag
+  #         path: .git
   dry-run-release:
     name: "${{ matrix.version }} from ${{ inputs.branch || 'main' }}"
-    needs: [create-fake-tag]
+    # needs: [create-fake-tag]
     uses: ./.github/workflows/camunda-platform-release.yml
     secrets: inherit
     strategy:
@@ -65,7 +65,7 @@ jobs:
   notify:
     name: Send Slack notification
     runs-on: ubuntu-latest
-    needs: [create-fake-tag, dry-run-release]
+    needs: [dry-run-release]
     if: always()
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -16,22 +16,44 @@ on:
     - cron: '0 1 * * 1-5'
 
 jobs:
+  create-fake-tag:
+    name: "Create fake tag for dry runs"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Git User Setup
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Create fake tag locally
+        run: |
+          git fetch origin tag 0.0.0-dryrun-minor --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-minor -m "Dummy tag for dry run minor"
+          git fetch origin tag 0.0.0-dryrun-alpha --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-alpha -m "Dummy tag for dry run alpha"
+          echo "Created fake tags for all dry runs locally (not pushed)"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: create-fake-tag
+          path: .git
   dry-run-release:
     name: "${{ matrix.version }} from ${{ inputs.branch || 'main' }}"
+    needs: [create-fake-tag]
     uses: ./.github/workflows/camunda-platform-release.yml
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        # These versions were selected to ensure compatibility with the japicmp plugin (introduced Oct 10, 2025),
-        # which requires webapps-schema artifact (introduced Sep 13, 2024).
-        # Earlier versions from 2021 predate this dependency and cause build failures.
-        # See discussion at: https://camunda.slack.com/archives/C06UWQNCU7M/p1760468857576009?thread_ts=1760406101.424439&cid=C06UWQNCU7M
-        version: [ 8.6.1, 8.8.0-alpha8 ]
+        # Uses fake tag for dry run testing without affecting real releases
+        version: [ 0.0.0-dryrun-minor, 0.0.0-dryrun-alpha ]
         include:
-          - version: 8.6.1
+          - version: 0.0.0-dryrun-minor
             latest: true
-          - version: 8.8.0-alpha8
+          - version: 0.0.0-dryrun-alpha
             latest: false
     with:
       releaseBranch: ${{ inputs.branch || 'main' }}
@@ -43,7 +65,7 @@ jobs:
   notify:
     name: Send Slack notification
     runs-on: ubuntu-latest
-    needs: [dry-run-release]
+    needs: [create-fake-tag, dry-run-release]
     if: always()
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -11,35 +11,8 @@ on:
     - cron: '0 2 * * 1-5'
 
 jobs:
-  create-fake-tag:
-    name: "Create fake tag for dry runs"
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Git User Setup
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Create fake tag locally
-        run: |
-          git fetch origin tag 0.0.0-dryrun-86 --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-86 -m "Dummy tag for dry run 8.6"
-          git fetch origin tag 0.0.0-dryrun-87 --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-87 -m "Dummy tag for dry run 8.7"  
-          git fetch origin tag 0.0.0-dryrun-88 --no-tags 2>/dev/null || git tag -a 0.0.0-dryrun-88 -m "Dummy tag for dry run 8.8"
-          echo "Created fake tags for all dry runs locally (not pushed)"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: create-fake-tag
-          path: .git
-
   dry-run-release-88:
     name: "Release from stable/8.8"
-    needs: create-fake-tag
     uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.8
     secrets: inherit
     strategy:
@@ -53,7 +26,6 @@ jobs:
       dryRun: true
   dry-run-release-87:
     name: "Release from stable/8.7"
-    needs: create-fake-tag
     uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.7
     secrets: inherit
     strategy:
@@ -67,7 +39,6 @@ jobs:
       dryRun: true
   dry-run-release-86:
     name: "Release from stable/8.6"
-    needs: create-fake-tag
     uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.6
     secrets: inherit
     strategy:
@@ -83,7 +54,7 @@ jobs:
   notify-camunda:
     name: Send Slack notification for 8.6+
     runs-on: ubuntu-latest
-    needs: [create-fake-tag, dry-run-release-86, dry-run-release-87, dry-run-release-88]
+    needs: [dry-run-release-86, dry-run-release-87, dry-run-release-88]
     if: always()
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
@@ -102,7 +73,7 @@ jobs:
 
       - name: Send failure Slack notification
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        if: ${{ always() && (needs.dry-run-release-86.result != 'success' || needs.dry-run-release-87.result != 'success' || needs.dry-run-release-88.result != 'success') && github.event_name == 'schedule' }}
+        if: ${{ (needs.dry-run-release-86.result != 'success' || needs.dry-run-release-87.result != 'success' || needs.dry-run-release-88.result != 'success') && github.event_name == 'schedule' }}
         with:
           webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Description

This pull request updates the dry run workflow for the Camunda Platform release process to improve safety and reliability. The main change is introducing a new job that creates local "fake" tags for dry run releases, ensuring that no real release tags are created or pushed during testing. The workflow now uses these fake tags for all dry run operations, and dependencies between jobs are updated accordingly.

Workflow improvements for safer dry runs:

* Added a new `create-fake-tag` job in `.github/workflows/camunda-platform-release-main-dry-run.yml` that creates local fake tags (`0.0.0-dryrun-minor` and `0.0.0-dryrun-alpha`) for use in dry run release testing, without pushing any tags to the remote repository.
* Updated the `dry-run-release` job to depend on `create-fake-tag` and to use the fake tags as the only versions in its matrix, preventing accidental use of real release tags.
* Adjusted the `notify` job to depend on both `create-fake-tag` and `dry-run-release`, ensuring notifications are only sent after both jobs complete.

Inspired by: https://github.com/camunda/camunda/pull/40040/files

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
