### PR TITLE
[CPT] build: Enable RevAPI

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -195,14 +195,10 @@
 
     <plugins>
 
-      <!-- we are breaking backwards compatibility with 8.8.0 -->
-      <!-- TODO re-enable the plugin after the 8.8.0 minor release -->
-      <!--
       <plugin>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
       </plugin>
-      -->
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/testing/camunda-process-test-java/revapi.json
+++ b/testing/camunda-process-test-java/revapi.json
@@ -19,5 +19,22 @@
         ]
       }
     }
+  },
+  {
+    "extension": "revapi.differences",
+    "id": "differences",
+    "configuration": {
+      "differences": [
+        {
+          "ignore": true,
+          "code": "java.class.removed",
+          "old": {
+            "matcher": "java-package",
+            "match": "/io\\.camunda\\.process\\.test\\.api\\.coverage(\\..*)?/"
+          },
+          "justification": "These classes were in the API package accidentally. They are for internal use only. We moved them into the impl package."
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description

Enable RevAPI in the CPT Java module to ensure that we don't break the public API.

The plugin is already enabled in the CPT Spring module. :white_check_mark: 

## Related issues


