### PR TITLE
fix: stabilize tasklist variables e2e test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
@@ -11,6 +11,7 @@ import {test} from 'fixtures';
 import {deploy, createInstances} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
+import {waitForAssertion} from 'utils/waitForAssertion';
 
 test.beforeAll(async () => {
   await deploy([
@@ -171,7 +172,9 @@ test.describe('variables page', () => {
     await taskPanelPage.openTask('usertask_with_variables');
 
     await expect(taskDetailsPage.addVariableButton).toBeHidden();
-    await expect(taskDetailsPage.assignToMeButton).toBeVisible({timeout: 60000});
+    await expect(taskDetailsPage.assignToMeButton).toBeVisible({
+      timeout: 60000,
+    });
     await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
     await taskDetailsPage.clickAssignToMeButton();
 
@@ -193,7 +196,19 @@ test.describe('variables page', () => {
     await taskPanelPage.filterBy('Completed');
     await taskPanelPage.openTask('usertask_with_variables');
 
-    await expect(page.getByText('newVariableName')).toBeVisible({timeout: 60000});
-    await expect(page.getByText('newVariableValue')).toBeVisible();
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(page.getByText('newVariableName')).toBeVisible({
+          timeout: 60000,
+        });
+        await expect(page.getByText('newVariableValue')).toBeVisible();
+      },
+      onFailure: async () => {
+        console.log('Variables not visible, reloading page...');
+        await page.reload();
+        await taskPanelPage.filterBy('Completed');
+        await taskPanelPage.openTask('usertask_with_variables');
+      },
+    });
   });
 });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Test is flaky, this PR add retries to stabilize the test

🧪 [Successful test run](https://github.com/camunda/camunda/actions/runs/19231135750)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
