### PR TITLE
ci: modify issue templates to accommodate for management identity

### DIFF
--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -17,6 +17,7 @@ body:
         - <!-- Data Layer- -->
         - <!-- Feel- -->
         - <!-- Identity- -->
+        - <!-- Management Identity- -->
         - <!-- Operate- -->
         - <!-- Optimize- -->
         - <!-- Spring SDK- -->

--- a/.github/ISSUE_TEMPLATE/2. feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2. feature_request.yml
@@ -17,6 +17,7 @@ body:
         - <!-- Data Layer- -->
         - <!-- Feel- -->
         - <!-- Identity- -->
+        - <!-- Management Identity- -->
         - <!-- Operate- -->
         - <!-- Optimize- -->
         - <!-- Spring SDK- -->

--- a/.github/ISSUE_TEMPLATE/3. task.yml
+++ b/.github/ISSUE_TEMPLATE/3. task.yml
@@ -17,6 +17,7 @@ body:
         - <!-- Data Layer- -->
         - <!-- Feel- -->
         - <!-- Identity- -->
+        - <!-- Management Identity- -->
         - <!-- Operate- -->
         - <!-- Optimize- -->
         - <!-- Spring SDK- -->

--- a/.github/ISSUE_TEMPLATE/4. epic breakdown.yml
+++ b/.github/ISSUE_TEMPLATE/4. epic breakdown.yml
@@ -18,6 +18,7 @@ body:
         - <!-- Data Layer- -->
         - <!-- Feel- -->
         - <!-- Identity- -->
+        - <!-- Management Identity- -->
         - <!-- Operate- -->
         - <!-- Optimize- -->
         - <!-- Spring SDK- -->

--- a/.github/ISSUE_TEMPLATE/5. CVE.yml
+++ b/.github/ISSUE_TEMPLATE/5. CVE.yml
@@ -17,6 +17,7 @@ body:
         - <!-- Data Layer- -->
         - <!-- Feel- -->
         - <!-- Identity- -->
+        - <!-- Management Identity- -->
         - <!-- Operate- -->
         - <!-- Optimize- -->
         - <!-- Spring SDK- -->

--- a/.github/ISSUE_TEMPLATE/6. tech debt.yml
+++ b/.github/ISSUE_TEMPLATE/6. tech debt.yml
@@ -17,6 +17,7 @@ body:
         - <!-- Data Layer- -->
         - <!-- Feel- -->
         - <!-- Identity- -->
+        - <!-- Management Identity- -->
         - <!-- Operate- -->
         - <!-- Optimize- -->
         - <!-- Spring SDK- -->

--- a/.github/opened_issue_labeler.yml
+++ b/.github/opened_issue_labeler.yml
@@ -14,6 +14,8 @@ component/feel-scala:
   '(Feel-)'
 component/identity:
   '(Identity-)'
+component/management-identity:
+  '(Management Identity-)'
 component/operate:
   '(Operate-)'
 component/optimize:

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           project-url: https://github.com/orgs/camunda/projects/209
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
-          labeled: component/identity
+          labeled: component/identity, component/management-identity
       - id: add-to-distribution
         name: Add to Distribution Team project
         uses: actions/add-to-project@v1.0.2


### PR DESCRIPTION
## Description

Modifying issue templates and related workflows to accommodate for the Management Identity issues. This is part of the [central public issue tracker ](https://github.com/camunda/engineering-leadership-team/issues/216) project.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
