### PR TITLE
fix: only apply job worker defaults if they are not default

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizer.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizer.java
@@ -207,7 +207,8 @@ public class PropertyBasedJobWorkerValueCustomizer implements JobWorkerValueCust
       final Consumer<T> setter,
       final T defaultValue) {
     final T value = getter.get();
-    if (value != null && !Objects.equals(value, defaultValue) || overrideSource == OverrideSource.worker) {
+    if (value != null && !Objects.equals(value, defaultValue)
+        || overrideSource == OverrideSource.worker) {
       LOG.debug("Overriding property '{}' from source {}", propertyName, overrideSource);
       setter.accept(value);
     }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizer.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizer.java
@@ -207,8 +207,8 @@ public class PropertyBasedJobWorkerValueCustomizer implements JobWorkerValueCust
       final Consumer<T> setter,
       final T defaultValue) {
     final T value = getter.get();
-    if (value != null && !Objects.equals(value, defaultValue)
-        || overrideSource == OverrideSource.worker) {
+    if (value != null
+        && (!Objects.equals(value, defaultValue) || overrideSource == OverrideSource.worker)) {
       LOG.debug("Overriding property '{}' from source {}", propertyName, overrideSource);
       setter.accept(value);
     }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizerTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/PropertyBasedJobWorkerValueCustomizerTest.java
@@ -57,6 +57,36 @@ public class PropertyBasedJobWorkerValueCustomizerTest {
   }
 
   @Test
+  void shouldNotApplyDefaultValue() {
+    final CamundaClientProperties properties = properties();
+    final PropertyBasedJobWorkerValueCustomizer customizer =
+        new PropertyBasedJobWorkerValueCustomizer(properties);
+    final JobWorkerValue jobWorkerValue = new JobWorkerValue();
+    jobWorkerValue.setMethodInfo(methodInfo(this, "testBean", "emptyWorker"));
+    jobWorkerValue.setMaxJobsActive(2);
+    customizer.customize(jobWorkerValue);
+    assertThat(jobWorkerValue.getMaxJobsActive()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldApplyOverrideValue() {
+    final CamundaClientProperties properties = properties();
+
+    final CamundaClientJobWorkerProperties overrideProperties =
+        new CamundaClientJobWorkerProperties();
+    overrideProperties.setMaxJobsActive(32);
+    properties.getWorker().getOverride().put("test", overrideProperties);
+    final PropertyBasedJobWorkerValueCustomizer customizer =
+        new PropertyBasedJobWorkerValueCustomizer(properties);
+    final JobWorkerValue jobWorkerValue = new JobWorkerValue();
+    jobWorkerValue.setMethodInfo(methodInfo(this, "testBean", "emptyWorker"));
+    jobWorkerValue.setMaxJobsActive(2);
+    jobWorkerValue.setType("test");
+    customizer.customize(jobWorkerValue);
+    assertThat(jobWorkerValue.getMaxJobsActive()).isEqualTo(32);
+  }
+
+  @Test
   void shouldApplyDistinctFetchVariables() {
     // given
     final CamundaClientProperties properties = properties();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR fixes an issue for 8.8 where a default property of the worker defaults would always override a property set by the job worker annotation.

Hint: this will be fixed in 8.9 by https://github.com/camunda/camunda/pull/36592

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
