### PR TITLE
[Backport stable/8.8] fix: do not use shared singleton for partition transition steps

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -85,26 +85,6 @@ public final class ZeebePartitionFactory {
 
   private static final List<StartupStep<PartitionStartupContext>> STARTUP_STEPS = List.of();
 
-  private static final List<PartitionTransitionStep> TRANSITION_STEPS =
-      List.of(
-          new MetricsStep(),
-          new LogStoragePartitionTransitionStep(),
-          new LogStreamPartitionTransitionStep(),
-          new ZeebeDbPartitionTransitionStep(),
-          new MigrationTransitionStep(),
-          new QueryServicePartitionTransitionStep(),
-          new BackupStoreTransitionStep(),
-          new BackupServiceTransitionStep(),
-          new InterPartitionCommandServiceStep(),
-          new StreamProcessorTransitionStep(),
-          new CommandApiServiceTransitionStep(),
-          new SnapshotDirectorPartitionTransitionStep(),
-          new SnapshotAfterMigrationTransitionStep(),
-          new SnapshotApiHandlerTransitionStep(),
-          new ExporterDirectorPartitionTransitionStep(),
-          new BackupApiRequestHandlerStep(),
-          new AdminApiRequestHandlerStep());
-
   private final ActorSchedulingService actorSchedulingService;
   private final BrokerCfg brokerCfg;
   private final BrokerInfo localBroker;
@@ -211,9 +191,31 @@ public final class ZeebePartitionFactory {
             partitionMeterRegistry);
     context.setDynamicPartitionConfig(initialPartitionConfig);
 
-    final PartitionTransition newTransitionBehavior = new PartitionTransitionImpl(TRANSITION_STEPS);
+    final PartitionTransition newTransitionBehavior =
+        new PartitionTransitionImpl(generateTransitionSteps());
 
     return new ZeebePartition(context, newTransitionBehavior, STARTUP_STEPS);
+  }
+
+  private List<PartitionTransitionStep> generateTransitionSteps() {
+    return List.of(
+        new MetricsStep(),
+        new LogStoragePartitionTransitionStep(),
+        new LogStreamPartitionTransitionStep(),
+        new ZeebeDbPartitionTransitionStep(),
+        new MigrationTransitionStep(),
+        new QueryServicePartitionTransitionStep(),
+        new BackupStoreTransitionStep(),
+        new BackupServiceTransitionStep(),
+        new InterPartitionCommandServiceStep(),
+        new StreamProcessorTransitionStep(),
+        new CommandApiServiceTransitionStep(),
+        new SnapshotDirectorPartitionTransitionStep(),
+        new SnapshotAfterMigrationTransitionStep(),
+        new SnapshotApiHandlerTransitionStep(),
+        new ExporterDirectorPartitionTransitionStep(),
+        new BackupApiRequestHandlerStep(),
+        new AdminApiRequestHandlerStep());
   }
 
   private StateController createStateController(


### PR DESCRIPTION
# Description
Backport of #40591 to `stable/8.8`.

relates to #39856