### PR TITLE
feat: Add exporter support for `resourcePropertyName` in `Authorization` record

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -537,6 +537,12 @@
     </createIndex>
   </changeSet>
 
+  <changeSet id="add_resource_property_name_to_authorizations_table" author="camunda">
+    <addColumn tableName="${prefix}AUTHORIZATIONS">
+      <column name="RESOURCE_PROPERTY_NAME" type="VARCHAR(${userCharColumnSize})" defaultValue=""/>
+    </addColumn>
+  </changeSet>
+
   <changeSet id="create_batch_operation_table" author="camunda">
     <createTable tableName="${prefix}BATCH_OPERATION">
       <column name="BATCH_OPERATION_KEY" type="VARCHAR(255)">

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -513,6 +513,7 @@
       <column name="RESOURCE_TYPE" type="VARCHAR(255)"/>
       <column name="RESOURCE_MATCHER" type="SMALLINT"/>
       <column name="RESOURCE_ID" type="VARCHAR(${userCharColumnSize})"/>
+      <column name="RESOURCE_PROPERTY_NAME" type="VARCHAR(${userCharColumnSize})"/>
       <column name="PERMISSION_TYPE" type="VARCHAR(255)"/>
     </createTable>
 
@@ -535,12 +536,6 @@
       indexName="${prefix}IDX_AUTHORIZATIONS_RESOURCE_TYPE">
       <column name="RESOURCE_TYPE"/>
     </createIndex>
-  </changeSet>
-
-  <changeSet id="add_resource_property_name_to_authorizations_table" author="camunda">
-    <addColumn tableName="${prefix}AUTHORIZATIONS">
-      <column name="RESOURCE_PROPERTY_NAME" type="VARCHAR(${userCharColumnSize})" defaultValue=""/>
-    </addColumn>
   </changeSet>
 
   <changeSet id="create_batch_operation_table" author="camunda">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
@@ -97,6 +97,7 @@ public class AuthorizationDbReader extends AbstractEntityReader<AuthorizationEnt
         model.resourceType(),
         model.resourceMatcher(),
         model.resourceId(),
+        model.resourcePropertyName(),
         new HashSet<>(model.permissionTypes()));
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AuthorizationSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AuthorizationSearchColumn.java
@@ -13,7 +13,8 @@ public enum AuthorizationSearchColumn implements SearchColumn<AuthorizationEntit
   OWNER_ID("ownerId"),
   OWNER_TYPE("ownerType"),
   RESOURCE_TYPE("resourceType"),
-  RESOURCE_ID("resourceId");
+  RESOURCE_ID("resourceId"),
+  RESOURCE_PROPERTY_NAME("resourcePropertyName");
 
   private final String property;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
@@ -20,6 +20,7 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
   private String resourceType;
   private Short resourceMatcher;
   private String resourceId;
+  private String resourcePropertyName;
   private Set<PermissionType> permissionTypes;
 
   public Long authorizationKey() {
@@ -70,6 +71,14 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
     this.resourceId = resourceId;
   }
 
+  public String resourcePropertyName() {
+    return resourcePropertyName;
+  }
+
+  public void resourcePropertyName(final String resourcePropertyName) {
+    this.resourcePropertyName = resourcePropertyName;
+  }
+
   public Set<PermissionType> permissionTypes() {
     return permissionTypes;
   }
@@ -90,6 +99,7 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
                 .ownerType(ownerType)
                 .resourceMatcher(resourceMatcher)
                 .resourceId(resourceId)
+                .resourcePropertyName(resourcePropertyName)
                 .resourceType(resourceType)
                 .permissionTypes(permissionTypes))
         .build();
@@ -102,6 +112,7 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
     private String ownerType;
     private Short resourceMatcher;
     private String resourceId;
+    private String resourcePropertyName;
     private String resourceType;
     private Set<PermissionType> permissionTypes;
 
@@ -137,6 +148,11 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
       return this;
     }
 
