### PR TITLE
Add audit log exporter entity

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -34,6 +34,7 @@ import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TasklistMetricIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
@@ -138,6 +139,8 @@ public class BackupPriorityConfiguration {
             // USAGE METRICS
             new UsageMetricTemplate(indexPrefix, isElasticsearch),
             new UsageMetricTUTemplate(indexPrefix, isElasticsearch),
+            // AUDIT LOG
+            new AuditLogTemplate(indexPrefix, isElasticsearch),
             // CAMUNDA
             new ClusterVariableIndex(indexPrefix, isElasticsearch));
 

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -175,6 +175,7 @@ class BackupPrioritiesTest {
             "camunda-user-8.8.0_",
             "camunda-usage-metric-8.8.0_",
             "camunda-usage-metric-tu-8.8.0_",
+            "camunda-audit-log-8.9.0_",
             "camunda-cluster-variable-8.9.0_");
 
     for (final var indexList : indices) {

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -1010,6 +1010,7 @@ public class SchemaManagerIT {
             newPrefix + "-camunda-usage-metric-tu-8.8.0_",
             newPrefix + "-camunda-user-8.8.0_",
             newPrefix + "-camunda-web-session-8.8.0_",
+            newPrefix + "-camunda-audit-log-8.9.0_",
             newPrefix + "-operate-batch-operation-1.0.0_",
             newPrefix + "-operate-decision-8.3.0_",
             newPrefix + "-operate-decision-instance-8.3.0_",

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
@@ -22,6 +22,7 @@ import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TasklistMetricIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
@@ -84,7 +85,8 @@ public class IndexDescriptors {
                 new ClusterVariableIndex(indexPrefix, isElasticsearch),
                 new MessageTemplate(indexPrefix, isElasticsearch),
                 new UsageMetricTemplate(indexPrefix, isElasticsearch),
-                new UsageMetricTUTemplate(indexPrefix, isElasticsearch))
+                new UsageMetricTUTemplate(indexPrefix, isElasticsearch),
+                new AuditLogTemplate(indexPrefix, isElasticsearch))
             .collect(Collectors.toMap(Object::getClass, Function.identity()));
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/GroupIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/GroupIndex.java
@@ -25,9 +25,10 @@ public class GroupIndex extends AbstractIndexDescriptor implements Prio5Backup {
   public static final String JOIN = "join";
   public static final String MEMBER_TYPE = "memberType";
 
-  public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
-      new EntityJoinRelationFactory(
-          IdentityJoinRelationshipType.GROUP, IdentityJoinRelationshipType.MEMBER);
+  public static final EntityJoinRelationFactory<IdentityJoinRelationshipType>
+      JOIN_RELATION_FACTORY =
+          new EntityJoinRelationFactory<>(
+              IdentityJoinRelationshipType.GROUP, IdentityJoinRelationshipType.MEMBER);
 
   public GroupIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
@@ -24,9 +24,10 @@ public class RoleIndex extends AbstractIndexDescriptor implements Prio5Backup {
   public static final String MEMBER_TYPE = "memberType";
   public static final String JOIN = "join";
 
-  public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
-      new EntityJoinRelationFactory(
-          IdentityJoinRelationshipType.ROLE, IdentityJoinRelationshipType.MEMBER);
+  public static final EntityJoinRelationFactory<IdentityJoinRelationshipType>
+      JOIN_RELATION_FACTORY =
+          new EntityJoinRelationFactory<>(
+              IdentityJoinRelationshipType.ROLE, IdentityJoinRelationshipType.MEMBER);
 
   public RoleIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/TenantIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/TenantIndex.java
@@ -12,6 +12,7 @@ import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.EntityJoinRelationFactory;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
 
 public class TenantIndex extends AbstractIndexDescriptor implements Prio5Backup {
 
@@ -25,10 +26,11 @@ public class TenantIndex extends AbstractIndexDescriptor implements Prio5Backup 
   public static final String MEMBER_TYPE = "memberType";
   public static final String MEMBER_ID = "memberId";
 
-  public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
-      new EntityJoinRelationFactory(
-          EntityJoinRelation.IdentityJoinRelationshipType.TENANT,
-          EntityJoinRelation.IdentityJoinRelationshipType.MEMBER);
+  public static final EntityJoinRelationFactory<IdentityJoinRelationshipType>
+      JOIN_RELATION_FACTORY =
+          new EntityJoinRelationFactory<>(
+              EntityJoinRelation.IdentityJoinRelationshipType.TENANT,
+              EntityJoinRelation.IdentityJoinRelationshipType.MEMBER);
 
   public TenantIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.template;
+
+import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.ComponentNames;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogJoinRelationshipType;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.EntityJoinRelationFactory;
+
+public class AuditLogTemplate extends AbstractTemplateDescriptor
+    implements ProcessInstanceDependant, Prio5Backup {
+
+  public static final String INDEX_NAME = "audit-log";
+  public static final String INDEX_VERSION = "8.9.0";
+  public static final String ENTITY_KEY = "entityKey";
+
+  public static final EntityJoinRelationFactory<AuditLogJoinRelationshipType>
+      JOIN_RELATION_FACTORY =
+          new EntityJoinRelationFactory<>(
+              AuditLogJoinRelationshipType.BATCH_OPERATION,
+              AuditLogJoinRelationshipType.BATCH_ITEM);
+
+  public AuditLogTemplate(final String indexPrefix, final boolean isElasticsearch) {
+    super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public String getIndexName() {
+    return INDEX_NAME;
+  }
+
+  @Override
+  public String getVersion() {
+    return INDEX_VERSION;
+  }
+
+  @Override
+  public String getComponentName() {
+    return ComponentNames.CAMUNDA.toString();
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JoinRelationshipType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JoinRelationshipType.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities;
+
+public interface JoinRelationshipType {
+  String getType();
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogActorType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogActorType.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.auditlog;
+
+public enum AuditLogActorType {
+  USER,
+  CLIENT;
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntity.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.auditlog;
+
+import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
+
+public class AuditLogEntity extends AbstractExporterEntity<AuditLogEntity> {
+
+  // the key of the affected entity
+  private Long entityKey;
+  // the id of the affected entity, if applicable (ex. Identity-related entities)
+  private String entityId;
+  // the type of the affected entity
+  private AuditLogEntityType entityType;
+  // the type of operation that was performed, i.e. the Zeebe record intent
+  private AuditLogOperationType operationType;
+  // the version of the affected entity, i.e. the Zeebe record version
+  private Integer entityVersion;
+  // the value type of the affected entity, i.e. the Zeebe record value type
+  private Short entityValueType;
+  // the intent of the affected entity, i.e. the Zeebe record intent
+  private Short entityOperationIntent;
+  // the key of the batch operation, if applicable
+  private Long batchOperationKey;
+  // the type of the batch operation, if applicable
+  private BatchOperationType batchOperationType;
+  // the creation timestamp of the Zeebe event that triggered the audit log entry
+  private Long timestamp;
+  // the type of the actor that performed the operation, (USER or CLIENT)
+  private AuditLogActorType actorType;
+  // the id of the actor that performed the operation
+  private String actorId;
+  // the id of the tenant the operation was performed in
+  private String tenantId;
+  private ClusterVariableScope tenantScope;
+  // marks if the operations was successful or failed
+  private AuditLogOperationResult result;
+  // details
+  private String details;
+  // the explanation on why the operation was performed
+  private String annotation;
+  // the category of the operation (ADMIN, OPERATOR, USER_TASK)
+  private AuditLogOperationCategory category;
+
+  // searchable fields dependent on the entity type
+  private String bpmnProcessId;
+  private String decisionRequirementsId;
+  private String decisionId;
+  private Long deploymentKey;
+  private Long formKey;
+  private Long resourceKey;
+  private Long processDefinitionKey;
+  private Long processInstanceKey;
+  private Long elementInstanceKey;
+  private Long jobKey;
+  private Long userTaskKey;
+  private Long decisionRequirementsKey;
+  private Long decisionKey;
+
+  // join relation for batch operation parent and items
+  private EntityJoinRelation join;
+
+  public Long getEntityKey() {
+    return entityKey;
+  }
+
+  public AuditLogEntity setEntityKey(final Long entityKey) {
+    this.entityKey = entityKey;
+    return this;
+  }
+
+  public AuditLogEntityType getEntityType() {
+    return entityType;
+  }
+
+  public AuditLogEntity setEntityType(final AuditLogEntityType auditLogEntityType) {
+    entityType = auditLogEntityType;
+    return this;
+  }
+
+  public String getEntityId() {
+    return entityId;
+  }
+
+  public AuditLogEntity setEntityId(final String entityId) {
+    this.entityId = entityId;
+    return this;
+  }
+
+  public AuditLogOperationType getOperationType() {
+    return operationType;
+  }
+
+  public AuditLogEntity setOperationType(final AuditLogOperationType operationType) {
+    this.operationType = operationType;
+    return this;
+  }
+
+  public Integer getEntityVersion() {
+    return entityVersion;
+  }
+
+  public AuditLogEntity setEntityVersion(final Integer entityVersion) {
+    this.entityVersion = entityVersion;
+    return this;
+  }
+
+  public Short getEntityValueType() {
+    return entityValueType;
+  }
+
+  public AuditLogEntity setEntityValueType(final Short entityValueType) {
+    this.entityValueType = entityValueType;
+    return this;
+  }
+
+  public Short getEntityOperationIntent() {
+    return entityOperationIntent;
+  }
+
+  public AuditLogEntity setEntityOperationIntent(final Short entityOperationIntent) {
+    this.entityOperationIntent = entityOperationIntent;
+    return this;
+  }
+
+  public Long getBatchOperationKey() {
+    return batchOperationKey;
+  }
+
+  public AuditLogEntity setBatchOperationKey(final Long batchOperationKey) {
+    this.batchOperationKey = batchOperationKey;
+    return this;
+  }
+
+  public BatchOperationType getBatchOperationType() {
+    return batchOperationType;
+  }
+
+  public AuditLogEntity setBatchOperationType(final BatchOperationType batchOperationType) {
+    this.batchOperationType = batchOperationType;
+    return this;
+  }
+
+  public Long getTimestamp() {
+    return timestamp;
+  }
+
+  public AuditLogEntity setTimestamp(final Long timestamp) {
+    this.timestamp = timestamp;
+    return this;
+  }
+
+  public String getActorId() {
+    return actorId;
+  }
+
+  public AuditLogEntity setActorId(final String actorId) {
+    this.actorId = actorId;
+    return this;
+  }
+
+  public AuditLogActorType getActorType() {
+    return actorType;
+  }
+
+  public AuditLogEntity setActorType(final AuditLogActorType actorType) {
+    this.actorType = actorType;
+    return this;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public AuditLogEntity setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  public AuditLogOperationResult getResult() {
+    return result;
+  }
+
+  public AuditLogEntity setResult(final AuditLogOperationResult result) {
+    this.result = result;
+    return this;
+  }
+
+  public String getAnnotation() {
+    return annotation;
+  }
+
+  public AuditLogEntity setAnnotation(final String annotation) {
+    this.annotation = annotation;
+    return this;
+  }
+
+  public String getDetails() {
+    return details;
+  }
+
+  public AuditLogEntity setDetails(final String details) {
+    this.details = details;
+    return this;
+  }
+
+  public AuditLogOperationCategory getCategory() {
+    return category;
+  }
+
+  public AuditLogEntity setCategory(final AuditLogOperationCategory category) {
+    this.category = category;
+    return this;
+  }
+
+  public Long getDeploymentKey() {
+    return deploymentKey;
+  }
+
+  public AuditLogEntity setDeploymentKey(final Long deploymentKey) {
+    this.deploymentKey = deploymentKey;
+    return this;
+  }
+
+  public Long getFormKey() {
+    return formKey;
+  }
+
+  public AuditLogEntity setFormKey(final Long formKey) {
+    this.formKey = formKey;
+    return this;
+  }
+
+  public Long getResourceKey() {
+    return resourceKey;
+  }
+
+  public AuditLogEntity setResourceKey(final Long resourceKey) {
+    this.resourceKey = resourceKey;
+    return this;
+  }
+
+  public Long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public AuditLogEntity setProcessDefinitionKey(final Long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+    return this;
+  }
+
+  public Long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public AuditLogEntity setProcessInstanceKey(final Long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+    return this;
+  }
+
+  public Long getElementInstanceKey() {
+    return elementInstanceKey;
+  }
+
+  public AuditLogEntity setElementInstanceKey(final Long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
+    return this;
+  }
+
+  public Long getJobKey() {
+    return jobKey;
+  }
+
+  public AuditLogEntity setJobKey(final Long jobKey) {
+    this.jobKey = jobKey;
+    return this;
+  }
+
+  public Long getUserTaskKey() {
+    return userTaskKey;
+  }
+
+  public AuditLogEntity setUserTaskKey(final Long userTaskKey) {
+    this.userTaskKey = userTaskKey;
+    return this;
+  }
+
+  public Long getDecisionRequirementsKey() {
+    return decisionRequirementsKey;
+  }
+
+  public AuditLogEntity setDecisionRequirementsKey(final Long decisionRequirementsKey) {
+    this.decisionRequirementsKey = decisionRequirementsKey;
+    return this;
+  }
+
+  public Long getDecisionKey() {
+    return decisionKey;
+  }
+
+  public AuditLogEntity setDecisionKey(final Long decisionKey) {
+    this.decisionKey = decisionKey;
+    return this;
+  }
+
+  public EntityJoinRelation getJoin() {
+    return join;
+  }
+
+  public AuditLogEntity setJoin(final EntityJoinRelation join) {
+    this.join = join;
+    return this;
+  }
+
+  public ClusterVariableScope getTenantScope() {
+    return tenantScope;
+  }
+
+  public AuditLogEntity setTenantScope(final ClusterVariableScope tenantScope) {
+    this.tenantScope = tenantScope;
+    return this;
+  }
+
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public AuditLogEntity setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+    return this;
+  }
+
+  public String getDecisionRequirementsId() {
+    return decisionRequirementsId;
+  }
+
+  public AuditLogEntity setDecisionRequirementsId(final String decisionRequirementsId) {
+    this.decisionRequirementsId = decisionRequirementsId;
+    return this;
+  }
+
+  public String getDecisionId() {
+    return decisionId;
+  }
+
+  public AuditLogEntity setDecisionId(final String decisionId) {
+    this.decisionId = decisionId;
+    return this;
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntityType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntityType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.auditlog;
+
+public enum AuditLogEntityType {
+  PROCESS_INSTANCE,
+  VARIABLE,
+  INCIDENT,
+  USER_TASK,
+  DECISION,
+  BATCH,
+  USER,
+  MAPPING_RULE,
+  ROLE,
+  GROUP,
+  TENANT,
+  AUTHORIZATION,
+  RESOURCE
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogJoinRelationshipType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogJoinRelationshipType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.auditlog;
+
+import io.camunda.webapps.schema.entities.JoinRelationshipType;
+
+public enum AuditLogJoinRelationshipType implements JoinRelationshipType {
+  BATCH_OPERATION("batchOperation"),
+  BATCH_ITEM("batchItem");
+
+  private final String type;
+
+  AuditLogJoinRelationshipType(final String type) {
+    this.type = type;
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogOperationCategory.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogOperationCategory.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.auditlog;
+
+public enum AuditLogOperationCategory {
+  ADMIN,
+  OPERATOR,
+  USER_TASK;
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogOperationResult.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogOperationResult.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.auditlog;
+
+public enum AuditLogOperationResult {
+  SUCCESS,
+  FAILURE
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogOperationType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogOperationType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.auditlog;
+
+public enum AuditLogOperationType {
+  CREATE,
+  UPDATE,
+  DELETE,
+  ASSIGN,
+  UNASSIGN,
+  MODIFY,
+  MIGRATE,
+  CANCEL,
+  RESOLVE,
+  COMPLETE,
+  SUSPEND,
+  RESUME,
+  EVALUATE
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
@@ -7,17 +7,17 @@
  */
 package io.camunda.webapps.schema.entities.usermanagement;
 
+import io.camunda.webapps.schema.entities.JoinRelationshipType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public record EntityJoinRelation(String name, String parent) {
 
-  public static class EntityJoinRelationFactory {
+  public static class EntityJoinRelationFactory<T extends JoinRelationshipType> {
 
-    private final IdentityJoinRelationshipType parent;
-    private final IdentityJoinRelationshipType child;
+    private final T parent;
+    private final T child;
 
-    public EntityJoinRelationFactory(
-        final IdentityJoinRelationshipType parent, final IdentityJoinRelationshipType child) {
+    public EntityJoinRelationFactory(final T parent, final T child) {
       this.parent = parent;
       this.child = child;
     }
@@ -46,7 +46,7 @@ public record EntityJoinRelation(String name, String parent) {
     }
   }
 
-  public enum IdentityJoinRelationshipType {
+  public enum IdentityJoinRelationshipType implements JoinRelationshipType {
     GROUP("group"),
     ROLE("role"),
     TENANT("tenant"),
@@ -58,6 +58,7 @@ public record EntityJoinRelation(String name, String parent) {
       this.type = type;
     }
 
+    @Override
     public String getType() {
       return type;
     }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-audit-log.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-audit-log.json
@@ -1,0 +1,112 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "entityKey": {
+        "type": "long"
+      },
+      "entityId": {
+        "type": "keyword"
+      },
+      "entityType": {
+        "type": "keyword"
+      },
+      "operationType": {
+        "type": "keyword"
+      },
+      "entityVersion": {
+        "type": "integer"
+      },
+      "entityValueType": {
+        "type": "short"
+      },
+      "entityOperationIntent": {
+        "type": "short"
+      },
+      "batchOperationKey": {
+        "type": "long"
+      },
+      "batchOperationType": {
+        "type": "keyword"
+      },
+      "timestamp": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "actorType": {
+        "type": "keyword"
+      },
+      "actorId": {
+        "type": "keyword"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "tenantScope": {
+        "type": "keyword"
+      },
+      "result": {
+        "type": "keyword"
+      },
+      "details": {
+        "type": "object",
+        "enabled": false
+      },
+      "annotation": {
+        "type": "text"
+      },
+      "category": {
+        "type": "keyword"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "decisionRequirementsId": {
+        "type": "keyword"
+      },
+      "decisionId": {
+        "type": "keyword"
+      },
+      "deploymentKey": {
+        "type": "long"
+      },
+      "formKey": {
+        "type": "long"
+      },
+      "resourceKey": {
+        "type": "long"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "elementInstanceKey": {
+        "type": "long"
+      },
+      "jobKey": {
+        "type": "long"
+      },
+      "userTaskKey": {
+        "type": "long"
+      },
+      "decisionRequirementsKey": {
+        "type": "long"
+      },
+      "decisionKey": {
+        "type": "long"
+      },
+      "join": {
+        "type": "join",
+        "eager_global_ordinals": true,
+        "relations": {
+          "batchOperation": ["batchItem"]
+        }
+      }
+    }
+  }
+}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-audit-log.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-audit-log.json
@@ -1,0 +1,111 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "entityKey": {
+        "type": "long"
+      },
+      "entityId": {
+        "type": "keyword"
+      },
+      "entityType": {
+        "type": "keyword"
+      },
+      "operationType": {
+        "type": "keyword"
+      },
+      "entityVersion": {
+        "type": "integer"
+      },
+      "entityValueType": {
+        "type": "short"
+      },
+      "entityOperationIntent": {
+        "type": "short"
+      },
+      "batchOperationKey": {
+        "type": "long"
+      },
+      "batchOperationType": {
+        "type": "keyword"
+      },
+      "timestamp": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "actorType": {
+        "type": "keyword"
+      },
+      "actorId": {
+        "type": "keyword"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "tenantScope": {
+        "type": "keyword"
+      },
+      "result": {
+        "type": "keyword"
+      },
+      "details": {
+        "type": "object",
+        "enabled": false
+      },
+      "annotation": {
+        "type": "text"
+      },
+      "category": {
+        "type": "keyword"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "decisionRequirementsId": {
+        "type": "keyword"
+      },
+      "decisionId": {
+        "type": "keyword"
+      },
+      "deploymentKey": {
+        "type": "long"
+      },
+      "formKey": {
+        "type": "long"
+      },
+      "resourceKey": {
+        "type": "long"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "elementInstanceKey": {
+        "type": "long"
+      },
+      "jobKey": {
+        "type": "long"
+      },
+      "userTaskKey": {
+        "type": "long"
+      },
+      "decisionRequirementsKey": {
+        "type": "long"
+      },
+      "decisionKey": {
+        "type": "long"
+      },
+      "join": {
+        "type": "join",
+        "relations": {
+          "batchOperation": ["batchItem"]
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -834,13 +834,13 @@ final class ElasticsearchArchiverRepositoryIT {
         .untilAsserted(
             () ->
                 verify(
-                        indicesClientSpy, times(18) // number of index templates
+                        indicesClientSpy, times(19) // number of index templates
                         )
                     .putSettings(captor.capture()));
 
     final var putIndicesSettingsRequests = captor.getAllValues();
     assertThat(putIndicesSettingsRequests)
-        .hasSize(18)
+        .hasSize(19)
         .allSatisfy(
             request -> {
               assertThat(request.index()).hasSize(1);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -810,13 +810,13 @@ final class OpenSearchArchiverRepositoryIT {
         .untilAsserted(
             () ->
                 verify(
-                        genericClientSpy, times(18) // number of index templates
+                        genericClientSpy, times(19) // number of index templates
                         )
                     .executeAsync(captor.capture()));
 
     final var putIndicesSettingsRequests = captor.getAllValues();
     assertThat(putIndicesSettingsRequests)
-        .hasSize(18)
+        .hasSize(19)
         .allSatisfy(
             request -> {
               final var indexPattern =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds a new `AuditLogEntity` class to encapsulate audit log entries in secondary storage.

Furthermore, the PR defines an `AuditLogIndex` and corresponding ES and OS mappings for the audit log entity.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41116
