### PR TITLE
ci(fossa): ping @monorepo-ci-medic in Slack notifications for active issues

### DIFF
--- a/.github/workflows/check-licenses-active-issues.yml
+++ b/.github/workflows/check-licenses-active-issues.yml
@@ -129,7 +129,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "*${{ steps.check-issues.outputs.active-issues-found }}* active licensing issue(s) found across projects and tracked branches:\n\n${{ steps.check-issues.outputs.active-issues-list }}"
+                  "text": "*${{ steps.check-issues.outputs.active-issues-found }}* active licensing issue(s) found across projects and tracked branches:\n\n${{ steps.check-issues.outputs.active-issues-list }}\n\nDRI: <!subteam^S07D6C6B18T|monorepo-ci-medic>"
                 }
               }
             ]


### PR DESCRIPTION
## Description

Add @camunda/monorepo-ci-dri  as the DRI in Slack notifications for unhandled FOSSA Licensing issues.

Related to:
- https://app.asana.com/1/384886434863350/project/1208645748975331/task/1211816746454891
- https://camunda.slack.com/archives/C071KP5BTHB/p1762769648141899?thread_ts=1762765882.203529&cid=C071KP5BTHB

Test: [Slack Block Kit  builder](https://app.slack.com/block-kit-builder/T0PM0P1SA#%7B%22blocks%22:%5B%7B%22type%22:%22header%22,%22text%22:%7B%22type%22:%22plain_text%22,%22text%22:%22:warning:%20Unhandled%20FOSSA%20Licensing%20Issues%20Found%22%7D%7D,%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22*$%7B%7B%20steps.check-issues.outputs.active-issues-found%20%7D%7D*%20active%20licensing%20issue(s)%20found%20across%20projects%20and%20tracked%20branches:%5Cn%5Cn$%7B%7B%20steps.check-issues.outputs.active-issues-list%20%7D%7D%5Cn%5CnDRI:%20%3C!subteam%5ES07D6C6B18T%7Cmonorepo-ci-medic%3E%20(%3Chttps://confluence.camunda.com/spaces/HAN/pages/277024795/FOSS+in+Camunda+8+FOSSA%7Cdoc%3E)%22%7D%7D%5D%7D)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).
