### PR TITLE
[Backport stable/8.7] fix: allow configuration of max concurrent HTTP Connections in zeebe client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -44,6 +44,11 @@ public final class ClientProperties {
   public static final String PREFER_REST_OVER_GRPC = "zeebe.client.gateway.preferRestOverGrpc";
 
   /**
+   * @see ZeebeClientBuilder#maxHttpConnections(int)
+   */
+  public static final String MAX_HTTP_CONNECTIONS = "camunda.client.gateway.maxHttpConnections";
+
+  /**
    * @see ZeebeClientBuilder#restAddress(URI)
    */
   public static final String REST_ADDRESS = "zeebe.client.gateway.rest.address";

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.zeebe.client;
 
-import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
 import io.camunda.zeebe.client.api.worker.JobHandler;
@@ -242,12 +241,11 @@ public interface ZeebeClientBuilder {
    * <p>NOTE: not all calls can be done over REST (or HTTP/1) yet, this is also subject to change.
    *
    * @param preferRestOverGrpc if true, the client will use REST instead of gRPC whenever possible
-   * @deprecated since 8.5, will be removed in 8.8
-   * @return this builder for chaining
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/16166")
-  @Deprecated
   ZeebeClientBuilder preferRestOverGrpc(final boolean preferRestOverGrpc);
+
+  /** Sets the maximum number of concurrent HTTP connections the client can open. */
+  ZeebeClientBuilder maxHttpConnections(int maxConnections);
 
   /**
    * @return a new {@link ZeebeClient} with the provided configuration options.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.zeebe.client;
 
-import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.grpc.ClientInterceptor;
 import java.net.URI;
@@ -167,6 +166,10 @@ public interface ZeebeClientConfiguration {
   /**
    * @see ZeebeClientBuilder#preferRestOverGrpc(boolean)
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/16166")
   boolean preferRestOverGrpc();
+
+  /**
+   * @see ZeebeClientBuilder#maxHttpConnections(int)
+   */
+  int getMaxHttpConnections();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -292,6 +292,12 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
+  public ZeebeClientBuilder maxHttpConnections(final int maxConnections) {
+    innerBuilder.maxHttpConnections(maxConnections);
+    return this;
+  }
+
+  @Override
   public ZeebeClient build() {
     innerBuilder.grpcAddress(determineGrpcAddress());
     innerBuilder.restAddress(determineRestAddress());

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -61,6 +61,7 @@ import org.apache.hc.core5.http.config.CharCodingConfig;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.net.URIBuilder;
+import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
@@ -135,7 +136,11 @@ public class HttpClientFactory {
             .setHostnameVerifier(hostnameVerifier)
             .build();
     final PoolingAsyncClientConnectionManager connectionManager =
-        PoolingAsyncClientConnectionManagerBuilder.create().setTlsStrategy(tlsStrategy).build();
+        PoolingAsyncClientConnectionManagerBuilder.create()
+            .setTlsStrategy(tlsStrategy)
+            .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.LAX)
+            .setMaxConnPerRoute(config.getMaxHttpConnections())
+            .build();
 
     final HttpAsyncClientBuilder builder =
         HttpAsyncClients.custom()

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -21,6 +21,7 @@ import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT_OFFSET;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID;
 import static io.camunda.zeebe.client.ClientProperties.GRPC_ADDRESS;
+import static io.camunda.zeebe.client.ClientProperties.MAX_HTTP_CONNECTIONS;
 import static io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE;
 import static io.camunda.zeebe.client.ClientProperties.MAX_METADATA_SIZE;
 import static io.camunda.zeebe.client.ClientProperties.PREFER_REST_OVER_GRPC;
@@ -33,11 +34,13 @@ import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.CA_CERTIFICATE
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_GATEWAY_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_GRPC_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MAX_HTTP_CONNECTIONS;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_REST_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_TENANT_ID_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.GRPC_ADDRESS_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.KEEP_ALIVE_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.MAX_HTTP_CONNECTIONS_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.OVERRIDE_AUTHORITY_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.PLAINTEXT_CONNECTION_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.PREFER_REST_VAR;
@@ -113,6 +116,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultJobWorkerTenantIds())
           .containsExactly(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
       assertThat(configuration.preferRestOverGrpc()).isFalse();
+      assertThat(configuration.getMaxHttpConnections()).isEqualTo(DEFAULT_MAX_HTTP_CONNECTIONS);
     }
   }
 
@@ -1014,5 +1018,46 @@ public final class ZeebeClientTest extends ClientTest {
 
     // then
     assertThat(builder.getDefaultRequestTimeoutOffset()).isEqualTo(Duration.ofMillis(100));
+  }
+
+  @Test
+  public void shouldSetMaxHttpConnections() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.maxHttpConnections(1234);
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getMaxHttpConnections()).isEqualTo(1234);
+  }
+
+  @Test
+  public void shouldSetMaxHttpConnectionsWithProperty() {
+    // given
+    final Properties properties = new Properties();
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    properties.setProperty(MAX_HTTP_CONNECTIONS, "1234");
+    builder.withProperties(properties);
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getMaxHttpConnections()).isEqualTo(1234);
+  }
+
+  @Test
+  public void shouldSetMaxHttpConnectionsWithEnv() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    Environment.system().put(MAX_HTTP_CONNECTIONS_VAR, "1234");
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getMaxHttpConnections()).isEqualTo(1234);
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -230,6 +230,11 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
         .orElse(DEFAULT.preferRestOverGrpc());
   }
 
