### PR TITLE
refactor: remove v1 MetadataPopover component

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/DetailsModal.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/DetailsModal.tsx
@@ -9,13 +9,13 @@
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
 import {useGetIncidentsByElementInstance} from 'modules/queries/incidents/useGetIncidentsByElementInstance';
 import {buildMetadata} from './buildMetadata';
-import type {V2InstanceMetadata} from '../types';
+import type {InstanceMetadata} from '../types';
 import {resolveIncidentErrorType} from '../Incidents/resolveIncidentErrorType';
 
 type Props = {
   elementName: string;
   elementInstanceKey: string;
-  instanceMetadata: V2InstanceMetadata;
+  instanceMetadata: InstanceMetadata;
   isVisible: boolean;
   onClose: () => void;
 };

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/buildMetadata.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/buildMetadata.ts
@@ -6,10 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type V2InstanceMetadata} from '../types';
+import {type InstanceMetadata} from '../types';
 
 export const buildMetadata = (
-  metadata: V2InstanceMetadata | null,
+  metadata: InstanceMetadata | null,
   incident: {
     errorType: {id: string; name: string};
     errorMessage: string;

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/getExecutionDuration.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/getExecutionDuration.test.tsx
@@ -22,7 +22,7 @@ vi.mock('date-fns', async () => {
 
 describe('getExecutionDuration', () => {
   it('should return a duration for open periods', () => {
-    expect(getExecutionDuration(MOCK_START_DATE, null)).toBe(
+    expect(getExecutionDuration(MOCK_START_DATE, undefined)).toBe(
       `${MOCK_EXECUTION_DATE} (running)`,
     );
   });

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/getExecutionDuration.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/getExecutionDuration.tsx
@@ -13,13 +13,10 @@ import {
   parseISO,
 } from 'date-fns';
 
-function getExecutionDuration(
-  startDate: string,
-  endDate: string | null,
-): string {
+function getExecutionDuration(startDate: string, endDate?: string): string {
   const parsedStartDate = parseISO(startDate);
 
-  if (endDate === null) {
+  if (endDate === undefined) {
     return `${formatDistanceToNowStrict(parsedStartDate)} (running)`;
   }
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/mocks.tsx
@@ -9,51 +9,87 @@
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
-import {type V2MetaDataDto} from '../types';
+import type {
+  ElementInstance,
+  Job,
+  ProcessInstance,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import type {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {MemoryRouter} from 'react-router-dom';
 
-const baseMetaData: V2MetaDataDto = {
-  flowNodeInstanceId: '123456789',
-  flowNodeId: 'Task_1',
-  flowNodeType: 'SERVICE_TASK',
-  instanceCount: 1,
-  instanceMetadata: {
-    elementInstanceKey: '123456789',
-    elementId: 'Task_1',
-    elementName: 'Service Task',
-    type: 'SERVICE_TASK',
-    state: 'COMPLETED',
-    startDate: '2023-01-15T10:00:00.000Z',
-    endDate: '2023-01-15T10:05:00.000Z',
-    processDefinitionId: 'process-def-1',
-    processInstanceKey: '111222333',
-    processDefinitionKey: '444555666',
-    hasIncident: false,
-    incidentKey: undefined,
-    tenantId: '<default>',
-    calledProcessInstanceId: '987654321',
-    calledProcessDefinitionName: 'Called Process',
-    calledDecisionInstanceId: null,
-    calledDecisionDefinitionName: null,
-    jobRetries: 3,
-    flowNodeInstanceId: '123456789',
-    flowNodeId: 'Task_1',
-    flowNodeType: 'SERVICE_TASK',
-    eventId: undefined,
-    jobType: 'httpService',
-    jobWorker: 'worker-1',
-    jobDeadline: '2023-01-15T10:10:00.000Z',
-    jobCustomHeaders: {timeout: '30s'},
-    jobKey: '555666777',
-  },
-  incidentCount: 0,
+const mockElementInstance: ElementInstance = {
+  elementInstanceKey: '123456789',
+  elementId: 'Task_1',
+  elementName: 'Service Task',
+  type: 'SERVICE_TASK',
+  state: 'COMPLETED',
+  startDate: '2023-01-15T10:00:00.000Z',
+  endDate: '2023-01-15T10:05:00.000Z',
+  processDefinitionId: 'process-def-1',
+  processInstanceKey: '111222333',
+  processDefinitionKey: '444555666',
+  hasIncident: false,
+  tenantId: '<default>',
+};
+
+const mockJob: Job = {
+  jobKey: '555666777',
+  processInstanceKey: '111222333',
+  processDefinitionKey: '444555666',
+  processDefinitionId: 'process-def-1',
+  elementId: 'Task_1',
+  elementInstanceKey: '123456789',
+  type: 'httpService',
+  worker: 'worker-1',
+  retries: 3,
+  deadline: '2023-01-15T10:10:00.000Z',
+  customHeaders: {timeout: '30s'},
+  state: 'CREATED',
+  tenantId: '<default>',
+  kind: 'BPMN_ELEMENT',
+  listenerEventType: 'UNSPECIFIED',
+  isDenied: false,
+  deniedReason: '',
+  hasFailedWithRetriesLeft: false,
+  errorCode: '',
+  errorMessage: '',
+  endTime: '',
+};
+
+const mockCalledProcessInstance: ProcessInstance = {
+  processInstanceKey: '987654321',
+  processDefinitionId: 'called-process-def',
+  processDefinitionKey: '888999000',
+  processDefinitionName: 'Called Process',
+  processDefinitionVersion: 1,
+  state: 'ACTIVE',
+  startDate: '2023-01-15T10:00:00.000Z',
+  tenantId: '<default>',
+  parentProcessInstanceKey: '111222333',
+  parentElementInstanceKey: '123456789',
+  hasIncident: false,
+};
+
+const mockBusinessObject: BusinessObject = {
+  id: 'Task_1',
+  name: 'Service Task',
+  $type: 'bpmn:ServiceTask',
 };
 
 const TestWrapper: React.FC<{children: React.ReactNode}> = ({children}) => (
-  <ProcessDefinitionKeyContext.Provider value="test-process-key">
-    <QueryClientProvider client={getMockQueryClient()}>
-      {children}
-    </QueryClientProvider>
-  </ProcessDefinitionKeyContext.Provider>
+  <MemoryRouter>
+    <ProcessDefinitionKeyContext.Provider value="test-process-key">
+      <QueryClientProvider client={getMockQueryClient()}>
+        {children}
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
+  </MemoryRouter>
 );
 
-export {TestWrapper, baseMetaData};
+export {
+  TestWrapper,
+  mockElementInstance,
+  mockJob,
+  mockCalledProcessInstance,
+  mockBusinessObject,
+};

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
@@ -425,7 +425,7 @@ describe('MetadataPopover', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/This Element instance triggered 10 times/),
+        screen.getByText(/This element instance triggered 10 times/),
       ).toBeInTheDocument();
     });
     expect(

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.tsx
@@ -231,7 +231,7 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
         {instanceCount !== null && instanceCount > 1 && !elementInstanceKey && (
           <>
             <Header
-              title={`This Element instance triggered ${instanceCount} times`}
+              title={`This element instance triggered ${instanceCount} times`}
             />
             <Content>
               To view details for any of these, select one Instance in the

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import {Popover, Content, Divider} from './styled';
-import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {observer} from 'mobx-react';
 import {flip, offset} from '@floating-ui/react-dom';
@@ -20,7 +19,6 @@ import {useElementInstance} from 'modules/queries/elementInstances/useElementIns
 import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
 import {useMemo} from 'react';
 import {Details} from './Details';
-import {createV2InstanceMetadata} from './types';
 import {useGetUserTaskByElementInstance} from 'modules/queries/userTasks/useGetUserTaskByElementInstance';
 import {useProcessInstancesSearch} from 'modules/queries/processInstance/useProcessInstancesSearch';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
@@ -45,7 +43,6 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
   const elementId = selection?.flowNodeId;
   const elementInstanceKey = selection?.flowNodeInstanceId;
   const isMultiInstance = selection?.isMultiInstance ?? false;
-  const {metaData} = flowNodeMetaDataStore.state;
 
   const processDefinitionKey = useProcessDefinitionKeyContext();
   const {data} = useProcessInstanceXml({
@@ -207,7 +204,6 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
 
   if (
     elementId === undefined ||
-    metaData === null ||
     (shouldFetchElementInstances && isSearchingElementInstances) ||
     (!!elementInstanceKey && isFetchingInstance) ||
     isSearchingUserTasks ||
@@ -219,8 +215,6 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
   ) {
     return null;
   }
-
-  const {instanceMetadata} = metaData;
 
   return (
     <Popover
@@ -249,23 +243,18 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
         {elementInstanceMetadata && (
           <>
             <Details
-              metaData={{
-                ...metaData,
-                instanceMetadata: createV2InstanceMetadata(
-                  instanceMetadata,
-                  elementInstanceMetadata,
-                  jobSearchResult?.[0],
-                  processInstancesSearchResult?.items?.[0],
-                  messageSubscriptionSearchResult?.items?.[0],
-                  calledDecisionDefinition,
-                  calledDecisionInstance,
-                  elementInstanceMetadata.type === 'USER_TASK'
-                    ? userTask
-                    : undefined,
-                ),
-              }}
-              elementId={elementInstanceMetadata.elementId}
+              elementInstance={elementInstanceMetadata}
               businessObject={businessObject}
+              job={jobSearchResult?.[0]}
+              calledProcessInstance={processInstancesSearchResult?.items?.[0]}
+              messageSubscription={messageSubscriptionSearchResult?.items?.[0]}
+              calledDecisionDefinition={calledDecisionDefinition}
+              calledDecisionInstance={calledDecisionInstance}
+              userTask={
+                elementInstanceMetadata.type === 'USER_TASK'
+                  ? userTask
+                  : undefined
+              }
             />
             {elementInstanceMetadata.hasIncident && (
               <Incidents

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/types.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/types.ts
@@ -16,14 +16,12 @@ import type {
   DecisionInstance,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 
-type TaskState = ElementInstance['state'] | UserTask['state'];
-
 type InstanceMetadata = {
   elementInstanceKey: string;
   elementId: string;
   elementName?: string;
   type: ElementInstance['type'];
-  userTaskState?: TaskState;
+  userTaskState?: UserTask['state'];
   elementInstanceState: ElementInstance['state'];
   startDate: string;
   endDate: string | null;

--- a/operate/client/src/modules/mocks/metadata.ts
+++ b/operate/client/src/modules/mocks/metadata.ts
@@ -83,28 +83,6 @@ const calledInstanceMetadata = {
   },
 };
 
-const calledInstanceWithIncidentMetadata = {
-  ...calledInstanceMetadata,
-  incident: {
-    id: '4503599627375678',
-    errorType: {
-      id: 'CALLED_ELEMENT_ERROR',
-      name: 'Called Element Error',
-    },
-    errorMessage:
-      "Expected process with BPMN process id 'called-process' to be deployed, but not found.",
-    flowNodeId: 'call-order-process',
-    flowNodeInstanceId: FLOW_NODE_INSTANCE_ID,
-    jobId: null,
-    creationTime: '2022-02-03T16:44:06.981+0000',
-    hasActiveOperation: false,
-    lastOperation: null,
-    rootCauseInstance: null,
-    rootCauseDecision: null,
-  },
-  incidentCount: 1,
-};
-
 const multiInstancesMetadata = {
   ...baseMetadata,
   flowNodeInstanceId: null,
@@ -136,18 +114,6 @@ const calledUnevaluatedDecisionMetadata = {
     flowNodeType: 'TASK_BUSINESS_RULE',
     calledDecisionInstanceId: null,
     calledDecisionDefinitionName: 'Take decision',
-  },
-};
-
-const rootIncidentFlowNodeMetaData = {
-  ...calledInstanceWithIncidentMetadata,
-  incident: {
-    ...calledInstanceWithIncidentMetadata.incident,
-    rootCauseInstance: {
-      processDefinitionId: 'called-process',
-      processDefinitionName: 'Called Process',
-      instanceId: PROCESS_INSTANCE_ID,
-    },
   },
 };
 
@@ -192,35 +158,6 @@ const userTaskFlowNodeMetaData = {
 const retriesLeftFlowNodeMetaData = {
   ...baseMetadata,
   instanceMetadata: {...baseInstanceMetadata, jobRetries: 2},
-};
-
-const incidentsByProcessKeyMetadata = {
-  items: [
-    {
-      processDefinitionId: 'invoice',
-      errorType: 'JOB_NO_RETRIES' as const,
-      errorMessage: 'There are no more retries left.',
-      elementId: 'call-order-process',
-      creationTime: '2022-02-03T16:44:06.981+0000',
-      state: 'PENDING' as const,
-      tenantId: '<default>',
-      incidentKey: '2251799814080730',
-      processDefinitionKey: '2251799813686633',
-      processInstanceKey: '2251799813685593',
-      elementInstanceKey: FLOW_NODE_INSTANCE_ID,
-      jobKey: '2251799814080730',
-    },
-  ],
-  page: {totalItems: 1},
-};
-
-const processDefinitionMetadata = {
-  name: 'DMN invoice',
-  processDefinitionId: 'invoice',
-  processDefinitionKey: '2251799813686633',
-  resourceName: 'usertest/invoice.bpmn',
-  tenantId: '<default>',
-  version: 1,
 };
 
 const jobMetadata: Job = {
@@ -275,11 +212,8 @@ export {
   calledInstanceMetadata,
   multiInstancesMetadata,
   multiInstanceCallActivityMetadata,
-  rootIncidentFlowNodeMetaData,
   userTaskFlowNodeMetaData,
   retriesLeftFlowNodeMetaData,
-  incidentsByProcessKeyMetadata,
-  processDefinitionMetadata,
   jobMetadata,
   calledDecisionInstanceMetadata,
   PROCESS_INSTANCE_ID,
@@ -287,5 +221,4 @@ export {
   FLOW_NODE_ID,
   USER_TASK_FLOW_NODE_ID,
   BUSINESS_RULE_FLOW_NODE_ID,
-  FLOW_NODE_INSTANCE_ID,
 };


### PR DESCRIPTION
## Description

:bulb: Please review the commits individually, because the first two commits are mostly deleting and moving files, which caused a big changeset.

- Remove v1 MetadataPopover component
- Move MetadataPopover/v2 -> MetadataPopover
- Explicitly pass data from MetadataPopover component to Details component, adjust tests
- Fix capitalization of instance count text

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

related to #33213 
