### PR TITLE
ci: separate version and latest release Docker image uploads

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -461,13 +461,18 @@ jobs:
           version: ${{ inputs.releaseVersion }}
           platforms: ${{ env.PLATFORMS }}
       - name: Sync Docker Image to DockerHub
-        id: push-docker
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
         run: |
           docker buildx imagetools create \
             --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
-            ${{ inputs.isLatest && format('--tag {0}:latest', env.DOCKER_IMAGE) || '' }} \
+            ${{ steps.build-zeebe-docker.outputs.image }}
+      - name: Sync Latest Docker Image to DockerHub
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && inputs.isLatest }}
+        # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.DOCKER_IMAGE }}:latest \
             ${{ steps.build-zeebe-docker.outputs.image }}
       - name: Observe build status
         if: always()
@@ -543,13 +548,18 @@ jobs:
           dockerfile: operate.Dockerfile
           goldenfile: operate-docker-labels.golden.json
       - name: Sync Operate Docker Image to DockerHub
-        id: push-docker
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
         run: |
           docker buildx imagetools create \
             --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
-            ${{ inputs.isLatest && format('--tag {0}:latest', env.DOCKER_IMAGE) || '' }} \
+            ${{ steps.build-operate-docker.outputs.image }}
+      - name: Sync Latest Operate Docker Image to DockerHub
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && inputs.isLatest }}
+        # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.DOCKER_IMAGE }}:latest \
             ${{ steps.build-operate-docker.outputs.image }}
       - name: Observe build status
         if: always()
@@ -625,13 +635,18 @@ jobs:
           dockerfile: tasklist.Dockerfile
           goldenfile: tasklist-docker-labels.golden.json
       - name: Sync Tasklist Docker Image to DockerHub
-        id: push-docker
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
         run: |
           docker buildx imagetools create \
             --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
-            ${{ inputs.isLatest && format('--tag {0}:latest', env.DOCKER_IMAGE) || '' }} \
+            ${{ steps.build-tasklist-docker.outputs.image }}
+      - name: Sync Latest Tasklist Docker Image to DockerHub
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && inputs.isLatest }}
+        # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.DOCKER_IMAGE }}:latest \
             ${{ steps.build-tasklist-docker.outputs.image }}
       - name: Observe build status
         if: always()
@@ -707,13 +722,18 @@ jobs:
           dockerfile: camunda.Dockerfile
           goldenfile: camunda-docker-labels.golden.json
       - name: Sync Camunda Docker Image to DockerHub
-        id: push-docker
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
         run: |
           docker buildx imagetools create \
             --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
-            ${{ inputs.isLatest && format('--tag {0}:latest', env.DOCKER_IMAGE) || '' }} \
+            ${{ steps.build-camunda-docker.outputs.image }}
+      - name: Sync Latest Camunda Docker Image to DockerHub
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && inputs.isLatest }}
+        # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.DOCKER_IMAGE }}:latest \
             ${{ steps.build-camunda-docker.outputs.image }}
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

We noticed severe instability when trying to upload release Docker images to DockerHub, that sometimes is fixed by retries: https://github.com/camunda/camunda/actions/runs/19068207975/job/54467902740

With this PR we test if separating image uploads for version and latest Docker tags solve the problem - since 8.6 and 8.7 are unaffacted. This PR targets `stable/8.8` for now only, we can backport later to other branches if successful.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

Related to INC-3784
