### PR TITLE
feat: implement version list support for process definition statistics endpoint

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionInstanceVersionStatisticsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionInstanceVersionStatisticsDbReader.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.sql.columns.SearchColumn;
+import io.camunda.search.clients.reader.ProcessDefinitionInstanceVersionStatisticsReader;
+import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
+import io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+
+public class ProcessDefinitionInstanceVersionStatisticsDbReader
+    extends AbstractEntityReader<ProcessDefinitionInstanceVersionStatisticsEntity>
+    implements ProcessDefinitionInstanceVersionStatisticsReader {
+
+  public ProcessDefinitionInstanceVersionStatisticsDbReader() {
+    super(new SearchColumn[] {});
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity> aggregate(
+      final ProcessDefinitionInstanceVersionStatisticsQuery query,
+      final ResourceAccessChecks resourceAccessChecks) {
+    // Not implemented yet
+    return SearchQueryResult.empty();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -28,6 +28,7 @@ import io.camunda.db.rdbms.read.service.MappingRuleDbReader;
 import io.camunda.db.rdbms.read.service.MessageSubscriptionDbReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionInstanceStatisticsDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionInstanceVersionStatisticsDbReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionStatisticsDbReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceStatisticsDbReader;
@@ -69,6 +70,7 @@ import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
 import io.camunda.search.clients.reader.ProcessDefinitionInstanceStatisticsReader;
+import io.camunda.search.clients.reader.ProcessDefinitionInstanceVersionStatisticsReader;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -242,6 +244,11 @@ public class RdbmsConfiguration {
   @Bean
   public ProcessDefinitionInstanceStatisticsReader processDefinitionInstanceStatisticsReader() {
     return new ProcessDefinitionInstanceStatisticsDbReader();
+  }
+
+  @Bean
+  public ProcessDefinitionInstanceVersionStatisticsReader processDefinitionStatisticsDbReader() {
+    return new ProcessDefinitionInstanceVersionStatisticsDbReader();
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -29,6 +29,7 @@ import io.camunda.search.clients.reader.JobReader;
 import io.camunda.search.clients.reader.MappingRuleReader;
 import io.camunda.search.clients.reader.MessageSubscriptionReader;
 import io.camunda.search.clients.reader.ProcessDefinitionInstanceStatisticsReader;
+import io.camunda.search.clients.reader.ProcessDefinitionInstanceVersionStatisticsReader;
 import io.camunda.search.clients.reader.ProcessDefinitionReader;
 import io.camunda.search.clients.reader.ProcessDefinitionStatisticsReader;
 import io.camunda.search.clients.reader.ProcessInstanceReader;
@@ -139,6 +140,8 @@ public class SearchClientDatabaseConfiguration {
       final MessageSubscriptionReader messageSubscriptionReader,
       final ProcessDefinitionReader processDefinitionReader,
       final ProcessDefinitionInstanceStatisticsReader processDefinitionInstanceStatisticsReader,
+      final ProcessDefinitionInstanceVersionStatisticsReader
+          processDefinitionInstanceVersionStatisticsReader,
       final ProcessDefinitionStatisticsReader processDefinitionFlowNodeStatisticsReader,
       final ProcessInstanceReader processInstanceReader,
       final ProcessInstanceStatisticsReader processInstanceFlowNodeStatisticsReader,
@@ -172,6 +175,7 @@ public class SearchClientDatabaseConfiguration {
         processDefinitionFlowNodeStatisticsReader,
         processInstanceReader,
         processDefinitionInstanceStatisticsReader,
+        processDefinitionInstanceVersionStatisticsReader,
         processInstanceFlowNodeStatisticsReader,
         roleReader,
         roleMemberReader,

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
@@ -44,6 +44,8 @@ import io.camunda.search.clients.reader.MessageSubscriptionReader;
 import io.camunda.search.clients.reader.ProcessDefinitionDocumentReader;
 import io.camunda.search.clients.reader.ProcessDefinitionInstanceStatisticsDocumentReader;
 import io.camunda.search.clients.reader.ProcessDefinitionInstanceStatisticsReader;
+import io.camunda.search.clients.reader.ProcessDefinitionInstanceVersionStatisticsDocumentReader;
+import io.camunda.search.clients.reader.ProcessDefinitionInstanceVersionStatisticsReader;
 import io.camunda.search.clients.reader.ProcessDefinitionReader;
 import io.camunda.search.clients.reader.ProcessDefinitionStatisticsDocumentReader;
 import io.camunda.search.clients.reader.ProcessDefinitionStatisticsReader;
@@ -262,6 +264,16 @@ public class SearchClientReaderConfiguration {
       final IndexDescriptors descriptors,
       final IncidentErrorHashCodeNormalizer normalizer) {
     return new ProcessDefinitionInstanceStatisticsDocumentReader(
+        executor, descriptors.get(ListViewTemplate.class), normalizer) {};
+  }
+
+  @Bean
+  public ProcessDefinitionInstanceVersionStatisticsReader
+      processDefinitionInstanceVersionStatisticsReader(
+          final SearchClientBasedQueryExecutor executor,
+          final IndexDescriptors descriptors,
+          final IncidentErrorHashCodeNormalizer normalizer) {
+    return new ProcessDefinitionInstanceVersionStatisticsDocumentReader(
         executor, descriptors.get(ListViewTemplate.class), normalizer) {};
   }
 

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -12,7 +12,6 @@ import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.CardinalityAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket;
-import co.elastic.clients.elasticsearch._types.aggregations.LongTermsAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.LongTermsBucket;
 import co.elastic.clients.elasticsearch._types.aggregations.MultiBucketAggregateBase;
 import co.elastic.clients.elasticsearch._types.aggregations.MultiBucketBase;
@@ -68,10 +67,6 @@ public class SearchAggregationResultTransformer<T>
         .docCount(aggregate.docCount())
         .aggregations(transformAggregation(aggregate.aggregations()))
         .build();
-  }
-
-  private AggregationResult transformLTermsBucketAggregate(final LongTermsAggregate aggregate) {
-    return new Builder().docCount((long) aggregate.buckets().array().size()).build();
   }
 
   private AggregationResult transformSingleMetricAggregate(
@@ -142,7 +137,8 @@ public class SearchAggregationResultTransformer<T>
             final String key =
                 switch (bucket) {
                   case final StringTermsBucket b -> b.key().stringValue();
-                  case final LongTermsBucket b -> b.keyAsString();
+                  case final LongTermsBucket b ->
+                      b.keyAsString() != null ? b.keyAsString() : String.valueOf(b.key());
                   case final CompositeBucket b ->
                       b.key().values().stream()
                           .map(FieldValue::stringValue)
@@ -159,7 +155,11 @@ public class SearchAggregationResultTransformer<T>
             map.put(key, result);
           });
     }
-    return new Builder().aggregations(map).endCursor(Cursor.encode(searchAfter)).build();
+    return new Builder()
+        .docCount((long) buckets.array().size())
+        .aggregations(map)
+        .endCursor(Cursor.encode(searchAfter))
+        .build();
   }
 
   private <B extends MultiBucketBase> Object[] extractSearchAfter(
@@ -191,7 +191,7 @@ public class SearchAggregationResultTransformer<T>
             case Filter -> res = transformSingleBucketAggregate(aggregate.filter());
             case Filters -> res = transformMultiBucketAggregate(aggregate.filters());
             case Sterms -> res = transformMultiBucketAggregate(warnDocError(aggregate.sterms()));
-            case Lterms -> res = transformLTermsBucketAggregate(warnDocError(aggregate.lterms()));
+            case Lterms -> res = transformMultiBucketAggregate(warnDocError(aggregate.lterms()));
             case Composite -> res = transformMultiBucketAggregate(aggregate.composite());
             case TopHits -> res = transformTopHitsAggregate(key, aggregate.topHits());
             case Sum -> res = transformSingleMetricAggregate(aggregate.sum());

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -118,6 +118,7 @@ public class SearchAggregationResultTransformer<T>
     final var map = new LinkedHashMap<String, AggregationResult>();
     final var buckets = aggregate.buckets();
     final var searchAfter = extractSearchAfter(aggregate);
+    final var builder = new Builder().aggregations(map).endCursor(Cursor.encode(searchAfter));
     if (buckets.isKeyed()) {
       buckets
           .keyed()
@@ -132,6 +133,7 @@ public class SearchAggregationResultTransformer<T>
               });
     } else if (buckets.isArray()) {
       final List<B> array = buckets.array();
+      builder.docCount((long) array.size());
       array.forEach(
           bucket -> {
             final String key =
@@ -155,11 +157,7 @@ public class SearchAggregationResultTransformer<T>
             map.put(key, result);
           });
     }
-    return new Builder()
-        .docCount((long) buckets.array().size())
-        .aggregations(map)
-        .endCursor(Cursor.encode(searchAfter))
-        .build();
+    return builder.build();
   }
 
   private <B extends MultiBucketBase> Object[] extractSearchAfter(

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregator/AggregationResultTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregator/AggregationResultTransformerTest.java
@@ -111,6 +111,7 @@ public class AggregationResultTransformerTest {
                     "docCount": 2,
                     "aggregations": {
                       "group-flow-nodes": {
+                       "docCount": 1,
                         "aggregations": {
                           "EndEvent": {
                             "docCount": 2,

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -28,7 +28,6 @@ import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.aggregations.CardinalityAggregate;
 import org.opensearch.client.opensearch._types.aggregations.CompositeAggregate;
 import org.opensearch.client.opensearch._types.aggregations.CompositeBucket;
-import org.opensearch.client.opensearch._types.aggregations.LongTermsAggregate;
 import org.opensearch.client.opensearch._types.aggregations.LongTermsBucket;
 import org.opensearch.client.opensearch._types.aggregations.MultiBucketAggregateBase;
 import org.opensearch.client.opensearch._types.aggregations.MultiBucketBase;
@@ -67,10 +66,6 @@ public class SearchAggregationResultTransformer<T>
         .docCount(aggregate.docCount())
         .aggregations(transformAggregation(aggregate.aggregations()))
         .build();
-  }
-
-  private AggregationResult transformLTermsBucketAggregate(final LongTermsAggregate aggregate) {
-    return new Builder().docCount((long) aggregate.buckets().array().size()).build();
   }
 
   private AggregationResult transformSingleMetricAggregate(
@@ -122,6 +117,7 @@ public class SearchAggregationResultTransformer<T>
     final var map = new LinkedHashMap<String, AggregationResult>();
     final var buckets = aggregate.buckets();
     final var searchAfter = extractSearchAfter(aggregate);
+    final var builder = new Builder().aggregations(map).endCursor(Cursor.encode(searchAfter));
     if (buckets.isKeyed()) {
       buckets
           .keyed()
@@ -136,6 +132,7 @@ public class SearchAggregationResultTransformer<T>
               });
     } else if (buckets.isArray()) {
       final List<B> array = buckets.array();
+      builder.docCount((long) array.size());
       array.forEach(
           bucket -> {
             final String key =
@@ -158,7 +155,7 @@ public class SearchAggregationResultTransformer<T>
             map.put(key, result);
           });
     }
-    return new Builder().aggregations(map).endCursor(Cursor.encode(searchAfter)).build();
+    return builder.build();
   }
 
   private <B extends MultiBucketBase> Object[] extractSearchAfter(
@@ -191,7 +188,7 @@ public class SearchAggregationResultTransformer<T>
             case Filter -> res = transformSingleBucketAggregate(aggregate.filter());
             case Filters -> res = transformMultiBucketAggregate(aggregate.filters());
             case Sterms -> res = transformMultiBucketAggregate(warnDocError(aggregate.sterms()));
-            case Lterms -> res = transformLTermsBucketAggregate(warnDocError(aggregate.lterms()));
+            case Lterms -> res = transformMultiBucketAggregate(warnDocError(aggregate.lterms()));
             case Composite -> res = transformMultiBucketAggregate(aggregate.composite());
             case TopHits -> res = transformTopHitsAggregate(key, aggregate.topHits());
             case Sum -> res = transformSingleMetricAggregate(aggregate.sum());

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/AggregationResultTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/AggregationResultTransformerTest.java
@@ -111,6 +111,7 @@ public class AggregationResultTransformerTest {
                     "docCount": 2,
                     "aggregations": {
                       "group-flow-nodes": {
+                       "docCount": 1,
                         "aggregations": {
                           "EndEvent": {
                             "docCount": 2,

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionInstanceVersionStatisticsDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionInstanceVersionStatisticsDocumentReader.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_FIELD_KEY;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_FIELD_PROCESS_DEFINITION_ID;
+
+import io.camunda.search.aggregation.result.ProcessDefinitionInstanceVersionStatisticsAggregationResult;
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.clients.reader.utils.IncidentErrorHashCodeNormalizer;
+import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
+import io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class ProcessDefinitionInstanceVersionStatisticsDocumentReader extends DocumentBasedReader
+    implements ProcessDefinitionInstanceVersionStatisticsReader {
+
+  private final IncidentErrorHashCodeNormalizer normalizer;
+
+  public ProcessDefinitionInstanceVersionStatisticsDocumentReader(
+      final SearchClientBasedQueryExecutor executor,
+      final IndexDescriptor indexDescriptor,
+      final IncidentErrorHashCodeNormalizer normalizer) {
+    super(executor, indexDescriptor);
+    this.normalizer = normalizer;
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity> aggregate(
+      final ProcessDefinitionInstanceVersionStatisticsQuery query,
+      final ResourceAccessChecks resourceAccessChecks) {
+
+    final var filter =
+        normalizer.normalizeAndValidateProcessInstanceFilter(query.filter(), resourceAccessChecks);
+    if (filter.isEmpty()) {
+      return SearchQueryResult.empty();
+    }
+    // Update the query to use the normalized filter
+    final var normalizedQuery =
+        new ProcessDefinitionInstanceVersionStatisticsQuery(
+            filter.get(), query.sort(), query.page());
+
+    // Convert sorting field if needed
+    final var updatedQuery =
+        normalizedQuery.withConvertedSortingField(
+            AGGREGATION_FIELD_PROCESS_DEFINITION_ID, AGGREGATION_FIELD_KEY);
+
+    // Run a single paginated query; total count is provided by the cardinality aggregation
+    final var paginatedResult =
+        getSearchExecutor()
+            .aggregateWithQueryResult(
+                updatedQuery,
+                ProcessDefinitionInstanceVersionStatisticsAggregationResult.class,
+                resourceAccessChecks,
+                ProcessDefinitionInstanceVersionStatisticsAggregationResult::items);
+
+    // Return paginated items and total from the single query result
+    return new SearchQueryResult<>(
+        paginatedResult.total(),
+        paginatedResult.hasMoreTotalItems(),
+        paginatedResult.items(),
+        paginatedResult.startCursor(),
+        paginatedResult.endCursor());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.transformers;
 import io.camunda.search.aggregation.AggregationBase;
 import io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation;
 import io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation;
+import io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation;
 import io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation;
 import io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation;
 import io.camunda.search.aggregation.UsageMetricsAggregation;
@@ -17,6 +18,7 @@ import io.camunda.search.aggregation.UsageMetricsTUAggregation;
 import io.camunda.search.aggregation.result.AggregationResultBase;
 import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionInstanceStatisticsAggregationResult;
+import io.camunda.search.aggregation.result.ProcessDefinitionInstanceVersionStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionLatestVersionAggregationResult;
 import io.camunda.search.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.UsageMetricsAggregationResult;
@@ -28,6 +30,7 @@ import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.transformers.aggregation.AggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionFlowNodeStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionInstanceStatisticsAggregationTransformer;
+import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionLatestVersionAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessInstanceFlowNodeStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.UsageMetricsAggregationTransformer;
@@ -35,6 +38,7 @@ import io.camunda.search.clients.transformers.aggregation.UsageMetricsTUAggregat
 import io.camunda.search.clients.transformers.aggregation.result.AggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionInstanceStatisticsAggregationResultTransformer;
+import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionInstanceVersionStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionLatestVersionAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsAggregationResultTransformer;
@@ -175,6 +179,7 @@ import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
+import io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceFlowNodeStatisticsQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
@@ -352,6 +357,7 @@ public final class ServiceTransformers {
             ProcessDefinitionQuery.class,
             ProcessDefinitionFlowNodeStatisticsQuery.class,
             ProcessDefinitionInstanceStatisticsQuery.class,
+            ProcessDefinitionInstanceVersionStatisticsQuery.class,
             ProcessInstanceQuery.class,
             ProcessInstanceFlowNodeStatisticsQuery.class,
             RoleQuery.class,
@@ -538,6 +544,9 @@ public final class ServiceTransformers {
     mappers.put(
         ProcessDefinitionInstanceStatisticsAggregation.class,
         new ProcessDefinitionInstanceStatisticsAggregationTransformer());
+    mappers.put(
+        ProcessDefinitionInstanceVersionStatisticsAggregation.class,
+        new ProcessDefinitionInstanceVersionStatisticsAggregationTransformer());
 
     // aggregation result
     mappers.put(
@@ -556,5 +565,8 @@ public final class ServiceTransformers {
     mappers.put(
         ProcessDefinitionInstanceStatisticsAggregationResult.class,
         new ProcessDefinitionInstanceStatisticsAggregationResultTransformer());
+    mappers.put(
+        ProcessDefinitionInstanceVersionStatisticsAggregationResult.class,
+        new ProcessDefinitionInstanceVersionStatisticsAggregationResultTransformer());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessDefinitionInstanceVersionStatisticsAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessDefinitionInstanceVersionStatisticsAggregationTransformer.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_FIELD_KEY;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_NAME_PAGE;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_NAME_PROCESS_DEFINITION_VERSION;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_NAME_TOTAL_WITHOUT_INCIDENT;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_NAME_TOTAL_WITH_INCIDENT;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_NAME_VERSION_CARDINALITY;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_TERMS_SIZE;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.bucketSort;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.cardinality;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.filter;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.topHits;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.INCIDENT;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PROCESS_VERSION;
+
+import io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchTopHitsAggregator;
+import io.camunda.search.clients.aggregator.SearchTopHitsAggregator.Builder;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+
+public class ProcessDefinitionInstanceVersionStatisticsAggregationTransformer
+    implements AggregationTransformer<ProcessDefinitionInstanceVersionStatisticsAggregation> {
+
+  @Override
+  public List<SearchAggregator> apply(
+      final Tuple<ProcessDefinitionInstanceVersionStatisticsAggregation, ServiceTransformers>
+          value) {
+    final var aggregation = value.getLeft();
+
+    final var byProcessDefinitionVersionAggBuilder =
+        terms()
+            .name(ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_NAME_BY_VERSION)
+            .field(PROCESS_VERSION)
+            .size(AGGREGATION_TERMS_SIZE)
+            .sorting(
+                List.of(
+                    new FieldSorting(AGGREGATION_FIELD_KEY, io.camunda.search.sort.SortOrder.ASC)));
+
+    final Builder<ProcessInstanceForListViewEntity> topHits = topHits();
+    final SearchTopHitsAggregator<ProcessInstanceForListViewEntity> processDefinitionAgg =
+        topHits
+            .name(AGGREGATION_NAME_PROCESS_DEFINITION_VERSION)
+            .field(PROCESS_VERSION)
+            .size(1)
+            .documentClass(ProcessInstanceForListViewEntity.class)
+            .build();
+
+    final var totalWithIncidentsAgg =
+        filter().name(AGGREGATION_NAME_TOTAL_WITH_INCIDENT).query(term(INCIDENT, true)).build();
+
+    final var totalWithoutIncidentsAgg =
+        filter().name(AGGREGATION_NAME_TOTAL_WITHOUT_INCIDENT).query(term(INCIDENT, false)).build();
+
+    final var bucketSort =
+        bucketSort()
+            .name(AGGREGATION_NAME_PAGE)
+            .sorting(getCountSuffixSortings(aggregation))
+            .from(aggregation.page() != null ? aggregation.page().from() : null)
+            .size(aggregation.page() != null ? aggregation.page().size() : null)
+            .build();
+
+    final var byProcessDefinitionVersionAgg =
+        byProcessDefinitionVersionAggBuilder
+            .aggregations(
+                processDefinitionAgg, totalWithIncidentsAgg, totalWithoutIncidentsAgg, bucketSort)
+            .build();
+
+    final var processDefinitionKeyCardinalityAgg =
+        cardinality().name(AGGREGATION_NAME_VERSION_CARDINALITY).field(PROCESS_VERSION).build();
+
+    return List.of(byProcessDefinitionVersionAgg, processDefinitionKeyCardinalityAgg);
+  }
+
+  private static List<FieldSorting> getCountSuffixSortings(
+      final ProcessDefinitionInstanceVersionStatisticsAggregation aggregation) {
+    return aggregation.sort().getFieldSortings().stream()
+        .map(ordering -> new FieldSorting(ordering.field() + "._count", ordering.order()))
+        .toList();
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/ProcessDefinitionInstanceVersionStatisticsAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/ProcessDefinitionInstanceVersionStatisticsAggregationResultTransformer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_NAME_BY_VERSION;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_NAME_PROCESS_DEFINITION_VERSION;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_NAME_TOTAL_WITHOUT_INCIDENT;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_NAME_TOTAL_WITH_INCIDENT;
+import static io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation.AGGREGATION_NAME_VERSION_CARDINALITY;
+
+import io.camunda.search.aggregation.result.ProcessDefinitionInstanceVersionStatisticsAggregationResult;
+import io.camunda.search.clients.core.AggregationResult;
+import io.camunda.search.clients.core.SearchQueryHit;
+import io.camunda.search.clients.transformers.entity.ProcessInstanceEntityTransformer;
+import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import java.util.List;
+import java.util.Map;
+
+public class ProcessDefinitionInstanceVersionStatisticsAggregationResultTransformer
+    implements AggregationResultTransformer<
+        ProcessDefinitionInstanceVersionStatisticsAggregationResult> {
+
+  @Override
+  public ProcessDefinitionInstanceVersionStatisticsAggregationResult apply(
+      final Map<String, AggregationResult> value) {
+
+    final AggregationResult byVersionAgg = value.get(AGGREGATION_NAME_BY_VERSION);
+    final Map<String, AggregationResult> perProcessAggregations = byVersionAgg.aggregations();
+
+    final AggregationResult cardinalityAgg = value.get(AGGREGATION_NAME_VERSION_CARDINALITY);
+
+    final int totalItems =
+        cardinalityAgg != null
+            ? Math.toIntExact(cardinalityAgg.docCount())
+            : perProcessAggregations.size();
+
+    final List<ProcessDefinitionInstanceVersionStatisticsEntity> items =
+        perProcessAggregations.entrySet().stream()
+            .map(
+                entry -> {
+                  final String version = entry.getKey();
+                  final AggregationResult agg = entry.getValue();
+
+                  final var processInstanceEntity =
+                      agg
+                          .aggregations()
+                          .get(AGGREGATION_NAME_PROCESS_DEFINITION_VERSION)
+                          .hits()
+                          .stream()
+                          .map(SearchQueryHit::source)
+                          .map(ProcessInstanceForListViewEntity.class::cast)
+                          .map(new ProcessInstanceEntityTransformer()::apply)
+                          .findFirst();
+
+                  final long activeInstancesWithIncidents =
+                      agg.aggregations()
+                          .getOrDefault(
+                              AGGREGATION_NAME_TOTAL_WITH_INCIDENT, AggregationResult.EMPTY)
+                          .docCount();
+
+                  final long activeInstancesWithoutIncidents =
+                      agg.aggregations()
+                          .getOrDefault(
+                              AGGREGATION_NAME_TOTAL_WITHOUT_INCIDENT, AggregationResult.EMPTY)
+                          .docCount();
+
+                  return processInstanceEntity
+                      .map(
+                          entity ->
+                              new ProcessDefinitionInstanceVersionStatisticsEntity(
+                                  entity.processDefinitionId(),
+                                  entity.processDefinitionKey(),
+                                  entity.processDefinitionVersion(),
+                                  entity.processDefinitionName(),
+                                  activeInstancesWithIncidents,
+                                  activeInstancesWithoutIncidents))
+                      .orElse(null);
+                })
+            .toList();
+
+    return new ProcessDefinitionInstanceVersionStatisticsAggregationResult(items, totalItems);
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionInstanceVersionStatisticsReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/ProcessDefinitionInstanceVersionStatisticsReader.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
+import io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery;
+
+public interface ProcessDefinitionInstanceVersionStatisticsReader
+    extends SearchQueryStatisticsReader<
+        ProcessDefinitionInstanceVersionStatisticsEntity,
+        ProcessDefinitionInstanceVersionStatisticsQuery> {}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -27,6 +27,8 @@ public record SearchClientReaders(
     ProcessDefinitionStatisticsReader processDefinitionStatisticsReader,
     ProcessInstanceReader processInstanceReader,
     ProcessDefinitionInstanceStatisticsReader processDefinitionInstanceStatisticsReader,
+    ProcessDefinitionInstanceVersionStatisticsReader
+        processDefinitionInstanceVersionStatisticsReader,
     ProcessInstanceStatisticsReader processInstanceStatisticsReader,
     RoleReader roleReader,
     RoleMemberReader roleMemberReader,

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -30,6 +30,7 @@ import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
+import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
@@ -66,6 +67,7 @@ import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
+import io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceFlowNodeStatisticsQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
@@ -252,6 +254,13 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity>
       processDefinitionInstanceStatistics(final ProcessDefinitionInstanceStatisticsQuery query) {
     return doSearchWithReader(readers.processDefinitionInstanceStatisticsReader(), query);
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity>
+      processDefinitionInstanceVersionStatistics(
+          final ProcessDefinitionInstanceVersionStatisticsQuery query) {
+    return doSearchWithReader(readers.processDefinitionInstanceVersionStatisticsReader(), query);
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/ProcessDefinitionSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/ProcessDefinitionSearchClient.java
@@ -9,9 +9,11 @@ package io.camunda.search.clients;
 
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
+import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
+import io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
@@ -31,4 +33,8 @@ public interface ProcessDefinitionSearchClient {
 
   SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity> processDefinitionInstanceStatistics(
       final ProcessDefinitionInstanceStatisticsQuery query);
+
+  SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity>
+      processDefinitionInstanceVersionStatistics(
+          final ProcessDefinitionInstanceVersionStatisticsQuery query);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -25,6 +25,7 @@ import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
+import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
@@ -55,6 +56,7 @@ import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
+import io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.RoleMemberQuery;
@@ -212,6 +214,13 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity>
       processDefinitionInstanceStatistics(final ProcessDefinitionInstanceStatisticsQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity>
+      processDefinitionInstanceVersionStatistics(
+          final ProcessDefinitionInstanceVersionStatisticsQuery query) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -27,6 +27,7 @@ import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
+import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
@@ -56,6 +57,7 @@ import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
+import io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.RoleMemberQuery;
@@ -214,6 +216,13 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity>
       processDefinitionInstanceStatistics(final ProcessDefinitionInstanceStatisticsQuery query) {
+    return SearchQueryResult.empty();
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity>
+      processDefinitionInstanceVersionStatistics(
+          final ProcessDefinitionInstanceVersionStatisticsQuery query) {
     return SearchQueryResult.empty();
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/ProcessDefinitionInstanceVersionStatisticsAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/ProcessDefinitionInstanceVersionStatisticsAggregation.java
@@ -10,25 +10,24 @@ package io.camunda.search.aggregation;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.AggregationPaginated;
-import io.camunda.search.sort.ProcessDefinitionInstanceStatisticsSort;
+import io.camunda.search.sort.ProcessDefinitionInstanceVersionStatisticsSort;
 
-public record ProcessDefinitionInstanceStatisticsAggregation(
+public record ProcessDefinitionInstanceVersionStatisticsAggregation(
     ProcessInstanceFilter filter,
-    ProcessDefinitionInstanceStatisticsSort sort,
+    ProcessDefinitionInstanceVersionStatisticsSort sort,
     SearchQueryPage page)
     implements AggregationBase, AggregationPaginated {
 
   public static final int AGGREGATION_TERMS_SIZE = 10000;
-  public static final String AGGREGATION_NAME_BY_PROCESS_ID = "by_process_id";
+  public static final String AGGREGATION_NAME_BY_VERSION = "by_version";
   public static final String AGGREGATION_NAME_PAGE = "page";
+  public static final String AGGREGATION_FIELD_PROCESS_DEFINITION_ID = "processDefinitionId";
+  public static final String AGGREGATION_FIELD_KEY = "_key";
+  public static final String AGGREGATION_NAME_PROCESS_DEFINITION_VERSION =
+      "processDefinitionVersion";
   public static final String AGGREGATION_NAME_TOTAL_WITH_INCIDENT =
       "activeInstancesWithIncidentCount";
   public static final String AGGREGATION_NAME_TOTAL_WITHOUT_INCIDENT =
       "activeInstancesWithoutIncidentCount";
-  public static final String AGGREGATION_NAME_LATEST_PROCESS_DEFINITION = "latestProcessDefinition";
-  public static final String AGGREGATION_NAME_VERSION_COUNT = "versionCount";
-  public static final String AGGREGATION_FIELD_KEY = "_key";
-  public static final String AGGREGATION_FIELD_PROCESS_DEFINITION_ID = "processDefinitionId";
-  public static final String AGGREGATION_NAME_PROCESS_DEFINITION_KEY_CARDINALITY =
-      "processDefinitionKeyCardinality";
+  public static final String AGGREGATION_NAME_VERSION_CARDINALITY = "versionCardinality";
 }

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/ProcessDefinitionInstanceVersionStatisticsAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/ProcessDefinitionInstanceVersionStatisticsAggregationResult.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation.result;
+
+import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
+import java.util.List;
+
+public record ProcessDefinitionInstanceVersionStatisticsAggregationResult(
+    List<ProcessDefinitionInstanceVersionStatisticsEntity> items, int totalItems)
+    implements AggregationResultBase, HasTotalItems {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionInstanceVersionStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionInstanceVersionStatisticsEntity.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.util.ObjectBuilder;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ProcessDefinitionInstanceVersionStatisticsEntity(
+    String processDefinitionId,
+    Long processDefinitionKey,
+    Integer processDefinitionVersion,
+    String processDefinitionName,
+    Long activeInstancesWithoutIncidentCount,
+    Long activeInstancesWithIncidentCount) {
+
+  public static class Builder
+      implements ObjectBuilder<ProcessDefinitionInstanceVersionStatisticsEntity> {
+    private String processDefinitionId;
+    private Long processDefinitionKey;
+    private Integer processDefinitionVersion;
+    private String processDefinitionName;
+    private Long activeInstancesWithoutIncidentCount;
+    private Long activeInstancesWithIncidentCount;
+
+    public Builder processDefinitionId(final String processDefinitionId) {
+      this.processDefinitionId = processDefinitionId;
+      return this;
+    }
+
+    public Builder processDefinitionKey(final Long processDefinitionKey) {
+      this.processDefinitionKey = processDefinitionKey;
+      return this;
+    }
+
+    public Builder processDefinitionVersion(final Integer processDefinitionVersion) {
+      this.processDefinitionVersion = processDefinitionVersion;
+      return this;
+    }
+
+    public Builder processDefinitionName(final String processDefinitionName) {
+      this.processDefinitionName = processDefinitionName;
+      return this;
+    }
+
+    public Builder activeInstancesWithoutIncidentCount(final Long count) {
+      activeInstancesWithoutIncidentCount = count;
+      return this;
+    }
+
+    public Builder activeInstancesWithIncidentCount(final Long count) {
+      activeInstancesWithIncidentCount = count;
+      return this;
+    }
+
+    @Override
+    public ProcessDefinitionInstanceVersionStatisticsEntity build() {
+      return new ProcessDefinitionInstanceVersionStatisticsEntity(
+          processDefinitionId,
+          processDefinitionKey,
+          processDefinitionVersion,
+          processDefinitionName,
+          activeInstancesWithoutIncidentCount,
+          activeInstancesWithIncidentCount);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/ProcessDefinitionInstanceStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/ProcessDefinitionInstanceStatisticsQuery.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.search.query;
 
-import static io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation.AGGREGATION_TERMS_SIZE;
-
 import io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.ProcessInstanceFilter;
@@ -54,14 +52,6 @@ public record ProcessDefinitionInstanceStatisticsQuery(
       return new ProcessDefinitionInstanceStatisticsQuery(filter, newSort, page);
     }
     return this;
-  }
-
-  public ProcessDefinitionInstanceStatisticsQuery withUnlimitedPage() {
-    return ProcessDefinitionInstanceStatisticsQuery.of(
-        b ->
-            b.filter(filter)
-                .sort(sort)
-                .page(p -> p.size(AGGREGATION_TERMS_SIZE).from(0).after(null).before(null)));
   }
 
   public static final class Builder

--- a/search/search-domain/src/main/java/io/camunda/search/query/ProcessDefinitionInstanceVersionStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/ProcessDefinitionInstanceVersionStatisticsQuery.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.ProcessDefinitionInstanceVersionStatisticsSort;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record ProcessDefinitionInstanceVersionStatisticsQuery(
+    ProcessInstanceFilter filter,
+    ProcessDefinitionInstanceVersionStatisticsSort sort,
+    SearchQueryPage page)
+    implements TypedSearchAggregationQuery<
+        ProcessInstanceFilter,
+        ProcessDefinitionInstanceVersionStatisticsSort,
+        ProcessDefinitionInstanceVersionStatisticsAggregation> {
+
+  public static ProcessDefinitionInstanceVersionStatisticsQuery of(
+      final java.util.function.Function<
+              Builder,
+              io.camunda.util.ObjectBuilder<ProcessDefinitionInstanceVersionStatisticsQuery>>
+          fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  @Override
+  public ProcessDefinitionInstanceVersionStatisticsAggregation aggregation() {
+    return new ProcessDefinitionInstanceVersionStatisticsAggregation(filter, sort, page);
+  }
+
+  public ProcessDefinitionInstanceVersionStatisticsQuery withConvertedSortingField(
+      final String originalField, final String convertedField) {
+    if (sort != null && sort.orderings() != null) {
+      final var updatedOrderings =
+          sort.orderings().stream()
+              .map(
+                  ordering ->
+                      ordering.field().equals(originalField)
+                          ? new io.camunda.search.sort.SortOption.FieldSorting(
+                              convertedField, ordering.order())
+                          : ordering)
+              .toList();
+      final var newSort = new ProcessDefinitionInstanceVersionStatisticsSort(updatedOrderings);
+      return new ProcessDefinitionInstanceVersionStatisticsQuery(filter, newSort, page);
+    }
+    return this;
+  }
+
+  public static final class Builder
+      extends SearchQueryBase.AbstractQueryBuilder<
+          ProcessDefinitionInstanceVersionStatisticsQuery.Builder>
+      implements TypedSearchQueryBuilder<
+          ProcessDefinitionInstanceVersionStatisticsQuery,
+          ProcessDefinitionInstanceVersionStatisticsQuery.Builder,
+          ProcessInstanceFilter,
+          ProcessDefinitionInstanceVersionStatisticsSort> {
+
+    private static final ProcessInstanceFilter DEFAULT_FILTER =
+        io.camunda.search.filter.FilterBuilders.processInstance().build();
+
+    private static final ProcessDefinitionInstanceVersionStatisticsSort DEFAULT_SORT =
+        SortOptionBuilders.processDefinitionInstanceVersionStatistics().build();
+
+    private ProcessInstanceFilter filter;
+    private ProcessDefinitionInstanceVersionStatisticsSort sort;
+
+    @Override
+    public Builder filter(final ProcessInstanceFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final ProcessDefinitionInstanceVersionStatisticsSort value) {
+      sort = value;
+      return this;
+    }
+
+    public ProcessDefinitionInstanceVersionStatisticsQuery.Builder filter(
+        final Function<ProcessInstanceFilter.Builder, ObjectBuilder<ProcessInstanceFilter>> fn) {
+      return filter(FilterBuilders.processInstance(fn));
+    }
+
+    public ProcessDefinitionInstanceVersionStatisticsQuery.Builder sort(
+        final Function<
+                ProcessDefinitionInstanceVersionStatisticsSort.Builder,
+                ObjectBuilder<ProcessDefinitionInstanceVersionStatisticsSort>>
+            fn) {
+      return sort(SortOptionBuilders.processDefinitionInstanceVersionStatistics(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public ProcessDefinitionInstanceVersionStatisticsQuery build() {
+      filter = Objects.requireNonNullElse(filter, DEFAULT_FILTER);
+      sort = Objects.requireNonNullElse(sort, DEFAULT_SORT);
+      return new ProcessDefinitionInstanceVersionStatisticsQuery(filter, sort, page());
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -243,4 +243,9 @@ public final class SearchQueryBuilders {
       processDefinitionInstanceStatisticsQuery() {
     return new ProcessDefinitionInstanceStatisticsQuery.Builder();
   }
+
+  public static ProcessDefinitionInstanceVersionStatisticsQuery.Builder
+      processDefinitionInstanceVersionStatisticsQuery() {
+    return new ProcessDefinitionInstanceVersionStatisticsQuery.Builder();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/ProcessDefinitionInstanceVersionStatisticsSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/ProcessDefinitionInstanceVersionStatisticsSort.java
@@ -11,7 +11,7 @@ import io.camunda.util.ObjectBuilder;
 import java.util.List;
 import java.util.function.Function;
 
-public record ProcessDefinitionInstanceStatisticsSort(List<FieldSorting> orderings)
+public record ProcessDefinitionInstanceVersionStatisticsSort(List<FieldSorting> orderings)
     implements SortOption {
 
   @Override
@@ -19,17 +19,32 @@ public record ProcessDefinitionInstanceStatisticsSort(List<FieldSorting> orderin
     return orderings;
   }
 
-  public static ProcessDefinitionInstanceStatisticsSort of(
-      final Function<Builder, ObjectBuilder<ProcessDefinitionInstanceStatisticsSort>> fn) {
-    return SortOptionBuilders.processDefinitionInstanceStatistics(fn);
+  public static ProcessDefinitionInstanceVersionStatisticsSort of(
+      final Function<Builder, ObjectBuilder<ProcessDefinitionInstanceVersionStatisticsSort>> fn) {
+    return SortOptionBuilders.processDefinitionInstanceVersionStatistics(fn);
   }
 
   public static final class Builder
-      extends SortOption.AbstractBuilder<ProcessDefinitionInstanceStatisticsSort.Builder>
-      implements ObjectBuilder<ProcessDefinitionInstanceStatisticsSort> {
+      extends SortOption.AbstractBuilder<ProcessDefinitionInstanceVersionStatisticsSort.Builder>
+      implements ObjectBuilder<ProcessDefinitionInstanceVersionStatisticsSort> {
 
     public Builder processDefinitionId() {
       currentOrdering = new FieldSorting("processDefinitionId", null);
+      return this;
+    }
+
+    public Builder processDefinitionKey() {
+      currentOrdering = new FieldSorting("processDefinitionKey", null);
+      return this;
+    }
+
+    public Builder processDefinitionName() {
+      currentOrdering = new FieldSorting("processDefinitionName", null);
+      return this;
+    }
+
+    public Builder processDefinitionVersion() {
+      currentOrdering = new FieldSorting("processDefinitionVersion", null);
       return this;
     }
 
@@ -49,8 +64,8 @@ public record ProcessDefinitionInstanceStatisticsSort(List<FieldSorting> orderin
     }
 
     @Override
-    public ProcessDefinitionInstanceStatisticsSort build() {
-      return new ProcessDefinitionInstanceStatisticsSort(orderings);
+    public ProcessDefinitionInstanceVersionStatisticsSort build() {
+      return new ProcessDefinitionInstanceVersionStatisticsSort(orderings);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -250,4 +250,18 @@ public final class SortOptionBuilders {
           fn) {
     return fn.apply(processDefinitionInstanceStatistics()).build();
   }
+
+  public static ProcessDefinitionInstanceVersionStatisticsSort.Builder
+      processDefinitionInstanceVersionStatistics() {
+    return new ProcessDefinitionInstanceVersionStatisticsSort.Builder();
+  }
+
+  public static ProcessDefinitionInstanceVersionStatisticsSort
+      processDefinitionInstanceVersionStatistics(
+          final Function<
+                  ProcessDefinitionInstanceVersionStatisticsSort.Builder,
+                  ObjectBuilder<ProcessDefinitionInstanceVersionStatisticsSort>>
+              fn) {
+    return fn.apply(new ProcessDefinitionInstanceVersionStatisticsSort.Builder()).build();
+  }
 }

--- a/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
@@ -15,9 +15,12 @@ import io.camunda.search.clients.ProcessDefinitionSearchClient;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
+import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
+import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
+import io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -109,6 +112,28 @@ public class ProcessDefinitionServices
                     securityContextProvider.provideSecurityContext(
                         authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
                 .processDefinitionInstanceStatistics(query));
+  }
+
+  public SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity>
+      searchProcessDefinitionInstanceVersionStatistics(
+          final String processDefinitionId,
+          final ProcessDefinitionInstanceVersionStatisticsQuery query) {
+
+    final var filter =
+        query.filter().toBuilder()
+            .processDefinitionIds(processDefinitionId)
+            .states(ProcessInstanceState.ACTIVE.name())
+            .build();
+    final var updatedQuery =
+        ProcessDefinitionInstanceVersionStatisticsQuery.of(
+            b -> b.filter(filter).sort(query.sort()).page(query.page()));
+    return executeSearchRequest(
+        () ->
+            processDefinitionSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
+                .processDefinitionInstanceVersionStatistics(updatedQuery));
   }
 
   public Optional<FormEntity> getProcessDefinitionStartForm(final long processDefinitionKey) {

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -201,12 +201,9 @@ paths:
       tags:
         - Process definition
       operationId: getProcessDefinitionInstanceStatistics
-      summary: Get statistics for process instances by process definition
+      summary: Get process instance statistics
       description: |
-        Get statistics about process instances, grouped by process definition. For each process
-        definition, the response includes the latest deployed instance name, total counts of active
-        instances without incident, total counts of active instances with incident and whether the
-        instance has more than one version.
+        Get statistics about process instances, grouped by process definition.
       requestBody:
         required: false
         content:
@@ -228,6 +225,45 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-eventually-consistent: true
+
+  /process-definitions/{processDefinitionId}/statistics/process-instances:
+    post:
+      tags:
+        - Process definition
+      operationId: getProcessDefinitionInstanceVersionStatistics
+      summary: Get process instance statistics by version
+      description: |
+        Get statistics about process instances, grouped by version for a given process definition.
+      parameters:
+        - name: processDefinitionId
+          in: path
+          required: true
+          description: The ID of the process definition.
+          schema:
+            $ref: "identifiers.yaml#/components/schemas/ProcessDefinitionId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProcessDefinitionInstanceVersionStatisticsQuery"
+      responses:
+        "200":
+          description: The process definition instance version statistic result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessDefinitionInstanceVersionStatisticsQueryResult"
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-eventually-consistent: true
 
 ## Schema definitions
 
@@ -456,8 +492,8 @@ components:
           type: string
           enum:
             - processDefinitionId
-            - activeInstancesWithIncident
-            - activeInstancesWithoutIncident
+            - activeInstancesWithIncidentCount
+            - activeInstancesWithoutIncidentCount
         order:
           $ref: 'enums.yaml#/components/schemas/SortOrderEnum'
       required:
@@ -486,3 +522,83 @@ components:
         hasMoreTotalItems:
           description: Indicates whether there are more items matching the criteria.
           type: boolean
+
+    ProcessDefinitionInstanceVersionStatisticsQuery:
+      type: object
+      properties:
+        page:
+          description: Pagination criteria.
+          allOf:
+            - $ref: '#/components/schemas/ProcessDefinitionInstanceStatisticsPageRequest'
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessDefinitionInstanceVersionStatisticsQuerySortRequest'
+
+    ProcessDefinitionInstanceVersionStatisticsQueryResult:
+      type: object
+      description: Process definition instance version statistics query response.
+      properties:
+        items:
+          description: The process definition instance version statistics result.
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessDefinitionInstanceVersionStatisticsResult'
+        page:
+          description: Pagination information about the search results.
+          allOf:
+            - $ref: '#/components/schemas/ProcessDefinitionInstanceStatisticsPageResponse'
+
+    ProcessDefinitionInstanceVersionStatisticsResult:
+      description: Process definition instance version statistics response.
+      type: object
+      properties:
+        processDefinitionId:
+          description: The ID associated with the process definition.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
+        processDefinitionKey:
+          description: The unique key of the process definition.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
+        processDefinitionName:
+          description: The name of the process definition.
+          type: string
+        processDefinitionVersion:
+          description: The version number of the process definition.
+          type: integer
+          format: int32
+        activeInstancesWithIncidentCount:
+          description: The number of active process instances for this version that currently have incidents.
+          type: integer
+          format: int64
+        activeInstancesWithoutIncidentCount:
+          description: The number of active process instances for this version that do not have any incidents.
+          type: integer
+          format: int64
+      required:
+        - processDefinitionId
+        - processDefinitionKey
+        - processDefinitionName
+        - processDefinitionVersion
+        - activeInstancesWithIncidentCount
+        - activeInstancesWithoutIncidentCount
+
+    ProcessDefinitionInstanceVersionStatisticsQuerySortRequest:
+      type: object
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - processDefinitionId
+            - processDefinitionKey
+            - processDefinitionName
+            - processDefinitionVersion
+            - activeInstancesWithIncidentCount
+            - activeInstancesWithoutIncidentCount
+        order:
+          $ref: 'enums.yaml#/components/schemas/SortOrderEnum'
+      required:
+        - field

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -219,6 +219,8 @@ paths:
     $ref: 'process-definitions.yaml#/paths/~1process-definitions~1{processDefinitionKey}~1statistics~1element-instances'
   /process-definitions/{processDefinitionKey}/xml:
     $ref: 'process-definitions.yaml#/paths/~1process-definitions~1{processDefinitionKey}~1xml'
+  /process-definitions/{processDefinitionId}/statistics/process-instances:
+    $ref: 'process-definitions.yaml#/paths/~1process-definitions~1{processDefinitionId}~1statistics~1process-instances'
 
   # Process instance endpoints
   /process-instances:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryRequestMapper.java
@@ -595,6 +595,27 @@ public final class SearchQueryRequestMapper {
         filter, sort, page, SearchQueryBuilders::processDefinitionInstanceStatisticsQuery);
   }
 
+  public static Either<
+          ProblemDetail, io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery>
+      toProcessDefinitionInstanceVersionStatisticsQuery(
+          final ProcessDefinitionInstanceVersionStatisticsQuery request) {
+    if (request == null) {
+      return Either.right(
+          SearchQueryBuilders.processDefinitionInstanceVersionStatisticsQuery().build());
+    }
+
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        SearchQuerySortRequestMapper.toSearchQuerySort(
+            SearchQuerySortRequestMapper
+                .fromProcessDefinitionInstanceVersionStatisticsQuerySortRequest(request.getSort()),
+            SortOptionBuilders::processDefinitionInstanceVersionStatistics,
+            SearchQuerySortRequestMapper::applyProcessDefinitionInstanceVersionStatisticsSortField);
+    final var filter = FilterBuilders.processInstance().build();
+    return buildSearchQuery(
+        filter, sort, page, SearchQueryBuilders::processDefinitionInstanceVersionStatisticsQuery);
+  }
+
   private static Either<List<String>, SearchQueryPage> toSearchQueryPage(
       final SearchQueryPageRequest requestedPage) {
     if (requestedPage == null) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQueryResponseMapper.java
@@ -35,6 +35,7 @@ import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
+import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
@@ -106,6 +107,8 @@ import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionElementStatistics
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionInstanceStatisticsPageResponse;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionInstanceStatisticsQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionInstanceStatisticsResult;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionInstanceVersionStatisticsQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionInstanceVersionStatisticsResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessElementStatisticsResult;
@@ -252,12 +255,36 @@ public final class SearchQueryResponseMapper {
                 .toList());
   }
 
+  public static ProcessDefinitionInstanceVersionStatisticsQueryResult
+      toProcessInstanceVersionStatisticsQueryResult(
+          final SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity> result) {
+    final var page = toProcessDefinitionInstanceStatisticsPageResponse(result);
+    return new ProcessDefinitionInstanceVersionStatisticsQueryResult()
+        .page(page)
+        .items(
+            result.items().stream()
+                .map(SearchQueryResponseMapper::toProcessInstanceVersionStatisticsResult)
+                .toList());
+  }
+
   private static ProcessDefinitionInstanceStatisticsResult toProcessInstanceStatisticsResult(
       final ProcessDefinitionInstanceStatisticsEntity result) {
     return new ProcessDefinitionInstanceStatisticsResult()
         .processDefinitionId(result.processDefinitionId())
         .latestProcessDefinitionName(result.latestProcessDefinitionName())
         .hasMultipleVersions(result.hasMultipleVersions())
+        .activeInstancesWithIncidentCount(result.activeInstancesWithIncidentCount())
+        .activeInstancesWithoutIncidentCount(result.activeInstancesWithoutIncidentCount());
+  }
+
+  private static ProcessDefinitionInstanceVersionStatisticsResult
+      toProcessInstanceVersionStatisticsResult(
+          final ProcessDefinitionInstanceVersionStatisticsEntity result) {
+    return new ProcessDefinitionInstanceVersionStatisticsResult()
+        .processDefinitionId(result.processDefinitionId())
+        .processDefinitionKey(KeyUtil.keyToString(result.processDefinitionKey()))
+        .processDefinitionName(result.processDefinitionName())
+        .processDefinitionVersion(result.processDefinitionVersion())
         .activeInstancesWithIncidentCount(result.activeInstancesWithIncidentCount())
         .activeInstancesWithoutIncidentCount(result.activeInstancesWithoutIncidentCount());
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/search/SearchQuerySortRequestMapper.java
@@ -24,6 +24,7 @@ import io.camunda.search.sort.JobSort;
 import io.camunda.search.sort.MappingRuleSort;
 import io.camunda.search.sort.MessageSubscriptionSort;
 import io.camunda.search.sort.ProcessDefinitionInstanceStatisticsSort;
+import io.camunda.search.sort.ProcessDefinitionInstanceVersionStatisticsSort;
 import io.camunda.search.sort.ProcessDefinitionSort;
 import io.camunda.search.sort.ProcessInstanceSort;
 import io.camunda.search.sort.RoleMemberSort;
@@ -211,6 +212,14 @@ public class SearchQuerySortRequestMapper {
           SearchQuerySortRequest<ProcessDefinitionInstanceStatisticsQuerySortRequest.FieldEnum>>
       fromProcessDefinitionInstanceStatisticsQuerySortRequest(
           final List<ProcessDefinitionInstanceStatisticsQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
+  public static List<
+          SearchQuerySortRequest<
+              ProcessDefinitionInstanceVersionStatisticsQuerySortRequest.FieldEnum>>
+      fromProcessDefinitionInstanceVersionStatisticsQuerySortRequest(
+          final List<ProcessDefinitionInstanceVersionStatisticsQuerySortRequest> requests) {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
@@ -764,8 +773,30 @@ public class SearchQuerySortRequestMapper {
     } else {
       switch (field) {
         case PROCESS_DEFINITION_ID -> builder.processDefinitionId();
-        case ACTIVE_INSTANCES_WITH_INCIDENT -> builder.activeInstancesWithIncident();
-        case ACTIVE_INSTANCES_WITHOUT_INCIDENT -> builder.activeInstancesWithoutIncident();
+        case ACTIVE_INSTANCES_WITH_INCIDENT_COUNT -> builder.activeInstancesWithIncidentCount();
+        case ACTIVE_INSTANCES_WITHOUT_INCIDENT_COUNT ->
+            builder.activeInstancesWithoutIncidentCount();
+        default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
+      }
+    }
+    return validationErrors;
+  }
+
+  public static List<String> applyProcessDefinitionInstanceVersionStatisticsSortField(
+      final ProcessDefinitionInstanceVersionStatisticsQuerySortRequest.FieldEnum field,
+      final ProcessDefinitionInstanceVersionStatisticsSort.Builder builder) {
+    final List<String> validationErrors = new ArrayList<>();
+    if (field == null) {
+      validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+    } else {
+      switch (field) {
+        case PROCESS_DEFINITION_ID -> builder.processDefinitionId();
+        case PROCESS_DEFINITION_KEY -> builder.processDefinitionKey();
+        case PROCESS_DEFINITION_NAME -> builder.processDefinitionName();
+        case PROCESS_DEFINITION_VERSION -> builder.processDefinitionVersion();
+        case ACTIVE_INSTANCES_WITH_INCIDENT_COUNT -> builder.activeInstancesWithIncidentCount();
+        case ACTIVE_INSTANCES_WITHOUT_INCIDENT_COUNT ->
+            builder.activeInstancesWithoutIncidentCount();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR implements the second part of the Process Definition Statistics API as described in [camunda/camunda#21720](https://github.com/camunda/camunda/issues/21720#issuecomment-3248165941)￼ and tracked under [camunda/camunda#39997](https://github.com/camunda/camunda/issues/39997)￼.

It introduces a new REST endpoint that returns a paginated list of all deployed versions for a given process definition ID, along with metadata such as active instance counts (with and without incidents) and definition details.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #39997
