### PR TITLE
fix: RollingUpdateTest for versions 8.8.0+

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -296,6 +296,15 @@ final class RollingUpdateTest {
     cluster.getBrokers().forEach((id, broker) -> updateBroker(broker, version));
   }
 
+  private String dockerImageName(final String version) {
+    final var parsed = SemanticVersion.parse(version).get();
+    if (parsed.minor() >= 8) {
+      return "camunda/camunda";
+    } else {
+      return "camunda/zeebe";
+    }
+  }
+
   private void updateBroker(final ZeebeBrokerNode<?> broker, final String version) {
     if ("CURRENT".equals(version)) {
       broker.setDockerImageName(
@@ -303,7 +312,7 @@ final class RollingUpdateTest {
       broker.withEnv(VersionUtil.VERSION_OVERRIDE_ENV_NAME, currentVersion());
     } else {
       broker.setDockerImageName(
-          DockerImageName.parse("camunda/zeebe").withTag(version).asCanonicalNameString());
+          DockerImageName.parse(dockerImageName(version)).withTag(version).asCanonicalNameString());
     }
   }
 

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -84,7 +84,10 @@ final class RollingUpdateTest {
               node ->
                   node.withEnv(CREATE_SCHEMA_ENV_VAR, "false")
                       .withEnv(UNPROTECTED_API_ENV_VAR, "true")
-                      .withEnv(AUTHORIZATION_CHECKS_ENV_VAR, "false"))
+                      .withEnv(AUTHORIZATION_CHECKS_ENV_VAR, "false")
+                      .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", "none")
+                      .withEnv("CAMUNDA_REST_QUERY_ENABLED", "false")
+                      .withEnv("CAMUNDA_PERSISTENT_SESSIONS_ENABLED", "false"))
           .build();
 
   @SuppressWarnings("unused")

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/ZeebeTestContainerDefaults.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/ZeebeTestContainerDefaults.java
@@ -13,7 +13,7 @@ import org.testcontainers.utility.DockerImageName;
 public final class ZeebeTestContainerDefaults {
   private static final String TEST_IMAGE_NAME =
       Optional.ofNullable(System.getenv("ZEEBE_TEST_DOCKER_IMAGE"))
-          .orElse("camunda/zeebe:current-test");
+          .orElse("camunda/camunda:current-test");
   private static final DockerImageName DEFAULT_TEST_IMAGE = DockerImageName.parse(TEST_IMAGE_NAME);
 
   private ZeebeTestContainerDefaults() {}


### PR DESCRIPTION
## Description
The `RollingUpdateTest` was not working for version 8.8+:
- broker was starting with secondary storage enabled, which was preventing it's readiness
- the image used has changed to `camunda/camunda` for 8.8+

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
