### PR TITLE
feat: filter incidents table for elementIds as fallback

### DIFF
--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/index.tsx
@@ -74,6 +74,9 @@ const IncidentsWrapper: React.FC<Props> = observer(
             processInstanceKey={processInstance.processInstanceKey}
             setIsInTransition={setIsInTransition}
             isPanelVisible={isPanelVisible}
+            selectedElementName={
+              incidentsPanelStore.state.selectedElementId ?? undefined
+            }
           />
         )}
       </IncidentsByProcessInstance>
@@ -151,6 +154,7 @@ const IncidentsByProcessInstance: React.FC<
   const sort = useIncidentsSort();
   const filter = getIncidentsSearchFilter(
     incidentsPanelStore.state.selectedErrorTypes,
+    incidentsPanelStore.state.selectedElementId ?? undefined,
   );
 
   const result = useGetIncidentsByProcessInstancePaginated(

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/index.test.tsx
@@ -174,4 +174,38 @@ describe('IncidentsWrapper', () => {
     unmount(); // Unmount avoids React reacting to the global state cleanup
     incidentsPanelStore.clearSelection();
   });
+
+  it('should render incidents filtered for an elementId when scoped to it', async () => {
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess({
+      page: {totalItems: 1},
+      items: [firstIncident],
+    });
+
+    incidentsPanelStore.showIncidentsForElementId(firstIncident.elementId);
+    incidentsPanelStore.setPanelOpen(true);
+    const {unmount} = render(
+      <IncidentsWrapper
+        processInstance={mockProcessInstance}
+        setIsInTransition={vi.fn()}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('data-table-skeleton'),
+    );
+    const table = within(screen.getByRole('table'));
+
+    expect(
+      screen.getByText(
+        `Incidents - Filtered by "${firstIncident.elementId}" - 1 result`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      table.getByText(getIncidentErrorName(firstIncident.errorType)),
+    ).toBeInTheDocument();
+
+    unmount(); // Unmount avoids React reacting to the global state cleanup
+    incidentsPanelStore.clearSelection();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.tsx
@@ -167,7 +167,7 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
             <MultiIncidents
               count={incidentCount}
               onButtonClick={() => {
-                incidentsPanelStore.setPanelOpen(true);
+                incidentsPanelStore.showIncidentsForElementId(elementId);
               }}
             />
           </>

--- a/operate/client/src/modules/stores/incidentsPanel.ts
+++ b/operate/client/src/modules/stores/incidentsPanel.ts
@@ -15,12 +15,14 @@ type State = {
     elementInstanceKey: string;
     elementName: string;
   } | null;
+  selectedElementId: string | null;
   selectedErrorTypes: IncidentErrorType[];
   isPanelVisible: boolean;
 };
 
 const DEFAULT_STATE: State = {
   selectedElementInstance: null,
+  selectedElementId: null,
   selectedErrorTypes: [],
   isPanelVisible: false,
 };
@@ -35,6 +37,7 @@ class IncidentsPanel {
   get hasActiveFilters(): boolean {
     return (
       this.state.selectedElementInstance !== null ||
+      this.state.selectedElementId !== null ||
       this.state.selectedErrorTypes.length > 0
     );
   }
@@ -45,6 +48,17 @@ class IncidentsPanel {
   ) {
     this.clearSelection();
     this.state.selectedElementInstance = {elementInstanceKey, elementName};
+    this.setPanelOpen(true);
+  }
+
+  /**
+   * Opens the incidents panel with a filter for the given `elementId`.
+   * Prefer to use {@linkcode showIncidentsForElementInstance}! This method
+   * is a fallback for cases where no element instance is available.
+   */
+  showIncidentsForElementId(elementId: string) {
+    this.clearSelection();
+    this.state.selectedElementId = elementId;
     this.setPanelOpen(true);
   }
 
@@ -64,6 +78,7 @@ class IncidentsPanel {
 
   clearSelection() {
     this.state.selectedElementInstance = null;
+    this.state.selectedElementId = null;
     this.state.selectedErrorTypes = [];
   }
 }

--- a/operate/client/src/modules/utils/incidents.ts
+++ b/operate/client/src/modules/utils/incidents.ts
@@ -52,9 +52,11 @@ const isSingleIncidentSelected = (
 
 const getIncidentsSearchFilter = (
   errorTypes: IncidentErrorType[],
+  elementId?: string,
 ): QueryIncidentsRequestBody['filter'] => {
   return {
     errorType: errorTypes.length > 0 ? {$in: errorTypes} : undefined,
+    elementId,
   };
 };
 


### PR DESCRIPTION
## Description

Adds an alternative fallback for opening the incidents table panel with an `elementId`. The reason for this fallback is described in underlying issue.

## Checklist

- [ ] Notice that this PR is stacked on #40697

## Related issues

closes #40617
