### PR TITLE
feat: introduce NodeIdRepository w/ S3 implementation

### DIFF
--- a/zeebe/dynamic-node-id-provider/pom.xml
+++ b/zeebe/dynamic-node-id-provider/pom.xml
@@ -30,9 +30,72 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+
+    <!--  AWS -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>http-client-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>regions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>aws-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sdk-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>apache-client</artifactId>
+    </dependency>
+
+    <!--  TEST   -->
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- TestContainers-->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zeebe/dynamic-node-id-provider/pom.xml
+++ b/zeebe/dynamic-node-id-provider/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.9.0-SNAPSHOT</version>
+    <relativePath>../../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>dynamic-node-id-provider</artifactId>
+  <packaging>jar</packaging>
+  <name>Dynamic NodeId Provider</name>
+  <properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/zeebe/dynamic-node-id-provider/pom.xml
+++ b/zeebe/dynamic-node-id-provider/pom.xml
@@ -6,9 +6,7 @@
   ~ Licensed under the Camunda License 1.0. You may not use this file
   ~ except in compliance with the Camunda License 1.0.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.camunda</groupId>
@@ -29,6 +27,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <!--  AWS -->
@@ -86,12 +92,8 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+
+public record Lease(String taskId, long timestamp, NodeInstance nodeInstance) {
+  public String toJson(final ObjectMapper objectMapper) {
+    try {
+      return objectMapper.writeValueAsString(this);
+    } catch (final JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public byte[] toJsonBytes(final ObjectMapper objectMapper) {
+    try {
+      return objectMapper.writeValueAsBytes(this);
+    } catch (final JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static Lease fromJson(final ObjectMapper objectMapper, final String json) {
+    try {
+      return objectMapper.readValue(json, Lease.class);
+    } catch (final JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static Lease fromJsonBytes(final ObjectMapper objectMapper, final byte[] json)
+      throws IOException {
+    return objectMapper.readValue(json, Lease.class);
+  }
+
+  public boolean isStillValid(final long now, final Duration leaseDuration) {
+    return timestamp + leaseDuration.toMillis() > now;
+  }
+
+  public Lease renew(final long now, final Duration leaseDuration) {
+    if (!isStillValid(now, leaseDuration)) {
+      throw new IllegalStateException(
+          "Lease is not valid anymore, it expired at " + Instant.ofEpochMilli(timestamp));
+    }
+    final var millis = leaseDuration.toMillis();
+    return new Lease(taskId, now + millis, nodeInstance);
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeInstance.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeInstance.java
@@ -10,19 +10,8 @@ package io.camunda.zeebe.dynamic.nodeid;
 // id ~ integer from 0 to clusterSize
 public record NodeInstance(int id /*, int version*/) {
   public NodeInstance {
-    //    if (version < 0) {
-    //      throw new IllegalArgumentException("version cannot be negative, was " + version);
-    //    }
     if (id < 0) {
       throw new IllegalArgumentException("id cannot be negative, was " + id);
     }
   }
-
-  public static NodeInstance initial(final int id) {
-    return new NodeInstance(id /*, 0*/);
-  }
-
-  //  public NodeInstance nextVersion() {
-  //    return new NodeInstance(id, version + 1);
-  //  }
 }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeInstance.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeInstance.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+// id ~ integer from 0 to clusterSize
+public record NodeInstance(int id /*, int version*/) {
+  public NodeInstance {
+    //    if (version < 0) {
+    //      throw new IllegalArgumentException("version cannot be negative, was " + version);
+    //    }
+    if (id < 0) {
+      throw new IllegalArgumentException("id cannot be negative, was " + id);
+    }
+  }
+
+  public static NodeInstance initial(final int id) {
+    return new NodeInstance(id /*, 0*/);
+  }
+
+  //  public NodeInstance nextVersion() {
+  //    return new NodeInstance(id, version + 1);
+  //  }
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid.repository;
+
+import java.util.Map;
+
+public record Metadata(String task, long expiry) {
+
+  // KEYS MUST BE LOWERCASE
+  private static final String TASK_ID_KEY = "taskid";
+  private static final String EXPIRY_KEY = "expiry";
+
+  //    private static final String NODE_VERSIONKEY = "nodeversion";
+
+  public Map<String, String> asMap() {
+    return Map.of(TASK_ID_KEY, task, EXPIRY_KEY, String.valueOf(expiry));
+  }
+
+  public static Metadata fromMap(final Map<String, String> map) {
+    if (map.isEmpty()) {
+      return null;
+    }
+    return new Metadata(map.get(TASK_ID_KEY), Long.parseLong(map.get(EXPIRY_KEY)));
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -28,7 +28,8 @@ public interface NodeIdRepository extends AutoCloseable {
   StoredLease getLease(int nodeId);
 
   /**
-   * Acquire a lease, if it matches the provided {@param previousETag}.
+   * Acquire a lease, if it matches the provided {@param previousETag}. This method can be used both
+   * for the initial acquire and for renewing an existing lease.
    *
    * @param lease the lease to store
    * @param previousETag the eTag of the current lease in the store

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid.repository;
+
+import io.camunda.zeebe.dynamic.nodeid.Lease;
+
+public interface NodeIdRepository extends AutoCloseable {
+
+  /**
+   * Initialize the leases if they haven't been created yet.
+   *
+   * @param count the number of leases to create
+   */
+  void initialize(int count);
+
+  /**
+   * Get a lease without acquiring it. This can be used to verify the liveness of other nodes or
+   * their view of the cluster
+   *
+   * @param nodeId the node to get the lease for
+   * @return the lease
+   */
+  StoredLease getLease(int nodeId);
+
+  /**
+   * Acquire a lease, if it matches the provided {@param previousETag}.
+   *
+   * @param lease the lease to store
+   * @param previousETag the eTag of the current lease in the store
+   * @return
+   *     <ul>
+   *       <li>null if the lease could not be acquired
+   *       <li>the lease if it was acquired correctly.
+   *     </ul>
+   */
+  StoredLease.Initialized acquire(Lease lease, String previousETag);
+
+  /**
+   * Gracefully release the lease in the store
+   *
+   * @param lease the lease to release
+   */
+  void release(StoredLease.Initialized lease);
+
+  sealed interface StoredLease {
+    default boolean isInitialized() {
+      return switch (this) {
+        case final Uninitialized u -> false;
+        case final Initialized i -> true;
+      };
+    }
+
+    String eTag();
+
+    record Uninitialized(String eTag) implements StoredLease {}
+
+    record Initialized(Metadata metadata, Lease lease, String eTag) implements StoredLease {}
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -92,14 +92,14 @@ public class S3NodeIdRepository implements NodeIdRepository {
       if (!lease.isStillValid(clock.millis(), config.expiryDuration)) {
         throw new IllegalArgumentException("The provided lease is not valid anymore: " + lease);
       }
-      LOG.info("Acquiring lease {}, previous ETag {}", lease, previousETag);
+      LOG.debug("Acquiring lease {}, previous ETag {}", lease, previousETag);
       final var response =
           client.putObject(putRequest, RequestBody.fromBytes(lease.toJsonBytes(OBJECT_MAPPER)));
       final var storedLease = new StoredLease.Initialized(metadata, lease, response.eTag());
       LOG.debug("Lease acquired successfully {}", storedLease);
       return storedLease;
     } catch (final Exception e) {
-      LOG.warn("Failed to release the lease gracefully {}", lease, e);
+      LOG.warn("Failed to acquire the lease gracefully {}", lease, e);
       throw e;
     }
   }
@@ -122,7 +122,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
     final PutObjectRequest putRequest =
         createPutObjectRequest(nodeId, Optional.empty(), Optional.empty()).ifNoneMatch("*").build();
     try {
-      LOG.info("Creating file for node {}", nodeId);
+      LOG.debug("Creating file for node {}", nodeId);
       final var res = client.putObject(putRequest, RequestBody.empty());
       LOG.debug("File created for nodeId {}: {}", nodeId, res.eTag());
     } catch (final Exception e) {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid.repository.s3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.dynamic.nodeid.Lease;
+import io.camunda.zeebe.dynamic.nodeid.repository.Metadata;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.awscore.defaultsmode.DefaultsMode;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+public class S3NodeIdRepository implements NodeIdRepository {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3NodeIdRepository.class);
+  private final S3Client client;
+  private final Config config;
+  private final Clock clock;
+  private final boolean closeClient;
+
+  S3NodeIdRepository(
+      final S3Client s3AsyncClient,
+      final Config config,
+      final Clock clock,
+      final boolean closeClient) {
+    client = s3AsyncClient;
+    this.config = config;
+    this.clock = clock;
+    this.closeClient = closeClient;
+  }
+
+  public static S3NodeIdRepository of(
+      final S3ClientConfig s3ClientConfig, final Config config, final Clock clock) {
+    final var client = buildClient(s3ClientConfig);
+    // the client must be closed if it's built here
+    return new S3NodeIdRepository(client, config, clock, true);
+  }
+
+  @Override
+  public void initialize(final int count) {
+    IntStream.range(0, count).forEach(this::initializeForNode);
+  }
+
+  @Override
+  public StoredLease getLease(final int nodeId) {
+    final var request =
+        GetObjectRequest.builder().bucket(config.bucketName).key(objectKey(nodeId)).build();
+    final var response = client.getObject(request);
+    try {
+      final var bytes = response.readAllBytes();
+      final var lease = bytes.length > 0 ? Lease.fromJsonBytes(OBJECT_MAPPER, bytes) : null;
+      final var metadata = Metadata.fromMap(response.response().metadata());
+      final var eTag = response.response().eTag();
+      final var storedLease =
+          (lease != null && metadata != null)
+              ? new StoredLease.Initialized(metadata, lease, eTag)
+              : new StoredLease.Uninitialized(eTag);
+      LOG.trace("Lease for object {} is {}", nodeId, storedLease);
+      return storedLease;
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public StoredLease.Initialized acquire(final Lease lease, final String previousETag) {
+    final var nodeId = lease.nodeInstance().id();
+    final var metadata = new Metadata(config.taskId, lease.timestamp());
+    final PutObjectRequest putRequest =
+        createPutObjectRequest(nodeId, Optional.of(metadata), Optional.of(previousETag)).build();
+    try {
+      if (!lease.isStillValid(clock.millis(), config.expiryDuration)) {
+        throw new IllegalArgumentException("The provided lease is not valid anymore: " + lease);
+      }
+      LOG.info("Acquiring lease {}, previous ETag {}", lease, previousETag);
+      final var response =
+          client.putObject(putRequest, RequestBody.fromBytes(lease.toJsonBytes(OBJECT_MAPPER)));
+      final var storedLease = new StoredLease.Initialized(metadata, lease, response.eTag());
+      LOG.debug("Lease acquired successfully {}", storedLease);
+      return storedLease;
+    } catch (final Exception e) {
+      LOG.warn("Failed to release the lease gracefully {}", lease, e);
+      throw e;
+    }
+  }
+
+  @Override
+  public void release(final StoredLease.Initialized lease) {
+    final var nodeId = lease.lease().nodeInstance().id();
+    final PutObjectRequest putRequest =
+        createPutObjectRequest(nodeId, Optional.empty(), Optional.of(lease.eTag())).build();
+    try {
+      LOG.info("Release lease {}", lease);
+      client.putObject(putRequest, RequestBody.empty());
+      LOG.debug("Lease released gracefully: {}", lease);
+    } catch (final Exception e) {
+      LOG.warn("Failed to release the lease gracefully {}", lease, e);
+    }
+  }
+
+  public void initializeForNode(final int nodeId) {
+    final PutObjectRequest putRequest =
+        createPutObjectRequest(nodeId, Optional.empty(), Optional.empty()).ifNoneMatch("*").build();
+    try {
+      LOG.info("Creating file for node {}", nodeId);
+      final var res = client.putObject(putRequest, RequestBody.empty());
+      LOG.debug("File created for nodeId {}: {}", nodeId, res.eTag());
+    } catch (final Exception e) {
+      LOG.debug(
+          "File creation failed for nodeId {}: {}",
+          nodeId,
+          e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
+    }
+  }
+
+  private PutObjectRequest.Builder createPutObjectRequest(
+      final int nodeId, final Optional<Metadata> metadata, final Optional<String> eTag) {
+    final var builder =
+        PutObjectRequest.builder()
+            .bucket(config.bucketName)
+            .key(objectKey(nodeId))
+            .contentType("application/json");
+    metadata.ifPresent(value -> builder.metadata(value.asMap()));
+    eTag.ifPresent(builder::ifMatch);
+    return builder;
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (closeClient) {
+      client.close();
+    }
+  }
+
+  public static String objectKey(final int nodeId) {
+    return nodeId + ".json";
+  }
+
+  public static S3Client buildClient(final S3ClientConfig config) {
+    final var builder =
+        S3Client.builder()
+            .region(config.region())
+            .credentialsProvider(
+                () -> AwsBasicCredentials.create(config.accessKey(), config.secretKey()));
+
+    builder.defaultsMode(config.defaultsMode.orElse(DefaultsMode.AUTO));
+    builder.httpClientBuilder(
+        ApacheHttpClient.builder()
+            .tcpKeepAlive(true)
+            .connectionAcquisitionTimeout(
+                config.connectionAcquisitionTimeout.orElse(Duration.ofSeconds(5))));
+    config.endpoint.ifPresent(builder::endpointOverride);
+    builder.overrideConfiguration(
+        cfg -> cfg.retryStrategy(config.retryStrategy.orElse(RetryMode.ADAPTIVE_V2)));
+    return builder.build();
+  }
+
+  public record Config(String bucketName, String taskId, Duration expiryDuration) {
+    public Config {
+      if (taskId == null || taskId.isEmpty()) {
+        throw new IllegalArgumentException("taskId cannot be null or empty");
+      }
+      if (expiryDuration.toMillis() <= 0) {
+        throw new IllegalArgumentException("expiryDuration must be greater than 0");
+      }
+      if (bucketName == null || bucketName.isEmpty()) {
+        throw new IllegalArgumentException("bucketName cannot be null or empty");
+      }
+    }
+  }
+
+  public record S3ClientConfig(
+      String accessKey,
+      String secretKey,
+      Region region,
+      Optional<URI> endpoint,
+      Optional<RetryMode> retryStrategy,
+      Optional<DefaultsMode> defaultsMode,
+      Optional<Duration> connectionAcquisitionTimeout,
+      Optional<Duration> apiCallTimeout) {
+    public S3ClientConfig(
+        final String accessKey,
+        final String secretKey,
+        final Region region,
+        final Optional<URI> endpoint) {
+      this(
+          accessKey,
+          secretKey,
+          region,
+          endpoint,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty());
+    }
+
+    public S3ClientConfig {
+      if (accessKey == null || accessKey.isEmpty()) {
+        throw new IllegalArgumentException("accessKey cannot be null or empty");
+      }
+      if (secretKey == null || secretKey.isEmpty()) {
+        throw new IllegalArgumentException("secretKey cannot be null or empty");
+      }
+      if (region == null) {
+        throw new IllegalArgumentException("region cannot be null");
+      }
+    }
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public class LeaseTest {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  final NodeInstance nodeInstance = new NodeInstance(1);
+  final long originalTimestamp = 1000L;
+  final Lease lease = new Lease("task1", originalTimestamp, nodeInstance);
+
+  @Test
+  public void shouldRenewCorrectlyWhenValid() {
+    // given
+    final var currentTime = 2000L;
+    final var renewalDuration = Duration.ofSeconds(5);
+
+    // when
+    final var renewedLease = lease.renew(currentTime, renewalDuration);
+
+    // then
+    assertThat(renewedLease.taskId()).isEqualTo("task1");
+    assertThat(renewedLease.timestamp()).isEqualTo(currentTime + renewalDuration.toMillis());
+    assertThat(renewedLease.nodeInstance()).isEqualTo(nodeInstance);
+  }
+
+  @Test
+  public void shouldNotRenewLeaseWhenExpired() {
+    // given
+    final var currentTime = 10000L;
+    final var renewalDuration = Duration.ofSeconds(5);
+    assertThat(lease.isStillValid(currentTime, renewalDuration)).isFalse();
+
+    // when/then
+    assertThatThrownBy(() -> lease.renew(currentTime, renewalDuration))
+        .isInstanceOf(IllegalStateException.class)
+        .withFailMessage("Lease is not valid anymore, it expired at");
+  }
+
+  @Test
+  public void shouldSerializeDeserializeToJson() {
+    // when
+    final var serialized = lease.toJson(OBJECT_MAPPER);
+
+    // then
+    final var deserialized = Lease.fromJson(OBJECT_MAPPER, serialized);
+    assertThat(deserialized).isEqualTo(lease);
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
@@ -56,9 +56,8 @@ public class S3NodeIdRepositoryIT {
     client =
         S3NodeIdRepository.buildClient(
             new S3ClientConfig(
-                S3.getAccessKey(),
-                S3.getSecretKey(),
-                Region.of(S3.getRegion()),
+                Optional.of(new Credentials(S3.getAccessKey(), S3.getSecretKey())),
+                Optional.of(Region.of(S3.getRegion())),
                 Optional.of(S3.getEndpoint())));
   }
 

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid.repository.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.dynamic.nodeid.Lease;
+import io.camunda.zeebe.dynamic.nodeid.NodeInstance;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.Config;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.S3ClientConfig;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@Testcontainers
+public class S3NodeIdRepositoryIT {
+
+  private static final Duration EXPIRY_DURATION = Duration.ofSeconds(5);
+
+  @Container
+  private static final LocalStackContainer S3 =
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:4.10"))
+          .withServices(Service.S3)
+          .withEnv("LS_LOG", "trace");
+
+  @AutoClose private static S3Client client;
+  S3NodeIdRepository.Config config;
+  @AutoClose private S3NodeIdRepository repository;
+
+  @BeforeAll
+  public static void setUpAll() {
+    client =
+        S3NodeIdRepository.buildClient(
+            new S3ClientConfig(
+                S3.getAccessKey(),
+                S3.getSecretKey(),
+                Region.of(S3.getRegion()),
+                Optional.of(S3.getEndpoint())));
+  }
+
+  @BeforeEach
+  public void setUp() {
+    final var bucketName = UUID.randomUUID().toString();
+    final var taskId = UUID.randomUUID().toString();
+    config = new Config(bucketName, taskId, EXPIRY_DURATION);
+    client.createBucket(b -> b.bucket(config.bucketName()));
+  }
+
+  @Test
+  public void shouldInitializeAllFiles() {
+    // given
+    repository = fixed(Clock.systemUTC().millis());
+
+    // when
+    repository.initialize(2);
+
+    // then
+    for (int i = 0; i < 2; i++) {
+      final var lease = repository.getLease(i);
+      assertThat(lease).isInstanceOf(StoredLease.Uninitialized.class);
+      assertThat(lease.eTag()).isNotEmpty();
+    }
+  }
+
+  @Test
+  public void shouldAcquireOneLeaseWhenEtagMatches() {
+    // given
+    final var now = Clock.systemUTC().millis();
+    repository = fixed(now);
+    repository.initialize(3);
+    final var nodeInstance = new NodeInstance(2);
+
+    // when
+    final var lease = repository.getLease(nodeInstance.id());
+
+    final var toAcquire = new Lease(config.taskId(), now + 1000L, nodeInstance);
+    final var acquired = repository.acquire(toAcquire, lease.eTag());
+    final var fromGet = repository.getLease(nodeInstance.id());
+
+    // then
+    assertThat(fromGet).isEqualTo(acquired);
+    assertThat(acquired.lease()).isEqualTo(toAcquire);
+    assertThat(acquired.eTag()).isNotEmpty();
+    final var metadata = acquired.metadata();
+    assertThat(metadata.asMap()).isNotEmpty();
+    assertThat(metadata.expiry()).isEqualTo(toAcquire.timestamp());
+    assertThat(metadata.task()).isEqualTo(config.taskId());
+  }
+
+  @Test
+  public void shouldNotAcquireAnExpiredLease() {
+    // given
+    final var now = Clock.systemUTC().millis();
+    repository = fixed(now);
+    repository.initialize(3);
+    final var nodeInstance = new NodeInstance(2);
+
+    // when
+    final var lease = repository.getLease(nodeInstance.id());
+
+    final var toAcquire = new Lease(config.taskId(), now - 10000L, nodeInstance);
+    assertThatThrownBy(() -> repository.acquire(toAcquire, lease.eTag()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not valid anymore");
+  }
+
+  @Test
+  public void shouldNotAcquireOneLeaseWhenETagMismatch() {
+    // given
+    final var now = Clock.systemUTC().millis();
+    repository = fixed(now);
+    repository.initialize(1);
+    final var nodeInstance = new NodeInstance(0);
+
+    // when
+    final var lease = repository.getLease(nodeInstance.id());
+
+    final var toAcquire = new Lease(config.taskId(), now + 1000L, nodeInstance);
+
+    // then
+    assertThatThrownBy(() -> repository.acquire(toAcquire, "10298301928309128"))
+        .isInstanceOf(S3Exception.class)
+        .hasMessageContaining("At least one of the pre-conditions you specified did not hold");
+  }
+
+  @Test
+  public void shouldReleaseALeaseCorrectly() {
+    // given
+    final var now = Clock.systemUTC().millis();
+    repository = fixed(now);
+    repository.initialize(3);
+    final var nodeInstance = new NodeInstance(2);
+    final var lease = repository.getLease(nodeInstance.id());
+    final var toAcquire = new Lease(config.taskId(), now + 1000L, nodeInstance);
+    final var acquired = repository.acquire(toAcquire, lease.eTag());
+
+    // when
+    repository.release(acquired);
+
+    // then
+    final var afterRelease = repository.getLease(nodeInstance.id());
+    assertThat(afterRelease).isInstanceOf(StoredLease.Uninitialized.class);
+  }
+
+  @Test
+  public void shouldCloseS3Client() throws Exception {
+    // given
+    final var clientMock = Mockito.mock(S3Client.class);
+    repository = new S3NodeIdRepository(clientMock, config, Clock.systemUTC(), true);
+    // when
+    repository.close();
+
+    // then
+    verify(clientMock).close();
+  }
+
+  private S3NodeIdRepository fixed(final long time) {
+    return new S3NodeIdRepository(
+        client, config, Clock.fixed(Instant.ofEpochMilli(time), ZoneId.of("UTC")), false);
+  }
+}

--- a/zeebe/pom.xml
+++ b/zeebe/pom.xml
@@ -63,6 +63,7 @@
     <module>backup-stores/common</module>
     <module>restore</module>
     <module>dynamic-config</module>
+    <module>dynamic-node-id-provider</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
## Description
First PR that introduces the `dynamic-node-id` module under `zeebe/`.
Compared to the POC, I created a `NodeIdRepository` that uses the repository pattern to abstract the underlying implementation. 
The repository has less responsibilities and does not contain the retry logic, the cleanup etc. 
Those will be added later in another class. 

The repository is tested using `LocalStack` TestContainer.



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #40306
