### PR TITLE
Enforce processor naming convention

### DIFF
--- a/qa/archunit-tests/src/test/java/io/camunda/ProcessorNamingArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/ProcessorNamingArchTest.java
@@ -139,8 +139,8 @@ public final class ProcessorNamingArchTest {
                 private static final class NamingCache {
                   private static final Set<String> INTENTS = new HashSet<>();
                   private static final Set<String> VALUE_TYPES = new HashSet<>();
-                  private static final Set<String> WHITELIST = Set.of(
-                  );
+                  private static final Set<String> WHITELIST =
+                      Set.of("BpmnStreamProcessor", "CommandProcessor", "CommandProcessorImpl");
                   private static volatile boolean initialized = false;
 
                   private static void ensureInitialized() {

--- a/qa/archunit-tests/src/test/java/io/camunda/ProcessorNamingArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/ProcessorNamingArchTest.java
@@ -140,7 +140,11 @@ public final class ProcessorNamingArchTest {
                   private static final Set<String> INTENTS = new HashSet<>();
                   private static final Set<String> VALUE_TYPES = new HashSet<>();
                   private static final Set<String> WHITELIST =
-                      Set.of("BpmnStreamProcessor", "CommandProcessor", "CommandProcessorImpl");
+                      Set.of(
+                          "BpmnStreamProcessor", // special case
+                          "CommandProcessor", // will be removed in #40162
+                          "CommandProcessorImpl", // will be removed in #40162
+                          "UserTaskProcessor"); // will be refactored in the future
                   private static volatile boolean initialized = false;
 
                   private static void ensureInitialized() {

--- a/qa/archunit-tests/src/test/java/io/camunda/ProcessorNamingArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/ProcessorNamingArchTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.*;
+
+@AnalyzeClasses(
+    packages = "io.camunda.zeebe.engine",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public final class ProcessorNamingArchTest {
+
+  @ArchTest
+  static final ArchRule REQUIRE_PROCESSORS_TO_FOLLOW_NAMING_CONVENTION =
+      ArchRuleDefinition.classes()
+          .that()
+          .implement(TypedRecordProcessor.class)
+          .or()
+          .implement(CommandProcessor.class)
+          .should(
+              new ArchCondition<>(
+                  "follow the processor naming convention: <ValueType><Intent>Processor") {
+                @Override
+                public void check(final JavaClass item, final ConditionEvents events) {
+                  // The naming convention is that all processors must be named
+                  // <ValueType><Intent>Processor
+                  // where:
+                  // - <ValueType> is the name of the value type being processed (from the
+                  // io.camunda.zeebe.protocol.record.ValueType enum)
+                  // - <Intent> is the name of the intent being processed (from the
+                  // io.camunda.zeebe.protocol.record.intent.<ValueType>Intent enum)
+                  // - "Processor" is the suffix indicating that this class is a processor
+
+                  NamingCache.ensureInitialized();
+
+                  final String simpleName = item.getSimpleName();
+
+                  if (NamingCache.WHITELIST.contains(simpleName)) {
+                    return; // explicitly allowed exceptions
+                  }
+
+                  if (!simpleName.endsWith("Processor")) {
+                    events.add(
+                        violated(
+                            item,
+                            "Processor class '"
+                                + simpleName
+                                + "' must end with suffix 'Processor'."));
+                    return;
+                  }
+
+                  final String coreName =
+                      simpleName.substring(0, simpleName.length() - "Processor".length());
+                  if (coreName.isEmpty()) {
+                    events.add(
+                        violated(
+                            item,
+                            "Processor class '"
+                                + simpleName
+                                + "' must start with a value type prefix."));
+                    return;
+                  }
+
+                  final String matchedValueType = NamingCache.findMatchingValueType(coreName);
+                  if (matchedValueType == null) {
+                    events.add(
+                        violated(
+                            item,
+                            "Processor class '"
+                                + simpleName
+                                + "' must start with a valid value type (one of: "
+                                + String.join(", ", NamingCache.VALUE_TYPES)
+                                + ")."));
+                    return;
+                  }
+
+                  final String intentPart = coreName.substring(matchedValueType.length());
+                  if (intentPart.isEmpty()) {
+                    events.add(
+                        violated(
+                            item,
+                            "Processor class '"
+                                + simpleName
+                                + "' should specify an intent (e.g. '"
+                                + matchedValueType
+                                + "<Intent>Processor') or be added to the whitelist if it intentionally handles multiple intents."));
+                    return;
+                  }
+
+                  final Set<String> intents = NamingCache.intentsFor(matchedValueType);
+                  if (intents.isEmpty()) {
+                    // No intents known for value type; cannot validate intent portion strictly
+                    events.add(
+                        violated(
+                            item,
+                            "Processor class '"
+                                + simpleName
+                                + "' uses value type '"
+                                + matchedValueType
+                                + "' which has no discoverable intents; expected '<ValueType><Intent>Processor'."));
+                    return;
+                  }
+
+                  if (!intents.contains(intentPart)) {
+                    events.add(
+                        violated(
+                            item,
+                            "Processor class '"
+                                + simpleName
+                                + "' has unknown intent '"
+                                + intentPart
+                                + "' for value type '"
+                                + matchedValueType
+                                + "'. Known intents: "
+                                + String.join(", ", intents)
+                                + "."));
+                  }
+                }
+
+                // cache holder to avoid rebuilding reflection data for every class
+                private static final class NamingCache {
+                  private static final Set<String> INTENTS = new HashSet<>();
+                  private static final Set<String> VALUE_TYPES = new HashSet<>();
+                  private static final Set<String> WHITELIST = Set.of(
+                  );
+                  private static volatile boolean initialized = false;
+
+                  private static void ensureInitialized() {
+                    if (initialized) {
+                      return;
+                    }
+                    synchronized (NamingCache.class) {
+                      if (initialized) {
+                        return;
+                      }
+                      for (final ValueType constant : ValueType.values()) {
+                        final String enumName = constant.name();
+                        final String pascal = toPascal(enumName);
+                        VALUE_TYPES.add(pascal);
+                      }
+                      for (final Class<?> intentEnumClass : Intent.INTENT_CLASSES) {
+                        final Object[] intentConstants = intentEnumClass.getEnumConstants();
+                        if (intentConstants != null) {
+                          for (final Object intent : intentConstants) {
+                            final String intentPascal = toPascal(((Enum<?>) intent).name());
+                            INTENTS.add(intentPascal);
+                          }
+                        }
+                      }
+                      initialized = true;
+                    }
+                  }
+
+                  private static String toPascal(final String enumName) {
+                    final String[] parts = enumName.toLowerCase(Locale.ROOT).split("_");
+                    final StringBuilder sb = new StringBuilder();
+                    for (final String p : parts) {
+                      if (p.isEmpty()) {
+                        continue;
+                      }
+                      sb.append(Character.toUpperCase(p.charAt(0))).append(p.substring(1));
+                    }
+                    return sb.toString();
+                  }
+
+                  private static String findMatchingValueType(final String coreName) {
+                    // longest prefix match to avoid accidental short matches
+                    String match = null;
+                    for (final String vt : VALUE_TYPES) {
+                      if (coreName.startsWith(vt)
+                          && (match == null || vt.length() > match.length())) {
+                        match = vt;
+                      }
+                    }
+                    return match;
+                  }
+
+                  private static Set<String> intentsFor(final String valueTypePascal) {
+                    return INTENTS;
+                  }
+                }
+              });
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstruc
 import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstructionCompleteProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
-import io.camunda.zeebe.engine.processing.conditional.ConditionalTriggerProcessor;
+import io.camunda.zeebe.engine.processing.conditional.ConditionalSubscriptionTriggerProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.message.PendingProcessMessageSubscriptionChecker;
@@ -148,7 +148,7 @@ public final class BpmnProcessors {
     typedRecordProcessors.onCommand(
         ValueType.CONDITIONAL_SUBSCRIPTION,
         ConditionalSubscriptionIntent.TRIGGER,
-        new ConditionalTriggerProcessor(processingState, bpmnBehaviors, writers));
+        new ConditionalSubscriptionTriggerProcessor(processingState, bpmnBehaviors, writers));
   }
 
   private static void addProcessInstanceCommandProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -25,7 +25,7 @@ import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchAc
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchTerminateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCancelProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateProcessor;
-import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateWithResultProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateWithAwaitingResultProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceModificationModifyProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -283,7 +283,7 @@ public final class BpmnProcessors {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_CREATION,
         ProcessInstanceCreationIntent.CREATE_WITH_AWAITING_RESULT,
-        new ProcessInstanceCreationCreateWithResultProcessor(
+        new ProcessInstanceCreationCreateWithAwaitingResultProcessor(
             createProcessor, elementInstanceState));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -24,7 +24,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavio
 import io.camunda.zeebe.engine.processing.clock.ClockProcessors;
 import io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableProcessors;
 import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
-import io.camunda.zeebe.engine.processing.conditional.ConditionalEvaluationProcessor;
+import io.camunda.zeebe.engine.processing.conditional.ConditionalEvaluationEvaluateProcessor;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributeProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
@@ -619,7 +619,7 @@ public final class EngineProcessors {
       final MutableProcessingState processingState,
       final AuthorizationCheckBehavior authCheckBehavior) {
     final var conditionalEvaluationProcessor =
-        new ConditionalEvaluationProcessor(
+        new ConditionalEvaluationEvaluateProcessor(
             writers,
             processingState.getKeyGenerator(),
             processingState,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -35,7 +35,7 @@ import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavi
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionContinueProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionFinishProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandRedistributor;
-import io.camunda.zeebe.engine.processing.dmn.DecisionEvaluationEvaluteProcessor;
+import io.camunda.zeebe.engine.processing.dmn.DecisionEvaluationEvaluateProcessor;
 import io.camunda.zeebe.engine.processing.historydeletion.HistoryDeletionProcessors;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationProcessors;
 import io.camunda.zeebe.engine.processing.identity.GroupProcessors;
@@ -553,13 +553,13 @@ public final class EngineProcessors {
       final MutableProcessingState processingState,
       final AuthorizationCheckBehavior authCheckBehavior) {
 
-    final DecisionEvaluationEvaluteProcessor decisionEvaluationEvaluteProcessor =
-        new DecisionEvaluationEvaluteProcessor(
+    final DecisionEvaluationEvaluateProcessor decisionEvaluationEvaluateProcessor =
+        new DecisionEvaluationEvaluateProcessor(
             decisionBehavior, processingState.getKeyGenerator(), writers, authCheckBehavior);
     typedRecordProcessors.onCommand(
         ValueType.DECISION_EVALUATION,
         DecisionEvaluationIntent.EVALUATE,
-        decisionEvaluationEvaluteProcessor);
+        decisionEvaluationEvaluateProcessor);
   }
 
   private static void addResourceDeletionProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationChunkCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationChunkCreateProcessor.java
@@ -11,32 +11,35 @@ import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationInitializationRecord;
-import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** Processes commands to create batch operation chunks. */
 @ExcludeAuthorizationCheck
-public final class BatchOperationInitializeProcessor
-    implements TypedRecordProcessor<BatchOperationInitializationRecord> {
+public final class BatchOperationChunkCreateProcessor
+    implements TypedRecordProcessor<BatchOperationChunkRecord> {
 
   private static final Logger LOGGER =
-      LoggerFactory.getLogger(BatchOperationInitializeProcessor.class);
+      LoggerFactory.getLogger(BatchOperationChunkCreateProcessor.class);
 
   private final StateWriter stateWriter;
 
-  public BatchOperationInitializeProcessor(final Writers writers) {
+  public BatchOperationChunkCreateProcessor(final Writers writers) {
     stateWriter = writers.state();
   }
 
   @Override
-  public void processRecord(final TypedRecord<BatchOperationInitializationRecord> command) {
+  public void processRecord(final TypedRecord<BatchOperationChunkRecord> command) {
     final var recordValue = command.getValue();
     LOGGER.debug(
-        "Marking batch operation {} as initializing", command.getValue().getBatchOperationKey());
+        "Creating a new chunk with {} items for batch operation {}",
+        recordValue.getItems().size(),
+        recordValue.getBatchOperationKey());
 
     stateWriter.appendFollowUpEvent(
-        command.getKey(), BatchOperationIntent.INITIALIZING, recordValue);
+        command.getKey(), BatchOperationChunkIntent.CREATED, recordValue);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreationCreateProcessor.java
@@ -40,10 +40,11 @@ import org.slf4j.LoggerFactory;
  * Processes commands to create batch operations. It validates the command and checks for
  * authorization. This command will be distributed to all other existing partitions.
  */
-public final class BatchOperationCreateProcessor
+public final class BatchOperationCreationCreateProcessor
     implements DistributedTypedRecordProcessor<BatchOperationCreationRecord> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationCreateProcessor.class);
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BatchOperationCreationCreateProcessor.class);
 
   private static final String EMPTY_JSON_OBJECT = "{}";
   private static final String MESSAGE_GIVEN_FILTER_IS_EMPTY = "Given filter is empty";
@@ -60,7 +61,7 @@ public final class BatchOperationCreateProcessor
   private final BatchOperationMetrics metrics;
   private final BatchOperationState batchOperationState;
 
-  public BatchOperationCreateProcessor(
+  public BatchOperationCreationCreateProcessor(
       final Writers writers,
       final ProcessingState state,
       final KeyGenerator keyGenerator,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionExecuteProcessor.java
@@ -63,11 +63,11 @@ import org.slf4j.LoggerFactory;
  * </ul>
  */
 @ExcludeAuthorizationCheck
-public final class BatchOperationExecuteProcessor
+public final class BatchOperationExecutionExecuteProcessor
     implements TypedRecordProcessor<BatchOperationExecutionRecord> {
 
   private static final Logger LOGGER =
-      LoggerFactory.getLogger(BatchOperationExecuteProcessor.class);
+      LoggerFactory.getLogger(BatchOperationExecutionExecuteProcessor.class);
 
   private static final int BATCH_SIZE = 10;
   private static final int HEARTBEAT_INTERVAL = 1000;
@@ -81,7 +81,7 @@ public final class BatchOperationExecuteProcessor
 
   private final Map<BatchOperationType, BatchOperationExecutor> handlers;
 
-  public BatchOperationExecuteProcessor(
+  public BatchOperationExecutionExecuteProcessor(
       final Writers writers,
       final ProcessingState processingState,
       final CommandDistributionBehavior commandDistributionBehavior,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationInitializationFinishInitializationProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationInitializationFinishInitializationProcessor.java
@@ -19,16 +19,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ExcludeAuthorizationCheck
-public final class BatchOperationFinishInitializationProcessor
+public final class BatchOperationInitializationFinishInitializationProcessor
     implements TypedRecordProcessor<BatchOperationInitializationRecord> {
 
   private static final Logger LOGGER =
-      LoggerFactory.getLogger(BatchOperationFinishInitializationProcessor.class);
+      LoggerFactory.getLogger(BatchOperationInitializationFinishInitializationProcessor.class);
 
   private final StateWriter stateWriter;
   private final BatchOperationMetrics metrics;
 
-  public BatchOperationFinishInitializationProcessor(
+  public BatchOperationInitializationFinishInitializationProcessor(
       final Writers writers, final BatchOperationMetrics metrics) {
     stateWriter = writers.state();
     this.metrics = metrics;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationInitializationInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationInitializationInitializeProcessor.java
@@ -11,35 +11,32 @@ import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
-import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationInitializationRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Processes commands to create batch operation chunks. */
 @ExcludeAuthorizationCheck
-public final class BatchOperationCreateChunkProcessor
-    implements TypedRecordProcessor<BatchOperationChunkRecord> {
+public final class BatchOperationInitializationInitializeProcessor
+    implements TypedRecordProcessor<BatchOperationInitializationRecord> {
 
   private static final Logger LOGGER =
-      LoggerFactory.getLogger(BatchOperationCreateChunkProcessor.class);
+      LoggerFactory.getLogger(BatchOperationInitializationInitializeProcessor.class);
 
   private final StateWriter stateWriter;
 
-  public BatchOperationCreateChunkProcessor(final Writers writers) {
+  public BatchOperationInitializationInitializeProcessor(final Writers writers) {
     stateWriter = writers.state();
   }
 
   @Override
-  public void processRecord(final TypedRecord<BatchOperationChunkRecord> command) {
+  public void processRecord(final TypedRecord<BatchOperationInitializationRecord> command) {
     final var recordValue = command.getValue();
     LOGGER.debug(
-        "Creating a new chunk with {} items for batch operation {}",
-        recordValue.getItems().size(),
-        recordValue.getBatchOperationKey());
+        "Marking batch operation {} as initializing", command.getValue().getBatchOperationKey());
 
     stateWriter.appendFollowUpEvent(
-        command.getKey(), BatchOperationChunkIntent.CREATED, recordValue);
+        command.getKey(), BatchOperationIntent.INITIALIZING, recordValue);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementCancelProcessor.java
@@ -33,33 +33,31 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Processes commands to suspend batch operations. It validates the command and checks for
- * authorization. The SUSPEND command is then distributed to all other partitions.
+ * Processes commands to cancel batch operations. It validates the command and checks for
+ * authorization. The CANCEL command is then distributed to all other partitions.
  */
 @ExcludeAuthorizationCheck
-public final class BatchOperationSuspendProcessor
+public final class BatchOperationLifecycleManagementCancelProcessor
     implements DistributedTypedRecordProcessor<BatchOperationLifecycleManagementRecord> {
 
   private static final Logger LOGGER =
-      LoggerFactory.getLogger(BatchOperationSuspendProcessor.class);
+      LoggerFactory.getLogger(BatchOperationLifecycleManagementCancelProcessor.class);
 
   private static final String MESSAGE_PREFIX =
-      "Expected to suspend a batch operation with key '%d', but ";
+      "Expected to cancel a batch operation with key '%d', but ";
   private static final String BATCH_OPERATION_NOT_FOUND_MESSAGE =
-      MESSAGE_PREFIX + "no such batch operation was found.";
-  private static final String BATCH_OPERATION_INVALID_STATE_MESSAGE =
-      MESSAGE_PREFIX + "it has an invalid state '%s'.";
+      MESSAGE_PREFIX + "no such batch operation was found";
 
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
-  private final KeyGenerator keyGenerator;
   private final BatchOperationState batchOperationState;
   private final AuthorizationCheckBehavior authCheckBehavior;
+  private final KeyGenerator keyGenerator;
   private final BatchOperationMetrics metrics;
 
-  public BatchOperationSuspendProcessor(
+  public BatchOperationLifecycleManagementCancelProcessor(
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
       final ProcessingState processingState,
@@ -94,34 +92,31 @@ public final class BatchOperationSuspendProcessor
     }
 
     final var recordValue = command.getValue();
-    final var batchOperationKey = command.getValue().getBatchOperationKey();
-    final var suspendKey = keyGenerator.nextKey();
-    LOGGER.debug(
-        "Suspending batch operation with key {}", command.getValue().getBatchOperationKey());
+    final var batchOperationKey = recordValue.getBatchOperationKey();
+    final var cancelKey = keyGenerator.nextKey();
+    LOGGER.debug("Cancelling batch operation with key {}", batchOperationKey);
 
-    // validation
     final var batchOperation = batchOperationState.get(batchOperationKey);
-    if (batchOperation.isEmpty()) {
-      rejectNotFound(command, batchOperationKey, recordValue);
-      return;
+    if (batchOperation.isPresent() && batchOperation.get().canCancel()) {
+      cancelBatchOperationEvent(cancelKey, recordValue);
+      responseWriter.writeEventOnCommand(
+          cancelKey, BatchOperationIntent.CANCELED, command.getValue(), command);
+      commandDistributionBehavior
+          .withKey(cancelKey)
+          .inQueue(DistributionQueue.BATCH_OPERATION)
+          .distribute(command);
+
+      metrics.recordCancelled(batchOperation.get().getBatchOperationType());
+    } else {
+      rejectionWriter.appendRejection(
+          command,
+          RejectionType.NOT_FOUND,
+          String.format(BATCH_OPERATION_NOT_FOUND_MESSAGE, batchOperationKey));
+      responseWriter.writeRejectionOnCommand(
+          command,
+          RejectionType.NOT_FOUND,
+          String.format(BATCH_OPERATION_NOT_FOUND_MESSAGE, batchOperationKey));
     }
-
-    // check if the batch operation can be suspended
-    if (!batchOperation.get().canSuspend()) {
-      final var batchOperationStatus = batchOperation.get().getStatus().name();
-      rejectInvalidState(command, batchOperationKey, batchOperationStatus, recordValue);
-      return;
-    }
-
-    suspendBatchOperation(suspendKey, recordValue);
-    responseWriter.writeEventOnCommand(
-        suspendKey, BatchOperationIntent.SUSPENDED, command.getValue(), command);
-    commandDistributionBehavior
-        .withKey(suspendKey)
-        .inQueue(DistributionQueue.BATCH_OPERATION)
-        .distribute(command);
-
-    metrics.recordSuspended(batchOperation.get().getBatchOperationType());
   }
 
   @Override
@@ -130,71 +125,29 @@ public final class BatchOperationSuspendProcessor
     final var recordValue = command.getValue();
     final var batchOperationKey = recordValue.getBatchOperationKey();
 
-    // Validation
     final var batchOperation = batchOperationState.get(batchOperationKey);
-    if (batchOperation.isPresent() && batchOperation.get().canSuspend()) {
-      LOGGER.debug(
-          "Processing distributed command to suspend with key '{}': {}",
-          batchOperationKey,
-          recordValue);
-      suspendBatchOperation(batchOperationKey, recordValue);
-    } else {
-      LOGGER.debug(
-          "Distributed command to suspend batch operation with key '{}' will be ignored: {}",
-          batchOperationKey,
-          recordValue);
+    if (batchOperation.isEmpty()) {
+      rejectionWriter.appendRejection(
+          command, RejectionType.NOT_FOUND, "Batch operation does not exist!");
+      commandDistributionBehavior.acknowledgeCommand(command);
+      return;
     }
 
+    LOGGER.debug(
+        "Processing distributed command to cancel a batch operation with key '{}': {}",
+        batchOperationKey,
+        recordValue);
+    cancelBatchOperationEvent(batchOperationKey, recordValue);
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
-  private void suspendBatchOperation(
-      final Long suspendKey, final BatchOperationLifecycleManagementRecord recordValue) {
+  private void cancelBatchOperationEvent(
+      final Long cancelKey, final BatchOperationLifecycleManagementRecord recordValue) {
     stateWriter.appendFollowUpEvent(
-        suspendKey,
-        BatchOperationIntent.SUSPENDED,
+        cancelKey,
+        BatchOperationIntent.CANCELED,
         recordValue,
         FollowUpEventMetadata.of(
             b -> b.batchOperationReference(recordValue.getBatchOperationKey())));
-  }
-
-  private void rejectInvalidState(
-      final TypedRecord<BatchOperationLifecycleManagementRecord> command,
-      final long batchOperationKey,
-      final String batchOperationStatus,
-      final BatchOperationLifecycleManagementRecord recordValue) {
-    LOGGER.info(
-        "Batch operation with key '{}' cannot be suspended because of invalid status '{}', rejecting command: {}",
-        batchOperationKey,
-        batchOperationStatus,
-        recordValue);
-    rejectionWriter.appendRejection(
-        command,
-        RejectionType.INVALID_STATE,
-        String.format(
-            BATCH_OPERATION_INVALID_STATE_MESSAGE, batchOperationKey, batchOperationStatus));
-    responseWriter.writeRejectionOnCommand(
-        command,
-        RejectionType.INVALID_STATE,
-        String.format(
-            BATCH_OPERATION_INVALID_STATE_MESSAGE, batchOperationKey, batchOperationStatus));
-  }
-
-  private void rejectNotFound(
-      final TypedRecord<BatchOperationLifecycleManagementRecord> command,
-      final long batchOperationKey,
-      final BatchOperationLifecycleManagementRecord recordValue) {
-    LOGGER.info(
-        "Batch operation with key '{}' not found, rejecting command: {}",
-        batchOperationKey,
-        recordValue);
-    rejectionWriter.appendRejection(
-        command,
-        RejectionType.NOT_FOUND,
-        String.format(BATCH_OPERATION_NOT_FOUND_MESSAGE, batchOperationKey));
-    responseWriter.writeRejectionOnCommand(
-        command,
-        RejectionType.NOT_FOUND,
-        String.format(BATCH_OPERATION_NOT_FOUND_MESSAGE, batchOperationKey));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementResumeProcessor.java
@@ -43,10 +43,11 @@ import org.slf4j.LoggerFactory;
  * authorization. The RESUME command is then distributed to all other partitions.
  */
 @ExcludeAuthorizationCheck
-public final class BatchOperationResumeProcessor
+public final class BatchOperationLifecycleManagementResumeProcessor
     implements DistributedTypedRecordProcessor<BatchOperationLifecycleManagementRecord> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationResumeProcessor.class);
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BatchOperationLifecycleManagementResumeProcessor.class);
 
   private static final String MESSAGE_PREFIX =
       "Expected to resume a batch operation with key '%d', but ";
@@ -66,7 +67,7 @@ public final class BatchOperationResumeProcessor
 
   private final BatchOperationState batchOperationState;
 
-  public BatchOperationResumeProcessor(
+  public BatchOperationLifecycleManagementResumeProcessor(
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
       final ProcessingState processingState,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionLifecycleCompletePartitionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionLifecycleCompletePartitionProcessor.java
@@ -29,18 +29,18 @@ import org.slf4j.LoggerFactory;
  * mark follower partitions as completed.
  */
 @ExcludeAuthorizationCheck
-public final class BatchOperationLeadPartitionCompleteProcessor
+public final class BatchOperationPartitionLifecycleCompletePartitionProcessor
     implements DistributedTypedRecordProcessor<BatchOperationPartitionLifecycleRecord> {
 
   private static final Logger LOGGER =
-      LoggerFactory.getLogger(BatchOperationLeadPartitionCompleteProcessor.class);
+      LoggerFactory.getLogger(BatchOperationPartitionLifecycleCompletePartitionProcessor.class);
 
   private final StateWriter stateWriter;
   private final BatchOperationState batchOperationState;
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final BatchOperationMetrics metrics;
 
-  public BatchOperationLeadPartitionCompleteProcessor(
+  public BatchOperationPartitionLifecycleCompletePartitionProcessor(
       final Writers writers,
       final ProcessingState processingState,
       final CommandDistributionBehavior commandDistributionBehavior,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionLifecycleFailPartitionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionLifecycleFailPartitionProcessor.java
@@ -28,18 +28,18 @@ import org.slf4j.LoggerFactory;
  * mark follower partitions as failed.
  */
 @ExcludeAuthorizationCheck
-public final class BatchOperationLeadPartitionFailProcessor
+public final class BatchOperationPartitionLifecycleFailPartitionProcessor
     implements DistributedTypedRecordProcessor<BatchOperationPartitionLifecycleRecord> {
 
   private static final Logger LOGGER =
-      LoggerFactory.getLogger(BatchOperationLeadPartitionFailProcessor.class);
+      LoggerFactory.getLogger(BatchOperationPartitionLifecycleFailPartitionProcessor.class);
 
   private final StateWriter stateWriter;
   private final BatchOperationState batchOperationState;
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final BatchOperationMetrics batchOperationMetrics;
 
-  public BatchOperationLeadPartitionFailProcessor(
+  public BatchOperationPartitionLifecycleFailPartitionProcessor(
       final Writers writers,
       final ProcessingState processingState,
       final CommandDistributionBehavior commandDistributionBehavior,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionLifecycleFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionLifecycleFailProcessor.java
@@ -30,10 +30,11 @@ import org.slf4j.LoggerFactory;
 
 /** Local command processor which sends the FAIL_PARTITION command to the lead partition. */
 @ExcludeAuthorizationCheck
-public final class BatchOperationFailProcessor
+public final class BatchOperationPartitionLifecycleFailProcessor
     implements TypedRecordProcessor<BatchOperationPartitionLifecycleRecord> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationFailProcessor.class);
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BatchOperationPartitionLifecycleFailProcessor.class);
 
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
@@ -42,7 +43,7 @@ public final class BatchOperationFailProcessor
   private final BatchOperationMetrics metrics;
   private final BatchOperationState batchOperationState;
 
-  public BatchOperationFailProcessor(
+  public BatchOperationPartitionLifecycleFailProcessor(
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
       final KeyGenerator keyGenerator,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -95,7 +95,7 @@ public final class BatchOperationSetupProcessors {
         .onCommand(
             ValueType.BATCH_OPERATION_CREATION,
             BatchOperationIntent.CREATE,
-            new BatchOperationCreateProcessor(
+            new BatchOperationCreationCreateProcessor(
                 writers,
                 processingState,
                 keyGenerator,
@@ -106,15 +106,16 @@ public final class BatchOperationSetupProcessors {
         .onCommand(
             ValueType.BATCH_OPERATION_INITIALIZATION,
             BatchOperationIntent.INITIALIZE,
-            new BatchOperationInitializeProcessor(writers))
+            new BatchOperationInitializationInitializeProcessor(writers))
         .onCommand(
             ValueType.BATCH_OPERATION_INITIALIZATION,
             BatchOperationIntent.FINISH_INITIALIZATION,
-            new BatchOperationFinishInitializationProcessor(writers, batchOperationMetrics))
+            new BatchOperationInitializationFinishInitializationProcessor(
+                writers, batchOperationMetrics))
         .onCommand(
             ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
             BatchOperationIntent.FAIL,
-            new BatchOperationFailProcessor(
+            new BatchOperationPartitionLifecycleFailProcessor(
                 writers,
                 commandDistributionBehavior,
                 keyGenerator,
@@ -123,11 +124,11 @@ public final class BatchOperationSetupProcessors {
         .onCommand(
             ValueType.BATCH_OPERATION_CHUNK,
             BatchOperationChunkIntent.CREATE,
-            new BatchOperationCreateChunkProcessor(writers))
+            new BatchOperationChunkCreateProcessor(writers))
         .onCommand(
             ValueType.BATCH_OPERATION_EXECUTION,
             BatchOperationExecutionIntent.EXECUTE,
-            new BatchOperationExecuteProcessor(
+            new BatchOperationExecutionExecuteProcessor(
                 writers,
                 processingState,
                 commandDistributionBehavior,
@@ -137,7 +138,7 @@ public final class BatchOperationSetupProcessors {
         .onCommand(
             ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
             BatchOperationIntent.CANCEL,
-            new BatchOperationCancelProcessor(
+            new BatchOperationLifecycleManagementCancelProcessor(
                 writers,
                 commandDistributionBehavior,
                 processingState,
@@ -147,7 +148,7 @@ public final class BatchOperationSetupProcessors {
         .onCommand(
             ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
             BatchOperationIntent.SUSPEND,
-            new BatchOperationSuspendProcessor(
+            new BatchOperationLifecycleManagementSuspendProcessor(
                 writers,
                 commandDistributionBehavior,
                 processingState,
@@ -157,7 +158,7 @@ public final class BatchOperationSetupProcessors {
         .onCommand(
             ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
             BatchOperationIntent.RESUME,
-            new BatchOperationResumeProcessor(
+            new BatchOperationLifecycleManagementResumeProcessor(
                 writers,
                 commandDistributionBehavior,
                 processingState,
@@ -167,12 +168,12 @@ public final class BatchOperationSetupProcessors {
         .onCommand(
             ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
             BatchOperationIntent.COMPLETE_PARTITION,
-            new BatchOperationLeadPartitionCompleteProcessor(
+            new BatchOperationPartitionLifecycleCompletePartitionProcessor(
                 writers, processingState, commandDistributionBehavior, batchOperationMetrics))
         .onCommand(
             ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
             BatchOperationIntent.FAIL_PARTITION,
-            new BatchOperationLeadPartitionFailProcessor(
+            new BatchOperationPartitionLifecycleFailPartitionProcessor(
                 writers, processingState, commandDistributionBehavior, batchOperationMetrics))
         .withListener(
             new BatchOperationExecutionScheduler(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessors.java
@@ -26,10 +26,15 @@ public final class ClockProcessors {
       final ControllableStreamClock clock,
       final CommandDistributionBehavior commandDistributionBehavior,
       final AuthorizationCheckBehavior authCheckBehavior) {
-    final var clockProcessor =
-        new ClockProcessor(
-            writers, keyGenerator, clock, commandDistributionBehavior, authCheckBehavior);
-    typedRecordProcessors.onCommand(ValueType.CLOCK, ClockIntent.PIN, clockProcessor);
-    typedRecordProcessors.onCommand(ValueType.CLOCK, ClockIntent.RESET, clockProcessor);
+    typedRecordProcessors.onCommand(
+        ValueType.CLOCK,
+        ClockIntent.PIN,
+        new ClockPinProcessor(
+            writers, keyGenerator, clock, commandDistributionBehavior, authCheckBehavior));
+    typedRecordProcessors.onCommand(
+        ValueType.CLOCK,
+        ClockIntent.RESET,
+        new ClockResetProcessor(
+            writers, keyGenerator, clock, commandDistributionBehavior, authCheckBehavior));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockResetProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockResetProcessor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clock;
+
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.SideEffectProducer;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public final class ClockResetProcessor implements DistributedTypedRecordProcessor<ClockRecord> {
+
+  private final SideEffectWriter sideEffectWriter;
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
+  private final ControllableStreamClock clock;
+  private final CommandDistributionBehavior commandDistributionBehavior;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
+
+  public ClockResetProcessor(
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final ControllableStreamClock clock,
+      final CommandDistributionBehavior commandDistributionBehavior,
+      final AuthorizationCheckBehavior authCheckBehavior) {
+    sideEffectWriter = writers.sideEffect();
+    stateWriter = writers.state();
+    this.keyGenerator = keyGenerator;
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    this.clock = clock;
+    this.commandDistributionBehavior = commandDistributionBehavior;
+    this.authCheckBehavior = authCheckBehavior;
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<ClockRecord> command) {
+    // Validate authorization
+    final var authRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.SYSTEM)
+            .permissionType(PermissionType.UPDATE)
+            .build();
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
+    if (isAuthorized.isLeft()) {
+      final var rejection = isAuthorized.getLeft();
+      rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      return;
+    }
+
+    // Process command
+    final var clockRecord = command.getValue();
+    final long eventKey = keyGenerator.nextKey();
+    applyClockModification(eventKey, clockRecord);
+    if (command.hasRequestMetadata()) {
+      responseWriter.writeEventOnCommand(eventKey, ClockIntent.RESETTED, clockRecord, command);
+    }
+
+    // Distribute to other partitions
+    commandDistributionBehavior.withKey(eventKey).unordered().distribute(command);
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<ClockRecord> command) {
+    applyClockModification(command.getKey(), command.getValue());
+    commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  private void applyClockModification(final long key, final ClockRecord clockRecord) {
+    final SideEffectProducer sideEffect =
+        () -> {
+          clock.reset();
+          return true;
+        };
+    sideEffectWriter.appendSideEffect(sideEffect);
+    stateWriter.appendFollowUpEvent(key, ClockIntent.RESETTED, clockRecord);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
@@ -40,10 +40,11 @@ import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ConditionalEvaluationProcessor
+public class ConditionalEvaluationEvaluateProcessor
     implements TypedRecordProcessor<ConditionalEvaluationRecord> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ConditionalEvaluationProcessor.class);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ConditionalEvaluationEvaluateProcessor.class);
 
   private static final String NO_PROCESS_DEFINITION_FOUND_MESSAGE =
       "Expected to evaluate conditional with command key '%d' for process definition key '%d', but no such process was found.";
@@ -59,7 +60,7 @@ public class ConditionalEvaluationProcessor
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final ExpressionProcessor expressionProcessor;
 
-  public ConditionalEvaluationProcessor(
+  public ConditionalEvaluationEvaluateProcessor(
       final Writers writers,
       final KeyGenerator keyGenerator,
       final ProcessingState processingState,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalSubscriptionTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalSubscriptionTriggerProcessor.java
@@ -28,7 +28,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 @ExcludeAuthorizationCheck
-public class ConditionalTriggerProcessor
+public class ConditionalSubscriptionTriggerProcessor
     implements TypedRecordProcessor<ConditionalSubscriptionRecord> {
 
   private static final String NO_CONDITIONAL_SUBSCRIPTION_FOUND_MESSAGE =
@@ -49,7 +49,7 @@ public class ConditionalTriggerProcessor
 
   private final EventHandle eventHandle;
 
-  public ConditionalTriggerProcessor(
+  public ConditionalSubscriptionTriggerProcessor(
       final MutableProcessingState processingState,
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateProcessor.java
@@ -30,7 +30,7 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.collection.Tuple;
 
-public class DecisionEvaluationEvaluteProcessor
+public class DecisionEvaluationEvaluateProcessor
     implements TypedRecordProcessor<DecisionEvaluationRecord> {
 
   private static final String ERROR_MESSAGE_NO_IDENTIFIER_SPECIFIED =
@@ -43,7 +43,7 @@ public class DecisionEvaluationEvaluteProcessor
   private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;
 
-  public DecisionEvaluationEvaluteProcessor(
+  public DecisionEvaluationEvaluateProcessor(
       final DecisionBehavior decisionBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -108,7 +108,7 @@ public final class JobEventProcessors {
         .onCommand(
             ValueType.JOB,
             JobIntent.RECUR_AFTER_BACKOFF,
-            new JobRecurProcessor(
+            new JobRecurAfterBackoffProcessor(
                 processingState, writers, bpmnBehaviors.jobActivationBehavior(), clock))
         .onCommand(
             ValueType.JOB_BATCH,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurAfterBackoffProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurAfterBackoffProcessor.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.time.InstantSource;
 
 @ExcludeAuthorizationCheck
-public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
+public class JobRecurAfterBackoffProcessor implements TypedRecordProcessor<JobRecord> {
 
   private static final String NOT_FAILED_JOB_MESSAGE =
       "Expected to back off failed job with key '%d', but %s";
@@ -33,7 +33,7 @@ public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
   private final BpmnJobActivationBehavior jobActivationBehavior;
   private final InstantSource clock;
 
-  public JobRecurProcessor(
+  public JobRecurAfterBackoffProcessor(
       final ProcessingState processingState,
       final Writers writers,
       final BpmnJobActivationBehavior jobActivationBehavior,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricExportProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricExportProcessor.java
@@ -24,16 +24,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ExcludeAuthorizationCheck
-public class UsageMetricsExportProcessor implements TypedRecordProcessor<UsageMetricRecord> {
+public class UsageMetricExportProcessor implements TypedRecordProcessor<UsageMetricRecord> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(UsageMetricsExportProcessor.class);
+  private static final Logger LOG = LoggerFactory.getLogger(UsageMetricExportProcessor.class);
 
   private final UsageMetricState usageMetricState;
   private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;
   private final InstantSource clock;
 
-  public UsageMetricsExportProcessor(
+  public UsageMetricExportProcessor(
       final UsageMetricState usageMetricState,
       final Writers writers,
       final KeyGenerator keyGenerator,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsProcessors.java
@@ -29,7 +29,7 @@ public class UsageMetricsProcessors {
         .onCommand(
             ValueType.USAGE_METRIC,
             UsageMetricIntent.EXPORT,
-            new UsageMetricsExportProcessor(
+            new UsageMetricExportProcessor(
                 processingState.getUsageMetricState(), writers, keyGenerator, clock))
         .withListener(new UsageMetricsCheckerScheduler(config, clock));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 @ExcludeAuthorizationCheck
-public final class ProcessInstanceCreationCreateWithResultProcessor
+public final class ProcessInstanceCreationCreateWithAwaitingResultProcessor
     implements CommandProcessor<ProcessInstanceCreationRecord> {
 
   private final ProcessInstanceCreationCreateProcessor createProcessor;
@@ -34,7 +34,7 @@ public final class ProcessInstanceCreationCreateWithResultProcessor
 
   private boolean shouldRespond;
 
-  public ProcessInstanceCreationCreateWithResultProcessor(
+  public ProcessInstanceCreationCreateWithAwaitingResultProcessor(
       final ProcessInstanceCreationCreateProcessor createProcessor,
       final MutableElementInstanceState elementInstanceState) {
     this.createProcessor = createProcessor;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleMarkPartitionBootstrappedProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleMarkPartitionBootstrappedProcessor.java
@@ -32,7 +32,7 @@ import io.camunda.zeebe.util.Either.Right;
 import io.camunda.zeebe.util.collection.Tuple;
 
 @ExcludeAuthorizationCheck
-public class MarkPartitionBootstrappedProcessor
+public class ScaleMarkPartitionBootstrappedProcessor
     implements DistributedTypedRecordProcessor<ScaleRecord> {
 
   private final KeyGenerator keyGenerator;
@@ -44,7 +44,7 @@ public class MarkPartitionBootstrappedProcessor
   private final ProcessState processState;
   private final StartEventSubscriptions startEventSubscriptions;
 
-  public MarkPartitionBootstrappedProcessor(
+  public ScaleMarkPartitionBootstrappedProcessor(
       final KeyGenerator keyGenerator,
       final Writers writers,
       final ProcessingState processingState,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleScaleUpProcessor.java
@@ -28,7 +28,7 @@ import java.util.HashSet;
 import java.util.Optional;
 
 @ExcludeAuthorizationCheck
-public class ScaleUpProcessor implements DistributedTypedRecordProcessor<ScaleRecord> {
+public class ScaleScaleUpProcessor implements DistributedTypedRecordProcessor<ScaleRecord> {
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -36,7 +36,7 @@ public class ScaleUpProcessor implements DistributedTypedRecordProcessor<ScaleRe
   private final RoutingState routingState;
   private final CommandDistributionBehavior commandDistributionBehavior;
 
-  public ScaleUpProcessor(
+  public ScaleScaleUpProcessor(
       final KeyGenerator keyGenerator,
       final Writers writers,
       final ProcessingState processingState,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleStatusProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleStatusProcessor.java
@@ -20,14 +20,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ExcludeAuthorizationCheck
-public class ScaleUpStatusProcessor implements TypedRecordProcessor<ScaleRecord> {
-  private static final Logger LOG = LoggerFactory.getLogger(ScaleUpStatusProcessor.class);
+public class ScaleStatusProcessor implements TypedRecordProcessor<ScaleRecord> {
+  private static final Logger LOG = LoggerFactory.getLogger(ScaleStatusProcessor.class);
 
   private final Writers writers;
   private final KeyGenerator keyGenerator;
   private final RoutingState routingState;
 
-  public ScaleUpStatusProcessor(
+  public ScaleStatusProcessor(
       final KeyGenerator keyGenerator, final Writers writers, final RoutingState routingState) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScalingProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScalingProcessors.java
@@ -30,15 +30,15 @@ public final class ScalingProcessors {
     typedRecordProcessors.onCommand(
         ValueType.SCALE,
         ScaleIntent.SCALE_UP,
-        new ScaleUpProcessor(keyGenerator, writers, processingState, distributionBehavior));
+        new ScaleScaleUpProcessor(keyGenerator, writers, processingState, distributionBehavior));
     typedRecordProcessors.onCommand(
         ValueType.SCALE,
         ScaleIntent.STATUS,
-        new ScaleUpStatusProcessor(keyGenerator, writers, processingState.getRoutingState()));
+        new ScaleStatusProcessor(keyGenerator, writers, processingState.getRoutingState()));
     typedRecordProcessors.onCommand(
         ValueType.SCALE,
         ScaleIntent.MARK_PARTITION_BOOTSTRAPPED,
-        new MarkPartitionBootstrappedProcessor(
+        new ScaleMarkPartitionBootstrappedProcessor(
             keyGenerator, writers, processingState, distributionBehavior, bpmnBehaviours));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementResumeProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementResumeProcessorTest.java
@@ -26,11 +26,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 /** This test class only covers cases not covered by the LifecycleBatchOperationTest engine test */
-class BatchOperationResumeProcessorTest {
+class BatchOperationLifecycleManagementResumeProcessorTest {
 
   private StateWriter stateWriter;
   private TypedCommandWriter commandWriter;
-  private BatchOperationResumeProcessor processor;
+  private BatchOperationLifecycleManagementResumeProcessor processor;
 
   @BeforeEach
   void setUp() {
@@ -47,7 +47,7 @@ class BatchOperationResumeProcessorTest {
 
     // Inject mocked writers
     processor =
-        new BatchOperationResumeProcessor(
+        new BatchOperationLifecycleManagementResumeProcessor(
             writers, null, state, null, null, mock(BatchOperationMetrics.class));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementSuspendProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementSuspendProcessorTest.java
@@ -32,13 +32,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** This test class only covers cases not covered by the LifecycleBatchOperationTest engine test */
-class BatchOperationSuspendProcessorTest {
+class BatchOperationLifecycleManagementSuspendProcessorTest {
 
   private StateWriter stateWriter;
   private TypedCommandWriter commandWriter;
   private TypedRejectionWriter rejectionWriter;
   private TypedResponseWriter responseWriter;
-  private BatchOperationSuspendProcessor processor;
+  private BatchOperationLifecycleManagementSuspendProcessor processor;
   private KeyGenerator keyGenerator;
   private BatchOperationState batchOperationState;
 
@@ -68,7 +68,7 @@ class BatchOperationSuspendProcessorTest {
 
     // Inject mocked writers
     processor =
-        new BatchOperationSuspendProcessor(
+        new BatchOperationLifecycleManagementSuspendProcessor(
             writers,
             null,
             state,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationLifecycle
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationLifecycleManagementSuspendProcessor;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationPartitionLifecycleCompletePartitionProcessor;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationPartitionLifecycleFailPartitionProcessor;
+import io.camunda.zeebe.engine.processing.clock.ClockPinProcessor;
 import io.camunda.zeebe.engine.processing.clock.ClockResetProcessor;
 import io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableCreateProcessor;
 import io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableDeleteProcessor;
@@ -99,6 +100,7 @@ import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -341,6 +343,18 @@ public class CommandDistributionIdempotencyTest {
                       .execute();
                 }),
             BatchOperationPartitionLifecycleCompletePartitionProcessor.class
+          },
+          {
+            "Clock.PIN is idempotent",
+            new Scenario(
+                ValueType.CLOCK,
+                ClockIntent.PIN,
+                () -> {
+                  final var record = ENGINE.clock().pinAt(Instant.now());
+                  ENGINE.clock().reset(); // reset immediately to avoid timing issues
+                  return record;
+                }),
+            ClockPinProcessor.class
           },
           {
             "Clock.RESET is idempotent",

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -16,12 +16,12 @@ import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.filter.ProcessInstanceFilter.Builder;
 import io.camunda.zeebe.engine.EngineConfiguration;
-import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationCancelProcessor;
-import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationCreateProcessor;
-import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationLeadPartitionCompleteProcessor;
-import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationLeadPartitionFailProcessor;
-import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationResumeProcessor;
-import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationSuspendProcessor;
+import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationCreationCreateProcessor;
+import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationLifecycleManagementCancelProcessor;
+import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationLifecycleManagementResumeProcessor;
+import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationLifecycleManagementSuspendProcessor;
+import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationPartitionLifecycleCompletePartitionProcessor;
+import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationPartitionLifecycleFailPartitionProcessor;
 import io.camunda.zeebe.engine.processing.clock.ClockProcessor;
 import io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableCreateProcessor;
 import io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableDeleteProcessor;
@@ -44,8 +44,8 @@ import io.camunda.zeebe.engine.processing.identity.RoleRemoveEntityProcessor;
 import io.camunda.zeebe.engine.processing.identity.RoleUpdateProcessor;
 import io.camunda.zeebe.engine.processing.message.MessageSubscriptionMigrateProcessor;
 import io.camunda.zeebe.engine.processing.resource.ResourceDeletionDeleteProcessor;
-import io.camunda.zeebe.engine.processing.scaling.MarkPartitionBootstrappedProcessor;
-import io.camunda.zeebe.engine.processing.scaling.ScaleUpProcessor;
+import io.camunda.zeebe.engine.processing.scaling.ScaleMarkPartitionBootstrappedProcessor;
+import io.camunda.zeebe.engine.processing.scaling.ScaleScaleUpProcessor;
 import io.camunda.zeebe.engine.processing.signal.SignalBroadcastProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.tenant.TenantAddEntityProcessor;
@@ -262,7 +262,7 @@ public class CommandDistributionIdempotencyTest {
                                         .processInstanceKeys(1L, 3L, 8L)
                                         .build())))
                         .create()),
-            BatchOperationCreateProcessor.class
+            BatchOperationCreationCreateProcessor.class
           },
           {
             "BatchOperation.CANCEL is idempotent",
@@ -277,7 +277,7 @@ public class CommandDistributionIdempotencyTest {
                       .withBatchOperationKey(batchOperation.getKey())
                       .cancel();
                 }),
-            BatchOperationCancelProcessor.class
+            BatchOperationLifecycleManagementCancelProcessor.class
           },
           {
             "BatchOperation.SUSPEND is idempotent",
@@ -292,7 +292,7 @@ public class CommandDistributionIdempotencyTest {
                       .withBatchOperationKey(batchOperation.getKey())
                       .suspend();
                 }),
-            BatchOperationSuspendProcessor.class
+            BatchOperationLifecycleManagementSuspendProcessor.class
           },
           {
             "BatchOperation.RESUME is idempotent",
@@ -308,7 +308,7 @@ public class CommandDistributionIdempotencyTest {
                       .withBatchOperationKey(batchOperation.getKey())
                       .resume();
                 }),
-            BatchOperationResumeProcessor.class
+            BatchOperationLifecycleManagementResumeProcessor.class
           },
           {
             "BatchOperation.FAIL_PARTITION is idempotent",
@@ -324,7 +324,7 @@ public class CommandDistributionIdempotencyTest {
                       .withBatchOperationKey(batchOperation.getKey())
                       .fail();
                 }),
-            BatchOperationLeadPartitionFailProcessor.class
+            BatchOperationPartitionLifecycleFailPartitionProcessor.class
           },
           {
             "BatchOperation.COMPLETE_PARTITION is idempotent",
@@ -340,7 +340,7 @@ public class CommandDistributionIdempotencyTest {
                       .withBatchOperationKey(batchOperation.getKey())
                       .execute();
                 }),
-            BatchOperationLeadPartitionCompleteProcessor.class
+            BatchOperationPartitionLifecycleCompletePartitionProcessor.class
           },
           {
             "Clock.RESET is idempotent",
@@ -725,7 +725,7 @@ public class CommandDistributionIdempotencyTest {
                 // distribution of SCALE_UP can't complete because it's only enqueued for partition
                 // 3.
                 false),
-            ScaleUpProcessor.class,
+            ScaleScaleUpProcessor.class,
           },
           {
             "Scale.MARK_PARTITION_BOOTSTRAPPED is idempotent",
@@ -735,7 +735,7 @@ public class CommandDistributionIdempotencyTest {
                 () -> ENGINE.scale().markPartitionBootstrapped().markBootstrapped(3),
                 // EngineRule does not support a dynamic number of partitions
                 false),
-            MarkPartitionBootstrappedProcessor.class
+            ScaleMarkPartitionBootstrappedProcessor.class
           }
         });
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationLifecycle
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationLifecycleManagementSuspendProcessor;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationPartitionLifecycleCompletePartitionProcessor;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationPartitionLifecycleFailPartitionProcessor;
-import io.camunda.zeebe.engine.processing.clock.ClockProcessor;
+import io.camunda.zeebe.engine.processing.clock.ClockResetProcessor;
 import io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableCreateProcessor;
 import io.camunda.zeebe.engine.processing.clustervariable.ClusterVariableDeleteProcessor;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
@@ -345,7 +345,7 @@ public class CommandDistributionIdempotencyTest {
           {
             "Clock.RESET is idempotent",
             new Scenario(ValueType.CLOCK, ClockIntent.RESET, () -> ENGINE.clock().reset()),
-            ClockProcessor.class
+            ClockResetProcessor.class
           },
           {
             "Deployment.CREATE is idempotent",

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricExportProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricExportProcessorTest.java
@@ -33,12 +33,12 @@ import org.agrona.DirectBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class UsageMetricsExportProcessorTest {
+class UsageMetricExportProcessorTest {
   private static final long ASSIGNEE_HASH_1 = getStringHashValue("assignee1");
   private static final String TENANT_1 = "tenant1";
   private MutableUsageMetricState state;
   private StateWriter stateWriter;
-  private UsageMetricsExportProcessor processor;
+  private UsageMetricExportProcessor processor;
   private TypedRecord<UsageMetricRecord> record;
   private InstantSource clock;
 
@@ -58,7 +58,7 @@ class UsageMetricsExportProcessorTest {
     when(record.getValue()).thenReturn(recordValue);
     when(clock.millis()).thenReturn(2L);
 
-    processor = new UsageMetricsExportProcessor(state, writers, keyGenerator, clock);
+    processor = new UsageMetricExportProcessor(state, writers, keyGenerator, clock);
   }
 
   private DirectBuffer toDirectBuffer(final Object data) {


### PR DESCRIPTION
## Description

This PR introduces the enforcement of a naming convention for record processors. They all should be named: "\<_ValueType_\>\<_Intent_\>Processor" where:
- _ValueType_ is the Pascal case version of a value of the enumeration `ValueType`, corresponding to the type of record being processed
- _Intent_  is the Pascal case version of a value of the specific `Intent` subclass related to the value type

All processors should thus process a single record type and a single intent.
Processors have been refactored and renamed in order to follow this convention (see https://github.com/camunda/camunda/issues/40165#issuecomment-3498216115 for more details on the renaming).

Some exceptions have been explicitly whitelisted:
- `BpmnStreamProcessor`: it is a special case, handling record processing in a very different way than other processors
- `CommandProcessor` and `CommandProcessorImpl`: will be removed by #40162
- `UserTaskProcessor`: handles multiple intents in a complex way; will be refactored in the future

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40165
