### PR TITLE
ci: forbid Renovate to act on 8.5 branches due to EOL

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,6 +77,14 @@
       "enabled": false
     },
     {
+      "description": "Disable all Renovate updates on EOL 8.5 stable branches to prevent unwanted PRs from Renovate.",
+      "matchBaseBranches": [
+        "stable/8.5",
+        "stable/operate-8.5"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Identify updates related to builds, tooling, etc. that should be routed to Monorepo DevOps team.",
       "matchManagers": [
         "dockerfile",


### PR DESCRIPTION
## Description

This pull request updates the Renovate configuration to ensure that no automated dependency updates are created for end-of-life (EOL) 8.5 stable branches. This helps prevent unnecessary or unwanted pull requests on branches that are no longer maintained.

Renovate configuration updates:

* Added a rule to disable all Renovate updates on `stable/8.5` and `stable/operate-8.5` branches to prevent unwanted PRs from being created for EOL branches.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
