### PR TITLE
ci: create benchmarks with automatic leader balancing

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -279,10 +279,11 @@ jobs:
         run: >
           # shellcheck disable=SC2215
           kubectl create cronjob leader-balancer
-            --namespace ${{ inputs.name }}
-            --image=curlimages/curl:7.87.0
-            --schedule="*/10 * * * *"
-            -- curl -L -v -X POST http://camunda:9600/actuator/rebalance
+          --namespace ${{ inputs.name }}
+          --image=curlimages/curl:7.87.0
+          --schedule="*/10 * * * *"
+          -- curl -L -v -X POST http://camunda:9600/actuator/rebalance
+          || echo "Leader balancer cronjob already exists"
       - name: Label namespace
         run: >
           kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -275,6 +275,13 @@ jobs:
           ${{ inputs.stable-vms && '-f load-tests/setup/default/values-stable.yaml' || '' }}
           ${{ inputs.realistic && '-f https://raw.githubusercontent.com/zeebe-io/benchmark-helm/main/charts/zeebe-benchmark/values-realistic-benchmark.yaml' || '' }}
           ${{ inputs.benchmark-load }}
+      - name: Setup leader balancing
+        run: >
+          kubectl create cronjob leader-balancer
+            --namespace ${{ inputs.name }}
+            --image=curlimages/curl:7.87.0
+            --schedule="*/10 * * * *"
+            -- curl -L -v -X POST http://camunda:9600/actuator/rebalance
       - name: Label namespace
         run: >
           kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -276,13 +276,12 @@ jobs:
           ${{ inputs.realistic && '-f https://raw.githubusercontent.com/zeebe-io/benchmark-helm/main/charts/zeebe-benchmark/values-realistic-benchmark.yaml' || '' }}
           ${{ inputs.benchmark-load }}
       - name: Setup leader balancing
-        run: >
-          # shellcheck disable=SC2215
-          kubectl create cronjob leader-balancer
-          --namespace ${{ inputs.name }}
-          --image=curlimages/curl:7.87.0
-          --schedule="*/10 * * * *"
-          -- curl -L -v -X POST http://camunda:9600/actuator/rebalance
+        run: |
+          kubectl create cronjob leader-balancer \
+          --namespace ${{ inputs.name }} \
+          --image=curlimages/curl:7.87.0 \
+          --schedule="*/10 * * * *" \
+          -- curl -L -v -X POST http://camunda:9600/actuator/rebalance \
           || echo "Leader balancer cronjob already exists"
       - name: Label namespace
         run: >

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -277,6 +277,7 @@ jobs:
           ${{ inputs.benchmark-load }}
       - name: Setup leader balancing
         run: >
+          # shellcheck disable=SC2215
           kubectl create cronjob leader-balancer
             --namespace ${{ inputs.name }}
             --image=curlimages/curl:7.87.0


### PR DESCRIPTION
This cronjob previously existed in zeebe-benchmark-helm. Instead of adding it to camunda-load-test, we will simply create the job directly.