### PR TITLE
feat: make timeout configurable for initial dynamic config sync initializer

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Metadata.java
+++ b/configuration/src/main/java/io/camunda/configuration/Metadata.java
@@ -23,6 +23,9 @@ public class Metadata {
   private static final Set<String> LEGACY_GOSSIP_FANOUT_PROPERTIES =
       Set.of("zeebe.broker.cluster.configManager.gossip.gossipFanout");
 
+  private Duration syncInitializerDelay =
+      ClusterConfigurationGossiperConfig.DEFAULT_SYNC_INITIALIZER_DELAY;
+
   /**
    * The delay between two sync requests in the ClusterConfigurationManager. A sync request is sent
    * to another node to get the latest topology of the cluster.
@@ -69,5 +72,13 @@ public class Metadata {
 
   public void setGossipFanout(final Integer gossipFanout) {
     this.gossipFanout = gossipFanout;
+  }
+
+  public Duration getSyncInitializerDelay() {
+    return syncInitializerDelay;
+  }
+
+  public void setSyncInitializerDelay(final Duration delay) {
+    syncInitializerDelay = delay;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -494,8 +494,10 @@ public class BrokerBasedPropertiesOverride {
     final var syncDelay = metadata.getSyncDelay();
     final var syncTimeout = metadata.getSyncRequestTimeout();
     final var gossipFanout = metadata.getGossipFanout();
+    final var syncInitializerDelay = metadata.getSyncInitializerDelay();
     final var configManagerGossipConfig =
-        new ClusterConfigurationGossiperConfig(syncDelay, syncTimeout, gossipFanout);
+        new ClusterConfigurationGossiperConfig(
+            syncDelay, syncTimeout, gossipFanout, syncInitializerDelay);
     override.getCluster().setConfigManager(new ConfigManagerCfg(configManagerGossipConfig));
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
+++ b/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
@@ -54,7 +54,8 @@ public class DynamicClusterServices {
     return new ClusterConfigurationGossiperConfig(
         gossiperConfig.getSyncDelay(),
         gossiperConfig.getSyncRequestTimeout(),
-        gossiperConfig.getGossipFanout());
+        gossiperConfig.getGossipFanout(),
+        gossiperConfig.getSyncInitializerDelay());
   }
 
   @Bean

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -395,7 +395,10 @@ final class SystemContextTest {
     final var invalidconfigManagerCfg =
         new ConfigManagerCfg(
             new ClusterConfigurationGossiperConfig(
-                Duration.ofSeconds(10).negated(), Duration.ofSeconds(10).negated(), -1));
+                Duration.ofSeconds(10).negated(),
+                Duration.ofSeconds(10).negated(),
+                -1,
+                Duration.ofSeconds(1)));
     clusterCfg.setConfigManager(invalidconfigManagerCfg);
 
     // when
@@ -420,7 +423,7 @@ final class SystemContextTest {
     final var invalidConfigManagerCfg =
         new ConfigManagerCfg(
             new ClusterConfigurationGossiperConfig(
-                Duration.ofSeconds(0), Duration.ofSeconds(0), 0));
+                Duration.ofSeconds(0), Duration.ofSeconds(0), 0, Duration.ofSeconds(1)));
     clusterCfg.setConfigManager(invalidConfigManagerCfg);
 
     // when
@@ -445,7 +448,7 @@ final class SystemContextTest {
     final var invalidDynamicConfig =
         new ConfigManagerCfg(
             new ClusterConfigurationGossiperConfig(
-                Duration.ofSeconds(1), Duration.ofSeconds(1), 1));
+                Duration.ofSeconds(1), Duration.ofSeconds(1), 1, Duration.ofSeconds(1)));
     clusterCfg.setConfigManager(invalidDynamicConfig);
 
     // when

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
@@ -177,7 +177,7 @@ public final class ClusterCfgTest {
         .isEqualTo(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    Duration.ofSeconds(10), Duration.ofSeconds(30), 10)));
+                    Duration.ofSeconds(10), Duration.ofSeconds(30), 10, Duration.ofSeconds(1))));
   }
 
   @Test
@@ -199,7 +199,7 @@ public final class ClusterCfgTest {
         .isEqualTo(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    Duration.ofSeconds(5), Duration.ofSeconds(6), 6)));
+                    Duration.ofSeconds(5), Duration.ofSeconds(6), 6, Duration.ofSeconds(1))));
   }
 
   @Test

--- a/zeebe/broker/src/test/resources/system/config-manager.yaml
+++ b/zeebe/broker/src/test/resources/system/config-manager.yaml
@@ -7,3 +7,4 @@ zeebe:
           syncDelay: 10s
           syncRequestTimeout: 30s
           gossipFanout: 10
+          syncInitializerDelay: 1s

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -250,7 +250,7 @@ public interface ClusterConfigurationInitializer {
       implements ClusterConfigurationInitializer, ClusterConfigurationUpdateListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SyncInitializer.class);
-    private static final Duration SYNC_QUERY_RETRY_DELAY = Duration.ofSeconds(5);
+    private final Duration syncDelay;
     private final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier;
     private final ActorFuture<ClusterConfiguration> initialized;
     private final List<MemberId> knownMembersToSync;
@@ -258,10 +258,12 @@ public interface ClusterConfigurationInitializer {
     private final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester;
 
     public SyncInitializer(
+        final Duration syncDelay,
         final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier,
         final List<MemberId> knownMembersToSync,
         final ConcurrencyControl executor,
         final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester) {
+      this.syncDelay = syncDelay;
       this.clusterConfigurationUpdateNotifier = clusterConfigurationUpdateNotifier;
       this.knownMembersToSync = knownMembersToSync;
       this.executor = executor;
@@ -309,7 +311,7 @@ public interface ClusterConfigurationInitializer {
                 }
                 // retry
                 if (!initialized.isDone()) {
-                  executor.schedule(SYNC_QUERY_RETRY_DELAY, () -> tryInitializeFrom(memberId));
+                  executor.schedule(syncDelay, () -> tryInitializeFrom(memberId));
                 }
               });
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -58,6 +58,7 @@ public final class ClusterConfigurationManagerService
   private final ClusterConfigurationRequestServer configurationRequestServer;
   private final Actor gossipActor;
   private final Actor managerActor;
+  private final ClusterConfigurationGossiperConfig gossiperConfig;
   private final ClusterChangeExecutor clusterChangeExecutor;
   private final TopologyMetrics topologyMetrics;
   private final TopologyManagerMetrics topologyManagerMetrics;
@@ -69,6 +70,7 @@ public final class ClusterConfigurationManagerService
       final ClusterConfigurationGossiperConfig config,
       final ClusterChangeExecutor clusterChangeExecutor,
       final MeterRegistry meterRegistry) {
+    gossiperConfig = config;
     this.clusterChangeExecutor = clusterChangeExecutor;
     topologyMetrics = new TopologyMetrics(meterRegistry);
     topologyManagerMetrics = new TopologyManagerMetrics(meterRegistry);
@@ -125,6 +127,7 @@ public final class ClusterConfigurationManagerService
         .recover(
             PersistedConfigurationIsBroken.class,
             new SyncInitializer(
+                gossiperConfig.syncInitializerDelay(),
                 clusterConfigurationGossiper,
                 otherKnownMembers,
                 managerActor,
@@ -154,6 +157,7 @@ public final class ClusterConfigurationManagerService
     return new FileInitializer(configurationFile, new ProtoBufSerializer())
         .orThen(
             new SyncInitializer(
+                gossiperConfig.syncInitializerDelay(),
                 clusterConfigurationGossiper,
                 otherKnownMembers,
                 managerActor,
@@ -187,6 +191,7 @@ public final class ClusterConfigurationManagerService
   private CompletableActorFuture<Void> startClusterTopologyServices(
       final ActorSchedulingService actorSchedulingService,
       final StaticConfiguration staticConfiguration) {
+
     final var result = new CompletableActorFuture<Void>();
     final ClusterConfigurationInitializer clusterConfigurationInitializer =
         isCoordinator

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -191,7 +191,6 @@ public final class ClusterConfigurationManagerService
   private CompletableActorFuture<Void> startClusterTopologyServices(
       final ActorSchedulingService actorSchedulingService,
       final StaticConfiguration staticConfiguration) {
-
     final var result = new CompletableActorFuture<Void>();
     final ClusterConfigurationInitializer clusterConfigurationInitializer =
         isCoordinator

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperConfig.java
@@ -11,21 +11,33 @@ import java.time.Duration;
 import java.util.Optional;
 
 public record ClusterConfigurationGossiperConfig(
-    Duration syncDelay, Duration syncRequestTimeout, Integer gossipFanout) {
+    Duration syncDelay,
+    Duration syncRequestTimeout,
+    Integer gossipFanout,
+    Duration syncInitializerDelay) {
 
   public static final Duration DEFAULT_SYNC_DELAY = Duration.ofSeconds(10);
+  public static final Duration DEFAULT_SYNC_INITIALIZER_DELAY = Duration.ofSeconds(5);
   public static final Duration DEFAULT_SYNC_REQUEST_TIMEOUT = Duration.ofSeconds(2);
   public static final int DEFAULT_GOSSIP_FANOUT = 2;
 
   public static final ClusterConfigurationGossiperConfig DEFAULT =
       new ClusterConfigurationGossiperConfig(
-          DEFAULT_SYNC_DELAY, DEFAULT_SYNC_REQUEST_TIMEOUT, DEFAULT_GOSSIP_FANOUT);
+          DEFAULT_SYNC_DELAY,
+          DEFAULT_SYNC_REQUEST_TIMEOUT,
+          DEFAULT_GOSSIP_FANOUT,
+          DEFAULT_SYNC_INITIALIZER_DELAY);
 
   public ClusterConfigurationGossiperConfig(
-      final Duration syncDelay, final Duration syncRequestTimeout, final Integer gossipFanout) {
+      final Duration syncDelay,
+      final Duration syncRequestTimeout,
+      final Integer gossipFanout,
+      final Duration syncInitializerDelay) {
     this.syncDelay = Optional.ofNullable(syncDelay).orElse(DEFAULT_SYNC_DELAY);
     this.syncRequestTimeout =
         Optional.ofNullable(syncRequestTimeout).orElse(DEFAULT_SYNC_REQUEST_TIMEOUT);
     this.gossipFanout = Optional.ofNullable(gossipFanout).orElse(DEFAULT_GOSSIP_FANOUT);
+    this.syncInitializerDelay =
+        Optional.ofNullable(syncInitializerDelay).orElse(DEFAULT_SYNC_INITIALIZER_DELAY);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -151,6 +151,7 @@ final class ClusterConfigurationInitializerTest {
         id -> syncResponseFuture;
     final var initializer =
         new SyncInitializer(
+            Duration.ofSeconds(5),
             new TestClusterConfigurationNotifier(),
             knownMembers,
             new TestConcurrencyControl(),
@@ -180,6 +181,7 @@ final class ClusterConfigurationInitializerTest {
         id -> syncResponseFuture;
     final var initializer =
         new SyncInitializer(
+            Duration.ofSeconds(5),
             new TestClusterConfigurationNotifier(),
             knownMembers,
             new TestConcurrencyControl(),
@@ -320,6 +322,7 @@ final class ClusterConfigurationInitializerTest {
           id -> syncResponseFuture;
       final var syncInitializer =
           new SyncInitializer(
+              Duration.ofSeconds(5),
               new TestClusterConfigurationNotifier(),
               knownMembers,
               new TestConcurrencyControl(),
@@ -348,6 +351,7 @@ final class ClusterConfigurationInitializerTest {
           id -> syncResponseFuture;
       final var syncInitializer =
           new SyncInitializer(
+              Duration.ofSeconds(5),
               new TestClusterConfigurationNotifier(),
               knownMembers,
               new TestConcurrencyControl(),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -255,7 +255,7 @@ class ClusterConfigurationManagementIntegrationTest {
             cluster.getCommunicationService(),
             cluster.getMembershipService(),
             new ClusterConfigurationGossiperConfig(
-                Duration.ofSeconds(1), Duration.ofMillis(100), 2),
+                Duration.ofSeconds(1), Duration.ofMillis(100), 2, Duration.ofSeconds(1)),
             new NoopClusterChangeExecutor(),
             meterRegistry);
     return new TestNode(cluster, service);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
@@ -61,7 +61,8 @@ final class ClusterConfigurationGossiperTest {
   void shouldPropagateTopologyUpdate() {
     // given
     final var config =
-        new ClusterConfigurationGossiperConfig(Duration.ofMillis(100), Duration.ofSeconds(1), 0);
+        new ClusterConfigurationGossiperConfig(
+            Duration.ofMillis(100), Duration.ofSeconds(1), 0, Duration.ofSeconds(1));
     node1 =
         new TestGossiper(
             createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics);

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -48,7 +48,7 @@ public final class GatewayCfgTest {
         .setConfigManager(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    Duration.ofSeconds(5), Duration.ofSeconds(30), 6)));
+                    Duration.ofSeconds(5), Duration.ofSeconds(30), 6, Duration.ofSeconds(1))));
     CUSTOM_CFG
         .getSecurity()
         .setEnabled(true)
@@ -198,7 +198,7 @@ public final class GatewayCfgTest {
         .setConfigManager(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    Duration.ofSeconds(5), Duration.ofSeconds(5), 4)));
+                    Duration.ofSeconds(5), Duration.ofSeconds(5), 4, Duration.ofSeconds(1))));
     expected.getThreads().setManagementThreads(32);
     expected
         .getSecurity()

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -442,9 +442,14 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
         .setCompressionAlgorithm(io.camunda.configuration.Cluster.CompressionAlgorithm.NONE);
 
     // Set membership defaults for fast test execution
-    unifiedConfig.getCluster().getMembership().setFailureTimeout(Duration.ofSeconds(5));
-    unifiedConfig.getCluster().getMembership().setProbeInterval(Duration.ofMillis(100));
-    unifiedConfig.getCluster().getMembership().setSyncInterval(Duration.ofMillis(500));
+    final var membership = unifiedConfig.getCluster().getMembership();
+    membership.setFailureTimeout(Duration.ofSeconds(5));
+    membership.setProbeInterval(Duration.ofMillis(100));
+    membership.setSyncInterval(Duration.ofMillis(500));
+
+    final var metadata = unifiedConfig.getCluster().getMetadata();
+    metadata.setSyncInitializerDelay(Duration.ofMillis(500));
+    metadata.setSyncDelay(Duration.ofMillis(500));
 
     // Set raft defaults - disable flushing for faster tests
     unifiedConfig.getCluster().getRaft().setFlushEnabled(false);


### PR DESCRIPTION
## Description
The delay used in `SyncInitializer` was set to a static default of `5 seconds` which slows down the tests a lot. 
By adding this field to the config, we can provide much smaller delays when testing. 
I'm not sure this setting will be useful to users. 
## Dependencies 

- [x] #36058 currently it's not possible to configure the `ClusterConfigurationGossiper` via the legacy props

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #39858