+    public Builder resourcePropertyName(final String resourcePropertyName) {
+      this.resourcePropertyName = resourcePropertyName;
+      return this;
+    }
+
     public Builder permissionTypes(final Set<PermissionType> permissionTypes) {
       this.permissionTypes = permissionTypes;
       return this;
@@ -150,6 +166,7 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
       model.ownerType(ownerType);
       model.resourceMatcher(resourceMatcher);
       model.resourceId(resourceId);
+      model.resourcePropertyName(resourcePropertyName);
       model.resourceType(resourceType);
       model.permissionTypes(permissionTypes);
       return model;

--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -48,7 +48,7 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
     ) t
     JOIN ${prefix}AUTHORIZATIONS a ON t.AUTHORIZATION_KEY = a.AUTHORIZATION_KEY AND t.OWNER_ID = a.OWNER_ID AND t.OWNER_TYPE = a.OWNER_TYPE AND
-    t.RESOURCE_TYPE = a.RESOURCE_TYPE AND t.RESOURCE_ID = a.RESOURCE_ID
+    t.RESOURCE_TYPE = a.RESOURCE_TYPE AND t.RESOURCE_ID = a.RESOURCE_ID AND t.RESOURCE_PROPERTY_NAME = a.RESOURCE_PROPERTY_NAME
     <!-- outer orderBy for actual sorting -->
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
   </select>
@@ -95,6 +95,12 @@
       <if test="filter.resourceIds != null and !filter.resourceIds.isEmpty()">
         AND RESOURCE_ID IN
         <foreach collection="filter.resourceIds" item="value" open="(" separator=", "
+          close=")">#{value}
+        </foreach>
+      </if>
+      <if test="filter.resourcePropertyNames != null and !filter.resourcePropertyNames.isEmpty()">
+        AND RESOURCE_PROPERTY_NAME IN
+        <foreach collection="filter.resourcePropertyNames" item="value" open="(" separator=", "
           close=")">#{value}
         </foreach>
       </if>

--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -12,7 +12,7 @@
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.AuthorizationDbQuery">
     SELECT COUNT(*) FROM (
-    SELECT DISTINCT AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_MATCHER,RESOURCE_ID
+    SELECT DISTINCT AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_MATCHER, RESOURCE_ID, RESOURCE_PROPERTY_NAME
     FROM ${prefix}AUTHORIZATIONS a
     <include refid="io.camunda.db.rdbms.sql.AuthorizationMapper.searchFilter"/>
     ) t
@@ -27,7 +27,8 @@
     t.RESOURCE_TYPE,
     a.PERMISSION_TYPE,
     a.RESOURCE_MATCHER,
