### PR TITLE
refactor: fix flaky e2e test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -81,9 +81,9 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.fillParentProcessInstanceKeyFilter(
         callActivityProcessInstanceKey,
       );
-      await expect(
-        operateProcessesPage.noMatchingInstancesMessage,
-      ).toBeVisible();
+      await expect(operateProcessesPage.noMatchingInstancesMessage).toBeVisible(
+        {timeout: 60000},
+      );
       await operateProcessesPage.clickProcessCompletedCheckbox();
       await waitForAssertion({
         assertion: async () => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Added timeout to stabilize a flaky test
🧪 [Test run](https://github.com/camunda/camunda/actions/runs/19128787543)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
