### PR TITLE
feat: lease is renewed before its expiration

### DIFF
--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -50,7 +50,10 @@ public record Lease(String taskId, long timestamp, NodeInstance nodeInstance) {
   public Lease renew(final long now, final Duration leaseDuration) {
     if (!isStillValid(now, leaseDuration)) {
       throw new IllegalStateException(
-          "Lease is not valid anymore, it expired at " + Instant.ofEpochMilli(timestamp));
+          "Lease is not valid anymore("
+              + Instant.ofEpochMilli(now)
+              + "), it expired at "
+              + Instant.ofEpochMilli(timestamp));
     }
     final var millis = leaseDuration.toMillis();
     return new Lease(taskId, now + millis, nodeInstance);

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
@@ -89,9 +89,9 @@ public class NodeIdProvider implements AutoCloseable {
 
   private void renew() {
     try {
-      currentLease =
-          nodeIdRepository.acquire(
-              currentLease.lease().renew(clock.millis(), leaseDuration), currentLease.eTag());
+      final var newLease = currentLease.lease().renew(clock.millis(), leaseDuration);
+      LOG.trace("Renewing lease with {}", newLease);
+      currentLease = nodeIdRepository.acquire(newLease, currentLease.eTag());
     } catch (final Exception e) {
       LOG.warn("Failed to renew the lease: process is going to shut down immediately.", e);
       onLeaseFailure.run();

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProviderIT.java
@@ -8,13 +8,13 @@
 package io.camunda.zeebe.dynamic.nodeid;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
-import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease;
 import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;
 import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.Config;
@@ -22,7 +22,6 @@ import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.S3Client
 import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.S3ClientConfig.Credentials;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Optional;
 import java.util.UUID;
@@ -115,6 +114,7 @@ public class NodeIdProviderIT {
     final var expiredLease =
         repository.acquire(
             new Lease(taskId + "old", expiredLeaseTimestamp, new NodeInstance(0)), previousEtag);
+    assertThat(expiredLease).isNotNull();
     clock.advance(EXPIRY_DURATION.plusSeconds(1));
 
     // when


### PR DESCRIPTION
## Description
Renewal of the lease is scheduled at `expiryDuration / 3`. We might want to make it configurable as well in the future, but it should be ok as a starting step.
When the renewal fails, a callback is invoked. For production uses we want to shut down the node within a certain time frame.

## Related issues
relates #40308
