### PR TITLE
feat: integrate the NodeIdProvider in the application startup

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -58,6 +58,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>dynamic-node-id-provider</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-scheduler</artifactId>
     </dependency>
 

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -58,11 +58,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>dynamic-node-id-provider</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-scheduler</artifactId>
     </dependency>
 

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -78,7 +78,7 @@ public class Cluster implements Cloneable {
    * Specifies the unique id of this broker node in a cluster. The id should be between 0 and number
    * of nodes in the cluster (exclusive).
    */
-  private int nodeId = 0;
+  private Integer nodeId;
 
   /** The number of partitions in the cluster. */
   private int partitionCount = 1;
@@ -151,7 +151,7 @@ public class Cluster implements Cloneable {
     this.initialContactPoints = initialContactPoints;
   }
 
-  public int getNodeId() {
+  public Integer getNodeId() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         PREFIX + ".node-id",
         nodeId,

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -82,6 +82,10 @@ public class Cluster implements Cloneable {
    */
   private Integer nodeId;
 
+  /**
+   * Configuration to use when deploying camunda in a stateless setup, i.e. when each node cannot be
+   * assigned a static {@link #nodeId}.
+   */
   @NestedConfigurationProperty
   private DynamicNodeIdConfig dynamicNodeId = new DynamicNodeIdConfig();
 

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -80,6 +80,9 @@ public class Cluster implements Cloneable {
    */
   private Integer nodeId;
 
+  @NestedConfigurationProperty
+  private DynamicNodeIdConfig dynamicNodeId = new DynamicNodeIdConfig();
+
   /** The number of partitions in the cluster. */
   private int partitionCount = 1;
 
@@ -121,6 +124,14 @@ public class Cluster implements Cloneable {
    */
   @NestedConfigurationProperty
   private GlobalListenersCfg globalListeners = new GlobalListenersCfg();
+
+  public DynamicNodeIdConfig getDynamicNodeId() {
+    return dynamicNodeId;
+  }
+
+  public void setDynamicNodeId(final DynamicNodeIdConfig dynamicNodeId) {
+    this.dynamicNodeId = dynamicNodeId;
+  }
 
   public Metadata getMetadata() {
     return metadata;
@@ -260,6 +271,41 @@ public class Cluster implements Cloneable {
     } catch (final CloneNotSupportedException e) {
       throw new AssertionError("Unexpected: Class must implement Cloneable", e);
     }
+  }
+
+  @Override
+  public String toString() {
+    return "Cluster{"
+        + "legacyPropertiesMap="
+        + legacyPropertiesMap
+        + ", metadata="
+        + metadata
+        + ", network="
+        + network
+        + ", initialContactPoints="
+        + initialContactPoints
+        + ", nodeId="
+        + nodeId
+        + ", nodeIdProviderConfig="
+        + dynamicNodeId
+        + ", partitionCount="
+        + partitionCount
+        + ", replicationFactor="
+        + replicationFactor
+        + ", size="
+        + size
+        + ", membership="
+        + membership
+        + ", name='"
+        + name
+        + '\''
+        + ", raft="
+        + raft
+        + ", compressionAlgorithm="
+        + compressionAlgorithm
+        + ", globalListeners="
+        + globalListeners
+        + '}';
   }
 
   public Cluster withBrokerProperties() {

--- a/configuration/src/main/java/io/camunda/configuration/DynamicNodeIdConfig.java
+++ b/configuration/src/main/java/io/camunda/configuration/DynamicNodeIdConfig.java
@@ -65,7 +65,7 @@ public class DynamicNodeIdConfig {
     private Duration leaseDuration;
 
     /**
-     * Name of the bucket where the backup will be stored. The bucket must be already created. The
+     * Name of the bucket where the leases will be stored. The bucket must be already created. The
      * bucket must not be shared with other zeebe clusters. bucketName must not be empty.
      */
     private String bucketName;

--- a/configuration/src/main/java/io/camunda/configuration/DynamicNodeIdConfig.java
+++ b/configuration/src/main/java/io/camunda/configuration/DynamicNodeIdConfig.java
@@ -11,9 +11,15 @@ import java.time.Duration;
 import java.util.Optional;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-//  @ConfigurationProperties
 public class DynamicNodeIdConfig {
+
+  /**
+   * Set the {@link Type} of the implementation for the provider of dynamic node id. {@link
+   * Type#NONE} refers to no provider.
+   */
   private Type type = Type.NONE;
+
+  /** Configuration to use S3 for dynamic node id. */
   private @NestedConfigurationProperty S3 s3 = new S3();
 
   public Type getType() {
@@ -54,12 +60,7 @@ public class DynamicNodeIdConfig {
     return s3;
   }
 
-  public enum Type {
-    NONE,
-    S3;
-  }
-
-  public class S3 {
+  public static class S3 {
 
     /** Lease duration before expiry */
     private Duration leaseDuration;
@@ -190,5 +191,10 @@ public class DynamicNodeIdConfig {
     public void setTaskId(final String taskId) {
       this.taskId = Optional.ofNullable(taskId);
     }
+  }
+
+  public enum Type {
+    NONE,
+    S3;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/DynamicNodeIdConfig.java
+++ b/configuration/src/main/java/io/camunda/configuration/DynamicNodeIdConfig.java
@@ -63,6 +63,9 @@ public class DynamicNodeIdConfig {
     /** Lease duration before expiry */
     private Duration leaseDuration;
 
+    /** The taskId to use when registering to a lease * */
+    private String taskId;
+
     /**
      * Name of the bucket where the backup will be stored. The bucket must be already created. The
      * bucket must not be shared with other zeebe clusters. bucketName must not be empty.
@@ -177,6 +180,14 @@ public class DynamicNodeIdConfig {
 
     public void setLeaseDuration(final Duration leaseDuration) {
       this.leaseDuration = leaseDuration;
+    }
+
+    public String getTaskId() {
+      return taskId;
+    }
+
+    public void setTaskId(final String taskId) {
+      this.taskId = taskId;
     }
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/DynamicNodeIdConfig.java
+++ b/configuration/src/main/java/io/camunda/configuration/DynamicNodeIdConfig.java
@@ -8,6 +8,7 @@
 package io.camunda.configuration;
 
 import java.time.Duration;
+import java.util.Optional;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 //  @ConfigurationProperties
@@ -63,40 +64,40 @@ public class DynamicNodeIdConfig {
     /** Lease duration before expiry */
     private Duration leaseDuration;
 
-    /** The taskId to use when registering to a lease * */
-    private String taskId;
-
     /**
      * Name of the bucket where the backup will be stored. The bucket must be already created. The
      * bucket must not be shared with other zeebe clusters. bucketName must not be empty.
      */
     private String bucketName;
 
+    /** The taskId to use when registering to a lease * */
+    private Optional<String> taskId = Optional.empty();
+
     /**
      * Configure URL endpoint for the store. If no endpoint is provided, it will be determined based
      * on the configured region.
      */
-    private String endpoint;
+    private Optional<String> endpoint = Optional.empty();
 
     /**
      * Configure AWS region. If no region is provided it will be determined as documented in <a
      * href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment">...</a>
      */
-    private String region;
+    private Optional<String> region = Optional.empty();
 
     /**
      * Configure access credentials. If either accessKey or secretKey is not provided, the
      * credentials will be determined as documented in <a
      * href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html#credentials-chain">...</a>
      */
-    private String accessKey;
+    private Optional<String> accessKey = Optional.empty();
 
     /**
      * Configure access credentials. If either accessKey or secretKey is not provided, the
      * credentials will be determined as documented in <a
      * href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html#credentials-chain">...</a>
      */
-    private String secretKey;
+    private Optional<String> secretKey = Optional.empty();
 
     /**
      * Configure a maximum duration for all S3 client API calls. Lower values will ensure that
@@ -107,36 +108,36 @@ public class DynamicNodeIdConfig {
      */
     private final Duration apiCallTimeout = Duration.ofSeconds(180);
 
-    public String getEndpoint() {
+    public Optional<String> getEndpoint() {
       return endpoint;
     }
 
     public void setEndpoint(final String endpoint) {
-      this.endpoint = endpoint;
+      this.endpoint = Optional.ofNullable(endpoint);
     }
 
-    public String getRegion() {
+    public Optional<String> getRegion() {
       return region;
     }
 
     public void setRegion(final String region) {
-      this.region = region;
+      this.region = Optional.ofNullable(region);
     }
 
-    public String getAccessKey() {
+    public Optional<String> getAccessKey() {
       return accessKey;
     }
 
     public void setAccessKey(final String accessKey) {
-      this.accessKey = accessKey;
+      this.accessKey = Optional.ofNullable(accessKey);
     }
 
-    public String getSecretKey() {
+    public Optional<String> getSecretKey() {
       return secretKey;
     }
 
     public void setSecretKey(final String secretKey) {
-      this.secretKey = secretKey;
+      this.secretKey = Optional.ofNullable(secretKey);
     }
 
     public Duration getApiCallTimeout() {
@@ -182,12 +183,12 @@ public class DynamicNodeIdConfig {
       this.leaseDuration = leaseDuration;
     }
 
-    public String getTaskId() {
+    public Optional<String> getTaskId() {
       return taskId;
     }
 
     public void setTaskId(final String taskId) {
-      this.taskId = taskId;
+      this.taskId = Optional.ofNullable(taskId);
     }
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/DynamicNodeIdConfig.java
+++ b/configuration/src/main/java/io/camunda/configuration/DynamicNodeIdConfig.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+//  @ConfigurationProperties
+public class DynamicNodeIdConfig {
+  private Type type = Type.NONE;
+  private @NestedConfigurationProperty S3 s3 = new S3();
+
+  public Type getType() {
+    return type;
+  }
+
+  public void setType(final Type type) {
+    this.type = type;
+  }
+
+  /**
+   * Returns the S3 configuration without validation. This method is intended for internal use by
+   * Spring Boot property binding. For application code, use {@link #s3()} instead, which validates
+   * that the type is correctly set to S3.
+   */
+  S3 getS3() {
+    return s3;
+  }
+
+  public void setS3(final S3 s3) {
+    this.s3 = s3;
+  }
+
+  /**
+   * Returns the S3 configuration with validation. This method ensures that the dynamic node ID type
+   * is set to S3 before accessing the S3 configuration.
+   *
+   * @return the S3 configuration object
+   * @throws IllegalStateException if the type is not S3
+   */
+  public S3 s3() {
+    if (type != Type.S3) {
+      throw new IllegalStateException(
+          "Cannot access S3 configuration when dynamic node ID type is "
+              + type
+              + ". Use s3() method to access S3 configuration, which validates the type.");
+    }
+    return s3;
+  }
+
+  public enum Type {
+    NONE,
+    S3;
+  }
+
+  public class S3 {
+
+    /** Lease duration before expiry */
+    private Duration leaseDuration;
+
+    /**
+     * Name of the bucket where the backup will be stored. The bucket must be already created. The
+     * bucket must not be shared with other zeebe clusters. bucketName must not be empty.
+     */
+    private String bucketName;
+
+    /**
+     * Configure URL endpoint for the store. If no endpoint is provided, it will be determined based
+     * on the configured region.
+     */
+    private String endpoint;
+
+    /**
+     * Configure AWS region. If no region is provided it will be determined as documented in <a
+     * href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment">...</a>
+     */
+    private String region;
+
+    /**
+     * Configure access credentials. If either accessKey or secretKey is not provided, the
+     * credentials will be determined as documented in <a
+     * href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html#credentials-chain">...</a>
+     */
+    private String accessKey;
+
+    /**
+     * Configure access credentials. If either accessKey or secretKey is not provided, the
+     * credentials will be determined as documented in <a
+     * href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html#credentials-chain">...</a>
+     */
+    private String secretKey;
+
+    /**
+     * Configure a maximum duration for all S3 client API calls. Lower values will ensure that
+     * failed or slow API calls don't block other backups but may increase the risk that backups
+     * can't be stored if uploading parts of the backup takes longer than the configured timeout.
+     * See <a
+     * href="https://github.com/aws/aws-sdk-java-v2/blob/master/docs/BestPractices.md#utilize-timeout-configurations">...</a>
+     */
+    private final Duration apiCallTimeout = Duration.ofSeconds(180);
+
+    public String getEndpoint() {
+      return endpoint;
+    }
+
+    public void setEndpoint(final String endpoint) {
+      this.endpoint = endpoint;
+    }
+
+    public String getRegion() {
+      return region;
+    }
+
+    public void setRegion(final String region) {
+      this.region = region;
+    }
+
+    public String getAccessKey() {
+      return accessKey;
+    }
+
+    public void setAccessKey(final String accessKey) {
+      this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+      return secretKey;
+    }
+
+    public void setSecretKey(final String secretKey) {
+      this.secretKey = secretKey;
+    }
+
+    public Duration getApiCallTimeout() {
+      return apiCallTimeout;
+    }
+
+    public String getBucketName() {
+      return bucketName;
+    }
+
+    public void setBucketName(final String bucketName) {
+      this.bucketName = bucketName;
+    }
+
+    @Override
+    public String toString() {
+      return "S3{"
+          + "bucketName='"
+          + bucketName
+          + '\''
+          + ", endpoint='"
+          + endpoint
+          + '\''
+          + ", region='"
+          + region
+          + '\''
+          + ", accessKey='"
+          + accessKey
+          + '\''
+          + ", secretKey='"
+          + secretKey
+          + '\''
+          + ", apiCallTimeout="
+          + apiCallTimeout
+          + '}';
+    }
+
+    public Duration getLeaseDuration() {
+      return leaseDuration;
+    }
+
+    public void setLeaseDuration(final Duration leaseDuration) {
+      this.leaseDuration = leaseDuration;
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/ClusterDynamicNodeIdTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterDynamicNodeIdTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.configuration.DynamicNodeIdConfig.S3;
+import io.camunda.configuration.DynamicNodeIdConfig.Type;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({UnifiedConfiguration.class, UnifiedConfigurationHelper.class})
+@ActiveProfiles("broker")
+public class ClusterDynamicNodeIdTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.dynamic-node-id.type=s3",
+        "camunda.cluster.dynamic-node-id.s3.bucketName=bucketExample",
+        "camunda.cluster.dynamic-node-id.s3.leaseDuration=PT10s",
+      })
+  class WithOnlyRequiredProperties {
+
+    private final Camunda camunda;
+
+    WithOnlyRequiredProperties(@Autowired final Camunda camunda) {
+      this.camunda = camunda;
+    }
+
+    @Test
+    void shouldSetWithOnlyRequiredProperties() {
+      final var cluster = camunda.getCluster();
+      assertThat(cluster.getDynamicNodeId()).returns(Type.S3, DynamicNodeIdConfig::getType);
+      assertThat(cluster.getDynamicNodeId().s3())
+          .returns("bucketExample", S3::getBucketName)
+          .returns(Duration.ofSeconds(10), S3::getLeaseDuration);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.cluster.dynamic-node-id.type=s3",
+        "camunda.cluster.dynamic-node-id.s3.bucketName=bucketExample",
+        "camunda.cluster.dynamic-node-id.s3.leaseDuration=PT10s",
+        "camunda.cluster.dynamic-node-id.s3.endpoint=https://s3.example.com",
+        "camunda.cluster.dynamic-node-id.s3.region=us-east-1",
+        "camunda.cluster.dynamic-node-id.s3.accessKey=myAccessKey",
+        "camunda.cluster.dynamic-node-id.s3.secretKey=mySecretKey",
+      })
+  class WithAllProperties {
+
+    private final Camunda camunda;
+
+    WithAllProperties(@Autowired final Camunda camunda) {
+      this.camunda = camunda;
+    }
+
+    @Test
+    void shouldSetWithAllProperties() {
+      final var cluster = camunda.getCluster();
+      assertThat(cluster.getDynamicNodeId()).returns(Type.S3, DynamicNodeIdConfig::getType);
+      assertThat(cluster.getDynamicNodeId().s3())
+          .returns("bucketExample", S3::getBucketName)
+          .returns(Duration.ofSeconds(10), S3::getLeaseDuration)
+          .returns("https://s3.example.com", S3::getEndpoint)
+          .returns("us-east-1", S3::getRegion)
+          .returns("myAccessKey", S3::getAccessKey)
+          .returns("mySecretKey", S3::getSecretKey);
+    }
+  }
+
+  @Nested
+  class WithTypeUnset {
+
+    private final Camunda camunda;
+
+    WithTypeUnset(@Autowired final Camunda camunda) {
+      this.camunda = camunda;
+    }
+
+    @Test
+    void shouldDefaultToNoneType() {
+      final var cluster = camunda.getCluster();
+      assertThat(cluster.getDynamicNodeId()).returns(Type.NONE, DynamicNodeIdConfig::getType);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenAccessingS3Config() {
+      final var cluster = camunda.getCluster();
+      assertThatThrownBy(() -> cluster.getDynamicNodeId().s3())
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Cannot access S3 configuration when dynamic node ID type is NONE");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.cluster.dynamic-node-id.type=none"})
+  class WithTypeSetToNone {
+
+    private final Camunda camunda;
+
+    WithTypeSetToNone(@Autowired final Camunda camunda) {
+      this.camunda = camunda;
+    }
+
+    @Test
+    void shouldSetTypeToNone() {
+      final var cluster = camunda.getCluster();
+      assertThat(cluster.getDynamicNodeId()).returns(Type.NONE, DynamicNodeIdConfig::getType);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenAccessingS3Config() {
+      final var cluster = camunda.getCluster();
+      assertThatThrownBy(() -> cluster.getDynamicNodeId().s3())
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Cannot access S3 configuration when dynamic node ID type is NONE");
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/ClusterDynamicNodeIdTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterDynamicNodeIdTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.configuration.DynamicNodeIdConfig.S3;
 import io.camunda.configuration.DynamicNodeIdConfig.Type;
 import java.time.Duration;
+import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,6 +55,7 @@ public class ClusterDynamicNodeIdTest {
         "camunda.cluster.dynamic-node-id.type=s3",
         "camunda.cluster.dynamic-node-id.s3.bucketName=bucketExample",
         "camunda.cluster.dynamic-node-id.s3.leaseDuration=PT10s",
+        "camunda.cluster.dynamic-node-id.s3.task-id=example-task-id",
         "camunda.cluster.dynamic-node-id.s3.endpoint=https://s3.example.com",
         "camunda.cluster.dynamic-node-id.s3.region=us-east-1",
         "camunda.cluster.dynamic-node-id.s3.accessKey=myAccessKey",
@@ -74,10 +76,11 @@ public class ClusterDynamicNodeIdTest {
       assertThat(cluster.getDynamicNodeId().s3())
           .returns("bucketExample", S3::getBucketName)
           .returns(Duration.ofSeconds(10), S3::getLeaseDuration)
-          .returns("https://s3.example.com", S3::getEndpoint)
-          .returns("us-east-1", S3::getRegion)
-          .returns("myAccessKey", S3::getAccessKey)
-          .returns("mySecretKey", S3::getSecretKey);
+          .returns(Optional.of("example-task-id"), S3::getTaskId)
+          .returns(Optional.of("https://s3.example.com"), S3::getEndpoint)
+          .returns(Optional.of("us-east-1"), S3::getRegion)
+          .returns(Optional.of("myAccessKey"), S3::getAccessKey)
+          .returns(Optional.of("mySecretKey"), S3::getSecretKey);
     }
   }
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -65,6 +65,11 @@
     </dependency>
 
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>regions</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-query-transformer</artifactId>
     </dependency>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -76,6 +76,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>dynamic-node-id-provider</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-broker</artifactId>
     </dependency>
 

--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -48,6 +48,7 @@ public class BrokerBasedConfiguration {
     this.properties = properties;
     this.lifecycle = lifecycle;
 
+    properties.getCluster().setNodeId(nodeIdProvider.currentNodeInstance().id());
     properties.init(workingDirectory.path().toAbsolutePath().toString());
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -48,7 +48,10 @@ public class BrokerBasedConfiguration {
     this.properties = properties;
     this.lifecycle = lifecycle;
 
-    properties.getCluster().setNodeId(nodeIdProvider.currentNodeInstance().id());
+    if (properties.getCluster().getNodeId() == null) {
+      final var nodeIdFromProvider = nodeIdProvider.currentNodeInstance().id();
+      properties.getCluster().setNodeId(nodeIdFromProvider);
+    }
     properties.init(workingDirectory.path().toAbsolutePath().toString());
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -15,6 +15,7 @@ import io.camunda.application.commons.job.JobHandlerConfiguration.ActivateJobHan
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.zeebe.broker.clustering.ClusterConfigFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.gateway.RestApiCompositeFilter;
 import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
@@ -40,6 +41,7 @@ public class BrokerBasedConfiguration {
   @Autowired
   public BrokerBasedConfiguration(
       final WorkingDirectory workingDirectory,
+      final NodeIdProvider nodeIdProvider,
       final BrokerBasedProperties properties,
       final LifecycleProperties lifecycle) {
     this.workingDirectory = workingDirectory;

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker;
 
 import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.InvalidConfigurationException;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -27,6 +28,11 @@ public class NodeIdProviderConfiguration {
 
   @Bean
   public NodeIdProvider staticNodeIdProvider() {
-    return NodeIdProvider.staticProvider(properties.getCluster().getNodeId());
+    final var nodeId = properties.getCluster().getNodeId();
+    if (nodeId == null) {
+      // FIXME rephrase better
+      throw new InvalidConfigurationException("Expecting nodeId to be set, but is null", null);
+    }
+    return NodeIdProvider.staticProvider(nodeId);
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -7,32 +7,89 @@
  */
 package io.camunda.zeebe.broker;
 
-import io.camunda.configuration.beans.BrokerBasedProperties;
-import io.camunda.zeebe.broker.system.InvalidConfigurationException;
+import io.camunda.configuration.Cluster;
+import io.camunda.configuration.DynamicNodeIdConfig.S3;
+import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
+import io.camunda.zeebe.dynamic.nodeid.RepositoryNodeIdProvider;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.S3ClientConfig;
+import java.net.URI;
+import java.time.Clock;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.regions.Region;
 
 @Configuration(proxyBeanMethods = false)
 @Profile(value = {"broker", "restore"})
+@DependsOn("unifiedConfigurationHelper")
 public class NodeIdProviderConfiguration {
 
-  private final BrokerBasedProperties properties;
+  private final Cluster cluster;
 
   @Autowired
-  public NodeIdProviderConfiguration(final BrokerBasedProperties properties) {
-    this.properties = properties;
+  public NodeIdProviderConfiguration(final UnifiedConfiguration configuration) {
+    cluster = configuration.getCamunda().getCluster();
   }
 
   @Bean
-  public NodeIdProvider staticNodeIdProvider() {
-    final var nodeId = properties.getCluster().getNodeId();
-    if (nodeId == null) {
-      // FIXME rephrase better
-      throw new InvalidConfigurationException("Expecting nodeId to be set, but is null", null);
+  /** Create the S3NodeReposiotry as a separate bean so it's lifecycle is managed by spring */
+  public Optional<S3NodeIdRepository> s3NodeIdRepository() {
+    return switch (cluster.getDynamicNodeId().getType()) {
+      case NONE -> Optional.empty();
+      case S3 -> {
+        final var clientConfig = makeS3ClientConfig(cluster.getDynamicNodeId().s3());
+        final var config =
+            new S3NodeIdRepository.Config(
+                cluster.getDynamicNodeId().s3().getBucketName(),
+                cluster.getDynamicNodeId().s3().getLeaseDuration());
+        yield Optional.of(S3NodeIdRepository.of(clientConfig, config, Clock.systemUTC()));
+      }
+    };
+  }
+
+  @Bean
+  public NodeIdProvider nodeIdProvider(final Optional<NodeIdRepository> nodeIdRepository) {
+    return switch (cluster.getDynamicNodeId().getType()) {
+      case NONE -> {
+        final var nodeId = cluster.getNodeId();
+        yield NodeIdProvider.staticProvider(nodeId);
+      }
+      case S3 -> {
+        final var config = cluster.getDynamicNodeId().s3();
+        if (nodeIdRepository.isEmpty()) {
+          throw new IllegalStateException(
+              "DynamicNodeIdProvider configured to use S3: missing s3 node id repository");
+        }
+        yield new RepositoryNodeIdProvider(
+            nodeIdRepository.get(),
+            Clock.systemUTC(),
+            config.getLeaseDuration(),
+            UUID.randomUUID().toString(),
+            () -> System.exit(-1));
+      }
+    };
+  }
+
+  private static S3ClientConfig makeS3ClientConfig(final S3 s3) {
+    Optional<S3ClientConfig.Credentials> credentials = Optional.empty();
+    if (s3.getAccessKey() != null && s3.getSecretKey() != null) {
+      credentials =
+          Optional.of(new S3ClientConfig.Credentials(s3.getAccessKey(), s3.getSecretKey()));
     }
-    return NodeIdProvider.staticProvider(nodeId);
+    return new S3ClientConfig(
+        credentials,
+        Optional.ofNullable(s3.getRegion()).map(Region::of),
+        Optional.ofNullable(s3.getEndpoint()).map(URI::create),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.ofNullable(s3.getApiCallTimeout()));
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker;
+
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration(proxyBeanMethods = false)
+@Profile(value = {"broker", "restore"})
+public class NodeIdProviderConfiguration {
+
+  private final BrokerBasedProperties properties;
+
+  @Autowired
+  public NodeIdProviderConfiguration(final BrokerBasedProperties properties) {
+    this.properties = properties;
+  }
+
+  @Bean
+  public NodeIdProvider staticNodeIdProvider() {
+    return NodeIdProvider.staticProvider(properties.getCluster().getNodeId());
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -73,18 +73,15 @@ public class NodeIdProviderConfiguration {
             }
             final var taskId = config.getTaskId().orElse(UUID.randomUUID().toString());
             LOG.debug("Node configured with taskId {}", taskId);
-            final var repository =
-                new RepositoryNodeIdProvider(
-                    nodeIdRepository.get(),
-                    Clock.systemUTC(),
-                    config.getLeaseDuration(),
-                    taskId,
-                    () -> System.exit(-1));
-            repository.initialize(cluster.getSize());
-            yield repository;
+            yield new RepositoryNodeIdProvider(
+                nodeIdRepository.get(),
+                Clock.systemUTC(),
+                config.getLeaseDuration(),
+                taskId,
+                () -> System.exit(-1));
           }
         };
-    nodeIdProvider.initialize(cluster.getSize());
+    nodeIdProvider.initialize(cluster.getSize()).join();
 
     return nodeIdProvider;
   }

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -72,7 +72,7 @@ public class NodeIdProviderConfiguration {
                   "DynamicNodeIdProvider configured to use S3: missing s3 node id repository");
             }
             final var taskId = config.getTaskId().orElse(UUID.randomUUID().toString());
-            LOG.info("Node configured with taskId {}", taskId);
+            LOG.debug("Node configured with taskId {}", taskId);
             final var repository =
                 new RepositoryNodeIdProvider(
                     nodeIdRepository.get(),

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -17,6 +17,7 @@ import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.RestorePropertiesOverride;
 import io.camunda.configuration.beans.RestoreProperties;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.broker.NodeIdProviderConfiguration;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
@@ -42,6 +43,7 @@ import org.springframework.context.annotation.Import;
       UnifiedConfiguration.class,
       BrokerBasedPropertiesOverride.class,
       // ---
+      NodeIdProviderConfiguration.class,
       BrokerBasedConfiguration.class,
       RestorePropertiesOverride.class,
       WorkingDirectoryConfiguration.class

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -582,6 +582,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>dynamic-node-id-provider</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>camunda-search-client-plugin</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -515,6 +515,11 @@
       <artifactId>archunit-junit5-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -67,6 +67,11 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>dynamic-node-id-provider</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-qa-util</artifactId>
       <scope>test</scope>
     </dependency>
@@ -115,6 +120,24 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sdk-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>regions</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/DynamicNodeIdTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/DynamicNodeIdTest.java
@@ -61,6 +61,7 @@ public class DynamicNodeIdTest {
           .withBrokersCount(CLUSTER_SIZE)
           .withPartitionsCount(1)
           .withReplicationFactor(CLUSTER_SIZE)
+          .withoutNodeId()
           .withNodeConfig(
               app ->
                   app.withAdditionalProperties(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/DynamicNodeIdTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/DynamicNodeIdTest.java
@@ -68,15 +68,7 @@ public class DynamicNodeIdTest {
                               "camunda.persistent.sessions.enabled",
                               "false",
                               "camunda.data.secondary-storage.type",
-                              "none",
-                              "camunda.operate.importerenabled",
-                              "false",
-                              "camunda.operate.archiverenabled",
-                              "false",
-                              "camunda.tasklist.importerenabled",
-                              "false",
-                              "camunda.tasklist.archiverenabled",
-                              "false"))
+                              "none"))
                       .withAdditionalProperties(
                           Map.of(
                               "camunda.cluster.size",

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/DynamicNodeIdTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/DynamicNodeIdTest.java
@@ -7,5 +7,136 @@
  */
 package io.camunda.it.cluster;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.dynamic.nodeid.Lease;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.S3ClientConfig;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import net.bytebuddy.utility.dispatcher.JavaDispatcher.Container;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Testcontainers
+@ZeebeIntegration
 public class DynamicNodeIdTest {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final Duration LEASE_DURATION = Duration.ofSeconds(10);
+
+  @org.testcontainers.junit.jupiter.Container
+  private static final LocalStackContainer S3 =
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:4.10"))
+          .withServices(Service.S3)
+          .withEnv("LS_LOG", "trace");
+
+  @AutoClose private static S3Client s3Client;
+
+  @TestZeebe(autoStart = false)
+  protected TestStandaloneApplication<?> testStandaloneApplication;
+
+  private String bucketName;
+  private String taskId;
+  private int clusterSize;
+
+  @Container
+  @BeforeEach
+  public void setup() {
+    bucketName = UUID.randomUUID().toString();
+
+    taskId = UUID.randomUUID().toString();
+    clusterSize = 3;
+    s3Client =
+        S3NodeIdRepository.buildClient(
+            new S3ClientConfig(
+                Optional.of(new S3ClientConfig.Credentials(S3.getAccessKey(), S3.getSecretKey())),
+                Optional.of(Region.of(S3.getRegion())),
+                Optional.of(S3.getEndpoint())));
+
+    // bucket must be created before the application is started
+    s3Client.createBucket(b -> b.bucket(bucketName));
+
+    testStandaloneApplication =
+        new TestStandaloneBroker()
+            .withCreateSchema(false)
+            .withAdditionalProperties(
+                // Disable secondary storage
+                Map.of(
+                    "camunda.rest.query.enabled",
+                    "false",
+                    "camunda.persistent.sessions.enabled",
+                    "false",
+                    "camunda.data.secondary-storage.type",
+                    "none",
+                    "camunda.operate.importerenabled",
+                    "false",
+                    "camunda.operate.archiverenabled",
+                    "false",
+                    "camunda.tasklist.importerenabled",
+                    "false",
+                    "camunda.tasklist.archiverenabled",
+                    "false"))
+            .withAdditionalProperties(
+                Map.of(
+                    "camunda.cluster.size",
+                    clusterSize,
+                    "camunda.cluster.dynamic-node-id.type",
+                    "s3",
+                    "camunda.cluster.dynamic-node-id.s3.taskId",
+                    taskId,
+                    "camunda.cluster.dynamic-node-id.s3.bucketName",
+                    bucketName,
+                    "camunda.cluster.dynamic-node-id.s3.leaseDuration",
+                    LEASE_DURATION,
+                    "camunda.cluster.dynamic-node-id.s3.endpoint",
+                    S3.getEndpoint(),
+                    "camunda.cluster.dynamic-node-id.s3.region",
+                    S3.getRegion(),
+                    "camunda.cluster.dynamic-node-id.s3.accessKey",
+                    S3.getAccessKey(),
+                    "camunda.cluster.dynamic-node-id.s3.secretKey",
+                    S3.getSecretKey()));
+
+    testStandaloneApplication.start();
+  }
+
+  @Test
+  public void shouldStartAppCorrectlyAndAcquireALease() throws IOException {
+    final var objectsInBucket = s3Client.listObjects(b -> b.bucket(bucketName)).contents();
+
+    Awaitility.await("Repository has been initialized")
+        .untilAsserted(() -> assertThat(objectsInBucket).hasSize(clusterSize));
+
+    final var leases = new ArrayList<Lease>();
+    for (final var object : objectsInBucket) {
+      final var lease = s3Client.getObject(b -> b.bucket(bucketName).key(object.key()));
+      final var payload = lease.readAllBytes();
+      if (payload.length > 0) {
+        final var parsed = Lease.fromJsonBytes(OBJECT_MAPPER, payload);
+        if (parsed.isStillValid(System.currentTimeMillis(), LEASE_DURATION)
+            && parsed.taskId().equals(taskId)) {
+          leases.add(parsed);
+        }
+      }
+    }
+
+    assertThat(leases).hasSize(1);
+  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/DynamicNodeIdTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/DynamicNodeIdTest.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.cluster;
+
+public class DynamicNodeIdTest {
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -22,7 +22,6 @@ import java.util.stream.IntStream;
 public final class ClusterCfg implements ConfigurationEntry {
 
   public static final List<String> DEFAULT_CONTACT_POINTS = Collections.emptyList();
-  public static final int DEFAULT_NODE_ID = 0;
   public static final int DEFAULT_PARTITIONS_COUNT = 1;
   public static final int DEFAULT_REPLICATION_FACTOR = 1;
   public static final int DEFAULT_CLUSTER_SIZE = 1;
@@ -46,7 +45,7 @@ public final class ClusterCfg implements ConfigurationEntry {
   private List<String> initialContactPoints = DEFAULT_CONTACT_POINTS;
 
   private List<Integer> partitionIds;
-  private int nodeId = DEFAULT_NODE_ID;
+  private Integer nodeId;
   private String clusterId;
   private int partitionsCount = DEFAULT_PARTITIONS_COUNT;
   private int replicationFactor = DEFAULT_REPLICATION_FACTOR;
@@ -111,11 +110,11 @@ public final class ClusterCfg implements ConfigurationEntry {
     this.initialContactPoints = LIST_SANITIZER.apply(initialContactPoints);
   }
 
-  public int getNodeId() {
+  public Integer getNodeId() {
     return nodeId;
   }
 
-  public void setNodeId(final int nodeId) {
+  public void setNodeId(final Integer nodeId) {
     this.nodeId = nodeId;
   }
 
@@ -238,7 +237,7 @@ public final class ClusterCfg implements ConfigurationEntry {
       return false;
     }
     final ClusterCfg that = (ClusterCfg) o;
-    return nodeId == that.nodeId
+    return Objects.equals(nodeId, that.nodeId)
         && partitionsCount == that.partitionsCount
         && replicationFactor == that.replicationFactor
         && clusterSize == that.clusterSize

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -45,7 +45,7 @@ public final class ClusterCfg implements ConfigurationEntry {
   private List<String> initialContactPoints = DEFAULT_CONTACT_POINTS;
 
   private List<Integer> partitionIds;
-  private Integer nodeId = 0;
+  private Integer nodeId;
   private String clusterId;
   private int partitionsCount = DEFAULT_PARTITIONS_COUNT;
   private int replicationFactor = DEFAULT_REPLICATION_FACTOR;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -45,7 +45,7 @@ public final class ClusterCfg implements ConfigurationEntry {
   private List<String> initialContactPoints = DEFAULT_CONTACT_POINTS;
 
   private List<Integer> partitionIds;
-  private Integer nodeId;
+  private Integer nodeId = 0;
   private String clusterId;
   private int partitionsCount = DEFAULT_PARTITIONS_COUNT;
   private int replicationFactor = DEFAULT_REPLICATION_FACTOR;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -58,6 +58,7 @@ public final class SimpleBrokerStartTest {
   public void shouldFailToCreateBrokerWithSmallSnapshotPeriod() {
     // given
     final var brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().setNodeId(0);
     brokerCfg.getData().setSnapshotPeriod(Duration.ofMillis(1));
     brokerCfg.init(newTemporaryFolder.getAbsolutePath());
 
@@ -89,6 +90,7 @@ public final class SimpleBrokerStartTest {
   public void shouldCallPartitionListenerAfterStart() throws Exception {
     // given
     final var brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().setNodeId(0);
     assignSocketAddresses(brokerCfg);
     brokerCfg.init(newTemporaryFolder.getAbsolutePath());
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -131,6 +131,7 @@ public final class BrokerCfgTest {
     final ExporterCfg exporterCfgInternal2 = new ExporterCfg();
 
     final BrokerCfg config = new BrokerCfg();
+    config.getCluster().setNodeId(0);
     config.getExporters().put("external", exporterCfgExternal);
     config.getExporters().put("internal-1", exporterCfgInternal1);
     config.getExporters().put("internal-2", exporterCfgInternal2);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
@@ -223,6 +223,7 @@ public final class ClusterCfgTest {
     // given
     final ClusterCfg clusterCfg = new ClusterCfg();
     clusterCfg.setPartitionsCount(8);
+    clusterCfg.setNodeId(0);
 
     // when
     clusterCfg.init(new BrokerCfg(), "");

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
@@ -250,7 +250,7 @@ public final class ClusterCfgTest {
     // when - then
     assertThatCode(() -> TestConfigReader.readConfig("default", environment))
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("to int"); // spring related exception
+        .hasMessageContaining("to java.lang.Integer"); // spring related exception
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/TestConfigReader.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/TestConfigReader.java
@@ -23,6 +23,9 @@ public final class TestConfigReader {
     final BrokerCfg config =
         new TestConfigurationFactory()
             .create(environmentVariables, "zeebe.broker", configPath, BrokerCfg.class);
+    if (config.getCluster().getNodeId() == null) {
+      config.getCluster().setNodeId(0);
+    }
     config.init(BROKER_BASE, environmentVariables);
 
     return config;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -313,6 +313,10 @@ public final class EmbeddedBrokerRule extends ExternalResource {
     // set random port numbers
     assignSocketAddresses(brokerCfg);
 
+    if (brokerCfg.getCluster().getNodeId() == null) {
+      brokerCfg.getCluster().setNodeId(0);
+    }
+
     // initialize configuration
     brokerCfg.init(brokerBase.getAbsolutePath());
   }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletableFuture;
 
 public interface NodeIdProvider extends AutoCloseable {
 
-  void initialize(int clusterSize);
+  CompletableFuture<Void> initialize(int clusterSize);
 
   /**
    * @return the node instance. Null can be returned when the provider is shutting down
@@ -42,7 +42,9 @@ public interface NodeIdProvider extends AutoCloseable {
       public void close() throws Exception {}
 
       @Override
-      public void initialize(final int clusterSize) {}
+      public CompletableFuture<Void> initialize(final int clusterSize) {
+        return CompletableFuture.completedFuture(null);
+      }
 
       @Override
       public NodeInstance currentNodeInstance() {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
@@ -11,6 +11,8 @@ import java.util.concurrent.CompletableFuture;
 
 public interface NodeIdProvider extends AutoCloseable {
 
+  void initialize(int clusterSize);
+
   /**
    * @return the node instance. Null cna be returned when the provider is shutting down
    */
@@ -38,6 +40,9 @@ public interface NodeIdProvider extends AutoCloseable {
 
       @Override
       public void close() throws Exception {}
+
+      @Override
+      public void initialize(final int clusterSize) {}
 
       @Override
       public NodeInstance currentNodeInstance() {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
@@ -9,10 +9,20 @@ package io.camunda.zeebe.dynamic.nodeid;
 
 import java.util.concurrent.CompletableFuture;
 
-public interface NodeIdProvider {
+public interface NodeIdProvider extends AutoCloseable {
+
+  /**
+   * @return the node instance. Null cna be returned when the provider is shutting down
+   */
   NodeInstance currentNodeInstance();
 
-  // FIXME rename
+  /**
+   * Verify that the NodeIdProvider is currently active and that the node instance acquired is still
+   * valid.
+   *
+   * @return A CompletableFuture with true if it's valid, false otherwise. The future always returns
+   *     within a predefined time.
+   */
   CompletableFuture<Boolean> isValid();
 
   /**
@@ -25,6 +35,9 @@ public interface NodeIdProvider {
       throw new IllegalArgumentException("Invalid nodeId: " + nodeId);
     }
     return new NodeIdProvider() {
+
+      @Override
+      public void close() throws Exception {}
 
       @Override
       public NodeInstance currentNodeInstance() {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
@@ -7,190 +7,34 @@
  */
 package io.camunda.zeebe.dynamic.nodeid;
 
-import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
-import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease;
-import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease.Initialized;
-import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease.Uninitialized;
-import io.camunda.zeebe.util.ExponentialBackoff;
-import java.time.Duration;
-import java.time.InstantSource;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class NodeIdProvider implements AutoCloseable {
+public interface NodeIdProvider {
+  NodeInstance currentNodeInstance();
 
-  private static final Logger LOG = LoggerFactory.getLogger(NodeIdProvider.class);
-  private final NodeIdRepository nodeIdRepository;
-  private final int clusterSize;
-  private final InstantSource clock;
-  private volatile StoredLease.Initialized currentLease;
-  private final Duration leaseDuration;
-  private final String taskId;
-  private final Runnable onLeaseFailure;
-  private final ScheduledExecutorService executor;
-  private final ExponentialBackoff backoff;
-  private long currentDelay;
-  private final Duration renewalDelay;
-  private ScheduledFuture<?> renewalTask;
-
-  public NodeIdProvider(
-      final NodeIdRepository nodeIdRepository,
-      final int clusterSize,
-      final InstantSource clock,
-      final Duration expiryDuration,
-      final String taskId,
-      final Runnable onLeaseFailure) {
-    this.nodeIdRepository = nodeIdRepository;
-    this.clusterSize = clusterSize;
-    this.clock = clock;
-    leaseDuration = expiryDuration;
-    this.taskId = taskId;
-    this.onLeaseFailure = onLeaseFailure;
-    backoff = new ExponentialBackoff(Duration.ofSeconds(1), leaseDuration.dividedBy(2));
-    renewalDelay = leaseDuration.dividedBy(3);
-    currentDelay = 0L;
-    executor = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "NodeIdProvider"));
-    CompletableFuture.runAsync(this::acquireInitialLease, executor)
-        .thenRun(this::startRenewalTimer);
-  }
-
-  private void startRenewalTimer() {
-    renewalTask =
-        executor.scheduleAtFixedRate(
-            this::renew, renewalDelay.toMillis(), renewalDelay.toMillis(), TimeUnit.MILLISECONDS);
-  }
+  // FIXME rename
+  CompletableFuture<Boolean> isValid();
 
   /**
-   * Verify the status of the lease, to be used for health checks. If the scheduler is not able to
-   * reply in time, then it's marked as invalid. There's no need to set an external timeout, the
-   * future will be completed with false.
+   * NodeIdProvider to be used when the nodeId is static, i.e. it's defined in the configuration.
    *
-   * @return A future that completes with true if the lease is acquired and valid. false if the
-   *     lease is not present anymore or invalid. The future never fails, all exceptions are
-   *     converted to `false` (timeouts included).
+   * @param nodeId the nodeId for this application
    */
-  public CompletableFuture<Boolean> isLeaseValid() {
-    final var now = clock.millis();
-    return CompletableFuture.supplyAsync(
-            () -> currentLease != null && currentLease.lease().isStillValid(now, leaseDuration))
-        .orTimeout(leaseDuration.dividedBy(2).toMillis(), TimeUnit.MILLISECONDS)
-        .exceptionally(
-            t -> {
-              LOG.warn("Failed to check the status of the lease. Marking it as failed", t);
-              return false;
-            });
-  }
-
-  public Initialized getCurrentLease() {
-    return currentLease;
-  }
-
-  private void renew() {
-    try {
-      final var newLease = currentLease.lease().renew(clock.millis(), leaseDuration);
-      LOG.trace("Renewing lease with {}", newLease);
-      currentLease = nodeIdRepository.acquire(newLease, currentLease.eTag());
-    } catch (final Exception e) {
-      LOG.warn("Failed to renew the lease: process is going to shut down immediately.", e);
-      currentLease = null;
-      onLeaseFailure.run();
+  static NodeIdProvider staticProvider(final int nodeId) {
+    if (nodeId < 0) {
+      throw new IllegalArgumentException("Invalid nodeId: " + nodeId);
     }
-  }
+    return new NodeIdProvider() {
 
-  /**
-   * Method to initialize the provider. Performs a "blocking" iteration over all leases to acquire
-   * one. Until a lease is acquired, this object cannot perform other tasks, so it's ok to block all
-   * the other operations (including health checks)
-   */
-  private void acquireInitialLease() {
-    var i = 0;
-    var retryRound = 0;
-    while (currentLease == null) {
-      if (i % clusterSize == 0) {
-        retryRound++;
-        // wait a bit before retrying on all leases again.
-        if (retryRound > 1) {
-          try {
-            currentDelay = backoff.supplyRetryDelay(currentDelay);
-            LOG.debug(
-                "Attempt to acquire the lease failed for all nodeIds, sleeping {} and retrying again",
-                currentDelay);
-            Thread.sleep(currentDelay);
-          } catch (final InterruptedException e) {
-            break;
-          }
-        }
+      @Override
+      public NodeInstance currentNodeInstance() {
+        return new NodeInstance(nodeId);
       }
-      final var nodeId = i++ % clusterSize;
-      final var storedLease = nodeIdRepository.getLease(nodeId);
-      currentLease = tryAcquire(storedLease);
-    }
-    if (currentLease != null) {
-      LOG.info(
-          "Acquired lease w/ nodeId={}.  {}", currentLease.lease().nodeInstance(), currentLease);
-    } else {
-      throw new IllegalStateException("Failed to acquire a lease");
-    }
-  }
 
-  private StoredLease.Initialized tryAcquire(final StoredLease lease) {
-    try {
-      switch (lease) {
-        case final Initialized initialized -> {
-          if (initialized.lease().isStillValid(clock.millis(), leaseDuration)) {
-            LOG.debug("Lease {} is held by another process, skipping it", initialized);
-            return null;
-          } else {
-            LOG.debug("Trying to acquire an expired lease {}", initialized);
-            final var newLease =
-                (initialized.metadata().task().equals(taskId))
-                    ? initialized.lease().renew(clock.millis(), leaseDuration)
-                    : new Lease(
-                        taskId,
-                        clock.millis() + leaseDuration.toMillis(),
-                        initialized.lease().nodeInstance());
-            return nodeIdRepository.acquire(newLease, initialized.eTag());
-          }
-        }
-        case final Uninitialized uninitialized -> {
-          final var newLease =
-              new Lease(taskId, clock.millis() + leaseDuration.toMillis(), uninitialized.node());
-          LOG.debug(
-              "Trying to take uninitialized lease: {} with new lease {}", uninitialized, newLease);
-          return nodeIdRepository.acquire(newLease, uninitialized.eTag());
-        }
+      @Override
+      public CompletableFuture<Boolean> isValid() {
+        return CompletableFuture.completedFuture(true);
       }
-    } catch (final Exception e) {
-      LOG.warn("Failed to acquire the lease {}", lease, e);
-      return null;
-    }
-  }
-
-  @Override
-  public void close() throws Exception {
-    // use the executor status to avoid closing multiple times
-    if (!executor.isShutdown()) {
-      try {
-        if (renewalTask != null) {
-          renewalTask.cancel(true);
-        }
-        if (currentLease != null) {
-          nodeIdRepository.release(currentLease);
-        }
-      } finally {
-        currentLease = null;
-        // release is already submitted to the executor, we can shut it down gracefully.
-        executor.shutdown();
-        // shutdown is taking too much time, let's shut it down by interrupting running tasks.
-        if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
-          executor.shutdownNow();
-        }
-      }
-    }
+    };
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
@@ -14,7 +14,7 @@ public interface NodeIdProvider extends AutoCloseable {
   void initialize(int clusterSize);
 
   /**
-   * @return the node instance. Null cna be returned when the provider is shutting down
+   * @return the node instance. Null can be returned when the provider is shutting down
    */
   NodeInstance currentNodeInstance();
 

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease.Initialized;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease.Uninitialized;
+import io.camunda.zeebe.util.ExponentialBackoff;
+import java.time.Duration;
+import java.time.InstantSource;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RepositoryNodeIdProvider.class);
+  private final NodeIdRepository nodeIdRepository;
+  private final int clusterSize;
+  private final InstantSource clock;
+  private volatile StoredLease.Initialized currentLease;
+  private final Duration leaseDuration;
+  private final String taskId;
+  private final Runnable onLeaseFailure;
+  private final ScheduledExecutorService executor;
+  private final ExponentialBackoff backoff;
+  private long currentDelay;
+  private final Duration renewalDelay;
+  private ScheduledFuture<?> renewalTask;
+
+  public RepositoryNodeIdProvider(
+      final NodeIdRepository nodeIdRepository,
+      final int clusterSize,
+      final InstantSource clock,
+      final Duration expiryDuration,
+      final String taskId,
+      final Runnable onLeaseFailure) {
+    this.nodeIdRepository = nodeIdRepository;
+    this.clusterSize = clusterSize;
+    this.clock = clock;
+    leaseDuration = expiryDuration;
+    this.taskId = taskId;
+    this.onLeaseFailure = onLeaseFailure;
+    backoff = new ExponentialBackoff(Duration.ofSeconds(1), leaseDuration.dividedBy(2));
+    renewalDelay = leaseDuration.dividedBy(3);
+    currentDelay = 0L;
+    executor = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "NodeIdProvider"));
+    CompletableFuture.runAsync(this::acquireInitialLease, executor)
+        .thenRun(this::startRenewalTimer);
+  }
+
+  private void startRenewalTimer() {
+    renewalTask =
+        executor.scheduleAtFixedRate(
+            this::renew, renewalDelay.toMillis(), renewalDelay.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  public Initialized getCurrentLease() {
+    return currentLease;
+  }
+
+  private void renew() {
+    try {
+      final var newLease = currentLease.lease().renew(clock.millis(), leaseDuration);
+      LOG.trace("Renewing lease with {}", newLease);
+      currentLease = nodeIdRepository.acquire(newLease, currentLease.eTag());
+    } catch (final Exception e) {
+      LOG.warn("Failed to renew the lease: process is going to shut down immediately.", e);
+      currentLease = null;
+      onLeaseFailure.run();
+    }
+  }
+
+  /**
+   * Method to initialize the provider. Performs a "blocking" iteration over all leases to acquire
+   * one. Until a lease is acquired, this object cannot perform other tasks, so it's ok to block all
+   * the other operations (including health checks)
+   */
+  private void acquireInitialLease() {
+    var i = 0;
+    var retryRound = 0;
+    while (currentLease == null) {
+      if (i % clusterSize == 0) {
+        retryRound++;
+        // wait a bit before retrying on all leases again.
+        if (retryRound > 1) {
+          try {
+            currentDelay = backoff.supplyRetryDelay(currentDelay);
+            LOG.debug(
+                "Attempt to acquire the lease failed for all nodeIds, sleeping {} and retrying again",
+                currentDelay);
+            Thread.sleep(currentDelay);
+          } catch (final InterruptedException e) {
+            break;
+          }
+        }
+      }
+      final var nodeId = i++ % clusterSize;
+      final var storedLease = nodeIdRepository.getLease(nodeId);
+      currentLease = tryAcquire(storedLease);
+    }
+    if (currentLease != null) {
+      LOG.info(
+          "Acquired lease w/ nodeId={}.  {}", currentLease.lease().nodeInstance(), currentLease);
+    } else {
+      throw new IllegalStateException("Failed to acquire a lease");
+    }
+  }
+
+  private StoredLease.Initialized tryAcquire(final StoredLease lease) {
+    try {
+      switch (lease) {
+        case final Initialized initialized -> {
+          if (initialized.lease().isStillValid(clock.millis(), leaseDuration)) {
+            LOG.debug("Lease {} is held by another process, skipping it", initialized);
+            return null;
+          } else {
+            LOG.debug("Trying to acquire an expired lease {}", initialized);
+            final var newLease =
+                (initialized.metadata().task().equals(taskId))
+                    ? initialized.lease().renew(clock.millis(), leaseDuration)
+                    : new Lease(
+                        taskId,
+                        clock.millis() + leaseDuration.toMillis(),
+                        initialized.lease().nodeInstance());
+            return nodeIdRepository.acquire(newLease, initialized.eTag());
+          }
+        }
+        case final Uninitialized uninitialized -> {
+          final var newLease =
+              new Lease(taskId, clock.millis() + leaseDuration.toMillis(), uninitialized.node());
+          LOG.debug(
+              "Trying to take uninitialized lease: {} with new lease {}", uninitialized, newLease);
+          return nodeIdRepository.acquire(newLease, uninitialized.eTag());
+        }
+      }
+    } catch (final Exception e) {
+      LOG.warn("Failed to acquire the lease {}", lease, e);
+      return null;
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    // use the executor status to avoid closing multiple times
+    if (!executor.isShutdown()) {
+      try {
+        if (renewalTask != null) {
+          renewalTask.cancel(true);
+        }
+        if (currentLease != null) {
+          nodeIdRepository.release(currentLease);
+        }
+      } finally {
+        currentLease = null;
+        // release is already submitted to the executor, we can shut it down gracefully.
+        executor.shutdown();
+        // shutdown is taking too much time, let's shut it down by interrupting running tasks.
+        if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+          executor.shutdownNow();
+        }
+      }
+    }
+  }
+
+  @Override
+  public NodeInstance currentNodeInstance() {
+    return getCurrentLease().lease().nodeInstance();
+  }
+
+  /**
+   * Verify the status of the lease, to be used for health checks. If the scheduler is not able to
+   * reply in time, then it's marked as invalid. There's no need to set an external timeout, the
+   * future will be completed with false.
+   *
+   * @return A future that completes with true if the lease is acquired and valid. false if the
+   *     lease is not present anymore or invalid. The future never fails, all exceptions are
+   *     converted to `false` (timeouts included).
+   */
+  @Override
+  public CompletableFuture<Boolean> isValid() {
+    final var now = clock.millis();
+    return CompletableFuture.supplyAsync(
+            () -> currentLease != null && currentLease.lease().isStillValid(now, leaseDuration))
+        .orTimeout(leaseDuration.dividedBy(2).toMillis(), TimeUnit.MILLISECONDS)
+        .exceptionally(
+            t -> {
+              LOG.warn("Failed to check the status of the lease. Marking it as failed", t);
+              return false;
+            });
+  }
+
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -199,5 +199,4 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
               return false;
             });
   }
-
 }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -57,11 +57,10 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
   }
 
   @Override
-  public void initialize(final int clusterSize) {
+  public CompletableFuture<Void> initialize(final int clusterSize) {
     nodeIdRepository.initialize(clusterSize);
-    CompletableFuture.runAsync(() -> acquireInitialLease(clusterSize), executor)
-        .thenRun(this::startRenewalTimer)
-        .join();
+    return CompletableFuture.runAsync(() -> acquireInitialLease(clusterSize), executor)
+        .thenRun(this::startRenewalTimer);
   }
 
   @Override

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository.StoredLease.U
 import io.camunda.zeebe.util.ExponentialBackoff;
 import java.time.Duration;
 import java.time.InstantSource;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -43,11 +44,12 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
       final Duration expiryDuration,
       final String taskId,
       final Runnable onLeaseFailure) {
-    this.nodeIdRepository = nodeIdRepository;
-    this.clock = clock;
-    leaseDuration = expiryDuration;
-    this.taskId = taskId;
-    this.onLeaseFailure = onLeaseFailure;
+    this.nodeIdRepository =
+        Objects.requireNonNull(nodeIdRepository, "nodeIdRepository cannot be null");
+    this.clock = Objects.requireNonNull(clock, "clock cannot be null");
+    leaseDuration = Objects.requireNonNull(expiryDuration, "expiryDuration cannot be null");
+    this.taskId = Objects.requireNonNull(taskId, "taskId cannot be null");
+    this.onLeaseFailure = Objects.requireNonNull(onLeaseFailure, "onLeaseFailure cannot be null");
     backoff = new ExponentialBackoff(Duration.ofSeconds(1), leaseDuration.dividedBy(2));
     renewalDelay = leaseDuration.dividedBy(3);
     currentDelay = 0L;

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -60,7 +60,8 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
   public void initialize(final int clusterSize) {
     nodeIdRepository.initialize(clusterSize);
     CompletableFuture.runAsync(() -> acquireInitialLease(clusterSize), executor)
-        .thenRun(this::startRenewalTimer);
+        .thenRun(this::startRenewalTimer)
+        .join();
   }
 
   @Override

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -39,6 +39,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
   private final Config config;
   private final InstantSource clock;
   private final boolean closeClient;
+  private volatile boolean initialized = false;
 
   public S3NodeIdRepository(
       final S3Client s3Client,
@@ -60,7 +61,10 @@ public class S3NodeIdRepository implements NodeIdRepository {
 
   @Override
   public void initialize(final int count) {
-    IntStream.range(0, count).forEach(this::initializeForNode);
+    if (!initialized) {
+      IntStream.range(0, count).forEach(this::initializeForNode);
+    }
+    initialized = true;
   }
 
   @Override

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -134,7 +134,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
         // if bucket does not exist, it return 404
         if (s3Exception.statusCode() == 404) {
           throw new IllegalArgumentException(
-              "Cannot create file for node " + nodeId + " in bucket" + config.bucketName, e);
+              "Cannot create file for node " + nodeId + " in bucket " + config.bucketName, e);
         }
       }
       LOG.debug(

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -41,11 +41,11 @@ public class S3NodeIdRepository implements NodeIdRepository {
   private final boolean closeClient;
 
   public S3NodeIdRepository(
-      final S3Client s3AsyncClient,
+      final S3Client s3Client,
       final Config config,
       final InstantSource clock,
       final boolean closeClient) {
-    client = s3AsyncClient;
+    client = s3Client;
     this.config = config;
     this.clock = clock;
     this.closeClient = closeClient;

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -88,7 +88,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
     final PutObjectRequest putRequest =
         createPutObjectRequest(nodeId, Optional.of(metadata), Optional.of(previousETag)).build();
     try {
-      if (!lease.isStillValid(clock.millis(), config.expiryDuration)) {
+      if (!lease.isStillValid(clock.millis(), config.leaseDuration)) {
         throw new IllegalArgumentException("The provided lease is not valid anymore: " + lease);
       }
       LOG.debug("Acquiring lease {}, previous ETag {}", lease, previousETag);
@@ -177,10 +177,10 @@ public class S3NodeIdRepository implements NodeIdRepository {
     return builder.build();
   }
 
-  public record Config(String bucketName, Duration expiryDuration) {
+  public record Config(String bucketName, Duration leaseDuration) {
     public Config {
-      if (expiryDuration.toMillis() <= 0) {
-        throw new IllegalArgumentException("expiryDuration must be greater than 0");
+      if (leaseDuration.toMillis() <= 0) {
+        throw new IllegalArgumentException("leaseDuration must be greater than 0");
       }
       if (bucketName == null || bucketName.isEmpty()) {
         throw new IllegalArgumentException("bucketName cannot be null or empty");

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -249,7 +249,10 @@ public class RepositoryNodeIdProviderIT {
   }
 
   RepositoryNodeIdProvider ofSize(final int clusterSize) {
-    return new RepositoryNodeIdProvider(
-        repository, clusterSize, clock, EXPIRY_DURATION, taskId, () -> leaseFailed = true);
+    final var provider =
+        new RepositoryNodeIdProvider(
+            repository, clock, EXPIRY_DURATION, taskId, () -> leaseFailed = true);
+    provider.initialize(clusterSize);
+    return provider;
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -26,12 +26,15 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
@@ -42,6 +45,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Testcontainers
+@Timeout(value = 120)
 public class RepositoryNodeIdProviderIT {
 
   private static final Duration EXPIRY_DURATION = Duration.ofSeconds(5);
@@ -84,7 +88,8 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldAcquireALease() {
+  public void shouldAcquireALease()
+      throws ExecutionException, InterruptedException, TimeoutException {
     // given
     clusterSize = 3;
     repository.initialize(clusterSize);
@@ -105,7 +110,8 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldAcquireAnExpiredLease() {
+  public void shouldAcquireAnExpiredLease()
+      throws ExecutionException, InterruptedException, TimeoutException {
     // given
     clusterSize = 3;
     repository.initialize(clusterSize);
@@ -136,7 +142,8 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldBlockInitializationIfAllLeasesAreTaken() {
+  public void shouldBlockInitializationIfAllLeasesAreTaken()
+      throws ExecutionException, InterruptedException, TimeoutException {
     // given
     clusterSize = 3;
     repository.initialize(clusterSize);
@@ -154,7 +161,7 @@ public class RepositoryNodeIdProviderIT {
         .allSatisfy(l -> assertThat(l).isInstanceOf(StoredLease.Initialized.class));
 
     // when
-    nodeIdProvider = ofSize(clusterSize);
+    nodeIdProvider = ofSize(clusterSize, false);
 
     // then
     // verify that the lease status is not ready continuously
@@ -166,7 +173,8 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldRenewTheLeaseBeforeExpiration() {
+  public void shouldRenewTheLeaseBeforeExpiration()
+      throws ExecutionException, InterruptedException, TimeoutException {
     // given
     clusterSize = 3;
     repository.initialize(clusterSize);
@@ -190,7 +198,8 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldInvokeFailureListenerWhenFailsToRenew() {
+  public void shouldInvokeFailureListenerWhenFailsToRenew()
+      throws ExecutionException, InterruptedException, TimeoutException {
     // given
     clusterSize = 3;
     repository.initialize(clusterSize);
@@ -210,7 +219,8 @@ public class RepositoryNodeIdProviderIT {
   }
 
   @Test
-  public void shouldReleaseGracefullyWhenClosed() {
+  public void shouldReleaseGracefullyWhenClosed()
+      throws ExecutionException, InterruptedException, TimeoutException {
     // given
     clusterSize = 3;
     repository.initialize(clusterSize);
@@ -249,10 +259,17 @@ public class RepositoryNodeIdProviderIT {
   }
 
   RepositoryNodeIdProvider ofSize(final int clusterSize) {
+    return ofSize(clusterSize, true);
+  }
+
+  RepositoryNodeIdProvider ofSize(final int clusterSize, final boolean awaitInitialization) {
     final var provider =
         new RepositoryNodeIdProvider(
             repository, clock, EXPIRY_DURATION, taskId, () -> leaseFailed = true);
-    provider.initialize(clusterSize);
+    final var future = provider.initialize(clusterSize);
+    if (awaitInitialization) {
+      future.join();
+    }
     return provider;
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -42,7 +42,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Testcontainers
-public class NodeIdProviderIT {
+public class RepositoryNodeIdProviderIT {
 
   private static final Duration EXPIRY_DURATION = Duration.ofSeconds(5);
 
@@ -55,7 +55,7 @@ public class NodeIdProviderIT {
   @AutoClose private static S3Client client;
   S3NodeIdRepository.Config config;
   @AutoClose private S3NodeIdRepository repository;
-  @AutoClose private NodeIdProvider nodeIdProvider;
+  @AutoClose private RepositoryNodeIdProvider nodeIdProvider;
   private ControlledInstantSource clock;
   private int clusterSize;
   private String taskId;
@@ -243,13 +243,13 @@ public class NodeIdProviderIT {
     Awaitility.await("Until the lease is acquired")
         .untilAsserted(
             () ->
-                assertThat(nodeIdProvider.isLeaseValid())
+                assertThat(nodeIdProvider.isValid())
                     .succeedsWithin(Duration.ofSeconds(1))
                     .isEqualTo(status));
   }
 
-  NodeIdProvider ofSize(final int clusterSize) {
-    return new NodeIdProvider(
+  RepositoryNodeIdProvider ofSize(final int clusterSize) {
+    return new RepositoryNodeIdProvider(
         repository, clusterSize, clock, EXPIRY_DURATION, taskId, () -> leaseFailed = true);
   }
 }

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -189,6 +189,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>dynamic-node-id-provider</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
       <scope>test</scope>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -51,6 +51,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminService;
 import io.camunda.zeebe.broker.system.management.PartitionStatus;
 import io.camunda.zeebe.dynamic.config.GatewayClusterConfigurationService;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.gateway.Gateway;
 import io.camunda.zeebe.gateway.JobStreamComponent;
@@ -977,7 +978,9 @@ public class ClusteringRule extends ExternalResource {
     final var workingDir =
         new WorkingDirectoryConfiguration.WorkingDirectory(brokerBase.toPath(), false);
 
-    return new BrokerBasedConfiguration(workingDir, cfg, new LifecycleProperties());
+    final var staticNodeIdProvider = NodeIdProvider.staticProvider(cfg.getCluster().getNodeId());
+    return new BrokerBasedConfiguration(
+        workingDir, staticNodeIdProvider, cfg, new LifecycleProperties());
   }
 
   public Leader getCurrentLeaderForPartition(final int partition) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -43,6 +43,7 @@ public final class TestClusterBuilder {
 
   private final Map<MemberId, TestStandaloneGateway> gateways = new HashMap<>();
   private final Map<MemberId, TestStandaloneBroker> brokers = new HashMap<>();
+  private boolean setNodeId = true;
 
   /**
    * If true, the brokers created by this cluster will use embedded gateways. By default this is
@@ -255,6 +256,11 @@ public final class TestClusterBuilder {
     return this;
   }
 
+  public TestClusterBuilder withoutNodeId() {
+    setNodeId = false;
+    return this;
+  }
+
   /**
    * Builds a new Zeebe cluster. Will create {@link #brokersCount} brokers (accessible later via
    * {@link TestCluster#brokers()}) and {@link #gatewaysCount} standalone gateways (accessible later
@@ -346,7 +352,9 @@ public final class TestClusterBuilder {
             .withBrokerConfig(
                 cfg -> {
                   final var cluster = cfg.getCluster();
-                  cluster.setNodeId(index);
+                  if (setNodeId) {
+                    cluster.setNodeId(index);
+                  }
                   cluster.setPartitionsCount(partitionsCount);
                   cluster.setReplicationFactor(replicationFactor);
                   cluster.setClusterSize(brokersCount);

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -28,6 +28,7 @@ import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
+import io.camunda.zeebe.broker.NodeIdProviderConfiguration;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
@@ -65,6 +66,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
         CommonsModuleConfiguration.class,
         UnifiedConfigurationHelper.class,
         UnifiedConfiguration.class,
+        NodeIdProviderConfiguration.class,
         GatewayRestPropertiesOverride.class,
         SearchEngineConnectPropertiesOverride.class,
         SearchEngineIndexPropertiesOverride.class);

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreManagerTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreManagerTest.java
@@ -25,6 +25,7 @@ final class RestoreManagerTest {
   void shouldFailWhenDirectoryIsNotEmpty(@TempDir final Path dir) throws IOException {
     // given
     final var configuration = new BrokerCfg();
+    configuration.getCluster().setNodeId(0);
     configuration.getData().setDirectory(dir.toString());
     final var restoreManager =
         new RestoreManager(
@@ -42,6 +43,7 @@ final class RestoreManagerTest {
   void shouldIgnoreConfigurableFilesInTarget(@TempDir final Path dir) throws IOException {
     // given
     final var configuration = new BrokerCfg();
+    configuration.getCluster().setNodeId(0);
     configuration.getData().setDirectory(dir.toString());
     final var restoreManager =
         new RestoreManager(


### PR DESCRIPTION
## Description
In this PR the `NodeIdProvider` is integrated in the rest of the application in the `dist` and `configuration` modules.
A new configuration is introduced to configure the `S3NodeIdRepository` in such a way that it can be extended later on if different providers need to be added (e.g. RDBMS, azure, gcp).
The configuration is backward compatible:
- `camunda.cluster.node-id` is now nullable, to allow for better validation of the configurations.
- `camunda.cluster.dynamic-node-id` is introduced with a `.s3` section for `S3NodeIdRepository`.
- `camunda.cluster.dynamic-node-id.type` is used to discern between the possible implementation, defaulting to `none`.
  if set to `none`, then the configuration is not used and we default to the current behaviour, with `node-id=0` if not set.

An IT test is added that verifies that a cluster correctly starts up using `S3NodeIdRepository` with `LocalStack` as S3 implementation.




## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #40476 
