### PR TITLE
fix: update zeebe-protocol and zeebe-build-tools dependencies to version 8.9.0-alpha1-rc1

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -74,20 +74,20 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-connect</artifactId>
-      <version>${project.version}</version>
+      <version>8.9.0-alpha1-rc1</version>
     </dependency>
 
     <!-- Zeebe dependencies -->
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
-      <version>${project.version}</version>
+      <version>8.9.0-alpha1-rc1</version>
     </dependency>
 
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
-      <version>${project.version}</version>
+      <version>8.9.0-alpha1-rc1</version>
       <scope>test</scope>
     </dependency>
 
@@ -294,7 +294,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-jackson</artifactId>
-      <version>${project.version}</version>
+      <version>8.9.0-alpha1-rc1</version>
       <scope>test</scope>
     </dependency>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -104,6 +104,11 @@
     <dependencies>
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>camunda-search-client-plugin</artifactId>
+        <version>8.9.0-alpha1-rc1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>camunda-search-client-connect</artifactId>
         <version>8.9.0-alpha1-rc1</version>
       </dependency>
@@ -125,6 +130,36 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-search-domain</artifactId>
+        <version>8.9.0-alpha1-rc1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-security-protocol</artifactId>
+        <version>8.9.0-alpha1-rc1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-security-core</artifactId>
+        <version>8.9.0-alpha1-rc1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-bpmn-model</artifactId>
+        <version>8.9.0-alpha1-rc1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-search-client-reader</artifactId>
+        <version>8.9.0-alpha1-rc1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-spring-utils</artifactId>
+        <version>8.9.0-alpha1-rc1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-auth</artifactId>
         <version>8.9.0-alpha1-rc1</version>
       </dependency>
     </dependencies>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-build-tools</artifactId>
-      <version>8.9.0-SNAPSHOT</version>
+      <version>8.9.0-alpha1-rc1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -100,6 +100,36 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-search-client-connect</artifactId>
+        <version>8.9.0-alpha1-rc1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-protocol</artifactId>
+        <version>8.9.0-alpha1-rc1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-util</artifactId>
+        <version>8.9.0-alpha1-rc1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-search-client</artifactId>
+        <version>8.9.0-alpha1-rc1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-search-domain</artifactId>
+        <version>8.9.0-alpha1-rc1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Common test dependencies-->
     <dependency>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-connect</artifactId>
-      <version>${project.version}</version>
+      <version>8.9.0-alpha1-rc1</version>
     </dependency>
 
     <!-- this is necessary. Dependency:analyze error suppressed -->

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-connect</artifactId>
-      <version>${project.version}</version>
+      <version>8.9.0-alpha1-rc1</version>
     </dependency>
 
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-plugin</artifactId>
-      <version>${project.version}</version>
+      <version>8.9.0-alpha1-rc1</version>
       <scope>test</scope>
     </dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -401,7 +401,7 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-build-tools</artifactId>
-        <version>${project.version}</version>
+        <version>8.9.0-alpha1-rc1</version>
       </dependency>
 
       <dependency>
@@ -2242,7 +2242,7 @@
             <dependency>
               <groupId>io.camunda</groupId>
               <artifactId>zeebe-build-tools</artifactId>
-              <version>${project.version}</version>
+              <version>8.9.0-alpha1-rc1</version>
             </dependency>
           </dependencies>
           <executions>
@@ -2302,7 +2302,7 @@
             <dependency>
               <groupId>io.camunda</groupId>
               <artifactId>zeebe-build-tools</artifactId>
-              <version>${project.version}</version>
+              <version>8.9.0-alpha1-rc1</version>
             </dependency>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
@@ -2354,7 +2354,7 @@
             <dependency>
               <groupId>io.camunda</groupId>
               <artifactId>zeebe-build-tools</artifactId>
-              <version>${project.version}</version>
+              <version>8.9.0-alpha1-rc1</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -2394,7 +2394,7 @@
             <dependency>
               <groupId>io.camunda</groupId>
               <artifactId>zeebe-build-tools</artifactId>
-              <version>${project.version}</version>
+              <version>8.9.0-alpha1-rc1</version>
             </dependency>
           </dependencies>
           <executions>
@@ -2990,7 +2990,7 @@
               <dependency>
                 <groupId>io.camunda</groupId>
                 <artifactId>zeebe-build-tools</artifactId>
-                <version>${project.version}</version>
+                <version>8.9.0-alpha1-rc1</version>
               </dependency>
             </dependencies>
             <executions>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