-    a.RESOURCE_ID
+    a.RESOURCE_ID,
+    a.RESOURCE_PROPERTY_NAME
     FROM (
     SELECT * FROM (
     SELECT DISTINCT
@@ -36,7 +37,8 @@
     OWNER_TYPE,
     RESOURCE_TYPE,
     RESOURCE_MATCHER,
-    RESOURCE_ID
+    RESOURCE_ID,
+    RESOURCE_PROPERTY_NAME
     FROM ${prefix}AUTHORIZATIONS
     <include refid="io.camunda.db.rdbms.sql.AuthorizationMapper.searchFilter"/>
     ) t
@@ -105,8 +107,9 @@
     <id column="OWNER_ID" property="ownerId"/>
     <id column="OWNER_TYPE" property="ownerType"/>
     <id column="RESOURCE_TYPE" property="resourceType"/>
-    <id column="RESOURCE_MATCHER" property="resourceMatcher" />
-    <id column="RESOURCE_ID" property="resourceId" />
+    <id column="RESOURCE_MATCHER" property="resourceMatcher"/>
+    <id column="RESOURCE_ID" property="resourceId"/>
+    <id column="RESOURCE_PROPERTY_NAME" property="resourcePropertyName"/>
     <collection property="permissionTypes"
       ofType="io.camunda.zeebe.protocol.record.value.PermissionType"
       javaType="java.util.Set">
@@ -115,10 +118,10 @@
   </resultMap>
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.AuthorizationDbModel">
-    INSERT INTO ${prefix}AUTHORIZATIONS (AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_MATCHER, RESOURCE_ID, PERMISSION_TYPE)
+    INSERT INTO ${prefix}AUTHORIZATIONS (AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_MATCHER, RESOURCE_ID, RESOURCE_PROPERTY_NAME, PERMISSION_TYPE)
     VALUES
     <foreach collection="permissionTypes" item="permissionType" separator=",">
-      (#{authorizationKey}, #{ownerId}, #{ownerType}, #{resourceType}, #{resourceMatcher}, #{resourceId}, #{permissionType})
+      (#{authorizationKey}, #{ownerId}, #{ownerType}, #{resourceType}, #{resourceMatcher}, #{resourceId}, #{resourcePropertyName}, #{permissionType})
     </foreach>
   </insert>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSortIT.java
@@ -99,6 +99,24 @@ public class AuthorizationSortIT {
         Comparator.comparing(AuthorizationEntity::resourceId).reversed());
   }
 
+  @TestTemplate
+  public void shouldSortByResourcePropertyNameAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.resourcePropertyName().asc(),
+        Comparator.comparing(AuthorizationEntity::resourcePropertyName));
+  }
+
+  @TestTemplate
+  public void shouldSortByResourcePropertyNameDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.resourcePropertyName().desc(),
+        Comparator.comparing(AuthorizationEntity::resourcePropertyName).reversed());
+  }
+
   private void testSorting(
       final RdbmsService rdbmsService,
       final Function<Builder, ObjectBuilder<AuthorizationSort>> sortBuilder,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSpecificFilterIT.java
@@ -15,18 +15,21 @@ import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.db.rdbms.write.domain.AuthorizationDbModel;
 import io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.sort.AuthorizationSort;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -102,6 +105,39 @@ public class AuthorizationSpecificFilterIT {
 
     assertThat(searchResult.total()).isEqualTo(expectedCpount);
     assertThat(searchResult.items()).hasSize(expectedCpount);
+  }
+
+  @Test
+  public void shouldFindByResourcePropertyName() {
+    // given
+    createAndSaveRandomAuthorizations(rdbmsWriter);
+    final AuthorizationDbModel authDbModel =
+        AuthorizationFixtures.createRandomized(
+            b ->
+                b.resourceMatcher(AuthorizationResourceMatcher.PROPERTY.value())
+                    .resourcePropertyName("priority_prop"));
+
+    createAndSaveAuthorization(rdbmsWriter, authDbModel);
+
+    // when
+    final var searchResult =
+        authorizationReader.search(
+            new AuthorizationQuery(
+                new AuthorizationFilter.Builder().resourcePropertyNames("priority_prop").build(),
+                AuthorizationSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    // then
+    assertThat(searchResult.total()).isOne();
+    assertThat(searchResult.items())
+        .singleElement()
+        .satisfies(
+            a -> {
+              assertThat(a.authorizationKey()).isEqualTo(authDbModel.authorizationKey());
+              assertThat(a.resourceMatcher())
+                  .isEqualTo(AuthorizationResourceMatcher.PROPERTY.value());
+              assertThat(a.resourcePropertyName()).isEqualTo("priority_prop");
+            });
   }
 
   static List<AuthorizationFilter> shouldFindWithSpecificFilterParameters() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuthorizationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuthorizationFixtures.java
@@ -40,6 +40,7 @@ public final class AuthorizationFixtures extends CommonFixtures {
             .resourceType(randomEnum(ResourceType.class).name())
             .resourceMatcher(randomEnum(AuthorizationResourceMatcher.class).value())
             .resourceId(nextStringId())
+            .resourcePropertyName(nextStringId())
             .permissionTypes(Set.of(randomPermissionType1, randomPermissionType2));
 
     return builderFunction.apply(builder).build();

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuthorizationEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuthorizationEntityTransformer.java
@@ -26,6 +26,7 @@ public class AuthorizationEntityTransformer
         value.getResourceType(),
         value.getResourceMatcher(),
         value.getResourceId(),
+        value.getResourcePropertyName(),
         new HashSet<>(value.getPermissionTypes()));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuthorizationFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuthorizationFilterTransformer.java
@@ -18,6 +18,7 @@ import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.OWN
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.PERMISSIONS_TYPES;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_ID;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_MATCHER;
+import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_PROPERTY_NAME;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_TYPE;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -71,6 +72,7 @@ public final class AuthorizationFilterTransformer
     return and(
         filter.authorizationKey() == null ? null : term(ID, filter.authorizationKey()),
         stringTerms(RESOURCE_ID, filter.resourceIds()),
+        stringTerms(RESOURCE_PROPERTY_NAME, filter.resourcePropertyNames()),
         filter.resourceMatcher() == null ? null : term(RESOURCE_MATCHER, filter.resourceMatcher()),
         filter.resourceType() == null ? null : term(RESOURCE_TYPE, filter.resourceType()),
         filter.permissionTypes() == null

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AuthorizationFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AuthorizationFieldSortingTransformer.java
@@ -12,6 +12,7 @@ import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.OWN
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.OWNER_TYPE;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_ID;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_MATCHER;
+import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_PROPERTY_NAME;
 import static io.camunda.webapps.schema.descriptors.index.AuthorizationIndex.RESOURCE_TYPE;
 
 public class AuthorizationFieldSortingTransformer implements FieldSortingTransformer {
@@ -24,6 +25,7 @@ public class AuthorizationFieldSortingTransformer implements FieldSortingTransfo
       case "resourceType" -> RESOURCE_TYPE;
       case "resourceMatcher" -> RESOURCE_MATCHER;
       case "resourceId" -> RESOURCE_ID;
+      case "resourcePropertyName" -> RESOURCE_PROPERTY_NAME;
       default -> throw new IllegalArgumentException("Unknown field: " + domainField);
     };
   }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AuthorizationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AuthorizationEntity.java
@@ -19,4 +19,5 @@ public record AuthorizationEntity(
     String resourceType,
     Short resourceMatcher,
     String resourceId,
+    String resourcePropertyName,
     Set<PermissionType> permissionTypes) {}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
@@ -25,6 +25,7 @@ public record AuthorizationFilter(
     String ownerType,
     Short resourceMatcher,
     List<String> resourceIds,
+    List<String> resourcePropertyNames,
     String resourceType,
     List<PermissionType> permissionTypes,
     Map<EntityType, Set<String>> ownerTypeToOwnerIds)
@@ -34,6 +35,7 @@ public record AuthorizationFilter(
     private List<String> ownerIds;
     private String ownerType;
     private List<String> resourceIds;
+    private List<String> resourcePropertyNames;
     private Short resourceMatcher;
     private String resourceType;
     private List<PermissionType> permissionTypes;
@@ -71,6 +73,15 @@ public record AuthorizationFilter(
 
     public Builder resourceIds(final String... values) {
       return resourceIds(collectValuesAsList(values));
+    }
+
+    public Builder resourcePropertyNames(final List<String> value) {
+      resourcePropertyNames = value;
+      return this;
+    }
+
+    public Builder resourcePropertyNames(final String... values) {
+      return resourcePropertyNames(collectValuesAsList(values));
     }
 
     public Builder resourceType(final String value) {
@@ -120,6 +131,7 @@ public record AuthorizationFilter(
           ownerType,
           resourceMatcher,
           resourceIds,
+          resourcePropertyNames,
           resourceType,
           permissionTypes,
           getValidOwnerTypeToOwnerIdsOrThrow());

--- a/search/search-domain/src/main/java/io/camunda/search/query/AuthorizationQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/AuthorizationQuery.java
@@ -28,7 +28,8 @@ public record AuthorizationQuery(
 
   @Override
   public List<SearchSortOptions> retainValidSortings(final List<SearchSortOptions> sorting) {
-    final var fieldNames = List.of("ownerId", "ownerType", "resourceId", "resourceType");
+    final var fieldNames =
+        List.of("ownerId", "ownerType", "resourceId", "resourcePropertyName", "resourceType");
     return sorting.stream().filter(s -> fieldNames.contains(s.field().field())).toList();
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/sort/AuthorizationSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/AuthorizationSort.java
@@ -40,6 +40,11 @@ public record AuthorizationSort(List<FieldSorting> orderings) implements SortOpt
       return this;
     }
 
+    public Builder resourcePropertyName() {
+      currentOrdering = new FieldSorting("resourcePropertyName", null);
+      return this;
+    }
+
     public Builder resourceType() {
       currentOrdering = new FieldSorting("resourceType", null);
       return this;

--- a/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
+++ b/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class AuthorizationCheckerTest {
 
+  private static final String EMPTY_STRING = "";
+
   private AuthorizationChecker authorizationChecker;
 
   @BeforeEach
@@ -109,6 +111,7 @@ public class AuthorizationCheckerTest {
               AuthorizationResourceType.PROCESS_DEFINITION.name(),
               AuthorizationResourceMatcher.ANY.value(),
               WILDCARD_RESOURCE_ID,
+              EMPTY_STRING,
               Set.of(PermissionType.READ_PROCESS_INSTANCE)));
       authorizationReader.create(
           new AuthorizationEntity(
@@ -118,6 +121,7 @@ public class AuthorizationCheckerTest {
               AuthorizationResourceType.PROCESS_DEFINITION.name(),
               AuthorizationResourceMatcher.ID.value(),
               RESOURCE_ID,
+              EMPTY_STRING,
               Set.of(PermissionType.READ_PROCESS_INSTANCE)));
       // client based authorizations
       authorizationReader.create(
@@ -128,6 +132,7 @@ public class AuthorizationCheckerTest {
               AuthorizationResourceType.PROCESS_DEFINITION.name(),
               AuthorizationResourceMatcher.ANY.value(),
               WILDCARD_RESOURCE_ID,
+              EMPTY_STRING,
               Set.of(PermissionType.READ_PROCESS_INSTANCE)));
       authorizationReader.create(
           new AuthorizationEntity(
@@ -137,6 +142,7 @@ public class AuthorizationCheckerTest {
               AuthorizationResourceType.PROCESS_DEFINITION.name(),
               AuthorizationResourceMatcher.ID.value(),
               RESOURCE_ID,
+              EMPTY_STRING,
               Set.of(PermissionType.READ_PROCESS_INSTANCE)));
       // mapping rule based authorizations
       authorizationReader.create(
@@ -147,6 +153,7 @@ public class AuthorizationCheckerTest {
               AuthorizationResourceType.PROCESS_DEFINITION.name(),
               AuthorizationResourceMatcher.ANY.value(),
               WILDCARD_RESOURCE_ID,
+              EMPTY_STRING,
               Set.of(PermissionType.READ_PROCESS_INSTANCE)));
       authorizationReader.create(
           new AuthorizationEntity(
@@ -156,6 +163,7 @@ public class AuthorizationCheckerTest {
               AuthorizationResourceType.PROCESS_DEFINITION.name(),
               AuthorizationResourceMatcher.ID.value(),
               RESOURCE_ID,
+              EMPTY_STRING,
               Set.of(PermissionType.READ_PROCESS_INSTANCE)));
     }
 
@@ -781,6 +789,7 @@ public class AuthorizationCheckerTest {
           resourceType.name(),
           matcher.value(),
           resourceId,
+          EMPTY_STRING,
           permissionTypes);
     }
 
@@ -1132,6 +1141,7 @@ public class AuthorizationCheckerTest {
           resourceType.name(),
           matcher.value(),
           resourceId,
+          EMPTY_STRING,
           permissionTypes);
     }
 

--- a/security/security-services/src/test/java/io/camunda/security/impl/FakeAuthorizationReader.java
+++ b/security/security-services/src/test/java/io/camunda/security/impl/FakeAuthorizationReader.java
@@ -97,6 +97,10 @@ class FakeAuthorizationReader implements AuthorizationReader, AutoCloseable {
         && !filter.resourceIds().contains(authorization.resourceId())) {
       return false;
     }
+    if (filter.resourcePropertyNames() != null
+        && !filter.resourcePropertyNames().contains(authorization.resourcePropertyName())) {
+      return false;
+    }
     if (filter.resourceType() != null
         && !filter.resourceType().equals(authorization.resourceType())) {
       return false;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/AuthorizationIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/AuthorizationIndex.java
@@ -22,6 +22,7 @@ public class AuthorizationIndex extends AbstractIndexDescriptor implements Prio5
   public static final String PERMISSIONS_TYPES = "permissionTypes";
   public static final String RESOURCE_MATCHER = "resourceMatcher";
   public static final String RESOURCE_ID = "resourceId";
+  public static final String RESOURCE_PROPERTY_NAME = "resourcePropertyName";
 
   public AuthorizationIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
@@ -20,6 +20,7 @@ public class AuthorizationEntity extends AbstractExporterEntity<AuthorizationEnt
   private String resourceType;
   private Short resourceMatcher;
   private String resourceId;
+  private String resourcePropertyName;
   private Set<PermissionType> permissionTypes;
 
   public AuthorizationEntity() {}
@@ -66,6 +67,15 @@ public class AuthorizationEntity extends AbstractExporterEntity<AuthorizationEnt
 
   public AuthorizationEntity setResourceId(final String resourceId) {
     this.resourceId = resourceId;
+    return this;
+  }
+
+  public String getResourcePropertyName() {
+    return resourcePropertyName;
+  }
+
+  public AuthorizationEntity setResourcePropertyName(final String resourcePropertyName) {
+    this.resourcePropertyName = resourcePropertyName;
     return this;
   }
 

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-authorization.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-authorization.json
@@ -23,6 +23,9 @@
       "resourceId": {
         "type": "keyword"
       },
+      "resourcePropertyName": {
+        "type": "keyword"
+      },
       "permissionTypes": {
         "type": "keyword"
       }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-authorization.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-authorization.json
@@ -23,6 +23,9 @@
       "resourceId": {
         "type": "keyword"
       },
+      "resourcePropertyName": {
+        "type": "keyword"
+      },
       "permissionTypes": {
         "type": "keyword"
       }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
@@ -66,6 +66,7 @@ public class AuthorizationCreatedUpdatedHandler
         .setResourceMatcher(value.getResourceMatcher().value())
         .setResourceType(value.getResourceType().name())
         .setResourceId(value.getResourceId())
+        .setResourcePropertyName(value.getResourcePropertyName())
         .setPermissionTypes(new HashSet<>(value.getPermissionTypes()));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationDeletedHandler.java
@@ -62,6 +62,7 @@ public class AuthorizationDeletedHandler
         .setResourceType(value.getResourceType().name())
         .setResourceMatcher(value.getResourceMatcher().value())
         .setResourceId(value.getResourceId())
+        .setResourcePropertyName(value.getResourcePropertyName())
         .setPermissionTypes(new HashSet<>(value.getPermissionTypes()));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
@@ -133,6 +133,8 @@ public class AuthorizationCreatedUpdatedHandlerTest {
         .isEqualTo(authorizationRecordValue.getResourceMatcher().value());
     assertThat(authorizationEntity.getResourceId())
         .isEqualTo(authorizationRecordValue.getResourceId());
+    assertThat(authorizationEntity.getResourcePropertyName())
+        .isEqualTo(authorizationRecordValue.getResourcePropertyName());
     assertThat(authorizationEntity.getPermissionTypes())
         .isEqualTo(authorizationRecordValue.getPermissionTypes());
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/AuthorizationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/AuthorizationExportHandler.java
@@ -51,6 +51,7 @@ public class AuthorizationExportHandler implements RdbmsExportHandler<Authorizat
         .resourceType(authorization.getResourceType().name())
         .resourceMatcher(authorization.getResourceMatcher().value())
         .resourceId(authorization.getResourceId())
+        .resourcePropertyName(authorization.getResourcePropertyName())
         .permissionTypes(authorization.getPermissionTypes())
         .build();
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -81,6 +81,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
                       ResourceTypeEnum.PROCESS_DEFINITION.getValue(),
                       AuthorizationResourceMatcher.ID.value(),
                       "2",
+                      "",
                       Set.of(PermissionType.CREATE))))
           .startCursor("f")
           .endCursor("v")
@@ -108,6 +109,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
             ResourceTypeEnum.PROCESS_DEFINITION.getValue(),
             AuthorizationResourceMatcher.ID.value(),
             "resourceId",
+            "",
             Set.of(PermissionType.CREATE));
 
     final Long authorizationKey = authorizationEntity.authorizationKey();


### PR DESCRIPTION
### Description
Extends the exporter infrastructure to support the new `resourcePropertyName` field in `AuthorizationRecord`, enabling property-based authorization data to be properly persisted in secondary storage (RDBMS, ES/OS).

This PR implements support for the `resourcePropertyName` field across:
- **ES/OS**: Updated `AuthorizationEntity` model and authorization handlers (`AuthorizationCreatedUpdatedHandler`, `AuthorizationDeletedHandler`)
- **RDBMS**: Updated `AuthorizationDbModel` and `AuthorizationExportHandler`

Additionally, this PR adds backend support for sorting and filtering by `resourcePropertyName`, consistent with existing properties like `resourceId`. 
NOTE: that exposing these capabilities through the Authorization REST API and CamundaClient will be handled in the follow-up issue: #40079.

### Motivation
The `AuthorizationRecord` was extended with `resourcePropertyName` to enable fine-grained authorization checks at the property level. Without exporter support, this field would not be persisted to Elasticsearch/OpenSearch or RDBMS, resulting in incomplete authorization data in secondary storage.

### Changes
- Updated Elasticsearch/OpenSearch exporter components
- Updated RDBMS exporter components  
- Added support for sorting and filtering by `resourcePropertyName(s)`
- Adjusted/added new tests

## Related issues

closes #40116
