### PR TITLE
Reduce bulk delay to 1s default

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -141,7 +141,7 @@ public class ExporterConfiguration {
 
   public static class BulkConfiguration {
     // delay before forced flush
-    private int delay = 5;
+    private int delay = 1;
     // bulk size before flush
     private int size = 1_000;
     // bulk memory utilisation before flush (in Mb)


### PR DESCRIPTION
## Description

To give a better UX, reduce the bulk delay from 5s to 1s so data is visible to users faster.  (from 4s to 2s in low load conditions, unchanged for high load conditions)

Investigations on impact documented here https://github.com/camunda/camunda/issues/33165#issuecomment-3411740977

Matching docs PR here https://github.com/camunda/camunda-docs/pull/7215

## Related issues

closes #33165 
