### PR TITLE
ci: generate cpt coverage frontend into target dir

### DIFF
--- a/testing/camunda-process-test-coverage-frontend/package.json
+++ b/testing/camunda-process-test-coverage-frontend/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "cross-env NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
-    "build": "cross-env BUILD_PATH=../camunda-process-test-java/target/generated-resources/coverage NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
+    "build": "cross-env BUILD_PATH=../camunda-process-test-java/target/generated-frontend-resources/coverage NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/testing/camunda-process-test-coverage-frontend/package.json
+++ b/testing/camunda-process-test-coverage-frontend/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "cross-env NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
-    "build": "cross-env BUILD_PATH=../camunda-process-test-java/src/main/resources/coverage NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
+    "build": "cross-env BUILD_PATH=../camunda-process-test-java/target/generated-resources/coverage NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -178,18 +178,12 @@
       <!-- Regular resources with filtering enabled -->
       <resource>
         <filtering>true</filtering>
-        <directory>target/generated-resources</directory>
-        <excludes>
-          <exclude>coverage/static/media/**</exclude>
-        </excludes>
+        <directory>src/main/resources</directory>
       </resource>
-      <!-- Binary files with filtering disabled -->
+      <!-- Frontend files with filtering disabled -->
       <resource>
         <filtering>false</filtering>
-        <directory>target/generated-resources</directory>
-        <includes>
-          <include>coverage/static/media/**</include>
-        </includes>
+        <directory>target/generated-frontend-resources</directory>
       </resource>
     </resources>
 
@@ -243,7 +237,7 @@
               <arguments>install</arguments>
             </configuration>
           </execution>
-          <!-- Build frontend (output: target/generated-resources/coverage) -->
+          <!-- Build frontend (output: target/generated-frontend-resources/coverage) -->
           <execution>
             <id>npm-build</id>
             <goals>

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -178,7 +178,7 @@
       <!-- Regular resources with filtering enabled -->
       <resource>
         <filtering>true</filtering>
-        <directory>src/main/resources</directory>
+        <directory>target/generated-resources</directory>
         <excludes>
           <exclude>coverage/static/media/**</exclude>
         </excludes>
@@ -186,7 +186,7 @@
       <!-- Binary files with filtering disabled -->
       <resource>
         <filtering>false</filtering>
-        <directory>src/main/resources</directory>
+        <directory>target/generated-resources</directory>
         <includes>
           <include>coverage/static/media/**</include>
         </includes>
@@ -243,7 +243,7 @@
               <arguments>install</arguments>
             </configuration>
           </execution>
-          <!-- Build frontend (output: src/main/resources/coverage) -->
+          <!-- Build frontend (output: target/generated-resources/coverage) -->
           <execution>
             <id>npm-build</id>
             <goals>


### PR DESCRIPTION


## Description

It was added to src which caused build issues when switching to stable branches. Generally generated sources should not end up in `.src/*`.

Build errors caused by this when switching to stable branches were:
```
[INFO] Camunda Process Test Java .......................... FAILURE [  0.264 s]
[INFO] Camunda Process Test Spring ........................ SKIPPED
[INFO] Camunda Process Test Example ....................... SKIPPED
[INFO] Camunda QA ......................................... SUCCESS [  0.103 s]
[INFO] Camunda QA Utilities ............................... SKIPPED
[INFO] Camunda QA Integration Tests ....................... SKIPPED
[INFO] Camunda ArchUnit Tests ............................. SKIPPED
[INFO] Camunda 8 Root ..................................... SUCCESS [  0.035 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.939 s (Wall Clock)
[INFO] Finished at: 2025-11-06T16:10:22+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-resources-plugin:3.3.1:resources (default-resources) on project camunda-process-test-java: filtering /Users/sebastian.bathke/git/camunda/testing/camunda-process-test-java/src/main/resources/coverage/static/media/bootstrap-icons.1295669c.woff to /Users/sebastian.bathke/git/camunda/testing/camunda-process-test-java/target/classes/coverage/static/media/bootstrap-icons.1295669c.woff failed with MalformedInputException: Input length = 1 -> [Help 1]
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
