### PR TITLE
fix: truncate Elasticsearch log on restart

### DIFF
--- a/c8run/internal/processmanagement/processhandler_unix.go
+++ b/c8run/internal/processmanagement/processhandler_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package processmanagement
 

--- a/c8run/internal/processmanagement/processhandler_windows.go
+++ b/c8run/internal/processmanagement/processhandler_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package processmanagement
 

--- a/c8run/internal/start/startuphandler.go
+++ b/c8run/internal/start/startuphandler.go
@@ -61,11 +61,18 @@ type StartupHandler struct {
 }
 
 func (s *StartupHandler) startApplication(cmd *exec.Cmd, pid string, logPath string, stop context.CancelFunc) error {
-	logFile, err := os.OpenFile(logPath, os.O_RDWR|os.O_CREATE, 0644)
+	logFile, err := os.OpenFile(logPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		log.Err(err).Msg("Failed to open file: " + logPath)
 		return err
 	}
+
+	defer func() {
+		if cerr := logFile.Close(); cerr != nil {
+			log.Err(cerr).Msg("Failed to close file: " + logPath)
+		}
+	}()
+
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	err = cmd.Start()


### PR DESCRIPTION
## Description

- fix for start clean log files on app start
- fix for issue with not closing (and make available for writing) resources for Windows

## Related issues
https://github.com/camunda/camunda/issues/31522

closes #
