### PR TITLE
test: prepare operate unit tests for incidents-table v2

### DIFF
--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.setup.ts
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.setup.ts
@@ -12,21 +12,21 @@ const mockIncidents = {
   count: 2,
   incidents: [
     createIncident({
-      errorType: {id: 'CONDITION_ERROR', name: 'Condition error'},
+      errorType: {id: 'CONDITION_ERROR', name: 'Condition error.'},
       flowNodeId: 'flowNodeId_exclusiveGateway',
     }),
     createIncident({
-      errorType: {id: 'EXTRACT_VALUE_ERROR', name: 'Extract value error'},
+      errorType: {id: 'EXTRACT_VALUE_ERROR', name: 'Extract value error.'},
       flowNodeId: 'flowNodeName_alwaysFailingTask',
     }),
   ],
   errorTypes: [
     {
       id: 'CONDITION_ERROR',
-      name: 'Condition error',
+      name: 'Condition error.',
       count: 2,
     },
-    {id: 'EXTRACT_VALUE_ERROR', name: 'Extract value error', count: 1},
+    {id: 'EXTRACT_VALUE_ERROR', name: 'Extract value error.', count: 1},
   ],
   flowNodes: [
     {

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.test.tsx
@@ -17,6 +17,7 @@ import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinit
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {IS_INCIDENTS_PANEL_V2} from 'modules/feature-flags';
 
 const {reset, fetchIncidents} = incidentsStore;
 
@@ -49,12 +50,16 @@ describe('IncidentsFilter', () => {
       screen.getByRole('combobox', {name: /filter by incident type/i}),
     );
     expect(
-      screen.getByRole('option', {name: 'Condition error'}),
+      screen.getByRole('option', {name: 'Condition error.'}),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('option', {name: 'Extract value error'}),
+      screen.getByRole('option', {name: 'Extract value error.'}),
     ).toBeInTheDocument();
 
+    if (IS_INCIDENTS_PANEL_V2) {
+      // TODO: V2 has no flow node filter. Remove code below with full v2 migration in issue https://github.com/camunda/camunda/issues/39548
+      return;
+    }
     await user.click(
       screen.getByRole('combobox', {name: /filter by flow node/i}),
     );
@@ -84,14 +89,14 @@ describe('IncidentsFilter', () => {
 
     await user.click(
       screen.getByRole('option', {
-        name: 'Condition error',
+        name: 'Condition error.',
       }),
     );
     expect(screen.getByRole('button', {name: 'Reset Filters'})).toBeEnabled();
 
     expect(
       screen.getByRole('option', {
-        name: 'Condition error',
+        name: 'Condition error.',
         selected: true,
       }),
     ).toBeInTheDocument();

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.test.tsx
@@ -18,13 +18,12 @@ import {
   createUser,
 } from 'modules/testUtils';
 import {mockMe} from 'modules/mocks/api/v2/me';
-import {IS_INCIDENTS_PANEL_V2} from 'modules/feature-flags';
 import {getIncidentErrorName} from 'modules/utils/incidents';
 
 const firstIncidentErrorName = getIncidentErrorName(firstIncident.errorType);
 const secondIncidentErrorName = getIncidentErrorName(secondIncident.errorType);
 
-describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
+describe('IncidentsTable', () => {
   beforeEach(() => {
     mockFetchProcessInstance().withSuccess(
       createInstance({permissions: ['UPDATE_PROCESS_INSTANCE']}),
@@ -223,6 +222,33 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
         description: `View root cause instance ${firstIncident.processDefinitionName} - ${firstIncident.processInstanceKey}`,
       }),
     ).toBeInTheDocument();
+  });
+
+  it('should provide a retry operation for incidents in the open process instance', async () => {
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        incidents={[
+          {...firstIncident, processInstanceKey: '1'},
+          {...secondIncident, processInstanceKey: '2'},
+        ]}
+      />,
+      {wrapper: Wrapper},
+    );
+    let firstIncidentRow = within(
+      screen.getByRole('row', {name: new RegExp(firstIncidentErrorName)}),
+    );
+    let secondIncidentRow = within(
+      screen.getByRole('row', {name: new RegExp(secondIncidentErrorName)}),
+    );
+
+    expect(
+      await firstIncidentRow.findByRole('button', {name: 'Retry Incident'}),
+    ).toBeInTheDocument();
+    expect(
+      secondIncidentRow.queryByRole('button', {name: 'Retry Incident'}),
+    ).not.toBeInTheDocument();
   });
 
   it('should show a more button for long error messages', () => {

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.test.tsx
@@ -17,9 +17,12 @@ import {
   createProcessInstance,
   createUser,
 } from 'modules/testUtils';
-import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {IS_INCIDENTS_PANEL_V2} from 'modules/feature-flags';
+import {getIncidentErrorName} from 'modules/utils/incidents';
+
+const firstIncidentErrorName = getIncidentErrorName(firstIncident.errorType);
+const secondIncidentErrorName = getIncidentErrorName(secondIncident.errorType);
 
 describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
   beforeEach(() => {
@@ -34,8 +37,6 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
   });
 
   it('should render incident details', async () => {
-    mockFetchProcessDefinitionXml().withSuccess('');
-
     render(
       <IncidentsTable
         state="content"
@@ -45,12 +46,10 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
       {wrapper: Wrapper},
     );
     let withinRow = within(
-      screen.getByRole('row', {
-        name: new RegExp(firstIncident.errorType),
-      }),
+      screen.getByRole('row', {name: new RegExp(firstIncidentErrorName)}),
     );
 
-    expect(withinRow.getByText(firstIncident.errorType)).toBeInTheDocument();
+    expect(withinRow.getByText(firstIncidentErrorName)).toBeInTheDocument();
     expect(withinRow.getByText(firstIncident.elementName)).toBeInTheDocument();
     expect(withinRow.getByText(firstIncident.jobKey!)).toBeInTheDocument();
     expect(
@@ -58,19 +57,12 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
     ).toBeInTheDocument();
     expect(withinRow.getByText(firstIncident.errorMessage)).toBeInTheDocument();
     expect(
-      withinRow.getByRole('link', {
-        description: /view root cause instance/i,
-      }),
-    ).toBeInTheDocument();
-    expect(
       withinRow.queryByRole('button', {name: 'Retry Incident'}),
     ).not.toBeInTheDocument();
     withinRow = within(
-      screen.getByRole('row', {
-        name: new RegExp(secondIncident.errorType),
-      }),
+      screen.getByRole('row', {name: new RegExp(secondIncidentErrorName)}),
     );
-    expect(withinRow.getByText(secondIncident.errorType)).toBeInTheDocument();
+    expect(withinRow.getByText(secondIncidentErrorName)).toBeInTheDocument();
     expect(withinRow.getByText(secondIncident.elementName)).toBeInTheDocument();
     expect(withinRow.getByText(secondIncident.jobKey!)).toBeInTheDocument();
     expect(
@@ -85,8 +77,6 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
   });
 
   it('should render the right column headers', async () => {
-    mockFetchProcessDefinitionXml().withSuccess('');
-
     render(
       <IncidentsTable
         state="content"
@@ -97,16 +87,14 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
     );
 
     expect(screen.getByText('Incident Type')).toBeInTheDocument();
-    expect(screen.getByText('Failing Flow Node')).toBeInTheDocument();
+    expect(screen.getByText('Failing Element')).toBeInTheDocument();
     expect(screen.getByText('Job Id')).toBeInTheDocument();
     expect(screen.getByText('Creation Date')).toBeInTheDocument();
     expect(screen.getByText('Error Message')).toBeInTheDocument();
     expect(await screen.findByText('Operations')).toBeInTheDocument();
-    expect(screen.getByText('Root Cause Instance')).toBeInTheDocument();
   });
 
   it('should render the right column headers for restricted user', async () => {
-    mockFetchProcessDefinitionXml().withSuccess('');
     mockMe().withSuccess(createUser());
 
     render(
@@ -119,16 +107,14 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
     );
 
     expect(screen.getByText('Incident Type')).toBeInTheDocument();
-    expect(screen.getByText('Failing Flow Node')).toBeInTheDocument();
+    expect(screen.getByText('Failing Element')).toBeInTheDocument();
     expect(screen.getByText('Job Id')).toBeInTheDocument();
     expect(screen.getByText('Creation Date')).toBeInTheDocument();
     expect(screen.getByText('Error Message')).toBeInTheDocument();
     expect(await screen.findByText('Operations')).toBeInTheDocument();
-    expect(screen.getByText('Root Cause Instance')).toBeInTheDocument();
   });
 
   it('should render the right column headers for restricted user (with resource-based permissions)', () => {
-    mockFetchProcessDefinitionXml().withSuccess('');
     mockMe().withSuccess(createUser());
     vi.stubGlobal('clientConfig', {
       resourcePermissionsEnabled: true,
@@ -144,16 +130,14 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
     );
 
     expect(screen.getByText('Incident Type')).toBeInTheDocument();
-    expect(screen.getByText('Failing Flow Node')).toBeInTheDocument();
+    expect(screen.getByText('Failing Element')).toBeInTheDocument();
     expect(screen.getByText('Job Id')).toBeInTheDocument();
     expect(screen.getByText('Creation Date')).toBeInTheDocument();
     expect(screen.getByText('Error Message')).toBeInTheDocument();
     expect(screen.queryByText('Operations')).not.toBeInTheDocument();
-    expect(screen.getByText('Root Cause Instance')).toBeInTheDocument();
   });
 
   it('should render incident details (with resource-based permissions enabled)', () => {
-    mockFetchProcessDefinitionXml().withSuccess('');
     mockMe().withSuccess(createUser());
     vi.stubGlobal('clientConfig', {
       resourcePermissionsEnabled: true,
@@ -168,34 +152,25 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
       {wrapper: Wrapper},
     );
     let withinRow = within(
-      screen.getByRole('row', {
-        name: new RegExp(firstIncident.errorType),
-      }),
+      screen.getByRole('row', {name: new RegExp(firstIncidentErrorName)}),
     );
 
-    expect(withinRow.getByText(firstIncident.errorType)).toBeInTheDocument();
+    expect(withinRow.getByText(firstIncidentErrorName)).toBeInTheDocument();
     expect(withinRow.getByText(firstIncident.elementName)).toBeInTheDocument();
     expect(withinRow.getByText(firstIncident.jobKey!)).toBeInTheDocument();
     expect(
       withinRow.getByText(formatDate(firstIncident.creationTime) || '--'),
     ).toBeInTheDocument();
     expect(withinRow.getByText(firstIncident.errorMessage)).toBeInTheDocument();
-
-    expect(
-      withinRow.getByRole('link', {
-        description: /view root cause instance/i,
-      }),
-    ).toBeInTheDocument();
     expect(
       withinRow.queryByRole('button', {name: 'Retry Incident'}),
     ).not.toBeInTheDocument();
 
     withinRow = within(
-      screen.getByRole('row', {
-        name: new RegExp(secondIncident.errorType),
-      }),
+      screen.getByRole('row', {name: new RegExp(secondIncidentErrorName)}),
     );
-    expect(withinRow.getByText(secondIncident.errorType)).toBeInTheDocument();
+
+    expect(withinRow.getByText(secondIncidentErrorName)).toBeInTheDocument();
     expect(withinRow.getByText(secondIncident.elementName)).toBeInTheDocument();
     expect(withinRow.getByText(secondIncident.jobKey!)).toBeInTheDocument();
     expect(
@@ -207,15 +182,9 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
     expect(
       withinRow.queryByRole('button', {name: 'Retry Incident'}),
     ).not.toBeInTheDocument();
-    expect(
-      withinRow.queryByRole('link', {
-        description: /view root cause instance/i,
-      }),
-    ).not.toBeInTheDocument();
   });
 
   it('should display -- for jobKey', () => {
-    mockFetchProcessDefinitionXml().withSuccess('');
     const incidentMock = {...firstIncident, jobKey: ''};
     const incidents = [incidentMock];
 
@@ -229,16 +198,34 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
     );
 
     let withinFirstRow = within(
-      screen.getByRole('row', {
-        name: new RegExp(incidentMock.errorType),
-      }),
+      screen.getByRole('row', {name: new RegExp(firstIncidentErrorName)}),
     );
 
     expect(withinFirstRow.getByText('--')).toBeInTheDocument();
   });
 
+  it('should provide a link for incidents in child process instances', () => {
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="7"
+        incidents={incidentsMock}
+      />,
+      {wrapper: Wrapper},
+    );
+    let withinRow = within(
+      screen.getByRole('row', {name: new RegExp(firstIncidentErrorName)}),
+    );
+
+    expect(
+      withinRow.getByRole('link', {
+        name: `${firstIncident.elementId} - ${firstIncident.processDefinitionName} - ${firstIncident.processInstanceKey}`,
+        description: `View root cause instance ${firstIncident.processDefinitionName} - ${firstIncident.processInstanceKey}`,
+      }),
+    ).toBeInTheDocument();
+  });
+
   it('should show a more button for long error messages', () => {
-    mockFetchProcessDefinitionXml().withSuccess('');
     render(
       <IncidentsTable
         state="content"
@@ -248,24 +235,19 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
       {wrapper: Wrapper},
     );
     let withinFirstRow = within(
-      screen.getByRole('row', {
-        name: new RegExp(firstIncident.errorType),
-      }),
+      screen.getByRole('row', {name: new RegExp(firstIncidentErrorName)}),
     );
 
     expect(withinFirstRow.queryByText('More')).not.toBeInTheDocument();
 
     let withinSecondRow = within(
-      screen.getByRole('row', {
-        name: new RegExp(secondIncident.errorType),
-      }),
+      screen.getByRole('row', {name: new RegExp(secondIncidentErrorName)}),
     );
 
     expect(withinSecondRow.getByText('More')).toBeInTheDocument();
   });
 
   it('should open an modal when clicking on the more button', async () => {
-    mockFetchProcessDefinitionXml().withSuccess('');
     const {user} = render(
       <IncidentsTable
         state="content"
@@ -276,9 +258,7 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
     );
 
     let withinSecondRow = within(
-      screen.getByRole('row', {
-        name: new RegExp(secondIncident.errorType),
-      }),
+      screen.getByRole('row', {name: new RegExp(secondIncidentErrorName)}),
     );
 
     expect(withinSecondRow.getByText('More')).toBeInTheDocument();
@@ -293,9 +273,7 @@ describe('IncidentsTable', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
       await within(modal).findByTestId('monaco-editor'),
     ).toBeInTheDocument();
     expect(
-      within(modal).getByText(
-        `Flow Node "${secondIncident.elementName}" Error`,
-      ),
+      within(modal).getByText(`Element "${secondIncident.elementName}" Error`),
     ).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/mocks.tsx
@@ -45,15 +45,16 @@ const longError =
 
 const firstIncident = createEnhancedIncidentV2({
   errorType: 'IO_MAPPING_ERROR',
+  processInstanceKey: '1',
   errorMessage: shortError,
   elementId: 'StartEvent_1',
   elementInstanceKey: '18239123812938',
-  processInstanceKey: '111111111111111111',
   processDefinitionId: 'calledInstance',
 });
 
 const secondIncident = createEnhancedIncidentV2({
   errorType: 'CALLED_DECISION_ERROR',
+  processInstanceKey: '1',
   errorMessage: longError,
   elementId: 'Event_1db567d',
   elementInstanceKey: id,

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/selection.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/selection.test.tsx
@@ -7,80 +7,57 @@
  */
 
 import {IncidentsTable} from '.';
-import {
-  createEnhancedIncidentV2,
-  createInstance,
-  createProcessInstance,
-} from 'modules/testUtils';
+import {createInstance, createProcessInstance} from 'modules/testUtils';
 import {render, screen} from 'modules/testing-library';
-import {Wrapper, firstIncident} from './mocks';
-import {selectFlowNode} from 'modules/utils/flowNodeSelection';
+import {Wrapper, firstIncident, secondIncident} from './mocks';
+import * as selectionUtils from 'modules/utils/flowNodeSelection';
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
-import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
-import {IS_INCIDENTS_PANEL_V2} from 'modules/feature-flags';
 
-// TODO: This test will no longer work because the selection state if an incident is
-// stored on the incident for rendering. Since they are now passed as prop, they
-// are not controlled by the "flowNodeSelectionStore" in this test.
-// Do we have to move away from passing data as props?
+// TanStack query is still fetching the data when the test executes, so "useRootNode"
+// falls back to undefined for the flowNodeInstanceId.
+const rootNode = {flowNodeInstanceId: undefined, isMultiInstance: false};
 
-describe('Selection', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
-  it('should deselect selected incident', async () => {
+describe('Selection', () => {
+  beforeEach(() => {
     mockFetchProcessInstance().withSuccess(createInstance());
-    mockFetchProcessDefinitionXml().withSuccess('');
     mockFetchProcessInstanceV2().withSuccess(
       createProcessInstance({
         hasIncident: true,
       }),
     );
-    selectFlowNode(
-      {},
-      {
-        flowNodeId: firstIncident.elementId,
-        isMultiInstance: false,
-      },
-    );
+  });
+
+  it('should deselect selected incident', async () => {
+    const spy = vi.spyOn(selectionUtils, 'clearSelection');
 
     const {user} = render(
       <IncidentsTable
         state="content"
         processInstanceKey="1"
-        incidents={[firstIncident]}
+        incidents={[{...firstIncident, isSelected: true}]}
       />,
       {wrapper: Wrapper},
     );
     expect(screen.getByRole('row', {selected: true})).toBeInTheDocument();
 
     await user.click(screen.getByRole('row', {selected: true}));
-    expect(screen.getByRole('row', {selected: false})).toBeInTheDocument();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(rootNode);
   });
 
   it('should select single incident when multiple incidents are selected', async () => {
-    mockFetchProcessInstance().withSuccess(createInstance());
-    mockFetchProcessDefinitionXml().withSuccess('');
-    mockFetchProcessInstanceV2().withSuccess(
-      createProcessInstance({
-        hasIncident: true,
-      }),
-    );
-    const incidents = [
-      createEnhancedIncidentV2({elementId: 'myTask'}),
-      createEnhancedIncidentV2({elementId: 'myTask'}),
-    ];
-    selectFlowNode(
-      {},
-      {
-        flowNodeId: 'myTask',
-        isMultiInstance: false,
-      },
-    );
+    const spy = vi.spyOn(selectionUtils, 'selectFlowNode');
 
     const {user} = render(
       <IncidentsTable
         state="content"
         processInstanceKey="1"
-        incidents={incidents}
+        incidents={[
+          {...firstIncident, isSelected: true, errorType: 'CONDITION_ERROR'},
+          {...secondIncident, isSelected: true, errorType: 'CONDITION_ERROR'},
+        ]}
       />,
       {wrapper: Wrapper},
     );
@@ -91,19 +68,13 @@ describe('Selection', {skip: !IS_INCIDENTS_PANEL_V2}, () => {
     });
 
     expect(firstRow).toBeInTheDocument();
-    await user.click(firstRow!);
+    await user.click(firstRow);
 
-    expect(
-      screen.getByRole('row', {
-        name: /condition error/i,
-        selected: true,
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('row', {
-        name: /condition error/i,
-        selected: false,
-      }),
-    ).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(rootNode, {
+      flowNodeId: firstIncident.elementId,
+      flowNodeInstanceId: firstIncident.elementInstanceKey,
+      isMultiInstance: false,
+    });
   });
 });

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/sorting.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/sorting.test.tsx
@@ -11,7 +11,6 @@ import {createInstance, createProcessInstance} from 'modules/testUtils';
 import {render, screen} from 'modules/testing-library';
 import {Wrapper, firstIncident, incidentsMock} from './mocks';
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
-import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 
 describe('Sorting', () => {
@@ -19,7 +18,6 @@ describe('Sorting', () => {
     mockFetchProcessInstance().withSuccess(
       createInstance({permissions: ['UPDATE_PROCESS_INSTANCE']}),
     );
-    mockFetchProcessDefinitionXml().withSuccess('');
     mockFetchProcessInstanceV2().withSuccess(
       createProcessInstance({
         hasIncident: true,

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/filtering.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/filtering.test.tsx
@@ -17,8 +17,9 @@ import {createInstance, createProcessInstance} from 'modules/testUtils';
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockProcessInstance} from 'modules/mocks/api/v2/mocks/processInstance';
+import {IS_INCIDENTS_PANEL_V2} from 'modules/feature-flags';
 
-describe('Filtering', () => {
+describe('Filtering', {skip: IS_INCIDENTS_PANEL_V2}, () => {
   beforeEach(async () => {
     mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);
     mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/index.test.tsx
@@ -16,8 +16,9 @@ import {createInstance, createProcessInstance} from 'modules/testUtils';
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockProcessInstance} from 'modules/mocks/api/v2/mocks/processInstance';
+import {IS_INCIDENTS_PANEL_V2} from 'modules/feature-flags';
 
-describe('IncidentsFilter', () => {
+describe('IncidentsWrapper', {skip: IS_INCIDENTS_PANEL_V2}, () => {
   beforeEach(async () => {
     mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);
     mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/sorting.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/sorting.test.tsx
@@ -16,8 +16,9 @@ import {createInstance, createProcessInstance} from 'modules/testUtils';
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockProcessInstance} from 'modules/mocks/api/v2/mocks/processInstance';
+import {IS_INCIDENTS_PANEL_V2} from 'modules/feature-flags';
 
-describe('Sorting', () => {
+describe('Sorting', {skip: IS_INCIDENTS_PANEL_V2}, () => {
   beforeEach(async () => {
     mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);
     mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);

--- a/operate/client/src/App/ProcessInstance/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/tests/index.test.tsx
@@ -10,7 +10,6 @@ import {render, screen, waitFor, within} from 'modules/testing-library';
 import {testData} from './index.setup';
 import {ProcessInstance} from '../index';
 import {storeStateLocally} from 'modules/utils/localStorage';
-import {incidentsStore} from 'modules/stores/incidents';
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import * as flowNodeInstanceUtils from 'modules/utils/flowNodeInstance';
 import {mockFetchProcessInstance as mockFetchProcessInstanceDeprecated} from 'modules/mocks/api/processInstances/fetchProcessInstance';
@@ -27,7 +26,6 @@ import {act} from 'react';
 vi.mock('modules/utils/bpmn');
 
 const clearPollingStates = () => {
-  incidentsStore.isPollRequestRunning = false;
   flowNodeInstanceStore.isPollRequestRunning = false;
 };
 
@@ -207,8 +205,6 @@ describe('ProcessInstance', () => {
   it('should stop polling if document is not visible', async () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
 
-    const handlePollingIncidentsSpy = vi.spyOn(incidentsStore, 'handlePolling');
-
     const initFlowNodeInstanceSpy = vi.spyOn(flowNodeInstanceUtils, 'init');
     const startPollingFlowNodeInstanceSpy = vi.spyOn(
       flowNodeInstanceUtils,
@@ -218,7 +214,6 @@ describe('ProcessInstance', () => {
     mockRequests();
     render(<ProcessInstance />, {wrapper: getWrapper()});
 
-    expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(0);
     expect(initFlowNodeInstanceSpy).toHaveBeenCalledTimes(0);
 
     clearPollingStates();
@@ -231,9 +226,6 @@ describe('ProcessInstance', () => {
     act(() => {
       vi.runOnlyPendingTimers();
     });
-    await waitFor(() =>
-      expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1),
-    );
 
     await waitFor(() => {
       expect(flowNodeInstanceStore.state.status).toBe('fetched');
@@ -246,14 +238,11 @@ describe('ProcessInstance', () => {
 
     vi.runOnlyPendingTimers();
 
-    expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1);
-
     clearPollingStates();
     mockRequests();
 
     vi.runOnlyPendingTimers();
 
-    expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1);
     expect(startPollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(0);
 
     mockRequests();
@@ -264,10 +253,6 @@ describe('ProcessInstance', () => {
     mockRequests();
 
     vi.runOnlyPendingTimers();
-
-    await waitFor(() => {
-      expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(3);
-    });
 
     await waitFor(() => {
       expect(startPollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(1);
@@ -283,8 +268,6 @@ describe('ProcessInstance', () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
     triggerVisibilityChange('hidden');
 
-    const handlePollingIncidentsSpy = vi.spyOn(incidentsStore, 'handlePolling');
-
     const initFlowNodeInstanceSpy = vi.spyOn(flowNodeInstanceUtils, 'init');
     const startPollingFlowNodeInstanceSpy = vi.spyOn(
       flowNodeInstanceUtils,
@@ -295,7 +278,6 @@ describe('ProcessInstance', () => {
 
     mockRequests();
 
-    expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(0);
     expect(initFlowNodeInstanceSpy).toHaveBeenCalledTimes(0);
 
     clearPollingStates();
@@ -303,7 +285,6 @@ describe('ProcessInstance', () => {
       await vi.runOnlyPendingTimersAsync();
     });
 
-    expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(0);
     expect(initFlowNodeInstanceSpy).toHaveBeenCalledTimes(1);
 
     triggerVisibilityChange('visible');
@@ -314,18 +295,11 @@ describe('ProcessInstance', () => {
       await vi.runOnlyPendingTimersAsync();
     });
 
-    await waitFor(() => {
-      expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(2);
-    });
-
     mockRequests();
     await act(async () => {
       await vi.runOnlyPendingTimersAsync();
     });
 
-    await waitFor(() => {
-      expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(3);
-    });
     expect(startPollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(1);
 
     await waitForPollingsToBeComplete();
@@ -341,8 +315,6 @@ describe('ProcessInstance', () => {
 
     vi.useFakeTimers({shouldAdvanceTime: true});
 
-    const handlePollingIncidentsSpy = vi.spyOn(incidentsStore, 'handlePolling');
-
     const handlePollingFlowNodeInstanceSpy = vi.spyOn(
       flowNodeInstanceStore,
       'pollInstances',
@@ -352,7 +324,6 @@ describe('ProcessInstance', () => {
 
     mockRequests();
 
-    expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(0);
 
     triggerVisibilityChange('hidden');
@@ -362,7 +333,6 @@ describe('ProcessInstance', () => {
 
     vi.runOnlyPendingTimers();
 
-    expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(0);
 
     vi.clearAllTimers();

--- a/operate/client/src/App/ProcessInstance/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/tests/mocks.tsx
@@ -27,7 +27,6 @@ import {useEffect} from 'react';
 import {waitFor} from '@testing-library/react';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import {sequenceFlowsStore} from 'modules/stores/sequenceFlows';
-import {incidentsStore} from 'modules/stores/incidents';
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import {mockFetchProcess} from 'modules/mocks/api/processes/fetchProcess';
 import {mockProcess} from 'modules/mocks/api/mocks/process';
@@ -138,6 +137,10 @@ const mockRequests = () => {
     items: [],
     page: {totalItems: 0},
   });
+  mockSearchIncidentsByProcessInstance('4294980768').withSuccess({
+    items: [],
+    page: {totalItems: 0},
+  });
   mockFetchProcess().withSuccess(mockProcess);
   mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
 };
@@ -228,7 +231,6 @@ const waitForPollingsToBeComplete = async () => {
   await waitFor(() => {
     expect(processInstanceDetailsStore.isPollRequestRunning).toBe(false);
     expect(sequenceFlowsStore.isPollRequestRunning).toBe(false);
-    expect(incidentsStore.isPollRequestRunning).toBe(false);
     expect(flowNodeInstanceStore.isPollRequestRunning).toBe(false);
   });
 };

--- a/operate/client/src/App/ProcessInstance/tests/modifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/tests/modifications.test.tsx
@@ -20,7 +20,6 @@ import {
   createvariable,
 } from 'modules/testUtils';
 import {storeStateLocally} from 'modules/utils/localStorage';
-import {incidentsStore} from 'modules/stores/incidents';
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import * as flowNodeInstanceUtils from 'modules/utils/flowNodeInstance';
 import {singleInstanceMetadata} from 'modules/mocks/metadata';
@@ -40,7 +39,6 @@ import {mockMe} from 'modules/mocks/api/v2/me';
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 
 const clearPollingStates = () => {
-  incidentsStore.isPollRequestRunning = false;
   flowNodeInstanceStore.isPollRequestRunning = false;
 };
 
@@ -272,8 +270,6 @@ describe('ProcessInstance - modification mode', () => {
   it('should stop polling during the modification mode', async () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
 
-    const handlePollingIncidentsSpy = vi.spyOn(incidentsStore, 'handlePolling');
-
     const initFlowNodeInstanceSpy = vi.spyOn(flowNodeInstanceUtils, 'init');
     const startPollingFlowNodeInstanceSpy = vi.spyOn(
       flowNodeInstanceUtils,
@@ -287,7 +283,6 @@ describe('ProcessInstance - modification mode', () => {
       [`hideModificationHelperModal`]: true,
     });
 
-    expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(0);
     expect(initFlowNodeInstanceSpy).toHaveBeenCalledTimes(0);
 
     clearPollingStates();
@@ -296,9 +291,6 @@ describe('ProcessInstance - modification mode', () => {
     });
     await act(async () => {
       await vi.runOnlyPendingTimersAsync();
-    });
-    await waitFor(() => {
-      expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1);
     });
     expect(initFlowNodeInstanceSpy).toHaveBeenCalledTimes(1);
 
@@ -324,16 +316,12 @@ describe('ProcessInstance - modification mode', () => {
       await vi.runOnlyPendingTimersAsync();
     });
 
-    expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1);
-
     clearPollingStates();
     mockRequests();
 
     await act(async () => {
       await vi.runOnlyPendingTimersAsync();
     });
-
-    expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1);
 
     mockRequests();
     await user.click(screen.getByTestId('discard-all-button'));

--- a/operate/client/src/modules/components/IncidentOperation/index.test.tsx
+++ b/operate/client/src/modules/components/IncidentOperation/index.test.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from 'modules/testing-library';
+import {IncidentOperationV2} from '.';
+import {notificationsStore} from 'modules/stores/notifications';
+import {mockResolveIncident} from 'modules/mocks/api/v2/incidents/resolveIncident';
+import {tracking} from 'modules/tracking';
+import {mockUpdateJob} from 'modules/mocks/api/v2/jobs/updateJob';
+
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
+
+const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+  return (
+    <QueryClientProvider client={getMockQueryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+};
+
+describe('IncidentOperationV2', () => {
+  const retryButton = () =>
+    screen.getByRole('button', {
+      name: 'Retry Incident',
+    });
+
+  it('should display an notification when retrying an incident fails', async () => {
+    mockResolveIncident().withServerError(500);
+    const {user} = render(<IncidentOperationV2 incidentKey="123" />, {
+      wrapper: Wrapper,
+    });
+
+    await user.click(retryButton());
+
+    expect(notificationsStore.displayNotification).toHaveBeenCalledTimes(1);
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+      kind: 'error',
+      title: 'Incident could not be resolved',
+      isDismissable: true,
+    });
+  });
+
+  it('should track successful retry operations', async () => {
+    mockResolveIncident().withSuccess(null);
+    const spy = vi.spyOn(tracking, 'track').mockReturnValue();
+    const {user} = render(<IncidentOperationV2 incidentKey="123" />, {
+      wrapper: Wrapper,
+    });
+
+    await user.click(retryButton());
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith({
+      eventName: 'single-operation',
+      operationType: 'RESOLVE_INCIDENT',
+      source: 'incident-table',
+    });
+  });
+
+  it('should update job retries before resolving incidents with jobKeys', async () => {
+    const updateSpy = vi.fn();
+    mockUpdateJob().withSuccess(null, {mockResolverFn: updateSpy});
+    const resolveSpy = vi.fn();
+    mockResolveIncident().withSuccess(null, {mockResolverFn: resolveSpy});
+    const {user} = render(
+      <IncidentOperationV2 incidentKey="123" jobKey="456" />,
+      {wrapper: Wrapper},
+    );
+
+    await user.click(retryButton());
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledBefore(resolveSpy);
+  });
+
+  it('should not resolve incidents when updating the related job fails', async () => {
+    mockUpdateJob().withServerError(500);
+    const resolveSpy = vi.fn();
+    mockResolveIncident().withSuccess(null, {mockResolverFn: resolveSpy});
+    const {user} = render(
+      <IncidentOperationV2 incidentKey="123" jobKey="456" />,
+      {wrapper: Wrapper},
+    );
+
+    await user.click(retryButton());
+
+    expect(notificationsStore.displayNotification).toHaveBeenCalledTimes(1);
+    expect(resolveSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should show a spinner and disable the button while the operation is pending', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    mockUpdateJob().withDelay(null);
+    mockResolveIncident().withDelay(null);
+    const {user} = render(<IncidentOperationV2 incidentKey="123" />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.queryByTestId('operation-spinner')).not.toBeInTheDocument();
+
+    await user.click(retryButton());
+
+    expect(retryButton()).toBeDisabled();
+    expect(screen.getByTestId('operation-spinner')).toBeInTheDocument();
+
+    vi.runOnlyPendingTimers();
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('operation-spinner'),
+    );
+
+    expect(retryButton()).toBeEnabled();
+    expect(screen.queryByTestId('operation-spinner')).not.toBeInTheDocument();
+    vi.useRealTimers();
+  });
+});

--- a/operate/client/src/modules/mocks/api/mockRequest.ts
+++ b/operate/client/src/modules/mocks/api/mockRequest.ts
@@ -170,6 +170,71 @@ const mockPutRequest = function <Type extends DefaultBodyType>(url: string) {
   };
 };
 
+const mockPatchRequest = function <Type extends DefaultBodyType>(url: string) {
+  return {
+    withSuccess: (
+      responseData: Type,
+      options?: {
+        mockResolverFn?: ReturnType<typeof vi.fn>;
+      },
+    ) => {
+      mockServer.use(
+        http.patch(
+          url,
+          () => {
+            options?.mockResolverFn?.();
+            return HttpResponse.json(responseData);
+          },
+          {once: true},
+        ),
+      );
+    },
+    withServerError: (statusCode: number = 500) => {
+      mockServer.use(
+        http.patch(
+          url,
+          () =>
+            HttpResponse.json(
+              {error: 'an error occurred'},
+              {status: statusCode},
+            ),
+          {once: true},
+        ),
+      );
+    },
+    withDelayedServerError: (statusCode: number = 500) => {
+      mockServer.use(
+        http.patch(
+          url,
+          async () => {
+            await delay(100);
+            return HttpResponse.json(
+              {error: 'an error occurred'},
+              {status: statusCode},
+            );
+          },
+          {once: true},
+        ),
+      );
+    },
+    withNetworkError: () => {
+      mockServer.use(http.patch(url, () => HttpResponse.error()));
+    },
+    withDelay: (responseData: Type) => {
+      mockServer.use(
+        http.patch(
+          url,
+          async () => {
+            await delay(100);
+            return HttpResponse.json(responseData);
+          },
+          {once: true},
+        ),
+      );
+    },
+  };
+};
+
 const mockGetRequest = function <Type extends DefaultBodyType>(url: string) {
   return {
     /**
@@ -318,5 +383,6 @@ export {
   mockXmlGetRequest,
   mockDeleteRequest,
   mockPutRequest,
+  mockPatchRequest,
   checkPollingHeader,
 };

--- a/operate/client/src/modules/mocks/api/mockRequest.ts
+++ b/operate/client/src/modules/mocks/api/mockRequest.ts
@@ -244,11 +244,18 @@ const mockGetRequest = function <Type extends DefaultBodyType>(url: string) {
      *
      * Otherwise an error will be thrown
      */
-    withSuccess: (responseData: Type, options?: {expectPolling?: boolean}) => {
+    withSuccess: (
+      responseData: Type,
+      options?: {
+        expectPolling?: boolean;
+        mockResolverFn?: ReturnType<typeof vi.fn>;
+      },
+    ) => {
       mockServer.use(
         http.get(
           url,
           ({request}) => {
+            options?.mockResolverFn?.();
             checkPollingHeader({
               req: request,
               expectPolling: options?.expectPolling,

--- a/operate/client/src/modules/mocks/api/v2/incidents/getIncident.ts
+++ b/operate/client/src/modules/mocks/api/v2/incidents/getIncident.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockGetRequest} from '../../mockRequest';
+import {
+  endpoints,
+  type GetIncidentResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+
+const mockGetIncident = (incidentKey = ':incidentKey') =>
+  mockGetRequest<GetIncidentResponseBody>(
+    `${endpoints.getIncident.getUrl({incidentKey})}`,
+  );
+
+export {mockGetIncident};

--- a/operate/client/src/modules/mocks/api/v2/incidents/resolveIncident.ts
+++ b/operate/client/src/modules/mocks/api/v2/incidents/resolveIncident.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPostRequest} from '../../mockRequest';
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
+
+const mockResolveIncident = (incidentKey = ':incidentKey') =>
+  mockPostRequest<null>(`${endpoints.resolveIncident.getUrl({incidentKey})}`);
+
+export {mockResolveIncident};

--- a/operate/client/src/modules/mocks/api/v2/jobs/updateJob.ts
+++ b/operate/client/src/modules/mocks/api/v2/jobs/updateJob.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPatchRequest} from '../../mockRequest';
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
+
+const mockUpdateJob = (jobKey = ':jobKey') =>
+  mockPatchRequest<null>(`${endpoints.updateJob.getUrl({jobKey})}`);
+
+export {mockUpdateJob};


### PR DESCRIPTION
## Description

Adjust the unit tests to pass with the `IS_INCIDENTS_PANEL_V2` feature flag both enabled and disabled. The tests for the `IncidentsWrapper` couldn't easily be adjusted to pass with both states of the flag. They are skipped for now and must be updated when the feature becomes the default.

Furthermore, I notices that we do not have tests that cover `IncidentOperation` v1 or v2. The [last commit](https://github.com/camunda/camunda/pull/40604/commits/a69fe76cea809eb5966fca8d0917e683277686ad) adds tests for the `IncidentOperationV2` component and its underlying TanStack mutation.

## Checklist

- [ ] Notice that this PR is stacked on #39945


## Related issues

relates #39548
