### PR TITLE
[Backport stable/8.7] fix: Fix flaky test shouldRejectBroadcastForOneUnauthorizedProcess

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
@@ -121,4 +121,179 @@ public class BroadcastSignalMultiplePartitionsTest {
             tuple("wf_2", ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple("wf_2", ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
+<<<<<<< HEAD
+=======
+
+  @Test
+  public void shouldAuthorizeOnAllPartitions() {
+    // given
+    final String signalName = newRandomSignal();
+    final String processId = Strings.newRandomValidBpmnId();
+    final String otherProcessId = Strings.newRandomValidBpmnId();
+    deployProcess(processId, "catch_main", signalName);
+    deployProcess(otherProcessId, "catch_other", signalName);
+
+    createProcessInstance(processId, 1);
+    createProcessInstance(otherProcessId, 2);
+
+    final UserRecordValue user = createUser();
+    grantProcessPermission(user.getUsername(), processId);
+
+    waitForSignalSubscriptions(signalName, 2);
+
+    // when
+    ENGINE.signal().withSignalName(signalName).broadcastWithMetadata(user.getUsername());
+
+    // then (rejection on partition hosting unauthorized process)
+    await("signal broadcast rejection for unauthorized process")
+        .pollInterval(Duration.ofMillis(10))
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        RecordingExporter.signalRecords(SignalIntent.BROADCAST)
+                            .withSignalName(signalName)
+                            .withPartitionId(2)
+                            .withRecordType(RecordType.COMMAND_REJECTION)
+                            .withRejectionReason(
+                                "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
+                                    .formatted(otherProcessId))
+                            .exists())
+                    .isTrue());
+
+    // then - the signal distribution is still finished because a redistribution is not necessary
+    assertThat(
+            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+                .withDistributionValueType(ValueType.SIGNAL)
+                .withDistributionIntent(SignalIntent.BROADCAST)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldRejectBroadcastForOneUnauthorizedProcess() {
+    // given
+    final String signalName = newRandomSignal();
+    final String processId = Strings.newRandomValidBpmnId();
+    final String otherProcessId = Strings.newRandomValidBpmnId();
+    deployProcess(processId, "catch_main", signalName);
+    deployProcess(otherProcessId, "catch_other", signalName);
+
+    createProcessInstance(processId, 2);
+    createProcessInstance(otherProcessId, 2);
+
+    final UserRecordValue user = createUser();
+    grantProcessPermission(user.getUsername(), processId);
+
+    waitForSignalSubscriptions(signalName, 2);
+
+    // when
+    ENGINE.signal().withSignalName(signalName).broadcastWithMetadata(user.getUsername());
+
+    // then - the command is rejected on the partition that hosts the unauthorized process instance
+    await("signal broadcast rejection for unauthorized process")
+        .pollInterval(Duration.ofMillis(10))
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        RecordingExporter.signalRecords(SignalIntent.BROADCAST)
+                            .withSignalName(signalName)
+                            .withPartitionId(2)
+                            .withRecordType(RecordType.COMMAND_REJECTION)
+                            .withRejectionReason(
+                                "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
+                                    .formatted(otherProcessId))
+                            .exists())
+                    .isTrue());
+
+    // then - the signal distribution is still finished because a redistribution is not necessary
+    assertThat(
+            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+                .withDistributionValueType(ValueType.SIGNAL)
+                .withDistributionIntent(SignalIntent.BROADCAST)
+                .exists())
+        .isTrue();
+  }
+
+  // --- helpers -------------------------------------------------------------------------------
+
+  private static String newRandomSignal() {
+    return "sig_" + UUID.randomUUID();
+  }
+
+  private static long deploySignalCatchingProcess(final String bpmnId, final String signalName) {
+    return ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(bpmnId).startEvent().signal(signalName).endEvent().done())
+        .deploy(DEFAULT_USER.getUsername())
+        .getKey();
+  }
+
+  private static void deployProcess(
+      final String processId, final String catchId, final String signalName) {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .intermediateCatchEvent(catchId)
+                .signal(signalName)
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private static long createProcessInstance(final String processId) {
+    return ENGINE.processInstance().ofBpmnProcessId(processId).create(DEFAULT_USER.getUsername());
+  }
+
+  private static void createProcessInstance(final String processId, final int partition) {
+    ENGINE
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .onPartition(partition)
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  private static UserRecordValue createUser() {
+    return ENGINE
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create(DEFAULT_USER.getUsername())
+        .getValue();
+  }
+
+  private static void grantProcessPermission(final String username, final String processId) {
+    ENGINE
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
+        .withOwnerId(username)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(processId)
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  private static void waitForSignalSubscriptions(final String signalName, final int processCount) {
+    await("signal subscriptions created for " + signalName)
+        .pollInterval(Duration.ofMillis(10))
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        RecordingExporter.signalSubscriptionRecords(
+                                SignalSubscriptionIntent.CREATED)
+                            .withSignalName(signalName)
+                            .limit(processCount)
+                            .count())
+                    .isEqualTo(processCount));
+  }
+>>>>>>> 62ed955f (fix: Fix flaky test BroadcastSignalMultiplePartitionsTest.java::shouldRejectBroadcastForOneUnauthorizedProcess)
 }


### PR DESCRIPTION
# Description
Backport of #40679 to `stable/8.7`.

relates to camunda/camunda#40333