### PR TITLE
feat: dynamic node discovery

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
@@ -9,8 +9,7 @@ package io.camunda.application.commons.configuration;
 
 import io.atomix.cluster.ClusterConfig;
 import io.atomix.cluster.MemberConfig;
-import io.atomix.cluster.NodeConfig;
-import io.atomix.cluster.discovery.BootstrapDiscoveryConfig;
+import io.atomix.cluster.discovery.DynamicDiscoveryConfig;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.protocol.SwimMembershipProtocolConfig;
 import io.atomix.utils.net.Address;
@@ -30,7 +29,6 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.context.LifecycleProperties;
 import org.springframework.context.annotation.Bean;
@@ -131,13 +129,8 @@ public final class GatewayBasedConfiguration {
         .setSyncInterval(config.getSyncInterval());
   }
 
-  private BootstrapDiscoveryConfig discoveryConfig(final Collection<String> contactPoints) {
-    final var nodes =
-        contactPoints.stream()
-            .map(Address::from)
-            .map(address -> new NodeConfig().setAddress(address))
-            .collect(Collectors.toSet());
-    return new BootstrapDiscoveryConfig().setNodes(nodes);
+  private DynamicDiscoveryConfig discoveryConfig(final Collection<String> contactPoints) {
+    return new DynamicDiscoveryConfig().setAddresses(contactPoints);
   }
 
   private MessagingConfig messagingConfig(final GatewayCfg config) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/discovery/DynamicDiscoveryConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/discovery/DynamicDiscoveryConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster.discovery;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/** DNS discovery provider configuration. */
+public class DynamicDiscoveryConfig extends NodeDiscoveryConfig {
+  private Collection<String> addresses = new ArrayList<>();
+  private Duration refreshInterval = Duration.ofSeconds(60);
+  private int defaultPort = 26502;
+
+  @Override
+  public NodeDiscoveryProvider.Type getType() {
+    return DynamicDiscoveryProvider.TYPE;
+  }
+
+  /**
+   * Returns the list of DNS addresses to resolve.
+   *
+   * @return the list of DNS addresses
+   */
+  public Collection<String> getAddresses() {
+    return addresses;
+  }
+
+  /**
+   * Sets the DNS addresses.
+   *
+   * @param addresses the DNS addresses in format "host:port" or "host"
+   * @return the DNS discovery configuration
+   */
+  public DynamicDiscoveryConfig setAddresses(final Collection<String> addresses) {
+    this.addresses = addresses;
+    return this;
+  }
+
+  /**
+   * Returns the DNS refresh interval.
+   *
+   * @return the refresh interval
+   */
+  public Duration getRefreshInterval() {
+    return refreshInterval;
+  }
+
+  /**
+   * Sets the DNS refresh interval.
+   *
+   * @param refreshInterval the interval at which to refresh DNS resolutions
+   * @return the DNS discovery configuration
+   */
+  public DynamicDiscoveryConfig setRefreshInterval(final Duration refreshInterval) {
+    this.refreshInterval = refreshInterval;
+    return this;
+  }
+
+  public int getDefaultPort() {
+    return defaultPort;
+  }
+
+  public void setDefaultPort(final int defaultPort) {
+    this.defaultPort = defaultPort;
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/discovery/DynamicDiscoveryProvider.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/discovery/DynamicDiscoveryProvider.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster.discovery;
+
+import com.google.common.collect.Sets;
+import com.google.common.net.HostAndPort;
+import io.atomix.cluster.BootstrapService;
+import io.atomix.cluster.Node;
+import io.atomix.cluster.NodeConfig;
+import io.atomix.cluster.NodeId;
+import io.atomix.utils.event.AbstractListenerManager;
+import io.atomix.utils.net.Address;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Dynamic cluster node discovery provider.
+ *
+ * <p>This provider resolves DNS addresses to discover nodes in the cluster. It supports:
+ *
+ * <ul>
+ *   <li>Host names that resolve to multiple IP addresses
+ *   <li>IPv4 addresses
+ *   <li>Addresses with or without explicit ports (defaults to MessagingConfig port)
+ *   <li>Periodic DNS resolution refresh to detect changes
+ * </ul>
+ *
+ * <p>The provider periodically refreshes DNS resolutions and fires {@link
+ * NodeDiscoveryEvent.Type#JOIN} events when new nodes are discovered and {@link
+ * NodeDiscoveryEvent.Type#LEAVE} events when nodes are no longer resolved.
+ */
+public final class DynamicDiscoveryProvider
+    extends AbstractListenerManager<NodeDiscoveryEvent, NodeDiscoveryEventListener>
+    implements NodeDiscoveryProvider {
+
+  public static final Type TYPE = new Type();
+  private static final Logger LOGGER = LoggerFactory.getLogger(DynamicDiscoveryProvider.class);
+
+  private final DynamicDiscoveryConfig config;
+  private final Set<Node> discoveredNodes = ConcurrentHashMap.newKeySet();
+  private final AtomicBoolean started = new AtomicBoolean(false);
+  private final ScheduledExecutorService scheduler =
+      Executors.newSingleThreadScheduledExecutor(
+          runnable -> {
+            final Thread thread = new Thread(runnable, "dynamic-discovery");
+            thread.setDaemon(true);
+            return thread;
+          });
+
+  private final int defaultPort;
+  private ScheduledFuture<?> refreshTask;
+  private final Function<String, List<InetAddress>> hostnameResolver;
+
+  /**
+   * Creates a new DNS discovery provider with the given configuration.
+   *
+   * @param config the DNS discovery configuration
+   */
+  public DynamicDiscoveryProvider(final DynamicDiscoveryConfig config) {
+    this(config, DynamicDiscoveryProvider::resolveAddress);
+  }
+
+  @VisibleForTesting
+  DynamicDiscoveryProvider(
+      final DynamicDiscoveryConfig config,
+      final Function<String, List<InetAddress>> hostnameResolver) {
+    this.config = Objects.requireNonNull(config, "config cannot be null");
+    defaultPort = config.getDefaultPort();
+    if (config.getRefreshInterval() == null
+        || config.getRefreshInterval().isZero()
+        || config.getRefreshInterval().isNegative()) {
+      throw new IllegalArgumentException(
+          "Refresh interval must be a positive duration, but given: "
+              + config.getRefreshInterval());
+    }
+    this.hostnameResolver = hostnameResolver;
+  }
+
+  @Override
+  public DynamicDiscoveryConfig config() {
+    return config;
+  }
+
+  @Override
+  public Set<Node> getNodes() {
+    return Set.copyOf(discoveredNodes);
+  }
+
+  @Override
+  public CompletableFuture<Void> join(final BootstrapService bootstrap, final Node localNode) {
+    if (started.compareAndSet(false, true)) {
+      scheduler.submit(
+          () -> {
+            scheduleRefresh();
+
+            LOGGER.debug(
+                "Dynamic discovery started with {} nodes discovered", discoveredNodes.size());
+          });
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> leave(final Node localNode) {
+    if (started.compareAndSet(true, false)) {
+      LOGGER.info("Stopping Dynamic discovery");
+
+      // Cancel refresh task
+      if (refreshTask != null) {
+        refreshTask.cancel(false);
+        refreshTask = null;
+      }
+
+      // Clear discovered nodes
+      discoveredNodes.clear();
+
+      // Shutdown scheduler
+      scheduler.shutdownNow();
+
+      LOGGER.info("Dynamic discovery stopped");
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  private void scheduleRefresh() {
+    refreshNodes();
+    final Duration refreshInterval = config.getRefreshInterval();
+    LOGGER.trace("Scheduling node refresh in {}", refreshInterval);
+    refreshTask =
+        scheduler.schedule(
+            this::scheduleRefresh, refreshInterval.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  /** Refreshes the list of discovered nodes by re-resolving DNS addresses. */
+  private void refreshNodes() {
+    try {
+      final Set<Node> newNodes = discoverNodes();
+      final Set<Node> currentNodes = Set.copyOf(discoveredNodes);
+
+      // Determine newly joined nodes
+      final Set<Node> joinedNodes = Sets.difference(newNodes, currentNodes);
+      for (final Node node : joinedNodes) {
+        discoveredNodes.add(node);
+        LOGGER.debug("Node joined: {}", node);
+        post(new NodeDiscoveryEvent(NodeDiscoveryEvent.Type.JOIN, node));
+      }
+
+      // Determine nodes that left
+      final Set<Node> leftNodes = Sets.difference(currentNodes, newNodes);
+      for (final Node node : leftNodes) {
+        discoveredNodes.remove(node);
+        LOGGER.debug("Node left: {}", node);
+        post(new NodeDiscoveryEvent(NodeDiscoveryEvent.Type.LEAVE, node));
+      }
+
+      if (!joinedNodes.isEmpty() || !leftNodes.isEmpty()) {
+        LOGGER.info(
+            "{} nodes joined, {} nodes left, {} total nodes",
+            joinedNodes.size(),
+            leftNodes.size(),
+            discoveredNodes.size());
+      }
+    } catch (final Exception e) {
+      LOGGER.error("Error refreshing discovery nodes", e);
+    }
+  }
+
+  /**
+   * Resolves all configured DNS addresses to a set of nodes.
+   *
+   * @return the set of resolved nodes
+   */
+  private Set<Node> discoverNodes() {
+    final Set<Node> nodes = ConcurrentHashMap.newKeySet();
+
+    for (final String address : config.getAddresses()) {
+      try {
+        nodes.addAll(discoverAddress(address));
+      } catch (final Exception e) {
+        LOGGER.warn("Failed to resolve address: {}", address, e);
+      }
+    }
+
+    return nodes;
+  }
+
+  /**
+   * Resolves a single DNS address to a set of nodes. If the hostname resolves to multiple IP
+   * addresses, creates a node for each one.
+   *
+   * @param address the address in format "host:port" or "host"
+   * @return the set of resolved nodes
+   */
+  private Set<Node> discoverAddress(final String address) {
+    final Set<Node> nodes = ConcurrentHashMap.newKeySet();
+
+    try {
+      // Parse host and port
+      final HostAndPort hostAndPort = HostAndPort.fromString(address).withDefaultPort(defaultPort);
+      final String host = hostAndPort.getHost();
+      final int port = hostAndPort.getPort();
+
+      // Resolve DNS to all IP addresses
+      final List<InetAddress> addresses = hostnameResolver.apply(host);
+
+      for (final InetAddress inetAddress : addresses) {
+        final String ipAddress = inetAddress.getHostAddress();
+        final Address nodeAddress = new Address(ipAddress, port, inetAddress);
+
+        // Create node ID from the resolved address
+        final NodeId nodeId = NodeId.from(ipAddress + ":" + port);
+        final NodeConfig nodeConfig = new NodeConfig().setId(nodeId).setAddress(nodeAddress);
+        final Node node = new Node(nodeConfig);
+
+        nodes.add(node);
+        LOGGER.debug("Resolved {} to {} ({}:{})", address, inetAddress, ipAddress, port);
+      }
+
+      if (nodes.isEmpty()) {
+        LOGGER.warn("No addresses resolved for: {}", address);
+      }
+    } catch (final Exception e) {
+      LOGGER.debug("Error resolving address: {}", address, e);
+    }
+
+    return nodes;
+  }
+
+  private static List<InetAddress> resolveAddress(final String host) {
+    try {
+      return Arrays.asList(InetAddress.getAllByName(host));
+    } catch (final UnknownHostException e) {
+      LOGGER.warn("Failed to resolve DNS for address: {}", host, e);
+      return List.of();
+    }
+  }
+
+  public static class Type implements NodeDiscoveryProvider.Type<DynamicDiscoveryConfig> {
+    private static final String NAME = "dynamic";
+
+    @Override
+    public String name() {
+      return NAME;
+    }
+
+    @Override
+    public NodeDiscoveryProvider newProvider(final DynamicDiscoveryConfig config) {
+      return new DynamicDiscoveryProvider(config);
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/discovery/DynamicDiscoveryProviderTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/discovery/DynamicDiscoveryProviderTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.atomix.cluster.Node;
+import io.atomix.cluster.NodeId;
+import io.atomix.cluster.discovery.NodeDiscoveryEvent.Type;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import org.awaitility.Awaitility;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class DynamicDiscoveryProviderTest {
+
+  private final List<DynamicDiscoveryProvider> providers = new ArrayList<>();
+
+  @AfterEach
+  void tearDown() throws Exception {
+    for (final DynamicDiscoveryProvider provider : providers) {
+      provider.leave(null).get(10, TimeUnit.SECONDS);
+    }
+    providers.clear();
+  }
+
+  @Test
+  void shouldResolveLocalhostAddress() throws Exception {
+    // given
+    final DynamicDiscoveryConfig config =
+        new DynamicDiscoveryConfig()
+            .setAddresses(List.of("localhost:26500"))
+            .setRefreshInterval(Duration.ofSeconds(30));
+    final DynamicDiscoveryProvider provider = new DynamicDiscoveryProvider(config);
+    providers.add(provider);
+
+    // when
+    provider.join(null, null).get(10, TimeUnit.SECONDS);
+
+    // then
+    Awaitility.await().until(() -> provider.getNodes().size(), is(1));
+    final Set<Node> nodes = provider.getNodes();
+    assertThat(nodes).isNotEmpty().allMatch(node -> node.address().port() == 26500);
+  }
+
+  @Test
+  void shouldResolveAddressWithDefaultPort() throws Exception {
+    // given
+    final DynamicDiscoveryConfig config =
+        new DynamicDiscoveryConfig()
+            .setAddresses(List.of("localhost"))
+            .setRefreshInterval(Duration.ofSeconds(30));
+    final DynamicDiscoveryProvider provider = new DynamicDiscoveryProvider(config);
+    providers.add(provider);
+
+    // when
+    provider.join(null, null).get(10, TimeUnit.SECONDS);
+
+    // then
+    Awaitility.await().until(() -> provider.getNodes().size(), is(Matchers.greaterThan(0)));
+    assertThat(provider.getNodes())
+        // Should use default port 26500
+        .allMatch(node -> node.address().port() == 26502);
+  }
+
+  @Test
+  void shouldResolveMultipleAddresses() throws Exception {
+    // given
+    final DynamicDiscoveryConfig config =
+        new DynamicDiscoveryConfig()
+            .setAddresses(List.of("localhost:26500", "127.0.0.1:26501"))
+            .setRefreshInterval(Duration.ofSeconds(30));
+    final DynamicDiscoveryProvider provider = new DynamicDiscoveryProvider(config);
+    providers.add(provider);
+
+    // when
+    provider.join(null, null).get(10, TimeUnit.SECONDS);
+
+    // then
+    Awaitility.await()
+        .untilAsserted(() -> assertThat(provider.getNodes()).hasSizeGreaterThanOrEqualTo(2));
+  }
+
+  @Test
+  void shouldHandleMultipleResolvedAddress() {
+    // given
+    final DynamicDiscoveryConfig config =
+        new DynamicDiscoveryConfig()
+            .setAddresses(List.of("multi.address.test"))
+            .setRefreshInterval(Duration.ofSeconds(30));
+    final Function<String, List<InetAddress>> mockResolver =
+        ignore -> {
+          try {
+            return List.of(
+                InetAddress.getByName("123.45.66.89"), InetAddress.getByName("123.54.76.98"));
+          } catch (final UnknownHostException e) {
+            throw new RuntimeException(e);
+          }
+        };
+    final DynamicDiscoveryProvider provider = new DynamicDiscoveryProvider(config, mockResolver);
+
+    // when
+    provider.join(null, null);
+    providers.add(provider);
+
+    // then
+    Awaitility.await().until(() -> provider.getNodes().size(), is(2));
+    assertThat(provider.getNodes())
+        .extracting(node -> node.address().host())
+        .containsExactlyInAnyOrder("123.45.66.89", "123.54.76.98");
+  }
+
+  @Test
+  void shouldCreateNodeWithCorrectId() throws Exception {
+    // given
+    final DynamicDiscoveryConfig config =
+        new DynamicDiscoveryConfig()
+            .setAddresses(List.of("127.0.0.1:26500"))
+            .setRefreshInterval(Duration.ofSeconds(30));
+    final DynamicDiscoveryProvider provider = new DynamicDiscoveryProvider(config);
+    providers.add(provider);
+
+    // when
+    provider.join(null, null).get(10, TimeUnit.SECONDS);
+
+    // then
+    Awaitility.await().until(() -> provider.getNodes().size(), Matchers.equalTo(1));
+    final Set<Node> nodes = provider.getNodes();
+    assertThat(nodes).first().extracting(Node::id).isEqualTo(NodeId.from("127.0.0.1:26500"));
+  }
+
+  @Test
+  void shouldFireJoinEventsOnDiscovery() throws Exception {
+    // given
+    final DynamicDiscoveryConfig config =
+        new DynamicDiscoveryConfig()
+            .setAddresses(List.of("localhost:26500"))
+            .setRefreshInterval(Duration.ofSeconds(30));
+    final DynamicDiscoveryProvider provider = new DynamicDiscoveryProvider(config);
+    providers.add(provider);
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final List<NodeDiscoveryEvent> events = new ArrayList<>();
+    provider.addListener(
+        event -> {
+          events.add(event);
+          latch.countDown();
+        });
+
+    // when
+    provider.join(null, null).get(10, TimeUnit.SECONDS);
+
+    // then
+    assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(events).isNotEmpty().allMatch(event -> event.type() == Type.JOIN);
+  }
+
+  @Test
+  void shouldFireLeaveEventsOnNodeRemoval() throws Exception {
+    // given
+    final DynamicDiscoveryConfig config =
+        new DynamicDiscoveryConfig()
+            .setAddresses(List.of("localhost:26500"))
+            .setRefreshInterval(Duration.ofSeconds(1));
+
+    // A mock resolver that returns an address on the first call and an empty list on subsequent
+    // calls to simulate a node leaving
+    final AtomicInteger callCount = new AtomicInteger(0);
+    final Function<String, List<InetAddress>> mockResolver =
+        ignore -> {
+          try {
+            if (callCount.getAndIncrement() < 1) {
+              return List.of(InetAddress.getByName("123.56.78.99"));
+            } else {
+              return List.of();
+            }
+          } catch (final UnknownHostException e) {
+            throw new RuntimeException(e);
+          }
+        };
+
+    final DynamicDiscoveryProvider provider = new DynamicDiscoveryProvider(config, mockResolver);
+    providers.add(provider);
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final List<NodeDiscoveryEvent> events = new ArrayList<>();
+    provider.addListener(
+        event -> {
+          events.add(event);
+          if (event.type() == Type.LEAVE) {
+            latch.countDown();
+          }
+        });
+
+    // when
+    provider.join(null, null).get(10, TimeUnit.SECONDS);
+
+    // wait for refresh interval to pass
+    Awaitility.await().atMost(Duration.ofSeconds(5)).until(() -> provider.getNodes().isEmpty());
+
+    // then
+    assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(events).anyMatch(event -> event.type() == Type.LEAVE);
+  }
+
+  @Test
+  void shouldNotFailWithUnresolvableAddress() throws Exception {
+    // given
+    final DynamicDiscoveryConfig config =
+        new DynamicDiscoveryConfig()
+            .setAddresses(List.of("unresolvable.invalid.host:26500", "localhost:26500"))
+            .setRefreshInterval(Duration.ofSeconds(30));
+
+    final Function<String, List<InetAddress>> mockResolver =
+        address -> {
+          if (address.equals("unresolvable.invalid.host:26500")) {
+            throw new RuntimeException("Failed to resolve address");
+          } else {
+            try {
+              return List.of(InetAddress.getByName(address));
+            } catch (final UnknownHostException e) {
+              throw new RuntimeException(e);
+            }
+          }
+        };
+
+    final DynamicDiscoveryProvider provider = new DynamicDiscoveryProvider(config);
+    providers.add(provider);
+
+    // when
+    provider.join(null, null).get(10, TimeUnit.SECONDS);
+
+    // then - should still resolve localhost
+    Awaitility.await().until(() -> provider.getNodes().size(), is(1));
+  }
+
+  @Test
+  void shouldUseConfigFromBuilder() {
+    // given
+    final Duration refreshInterval = Duration.ofMinutes(5);
+
+    // when
+    final DynamicDiscoveryConfig config =
+        new DynamicDiscoveryConfig()
+            .setAddresses(List.of("localhost:26500"))
+            .setRefreshInterval(refreshInterval);
+    final DynamicDiscoveryProvider provider = new DynamicDiscoveryProvider(config);
+    providers.add(provider);
+
+    // then
+    assertThat(config.getAddresses()).containsExactly("localhost:26500");
+    assertThat(config.getRefreshInterval()).isEqualTo(refreshInterval);
+  }
+
+  @Test
+  void shouldCreateProviderFromType() {
+    // given
+    final DynamicDiscoveryConfig config =
+        new DynamicDiscoveryConfig()
+            .setAddresses(List.of("localhost:26500"))
+            .setRefreshInterval(Duration.ofSeconds(30));
+
+    // when
+    final NodeDiscoveryProvider provider = DynamicDiscoveryProvider.TYPE.newProvider(config);
+    providers.add((DynamicDiscoveryProvider) provider);
+
+    // then
+    assertThat(provider).isInstanceOf(DynamicDiscoveryProvider.class);
+    assertThat(provider.config()).isEqualTo(config);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -9,8 +9,7 @@ package io.camunda.zeebe.broker.clustering;
 
 import io.atomix.cluster.ClusterConfig;
 import io.atomix.cluster.MemberConfig;
-import io.atomix.cluster.NodeConfig;
-import io.atomix.cluster.discovery.BootstrapDiscoveryConfig;
+import io.atomix.cluster.discovery.DynamicDiscoveryConfig;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.protocol.SwimMembershipProtocolConfig;
 import io.atomix.utils.net.Address;
@@ -21,7 +20,6 @@ import io.camunda.zeebe.broker.system.configuration.NetworkCfg;
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.stream.Collectors;
 
 // TODO: move this to BrokerClusterConfiguration in the dist module
 public final class ClusterConfigFactory {
@@ -64,14 +62,8 @@ public final class ClusterConfigFactory {
         .setSyncInterval(config.getSyncInterval());
   }
 
-  private BootstrapDiscoveryConfig discoveryConfig(final Collection<String> contactPoints) {
-    final var nodes =
-        contactPoints.stream()
-            .map(Address::from)
-            .map(address -> new NodeConfig().setAddress(address))
-            .collect(Collectors.toSet());
-
-    return new BootstrapDiscoveryConfig().setNodes(nodes);
+  private DynamicDiscoveryConfig discoveryConfig(final Collection<String> contactPoints) {
+    return new DynamicDiscoveryConfig().setAddresses(contactPoints);
   }
 
   private MessagingConfig messagingConfig(final ClusterCfg cluster, final NetworkCfg network) {


### PR DESCRIPTION
## Description

This PR add a DynamicNodeDiscoveryProvider that
* Accepts one or more hostname:port as initial contact points.
* Discover nodes by resolving provided hosts
* If a host name is resolved to multiple addresses, all addresses are used as discovered nodes
* Periodically refreshes the discovered nodes.

This can also accept individual addresses. So it can replace the existing BootstrapDiscoveryNodeProvider. 

Users can configure
1. One or more hostname or addresses of individual brokers / gateways
2. One or more dns name that resolves in to addresses of all brokers or gateways
3. Or both 1 and 2

There is no change in the user facing configuration. The existing configuration for initialContactPoint can accept all combinations. The default discovery provider is set to DynamicNodeDiscoveryProvider. 

As alternate, we considered choosing between Bootstrap discovery (existing mechanism) or the Dynamic provider based on the configuration. However, there is no need to add a new configuration as the dynamic provider can handle static node addresses as well.

## Checklist

## Related issues

closes #40288 
