### PR TITLE
docs: remove html comments from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -6,67 +6,67 @@ body:
   - type: dropdown
     id: Component
     attributes:
-      label: <!-- Component -->
+      label: Component
       description: In which component did the issue occur?
       # The components should be kept in alphabetical order, with "Not sure" at the top
       options:
-        - <!-- C8-API- -->
-        - <!-- C8Run- -->
-        - <!-- Camunda Process Test- -->
-        - <!-- Clients- -->
-        - <!-- Data Layer- -->
-        - <!-- Feel- -->
-        - <!-- Identity- -->
-        - <!-- Management Identity- -->
-        - <!-- Operate- -->
-        - <!-- Optimize- -->
-        - <!-- Spring SDK- -->
-        - <!-- Tasklist- -->
-        - <!-- Zeebe- -->
+        - C8-API-
+        - C8Run-
+        - Camunda Process Test-
+        - Clients-
+        - Data Layer-
+        - Feel-
+        - Identity-
+        - Management Identity-
+        - Operate-
+        - Optimize-
+        - Spring SDK-
+        - Tasklist-
+        - Zeebe-
       default: null
     validations:
       required: true
   - type: dropdown
     id: affected-version
     attributes:
-      label: <!-- Affected version -->
+      label: Affected version
       multiple: true
       description: Which version is affected? (You can select more than one)
       options:
-        - <!-- -8.3 -->
-        - <!-- -8.4 -->
-        - <!-- -8.5 -->
-        - <!-- -8.6 -->
-        - <!-- -8.7 -->
-        - <!-- -8.8 -->
-        - <!-- -8.9 -->
+        - -8.3
+        - -8.4
+        - -8.5
+        - -8.6
+        - -8.7
+        - -8.8
+        - -8.9
       default: null
     validations:
       required: true
   - type: dropdown
     id: severity
     attributes:
-      label: <!-- Severity -->
+      label: Severity
       description: <a href="https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#severity-and-likelihood-bugs"> What is the severity of the bug?
       options:
-        - <!-- Low- -->
-        - <!-- Medium- -->
-        - <!-- High- -->
-        - <!-- Critical- -->
-        - <!-- Unknown- -->
+        - Low-
+        - Medium-
+        - High-
+        - Critical-
+        - Unknown-
       default: null
     validations:
       required: true
   - type: dropdown
     id: likelihood
     attributes:
-      label: <!-- Likelihood -->
+      label: Likelihood
       description: <a href="https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#severity-and-likelihood-bugs"> How likely is it to occur?
       options:
-        - <!-- Unknown_ -->
-        - <!-- Low_ -->
-        - <!-- Medium_ -->
-        - <!-- High_ -->
+        - Unknown_
+        - Low_
+        - Medium_
+        - High_
       default: null
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/2. feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2. feature_request.yml
@@ -6,23 +6,23 @@ body:
   - type: dropdown
     id: Component
     attributes:
-      label: <!-- Component -->
+      label: Component
       description: For which component your improvement idea is for?
       # The components should be kept in alphabetical order, with "Not sure" at the top
       options:
-        - <!-- C8-API- -->
-        - <!-- C8Run- -->
-        - <!-- Camunda Process Test- -->
-        - <!-- Clients- -->
-        - <!-- Data Layer- -->
-        - <!-- Feel- -->
-        - <!-- Identity- -->
-        - <!-- Management Identity- -->
-        - <!-- Operate- -->
-        - <!-- Optimize- -->
-        - <!-- Spring SDK- -->
-        - <!-- Tasklist- -->
-        - <!-- Zeebe- -->
+        - C8-API-
+        - C8Run-
+        - Camunda Process Test-
+        - Clients-
+        - Data Layer-
+        - Feel-
+        - Identity-
+        - Management Identity-
+        - Operate-
+        - Optimize-
+        - Spring SDK-
+        - Tasklist-
+        - Zeebe-
       default: null
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/3. task.yml
+++ b/.github/ISSUE_TEMPLATE/3. task.yml
@@ -6,23 +6,23 @@ body:
   - type: dropdown
     id: Component
     attributes:
-      label: <!-- Component -->
+      label: Component
       description: In which component shall the task be carried out?
       # The components should be kept in alphabetical order, with "Not sure" at the top
       options:
-        - <!-- C8-API- -->
-        - <!-- C8Run- -->
-        - <!-- Camunda Process Test- -->
-        - <!-- Clients- -->
-        - <!-- Data Layer- -->
-        - <!-- Feel- -->
-        - <!-- Identity- -->
-        - <!-- Management Identity- -->
-        - <!-- Operate- -->
-        - <!-- Optimize- -->
-        - <!-- Spring SDK- -->
-        - <!-- Tasklist- -->
-        - <!-- Zeebe- -->
+        - C8-API-
+        - C8Run-
+        - Camunda Process Test-
+        - Clients-
+        - Data Layer-
+        - Feel-
+        - Identity-
+        - Management Identity-
+        - Operate-
+        - Optimize-
+        - Spring SDK-
+        - Tasklist-
+        - Zeebe-
       default: null
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/4. epic breakdown.yml
+++ b/.github/ISSUE_TEMPLATE/4. epic breakdown.yml
@@ -6,24 +6,24 @@ body:
   - type: dropdown
     id: Component
     attributes:
