### PR TITLE
feat: improve authentication error handling

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/handler/LoggingAuthenticationFailureHandler.java
+++ b/authentication/src/main/java/io/camunda/authentication/handler/LoggingAuthenticationFailureHandler.java
@@ -35,16 +35,18 @@ public class LoggingAuthenticationFailureHandler implements AuthenticationFailur
       final HttpServletResponse response,
       final AuthenticationException exception)
       throws IOException, ServletException {
-    // AuthenticationServiceException will not be handled by default failure handlers,
+    // Only AuthenticationServiceException will not be handled by default failure handlers,
     // instead it will be rethrown and bubble up to tomcat, causing an ERROR log.
-    if (AuthenticationServiceException.class.isAssignableFrom(exception.getClass())) {
-      LOG.warn("A technical authentication problem occurred", exception);
-      // Setting this attributes will cause Tomcat to initiate
-      // rendering an error response, ultimately calling our GlobalErrorController.
-      request.setAttribute(RequestDispatcher.ERROR_EXCEPTION, exception);
-      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    if (!AuthenticationServiceException.class.isAssignableFrom(exception.getClass())) {
+      delegate.onAuthenticationFailure(request, response, exception);
       return;
     }
-    delegate.onAuthenticationFailure(request, response, exception);
+
+    LOG.warn("A technical authentication problem occurred", exception);
+
+    // Setting this attributes will cause Tomcat to initiate
+    // rendering an error response, ultimately calling our GlobalErrorController.
+    request.setAttribute(RequestDispatcher.ERROR_EXCEPTION, exception);
+    response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/handler/LoggingAuthenticationFailureHandler.java
+++ b/authentication/src/main/java/io/camunda/authentication/handler/LoggingAuthenticationFailureHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.handler;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+public class LoggingAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(LoggingAuthenticationFailureHandler.class);
+
+  private final AuthenticationFailureHandler delegate;
+
+  public LoggingAuthenticationFailureHandler(final AuthenticationFailureHandler delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void onAuthenticationFailure(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final AuthenticationException exception)
+      throws IOException, ServletException {
+    // AuthenticationServiceException will not be handled by default failure handlers,
+    // instead it will be rethrown and bubble up to tomcat, causing an ERROR log.
+    if (AuthenticationServiceException.class.isAssignableFrom(exception.getClass())) {
+      LOG.warn("A technical authentication problem occurred", exception);
+      // Setting this attributes will cause Tomcat to initiate
+      // rendering an error response, ultimately calling our GlobalErrorController.
+      request.setAttribute(RequestDispatcher.ERROR_EXCEPTION, exception);
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      return;
+    }
+    delegate.onAuthenticationFailure(request, response, exception);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/handler/LoggingAuthenticationFailureHandlerTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/handler/LoggingAuthenticationFailureHandlerTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.handler;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.camunda.authentication.config.controllers.TestApiController.DUMMY_V2_API_ENDPOINT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.authentication.config.controllers.OidcFlowTestContext;
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+@SuppressWarnings({"SpringBootApplicationProperties", "WrongPropertyKeyValueDelimiter"})
+@AutoConfigureMockMvc
+@AutoConfigureWebMvc
+@SpringBootTest(
+    classes = {
+      OidcFlowTestContext.class,
+      WebSecurityConfig.class,
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+      "camunda.security.authentication.oidc.client-id="
+          + LoggingAuthenticationFailureHandlerTest.CLIENT_ID,
+      "camunda.security.authentication.oidc.redirect-uri=http://localhost/sso-callback",
+      "camunda.security.authentication.oidc.clientAuthenticationMethod="
+          + OidcAuthenticationConfiguration.CLIENT_AUTHENTICATION_METHOD_PRIVATE_KEY_JWT,
+      "camunda.security.authentication.oidc.assertion.keystore.path= ${user.dir}/src/test/resources/keystore.p12",
+      "camunda.security.authentication.oidc.assertion.keystore.password=password",
+      "camunda.security.authentication.oidc.assertion.keystore.keyAlias=camunda-standalone",
+      "camunda.security.authentication.oidc.assertion.keystore.keyPassword=password",
+      "camunda.security.authentication.oidc.resource=https://api.example.com/app1/, https://api.example.com/app2/",
+      "logging.level.io.camunda.authentication.config=DEBUG",
+      // essential for debugging the flow
+      "logging.level.org.springframework.security=TRACE",
+    })
+@ActiveProfiles("consolidated-auth")
+@ExtendWith(OutputCaptureExtension.class)
+class LoggingAuthenticationFailureHandlerTest {
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance()
+          .configureStaticDsl(true)
+          .options(wireMockConfig().notifier(new Slf4jNotifier(false)).dynamicPort())
+          .failOnUnmatchedRequests(true)
+          .build();
+
+  static final String CLIENT_ID = "camunda-client";
+  static final String REALM = "camunda-test";
+  static final String ENDPOINT_WELL_KNOWN_JWKS = "/realms/" + REALM + "/.well-known/jwks.json";
+  static final String ENDPOINT_WELL_KNOWN_OIDC =
+      "/realms/" + REALM + "/.well-known/openid-configuration";
+  @Autowired MockMvcTester mockMvcTester;
+
+  @DynamicPropertySource
+  static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+    registry.add(
+        "camunda.security.authentication.oidc.issuer-uri",
+        () -> "http://localhost:" + wireMock.getPort() + "/realms/" + REALM);
+  }
+
+  @BeforeAll
+  static void stubIdpEndpoints() {
+    stubFor(
+        get(urlEqualTo(ENDPOINT_WELL_KNOWN_OIDC))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(wellKnownResponse())));
+  }
+
+  @BeforeEach
+  void stubWellKnownForStartup() {
+    stubFor(
+        get(urlEqualTo(ENDPOINT_WELL_KNOWN_JWKS))
+            .willReturn(aResponse().withStatus(HttpStatus.INTERNAL_SERVER_ERROR.value())));
+  }
+
+  @Test
+  void shouldNotLogOnErrorLevel(final CapturedOutput capturedOutput) {
+    // Given: a random access token
+    final String accessToken = accessToken();
+
+    // When:
+    final MvcTestResult apiResult =
+        mockMvcTester
+            .get()
+            .uri(DUMMY_V2_API_ENDPOINT)
+            .accept(MediaType.APPLICATION_JSON)
+            .header("Authorization", "Bearer " + accessToken)
+            .exchange();
+    // Then:
+    assertThat(apiResult).hasStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(capturedOutput.getOut()).contains("A technical authentication problem occurred");
+    assertThat(capturedOutput.getOut()).doesNotContain("ERROR");
+  }
+
+  private static String wellKnownResponse() {
+    return """
+            {
+                "issuer": "http://localhost:000000/realms/KEYCLOAKREALM",
+                "authorization_endpoint": "http://localhost:000000/realms/KEYCLOAKREALM/oauth/authorize",
+                "token_endpoint": "http://localhost:000000/realms/KEYCLOAKREALM/oauth/token",
+                "userinfo_endpoint": "http://localhost:000000/realms/KEYCLOAKREALM/userinfo",
+                "jwks_uri": "http://localhost:000000/realms/KEYCLOAKREALM/.well-known/jwks.json",
+                "response_types_supported": [
+                    "code",
+                    "token",
+                    "id_token",
+                    "code token",
+                    "code id_token",
+                    "token id_token",
+                    "code token id_token",
+                    "none"
+                ],
+                "subject_types_supported": [
+                    "public"
+                ],
+                "id_token_signing_alg_values_supported": [
+                    "RS256"
+                ],
+                "scopes_supported": [
+                    "openid",
+                    "email",
+                    "profile"
+                ]
+            }
+        """
+        .replaceAll("000000", String.valueOf(wireMock.getPort()))
+        .replaceAll("KEYCLOAKREALM", REALM);
+  }
+
+  private static String accessToken() {
+    return "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkNhbXVuZG8gQ2FtdW5kb3Zza2kiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNzU2OTQwMjk5fQ.Tih2EbvzaCkREp4yNaP7Y_opD1YyO3bE95te66bVpTXtOOl9jL8Ovv2nCNm44HMpQPZVyVlR3bDd3tcWf6mRolkeFMrhe2mkz0xr_-WptpgkigrIKVhWZzjz6YEawJpYFNH6pwn74WVPlnruyzeqnItdcbM-0dQ9gsIOPPgubajKnTs1qA6NwkOWU9AI6Y5aQcflRpPewkPMHKL-KIe0lIGfLUaQhUZEAbQC7u6Pujx8l2cuom-xpWAeYHCoNfKbsssUWHY3DZ4yZGk6vQe_dLt5iYxlVcp-SSOnOKNd6EU_Rf4cD0zNWTX44YfwYM5ZYBBJd9QiwSj_xmzLLbBFmA";
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Only log technical authentication errors (e.g. OIDC provider unavailable) on WARN level.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34896 
