### PR TITLE
fix: mock BackupController in redirect test

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/controllers/OldRoutesRedirectionControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/controllers/OldRoutesRedirectionControllerIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.webapps.WebappsModuleConfiguration;
+import io.camunda.webapps.controllers.BackupController;
 import io.camunda.webapps.controllers.IndexController;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,6 +23,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest(
     classes = {
@@ -32,6 +34,8 @@ import org.springframework.http.ResponseEntity;
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class OldRoutesRedirectionControllerIT {
+
+  @MockitoBean private BackupController backupController;
 
   @LocalServerPort private int port;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Mock the `BackupController` instantiation so that the `OldRoutesRedirectionControllerIT` can properly initialize the Spring test context. The CI job has been failing on main with the config changes.

ref consistent CI failure: https://github.com/camunda/camunda/actions/runs/19178757805/job/54830009030?pr=40647

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