-      label: <!-- Component -->
+      label: Component
       multiple: true
       description: What component(s) are affected by this epic?
       # The components should be kept in alphabetical order.
       options:
-        - <!-- C8-API- -->
-        - <!-- C8Run- -->
-        - <!-- Camunda Process Test- -->
-        - <!-- Clients- -->
-        - <!-- Data Layer- -->
-        - <!-- Feel- -->
-        - <!-- Identity- -->
-        - <!-- Management Identity- -->
-        - <!-- Operate- -->
-        - <!-- Optimize- -->
-        - <!-- Spring SDK- -->
-        - <!-- Tasklist- -->
-        - <!-- Zeebe- -->
+        - C8-API-
+        - C8Run-
+        - Camunda Process Test-
+        - Clients-
+        - Data Layer-
+        - Feel-
+        - Identity-
+        - Management Identity-
+        - Operate-
+        - Optimize-
+        - Spring SDK-
+        - Tasklist-
+        - Zeebe-
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/5. CVE.yml
+++ b/.github/ISSUE_TEMPLATE/5. CVE.yml
@@ -6,40 +6,40 @@ body:
   - type: dropdown
     id: Component
     attributes:
-      label: <!-- Component -->
+      label: Component
       description: Which component is affected by this CVE?
       # The components should be kept in alphabetical order, with "Not sure" at the top
       options:
-        - <!-- C8-API- -->
-        - <!-- C8Run- -->
-        - <!-- Camunda Process Test- -->
-        - <!-- Clients- -->
-        - <!-- Data Layer- -->
-        - <!-- Feel- -->
-        - <!-- Identity- -->
-        - <!-- Management Identity- -->
-        - <!-- Operate- -->
-        - <!-- Optimize- -->
-        - <!-- Spring SDK- -->
-        - <!-- Tasklist- -->
-        - <!-- Zeebe- -->
+        - C8-API-
+        - C8Run-
+        - Camunda Process Test-
+        - Clients-
+        - Data Layer-
+        - Feel-
+        - Identity-
+        - Management Identity-
+        - Operate-
+        - Optimize-
+        - Spring SDK-
+        - Tasklist-
+        - Zeebe-
       default: null
     validations:
       required: true
   - type: dropdown
     id: affected-version
     attributes:
-      label: <!-- Affected version -->
+      label: Affected version
       multiple: true
       description: Which version is affected? (You can select more than one)
       options:
-        - <!-- -8.3 -->
-        - <!-- -8.4 -->
-        - <!-- -8.5 -->
-        - <!-- -8.6 -->
-        - <!-- -8.7 -->
-        - <!-- -8.8 -->
-        - <!-- -8.9 -->
+        - -8.3
+        - -8.4
+        - -8.5
+        - -8.6
+        - -8.7
+        - -8.8
+        - -8.9
       default: null
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/6. tech debt.yml
+++ b/.github/ISSUE_TEMPLATE/6. tech debt.yml
@@ -6,23 +6,23 @@ body:
   - type: dropdown
     id: Component
     attributes:
-      label: <!-- Component -->
+      label: Component
       description: Which component is affected by this technical debt?
       # The components should be kept in alphabetical order, with "Not sure" at the top
       options:
-        - <!-- C8-API- -->
-        - <!-- C8Run- -->
-        - <!-- Camunda Process Test- -->
-        - <!-- Clients- -->
-        - <!-- Data Layer- -->
-        - <!-- Feel- -->
-        - <!-- Identity- -->
-        - <!-- Management Identity- -->
-        - <!-- Operate- -->
-        - <!-- Optimize- -->
-        - <!-- Spring SDK- -->
-        - <!-- Tasklist- -->
-        - <!-- Zeebe- -->
+        - C8-API-
+        - C8Run-
+        - Camunda Process Test-
+        - Clients-
+        - Data Layer-
+        - Feel-
+        - Identity-
+        - Management Identity-
+        - Operate-
+        - Optimize-
+        - Spring SDK-
+        - Tasklist-
+        - Zeebe-
       default: null
     validations:
       required: true


### PR DESCRIPTION
## Description

<img width="972" height="258" alt="Screenshot 2025-11-06 at 09 45 37" src="https://github.com/user-attachments/assets/c365558f-4bf9-4098-84fc-0147df512bf8" />

I was annoyed by the backtick before the description, I think it's due to the html comments in the gh templates

