### PR TITLE
Fix 404 errors in identity assignment API tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
@@ -21,12 +21,10 @@ import {CREATE_GROUP_USERS_EXPECTED_BODY_USING_GROUP} from '../../../../utils/be
 import {
   assignUsersToGroup,
   createGroupAndStoreResponseFields,
+  createUser,
   userFromState,
 } from '@requestHelpers';
-import {
-  defaultAssertionOptions,
-  generateUniqueId,
-} from '../../../../utils/constants';
+import {defaultAssertionOptions} from '../../../../utils/constants';
 import {cleanupGroups} from '../../../../utils/groupsCleanup';
 
 /* eslint-disable playwright/expect-expect */
@@ -70,7 +68,10 @@ test.describe.parallel('Group Users API Tests', () => {
   });
 
   test('Assign User To Group', async ({request}) => {
-    const user = 'test-user' + generateUniqueId();
+    // Create the user first
+    const userBody = await createUser(request);
+    const user = userBody.username;
+
     const stateParams: Record<string, string> = {
       groupId: state['groupId1'] as string,
       username: user,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-users-api-tests.spec.ts
@@ -15,14 +15,12 @@ import {
   assertConflictRequest,
   assertPaginatedRequest,
 } from '../../../../utils/http';
-import {
-  defaultAssertionOptions,
-  generateUniqueId,
-} from '../../../../utils/constants';
+import {defaultAssertionOptions} from '../../../../utils/constants';
 import {
   assertUserNameInResponse,
   assignRoleToUsers,
   createRole,
+  createUser,
   userFromState,
 } from '@requestHelpers';
 import {cleanupRoles} from '../../../../utils/rolesCleanup';
@@ -61,8 +59,12 @@ test.describe.parallel('Role Users API Tests', () => {
   test('Assign Role To User', async ({request}) => {
     const role = await createRole(request);
     createdRoleIds.push(role.roleId as string);
-    const user = 'test-user' + generateUniqueId();
+
+    // Create the user first
+    const userBody = await createUser(request);
+    const user = userBody.username;
     createdUserIds.push(user);
+
     const p = {
       userId: user,
       roleId: role.roleId as string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-users-api-tests.spec.ts
@@ -15,14 +15,12 @@ import {
   assertConflictRequest,
   assertPaginatedRequest,
 } from '../../../../utils/http';
-import {
-  defaultAssertionOptions,
-  generateUniqueId,
-} from '../../../../utils/constants';
+import {defaultAssertionOptions} from '../../../../utils/constants';
 import {
   assertUserNameInResponse,
   assignUsersToTenant,
   createTenant,
+  createUser,
   userFromState,
 } from '@requestHelpers';
 import {cleanupUsers} from '../../../../utils/usersCleanup';
@@ -51,7 +49,11 @@ test.describe.parallel('Tenant Users API Tests', () => {
 
   test('Assign User To Tenant', async ({request}) => {
     const tenant = await createTenant(request);
-    const user = 'test-user' + generateUniqueId();
+
+    // Create the user first
+    const userBody = await createUser(request);
+    const user = userBody.username;
+
     const p = {
       userName: user,
       tenantId: tenant.tenantId as string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/group-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/group-requestHelpers.ts
@@ -8,6 +8,7 @@
 
 import type {APIRequestContext} from 'playwright-core';
 import {defaultAssertionOptions, generateUniqueId} from '../constants';
+import {createUsersAndStoreResponseFields} from './user-requestHelpers';
 import {
   assertEqualsForKeys,
   assertRequiredFields,
@@ -25,8 +26,11 @@ export async function assignUsersToGroup(
   groupId: string,
   state: Record<string, unknown>,
 ) {
+  // First create the users
+  await createUsersAndStoreResponseFields(request, numberOfUsers, state);
+
   for (let i = 1; i <= numberOfUsers; i++) {
-    const user = 'test-user' + generateUniqueId();
+    const user = state[`username${i}`] as string;
     const stateParams: Record<string, string> = {
       groupId: groupId,
       username: user,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/tenant-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/tenant-requestHelpers.ts
@@ -8,6 +8,7 @@
 
 import type {APIRequestContext} from 'playwright-core';
 import {groupIdFromState} from './get-value-from-state-requestHelpers';
+import {createUsersAndStoreResponseFields} from './user-requestHelpers';
 import {
   assertEqualsForKeys,
   assertRequiredFields,
@@ -26,8 +27,11 @@ export async function assignUsersToTenant(
   tenantId: string,
   state: Record<string, unknown>,
 ) {
+  // First create the users
+  await createUsersAndStoreResponseFields(request, numberOfUsers, state);
+
   for (let i = 1; i <= numberOfUsers; i++) {
-    const user = 'user' + generateUniqueId();
+    const user = state[`username${i}`] as string;
     const p = {
       userId: user,
       tenantId: tenantId,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/user-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/user-requestHelpers.ts
@@ -7,7 +7,6 @@
  */
 
 import type {APIRequestContext} from 'playwright-core';
-import {generateUniqueId} from '../constants';
 import {
   assertEqualsForKeys,
   assertRequiredFields,
@@ -34,8 +33,11 @@ export async function assignRoleToUsers(
   roleId: string,
   state: Record<string, unknown>,
 ) {
+  // First create the users
+  await createUsersAndStoreResponseFields(request, numberOfUsers, state);
+
   for (let i = 1; i <= numberOfUsers; i++) {
-    const user = 'user' + generateUniqueId();
+    const user = state[`username${i}`] as string;
     const p = {
       userId: user,
       roleId: roleId,


### PR DESCRIPTION
## Description

 Multiple E2E tests were failing with 404 errors when assigning roles/tenants to users/groups.

**Root Cause**: Tests were generating random user/group IDs but never creating the actual entities before attempting assignments.

**Solution**: 
- Fixed helper functions (`assignRoleToUsers`, `assignUsersToTenant`, `assignUsersToGroup`) to create entities before assignment
- Fixed direct API tests to create users before attempting role/tenant/group assignments

**Files Changed**:
- `utils/requestHelpers/user-requestHelpers.ts`
- `utils/requestHelpers/tenant-requestHelpers.ts` 
- `utils/requestHelpers/group-requestHelpers.ts`
- `tests/api/v2/role/role-users-api-tests.spec.ts`
- `tests/api/v2/group/group-users-api-tests.spec.ts`
- `tests/api/v2/tenant/tenant-users-api-tests.spec.ts`



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
