### PR TITLE
fix: improve regex for alpha version detection in release workflow to support 1.1

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -156,7 +156,7 @@ jobs:
           if [[ ! $RELEASE_VERSION =~ rc[0-9]+$ ]]; then
             is_rc="false"
           fi
-          if [[ ! $RELEASE_VERSION =~ alpha[0-9]+$ ]]; then
+          if [[ ! $RELEASE_VERSION =~ alpha[0-9]+(\.[0-9]+)*$ ]]; then
             is_alpha="false"
           fi
           {


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
We need to release an alpha1.1 release for Optimize and the current release workflow does not seem to support the 1.x notation. This PR addresses that.

For more information on why we are releaseing 1.1, see https://camunda.slack.com/archives/C09QZ7K0WUF

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
