### PR TITLE
[Backport stable/8.6] build: explicitly configure annotation processors

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -785,6 +785,30 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <!-- See https://logging.apache.org/log4j/2.x/manual/plugins.html#plugin-registry -->
+              <annotationProcessorPaths>
+                <!-- Include `log4j-core` providing `org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor` that generates `Log4j2Plugins.dat`-->
+                <path>
+                  <groupId>org.apache.logging.log4j</groupId>
+                  <artifactId>log4j-core</artifactId>
+                  <version>${version.log4j}</version>
+                </path>
+              </annotationProcessorPaths>
+              <annotationProcessors>
+                <!-- Process sources using `PluginProcessor` to generate `Log4j2Plugins.dat` -->
+                <processor>org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor</processor>
+              </annotationProcessors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -133,10 +133,27 @@
           <compilerArgs combine.children="append">
             <!-- required by javac detection logic in immutables -->
             <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-            <arg>-proc:full</arg>
           </compilerArgs>
           <fork>true</fork>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>org.immutables</groupId>
+                  <artifactId>value-processor</artifactId>
+                  <version>${version.immutables}</version>
+                </path>
+              </annotationProcessorPaths>
+              <annotationProcessors>
+                <processor>org.immutables.value.processor.Processor</processor>
+              </annotationProcessors>
+            </configuration>
+          </execution>
+        </executions>
+
       </plugin>
 
       <plugin>


### PR DESCRIPTION
# Description
Backport of #40708 to `stable/8.6`.

relates to 