### PR TITLE
fix: allow configuration of max concurrent HTTP Connections in client

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
@@ -185,6 +185,11 @@ public class SpringCamundaClientConfiguration implements CamundaClientConfigurat
     return camundaClientProperties.getPreferRestOverGrpc();
   }
 
+  @Override
+  public int getMaxHttpConnections() {
+    return camundaClientProperties.getMaxHttpConnections();
+  }
+
   private String composeGatewayAddress() {
     final URI gatewayUrl = getGrpcAddress();
     final int port = gatewayUrl.getPort();

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientProperties.java
@@ -111,6 +111,9 @@ public class CamundaClientProperties {
    */
   private Duration requestTimeoutOffset = DEFAULT_REQUEST_TIMEOUT_OFFSET;
 
+  /** The maximum number of concurrent HTTP connections the client can open. */
+  private int maxHttpConnections = DEFAULT_MAX_HTTP_CONNECTIONS;
+
   public CamundaClientCloudProperties getCloud() {
     return cloud;
   }
@@ -265,6 +268,14 @@ public class CamundaClientProperties {
     this.enabled = enabled;
   }
 
+  public int getMaxHttpConnections() {
+    return maxHttpConnections;
+  }
+
+  public void setMaxHttpConnections(final int maxHttpConnections) {
+    this.maxHttpConnections = maxHttpConnections;
+  }
+
   @Override
   public String toString() {
     return "CamundaClientProperties{"
@@ -296,6 +307,8 @@ public class CamundaClientProperties {
         + worker
         + ", preferRestOverGrpc="
         + preferRestOverGrpc
+        + ", maxHttpConnections="
+        + maxHttpConnections
         + ", grpcAddress="
         + grpcAddress
         + ", restAddress="

--- a/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -178,6 +178,10 @@
       "defaultValue": true
     },
     {
+      "name": "camunda.client.max-http-connections",
+      "defaultValue": 100
+    },
+    {
       "name": "camunda.client.max-message-size",
       "defaultValue": "5MB"
     },

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/CamundaClientConfigurationDefaultPropertiesTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/CamundaClientConfigurationDefaultPropertiesTest.java
@@ -68,5 +68,6 @@ public class CamundaClientConfigurationDefaultPropertiesTest {
     assertThat(configuration.getOverrideAuthority()).isNull();
     assertThat(configuration.getRestAddress()).isEqualTo(new URI("http://0.0.0.0:8080"));
     assertThat(configuration.preferRestOverGrpc()).isTrue();
+    assertThat(configuration.getMaxHttpConnections()).isEqualTo(100);
   }
 }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -62,6 +62,9 @@ public class AlignmentTest {
     // camunda.client.prefer-rest-over-grpc
     GETTERS.put(
         "camunda.client.prefer-rest-over-grpc", CamundaClientProperties::getPreferRestOverGrpc);
+    // camunda.client.prefer-rest-over-grpc
+    GETTERS.put(
+        "camunda.client.max-http-connections", CamundaClientProperties::getMaxHttpConnections);
     // camunda.client.rest-address
     GETTERS.put("camunda.client.rest-address", CamundaClientProperties::getRestAddress);
     MAPPERS.put("camunda.client.rest-address", p -> URI.create((String) p));

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/JavaClientPropertiesTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/JavaClientPropertiesTest.java
@@ -37,12 +37,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 @SpringBootTest
 @TestPropertySource(
     properties = {
-      "zeebe.client.gateway.address=localhost12345",
-      "zeebe.client.broker.grpcAddress=https://localhost:1234",
-      "zeebe.client.broker.restAddress=https://localhost:8080",
-      "zeebe.client.job.pollinterval=99s",
-      "zeebe.client.worker.name=testName",
-      "zeebe.client.cloud.secret=processOrchestration"
+      "camunda.client.grpcAddress=https://localhost:1234",
+      "camunda.client.restAddress=https://localhost:8080",
+      "camunda.client.max-http-connections=1234",
+      "camunda.client.worker.defaults.poll-interval=99s",
+      "camunda.client.worker.defaults.name=testName",
+      "camunda.client.auth.client-secret=processOrchestration"
     })
 @ContextConfiguration(classes = JavaClientPropertiesTest.TestConfig.class)
 public class JavaClientPropertiesTest {
@@ -57,6 +57,11 @@ public class JavaClientPropertiesTest {
   @Test
   public void hasRestAddress() {
     assertThat(properties.getRestAddress().toString()).isEqualTo("https://localhost:8080");
+  }
+
+  @Test
+  public void hasMaxHttpConnections() {
+    assertThat(properties.getMaxHttpConnections()).isEqualTo(1234);
   }
 
   @Test

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
@@ -228,9 +228,11 @@ public interface CamundaClientBuilder {
    * <p>NOTE: job streaming is only supported via gRPC
    *
    * @param preferRestOverGrpc if true, the client will use REST instead of gRPC whenever possible
-   * @return this builder for chaining
    */
   CamundaClientBuilder preferRestOverGrpc(final boolean preferRestOverGrpc);
+
+  /** Sets the maximum number of concurrent HTTP connections the client can open. */
+  CamundaClientBuilder maxHttpConnections(int maxConnections);
 
   /**
    * @return a new {@link CamundaClient} with the provided configuration options.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientConfiguration.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client;
 
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.JsonMapper;
 import io.grpc.ClientInterceptor;
 import java.net.URI;
@@ -154,6 +153,10 @@ public interface CamundaClientConfiguration {
   /**
    * @see CamundaClientBuilder#preferRestOverGrpc(boolean)
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/16166")
   boolean preferRestOverGrpc();
+
+  /**
+   * @see CamundaClientBuilder#maxHttpConnections(int)
+   */
+  int getMaxHttpConnections();
 }

--- a/clients/java/src/main/java/io/camunda/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/ClientProperties.java
@@ -38,6 +38,11 @@ public final class ClientProperties {
   public static final String PREFER_REST_OVER_GRPC = "camunda.client.gateway.preferRestOverGrpc";
 
   /**
+   * @see CamundaClientBuilder#maxHttpConnections(int)
+   */
+  public static final String MAX_HTTP_CONNECTIONS = "camunda.client.gateway.maxHttpConnections";
+
+  /**
    * @see CamundaClientBuilder#restAddress(URI)
    */
   public static final String REST_ADDRESS = "camunda.client.gateway.rest.address";

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
@@ -296,6 +296,12 @@ public class CamundaClientCloudBuilderImpl
   }
 
   @Override
+  public CamundaClientBuilder maxHttpConnections(final int maxConnections) {
+    innerBuilder.maxHttpConnections(maxConnections);
+    return this;
+  }
+
+  @Override
   public CamundaClient build() {
     innerBuilder.grpcAddress(determineGrpcAddress());
     innerBuilder.restAddress(determineRestAddress());

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientEnvironmentVariables.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientEnvironmentVariables.java
@@ -24,6 +24,7 @@ public final class CamundaClientEnvironmentVariables {
   public static final String REST_ADDRESS_VAR = "CAMUNDA_REST_ADDRESS";
   public static final String GRPC_ADDRESS_VAR = "CAMUNDA_GRPC_ADDRESS";
   public static final String PREFER_REST_VAR = "CAMUNDA_PREFER_REST";
+  public static final String MAX_HTTP_CONNECTIONS = "CAMUNDA_MAX_HTTP_CONNECTIONS";
   public static final String DEFAULT_TENANT_ID_VAR = "CAMUNDA_DEFAULT_TENANT_ID";
   public static final String DEFAULT_JOB_WORKER_TENANT_IDS_VAR =
       "CAMUNDA_DEFAULT_JOB_WORKER_TENANT_IDS";

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
@@ -138,6 +138,7 @@ public class HttpClientFactory {
         PoolingAsyncClientConnectionManagerBuilder.create()
             .setTlsStrategy(tlsStrategy)
             .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.LAX)
+            .setMaxConnPerRoute(config.getMaxHttpConnections())
             .build();
 
     final HttpAsyncClientBuilder builder =


### PR DESCRIPTION
## Description

Previously the apache httpclient5 defaulting to max 5 connections per route was bottlenecking client usage, especially when 5 concurrent job polls were active.

The new config is available on:
* the client builder `CamundaClientBuilder#maxHttpConnections`
* via a [client property `camunda.client.gateway.maxHttpConnections`](https://github.com/camunda/camunda/pull/40578/files#diff-e71b7942681f6de64e2e521b1a95a172ce6612ac649d8cdc70df73c0be475551R303-R306)
* via a [client env var `CAMUNDA_MAX_HTTP_CONNECTIONS`](https://github.com/camunda/camunda/pull/40578/files#diff-e71b7942681f6de64e2e521b1a95a172ce6612ac649d8cdc70df73c0be475551R646-R647)
* via a [spring boot starter config property `camunda.client.max-http-connections`](https://github.com/camunda/camunda/pull/40578/files#diff-e774dcb600fb4b8310a260703fa795545ccf7989e94a3d58d690c87596a05960R115)

The default is a magic number 🎲 agreed between @jonathanlukas  and me [here](https://camunda.slack.com/archives/C08MRKHJ0CD/p1762414375779699?thread_ts=1762171805.731809&cid=C08MRKHJ0CD) .

I will create a dedicated PR for the fix on the deprecated `zeebe-client-java` client that will get backported to 8.6 and 8.7 as well.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #40576 