+  @Override
+  public int getMaxHttpConnections() {
+    return camundaClientProperties.getMaxHttpConnections();
+  }
+
   private String composeGatewayAddress() {
     final URI gatewayUrl = getGrpcAddress();
     final int port = gatewayUrl.getPort();

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/CamundaClientProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/CamundaClientProperties.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.zeebe.spring.client.properties;
 
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MAX_HTTP_CONNECTIONS;
+
 import io.camunda.zeebe.spring.client.properties.common.AuthProperties;
 import io.camunda.zeebe.spring.client.properties.common.ZeebeClientProperties;
 import java.util.ArrayList;
@@ -33,6 +35,9 @@ public class CamundaClientProperties {
   private String tenantId;
   @NestedConfigurationProperty private AuthProperties auth = new AuthProperties();
   @NestedConfigurationProperty private ZeebeClientProperties zeebe = new ZeebeClientProperties();
+
+  /** The maximum number of concurrent HTTP connections the client can open. */
+  private int maxHttpConnections = DEFAULT_MAX_HTTP_CONNECTIONS;
 
   @NestedConfigurationProperty
   private CamundaClientCloudProperties cloud = new CamundaClientCloudProperties();
@@ -110,6 +115,14 @@ public class CamundaClientProperties {
     this.region = region;
   }
 
+  public int getMaxHttpConnections() {
+    return maxHttpConnections;
+  }
+
+  public void setMaxHttpConnections(final int maxHttpConnections) {
+    this.maxHttpConnections = maxHttpConnections;
+  }
+
   @Override
   public String toString() {
     return "CamundaClientProperties{"
@@ -122,6 +135,8 @@ public class CamundaClientProperties {
         + auth
         + ", zeebe="
         + zeebe
+        + ", maxHttpConnections="
+        + maxHttpConnections
         + ", cloud="
         + cloud
         + '}';

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
@@ -76,5 +76,6 @@ public class ZeebeClientConfigurationDefaultPropertiesTest {
     assertThat(client.getConfiguration().getRestAddress())
         .isEqualTo(new URI("http://0.0.0.0:8080"));
     assertThat(client.getConfiguration().preferRestOverGrpc()).isFalse();
+    assertThat(client.getConfiguration().getMaxHttpConnections()).isEqualTo(100);
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSaasTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSaasTest.java
@@ -40,7 +40,8 @@ import org.springframework.boot.test.system.OutputCaptureExtension;
       "camunda.client.cloud.cluster-id=12345",
       "camunda.client.cloud.region=bru-2",
       "camunda.client.auth.client-id=my-client-id",
-      "camunda.client.auth.client-secret=my-client-secret"
+      "camunda.client.auth.client-secret=my-client-secret",
+      "camunda.client.max-http-connections=1234"
     })
 @ExtendWith(OutputCaptureExtension.class)
 public class ZeebeClientConfigurationImplSaasTest {
@@ -206,5 +207,10 @@ public class ZeebeClientConfigurationImplSaasTest {
   void shouldHaveDefaultPreferRestOverGrpc() {
     assertThat(zeebeClientConfiguration.preferRestOverGrpc())
         .isEqualTo(DEFAULT.preferRestOverGrpc());
+  }
+
+  @Test
+  public void hasMaxHttpConnections() {
+    assertThat(zeebeClientConfiguration.getMaxHttpConnections()).isEqualTo(1234);
   }
 }


### PR DESCRIPTION
# Description
Backport of #40605 to `stable/8.7`.

relates to #40576