### PR TITLE
39581 add authorization to security config

### DIFF
--- a/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredAuthorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredAuthorization.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.Set;
+
+public record ConfiguredAuthorization(
+    AuthorizationOwnerType ownerType,
+    String ownerId,
+    AuthorizationResourceType resourceType,
+    String resourceId,
+    Set<PermissionType> permissions) {}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
@@ -23,6 +23,7 @@ public class InitializationConfiguration {
   private List<ConfiguredUser> users = new ArrayList<>();
   private List<ConfiguredMappingRule> mappingRules = new ArrayList<>();
   private Map<String, Map<String, Collection<String>>> defaultRoles = new HashMap<>();
+  private List<ConfiguredAuthorization> authorizations = new ArrayList<>();
 
   public List<ConfiguredUser> getUsers() {
     return users;
@@ -46,5 +47,13 @@ public class InitializationConfiguration {
 
   public void setDefaultRoles(final Map<String, Map<String, Collection<String>>> defaultRoles) {
     this.defaultRoles = defaultRoles;
+  }
+
+  public List<ConfiguredAuthorization> getAuthorizations() {
+    return authorizations;
+  }
+
+  public void setAuthorizations(final List<ConfiguredAuthorization> authorizations) {
+    this.authorizations = authorizations;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.security.configuration;
 import io.camunda.security.configuration.headers.HeaderConfiguration;
 import java.util.regex.Pattern;
 
+/** Will be populated with the configuration properties of 'camunda.security' */
 public class SecurityConfiguration {
 
   /** 1 or more alphanumeric characters, '_', '@', '.', '+', '-' or '~'. */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/IdentitySetupInitializer.java
@@ -84,9 +84,6 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
     PlatformDefaultEntities.setupDefaultTenant(setupRecord);
     PlatformDefaultEntities.setupDefaultRoles(setupRecord);
 
-    // TODO: remove after implementing actual functionality
-    LOG.debug("Configured authorizations: {}", initialization.getAuthorizations());
-
     initialization
         .getUsers()
         .forEach(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/IdentitySetupInitializer.java
@@ -84,6 +84,9 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
     PlatformDefaultEntities.setupDefaultTenant(setupRecord);
     PlatformDefaultEntities.setupDefaultRoles(setupRecord);
 
+    // TODO: remove after implementing actual functionality
+    LOG.debug("Configured authorizations: {}", initialization.getAuthorizations());
+
     initialization
         .getUsers()
         .forEach(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add the configuration properties to create user defined authorizations during initialization.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39581 
