### PR TITLE
feat: spring boot starter can make use of issuer url

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CredentialsProviderConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CredentialsProviderConfiguration.java
@@ -84,10 +84,10 @@ public class CredentialsProviderConfiguration {
             .audience(camundaClientProperties.getAuth().getAudience())
             .scope(camundaClientProperties.getAuth().getScope())
             .resource(camundaClientProperties.getAuth().getResource())
-            .authorizationServerUrl(
-                ofNullable(camundaClientProperties.getAuth().getTokenUrl())
-                    .map(URI::toString)
-                    .orElse(null))
+            .authorizationServerUrl(fromURI(camundaClientProperties.getAuth().getTokenUrl()))
+            .wellKnownConfigurationUrl(
+                fromURI(camundaClientProperties.getAuth().getWellKnownConfigurationUrl()))
+            .issuerUrl(fromURI(camundaClientProperties.getAuth().getIssuerUrl()))
             .credentialsCachePath(camundaClientProperties.getAuth().getCredentialsCachePath())
             .connectTimeout(camundaClientProperties.getAuth().getConnectTimeout())
             .readTimeout(camundaClientProperties.getAuth().getReadTimeout())
@@ -101,17 +101,11 @@ public class CredentialsProviderConfiguration {
                 camundaClientProperties.getAuth().getClientAssertion().getKeystoreKeyPassword());
 
     maybeConfigureIdentityProviderSSLConfig(credBuilder, camundaClientProperties);
-    try {
-      return credBuilder.build();
-    } catch (final Exception e) {
-      LOG.warn(
-          "Failed to configure oidc credential provider, falling back to use no authentication, cause: {}",
-          e.getMessage());
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(e.getMessage(), e);
-      }
-      return new NoopCredentialsProvider();
-    }
+    return credBuilder.build();
+  }
+
+  private String fromURI(final URI uri) {
+    return ofNullable(uri).map(URI::toString).orElse(null);
   }
 
   private void maybeConfigureIdentityProviderSSLConfig(

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientAuthProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientAuthProperties.java
@@ -55,9 +55,23 @@ public class CamundaClientAuthProperties {
 
   /**
    * The authorization server URL from which to request the access token. A default is set by
-   * `camunda.client.mode: saas` and `camunda.client.auth.method: oidc`.
+   * `camunda.client.mode: saas`.
    */
   private URI tokenUrl;
+
+  /**
+   * The url of the issuer for the access token. It is used to generate the well-known configuration
+   * url from which the `token-url` is retrieved. Only applied if the
+   * `camunda.client.auth.well-known-configuration-url` is not set. A default is set by
+   * `camunda.client.auth.method: oidc`.
+   */
+  private URI issuerUrl;
+
+  /**
+   * The url of the well-known configuration of the issuer. It is used to retrieve the `token-url`.
+   * Only applied if `camunda.client.auth.token-url` is not set.
+   */
+  private URI wellKnownConfigurationUrl;
 
   /**
    * The resource for which the access token must be valid. A default is set by
@@ -121,6 +135,22 @@ public class CamundaClientAuthProperties {
 
   public void setTokenUrl(final URI tokenUrl) {
     this.tokenUrl = tokenUrl;
+  }
+
+  public URI getIssuerUrl() {
+    return issuerUrl;
+  }
+
+  public void setIssuerUrl(final URI issuerUrl) {
+    this.issuerUrl = issuerUrl;
+  }
+
+  public URI getWellKnownConfigurationUrl() {
+    return wellKnownConfigurationUrl;
+  }
+
+  public void setWellKnownConfigurationUrl(final URI wellKnownConfigurationUrl) {
+    this.wellKnownConfigurationUrl = wellKnownConfigurationUrl;
   }
 
   public Duration getConnectTimeout() {
@@ -246,9 +276,8 @@ public class CamundaClientAuthProperties {
   @Override
   public String toString() {
     return "CamundaClientAuthProperties{"
-        + "method='"
+        + "method="
         + method
-        + '\''
         + ", username='"
         + username
         + '\''
@@ -263,6 +292,10 @@ public class CamundaClientAuthProperties {
         + '\''
         + ", tokenUrl="
         + tokenUrl
+        + ", issuerUrl="
+        + issuerUrl
+        + ", wellKnownConfigurationUrl="
+        + wellKnownConfigurationUrl
         + ", audience='"
         + audience
         + '\''
@@ -272,18 +305,16 @@ public class CamundaClientAuthProperties {
         + ", resource='"
         + resource
         + '\''
-        + ", keystorePath='"
+        + ", keystorePath="
         + keystorePath
-        + '\''
         + ", keystorePassword='"
         + (keystorePassword != null ? "***" : null)
         + '\''
         + ", keystoreKeyPassword='"
         + (keystoreKeyPassword != null ? "***" : null)
         + '\''
-        + ", truststorePath='"
+        + ", truststorePath="
         + truststorePath
-        + '\''
         + ", truststorePassword='"
         + (truststorePassword != null ? "***" : null)
         + '\''
@@ -294,6 +325,8 @@ public class CamundaClientAuthProperties {
         + connectTimeout
         + ", readTimeout="
         + readTimeout
+        + ", clientAssertion="
+        + clientAssertion
         + '}';
   }
 

--- a/clients/camunda-spring-boot-starter/src/main/resources/auth-methods/oidc.yaml
+++ b/clients/camunda-spring-boot-starter/src/main/resources/auth-methods/oidc.yaml
@@ -2,5 +2,5 @@ camunda:
   client:
     auth:
       method: oidc
-      token-url: http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+      issuer-url: http://localhost:18080/auth/realms/camunda-platform
       audience: zeebe-api

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/CredentialsProviderClientAssertionTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/CredentialsProviderClientAssertionTest.java
@@ -36,7 +36,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
       "camunda.client.mode=self-managed",
       "camunda.client.auth.client-id=CredentialsProviderSelfManagedTest-my-client-id",
       "camunda.client.auth.client-secret=my-client-secret",
-      "camunda.client.auth.client-assertion.keystore-password=mstest"
+      "camunda.client.auth.client-assertion.keystore-password=mstest",
+      "camunda.client.auth.token-url=https://auth.example.com/token"
     })
 @EnableConfigurationProperties(CamundaClientProperties.class)
 public class CredentialsProviderClientAssertionTest {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/CredentialsProviderResourceTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/CredentialsProviderResourceTest.java
@@ -34,7 +34,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
       "camunda.client.mode=self-managed",
       "camunda.client.auth.client-id=CredentialsProviderResourceTest-my-client-id",
       "camunda.client.auth.client-secret=my-client-secret",
-      "camunda.client.auth.resource=https://api.example.com"
+      "camunda.client.auth.resource=https://api.example.com",
+      "camunda.client.auth.token-url=https://auth.example.com/token"
     })
 @EnableConfigurationProperties(CamundaClientProperties.class)
 public class CredentialsProviderResourceTest {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/SpringCamundaClientConfigurationSelfManagedTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/SpringCamundaClientConfigurationSelfManagedTest.java
@@ -39,7 +39,8 @@ import org.springframework.boot.test.system.OutputCaptureExtension;
       "camunda.client.auth.method=oidc",
       "camunda.client.auth.client-id=my-client-id",
       "camunda.client.auth.client-secret=my-client-secret",
-      "logging.level.io.camunda.client.spring.configuration.CamundaClientProdAutoConfiguration=debug"
+      "logging.level.io.camunda.client.spring.configuration.CamundaClientProdAutoConfiguration=debug",
+      "camunda.client.auth.token-url=https://auth.example.com/token"
     })
 @ExtendWith(OutputCaptureExtension.class)
 public class SpringCamundaClientConfigurationSelfManagedTest {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/CamundaClientAuthMethodsTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/CamundaClientAuthMethodsTest.java
@@ -80,10 +80,8 @@ public class CamundaClientAuthMethodsTest {
     @Test
     void shouldLoadDefaultsBasic() {
       assertThat(properties.getAuth().getMethod()).isEqualTo(AuthMethod.oidc);
-      assertThat(properties.getAuth().getTokenUrl())
-          .isEqualTo(
-              URI.create(
-                  "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token"));
+      assertThat(properties.getAuth().getIssuerUrl())
+          .isEqualTo(URI.create("http://localhost:18080/auth/realms/camunda-platform"));
       assertThat(properties.getAuth().getAudience()).isEqualTo("zeebe-api");
       assertThat(properties.getAuth().getClientId()).isEqualTo("some-client");
     }
@@ -99,10 +97,8 @@ public class CamundaClientAuthMethodsTest {
     @Test
     void shouldLoadDefaultsBasic() {
       assertThat(properties.getAuth().getMethod()).isEqualTo(AuthMethod.oidc);
-      assertThat(properties.getAuth().getTokenUrl())
-          .isEqualTo(
-              URI.create(
-                  "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token"));
+      assertThat(properties.getAuth().getIssuerUrl())
+          .isEqualTo(URI.create("http://localhost:18080/auth/realms/camunda-platform"));
       assertThat(properties.getAuth().getAudience()).isEqualTo("zeebe-api");
       assertThat(properties.getAuth().getClientSecret()).isEqualTo("some-secret");
     }
@@ -133,10 +129,8 @@ public class CamundaClientAuthMethodsTest {
     @Test
     void shouldLoadDefaultsBasic() {
       assertThat(properties.getAuth().getMethod()).isEqualTo(AuthMethod.oidc);
-      assertThat(properties.getAuth().getTokenUrl())
-          .isEqualTo(
-              URI.create(
-                  "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token"));
+      assertThat(properties.getAuth().getIssuerUrl())
+          .isEqualTo(URI.create("http://localhost:18080/auth/realms/camunda-platform"));
       assertThat(properties.getAuth().getAudience()).isEqualTo("zeebe-api");
     }
   }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/CamundaClientModesWithAuthMethodsTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/CamundaClientModesWithAuthMethodsTest.java
@@ -108,10 +108,8 @@ public class CamundaClientModesWithAuthMethodsTest {
       assertThat(properties.getGrpcAddress().toString()).isEqualTo("http://localhost:26500");
       assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8088");
       assertThat(properties.getAuth().getMethod()).isEqualTo(AuthMethod.oidc);
-      assertThat(properties.getAuth().getTokenUrl())
-          .isEqualTo(
-              URI.create(
-                  "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token"));
+      assertThat(properties.getAuth().getIssuerUrl())
+          .isEqualTo(URI.create("http://localhost:18080/auth/realms/camunda-platform"));
       assertThat(properties.getAuth().getAudience()).isEqualTo("zeebe-api");
       assertThat(properties.getAuth().getClientId()).isEqualTo("basic");
     }
@@ -130,10 +128,8 @@ public class CamundaClientModesWithAuthMethodsTest {
       assertThat(properties.getGrpcAddress().toString()).isEqualTo("http://localhost:26500");
       assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8088");
       assertThat(properties.getAuth().getMethod()).isEqualTo(AuthMethod.oidc);
-      assertThat(properties.getAuth().getTokenUrl())
-          .isEqualTo(
-              URI.create(
-                  "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token"));
+      assertThat(properties.getAuth().getIssuerUrl())
+          .isEqualTo(URI.create("http://localhost:18080/auth/realms/camunda-platform"));
       assertThat(properties.getAuth().getAudience()).isEqualTo("zeebe-api");
     }
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR allows the spring boot starter to make use of the new configuration options introduced with #39437 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
