### PR TITLE
test: fix migration integration tests

### DIFF
--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/ElasticsearchUpdateRegressionTest.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/ElasticsearchUpdateRegressionTest.java
@@ -88,6 +88,9 @@ public class ElasticsearchUpdateRegressionTest {
     final TestStandaloneBroker testStandaloneBroker = new TestStandaloneBroker();
     final MultiDbConfigurator multiDbConfigurator = new MultiDbConfigurator(testStandaloneBroker);
     multiDbConfigurator.configureElasticsearchSupport(httpHostAddress, "");
+    // to allow migration from 8.7-SNAPSHOT to 8.8-SNAPSHOT
+    testStandaloneBroker.withProperty(
+        "camunda.database.schema-manager.version-check-restriction-enabled", "false");
 
     // when
     testStandaloneBroker.start();

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -80,7 +80,12 @@ public class PrefixMigrationIT {
 
   @MultiDbTestApplication(managedLifecycle = false)
   private static final TestCamundaApplication STANDALONE_CAMUNDA =
-      new TestCamundaApplication().withBasicAuth().withAuthorizationsEnabled();
+      new TestCamundaApplication()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          // to allow migration from 8.7-SNAPSHOT to 8.8-SNAPSHOT
+          .withProperty(
+              "camunda.database.schema-manager.version-check-restriction-enabled", "false");
 
   @BeforeAll
   public static void beforeAll() {

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/CamundaMigrator.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/CamundaMigrator.java
@@ -157,6 +157,9 @@ public class CamundaMigrator extends ApiCallable implements AutoCloseable {
                 })
             .withProperty("camunda.operate.importer-enabled", "true")
             .withProperty("camunda.tasklist.importer-enabled", "true")
+            // to allow migration from 8.7-SNAPSHOT to 8.8-SNAPSHOT
+            .withProperty(
+                "camunda.database.schema-manager.version-check-restriction-enabled", "false")
             .withWorkingDirectory(zeebeDataPath.resolve("usr/local/zeebe"));
 
     if (!authenticationEnabled) {

--- a/qa/migration-tests/src/test/java/io/camunda/it/migration/util/PrefixMigrationUtils.java
+++ b/qa/migration-tests/src/test/java/io/camunda/it/migration/util/PrefixMigrationUtils.java
@@ -16,7 +16,6 @@ import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
-import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
@@ -191,12 +190,6 @@ public class PrefixMigrationUtils {
     final var inverseOperateAliases = PrefixMigrationUtils.inverseAliases(operateAliases);
     PrefixMigrationHelper.OPERATE_INDICES_TO_MIGRATE.forEach(
         descriptorCls -> {
-          if (MetadataIndex.class.equals(descriptorCls)) {
-            // FIXME skip asserts on Metadata index until
-            // https://github.com/camunda/camunda/pull/39769 is merged and a new 8.7-SNAPSHOT is
-            // available
-            return;
-          }
           final var descriptor =
               PrefixMigrationHelper.getDescriptor(descriptorCls, descriptors, newPrefix, true);
           assertThat(operateAliases).containsKey(descriptor.getFullQualifiedName());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- allows upgrade from 8.7-SNAPSHOT to 8.8-SNAPSHOT in migration integration tests
- skips assert in prefix migration tests is not needed anymore, as the latest `8.7-SNAPSHOT` contains the new Metadata index

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
