### PR TITLE
[Backport stable/8.8] Expand logging on element instance not found in element tree path builder

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -128,7 +128,7 @@ public class ElementTreePathBuilder {
   private ElementInstance getElementInstance(final long elementInstanceKey) {
     final ElementInstance instance = elementInstanceProvider.getInstance(elementInstanceKey);
     if (instance == null) {
-      throw new IllegalStateException(
+      throw new ElementInstanceNotFoundException(
           String.format(
               "Expected to find element instance for given key '%d', but didn't exist.",
               elementInstanceKey));
@@ -145,4 +145,11 @@ public class ElementTreePathBuilder {
       Long elementInstanceKey,
       Long parentElementInstanceKey,
       ProcessInstanceRecordValue processInstanceRecord) {}
+
+  private static class ElementInstanceNotFoundException extends IllegalStateException {
+
+    ElementInstanceNotFoundException(final String message) {
+      super(message);
+    }
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -91,7 +91,18 @@ public class ElementTreePathBuilder {
       elementInstancePath.add(curr.elementInstanceKey);
       long currParent = curr.parentElementInstanceKey;
       while (currParent != -1) {
-        final var instance = getElementInstance(currParent);
+        final ElementInstance instance;
+        try {
+          instance = getElementInstance(currParent);
+        } catch (final ElementInstanceNotFoundException exception) {
+          throw new IllegalStateException(
+              """
+              Expected to build element tree path, but couldn't find element instance '%d'. \
+              Element tree path created so far: '%s'. \
+              Currently adding parent process instance's element instance path: '%s'."""
+                  .formatted(currParent, properties, elementInstancePath),
+              exception);
+        }
         elementInstancePath.addFirst(currParent);
         currParent = instance.getParentKey();
       }


### PR DESCRIPTION
# Description
Backport of #40216 to `stable/8.8`.

relates to #26755