### PR TITLE
feat: extend checkpoint state for timestamp and type

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import java.time.Instant;
 
 public class CheckpointBackupConfirmedApplier {
   private final CheckpointState checkpointState;
@@ -18,10 +19,14 @@ public class CheckpointBackupConfirmedApplier {
   }
 
   public void apply(final CheckpointRecord checkpointRecord) {
+    final var timestamp =
+        checkpointRecord.getCheckpointTimestamp() <= 0
+            ? null
+            : Instant.ofEpochMilli(checkpointRecord.getCheckpointTimestamp());
     checkpointState.setLatestBackupInfo(
         checkpointRecord.getCheckpointId(),
         checkpointRecord.getCheckpointPosition(),
-        checkpointRecord.getCheckpointTimestamp(),
+        timestamp,
         checkpointRecord.getCheckpointType());
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
@@ -19,6 +19,9 @@ public class CheckpointBackupConfirmedApplier {
 
   public void apply(final CheckpointRecord checkpointRecord) {
     checkpointState.setLatestBackupInfo(
-        checkpointRecord.getCheckpointId(), checkpointRecord.getCheckpointPosition());
+        checkpointRecord.getCheckpointId(),
+        checkpointRecord.getCheckpointPosition(),
+        checkpointRecord.getCheckpointTimestamp(),
+        checkpointRecord.getCheckpointType());
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
-import java.time.Instant;
 
 public class CheckpointBackupConfirmedApplier {
   private final CheckpointState checkpointState;
@@ -19,14 +18,10 @@ public class CheckpointBackupConfirmedApplier {
   }
 
   public void apply(final CheckpointRecord checkpointRecord) {
-    final var timestamp =
-        checkpointRecord.getCheckpointTimestamp() <= 0
-            ? null
-            : Instant.ofEpochMilli(checkpointRecord.getCheckpointTimestamp());
     checkpointState.setLatestBackupInfo(
         checkpointRecord.getCheckpointId(),
         checkpointRecord.getCheckpointPosition(),
-        timestamp,
+        checkpointRecord.getCheckpointTimestamp(),
         checkpointRecord.getCheckpointType());
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.backup.metrics.CheckpointMetrics;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import java.time.Instant;
 import java.util.Set;
 
 public final class CheckpointCreatedEventApplier {
@@ -30,10 +31,11 @@ public final class CheckpointCreatedEventApplier {
   }
 
   public void apply(final CheckpointRecord checkpointRecord) {
+    final var timestamp = checkpointRecord.getCheckpointTimestamp();
     checkpointState.setLatestCheckpointInfo(
         checkpointRecord.getCheckpointId(),
         checkpointRecord.getCheckpointPosition(),
-        checkpointRecord.getCheckpointTimestamp(),
+        timestamp > 0 ? Instant.ofEpochMilli(timestamp) : null,
         checkpointRecord.getCheckpointType());
     checkpointListeners.forEach(
         listener -> listener.onNewCheckpointCreated(checkpointState.getLatestCheckpointId()));

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
@@ -31,7 +31,10 @@ public final class CheckpointCreatedEventApplier {
 
   public void apply(final CheckpointRecord checkpointRecord) {
     checkpointState.setLatestCheckpointInfo(
-        checkpointRecord.getCheckpointId(), checkpointRecord.getCheckpointPosition());
+        checkpointRecord.getCheckpointId(),
+        checkpointRecord.getCheckpointPosition(),
+        checkpointRecord.getCheckpointTimestamp(),
+        checkpointRecord.getCheckpointType());
     checkpointListeners.forEach(
         listener -> listener.onNewCheckpointCreated(checkpointState.getLatestCheckpointId()));
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.backup.metrics.CheckpointMetrics;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
-import java.time.Instant;
 import java.util.Set;
 
 public final class CheckpointCreatedEventApplier {
@@ -31,11 +30,10 @@ public final class CheckpointCreatedEventApplier {
   }
 
   public void apply(final CheckpointRecord checkpointRecord) {
-    final var timestamp = checkpointRecord.getCheckpointTimestamp();
     checkpointState.setLatestCheckpointInfo(
         checkpointRecord.getCheckpointId(),
         checkpointRecord.getCheckpointPosition(),
-        timestamp > 0 ? Instant.ofEpochMilli(timestamp) : null,
+        checkpointRecord.getCheckpointTimestamp(),
         checkpointRecord.getCheckpointType());
     checkpointListeners.forEach(
         listener -> listener.onNewCheckpointCreated(checkpointState.getLatestCheckpointId()));

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
@@ -49,11 +49,11 @@ public final class CheckpointInfo extends UnpackedObject implements DbValue {
   }
 
   public Instant getTimestamp() {
-    return timestamp.getValue() > 0 ? Instant.ofEpochMilli(timestamp.getValue()) : Instant.MIN;
+    return timestamp.getValue() > 0 ? Instant.ofEpochMilli(timestamp.getValue()) : null;
   }
 
   public CheckpointInfo setTimestamp(final Instant timestamp) {
-    final var millis = timestamp.equals(Instant.MIN) ? -1L : timestamp.toEpochMilli();
+    final var millis = timestamp == null ? -1L : timestamp.toEpochMilli();
     this.timestamp.setValue(millis);
     return this;
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
-import java.time.Instant;
 
 /** Checkpoint info stored in db in msgpack format. */
 public final class CheckpointInfo extends UnpackedObject implements DbValue {
@@ -48,13 +47,12 @@ public final class CheckpointInfo extends UnpackedObject implements DbValue {
     return this;
   }
 
-  public Instant getTimestamp() {
-    return timestamp.getValue() > 0 ? Instant.ofEpochMilli(timestamp.getValue()) : null;
+  public long getTimestamp() {
+    return timestamp.getValue();
   }
 
-  public CheckpointInfo setTimestamp(final Instant timestamp) {
-    final var millis = timestamp == null ? -1L : timestamp.toEpochMilli();
-    this.timestamp.setValue(millis);
+  public CheckpointInfo setTimestamp(final long timestamp) {
+    this.timestamp.setValue(timestamp);
     return this;
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
@@ -27,7 +27,7 @@ public interface CheckpointState {
    */
   long getLatestCheckpointPosition();
 
-  /** Returns the type of the last checkpoint with a successful backup. */
+  /** Returns the timestamp of the last checkpoint with a successful backup. */
   long getLatestCheckpointTimestamp();
 
   /** Returns the type of the last created checkpoint. */

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.backup.processing.state;
 
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.time.Instant;
+
 public interface CheckpointState {
 
   long NO_CHECKPOINT = -1L;
@@ -25,25 +28,49 @@ public interface CheckpointState {
    */
   long getLatestCheckpointPosition();
 
+  /** Returns the type of the last checkpoint with a successful backup. */
+  Instant getLatestCheckpointTimestamp();
+
+  /** Returns the type of the last created checkpoint. */
+  CheckpointType getLatestCheckpointType();
+
   /**
    * Set id and position of the last created checkpoint
    *
    * @param checkpointId id of the checkpoint
    * @param checkpointPosition position of the checkpoint
+   * @param timestamp timestamp of the checkpoint
+   * @param type type of the checkpoint
    */
-  void setLatestCheckpointInfo(final long checkpointId, final long checkpointPosition);
+  void setLatestCheckpointInfo(
+      final long checkpointId,
+      final long checkpointPosition,
+      final Instant timestamp,
+      final CheckpointType type);
 
   /**
    * Set id and position of the last checkpoint with a successful backup.
    *
    * @param checkpointId id of the checkpoint for this backup.
    * @param checkpointPosition position of the checkpoint for this backup.
+   * @param timestamp timestamp of the checkpoint for this backup.
+   * @param type type of the checkpoint for this backup.
    */
-  void setLatestBackupInfo(long checkpointId, long checkpointPosition);
+  void setLatestBackupInfo(
+      final long checkpointId,
+      final long checkpointPosition,
+      final Instant timestamp,
+      final CheckpointType type);
 
   /** Returns the id of the last checkpoint with a successful backup. */
   long getLatestBackupId();
 
   /** Returns the position of the last checkpoint with a successful backup. */
   long getLatestBackupPosition();
+
+  /** Returns the timestamp of the last checkpoint with a successful backup. */
+  Instant getLatestBackupTimestamp();
+
+  /** Returns the type of the last created backup. */
+  CheckpointType getLatestBackupType();
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.backup.processing.state;
 
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
-import java.time.Instant;
 
 public interface CheckpointState {
 
@@ -29,7 +28,7 @@ public interface CheckpointState {
   long getLatestCheckpointPosition();
 
   /** Returns the type of the last checkpoint with a successful backup. */
-  Instant getLatestCheckpointTimestamp();
+  long getLatestCheckpointTimestamp();
 
   /** Returns the type of the last created checkpoint. */
   CheckpointType getLatestCheckpointType();
@@ -45,7 +44,7 @@ public interface CheckpointState {
   void setLatestCheckpointInfo(
       final long checkpointId,
       final long checkpointPosition,
-      final Instant timestamp,
+      final long timestamp,
       final CheckpointType type);
 
   /**
@@ -59,7 +58,7 @@ public interface CheckpointState {
   void setLatestBackupInfo(
       final long checkpointId,
       final long checkpointPosition,
-      final Instant timestamp,
+      final long timestamp,
       final CheckpointType type);
 
   /** Returns the id of the last checkpoint with a successful backup. */
@@ -69,7 +68,7 @@ public interface CheckpointState {
   long getLatestBackupPosition();
 
   /** Returns the timestamp of the last checkpoint with a successful backup. */
-  Instant getLatestBackupTimestamp();
+  long getLatestBackupTimestamp();
 
   /** Returns the type of the last created backup. */
   CheckpointType getLatestBackupType();

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
@@ -33,23 +33,17 @@ public final class DbCheckpointState implements CheckpointState {
 
   @Override
   public long getLatestCheckpointId() {
-    checkpointInfoKey.wrapString(LATEST_CHECKPOINT_KEY);
-    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
-    return info != null ? info.getId() : NO_CHECKPOINT;
+    return getCheckpointId(LATEST_CHECKPOINT_KEY);
   }
 
   @Override
   public long getLatestCheckpointPosition() {
-    checkpointInfoKey.wrapString(LATEST_CHECKPOINT_KEY);
-    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
-    return info != null ? info.getPosition() : NO_CHECKPOINT;
+    return getCheckpointPosition(LATEST_CHECKPOINT_KEY);
   }
 
   @Override
   public long getLatestCheckpointTimestamp() {
-    checkpointInfoKey.wrapString(LATEST_CHECKPOINT_KEY);
-    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
-    return info != null ? info.getTimestamp() : -1L;
+    return getCheckpointTimestamp(LATEST_CHECKPOINT_KEY);
   }
 
   @Override
@@ -89,23 +83,17 @@ public final class DbCheckpointState implements CheckpointState {
 
   @Override
   public long getLatestBackupId() {
-    checkpointInfoKey.wrapString(LATEST_BACKUP_KEY);
-    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
-    return info != null ? info.getId() : NO_CHECKPOINT;
+    return getCheckpointId(LATEST_BACKUP_KEY);
   }
 
   @Override
   public long getLatestBackupPosition() {
-    checkpointInfoKey.wrapString(LATEST_BACKUP_KEY);
-    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
-    return info != null ? info.getPosition() : NO_CHECKPOINT;
+    return getCheckpointPosition(LATEST_BACKUP_KEY);
   }
 
   @Override
   public long getLatestBackupTimestamp() {
-    checkpointInfoKey.wrapString(LATEST_BACKUP_KEY);
-    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
-    return info != null ? info.getTimestamp() : -1L;
+    return getCheckpointTimestamp(LATEST_BACKUP_KEY);
   }
 
   @Override
@@ -113,8 +101,26 @@ public final class DbCheckpointState implements CheckpointState {
     return getCheckpointType(LATEST_BACKUP_KEY);
   }
 
-  private CheckpointType getCheckpointType(final String latestCheckpointKey) {
-    checkpointInfoKey.wrapString(latestCheckpointKey);
+  private long getCheckpointId(final String key) {
+    checkpointInfoKey.wrapString(key);
+    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
+    return info != null ? info.getId() : NO_CHECKPOINT;
+  }
+
+  private long getCheckpointPosition(final String key) {
+    checkpointInfoKey.wrapString(key);
+    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
+    return info != null ? info.getPosition() : NO_CHECKPOINT;
+  }
+
+  private long getCheckpointTimestamp(final String key) {
+    checkpointInfoKey.wrapString(key);
+    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
+    return info != null ? info.getTimestamp() : -1L;
+  }
+
+  private CheckpointType getCheckpointType(final String key) {
+    checkpointInfoKey.wrapString(key);
     final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
     return info != null ? info.getType() : null;
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
-import java.time.Instant;
 
 public final class DbCheckpointState implements CheckpointState {
   private static final String LATEST_CHECKPOINT_KEY = "checkpoint";
@@ -47,10 +46,10 @@ public final class DbCheckpointState implements CheckpointState {
   }
 
   @Override
-  public Instant getLatestCheckpointTimestamp() {
+  public long getLatestCheckpointTimestamp() {
     checkpointInfoKey.wrapString(LATEST_CHECKPOINT_KEY);
     final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
-    return info != null ? info.getTimestamp() : Instant.MIN;
+    return info != null ? info.getTimestamp() : -1L;
   }
 
   @Override
@@ -62,7 +61,7 @@ public final class DbCheckpointState implements CheckpointState {
   public void setLatestCheckpointInfo(
       final long checkpointId,
       final long checkpointPosition,
-      final Instant timestamp,
+      final long timestamp,
       final CheckpointType type) {
     checkpointInfoKey.wrapString(LATEST_CHECKPOINT_KEY);
     checkpointInfo
@@ -77,7 +76,7 @@ public final class DbCheckpointState implements CheckpointState {
   public void setLatestBackupInfo(
       final long checkpointId,
       final long checkpointPosition,
-      final Instant timestamp,
+      final long timestamp,
       final CheckpointType type) {
     checkpointInfoKey.wrapString(LATEST_BACKUP_KEY);
     checkpointInfo
@@ -103,10 +102,10 @@ public final class DbCheckpointState implements CheckpointState {
   }
 
   @Override
-  public Instant getLatestBackupTimestamp() {
+  public long getLatestBackupTimestamp() {
     checkpointInfoKey.wrapString(LATEST_BACKUP_KEY);
     final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
-    return info != null ? info.getTimestamp() : Instant.MIN;
+    return info != null ? info.getTimestamp() : -1L;
   }
 
   @Override
@@ -117,6 +116,6 @@ public final class DbCheckpointState implements CheckpointState {
   private CheckpointType getCheckpointType(final String latestCheckpointKey) {
     checkpointInfoKey.wrapString(latestCheckpointKey);
     final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
-    return info != null ? info.getType() : CheckpointType.NONE;
+    return info != null ? info.getType() : null;
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -222,7 +222,7 @@ final class CheckpointRecordsProcessorTest {
         new CheckpointRecord()
             .setCheckpointId(checkpointId)
             .setCheckpointPosition(checkpointPosition)
-            .setCheckpointTimestamp(timestamp)
+            .setCheckpointTimestamp(timestamp.toEpochMilli())
             .setCheckpointType(CheckpointType.MARKER);
     final MockTypedCheckpointRecord record =
         new MockTypedCheckpointRecord(
@@ -480,7 +480,7 @@ final class CheckpointRecordsProcessorTest {
             .setCheckpointId(backupId)
             .setCheckpointPosition(backupPosition)
             .setCheckpointType(CheckpointType.MANUAL_BACKUP)
-            .setCheckpointTimestamp(timestamp);
+            .setCheckpointTimestamp(timestamp.toEpochMilli());
     final var record =
         new MockTypedCheckpointRecord(
             backupPosition + 1,
@@ -631,7 +631,7 @@ final class CheckpointRecordsProcessorTest {
     // then - backup state is updated
     assertThat(state.getLatestBackupId()).isEqualTo(backupId);
     assertThat(state.getLatestBackupPosition()).isEqualTo(backupPosition);
-    assertThat(state.getLatestBackupTimestamp()).isEqualTo(Instant.MIN);
+    assertThat(state.getLatestBackupTimestamp()).isNull();
     assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.MARKER);
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -643,6 +643,6 @@ final class CheckpointRecordsProcessorTest {
     assertThat(state.getLatestBackupId()).isEqualTo(backupId);
     assertThat(state.getLatestBackupPosition()).isEqualTo(backupPosition);
     assertThat(state.getLatestBackupTimestamp()).isEqualTo(-1L);
-    assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.MARKER);
+    assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
@@ -55,40 +55,38 @@ final class DbCheckpointStateTest {
     // when-then
     assertThat(state.getLatestCheckpointId()).isEqualTo(NO_CHECKPOINT);
     assertThat(state.getLatestCheckpointPosition()).isEqualTo(NO_CHECKPOINT);
-    assertThat(state.getLatestCheckpointTimestamp()).isEqualTo(Instant.MIN);
-    assertThat(state.getLatestCheckpointType()).isEqualTo(CheckpointType.NONE);
+    assertThat(state.getLatestCheckpointTimestamp()).isEqualTo(-1L);
+    assertThat(state.getLatestCheckpointType()).isNull();
   }
 
   @Test
   void shouldSetAndGetLatestCheckpointInfo() {
     // when
-    final var timestamp = Instant.now();
+    final var timestamp = Instant.now().toEpochMilli();
     state.setLatestCheckpointInfo(5L, 10L, timestamp, CheckpointType.SCHEDULED_BACKUP);
 
     // then
     assertThat(state.getLatestCheckpointId()).isEqualTo(5L);
     assertThat(state.getLatestCheckpointPosition()).isEqualTo(10L);
     assertThat(state.getLatestCheckpointType()).isEqualTo(CheckpointType.SCHEDULED_BACKUP);
-    assertThat(state.getLatestCheckpointTimestamp().toEpochMilli())
-        .isEqualTo(timestamp.toEpochMilli());
+    assertThat(state.getLatestCheckpointTimestamp()).isEqualTo(timestamp);
   }
 
   @Test
   void shouldOverwriteCheckpointInfo() {
     // given
-    final var tsBefore = Instant.now();
+    final var tsBefore = Instant.now().toEpochMilli();
     state.setLatestCheckpointInfo(5L, 10L, tsBefore, CheckpointType.MARKER);
 
     // when
-    final var tsAfter = Instant.now();
+    final var tsAfter = Instant.now().toEpochMilli();
     state.setLatestCheckpointInfo(15L, 20L, tsAfter, CheckpointType.SCHEDULED_BACKUP);
 
     // then
     assertThat(state.getLatestCheckpointId()).isEqualTo(15L);
     assertThat(state.getLatestCheckpointPosition()).isEqualTo(20L);
     assertThat(state.getLatestCheckpointType()).isEqualTo(CheckpointType.SCHEDULED_BACKUP);
-    assertThat(state.getLatestCheckpointTimestamp().toEpochMilli())
-        .isEqualTo(tsAfter.toEpochMilli());
+    assertThat(state.getLatestCheckpointTimestamp()).isEqualTo(tsAfter);
   }
 
   @Test
@@ -98,80 +96,91 @@ final class DbCheckpointStateTest {
     // then
     assertThat(state.getLatestBackupId()).isEqualTo(NO_CHECKPOINT);
     assertThat(state.getLatestBackupPosition()).isEqualTo(NO_CHECKPOINT);
-    assertThat(state.getLatestBackupTimestamp()).isEqualTo(Instant.MIN);
-    assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.NONE);
+    assertThat(state.getLatestBackupTimestamp()).isEqualTo(-1L);
+    assertThat(state.getLatestBackupType()).isNull();
   }
 
   @Test
   void shouldSetAndGetLatestBackupIdAndPosition() {
     // when
-    final var timestamp = Instant.now();
+    final var timestamp = Instant.now().toEpochMilli();
     state.setLatestBackupInfo(7L, 14L, timestamp, CheckpointType.MARKER);
 
     // then
     assertThat(state.getLatestBackupId()).isEqualTo(7L);
     assertThat(state.getLatestBackupPosition()).isEqualTo(14L);
-    assertThat(state.getLatestBackupTimestamp().toEpochMilli()).isEqualTo(timestamp.toEpochMilli());
+    assertThat(state.getLatestBackupTimestamp()).isEqualTo(timestamp);
   }
 
   @Test
   void shouldOverwriteBackupInfo() {
     // given
-    final var tsBefore = Instant.now();
+    final var tsBefore = Instant.now().toEpochMilli();
     state.setLatestBackupInfo(7L, 14L, tsBefore, CheckpointType.MARKER);
 
     // when
-    final var tsAfter = Instant.now();
+    final var tsAfter = Instant.now().toEpochMilli();
     state.setLatestBackupInfo(21L, 28L, tsAfter, CheckpointType.SCHEDULED_BACKUP);
 
     // then
     assertThat(state.getLatestBackupId()).isEqualTo(21L);
     assertThat(state.getLatestBackupPosition()).isEqualTo(28L);
-    assertThat(state.getLatestBackupTimestamp().toEpochMilli()).isEqualTo(tsAfter.toEpochMilli());
+    assertThat(state.getLatestBackupTimestamp()).isEqualTo(tsAfter);
   }
 
   @Test
   void shouldStoreCheckpointAndBackupInfoIndependently() {
     // when
-    final var tsCheckpoint = Instant.now();
-    final var tsBackup = Instant.now();
+    final var tsCheckpoint = Instant.now().toEpochMilli();
+    final var tsBackup = Instant.now().toEpochMilli();
     state.setLatestCheckpointInfo(5L, 10L, tsCheckpoint, CheckpointType.MARKER);
     state.setLatestBackupInfo(7L, 14L, tsBackup, CheckpointType.MANUAL_BACKUP);
 
     // then
     assertThat(state.getLatestCheckpointId()).isEqualTo(5L);
     assertThat(state.getLatestCheckpointPosition()).isEqualTo(10L);
+    assertThat(state.getLatestCheckpointTimestamp()).isEqualTo(tsCheckpoint);
+    assertThat(state.getLatestCheckpointType()).isEqualTo(CheckpointType.MARKER);
+
     assertThat(state.getLatestBackupId()).isEqualTo(7L);
     assertThat(state.getLatestBackupPosition()).isEqualTo(14L);
-    assertThat(state.getLatestCheckpointTimestamp().toEpochMilli())
-        .isEqualTo(tsCheckpoint.toEpochMilli());
-    assertThat(state.getLatestBackupTimestamp().toEpochMilli()).isEqualTo(tsBackup.toEpochMilli());
+    assertThat(state.getLatestBackupTimestamp()).isEqualTo(tsBackup);
+    assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
   }
 
   @Test
   void shouldUpdateCheckpointInfoWithoutAffectingBackupInfo() {
     // given
-    state.setLatestCheckpointInfo(5L, 10L, Instant.now(), CheckpointType.MARKER);
-    state.setLatestBackupInfo(7L, 14L, Instant.now(), CheckpointType.MANUAL_BACKUP);
+    final var tsCheckpoint = Instant.now().toEpochMilli();
+    final var tsBackup = Instant.now().toEpochMilli();
+    state.setLatestCheckpointInfo(5L, 10L, tsCheckpoint, CheckpointType.MARKER);
+    state.setLatestBackupInfo(7L, 14L, tsBackup, CheckpointType.MANUAL_BACKUP);
 
     // when
-    state.setLatestCheckpointInfo(15L, 20L, Instant.now(), CheckpointType.MARKER);
+    final var tsCheckpointUpdated = Instant.now().toEpochMilli();
+    state.setLatestCheckpointInfo(15L, 20L, tsCheckpointUpdated, CheckpointType.MARKER);
 
     // then
     assertThat(state.getLatestCheckpointId()).isEqualTo(15L);
     assertThat(state.getLatestCheckpointPosition()).isEqualTo(20L);
+    assertThat(state.getLatestCheckpointTimestamp()).isEqualTo(tsCheckpointUpdated);
+    assertThat(state.getLatestCheckpointType()).isEqualTo(CheckpointType.MARKER);
+
     assertThat(state.getLatestBackupId()).isEqualTo(7L);
     assertThat(state.getLatestBackupPosition()).isEqualTo(14L);
+    assertThat(state.getLatestBackupTimestamp()).isEqualTo(tsBackup);
+    assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
   }
 
   @Test
   void shouldUpdateBackupInfoWithoutAffectingCheckpointInfo() {
     // given
-    state.setLatestCheckpointInfo(5L, 10L, Instant.now(), CheckpointType.MARKER);
-    state.setLatestBackupInfo(7L, 14L, Instant.now(), CheckpointType.MANUAL_BACKUP);
+    state.setLatestCheckpointInfo(5L, 10L, Instant.now().toEpochMilli(), CheckpointType.MARKER);
+    state.setLatestBackupInfo(7L, 14L, Instant.now().toEpochMilli(), CheckpointType.MANUAL_BACKUP);
 
     // when
-    state.setLatestBackupInfo(21L, 28L, Instant.now(), CheckpointType.SCHEDULED_BACKUP);
+    state.setLatestBackupInfo(
+        21L, 28L, Instant.now().toEpochMilli(), CheckpointType.SCHEDULED_BACKUP);
 
     // then
     assertThat(state.getLatestCheckpointId()).isEqualTo(5L);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/management/CheckpointRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/management/CheckpointRecord.java
@@ -26,7 +26,7 @@ public class CheckpointRecord extends UnifiedRecordValue implements CheckpointRe
   private final LongProperty checkpointTimestampProperty =
       new LongProperty(CHECKPOINT_TIMESTAMP_KEY, -1L);
   private final EnumProperty<CheckpointType> checkpointTypeProperty =
-      new EnumProperty<>(CHECKPOINT_TYPE_KEY, CheckpointType.class, CheckpointType.MARKER);
+      new EnumProperty<>(CHECKPOINT_TYPE_KEY, CheckpointType.class, CheckpointType.MANUAL_BACKUP);
 
   public CheckpointRecord() {
     super(4);

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2174,7 +2174,7 @@ final class JsonSerializableToJsonTest {
             "checkpointId":1,
             "checkpointPosition":10,
             "checkpointTimestamp":-1,
-            "checkpointType":"MARKER"
+            "checkpointType":"MANUAL_BACKUP"
           }
           """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CheckpointRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CheckpointRecord.golden
@@ -26,7 +26,7 @@ public class CheckpointRecord extends UnifiedRecordValue implements CheckpointRe
   private final LongProperty checkpointTimestampProperty =
       new LongProperty(CHECKPOINT_TIMESTAMP_KEY, -1L);
   private final EnumProperty<CheckpointType> checkpointTypeProperty =
-      new EnumProperty<>(CHECKPOINT_TYPE_KEY, CheckpointType.class, CheckpointType.MARKER);
+      new EnumProperty<>(CHECKPOINT_TYPE_KEY, CheckpointType.class, CheckpointType.MANUAL_BACKUP);
 
   public CheckpointRecord() {
     super(4);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/management/CheckpointType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/management/CheckpointType.java
@@ -18,5 +18,7 @@ package io.camunda.zeebe.protocol.record.value.management;
 public enum CheckpointType {
   MARKER,
   SCHEDULED_BACKUP,
-  MANUAL_BACKUP
+  MANUAL_BACKUP,
+  // Empty state markup indicator
+  NONE
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/management/CheckpointType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/management/CheckpointType.java
@@ -18,7 +18,5 @@ package io.camunda.zeebe.protocol.record.value.management;
 public enum CheckpointType {
   MARKER,
   SCHEDULED_BACKUP,
-  MANUAL_BACKUP,
-  // Empty state markup indicator
-  NONE
+  MANUAL_BACKUP
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Extend Zeebe's `CheckpointState` to accommodate for the CheckpointType and the CheckpointTimestamp for the last checkpoint and the last backup taken columns.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40646
