### PR TITLE
[Backport release-8.9.0-alpha1] fix: upgrade org.apache.tomcat.embed from 10.1.44 to 10.1.48

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -145,11 +145,12 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>tomcat-annotations-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -103,8 +103,8 @@
     <version.rest-assured>5.5.5</version.rest-assured>
     <version.spring>6.2.11</version.spring>
     <version.spring-security>6.5.5</version.spring-security>
-    <version.spring-boot>3.5.5</version.spring-boot>
-    <version.tomcat>10.1.44</version.tomcat>
+    <version.spring-boot>3.5.6</version.spring-boot>
+    <version.tomcat>10.1.48</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -216,6 +216,12 @@
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
# Description
Backport of #40369 to `release-8.9.0-alpha1`.

relates to 