### PR TITLE
fix: worker cpu goes 100% if it fails to get topology when starting

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/App.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/App.java
@@ -145,10 +145,19 @@ abstract class App implements Runnable {
               "Failed to retrieve topology due to authentication error; check your config", e);
           System.exit(1);
         }
-        THROTTLED_LOGGER.warn("Failed to retrieve topology due to client exception: ", e);
+        reportErrorAndSleep("Failed to retrieve topology due to client exception: ", e);
       } catch (final Exception e) {
-        THROTTLED_LOGGER.warn("Topology request failed: ", e);
+        reportErrorAndSleep("Topology request failed: ", e);
       }
+    }
+  }
+
+  private void reportErrorAndSleep(final String error, final Exception e) {
+    THROTTLED_LOGGER.warn(error, e);
+    try {
+      Thread.sleep(1000);
+    } catch (final InterruptedException ex) {
+      throw new RuntimeException(ex);
     }
   }
 


### PR DESCRIPTION
## Description
Added some time to sleep between retries when getting the topology

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
