### PR TITLE
feat: default to log event rate limit of 1000 per second

### DIFF
--- a/dist/src/main/config/log4j2.xml
+++ b/dist/src/main/config/log4j2.xml
@@ -11,6 +11,19 @@
     <Property name="log.stackdriver.serviceVersion" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPERATE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICEVERSION:-${env:TASKLIST_LOG_STACKDRIVER_SERVICEVERSION:-}}}}"/>
   </Properties>
 
+  <!--
+    By default, limit to 1000 log events per second. Opt-out by setting `CAMUNDA_LOG_UNLIMITED`.
+  -->
+  <Select>
+    <EnvironmentArbiter propertyName="CAMUNDA_LOG_LIMIT" propertyValue="false"/>
+    <DefaultArbiter>
+      <BurstFilter
+        level="${env:CAMUNDA_LOG_LIMIT_LEVEL:-ERROR}"
+        rate="${env:CAMUNDA_LOG_LIMIT_RATE:-1000}"
+        maxBurst="${env:CAMUNDA_LOG_LIMIT_BURST:-10}"/>
+    </DefaultArbiter>
+  </Select>
+
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout


### PR DESCRIPTION
This ensures that we don't flood the log with excessive amounts of logs.

By default, we limit all log messages of level `ERROR` or lower to a maximum rate of 1000 per second with bursts of up to 10x. The log level, rate and maximum burst are configurable through env vars `CAMUNDA_LOG_LIMIT_LEVEL`, `CAMUNDA_LOG_LIMIT_RATE`, and `CAMUNDA_LOG_LIMIT_BURST`.
All limites can be disabled by setting `CAMUNDA_LOG_LIMIT` to `false`.
