### PR TITLE
fix: Speed Up History Cleanup ITs

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
@@ -33,6 +33,11 @@ public class HistoryCleanupIT {
 
   @Test
   void shouldDeleteProcessesWhichAreMarkedForCleanup() {
+    // this will deploy resource, start two process instances and complete user tasks for one that
+    // will end one instance
+    // that will get picked up by the archiver and they get moved to dated indices
+    // the dated indices have ILM/ISM deletion policy with `minAge=0` that will delete those records
+
     // given
     deployResource(camundaClient, RESOURCE_NAME).getProcesses().getFirst();
     waitForProcessesToBeDeployed(camundaClient, 1);
@@ -62,6 +67,8 @@ public class HistoryCleanupIT {
     // and soon it should be gone
     Awaitility.await("should wait until process and tasks are deleted")
         .atMost(Duration.ofMinutes(5))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(10))
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/ElasticsearchSetupHelper.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/ElasticsearchSetupHelper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.multidb;
+
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+
+public class ElasticsearchSetupHelper extends ElasticOpenSearchSetupHelper {
+  private static final Duration DEFAULT_INDICES_LIFECYCLE_POLL_INTERVAL = Duration.ofMinutes(10);
+
+  public ElasticsearchSetupHelper(
+      final String endpoint, final Collection<IndexDescriptor> expectedDescriptors) {
+    super(endpoint, expectedDescriptors);
+  }
+
+  @Override
+  protected Map<String, Object> getLifecyclePollIntervalSettings(final Duration pollInterval) {
+    if (pollInterval.toSeconds() < 1) {
+      throw new IllegalArgumentException(
+          "Elasticsearch index lifecycle poll interval must be at least 1 second");
+    }
+
+    return Map.of(
+        "persistent",
+        Map.of("indices.lifecycle.poll_interval", String.format("%ds", pollInterval.toSeconds())));
+  }
+
+  @Override
+  protected Map<String, Object> getResetLifecyclePollIntervalSettings() {
+    return getLifecyclePollIntervalSettings(DEFAULT_INDICES_LIFECYCLE_POLL_INTERVAL);
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbSetupHelper.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbSetupHelper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.qa.util.multidb;
 
+import java.time.Duration;
+
 /**
  * Helper used in {@link CamundaMultiDBExtension} to manage the multi database setup.
  *
@@ -21,6 +23,15 @@ public interface MultiDbSetupHelper extends AutoCloseable {
    * @return true if connection can be established, false otherwise
    */
   boolean validateConnection();
+
+  /**
+   * Set a custom index policies poll interval, primarily used for ElasticSearch & OpenSearch. This
+   * is used to speed up tests which depends on an index lifecycle being applied to an index, for
+   * example delete data past minAge. This is a cluster wide setting.
+   *
+   * @param pollInterval the poll interval duration
+   */
+  void applyIndexPoliciesPollInterval(final Duration pollInterval);
 
   /**
    * To validate schema creation, used to store related test data, which can be identified under

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/OpenSearchSetupHelper.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/OpenSearchSetupHelper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.multidb;
+
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+
+public class OpenSearchSetupHelper extends ElasticOpenSearchSetupHelper {
+  private static final Duration DEFAULT_INDEX_STATE_MGMT_JOB_INTERVAL = Duration.ofMinutes(5);
+  private static final String DEFAULT_INDEX_STATE_MGMT_JITTER = "0.6";
+
+  public OpenSearchSetupHelper(
+      final String endpoint, final Collection<IndexDescriptor> expectedDescriptors) {
+    super(endpoint, expectedDescriptors);
+  }
+
+  @Override
+  protected Map<String, Object> getLifecyclePollIntervalSettings(final Duration pollInterval) {
+    // set a very low jitter to make sure the job runs quickly after the interval
+    return getLifecycleJobInterval(pollInterval, "0.001");
+  }
+
+  @Override
+  protected Map<String, Object> getResetLifecyclePollIntervalSettings() {
+    return getLifecycleJobInterval(
+        DEFAULT_INDEX_STATE_MGMT_JOB_INTERVAL, DEFAULT_INDEX_STATE_MGMT_JITTER);
+  }
+
+  private Map<String, Object> getLifecycleJobInterval(
+      final Duration jobInterval, final String jitter) {
+    if (jobInterval.toMinutes() < 1) {
+      throw new IllegalArgumentException(
+          "OpenSearch index state management job interval must be at least 1 minute");
+    }
+
+    return Map.of(
+        "persistent",
+        Map.of(
+            "plugins.index_state_management.history.enabled",
+            "false",
+            "plugins.index_state_management.job_interval",
+            String.format("%d", jobInterval.toMinutes()),
+            "plugins.index_state_management.jitter",
+            jitter));
+  }
+}

--- a/qa/util/src/test/java/io/camunda/qa/util/multidb/ElasticsearchSetupHelperTest.java
+++ b/qa/util/src/test/java/io/camunda/qa/util/multidb/ElasticsearchSetupHelperTest.java
@@ -30,7 +30,7 @@ public class ElasticsearchSetupHelperTest {
 
   private static ElasticsearchContainer elasticsearchContainer;
   private static String elasticSearchUrl;
-  private ElasticOpenSearchSetupHelper elasticOpenSearchSetupHelper;
+  private ElasticsearchSetupHelper elasticsearchSetupHelper;
   private String indexPrefix;
 
   @BeforeAll
@@ -50,10 +50,10 @@ public class ElasticsearchSetupHelperTest {
     @Test
     public void shouldValidateConnection() {
       // given
-      elasticOpenSearchSetupHelper = new ElasticOpenSearchSetupHelper(elasticSearchUrl, List.of());
+      elasticsearchSetupHelper = new ElasticsearchSetupHelper(elasticSearchUrl, List.of());
 
       // when
-      final boolean connectionIsValid = elasticOpenSearchSetupHelper.validateConnection();
+      final boolean connectionIsValid = elasticsearchSetupHelper.validateConnection();
 
       // then
       assertThat(connectionIsValid).isTrue();
@@ -63,10 +63,10 @@ public class ElasticsearchSetupHelperTest {
     public void shouldFailValidatingConnectionOnWrongURL() {
       // given
       final String wrongEndpoint = "http://wrongUrl";
-      elasticOpenSearchSetupHelper = new ElasticOpenSearchSetupHelper(wrongEndpoint, List.of());
+      elasticsearchSetupHelper = new ElasticsearchSetupHelper(wrongEndpoint, List.of());
 
       // when
-      final boolean connectionIsValid = elasticOpenSearchSetupHelper.validateConnection();
+      final boolean connectionIsValid = elasticsearchSetupHelper.validateConnection();
 
       // then
       assertThat(connectionIsValid).isFalse();
@@ -89,8 +89,8 @@ public class ElasticsearchSetupHelperTest {
 
       multiDbConfigurator.configureElasticsearchSupport(elasticSearchUrl, indexPrefix);
       final var expectedDescriptors = new IndexDescriptors(indexPrefix, true).all();
-      elasticOpenSearchSetupHelper =
-          new ElasticOpenSearchSetupHelper(elasticSearchUrl, expectedDescriptors);
+      elasticsearchSetupHelper =
+          new ElasticsearchSetupHelper(elasticSearchUrl, expectedDescriptors);
 
       testApplication.start();
       testApplication.awaitCompleteTopology();
@@ -119,7 +119,7 @@ public class ElasticsearchSetupHelperTest {
           .untilAsserted(
               () -> {
                 final boolean schemaHasBeenCreated =
-                    elasticOpenSearchSetupHelper.validateSchemaCreation(indexPrefix);
+                    elasticsearchSetupHelper.validateSchemaCreation(indexPrefix);
 
                 // then
                 assertThat(schemaHasBeenCreated).isTrue();
@@ -132,7 +132,7 @@ public class ElasticsearchSetupHelperTest {
 
       // when
       final boolean schemaHasBeenCreated =
-          elasticOpenSearchSetupHelper.validateSchemaCreation("wrongPrefix");
+          elasticsearchSetupHelper.validateSchemaCreation("wrongPrefix");
 
       // then
       assertThat(schemaHasBeenCreated).isFalse();
@@ -145,7 +145,7 @@ public class ElasticsearchSetupHelperTest {
           .untilAsserted(
               () -> {
                 final boolean schemaHasBeenCreated =
-                    elasticOpenSearchSetupHelper.validateSchemaCreation(indexPrefix);
+                    elasticsearchSetupHelper.validateSchemaCreation(indexPrefix);
                 assertThat(schemaHasBeenCreated).isTrue();
 
                 // We want to wait in our test whether ES Indices have been created, to validate
@@ -157,11 +157,11 @@ public class ElasticsearchSetupHelperTest {
                 // generate additional data, to trigger such, which we don't want for most tests
                 final String esExporterPrefix = multiDbConfigurator.zeebeIndexPrefix() + "_";
                 final int indexCount =
-                    elasticOpenSearchSetupHelper.getCountOfIndicesWithPrefix(
+                    elasticsearchSetupHelper.getCountOfIndicesWithPrefix(
                         elasticSearchUrl, esExporterPrefix);
                 assertThat(indexCount).isNotZero();
                 final int templateCount =
-                    elasticOpenSearchSetupHelper.getCountOfIndexTemplatesWithPrefix(
+                    elasticsearchSetupHelper.getCountOfIndexTemplatesWithPrefix(
                         elasticSearchUrl, esExporterPrefix);
                 assertThat(templateCount).isNotZero();
               });
@@ -170,7 +170,7 @@ public class ElasticsearchSetupHelperTest {
       testApplication.close();
 
       // when
-      elasticOpenSearchSetupHelper.cleanup(indexPrefix);
+      elasticsearchSetupHelper.cleanup(indexPrefix);
 
       // then
       Awaitility.await("Indices should be cleaned up")
@@ -178,16 +178,16 @@ public class ElasticsearchSetupHelperTest {
           .untilAsserted(
               () -> {
                 final boolean schemaHasBeenCreated =
-                    elasticOpenSearchSetupHelper.validateSchemaCreation(indexPrefix);
+                    elasticsearchSetupHelper.validateSchemaCreation(indexPrefix);
                 assertThat(schemaHasBeenCreated).isFalse();
 
                 final int countOfIndicesWithPrefix =
-                    elasticOpenSearchSetupHelper.getCountOfIndicesWithPrefix(
+                    elasticsearchSetupHelper.getCountOfIndicesWithPrefix(
                         elasticSearchUrl, indexPrefix);
                 assertThat(countOfIndicesWithPrefix).isZero();
 
                 final int countOfIndexTemplatesWithPrefix =
-                    elasticOpenSearchSetupHelper.getCountOfIndexTemplatesWithPrefix(
+                    elasticsearchSetupHelper.getCountOfIndexTemplatesWithPrefix(
                         elasticSearchUrl, indexPrefix);
                 assertThat(countOfIndexTemplatesWithPrefix).isZero();
               });
@@ -195,7 +195,7 @@ public class ElasticsearchSetupHelperTest {
 
     @AfterEach
     public void tearDown() {
-      elasticOpenSearchSetupHelper.close();
+      elasticsearchSetupHelper.close();
       testApplication.close();
     }
   }


### PR DESCRIPTION
## Description

At the moment, the ILM/ISM policies can take any time up to 5-10 minutes to apply deletion to an index. This is for cleanup tests, and we set a very low poll interval so that they run often, as a result, speeding up the tests. 


## Related issues

closes #39870
