### PR TITLE
ci: disable spring boot minor updates on stable branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -112,24 +112,6 @@
       ]
     },
     {
-      "description": "Allow minor updates for Spring and Spring-boot for stable branches where the Spring support window is not matching the Camunda support window yet. Right now these are 8.6+. Since Spring has a 1-year support cycle while C8 is supported for 18 months, we allow minor updates to help mitigate security risks.",
-      "matchBaseBranches": [
-        "/^stable\\/8\\.([6-9]|\\d\\d)/",
-        "stable/operate-8.5"
-      ],
-      "matchManagers": [
-        "maven"
-      ],
-      "matchPackageNames": [
-        "org.springframework**"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "enabled": true
-    },
-    {
       "matchManagers": [
         "maven"
       ],


### PR DESCRIPTION
## Description

We changed the approach towards only doing that if it needs to be done for a CVE not fixed in a patch for the current minor. 
See https://github.com/camunda/camunda/issues/37112 .

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates #37112
