### PR TITLE
fix: Fix flaky test shouldRejectBroadcastForOneUnauthorizedProcess

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
@@ -160,16 +160,21 @@ public class BroadcastSignalMultiplePartitionsTest {
     ENGINE.signal().withSignalName(signalName).broadcastWithMetadata(user.getUsername());
 
     // then (rejection on partition hosting unauthorized process)
-    assertThat(
-            RecordingExporter.signalRecords(SignalIntent.BROADCAST)
-                .withSignalName(signalName)
-                .withPartitionId(2)
-                .withRecordType(RecordType.COMMAND_REJECTION)
-                .withRejectionReason(
-                    "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
-                        .formatted(otherProcessId))
-                .exists())
-        .isTrue();
+    await("signal broadcast rejection for unauthorized process")
+        .pollInterval(Duration.ofMillis(10))
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        RecordingExporter.signalRecords(SignalIntent.BROADCAST)
+                            .withSignalName(signalName)
+                            .withPartitionId(2)
+                            .withRecordType(RecordType.COMMAND_REJECTION)
+                            .withRejectionReason(
+                                "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
+                                    .formatted(otherProcessId))
+                            .exists())
+                    .isTrue());
 
     // then - the signal distribution is still finished because a redistribution is not necessary
     assertThat(
@@ -201,16 +206,21 @@ public class BroadcastSignalMultiplePartitionsTest {
     ENGINE.signal().withSignalName(signalName).broadcastWithMetadata(user.getUsername());
 
     // then - the command is rejected on the partition that hosts the unauthorized process instance
-    assertThat(
-            RecordingExporter.signalRecords(SignalIntent.BROADCAST)
-                .withSignalName(signalName)
-                .withPartitionId(2)
-                .withRecordType(RecordType.COMMAND_REJECTION)
-                .withRejectionReason(
-                    "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
-                        .formatted(otherProcessId))
-                .exists())
-        .isTrue();
+    await("signal broadcast rejection for unauthorized process")
+        .pollInterval(Duration.ofMillis(10))
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        RecordingExporter.signalRecords(SignalIntent.BROADCAST)
+                            .withSignalName(signalName)
+                            .withPartitionId(2)
+                            .withRecordType(RecordType.COMMAND_REJECTION)
+                            .withRejectionReason(
+                                "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
+                                    .formatted(otherProcessId))
+                            .exists())
+                    .isTrue());
 
     // then - the signal distribution is still finished because a redistribution is not necessary
     assertThat(


### PR DESCRIPTION
## Description

I re-ran the workflow that executed the test in question a few times to see if flakiness persists.

* [Run 1](https://github.com/camunda/camunda/actions/runs/19176191418/job/54821700877?pr=40679)
* [Run 2](https://github.com/camunda/camunda/actions/runs/19176191418/job/54823196523?pr=40679)
* [Run 3](https://github.com/camunda/camunda/actions/runs/19176191418/job/54825200257?pr=40679)
* [Run 4](https://github.com/camunda/camunda/actions/runs/19178381997/job/54828944935?pr=40679)

No flakiness was observed

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/40333
