### PR TITLE
fix: WIP DO NOT MERGE - dumb hacky fix

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaServicesBasedAdapter.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaServicesBasedAdapter.java
@@ -199,4 +199,9 @@ public class CamundaServicesBasedAdapter implements TasklistServicesAdapter {
     return new TasklistRuntimeException(
         String.format("Failed to execute request with %s", exception.getMessage()), exception);
   }
+
+  @Override
+  public boolean supportAuthenticatedRequests() {
+    return true;
+  }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ProcessService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ProcessService.java
@@ -83,8 +83,13 @@ public class ProcessService {
       final List<VariableInputDTO> variables,
       final String tenantId,
       final boolean executeWithAuthentication) {
+    // either this is from the public start forms, in which case this is anonymous, or the service
+    // adapter does not support impersonating the user; in either case, we should verify we are
+    // authorized to start this process here
+    final boolean shouldVerifyAuthorizationHere =
+        !executeWithAuthentication || !tasklistServicesAdapter.supportAuthenticatedRequests();
 
-    if (!executeWithAuthentication
+    if (shouldVerifyAuthorizationHere
         && !identityAuthorizationService.isAllowedToStartProcess(processDefinitionKey)) {
       throw new ForbiddenActionException(
           "User does not have the permission to start this process.");

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TasklistServicesAdapter.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TasklistServicesAdapter.java
@@ -29,4 +29,6 @@ public interface TasklistServicesAdapter {
   default boolean isJobBasedUserTask(final TaskEntity task) {
     return task.getImplementation().equals(TaskImplementation.JOB_WORKER);
   }
+
+  boolean supportAuthenticatedRequests();
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ZeebeClientBasedAdapter.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ZeebeClientBasedAdapter.java
@@ -119,4 +119,9 @@ public class ZeebeClientBasedAdapter implements TasklistServicesAdapter {
     return new ProcessInstanceCreationRecord()
         .setProcessInstanceKey(processInstanceEvent.getProcessInstanceKey());
   }
+
+  @Override
+  public boolean supportAuthenticatedRequests() {
+    return false;
+  }
 }


### PR DESCRIPTION
## Description

This PR highlights an issue with deployments using the ZeebeClientBasedAdapter, which does not support authentication or impersonating users, thus is incompatible with resource authorizations.
