### PR TITLE
[Backport stable/8.5] fix: do not use shared singleton for partition transition steps

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -74,6 +74,7 @@ public final class ZeebePartitionFactory {
   private static final List<StartupStep<PartitionStartupContext>> STARTUP_STEPS =
       List.of(new RockDbMetricExporterPartitionStartupStep());
 
+<<<<<<< HEAD
   private static final List<PartitionTransitionStep> TRANSITION_STEPS =
       List.of(
           new MetricsStep(),
@@ -92,6 +93,8 @@ public final class ZeebePartitionFactory {
           new BackupApiRequestHandlerStep(),
           new AdminApiRequestHandlerStep());
 
+=======
+>>>>>>> 9ed472e0 (fix: do not use shared singleton for partition transition steps)
   private final ActorSchedulingService actorSchedulingService;
   private final BrokerCfg brokerCfg;
   private final BrokerInfo localBroker;
@@ -172,11 +175,33 @@ public final class ZeebePartitionFactory {
             topologyManager,
             partitionMeterRegistry);
 
-    final PartitionTransition newTransitionBehavior = new PartitionTransitionImpl(TRANSITION_STEPS);
+    final PartitionTransition newTransitionBehavior =
+        new PartitionTransitionImpl(generateTransitionSteps());
 
     final ZeebePartition zeebePartition =
         new ZeebePartition(context, newTransitionBehavior, STARTUP_STEPS);
     return zeebePartition;
+  }
+
+  private List<PartitionTransitionStep> generateTransitionSteps() {
+    return List.of(
+        new MetricsStep(),
+        new LogStoragePartitionTransitionStep(),
+        new LogStreamPartitionTransitionStep(),
+        new ZeebeDbPartitionTransitionStep(),
+        new MigrationTransitionStep(),
+        new QueryServicePartitionTransitionStep(),
+        new BackupStoreTransitionStep(),
+        new BackupServiceTransitionStep(),
+        new InterPartitionCommandServiceStep(),
+        new StreamProcessorTransitionStep(),
+        new CommandApiServiceTransitionStep(),
+        new SnapshotDirectorPartitionTransitionStep(),
+        new SnapshotAfterMigrationTransitionStep(),
+        new SnapshotApiHandlerTransitionStep(),
+        new ExporterDirectorPartitionTransitionStep(),
+        new BackupApiRequestHandlerStep(),
+        new AdminApiRequestHandlerStep());
   }
 
   private StateController createStateController(


### PR DESCRIPTION
# Description
Backport of #40591 to `stable/8.5`.

relates to #39856