### PR TITLE
feat: consolidate filter building logic to one utility

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.15
+
+### 🩹 Fixes
+
+- update process definition filtering types ([#40663](https://github.com/camunda/camunda/pull/40663))
+
+### ❤️ Contributors
+
+- Yuliia Saienko ([@juliasaienko](https://github.com/juliasaienko))
+
 ## v0.0.14
 
 ### 🩹 Fixes

--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.14
+
+### 🩹 Fixes
+
+- update process instance filtering and item types ([#40663](https://github.com/camunda/camunda/pull/40663))
+
+### ❤️ Contributors
+
+- Yuliia Saienko ([@juliasaienko](https://github.com/juliasaienko))
+
 ## v0.0.13
 
 ### 🩹 Fixes

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/process-definition.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/process-definition.ts
@@ -17,6 +17,7 @@ import {
 	type Endpoint,
 	basicStringFilterSchema,
 	getOrFilterSchema,
+	advancedIntegerFilterSchema,
 } from './common';
 import {
 	processDefinitionSchema,
@@ -73,7 +74,7 @@ const processDefinitionStatisticsFilterFieldsSchema = z.object({
 	elementInstanceState: advancedProcessInstanceStateFilterSchema,
 	elementId: advancedStringFilterSchema,
 	hasElementInstanceIncident: z.boolean(),
-	incidentErrorHashCode: z.number(),
+	incidentErrorHashCode: advancedIntegerFilterSchema,
 });
 
 const getProcessDefinitionStatisticsRequestBodySchema = z

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/process-instance.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/process-instance.ts
@@ -61,7 +61,7 @@ const queryProcessInstancesFilterSchema = z
 		hasIncident: z.boolean(),
 		tenantId: advancedStringFilterSchema,
 		variables: z.array(processInstanceVariableFilterSchema),
-		batchOperationKey: z.string(),
+		batchOperationId: advancedStringFilterSchema,
 		errorMessage: advancedStringFilterSchema,
 		hasRetriesLeft: z.boolean(),
 		elementInstanceState: advancedProcessInstanceStateFilterSchema,

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/process-instance.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/process-instance.ts
@@ -14,6 +14,7 @@ import {
 	getQueryResponseBodySchema,
 	advancedDateTimeFilterSchema,
 	advancedStringFilterSchema,
+	advancedIntegerFilterSchema,
 	basicStringFilterSchema,
 	getOrFilterSchema,
 	type Endpoint,
@@ -49,7 +50,7 @@ const queryProcessInstancesFilterSchema = z
 	.object({
 		processDefinitionId: advancedStringFilterSchema,
 		processDefinitionName: advancedStringFilterSchema,
-		processDefinitionVersion: z.number().int(),
+		processDefinitionVersion: advancedIntegerFilterSchema,
 		processDefinitionVersionTag: advancedStringFilterSchema,
 		processDefinitionKey: basicStringFilterSchema,
 		processInstanceKey: basicStringFilterSchema,
@@ -66,8 +67,9 @@ const queryProcessInstancesFilterSchema = z
 		hasRetriesLeft: z.boolean(),
 		elementInstanceState: advancedProcessInstanceStateFilterSchema,
 		elementId: advancedStringFilterSchema,
-		hasElementInstanceIncidents: z.boolean(),
-		incidentErrorHashCode: z.number().int(),
+		hasElementInstanceIncident: z.boolean(),
+		incidentErrorHashCode: advancedIntegerFilterSchema,
+		tags: z.array(z.string().min(1).max(100).regex(/^[A-Za-z][A-Za-z0-9_\-:.]{0,99}$/)).max(10),
 	})
 	.partial();
 

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.14",
+	"version": "0.0.15",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.13",
+	"version": "0.0.14",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.10.2",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.14",
+        "@camunda/camunda-api-zod-schemas": "0.0.15",
         "@camunda/camunda-composite-components": "0.19.1",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.57.0",
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.14.tgz",
-      "integrity": "sha512-U/RvqX+CCiX4xB6SPhlqNfvPobtt8H1LZZjrJquhUmsxKCBFczdmK21pVmH5Ww0nWS6YN+0hQmm8x1g7MBuXrg==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.15.tgz",
+      "integrity": "sha512-26dPp6T3q+82I3Q/HHbnq7rcts/0UoHc4XMT1OXknpZ/XM//nC6jfv4ojOqaQR/iYzYLoqY/fIHZuTZIPcy8iQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.10.2",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.13",
+        "@camunda/camunda-api-zod-schemas": "0.0.14",
         "@camunda/camunda-composite-components": "0.19.1",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.57.0",
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.13.tgz",
-      "integrity": "sha512-YxONMDyQrEKu5gJsqJo+SPfhcqZogdrOJajVXZYcGtRvH8xwXa0gMD4Q2ojSo0hpdJ8TwRF3SuHoV/NBH8uECQ==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.14.tgz",
+      "integrity": "sha512-U/RvqX+CCiX4xB6SPhlqNfvPobtt8H1LZZjrJquhUmsxKCBFczdmK21pVmH5Ww0nWS6YN+0hQmm8x1g7MBuXrg==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -8923,7 +8923,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.10.2",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.14",
+    "@camunda/camunda-api-zod-schemas": "0.0.15",
     "@camunda/camunda-composite-components": "0.19.1",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.57.0",

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.10.2",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.13",
+    "@camunda/camunda-api-zod-schemas": "0.0.14",
     "@camunda/camunda-composite-components": "0.19.1",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.57.0",

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.test.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.test.ts
@@ -32,7 +32,7 @@ describe('buildMutationRequestBody', () => {
 
     expect(body).toEqual({
       filter: {
-        elementId: 'taskA',
+        elementId: {$eq: 'taskA'},
         hasIncident: true,
         processInstanceKey: {$in: ['1', '2']},
       },
@@ -48,7 +48,7 @@ describe('buildMutationRequestBody', () => {
 
     expect(body).toEqual({
       filter: {
-        elementId: 'taskA',
+        elementId: {$eq: 'taskA'},
         hasIncident: true,
         processInstanceKey: {$notIn: ['3', '4']},
       },
@@ -64,7 +64,7 @@ describe('buildMutationRequestBody', () => {
 
     expect(body).toEqual({
       filter: {
-        elementId: 'taskA',
+        elementId: {$eq: 'taskA'},
         hasIncident: true,
         processInstanceKey: {$in: ['1', '2'], $notIn: ['3']},
       },
@@ -80,7 +80,7 @@ describe('buildMutationRequestBody', () => {
 
     expect(body).toEqual({
       filter: {
-        elementId: 'taskA',
+        elementId: {$eq: 'taskA'},
         hasIncident: true,
         processInstanceKey: {$in: ['only'], $notIn: ['x']},
       },
@@ -96,7 +96,7 @@ describe('buildMutationRequestBody', () => {
 
     expect(body).toEqual({
       filter: {
-        elementId: 'taskA',
+        elementId: {$eq: 'taskA'},
         hasIncident: true,
       },
     });
@@ -115,8 +115,8 @@ describe('buildMutationRequestBody', () => {
 
     expect(body).toEqual({
       filter: {
-        elementId: 'taskA',
-        $or: [{hasIncident: true}, {state: {$eq: 'ACTIVE'}}],
+        elementId: {$eq: 'taskA'},
+        $or: [{state: {$in: ['ACTIVE']}}, {hasIncident: true}],
       },
     });
   });
@@ -134,7 +134,7 @@ describe('buildMutationRequestBody', () => {
 
     expect(body).toEqual({
       filter: {
-        elementId: 'taskA',
+        elementId: {$eq: 'taskA'},
         hasIncident: true,
       },
     });
@@ -153,7 +153,7 @@ describe('buildMutationRequestBody', () => {
 
     expect(body).toEqual({
       filter: {
-        elementId: 'taskA',
+        elementId: {$eq: 'taskA'},
         state: {$eq: 'ACTIVE'},
       },
     });
@@ -176,11 +176,11 @@ describe('buildMutationRequestBody', () => {
 
     expect(body).toEqual({
       filter: {
-        elementId: 'taskA',
-        errorMessage: 'some error',
-        tenantId: 'tenant-xyz',
-        batchOperationKey: 'batch-123',
-        parentProcessInstanceKey: 'parent-456',
+        elementId: {$eq: 'taskA'},
+        errorMessage: {$in: ['some error']},
+        tenantId: {$eq: 'tenant-xyz'},
+        batchOperationId: {$eq: 'batch-123'},
+        parentProcessInstanceKey: {$eq: 'parent-456'},
         hasRetriesLeft: true,
         incidentErrorHashCode: 37136123613781,
       },
@@ -200,7 +200,7 @@ describe('buildMutationRequestBody', () => {
 
     expect(body).toEqual({
       filter: {
-        elementId: 'taskA',
+        elementId: {$eq: 'taskA'},
         processDefinitionKey: {$in: ['p1', 'p2']},
       },
     });

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.ts
@@ -6,13 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {RequestFilters} from 'modules/utils/filter';
 import type {
   CreateCancellationBatchOperationRequestBody,
   CreateIncidentResolutionBatchOperationRequestBody,
 } from '@camunda/camunda-api-zod-schemas/8.8';
-import {buildProcessInstanceKeyCriterion} from 'modules/mutations/processes/buildProcessInstanceKeyCriterion';
-import {formatToISO} from 'modules/utils/date/formatDate';
+import type {RequestFilters} from 'modules/utils/filter';
+import {
+  buildProcessInstanceFilter,
+  type BuildProcessInstanceFilterOptions,
+} from 'modules/utils/filter/v2/processInstanceFilterBuilder';
 
 type BuildMutationRequestBodyParams = {
   baseFilter: RequestFilters;
@@ -22,97 +24,21 @@ type BuildMutationRequestBodyParams = {
 
 const buildMutationRequestBody = ({
   baseFilter,
-  includeIds,
-  excludeIds,
+  includeIds = [],
+  excludeIds = [],
 }: BuildMutationRequestBodyParams) => {
+  const builderOptions: BuildProcessInstanceFilterOptions = {
+    includeIds,
+    excludeIds,
+  };
+
+  const filter = buildProcessInstanceFilter(baseFilter, builderOptions);
+
   const requestBody:
     | CreateIncidentResolutionBatchOperationRequestBody
     | CreateCancellationBatchOperationRequestBody = {
-    filter: {
-      elementId: baseFilter.activityId,
-      errorMessage: baseFilter.errorMessage,
-      tenantId: baseFilter.tenantId,
-      batchOperationKey: baseFilter.batchOperationId,
-      parentProcessInstanceKey: baseFilter.parentInstanceId,
-      hasRetriesLeft: baseFilter.retriesLeft,
-      incidentErrorHashCode: baseFilter.incidentErrorHashCode,
-    },
+    filter,
   };
-
-  if (baseFilter.incidents && baseFilter.active) {
-    requestBody.filter.$or = [{hasIncident: true}, {state: {$eq: 'ACTIVE'}}];
-  } else if (baseFilter.incidents) {
-    requestBody.filter.hasIncident = true;
-  } else if (baseFilter.active) {
-    requestBody.filter.state = {$eq: 'ACTIVE'};
-  }
-
-  if (baseFilter.completed && baseFilter.canceled) {
-    requestBody.filter.state = {$in: ['COMPLETED', 'TERMINATED']};
-  } else if (baseFilter.completed) {
-    requestBody.filter.state = {$eq: 'COMPLETED'};
-  } else if (baseFilter.canceled) {
-    requestBody.filter.state = {$eq: 'TERMINATED'};
-  }
-
-  if (
-    Array.isArray(baseFilter.processIds) &&
-    baseFilter.processIds.length > 0
-  ) {
-    requestBody.filter.processDefinitionKey = {
-      $in: baseFilter.processIds,
-    };
-  }
-
-  if (baseFilter.startDateAfter || baseFilter.startDateBefore) {
-    const startDate: {
-      $gt?: string;
-      $lt?: string;
-    } = {};
-
-    if (baseFilter.startDateAfter) {
-      startDate.$gt = formatToISO(baseFilter.startDateAfter);
-    }
-    if (baseFilter.startDateBefore) {
-      startDate.$lt = formatToISO(baseFilter.startDateBefore);
-    }
-
-    requestBody.filter.startDate = startDate;
-  }
-
-  if (baseFilter.endDateAfter || baseFilter.endDateBefore) {
-    const endDate: {
-      $gt?: string;
-      $lt?: string;
-    } = {};
-
-    if (baseFilter.endDateAfter) {
-      endDate.$gt = formatToISO(baseFilter.endDateAfter);
-    }
-    if (baseFilter.endDateBefore) {
-      endDate.$lt = formatToISO(baseFilter.endDateBefore);
-    }
-
-    requestBody.filter.endDate = endDate;
-  }
-
-  if (
-    baseFilter.variable?.name &&
-    Array.isArray(baseFilter.variable.values) &&
-    baseFilter.variable.values.length > 0
-  ) {
-    requestBody.filter.variables = baseFilter.variable.values.map((value) => {
-      return {
-        name: baseFilter.variable!.name,
-        value,
-      };
-    });
-  }
-
-  const keyCriterion = buildProcessInstanceKeyCriterion(includeIds, excludeIds);
-  if (keyCriterion) {
-    requestBody.filter.processInstanceKey = keyCriterion;
-  }
 
   return requestBody;
 };

--- a/operate/client/src/App/Processes/MigrationView/Footer/buildMigrationBatchOperationFilter.ts
+++ b/operate/client/src/App/Processes/MigrationView/Footer/buildMigrationBatchOperationFilter.ts
@@ -13,7 +13,9 @@ import type {
 import {buildProcessInstanceKeyCriterion} from 'modules/mutations/processes/buildProcessInstanceKeyCriterion';
 
 type MigrationFilterOptions = {
-  baseFilter: GetProcessDefinitionStatisticsRequestBody['filter'];
+  baseFilter:
+    | GetProcessDefinitionStatisticsRequestBody['filter']
+    | CreateMigrationBatchOperationRequestBody['filter'];
   includeIds: string[];
   excludeIds: string[];
   processDefinitionKey?: string | null;

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
@@ -17,7 +17,7 @@ vi.mock('modules/hooks/useFilters');
 const mockedUseFilters = vi.mocked(useFilters);
 
 describe('useProcessInstanceFilters', () => {
-  it('should map filters to request correctly with both state and incidents', () => {
+  it('should correctly map filters to request', () => {
     const mockFilters: ProcessInstanceFilters = {
       startDateAfter: '2023-01-01',
       startDateBefore: '2023-01-31',
@@ -67,9 +67,6 @@ describe('useProcessInstanceFilters', () => {
           },
           {hasIncident: true},
         ],
-        state: {
-          $in: ['ACTIVE', 'COMPLETED', 'TERMINATED'],
-        },
         parentProcessInstanceKey: {
           $eq: 'parent1',
         },
@@ -88,7 +85,7 @@ describe('useProcessInstanceFilters', () => {
         incidentErrorHashCode: 321456,
         hasRetriesLeft: true,
       },
-    };
+    } as const;
 
     const {result} = renderHook(() => useProcessInstanceFilters());
     expect(result.current).toEqual(expectedRequest);
@@ -179,7 +176,7 @@ describe('useProcessInstanceFilters', () => {
           $gt: '2023-01-01T00:00:00.000Z',
         },
         state: {
-          $in: ['ACTIVE'],
+          $eq: 'ACTIVE',
         },
       },
     };

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
@@ -85,7 +85,7 @@ describe('useProcessInstanceFilters', () => {
         incidentErrorHashCode: 321456,
         hasRetriesLeft: true,
       },
-    } as const;
+    };
 
     const {result} = renderHook(() => useProcessInstanceFilters());
     expect(result.current).toEqual(expectedRequest);

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
@@ -24,7 +24,6 @@ describe('useProcessInstanceFilters', () => {
       endDateAfter: '2023-02-01',
       endDateBefore: '2023-02-28',
       process: 'process1',
-      version: '1',
       ids: 'id1,id2',
       active: true,
       incidents: true,

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -7,7 +7,10 @@
  */
 
 import {useFilters} from 'modules/hooks/useFilters';
-import type {GetProcessDefinitionStatisticsRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
+import {
+  getProcessDefinitionStatisticsRequestBodySchema,
+  type GetProcessDefinitionStatisticsRequestBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
 import type {ProcessInstanceFilters} from 'modules/utils/filter/shared';
 import {
   buildProcessInstanceFilter,
@@ -21,14 +24,16 @@ function mapFiltersToRequest(
     'includeIds' | 'excludeIds'
   > = {},
 ): GetProcessDefinitionStatisticsRequestBody {
-  const request: GetProcessDefinitionStatisticsRequestBody = {filter: {}};
-
   const builderOptions: BuildProcessInstanceFilterOptions = {
     ...options,
   };
 
-  request.filter = buildProcessInstanceFilter(filters, builderOptions);
-  return request;
+  const filter = buildProcessInstanceFilter(filters, builderOptions);
+  const result = getProcessDefinitionStatisticsRequestBodySchema.parse({
+    filter,
+  });
+
+  return result;
 }
 
 function useProcessInstanceFilters(

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -24,10 +24,10 @@ function useProcessInstanceFilters(
   const filter = buildProcessInstanceFilter(filters, options);
 
   return {
-    filter: filter as NonNullable<
-      GetProcessDefinitionStatisticsRequestBody['filter']
-    >,
-  };
+    filter,
+  } satisfies NonNullable<
+    Pick<GetProcessDefinitionStatisticsRequestBody, 'filter'>
+  >;
 }
 
 export {useProcessInstanceFilters};

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -7,34 +7,11 @@
  */
 
 import {useFilters} from 'modules/hooks/useFilters';
-import {
-  getProcessDefinitionStatisticsRequestBodySchema,
-  type GetProcessDefinitionStatisticsRequestBody,
-} from '@camunda/camunda-api-zod-schemas/8.8';
-import type {ProcessInstanceFilters} from 'modules/utils/filter/shared';
+import {type GetProcessDefinitionStatisticsRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
 import {
   buildProcessInstanceFilter,
   type BuildProcessInstanceFilterOptions,
 } from 'modules/utils/filter/v2/processInstanceFilterBuilder';
-
-function mapFiltersToRequest(
-  filters: ProcessInstanceFilters,
-  options: Omit<
-    BuildProcessInstanceFilterOptions,
-    'includeIds' | 'excludeIds'
-  > = {},
-): GetProcessDefinitionStatisticsRequestBody {
-  const builderOptions: BuildProcessInstanceFilterOptions = {
-    ...options,
-  };
-
-  const filter = buildProcessInstanceFilter(filters, builderOptions);
-  const result = getProcessDefinitionStatisticsRequestBodySchema.parse({
-    filter,
-  });
-
-  return result;
-}
 
 function useProcessInstanceFilters(
   options: Omit<
@@ -44,8 +21,13 @@ function useProcessInstanceFilters(
 ): GetProcessDefinitionStatisticsRequestBody {
   const {getFilters} = useFilters();
   const filters = getFilters();
+  const filter = buildProcessInstanceFilter(filters, options);
 
-  return mapFiltersToRequest(filters, options);
+  return {
+    filter: filter as NonNullable<
+      GetProcessDefinitionStatisticsRequestBody['filter']
+    >,
+  };
 }
 
 export {useProcessInstanceFilters};

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -6,142 +6,41 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type ProcessInstanceFilters} from 'modules/utils/filter/shared';
 import {useFilters} from 'modules/hooks/useFilters';
+import type {GetProcessDefinitionStatisticsRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
+import type {ProcessInstanceFilters} from 'modules/utils/filter/shared';
 import {
-  type GetProcessDefinitionStatisticsRequestBody,
-  type ProcessInstanceState,
-} from '@camunda/camunda-api-zod-schemas/8.8';
-import {formatToISO} from 'modules/utils/date/formatDate';
+  buildProcessInstanceFilter,
+  type BuildProcessInstanceFilterOptions,
+} from 'modules/utils/filter/v2/processInstanceFilterBuilder';
 
 function mapFiltersToRequest(
   filters: ProcessInstanceFilters,
+  options: Omit<
+    BuildProcessInstanceFilterOptions,
+    'includeIds' | 'excludeIds'
+  > = {},
 ): GetProcessDefinitionStatisticsRequestBody {
-  const {
-    flowNodeId,
-    startDateAfter,
-    startDateBefore,
-    endDateAfter,
-    endDateBefore,
-    errorMessage,
-    ids,
-    active,
-    incidentErrorHashCode,
-    incidents,
-    completed,
-    canceled,
-    operationId,
-    parentInstanceId,
-    retriesLeft,
-    tenant,
-    variableName,
-    variableValues,
-  } = filters;
+  const request: GetProcessDefinitionStatisticsRequestBody = {filter: {}};
 
-  const request: GetProcessDefinitionStatisticsRequestBody = {};
-  request.filter = {};
+  const builderOptions: BuildProcessInstanceFilterOptions = {
+    ...options,
+  };
 
-  if (startDateAfter || startDateBefore) {
-    request.filter.startDate = {
-      ...(startDateAfter && {$gt: formatToISO(startDateAfter)}),
-      ...(startDateBefore && {$lt: formatToISO(startDateBefore)}),
-    };
-  }
-
-  if (endDateAfter || endDateBefore) {
-    request.filter.endDate = {
-      ...(endDateAfter && {$gt: formatToISO(endDateAfter)}),
-      ...(endDateBefore && {$lt: formatToISO(endDateBefore)}),
-    };
-  }
-
-  if (ids) {
-    request.filter.processInstanceKey = {
-      $in: ids.split(','),
-    };
-  }
-
-  if (parentInstanceId) {
-    request.filter.parentProcessInstanceKey = {
-      $eq: parentInstanceId,
-    };
-  }
-
-  if (operationId) {
-    request.filter.batchOperationId = {
-      $eq: operationId,
-    };
-  }
-
-  if (errorMessage) {
-    request.filter.errorMessage = {
-      $in: [errorMessage],
-    };
-  }
-
-  if (retriesLeft) {
-    request.filter.hasRetriesLeft = true;
-  }
-
-  if (flowNodeId) {
-    request.filter.elementId = {
-      $eq: flowNodeId,
-    };
-  }
-
-  if (incidentErrorHashCode) {
-    request.filter.incidentErrorHashCode = incidentErrorHashCode;
-  }
-
-  if (tenant) {
-    request.filter.tenantId = {
-      $eq: tenant,
-    };
-  }
-
-  const state: Array<ProcessInstanceState> = [];
-  if (active) {
-    state.push('ACTIVE');
-  }
-  if (completed) {
-    state.push('COMPLETED');
-  }
-  if (canceled) {
-    state.push('TERMINATED');
-  }
-
-  if (incidents) {
-    if (active || completed || canceled) {
-      request.filter.$or = [{state: {$in: state}}, {hasIncident: true}];
-    } else {
-      request.filter.hasIncident = true;
-    }
-  }
-  if (state.length > 0) {
-    request.filter.state = {
-      $in: state,
-    };
-  }
-
-  if (variableName && variableValues) {
-    const variableNames = variableName.split(',');
-    const variableVals = variableValues.split(',');
-    request.filter.variables = variableNames
-      .map((name, index) => ({
-        name,
-        value: variableVals[index] || '',
-      }))
-      .filter((variable) => variable.value !== '');
-  }
-
+  request.filter = buildProcessInstanceFilter(filters, builderOptions);
   return request;
 }
 
-function useProcessInstanceFilters(): GetProcessDefinitionStatisticsRequestBody {
+function useProcessInstanceFilters(
+  options: Omit<
+    BuildProcessInstanceFilterOptions,
+    'includeIds' | 'excludeIds'
+  > = {},
+): GetProcessDefinitionStatisticsRequestBody {
   const {getFilters} = useFilters();
   const filters = getFilters();
 
-  return mapFiltersToRequest(filters);
+  return mapFiltersToRequest(filters, options);
 }
 
 export {useProcessInstanceFilters};

--- a/operate/client/src/modules/utils/filter/index.ts
+++ b/operate/client/src/modules/utils/filter/index.ts
@@ -262,7 +262,7 @@ function getProcessInstancesRequestFilters(): RequestFilters {
         if (key === 'incidentErrorHashCode') {
           return {...accumulator, incidentErrorHashCode: value};
         }
-      } else if (typeof value === 'string') {
+      } else {
         if (key === 'errorMessage') {
           return {
             ...accumulator,

--- a/operate/client/src/modules/utils/filter/index.ts
+++ b/operate/client/src/modules/utils/filter/index.ts
@@ -262,7 +262,7 @@ function getProcessInstancesRequestFilters(): RequestFilters {
         if (key === 'incidentErrorHashCode') {
           return {...accumulator, incidentErrorHashCode: value};
         }
-      } else {
+      } else if (typeof value === 'string') {
         if (key === 'errorMessage') {
           return {
             ...accumulator,
@@ -339,8 +339,7 @@ function getProcessInstancesRequestFilters(): RequestFilters {
             'startDateBefore',
             'endDateAfter',
             'endDateBefore',
-          ].includes(key) &&
-          value !== undefined
+          ].includes(key)
         ) {
           return {
             ...accumulator,

--- a/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.test.ts
+++ b/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {buildProcessInstanceFilter} from './processInstanceFilterBuilder';
+
+import type {ProcessInstanceFilters} from 'modules/utils/filter/shared';
+import type {RequestFilters} from 'modules/utils/filter';
+
+describe('buildProcessInstanceFilter', () => {
+  it('maps fields with correct operators and date ranges', () => {
+    const filters: ProcessInstanceFilters = {
+      startDateAfter: '2023-01-01T00:00:00Z',
+      startDateBefore: '2023-01-31T00:00:00Z',
+      endDateAfter: '2023-02-01T00:00:00Z',
+      endDateBefore: '2023-02-28T00:00:00Z',
+      ids: 'id1,id2',
+      parentInstanceId: 'parent1',
+      operationId: 'op1',
+      flowNodeId: 'node1',
+      tenant: 'tenant1',
+      retriesLeft: true,
+      errorMessage: 'boom',
+      incidentErrorHashCode: 123,
+    };
+
+    const result = buildProcessInstanceFilter(filters);
+
+    expect(result).toEqual({
+      processInstanceKey: {$in: ['id1', 'id2']},
+      parentProcessInstanceKey: {$eq: 'parent1'},
+      batchOperationId: {$eq: 'op1'},
+      elementId: {$eq: 'node1'},
+      tenantId: {$eq: 'tenant1'},
+      hasRetriesLeft: true,
+      errorMessage: {$in: ['boom']},
+      incidentErrorHashCode: 123,
+      startDate: {
+        $gt: '2023-01-01T00:00:00.000Z',
+        $lt: '2023-01-31T00:00:00.000Z',
+      },
+      endDate: {
+        $gt: '2023-02-01T00:00:00.000Z',
+        $lt: '2023-02-28T00:00:00.000Z',
+      },
+    });
+  });
+
+  it('emits hasIncident only when incidents=true and no states selected', () => {
+    const filters: ProcessInstanceFilters = {incidents: true};
+    const result = buildProcessInstanceFilter(filters);
+    expect(result).toEqual({hasIncident: true});
+  });
+
+  it('uses $eq for a single selected state, $in for multiple states', () => {
+    const singleStateFilter: ProcessInstanceFilters = {active: true};
+    const multipleStateFilters: ProcessInstanceFilters = {
+      completed: true,
+      canceled: true,
+    };
+
+    expect(buildProcessInstanceFilter(singleStateFilter)).toEqual({
+      state: {$eq: 'ACTIVE'},
+    });
+
+    expect(buildProcessInstanceFilter(multipleStateFilters)).toEqual({
+      state: {$in: ['COMPLETED', 'TERMINATED']},
+    });
+  });
+
+  it('injects processDefinitionKey from options', () => {
+    const filters: ProcessInstanceFilters = {};
+    const result = buildProcessInstanceFilter(filters, {
+      processDefinitionKeys: ['p1', 'p2'],
+    });
+
+    expect(result).toEqual({
+      processDefinitionKey: {$in: ['p1', 'p2']},
+    });
+  });
+
+  it('parses and stringifies variable values from URL format', () => {
+    const filters: ProcessInstanceFilters = {
+      variableName: 'orderId',
+      variableValues: '123,"test",true',
+    };
+    const result = buildProcessInstanceFilter(filters);
+
+    expect(result).toEqual({
+      variables: [
+        {name: 'orderId', value: '123'},
+        {name: 'orderId', value: '"test"'},
+        {name: 'orderId', value: 'true'},
+      ],
+    });
+  });
+
+  it('maps RequestFilters fields with operators', () => {
+    const filters: RequestFilters = {
+      activityId: 'act-1',
+      errorMessage: 'msg',
+      tenantId: 't-1',
+      batchOperationId: 'op-9',
+      parentInstanceId: 'pi-parent',
+      retriesLeft: true,
+      incidentErrorHashCode: 111,
+      processIds: ['pd1', 'pd2'],
+      startDateAfter: '2020-01-01T00:00:00Z',
+      endDateBefore: '2020-01-03T00:00:00Z',
+    };
+
+    const result = buildProcessInstanceFilter(filters);
+
+    expect(result).toEqual({
+      elementId: {$eq: 'act-1'},
+      errorMessage: {$in: ['msg']},
+      tenantId: {$eq: 't-1'},
+      batchOperationId: {$eq: 'op-9'},
+      parentProcessInstanceKey: {$eq: 'pi-parent'},
+      hasRetriesLeft: true,
+      incidentErrorHashCode: 111,
+      processDefinitionKey: {$in: ['pd1', 'pd2']},
+      startDate: {$gt: '2020-01-01T00:00:00.000Z'},
+      endDate: {$lt: '2020-01-03T00:00:00.000Z'},
+    });
+  });
+
+  it('passes variable values through as-is', () => {
+    const filters: RequestFilters = {
+      variable: {name: 'foo', values: ['a', 'b']},
+    };
+    const result = buildProcessInstanceFilter(filters);
+
+    expect(result).toEqual({
+      variables: [
+        {name: 'foo', value: 'a'},
+        {name: 'foo', value: 'b'},
+      ],
+    });
+  });
+
+  it('uses include/exclude ids from options', () => {
+    const filters: RequestFilters = {};
+    const result = buildProcessInstanceFilter(filters, {
+      includeIds: ['1', '2'],
+      excludeIds: ['x'],
+    });
+
+    expect(result).toEqual({
+      processInstanceKey: {$in: ['1', '2'], $notIn: ['x']},
+    });
+  });
+});

--- a/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.ts
+++ b/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.ts
@@ -248,7 +248,7 @@ const mapProcessKeys = (
   options: BuildProcessInstanceFilterOptions,
 ) => {
   if (
-    options.processDefinitionKeys &&
+    Array.isArray(options.processDefinitionKeys) &&
     options.processDefinitionKeys.length > 0
   ) {
     query.processDefinitionKey = {$in: options.processDefinitionKeys};

--- a/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.ts
+++ b/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.ts
@@ -18,6 +18,29 @@ type ProcessInstanceFilterQuery = NonNullable<
   QueryProcessInstancesRequestBody['filter']
 >;
 
+type NormalizedFilters = {
+  processInstanceKey?: string[];
+  elementId?: string;
+  batchOperationId?: string;
+  tenantId?: string;
+  processDefinitionVersionTag?: string;
+  processDefinitionKey?: string[];
+  variable?: {name: string; values: string[]};
+  parentInstanceId?: string;
+  errorMessage?: string;
+  hasElementInstanceIncident?: boolean;
+  incidentErrorHashCode?: number;
+  retriesLeft?: boolean;
+  startDateAfter?: string;
+  startDateBefore?: string;
+  endDateAfter?: string;
+  endDateBefore?: string;
+  active?: boolean;
+  completed?: boolean;
+  canceled?: boolean;
+  incidents?: boolean;
+};
+
 type BuildProcessInstanceFilterOptions = {
   includeIds?: string[];
   excludeIds?: string[];
@@ -61,8 +84,7 @@ const inputFilterSchema = z
     incidents: z.boolean().optional(),
   })
   .transform((data) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const normalized: Record<string, any> = {};
+    const normalized: NormalizedFilters = {};
 
     if (data.ids) {
       normalized.processInstanceKey =

--- a/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.ts
+++ b/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.ts
@@ -259,7 +259,22 @@ const buildProcessInstanceFilter = (
   filters: UnifiedProcessInstanceFilters,
   options: BuildProcessInstanceFilterOptions = {},
 ): ProcessInstanceFilterQuery => {
-  const normalizedFilters = inputFilterSchema.parse(filters);
+  const parseResult = inputFilterSchema.safeParse(filters);
+
+  if (!parseResult.success) {
+    console.error(
+      'Filter parsing failed. Returning empty filter to show all data.',
+      {
+        filters,
+        error: parseResult.error.issues,
+      },
+    );
+
+    // Return empy query to show all data rather than crashing the app
+    return {};
+  }
+
+  const normalizedFilters = parseResult.data;
 
   const query: ProcessInstanceFilterQuery = {};
 

--- a/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.ts
+++ b/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.ts
@@ -1,0 +1,220 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {formatToISO} from 'modules/utils/date/formatDate';
+import type {ProcessInstanceFilters} from 'modules/utils/filter/shared';
+import type {RequestFilters} from 'modules/utils/filter';
+import {getValidVariableValues} from 'modules/utils/filter/getValidVariableValues';
+import {buildProcessInstanceKeyCriterion} from 'modules/mutations/processes/buildProcessInstanceKeyCriterion';
+import type {QueryProcessInstancesRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
+
+type ProcessInstanceFilterQuery = NonNullable<
+  QueryProcessInstancesRequestBody['filter']
+>;
+
+type BuildProcessInstanceFilterOptions = {
+  includeIds?: string[];
+  excludeIds?: string[];
+  processDefinitionKeys?: string[];
+};
+
+// Unified input type that accepts either URL format or Request format
+type UnifiedProcessInstanceFilters = ProcessInstanceFilters | RequestFilters;
+
+const applyDateRanges = (
+  query: NonNullable<QueryProcessInstancesRequestBody['filter']>,
+  dates: {
+    startDateAfter?: string;
+    startDateBefore?: string;
+    endDateAfter?: string;
+    endDateBefore?: string;
+  },
+) => {
+  const {startDateAfter, startDateBefore, endDateAfter, endDateBefore} = dates;
+
+  if (startDateAfter || startDateBefore) {
+    query.startDate = {
+      ...(startDateAfter && {$gt: formatToISO(startDateAfter)}),
+      ...(startDateBefore && {$lt: formatToISO(startDateBefore)}),
+    };
+  }
+  if (endDateAfter || endDateBefore) {
+    query.endDate = {
+      ...(endDateAfter && {$gt: formatToISO(endDateAfter)}),
+      ...(endDateBefore && {$lt: formatToISO(endDateBefore)}),
+    };
+  }
+};
+
+const mapStatesAndIncidents = (
+  query: NonNullable<QueryProcessInstancesRequestBody['filter']>,
+  params: {
+    active: boolean;
+    completed: boolean;
+    canceled: boolean;
+    incidents: boolean;
+  },
+) => {
+  const states: Array<'ACTIVE' | 'COMPLETED' | 'TERMINATED'> = [];
+  if (params.active) {
+    states.push('ACTIVE');
+  }
+  if (params.completed) {
+    states.push('COMPLETED');
+  }
+  if (params.canceled) {
+    states.push('TERMINATED');
+  }
+
+  if (params.incidents) {
+    if (states.length > 0) {
+      query.$or = [{state: {$in: states}}, {hasIncident: true}];
+    } else {
+      query.hasIncident = true;
+    }
+  } else if (states.length > 0) {
+    query.state = states.length === 1 ? {$eq: states[0]} : {$in: states};
+  }
+};
+
+const mapVariables = (
+  query: NonNullable<QueryProcessInstancesRequestBody['filter']>,
+  variable: {name: string; values: string[]},
+) => {
+  const filteredValues = variable.values.filter((v) => v !== '');
+  if (filteredValues.length > 0) {
+    query.variables = filteredValues.map((value) => ({
+      name: variable.name,
+      value,
+    }));
+  }
+};
+
+const mapProcessKeys = (
+  query: NonNullable<QueryProcessInstancesRequestBody['filter']>,
+  options: BuildProcessInstanceFilterOptions,
+) => {
+  if (
+    options.processDefinitionKeys &&
+    options.processDefinitionKeys.length > 0
+  ) {
+    query.processDefinitionKey = {$in: options.processDefinitionKeys};
+  }
+};
+
+const buildProcessInstanceFilter = (
+  filters: UnifiedProcessInstanceFilters,
+  options: BuildProcessInstanceFilterOptions = {},
+): ProcessInstanceFilterQuery => {
+  const query: ProcessInstanceFilterQuery = {};
+
+  if ('ids' in filters && filters.ids) {
+    const ids =
+      typeof filters.ids === 'string' ? filters.ids.split(',') : filters.ids;
+    query.processInstanceKey = {$in: ids};
+  }
+
+  if (filters.parentInstanceId) {
+    query.parentProcessInstanceKey = {$eq: filters.parentInstanceId};
+  }
+
+  const batchOperationId =
+    ('operationId' in filters && filters.operationId) ||
+    ('batchOperationId' in filters && filters.batchOperationId);
+  if (batchOperationId) {
+    query.batchOperationId = {$eq: batchOperationId};
+  }
+
+  if (filters.errorMessage) {
+    query.errorMessage = {$in: [filters.errorMessage]};
+  }
+
+  if (typeof filters.incidentErrorHashCode === 'number') {
+    query.incidentErrorHashCode = filters.incidentErrorHashCode;
+  }
+
+  const elementId =
+    ('flowNodeId' in filters && filters.flowNodeId) ||
+    ('activityId' in filters && filters.activityId);
+  if (elementId) {
+    query.elementId = {$eq: elementId};
+  }
+
+  const tenantId =
+    ('tenant' in filters && filters.tenant) ||
+    ('tenantId' in filters && filters.tenantId);
+  if (tenantId && tenantId !== 'all') {
+    query.tenantId = {$eq: tenantId};
+  }
+
+  if (filters.retriesLeft) {
+    query.hasRetriesLeft = true;
+  }
+
+  if ('version' in filters && filters.version) {
+    query.processDefinitionVersionTag = filters.version;
+  }
+
+  if (
+    'processIds' in filters &&
+    Array.isArray(filters.processIds) &&
+    filters.processIds.length > 0
+  ) {
+    query.processDefinitionKey = {$in: filters.processIds};
+  } else {
+    mapProcessKeys(query, options);
+  }
+
+  applyDateRanges(query, {
+    startDateAfter: filters.startDateAfter,
+    startDateBefore: filters.startDateBefore,
+    endDateAfter: filters.endDateAfter,
+    endDateBefore: filters.endDateBefore,
+  });
+
+  mapStatesAndIncidents(query, {
+    active: !!filters.active,
+    completed: !!filters.completed,
+    canceled: !!filters.canceled,
+    incidents: !!filters.incidents,
+  });
+
+  if (
+    'variableName' in filters &&
+    filters.variableName &&
+    filters.variableValues
+  ) {
+    const parsed = (getValidVariableValues(filters.variableValues) ?? []).map(
+      (v) => JSON.stringify(v),
+    );
+    mapVariables(query, {name: filters.variableName, values: parsed});
+  } else if (
+    'variable' in filters &&
+    filters.variable?.name &&
+    Array.isArray(filters.variable.values)
+  ) {
+    mapVariables(query, {
+      name: filters.variable.name,
+      values: filters.variable.values,
+    });
+  }
+
+  const processInstanceKeyCriterion = buildProcessInstanceKeyCriterion(
+    options.includeIds,
+    options.excludeIds,
+  );
+
+  if (processInstanceKeyCriterion) {
+    query.processInstanceKey = processInstanceKeyCriterion;
+  }
+
+  return query;
+};
+
+export {buildProcessInstanceFilter};
+export type {BuildProcessInstanceFilterOptions, ProcessInstanceFilterQuery};

--- a/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.ts
+++ b/operate/client/src/modules/utils/filter/v2/processInstanceFilterBuilder.ts
@@ -172,7 +172,8 @@ const inputFilterSchema = z
     }
 
     return normalized;
-  });
+  })
+  .catch({});
 
 const applyDateRanges = (
   query: ProcessInstanceFilterQuery,
@@ -259,22 +260,7 @@ const buildProcessInstanceFilter = (
   filters: UnifiedProcessInstanceFilters,
   options: BuildProcessInstanceFilterOptions = {},
 ): ProcessInstanceFilterQuery => {
-  const parseResult = inputFilterSchema.safeParse(filters);
-
-  if (!parseResult.success) {
-    console.error(
-      'Filter parsing failed. Returning empty filter to show all data.',
-      {
-        filters,
-        error: parseResult.error.issues,
-      },
-    );
-
-    // Return empy query to show all data rather than crashing the app
-    return {};
-  }
-
-  const normalizedFilters = parseResult.data;
+  const normalizedFilters = inputFilterSchema.parse(filters);
 
   const query: ProcessInstanceFilterQuery = {};
 

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.18.0",
         "@bpmn-io/form-js-viewer": "1.18.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.14",
+        "@camunda/camunda-api-zod-schemas": "0.0.15",
         "@camunda/camunda-composite-components": "0.21.1",
         "@carbon/elements": "11.78.0",
         "@carbon/react": "1.94.2",
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.14.tgz",
-      "integrity": "sha512-U/RvqX+CCiX4xB6SPhlqNfvPobtt8H1LZZjrJquhUmsxKCBFczdmK21pVmH5Ww0nWS6YN+0hQmm8x1g7MBuXrg==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.15.tgz",
+      "integrity": "sha512-26dPp6T3q+82I3Q/HHbnq7rcts/0UoHc4XMT1OXknpZ/XM//nC6jfv4ojOqaQR/iYzYLoqY/fIHZuTZIPcy8iQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.18.0",
         "@bpmn-io/form-js-viewer": "1.18.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.13",
+        "@camunda/camunda-api-zod-schemas": "0.0.14",
         "@camunda/camunda-composite-components": "0.21.1",
         "@carbon/elements": "11.78.0",
         "@carbon/react": "1.94.2",
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.13.tgz",
-      "integrity": "sha512-YxONMDyQrEKu5gJsqJo+SPfhcqZogdrOJajVXZYcGtRvH8xwXa0gMD4Q2ojSo0hpdJ8TwRF3SuHoV/NBH8uECQ==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.14.tgz",
+      "integrity": "sha512-U/RvqX+CCiX4xB6SPhlqNfvPobtt8H1LZZjrJquhUmsxKCBFczdmK21pVmH5Ww0nWS6YN+0hQmm8x1g7MBuXrg==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.18.0",
     "@bpmn-io/form-js-viewer": "1.18.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.14",
+    "@camunda/camunda-api-zod-schemas": "0.0.15",
     "@camunda/camunda-composite-components": "0.21.1",
     "@carbon/elements": "11.78.0",
     "@carbon/react": "1.94.2",

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.18.0",
     "@bpmn-io/form-js-viewer": "1.18.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.13",
+    "@camunda/camunda-api-zod-schemas": "0.0.14",
     "@camunda/camunda-composite-components": "0.21.1",
     "@carbon/elements": "11.78.0",
     "@carbon/react": "1.94.2",


### PR DESCRIPTION
## Description

- Consolidate PI filter building to one file
- Reuse new builder in `useProcessInstancesFilters.ts` and `buildMutationRequestBody.ts`
- Update PI schema with correct operation id property name `batchOperationKey` => `batchOperationId`

## Related issues

closes #40474, #40478, #40479 
