### PR TITLE
fix: don't expose ElementInstanceNotFoundException

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
@@ -99,7 +99,7 @@ public class ElementTreePathBuilderTest {
 
     // when
     assertThatThrownBy(builder::build)
-        .hasMessageContaining("Expected to find element instance")
+        .hasMessageContaining("but couldn't find element instance")
         .isInstanceOf(IllegalStateException.class);
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This is a follow-up of #40216.

The `ElementInstanceNotFoundException` is private, but was exposed because it wasn't caught in all possible execution paths. This resulted in sometimes throwing `IllegalStateException` and sometimes throwing `ElementInstanceNotFoundException`.

This PR removes the `ElementInstanceNotFoundException` in favor of throwing `IllegalStateException`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #40216
relates to #26755