### PR TITLE
build: add profile to CPT to skip frontend build

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -307,4 +307,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>skipFrontendBuild</id>
+      <properties>
+        <skip.fe.build>true</skip.fe.build>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
The addition of the `skip.fe.build` property in 3f22e532 wasn't effective for CI where we only enable the `skipFrontendBuild` profile.

Just like other modules like `operate-webjar`, we need to support this profile directly.