### PR TITLE
fix: fix input validation

### DIFF
--- a/.github/workflows/create-urgent-hotfix-img.yml
+++ b/.github/workflows/create-urgent-hotfix-img.yml
@@ -70,6 +70,7 @@ jobs:
 
 
           [[ -z "$BRANCH" && -z "$COMMIT" ]] && { echo "❌ Either branch or commit required"; exit 1; }
+          [[ -n "$BRANCH" && "$BRANCH" =~ [[:space:]] ]] && { echo "❌ Branch name cannot contain whitespace"; exit 1; }
           [[ -n "$COMMIT" && ! "$COMMIT" =~ ^[a-f0-9]{40}$ ]] && { echo "❌ Commit must be a full 40-character SHA (got: $COMMIT)"; exit 1; }
           [[ -z "$TICKET_ID" ]] && { echo "❌ Support ticket ID required"; exit 1; }
           [[ ! "$TICKET_ID" =~ ^[a-zA-Z0-9_-]+$ ]] && { echo "❌ Invalid ticket ID format"; exit 1; }
@@ -86,6 +87,13 @@ jobs:
           IFS=',' read -ra ARRAY <<< "$COMPONENTS"
           for ITEM in "${ARRAY[@]}"; do
             ITEM=$(echo "$ITEM" | xargs)
+            
+            # Check for whitespace in the component:version string
+            if [[ "$ITEM" =~ [[:space:]] ]]; then
+              echo "❌ Invalid format: '$ITEM' contains whitespace (spaces are not allowed)"
+              exit 1
+            fi
+            
             if [[ "$ITEM" =~ ^([^:]+):(.+)$ ]]; then
               COMP="${BASH_REMATCH[1]}"
               case "$COMP" in


### PR DESCRIPTION
Adding whitespace check for component and branch name validation.

## Reason:
- Whitespace in component input caused docker error:
<img width="1349" height="141" alt="image" src="https://github.com/user-attachments/assets/c0434a47-c658-4e3d-91a4-6579d3b04246" />

After:
[Invalid branch name](https://github.com/camunda/camunda/actions/runs/18967019706/job/54165733338#step:2:52):
<img width="480" height="294" alt="image" src="https://github.com/user-attachments/assets/ede4f67d-a089-4dd6-b61f-cc575afdf2ba" />

[Invalid component](https://github.com/camunda/camunda/actions/runs/18967049965/job/54165824248#step:2:52):
<img width="814" height="171" alt="image" src="https://github.com/user-attachments/assets/e2ab9c71-bd60-413e-95e5-4089866f83e6" />

