### PR TITLE
feat: create `NodeIdProvider` class 

### DIFF
--- a/zeebe/dynamic-node-id-provider/pom.xml
+++ b/zeebe/dynamic-node-id-provider/pom.xml
@@ -100,6 +100,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/zeebe/dynamic-node-id-provider/pom.xml
+++ b/zeebe/dynamic-node-id-provider/pom.xml
@@ -105,6 +105,10 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
@@ -91,6 +91,9 @@ public class NodeIdProvider implements AutoCloseable {
         if (retryRound > 1) {
           try {
             currentDelay = backoff.supplyRetryDelay(currentDelay);
+            LOG.debug(
+                "Attempt to acquire the lease failed for all nodeIds, sleeping {} and retrying again",
+                currentDelay);
             Thread.sleep(currentDelay);
           } catch (final InterruptedException e) {
             break;
@@ -114,7 +117,7 @@ public class NodeIdProvider implements AutoCloseable {
       switch (lease) {
         case final Initialized initialized -> {
           if (initialized.lease().isStillValid(clock.millis(), leaseDuration)) {
-            LOG.debug("Lease {} is is held by another process, skipping it", initialized);
+            LOG.debug("Lease {} is held by another process, skipping it", initialized);
             return null;
           } else {
             LOG.debug("Trying to acquire an expired lease {}", initialized);

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.nodeid.repository;
 
+import io.camunda.zeebe.dynamic.nodeid.Lease;
 import java.util.Map;
 
 public record Metadata(String task, long expiry) {
@@ -16,6 +17,10 @@ public record Metadata(String task, long expiry) {
   private static final String EXPIRY_KEY = "expiry";
 
   //    private static final String NODE_VERSIONKEY = "nodeversion";
+
+  public static Metadata fromLease(final Lease lease) {
+    return new Metadata(lease.taskId(), lease.timestamp());
+  }
 
   public Map<String, String> asMap() {
     return Map.of(TASK_ID_KEY, task, EXPIRY_KEY, String.valueOf(expiry));

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -73,12 +73,12 @@ public interface NodeIdRepository extends AutoCloseable {
     String eTag();
 
     record Uninitialized(NodeInstance node, String eTag) implements StoredLease {
-     public Uninitialized{
-       Objects.requireNonNull(eTag, "ETag cannot be null");
-       if (eTag.isEmpty()) {
-         throw new IllegalArgumentException("eTag cannot be empty");
-       }
-     }
+      public Uninitialized {
+        Objects.requireNonNull(eTag, "ETag cannot be null");
+        if (eTag.isEmpty()) {
+          throw new IllegalArgumentException("eTag cannot be empty");
+        }
+      }
     }
 
     record Initialized(Metadata metadata, Lease lease, String eTag) implements StoredLease {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.dynamic.nodeid.repository;
 
 import io.camunda.zeebe.dynamic.nodeid.Lease;
+import io.camunda.zeebe.dynamic.nodeid.NodeInstance;
+import java.util.Objects;
 
 public interface NodeIdRepository extends AutoCloseable {
 
@@ -56,10 +58,38 @@ public interface NodeIdRepository extends AutoCloseable {
       };
     }
 
+    static StoredLease of(
+        final int nodeId, final Lease lease, final Metadata metadata, final String eTag) {
+      if (eTag == null || eTag.isEmpty()) {
+        throw new IllegalArgumentException("eTag cannot be null or empty:" + eTag);
+      }
+      if (lease == null || metadata == null) {
+        return new StoredLease.Uninitialized(new NodeInstance(nodeId), eTag);
+      } else {
+        return new StoredLease.Initialized(metadata, lease, eTag);
+      }
+    }
+
     String eTag();
 
-    record Uninitialized(String eTag) implements StoredLease {}
+    record Uninitialized(NodeInstance node, String eTag) implements StoredLease {
+     public Uninitialized{
+       Objects.requireNonNull(eTag, "ETag cannot be null");
+       if (eTag.isEmpty()) {
+         throw new IllegalArgumentException("eTag cannot be empty");
+       }
+     }
+    }
 
-    record Initialized(Metadata metadata, Lease lease, String eTag) implements StoredLease {}
+    record Initialized(Metadata metadata, Lease lease, String eTag) implements StoredLease {
+      public Initialized {
+        Objects.requireNonNull(metadata, "Metadata cannot be null");
+        Objects.requireNonNull(lease, "Lease cannot be null");
+        Objects.requireNonNull(eTag, "ETag cannot be null");
+        if (eTag.isEmpty()) {
+          throw new IllegalArgumentException("eTag cannot be empty");
+        }
+      }
+    }
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -97,7 +97,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
       LOG.debug("Lease acquired successfully {}", storedLease);
       return storedLease;
     } catch (final Exception e) {
-      LOG.warn("Failed to acquire the lease gracefully {}", lease, e);
+      LOG.warn("Failed to acquire the lease {}", lease, e);
       throw e;
     }
   }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.slf4j.Logger;
@@ -36,13 +37,13 @@ public class S3NodeIdRepository implements NodeIdRepository {
   private static final Logger LOG = LoggerFactory.getLogger(S3NodeIdRepository.class);
   private final S3Client client;
   private final Config config;
-  private final Clock clock;
+  private final InstantSource clock;
   private final boolean closeClient;
 
-  S3NodeIdRepository(
+  public S3NodeIdRepository(
       final S3Client s3AsyncClient,
       final Config config,
-      final Clock clock,
+      final InstantSource clock,
       final boolean closeClient) {
     client = s3AsyncClient;
     this.config = config;

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -72,10 +72,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
       final var lease = bytes.length > 0 ? Lease.fromJsonBytes(OBJECT_MAPPER, bytes) : null;
       final var metadata = Metadata.fromMap(response.response().metadata());
       final var eTag = response.response().eTag();
-      final var storedLease =
-          (lease != null && metadata != null)
-              ? new StoredLease.Initialized(metadata, lease, eTag)
-              : new StoredLease.Uninitialized(eTag);
+      final var storedLease = StoredLease.of(nodeId, lease, metadata, eTag);
       LOG.trace("Lease for object {} is {}", nodeId, storedLease);
       return storedLease;
     } catch (final IOException e) {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -84,7 +84,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
   @Override
   public StoredLease.Initialized acquire(final Lease lease, final String previousETag) {
     final var nodeId = lease.nodeInstance().id();
-    final var metadata = new Metadata(config.taskId, lease.timestamp());
+    final var metadata = Metadata.fromLease(lease);
     final PutObjectRequest putRequest =
         createPutObjectRequest(nodeId, Optional.of(metadata), Optional.of(previousETag)).build();
     try {
@@ -177,11 +177,8 @@ public class S3NodeIdRepository implements NodeIdRepository {
     return builder.build();
   }
 
-  public record Config(String bucketName, String taskId, Duration expiryDuration) {
+  public record Config(String bucketName, Duration expiryDuration) {
     public Config {
-      if (taskId == null || taskId.isEmpty()) {
-        throw new IllegalArgumentException("taskId cannot be null or empty");
-      }
       if (expiryDuration.toMillis() <= 0) {
         throw new IllegalArgumentException("expiryDuration must be greater than 0");
       }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/ControlledInstantSource.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/ControlledInstantSource.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.nodeid;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.InstantSource;
 
@@ -20,6 +21,10 @@ public class ControlledInstantSource implements InstantSource {
 
   public void setInstant(final Instant instant) {
     this.instant = instant;
+  }
+
+  public void advance(final Duration duration) {
+    instant = instant.plus(duration);
   }
 
   @Override

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/ControlledInstantSource.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/ControlledInstantSource.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import java.time.Instant;
+import java.time.InstantSource;
+
+public class ControlledInstantSource implements InstantSource {
+
+  private Instant instant;
+
+  public ControlledInstantSource(final Instant initial) {
+    instant = initial;
+  }
+
+  public void setInstant(final Instant instant) {
+    this.instant = instant;
+  }
+
+  @Override
+  public Instant instant() {
+    return instant;
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProviderIT.java
@@ -65,12 +65,11 @@ public class NodeIdProviderIT {
   @BeforeEach
   public void setUp() {
     final var bucketName = UUID.randomUUID().toString();
-    var taskId = UUID.randomUUID().toString();
+    taskId = UUID.randomUUID().toString();
     config = new Config(bucketName, taskId, EXPIRY_DURATION);
     client.createBucket(b -> b.bucket(config.bucketName()));
     clock = new ControlledInstantSource(Instant.now());
     repository = new S3NodeIdRepository(client, config, clock, false);
-    taskId = UUID.randomUUID().toString();
   }
 
   @Test

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProviderIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.Config;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.S3ClientConfig;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.S3ClientConfig.Credentials;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Testcontainers
+public class NodeIdProviderIT {
+
+  private static final Duration EXPIRY_DURATION = Duration.ofSeconds(5);
+
+  @Container
+  private static final LocalStackContainer S3 =
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:4.10"))
+          .withServices(Service.S3)
+          .withEnv("LS_LOG", "trace");
+
+  @AutoClose private static S3Client client;
+  S3NodeIdRepository.Config config;
+  @AutoClose private S3NodeIdRepository repository;
+  @AutoClose private NodeIdProvider nodeIdProvider;
+  private InstantSource clock;
+  private int clusterSize;
+  private String taskId;
+
+  @BeforeAll
+  public static void setUpAll() {
+    client =
+        S3NodeIdRepository.buildClient(
+            new S3ClientConfig(
+                Optional.of(new Credentials(S3.getAccessKey(), S3.getSecretKey())),
+                Optional.of(Region.of(S3.getRegion())),
+                Optional.of(S3.getEndpoint())));
+  }
+
+  @BeforeEach
+  public void setUp() {
+    final var bucketName = UUID.randomUUID().toString();
+    var taskId = UUID.randomUUID().toString();
+    config = new Config(bucketName, taskId, EXPIRY_DURATION);
+    client.createBucket(b -> b.bucket(config.bucketName()));
+    clock = new ControlledInstantSource(Instant.now());
+    repository = new S3NodeIdRepository(client, config, clock, false);
+    taskId = UUID.randomUUID().toString();
+  }
+
+  @Test
+  public void shouldAcquireALease() {
+    // given
+    clusterSize = 3;
+    repository.initialize(clusterSize);
+
+    // when
+    nodeIdProvider = ofSize(clusterSize);
+
+    // then
+    assertLeaseIsReady();
+
+    final var acquiredLease = nodeIdProvider.getCurrentLease();
+    final var nodeId = acquiredLease.lease().nodeInstance().id();
+    assertThat(nodeId).isEqualTo(0);
+    assertThat(repository.getLease(nodeId)).isEqualTo(acquiredLease);
+  }
+
+  @Test
+  public void shouldBlockInitializationIfAllLeasesAreTaken() {
+    // given
+    clusterSize = 3;
+    repository.initialize(clusterSize);
+    // we acquire all leases
+    final var acquiredLeases =
+        IntStream.range(0, clusterSize)
+            .mapToObj(
+                i -> {
+                  final var lease = repository.getLease(i);
+                  return repository.acquire(
+                      new Lease(taskId, clock.millis() + 2000L, new NodeInstance(i)), lease.eTag());
+                })
+            .toList();
+    assertThat(acquiredLeases)
+        .allSatisfy(l -> assertThat(l).isInstanceOf(StoredLease.Initialized.class));
+
+    // when
+    nodeIdProvider = ofSize(clusterSize);
+
+    // then
+    // verify that the lease status is not ready continuously
+    Awaitility.await().during(EXPIRY_DURATION).untilAsserted(this::assertLeaseIsNotReady);
+    // all leases are unchanged
+    final var currentLeases =
+        IntStream.range(0, clusterSize).mapToObj(repository::getLease).toList();
+    assertThat(acquiredLeases).isEqualTo(currentLeases);
+  }
+
+  public void assertLeaseIsReady() {
+    assertLeaseIs(true);
+  }
+
+  public void assertLeaseIsNotReady() {
+    assertLeaseIs(false);
+  }
+
+  public void assertLeaseIs(final boolean status) {
+    Awaitility.await("Until the lease is acquired")
+        .untilAsserted(
+            () ->
+                assertThat(nodeIdProvider.isLeaseValid())
+                    .succeedsWithin(Duration.ofSeconds(1))
+                    .isEqualTo(status));
+  }
+
+  NodeIdProvider ofSize(final int clusterSize) {
+    return new NodeIdProvider(repository, clusterSize, clock, EXPIRY_DURATION, taskId);
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProviderIT.java
@@ -66,7 +66,7 @@ public class NodeIdProviderIT {
   public void setUp() {
     final var bucketName = UUID.randomUUID().toString();
     taskId = UUID.randomUUID().toString();
-    config = new Config(bucketName, taskId, EXPIRY_DURATION);
+    config = new Config(bucketName, EXPIRY_DURATION);
     client.createBucket(b -> b.bucket(config.bucketName()));
     clock = new ControlledInstantSource(Instant.now());
     repository = new S3NodeIdRepository(client, config, clock, false);

--- a/zeebe/dynamic-node-id-provider/src/test/resources/log4j2-test.xml
+++ b/zeebe/dynamic-node-id-provider/src/test/resources/log4j2-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.camunda" level="debug"/>
+
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/ExponentialBackoff.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/ExponentialBackoff.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.util;
 
+import java.time.Duration;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.DoubleSupplier;
 import java.util.function.LongUnaryOperator;
@@ -42,6 +43,10 @@ public final class ExponentialBackoff implements LongUnaryOperator {
         DEFAULT_MIN_RETRY_DELAY_MS,
         DEFAULT_BACKOFF_FACTOR,
         DEFAULT_JITTER_FACTOR);
+  }
+
+  public ExponentialBackoff(final Duration maxDelay, final Duration minDelay) {
+    this(maxDelay.toMillis(), minDelay.toMillis());
   }
 
   public ExponentialBackoff(final long maxDelay, final long minDelay) {


### PR DESCRIPTION
## Description
In this PR I added a new  class `NodeIdProvider` whose responsibility is to initialize by acquiring a Lease.
The lease is acquired by iterating over all possible leases & acquiring one that is either timedout or free.
It tries to acquire the same element more than once if it fails to find an empty spot on the first iteration of the leases, as it may happen that a lease expires of just after the first iteration.

To avoid making too many calls, on every complete iteration of the leases, it invokes a RetryStrategy to wait a bit.

All the logic in the class is run inside an `ScheduledThreadPoolExecutor` which is managed by the class itself.

There is a method to check the health/status of the class that will be used by external health checks.

Node version is not yet part of the repository so it's not been added here yet.

Renewal & release will be added with subsequent PRs.
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40307
