### PR TITLE
feat: Allow Operate to start with RDBMS

### DIFF
--- a/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
@@ -99,8 +99,10 @@ public class HealthConfigurationInitializer
     }
 
     if (secondaryStorageEnabled && activeProfiles.contains(Profile.OPERATE.getId())) {
-      healthIndicators.add(INDICATOR_OPERATE_INDICES_CHECK);
       healthIndicators.add(INDICATOR_SPRING_READINESS_STATE);
+      if (DatabaseTypeUtils.isRdbmsDisabled(env)) {
+        healthIndicators.add(INDICATOR_OPERATE_INDICES_CHECK);
+      }
     }
 
     if (secondaryStorageEnabled

--- a/operate/Makefile
+++ b/operate/Makefile
@@ -1,5 +1,23 @@
 ## Environment
 
+.PHONY: env-h2-up
+env-h2-up:
+	mvn install -DskipTests=true -Dskip.fe.build=false -DskipChecks -DskipQaBuild \
+    && CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME=demo \
+	CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD=demo \
+	CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME=Demo \
+	CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL=demo@example.com \
+	CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0=demo \
+	CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=true \
+	CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED=false \
+	CAMUNDA_BACKUP_WEBAPPS_ENABLED=false \
+	CAMUNDA_DATABASE_URL=jdbc:h2:mem:camunda \
+	CAMUNDA_DATA_SECONDARYSTORAGE_TYPE=rdbms \
+	ZEEBE_BROKER_EXPORTERS_RDBMS_CLASSNAME=io.camunda.exporter.rdbms.RdbmsExporter \
+	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java \
+	  -Dexec.mainClass="io.camunda.application.StandaloneCamunda" \
+	  -Dspring.profiles.active=operate,broker,dev,dev-data,identity,consolidated-auth
+
 .PHONY: env-up
 env-up:
 	docker compose -f docker-compose.yml up -d elasticsearch \

--- a/operate/data-generator/pom.xml
+++ b/operate/data-generator/pom.xml
@@ -34,6 +34,11 @@
       <artifactId>camunda-security-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-spring-utils</artifactId>
+    </dependency>
+
     <!-- SPRING -->
     <dependency>
       <groupId>org.springframework</groupId>

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -42,7 +42,9 @@ public abstract class AbstractDataGenerator implements DataGenerator {
   protected ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(3);
   @Autowired private SecurityConfiguration securityConfiguration;
   private boolean shutdown = false;
-  @Autowired private ProcessStore processStore;
+
+  @Autowired(required = false)
+  private ProcessStore processStore;
 
   @PostConstruct
   private void startDataGenerator() {
@@ -105,6 +107,10 @@ public abstract class AbstractDataGenerator implements DataGenerator {
   }
 
   public boolean shouldCreateData(final boolean manuallyCalled) {
+    if (processStore == null) {
+      LOGGER.warn("ProcessStore is null. Assuming no data exists and it should be created...");
+      return true;
+    }
     if (!manuallyCalled) { // when called manually, always create the data
       final boolean exists;
       try {

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/util/DecisionDataUtil.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/util/DecisionDataUtil.java
@@ -12,6 +12,7 @@ import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.store.DecisionStore;
 import io.camunda.operate.util.PayloadUtil;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
@@ -35,6 +36,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class DecisionDataUtil {
 
   public static final String DECISION_INSTANCE_ID_1_1 = "12121212-1";

--- a/operate/schema/pom.xml
+++ b/operate/schema/pom.xml
@@ -45,6 +45,11 @@
       <artifactId>camunda-search-client-connect</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-spring-utils</artifactId>
+    </dependency>
+
     <!-- SPRING -->
 
     <dependency>

--- a/operate/schema/src/main/java/io/camunda/operate/cache/ProcessCache.java
+++ b/operate/schema/src/main/java/io/camunda/operate/cache/ProcessCache.java
@@ -10,6 +10,7 @@ package io.camunda.operate.cache;
 import static io.camunda.operate.util.ThreadUtil.sleepFor;
 
 import io.camunda.operate.store.ProcessStore;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.ProcessFlowNodeEntity;
 import java.util.Iterator;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class ProcessCache {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessCache.class);

--- a/operate/schema/src/main/java/io/camunda/operate/management/IndicesCheck.java
+++ b/operate/schema/src/main/java/io/camunda/operate/management/IndicesCheck.java
@@ -16,6 +16,7 @@ import io.camunda.search.schema.SearchEngineClient;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
 import io.camunda.search.schema.opensearch.OpensearchEngineClient;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.util.CloseableSilently;
 import org.slf4j.Logger;
@@ -23,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class IndicesCheck implements CloseableSilently {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IndicesCheck.class);

--- a/operate/schema/src/main/java/io/camunda/operate/management/IndicesHealthIndicator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/management/IndicesHealthIndicator.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.management;
 
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.health.Health;
@@ -15,6 +16,7 @@ import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.stereotype.Component;
 
 @Component("indicesCheck")
+@ConditionalOnRdbmsDisabled
 public class IndicesHealthIndicator implements HealthIndicator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IndicesHealthIndicator.class);

--- a/operate/schema/src/main/java/io/camunda/operate/management/ModelMetricProvider.java
+++ b/operate/schema/src/main/java/io/camunda/operate/management/ModelMetricProvider.java
@@ -11,6 +11,7 @@ import io.camunda.operate.Metrics;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.DecisionStore;
 import io.camunda.operate.store.ProcessStore;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import jakarta.annotation.PostConstruct;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class ModelMetricProvider {
 
   protected final Logger logger = LoggerFactory.getLogger(getClass());

--- a/operate/schema/src/main/java/io/camunda/operate/util/OperationsManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/util/OperationsManager.java
@@ -10,6 +10,7 @@ package io.camunda.operate.util;
 import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.store.OperationStore;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.ExporterEntity;
@@ -27,6 +28,7 @@ import org.springframework.stereotype.Component;
 
 /** Common methods to deal with operations, that can be used by different modules. */
 @Component
+@ConditionalOnRdbmsDisabled
 public class OperationsManager {
 
   private final Logger logger;

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -68,6 +68,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-spring-utils</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <exclusions>

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.webapp;
 
 import io.camunda.operate.webapp.zeebe.operation.OperationExecutor;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Component;
 @Component
 @DependsOn("searchEngineSchemaInitializer")
 @Profile({"!test", "test-executor"})
+@ConditionalOnRdbmsDisabled
 public class StartupBean {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StartupBean.class);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionDefinitionController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionDefinitionController.java
@@ -23,6 +23,7 @@ import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -44,6 +45,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(URI)
 @Tag(name = "DecisionDefinition", description = "Decision Definition API")
 @Validated
+@ConditionalOnRdbmsDisabled
 public class DecisionDefinitionController extends ErrorController
     implements SearchController<DecisionDefinition> {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionInstanceController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionInstanceController.java
@@ -21,6 +21,7 @@ import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping(URI)
 @Tag(name = "DecisionInstance", description = "Decision Instance API")
 @Validated
+@ConditionalOnRdbmsDisabled
 public class DecisionInstanceController extends ErrorController {
 
   public static final String URI = "/v1/decision-instances";

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionRequirementsController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionRequirementsController.java
@@ -22,6 +22,7 @@ import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -41,6 +42,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping(URI)
 @Tag(name = "DecisionRequirements", description = "Decision Requirements API")
 @Validated
+@ConditionalOnRdbmsDisabled
 public class DecisionRequirementsController extends ErrorController
     implements SearchController<DecisionRequirements> {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/FlowNodeInstanceController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/FlowNodeInstanceController.java
@@ -23,6 +23,7 @@ import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -43,6 +44,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(URI)
 @Tag(name = "FlownodeInstance", description = "Flownode Instance API")
 @Validated
+@ConditionalOnRdbmsDisabled
 public class FlowNodeInstanceController extends ErrorController
     implements SearchController<FlowNodeInstance> {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/IncidentController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/IncidentController.java
@@ -25,6 +25,7 @@ import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -46,6 +47,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(URI)
 @Tag(name = "Incident", description = "Incident API")
 @Validated
+@ConditionalOnRdbmsDisabled
 public class IncidentController extends ErrorController implements SearchController<Incident> {
 
   public static final String URI = "/v1/incidents";

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ProcessDefinitionController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ProcessDefinitionController.java
@@ -23,6 +23,7 @@ import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -47,6 +48,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(URI)
 @Tag(name = "ProcessDefinition", description = "Process Definition API")
 @Validated
+@ConditionalOnRdbmsDisabled
 public class ProcessDefinitionController extends ErrorController
     implements SearchController<ProcessDefinition> {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ProcessInstanceController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ProcessInstanceController.java
@@ -29,6 +29,7 @@ import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -58,6 +59,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(URI)
 @Tag(name = "ProcessInstance", description = "Process Instance API")
 @Validated
+@ConditionalOnRdbmsDisabled
 public class ProcessInstanceController extends ErrorController
     implements SearchController<ProcessInstance> {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/VariableController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/VariableController.java
@@ -23,6 +23,7 @@ import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.api.v1.exceptions.ValidationException;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -43,6 +44,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(URI)
 @Tag(name = "Variable", description = "Variable API")
 @Validated
+@ConditionalOnRdbmsDisabled
 public class VariableController extends ErrorController implements SearchController<Variable> {
 
   public static final String URI = "/v1/variables";

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ProcessInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ProcessInstanceReader.java
@@ -14,6 +14,7 @@ import io.camunda.operate.webapp.rest.dto.ProcessInstanceCoreStatisticsDto;
 import io.camunda.operate.webapp.rest.dto.ProcessInstanceReferenceDto;
 import io.camunda.operate.webapp.rest.dto.listview.ListViewProcessInstanceDto;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.operate.TreePath;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -26,6 +27,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class ProcessInstanceReader {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessInstanceReader.class);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/DecisionWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/DecisionWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.webapp.elasticsearch.writer;
 
 import io.camunda.operate.store.DecisionStore;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
@@ -18,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class DecisionWriter implements io.camunda.operate.webapp.writer.DecisionWriter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DecisionWriter.class);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/management/UsageMetricsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/management/UsageMetricsService.java
@@ -10,6 +10,7 @@ package io.camunda.operate.webapp.management;
 import io.camunda.operate.store.MetricsStore;
 import io.camunda.operate.webapp.management.dto.UsageMetricDTO;
 import io.camunda.operate.webapp.management.dto.UsageMetricQueryDTO;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.http.MediaType;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Component
 @Deprecated(forRemoval = true, since = "8.8")
 @RestControllerEndpoint(id = "usage-metrics")
+@ConditionalOnRdbmsDisabled
 public class UsageMetricsService {
 
   @Autowired private MetricsStore metricsStore;
@@ -36,7 +38,7 @@ public class UsageMetricsService {
   @GetMapping(
       value = "/process-instances",
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public UsageMetricDTO retrieveProcessInstanceCount(UsageMetricQueryDTO query) {
+  public UsageMetricDTO retrieveProcessInstanceCount(final UsageMetricQueryDTO query) {
     final Long total =
         metricsStore.retrieveProcessInstanceCount(
             query.getStartTime(), query.getEndTime(), query.getTenantId());
@@ -52,7 +54,7 @@ public class UsageMetricsService {
   @GetMapping(
       value = "/decision-instances",
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public UsageMetricDTO retrieveDecisionInstancesCount(UsageMetricQueryDTO query) {
+  public UsageMetricDTO retrieveDecisionInstancesCount(final UsageMetricQueryDTO query) {
     final Long total =
         metricsStore.retrieveDecisionInstanceCount(
             query.getStartTime(), query.getEndTime(), query.getTenantId());

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/ProcessReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/ProcessReader.java
@@ -10,6 +10,7 @@ package io.camunda.operate.webapp.reader;
 import io.camunda.operate.store.ProcessStore;
 import io.camunda.operate.webapp.rest.dto.ProcessRequestDto;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
@@ -20,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class ProcessReader {
 
   private static final Logger LOGGER =

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/BatchOperationRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/BatchOperationRestService.java
@@ -16,6 +16,7 @@ import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
 import io.camunda.operate.webapp.rest.dto.operation.BatchOperationRequestDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
 import io.camunda.operate.webapp.transform.DataAggregator;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Batch operations")
 @RestController
 @RequestMapping(value = BATCH_OPERATIONS_URL)
+@ConditionalOnRdbmsDisabled
 public class BatchOperationRestService extends InternalAPIErrorController {
 
   public static final String BATCH_OPERATIONS_URL = "/api/batch-operations";

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionInstanceRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionInstanceRestService.java
@@ -19,6 +19,7 @@ import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
 import io.camunda.operate.webapp.rest.exception.NotAuthorizedException;
 import io.camunda.operate.webapp.rest.exception.NotFoundException;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,6 +38,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(value = DECISION_INSTANCE_URL)
 @Validated
+@ConditionalOnRdbmsDisabled
 public class DecisionInstanceRestService extends InternalAPIErrorController {
 
   public static final String DECISION_INSTANCE_URL = "/api/decision-instances";

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionRestService.java
@@ -15,6 +15,7 @@ import io.camunda.operate.webapp.rest.dto.dmn.DecisionGroupDto;
 import io.camunda.operate.webapp.rest.exception.NotAuthorizedException;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.camunda.operate.webapp.writer.BatchOperationWriter;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Decisions")
 @RestController
 @RequestMapping(value = DecisionRestService.DECISION_URL)
+@ConditionalOnRdbmsDisabled
 public class DecisionRestService extends InternalAPIErrorController {
 
   public static final String DECISION_URL = "/api/decisions";

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilder.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilder.java
@@ -18,6 +18,7 @@ import io.camunda.operate.webapp.rest.dto.metadata.FlowNodeInstanceMetadata;
 import io.camunda.operate.webapp.rest.dto.metadata.FlowNodeInstanceMetadataDto;
 import io.camunda.operate.webapp.rest.dto.metadata.ServiceTaskInstanceMetadataDto;
 import io.camunda.operate.webapp.rest.dto.metadata.UserTaskInstanceMetadataDto;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
@@ -31,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class FlowNodeInstanceMetadataBuilder {
 
   private static final Logger LOGGER =

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/FlowNodeInstanceRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/FlowNodeInstanceRestService.java
@@ -18,6 +18,7 @@ import io.camunda.operate.webapp.rest.dto.activity.FlowNodeInstanceResponseDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
 import io.camunda.operate.webapp.rest.exception.NotAuthorizedException;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Flow node instances")
 @RestController
 @RequestMapping(value = FlowNodeInstanceRestService.FLOW_NODE_INSTANCE_URL)
+@ConditionalOnRdbmsDisabled
 public class FlowNodeInstanceRestService extends InternalAPIErrorController {
 
   public static final String FLOW_NODE_INSTANCE_URL = "/api/flow-node-instances";

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/IncidentRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/IncidentRestService.java
@@ -13,6 +13,7 @@ import io.camunda.operate.webapp.InternalAPIErrorController;
 import io.camunda.operate.webapp.reader.IncidentStatisticsReader;
 import io.camunda.operate.webapp.rest.dto.incidents.IncidentsByErrorMsgStatisticsDto;
 import io.camunda.operate.webapp.rest.dto.incidents.IncidentsByProcessGroupStatisticsDto;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Collection;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Incidents statistics")
 @RestController
 @RequestMapping(value = INCIDENT_URL)
+@ConditionalOnRdbmsDisabled
 public class IncidentRestService extends InternalAPIErrorController {
 
   public static final String INCIDENT_URL = "/api/incidents";

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessInstanceRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessInstanceRestService.java
@@ -35,6 +35,7 @@ import io.camunda.operate.webapp.rest.validation.ModifyProcessInstanceRequestVal
 import io.camunda.operate.webapp.rest.validation.ProcessInstanceRequestValidator;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.camunda.operate.webapp.writer.BatchOperationWriter;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
@@ -52,6 +53,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping(value = PROCESS_INSTANCE_URL)
 @Validated
+@ConditionalOnRdbmsDisabled
 public class ProcessInstanceRestService extends InternalAPIErrorController {
 
   public static final String PROCESS_INSTANCE_URL = "/api/process-instances";

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessRestService.java
@@ -17,6 +17,7 @@ import io.camunda.operate.webapp.rest.dto.ProcessRequestDto;
 import io.camunda.operate.webapp.rest.exception.NotAuthorizedException;
 import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.camunda.operate.webapp.writer.BatchOperationWriter;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Processes")
 @RestController
 @RequestMapping(value = PROCESS_URL)
+@ConditionalOnRdbmsDisabled
 public class ProcessRestService extends InternalAPIErrorController {
 
   public static final String PROCESS_URL = "/api/processes";

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidator.java
@@ -14,6 +14,7 @@ import io.camunda.operate.webapp.reader.OperationReader;
 import io.camunda.operate.webapp.reader.VariableReader;
 import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import java.util.EnumSet;
@@ -21,6 +22,7 @@ import java.util.Set;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class CreateRequestOperationValidator {
 
   private static final Set<OperationType> VARIABLE_OPERATIONS =

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/ModifyProcessInstanceRequestValidator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/ModifyProcessInstanceRequestValidator.java
@@ -13,11 +13,13 @@ import io.camunda.operate.util.CollectionUtil;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import org.apache.commons.collections4.MapUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class ModifyProcessInstanceRequestValidator {
 
   private final ProcessInstanceReader processInstanceReader;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/ProcessInstanceRequestValidator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/ProcessInstanceRequestValidator.java
@@ -15,12 +15,14 @@ import io.camunda.operate.webapp.rest.dto.metadata.FlowNodeMetadataRequestDto;
 import io.camunda.operate.webapp.rest.dto.operation.CreateBatchOperationRequestDto;
 import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.listener.ListenerType;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class ProcessInstanceRequestValidator {
   private final CreateBatchOperationRequestValidator createBatchOperationRequestValidator;
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/writer/PersistOperationHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/writer/PersistOperationHelper.java
@@ -19,6 +19,7 @@ import io.camunda.operate.webapp.rest.dto.operation.CreateBatchOperationRequestD
 import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto;
 import io.camunda.operate.webapp.rest.exception.NotFoundException;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
@@ -39,6 +40,7 @@ import org.springframework.stereotype.Component;
  * be modified and all the modifications are serialized into a single field.
  */
 @Component
+@ConditionalOnRdbmsDisabled
 public class PersistOperationHelper {
   private final OperationStore operationStore;
   private final IncidentReader incidentReader;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/CancelProcessInstanceHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/CancelProcessInstanceHandler.java
@@ -10,6 +10,7 @@ package io.camunda.operate.webapp.zeebe.operation;
 import static io.camunda.webapps.schema.entities.operation.OperationType.CANCEL_PROCESS_INSTANCE;
 
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceState;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component;
 
 /** Operation handler to cancel process instances. */
 @Component
+@ConditionalOnRdbmsDisabled
 public class CancelProcessInstanceHandler extends AbstractOperationHandler
     implements OperationHandler {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteDecisionDefinitionHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteDecisionDefinitionHandler.java
@@ -11,6 +11,7 @@ import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.util.OperationsManager;
 import io.camunda.operate.webapp.reader.DecisionReader;
 import io.camunda.operate.webapp.writer.DecisionWriter;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntity;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component;
 
 /** Operation handler to delete decision definitions and related data */
 @Component
+@ConditionalOnRdbmsDisabled
 public class DeleteDecisionDefinitionHandler extends AbstractOperationHandler
     implements OperationHandler {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteProcessDefinitionHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteProcessDefinitionHandler.java
@@ -14,6 +14,7 @@ import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.store.ProcessStore;
 import io.camunda.operate.util.OperationsManager;
 import io.camunda.operate.webapp.reader.ProcessReader;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceState;
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Component;
 
 /** Operation handler to delete process definitions and related data */
 @Component
+@ConditionalOnRdbmsDisabled
 public class DeleteProcessDefinitionHandler extends AbstractOperationHandler
     implements OperationHandler {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteProcessInstanceHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteProcessInstanceHandler.java
@@ -13,6 +13,7 @@ import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.util.OperationsManager;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.writer.ProcessInstanceWriter;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationState;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Component;
 
 /** Operation handler to delete process instances. */
 @Component
+@ConditionalOnRdbmsDisabled
 public class DeleteProcessInstanceHandler extends AbstractOperationHandler
     implements OperationHandler {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/MigrateProcessInstanceHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/MigrateProcessInstanceHandler.java
@@ -12,6 +12,7 @@ import io.camunda.client.api.command.MigrationPlan;
 import io.camunda.client.api.command.MigrationPlanBuilderImpl;
 import io.camunda.client.api.command.MigrationPlanImpl;
 import io.camunda.operate.webapp.rest.dto.operation.MigrationPlanDto;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import java.util.ArrayList;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Component;
 
 /** Operation handler to migrate process instances */
 @Component
+@ConditionalOnRdbmsDisabled
 public class MigrateProcessInstanceHandler extends AbstractOperationHandler
     implements OperationHandler {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/OperationExecutor.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/OperationExecutor.java
@@ -13,6 +13,7 @@ import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.BackoffIdleStrategy;
 import io.camunda.operate.webapp.writer.BatchOperationWriter;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import jakarta.annotation.PreDestroy;
@@ -32,6 +33,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Configuration
+@ConditionalOnRdbmsDisabled
 public class OperationExecutor extends Thread {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OperationExecutor.class);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.webapps.schema.entities.operation.OperationType.RESOLVE
 
 import io.camunda.operate.webapp.reader.IncidentReader;
 import io.camunda.operate.webapp.rest.exception.NotFoundException;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.incident.ErrorType;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Component;
 
 /** Resolve the incident. */
 @Component
+@ConditionalOnRdbmsDisabled
 public class ResolveIncidentHandler extends AbstractOperationHandler implements OperationHandler {
 
   @Autowired private IncidentReader incidentReader;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/UpdateVariableHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/UpdateVariableHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.webapps.schema.entities.operation.OperationType.UPDATE_
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import java.util.Map;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component;
 
 /** Update the variable. */
 @Component
+@ConditionalOnRdbmsDisabled
 public class UpdateVariableHandler extends AbstractOperationHandler implements OperationHandler {
 
   private final ObjectMapper objectMapper = new ObjectMapper();

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/adapter/ServicesBasedAdapter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/adapter/ServicesBasedAdapter.java
@@ -28,6 +28,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
 import io.camunda.service.ResourceServices;
 import io.camunda.service.ResourceServices.ResourceDeletionRequest;
 import io.camunda.service.exception.ServiceException;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
@@ -49,6 +50,7 @@ import org.springframework.util.StringUtils;
 
 @Component
 @ConditionalOnOperateCompatibility(enabled = "false", matchIfMissing = true)
+@ConditionalOnRdbmsDisabled
 public class ServicesBasedAdapter implements OperateServicesAdapter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ServicesBasedAdapter.class);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/CancelTokenHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/CancelTokenHandler.java
@@ -11,6 +11,7 @@ import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.webapp.reader.FlowNodeInstanceReader;
 import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto.Modification;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import java.util.Iterator;
 import java.util.List;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class CancelTokenHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(CancelTokenHandler.class);
   private final FlowNodeInstanceReader flowNodeInstanceReader;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/ModifyProcessInstanceHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/ModifyProcessInstanceHandler.java
@@ -18,6 +18,7 @@ import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequest
 import io.camunda.operate.webapp.zeebe.operation.AbstractOperationHandler;
 import io.camunda.operate.webapp.zeebe.operation.OperationHandler;
 import io.camunda.operate.webapp.zeebe.operation.adapter.OperateServicesAdapter;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.springframework.stereotype.Component;
 // 'transaction'
 // So for one operation we have only one 'camundaClient.send().join()'
 @Component
+@ConditionalOnRdbmsDisabled
 public class ModifyProcessInstanceHandler extends AbstractOperationHandler
     implements OperationHandler {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/MoveTokenHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/MoveTokenHandler.java
@@ -11,6 +11,7 @@ import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.webapp.reader.FlowNodeInstanceReader;
 import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto.Modification;
+import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 @Component
+@ConditionalOnRdbmsDisabled
 public class MoveTokenHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(MoveTokenHandler.class);
   private final FlowNodeInstanceReader flowNodeInstanceReader;


### PR DESCRIPTION
## Description

This PR disables many Spring Beans in Operate that depend on Elasticsearch/Opensearch when RDBMS is used as secondary storage.

This means that the V1 API of Operate will not be reachable and instead calls will return `404`s.

The new `env-h2-up` target in the Makefile can be used to spin up Operate with H2.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/39306
