### PR TITLE
test: only run junit reporter on CI

### DIFF
--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "start": "vite",
     "build": "npm run ts-check && vite build && node ./renameProdIndex.js && node license-build.js",
-    "test": "vitest run --project=unit --reporter=default --reporter=junit --outputFile=TEST-unit.xml",
+    "test": "vitest run --project=unit",
     "test:browser": "vitest run --project=browser",
     "ts-check": "tsc -b",
     "eslint": "eslint .",

--- a/operate/client/vite.config.ts
+++ b/operate/client/vite.config.ts
@@ -9,7 +9,7 @@
 /// <reference types="vitest" />
 /// <reference types="vite/client" />
 
-import {defineConfig, type PluginOption} from 'vite';
+import {defineConfig, type PluginOption, type UserConfig} from 'vite';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import svgr from 'vite-plugin-svgr';
@@ -21,6 +21,23 @@ import {configDefaults} from 'vitest/config';
 
 const plugins: PluginOption[] = [react(), tsconfigPaths(), svgr()];
 const outDir = 'build';
+
+function getReporters(): Pick<
+  NonNullable<UserConfig['test']>,
+  'reporters' | 'outputFile'
+> {
+  if (process.env.CI) {
+    return {
+      reporters: ['default', 'junit', 'github-actions'],
+      outputFile: {
+        junit: 'TEST-unit.xml',
+      },
+    };
+  }
+  return {
+    reporters: ['default'],
+  };
+}
 
 export default defineConfig(({mode}) => ({
   base: mode === 'production' ? './' : undefined,
@@ -84,6 +101,7 @@ export default defineConfig(({mode}) => ({
     clearMocks: true,
     resetMocks: true,
     unstubEnvs: true,
+    ...getReporters(),
     projects: [
       {
         extends: true,


### PR DESCRIPTION
## Description

Context: https://github.com/camunda/camunda/pull/39987

@cmur2 We don't have to run the junit reporter locally. With these changes we only run it on the CI.

Could you check if I didn't break anything in your setup?

