### PR TITLE
ci: remove docker build from zeebe-engine-integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -794,8 +794,6 @@ jobs:
             maven-build-threads: 1
             maven-test-fork-count: 10
             runs-on: gcp-perf-core-16-default
-            docker-repository: localhost:5000/camunda/zeebe
-            docker-file: Dockerfile
             owner: "Core Features"
             module: "Zeebe"
             test-filter: "io.camunda.zeebe.it.engine.**,!**/*$*.java"


### PR DESCRIPTION
## Description

Removes the docker build step from the `zeebe-engine-integration` test matrix entry in the CI workflow by removing the `docker-repository` and `docker-file` configuration properties.

This change skips the unnecessary Docker image build for these tests, improving CI performance and reducing resource usage.

## Related Issues

Closes #39968

## Testing

- The zeebe-engine-integration tests will continue to run without the Docker build step
- The conditional check `if: ${{ matrix.docker-file != '' }}` will prevent the build-platform-docker action from executing for this test group