### PR TITLE
fix: upgrade org.apache.tomcat.embed from 10.1.44 to 10.1.48

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -145,11 +145,12 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>tomcat-annotations-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -103,8 +103,8 @@
     <version.rest-assured>5.5.5</version.rest-assured>
     <version.spring>6.2.11</version.spring>
     <version.spring-security>6.5.5</version.spring-security>
-    <version.spring-boot>3.5.5</version.spring-boot>
-    <version.tomcat>10.1.44</version.tomcat>
+    <version.spring-boot>3.5.6</version.spring-boot>
+    <version.tomcat>10.1.48</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -216,6 +216,12 @@
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
<img width="1088" height="616" alt="image" src="https://github.com/user-attachments/assets/80dbfa6d-c919-4e3b-9ddd-c242e6a81ad9" />

### Dependency overview
spring-boot-starter-web
├── spring-boot-starter-tomcat
│   └── tomcat-embed-core

### Fix CVE-2025-61795
- updated `version.spring-boot` from `3.5.5` to `3.5.6`
  - updated `org.apache.tomcat.embed*` from `10.1.44` to `10.1.48`, align version with `stable/8.6` and `stable/8.7` (already bumped up)
- exclude `tomcat-annotations-api` dependency, already excluded from all other `tomcat-embed-core` dependencies
  - this jar includes only jakarta-annotation, excluding it is safe at the moment, jakarta-annotation is declared as direct dependency already in project

### CVE Registry URL 
- https://cve-registry.infosec.camunda-it.rocks/team/1/finding/2128

### CVE JIRA URL
- https://jira.camunda.com/browse/SEC-1714
- https://jira.camunda.com/browse/SEC-1715
- https://jira.camunda.com/browse/SEC-1716
- https://jira.camunda.com/browse/SEC-1717