### PR TITLE
extend backup descriptor to contain scheduler data

### DIFF
--- a/zeebe/backup-stores/common/pom.xml
+++ b/zeebe/backup-stores/common/pom.xml
@@ -30,6 +30,25 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/FileSetTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/FileSetTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.backup.gcs.manifest;
+package io.camunda.zeebe.backup.common.manifest;
 
 import io.camunda.zeebe.backup.common.FileSet;
 import io.camunda.zeebe.backup.common.FileSet.NamedFile;

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/ManifestStateCastingTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/ManifestStateCastingTest.java
@@ -5,9 +5,9 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.backup.gcs.manifest;
+package io.camunda.zeebe.backup.common.manifest;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/ManifestStateTransitionTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/ManifestStateTransitionTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.backup.gcs.manifest;
+package io.camunda.zeebe.backup.common.manifest;
 
 import static io.camunda.zeebe.backup.common.Manifest.StatusCode.COMPLETED;
 import static io.camunda.zeebe.backup.common.Manifest.StatusCode.FAILED;

--- a/zeebe/backup-stores/filesystem/pom.xml
+++ b/zeebe/backup-stores/filesystem/pom.xml
@@ -82,9 +82,16 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
@@ -22,11 +22,13 @@ import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.Manifest.FailedManifest;
 import io.camunda.zeebe.backup.common.Manifest.InProgressManifest;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -167,7 +169,12 @@ class ManifestManagerTest {
     return new BackupImpl(
         backupIdentifier,
         new BackupDescriptorImpl(
-            Optional.of("snapshotId"), backupIdentifier.checkpointId(), 1, "8.7.0"),
+            Optional.of("snapshotId"),
+            backupIdentifier.checkpointId(),
+            1,
+            "8.7.0",
+            Instant.now(),
+            CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of()),
         new NamedFileSetImpl(Map.of()));
   }

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -134,6 +134,12 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBucketIT.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBucketIT.java
@@ -16,8 +16,10 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import io.camunda.zeebe.backup.gcs.util.GcsContainer;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
@@ -66,7 +68,8 @@ public class GcsBucketIT {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(Optional.empty(), 1, 1, "version"),
+            new BackupDescriptorImpl(
+                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(
                 Map.of(
                     "snapshotFile1",
@@ -113,7 +116,8 @@ public class GcsBucketIT {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(Optional.empty(), 1, 1, "version"),
+            new BackupDescriptorImpl(
+                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(
                 Map.of(
                     "snapshotFile1",

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -19,8 +19,10 @@ import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
@@ -37,7 +39,8 @@ final class ManifestManagerTest {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(Optional.empty(), 1, 1, "version"),
+            new BackupDescriptorImpl(
+                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(
                 Map.of("snapshotFile1", Path.of("file1"), "snapshotFile2", Path.of("file2"))),
             new NamedFileSetImpl(Map.of("segmentFile1", Path.of("file3"))));
@@ -68,7 +71,8 @@ final class ManifestManagerTest {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(Optional.empty(), 1, 1, "version"),
+            new BackupDescriptorImpl(
+                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(
                 Map.of("snapshotFile1", Path.of("file1"), "snapshotFile2", Path.of("file2"))),
             new NamedFileSetImpl(Map.of("segmentFile1", Path.of("file3"))));
@@ -108,7 +112,8 @@ final class ManifestManagerTest {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(Optional.empty(), 1, 1, "version"),
+            new BackupDescriptorImpl(
+                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(Map.of()),
             new NamedFileSetImpl(Map.of()));
 
@@ -131,7 +136,8 @@ final class ManifestManagerTest {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(Optional.empty(), 1, 1, "version"),
+            new BackupDescriptorImpl(
+                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(Map.of()),
             new NamedFileSetImpl(Map.of()));
 
@@ -154,7 +160,8 @@ final class ManifestManagerTest {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(Optional.empty(), 1, 1, "version"),
+            new BackupDescriptorImpl(
+                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(Map.of()),
             new NamedFileSetImpl(Map.of()));
 
@@ -186,7 +193,8 @@ final class ManifestManagerTest {
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
-            new BackupDescriptorImpl(Optional.empty(), 1, 1, "version"),
+            new BackupDescriptorImpl(
+                Optional.empty(), 1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
             new NamedFileSetImpl(Map.of()),
             new NamedFileSetImpl(Map.of()));
 

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestSerializationTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestSerializationTest.java
@@ -389,22 +389,8 @@ final class ManifestSerializationTest {
     final var manifest = MAPPER.readValue(json, Manifest.class);
 
     // then
-    final BackupIdentifierImpl id = manifest.id();
-    assertThat(id).isNotNull();
-    assertThat(id.nodeId()).isEqualTo(1);
-    assertThat(manifest.id().partitionId()).isEqualTo(2);
-    assertThat(manifest.id().checkpointId()).isEqualTo(43);
-
     final BackupDescriptorImpl descriptor = manifest.descriptor();
-    assertThat(descriptor.brokerVersion()).isEqualTo("1.2.0-SNAPSHOT");
-    assertThat(descriptor.checkpointPosition()).isEqualTo(2345234L);
-    assertThat(descriptor.numberOfPartitions()).isEqualTo(3);
-    assertThat(descriptor.snapshotId()).isNotPresent();
     assertThat(descriptor.checkpointType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
     assertThat(descriptor.checkpointTimestamp()).isNull();
-
-    assertThat(manifest.statusCode()).isEqualTo(COMPLETED);
-    assertThat(manifest.createdAt()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
-    assertThat(manifest.modifiedAt()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
   }
 }

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestSerializationTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestSerializationTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.backup.common.FileSet;
 import io.camunda.zeebe.backup.common.FileSet.NamedFile;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.ManifestImpl;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -71,7 +72,13 @@ final class ManifestSerializationTest {
     final var manifest =
         new ManifestImpl(
             new BackupIdentifierImpl(1, 2, 43),
-            new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+            new BackupDescriptorImpl(
+                Optional.empty(),
+                2345234L,
+                3,
+                "1.2.0-SNAPSHOT",
+                Instant.ofEpochMilli(1678790708000L),
+                CheckpointType.MANUAL_BACKUP),
             IN_PROGRESS,
             null,
             null,
@@ -81,7 +88,7 @@ final class ManifestSerializationTest {
         """
         {
           "id": { "nodeId": 1, "partitionId": 2, "checkpointId": 43 },
-          "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT"},
+          "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT", "checkpointTimestamp": "2023-03-14T10:45:08Z", "checkpointType": "MANUAL_BACKUP" },
           "statusCode": "IN_PROGRESS",
           "createdAt": "2023-03-14T10:45:08Z",
           "modifiedAt": "2023-03-14T10:45:08Z"
@@ -106,7 +113,13 @@ final class ManifestSerializationTest {
         Manifest.createInProgress(
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
-                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                new BackupDescriptorImpl(
+                    Optional.empty(),
+                    2345234L,
+                    3,
+                    "1.2.0-SNAPSHOT",
+                    Instant.ofEpochMilli(1678790708000L),
+                    CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
     final var failed = created.fail("expected failure reason");
@@ -114,7 +127,7 @@ final class ManifestSerializationTest {
         """
         {
           "id": { "nodeId": 1, "partitionId": 2, "checkpointId": 43 },
-          "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT"},
+          "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT", "checkpointTimestamp": "2023-03-14T10:45:08Z", "checkpointType": "MANUAL_BACKUP"},
           "statusCode": "FAILED",
           "snapshot": { "files": [] },
           "segments": { "files": [] },
@@ -174,7 +187,7 @@ final class ManifestSerializationTest {
         """
         {
           "id": { "nodeId": 1, "partitionId": 2, "checkpointId": 43 },
-          "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT"},
+          "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT", "checkpointTimestamp": "2023-03-14T10:45:08Z", "checkpointType": "MANUAL_BACKUP"},
           "statusCode": "FAILED",
           "createdAt": "2023-03-14T10:45:08+00:00",
           "modifiedAt": "2023-03-14T10:45:08+00:00",
@@ -197,6 +210,8 @@ final class ManifestSerializationTest {
     assertThat(descriptor.checkpointPosition()).isEqualTo(2345234L);
     assertThat(descriptor.numberOfPartitions()).isEqualTo(3);
     assertThat(descriptor.snapshotId()).isNotPresent();
+    assertThat(descriptor.checkpointType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
+    assertThat(descriptor.checkpointTimestamp()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
 
     assertThat(manifest.statusCode()).isEqualTo(FAILED);
     assertThat(manifest.createdAt()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
@@ -211,7 +226,7 @@ final class ManifestSerializationTest {
         """
         {
           "id": { "nodeId": 1, "partitionId": 2, "checkpointId": 43 },
-          "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT"},
+          "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT", "checkpointTimestamp": "2023-03-14T10:45:08+00:00", "checkpointType": "MANUAL_BACKUP"},
           "statusCode": "IN_PROGRESS",
           "createdAt": "2023-03-14T10:45:08+00:00",
           "modifiedAt": "2023-03-14T10:45:08+00:00"
@@ -233,6 +248,8 @@ final class ManifestSerializationTest {
     assertThat(descriptor.checkpointPosition()).isEqualTo(2345234L);
     assertThat(descriptor.numberOfPartitions()).isEqualTo(3);
     assertThat(descriptor.snapshotId()).isNotPresent();
+    assertThat(descriptor.checkpointType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
+    assertThat(descriptor.checkpointTimestamp()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
 
     assertThat(manifest.statusCode()).isEqualTo(IN_PROGRESS);
     assertThat(manifest.createdAt()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
@@ -246,7 +263,7 @@ final class ManifestSerializationTest {
         """
         {
           "id": { "nodeId": 1, "partitionId": 2, "checkpointId": 43 },
-          "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT"},
+          "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT", "checkpointTimestamp": "2023-03-14T10:45:08+00:00", "checkpointType": "MANUAL_BACKUP"},
           "statusCode": "IN_PROGRESS",
           "createdAt": "2023-03-14T10:45:08+00:00",
           "modifiedAt": "2023-03-14T10:45:08+00:00"
@@ -269,6 +286,8 @@ final class ManifestSerializationTest {
     assertThat(descriptor.checkpointPosition()).isEqualTo(2345234L);
     assertThat(descriptor.numberOfPartitions()).isEqualTo(3);
     assertThat(descriptor.snapshotId()).isNotPresent();
+    assertThat(descriptor.checkpointType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
+    assertThat(descriptor.checkpointTimestamp()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
 
     assertThat(complete.statusCode()).isEqualTo(COMPLETED);
     assertThat(complete.createdAt()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
@@ -278,6 +297,83 @@ final class ManifestSerializationTest {
   @Test
   void shouldDeserializeCompletedManifest() throws JsonProcessingException {
     // given
+    final var json =
+        """
+        {
+          "id": { "nodeId": 1, "partitionId": 2, "checkpointId": 43 },
+          "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT", "checkpointTimestamp": "2023-03-14T10:45:08+00:00", "checkpointType": "MANUAL_BACKUP"},
+          "statusCode": "COMPLETED",
+          "createdAt": "2023-03-14T10:45:08+00:00",
+          "modifiedAt": "2023-03-14T10:45:08+00:00"
+        }
+        """;
+
+    // when
+    final var manifest = MAPPER.readValue(json, Manifest.class);
+
+    // then
+    final BackupIdentifierImpl id = manifest.id();
+    assertThat(id).isNotNull();
+    assertThat(id.nodeId()).isEqualTo(1);
+    assertThat(manifest.id().partitionId()).isEqualTo(2);
+    assertThat(manifest.id().checkpointId()).isEqualTo(43);
+
+    final BackupDescriptorImpl descriptor = manifest.descriptor();
+    assertThat(descriptor.brokerVersion()).isEqualTo("1.2.0-SNAPSHOT");
+    assertThat(descriptor.checkpointPosition()).isEqualTo(2345234L);
+    assertThat(descriptor.numberOfPartitions()).isEqualTo(3);
+    assertThat(descriptor.snapshotId()).isNotPresent();
+    assertThat(descriptor.checkpointType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
+    assertThat(descriptor.checkpointTimestamp()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
+
+    assertThat(manifest.statusCode()).isEqualTo(COMPLETED);
+    assertThat(manifest.createdAt()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
+    assertThat(manifest.modifiedAt()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
+  }
+
+  @Test
+  void shouldSerializeFileSets() throws JsonProcessingException {
+    // given
+    final var manifest =
+        new ManifestImpl(
+            new BackupIdentifierImpl(1, 2, 43),
+            new BackupDescriptorImpl(
+                Optional.empty(),
+                2345234L,
+                3,
+                "1.2.0-SNAPSHOT",
+                Instant.ofEpochMilli(1678790708000L),
+                CheckpointType.MANUAL_BACKUP),
+            IN_PROGRESS,
+            new FileSet(List.of(new NamedFile("snapshotFile1"), new NamedFile("snapshotFile2"))),
+            new FileSet(List.of(new NamedFile("segmentFile1"))),
+            Instant.ofEpochMilli(1678790708000L),
+            Instant.ofEpochMilli(1678790708000L));
+    final var expectedJsonString =
+        // language=json
+        """
+          {
+            "id": { "nodeId": 1, "partitionId": 2, "checkpointId": 43 },
+            "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT", "checkpointTimestamp": "2023-03-14T10:45:08Z", "checkpointType": "MANUAL_BACKUP" },
+            "statusCode": "IN_PROGRESS",
+            "snapshot": { "files": [ { "name": "snapshotFile1" }, { "name": "snapshotFile2" } ] },
+            "segments": { "files": [ { "name": "segmentFile1" } ] },
+            "createdAt": "2023-03-14T10:45:08Z",
+            "modifiedAt": "2023-03-14T10:45:08Z"
+          }
+          """;
+
+    // when
+    final var actualJsonString = MAPPER.writeValueAsString(manifest);
+
+    // then
+    final JsonNode actualJson = MAPPER.readTree(actualJsonString);
+    final JsonNode expectedJson = MAPPER.readTree(expectedJsonString);
+    assertThat(actualJson).isEqualTo(expectedJson);
+  }
+
+  @Test
+  void shouldDeserializeWithoutTypeAndTimestamp() throws JsonProcessingException {
     final var json =
         """
         {
@@ -304,44 +400,11 @@ final class ManifestSerializationTest {
     assertThat(descriptor.checkpointPosition()).isEqualTo(2345234L);
     assertThat(descriptor.numberOfPartitions()).isEqualTo(3);
     assertThat(descriptor.snapshotId()).isNotPresent();
+    assertThat(descriptor.checkpointType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
+    assertThat(descriptor.checkpointTimestamp()).isNull();
 
     assertThat(manifest.statusCode()).isEqualTo(COMPLETED);
     assertThat(manifest.createdAt()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
     assertThat(manifest.modifiedAt()).isEqualTo(Instant.ofEpochMilli(1678790708000L));
-  }
-
-  @Test
-  void shouldSerializeFileSets() throws JsonProcessingException {
-    // given
-    final var manifest =
-        new ManifestImpl(
-            new BackupIdentifierImpl(1, 2, 43),
-            new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
-            IN_PROGRESS,
-            new FileSet(List.of(new NamedFile("snapshotFile1"), new NamedFile("snapshotFile2"))),
-            new FileSet(List.of(new NamedFile("segmentFile1"))),
-            Instant.ofEpochMilli(1678790708000L),
-            Instant.ofEpochMilli(1678790708000L));
-    final var expectedJsonString =
-        // language=json
-        """
-          {
-            "id": { "nodeId": 1, "partitionId": 2, "checkpointId": 43 },
-            "descriptor": { "checkpointPosition": 2345234, "numberOfPartitions": 3, "brokerVersion": "1.2.0-SNAPSHOT" },
-            "statusCode": "IN_PROGRESS",
-            "snapshot": { "files": [ { "name": "snapshotFile1" }, { "name": "snapshotFile2" } ] },
-            "segments": { "files": [ { "name": "segmentFile1" } ] },
-            "createdAt": "2023-03-14T10:45:08Z",
-            "modifiedAt": "2023-03-14T10:45:08Z"
-          }
-          """;
-
-    // when
-    final var actualJsonString = MAPPER.writeValueAsString(manifest);
-
-    // then
-    final JsonNode actualJson = MAPPER.readTree(actualJsonString);
-    final JsonNode expectedJson = MAPPER.readTree(expectedJsonString);
-    assertThat(actualJson).isEqualTo(expectedJson);
   }
 }

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestStateCastingTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestStateCastingTest.java
@@ -15,6 +15,8 @@ import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -27,7 +29,13 @@ final class ManifestStateCastingTest {
         Manifest.createInProgress(
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
-                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                new BackupDescriptorImpl(
+                    Optional.empty(),
+                    2345234L,
+                    3,
+                    "1.2.0-SNAPSHOT",
+                    Instant.now(),
+                    CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
 
@@ -46,7 +54,13 @@ final class ManifestStateCastingTest {
         Manifest.createInProgress(
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
-                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                new BackupDescriptorImpl(
+                    Optional.empty(),
+                    2345234L,
+                    3,
+                    "1.2.0-SNAPSHOT",
+                    Instant.now(),
+                    CheckpointType.MANUAL_BACKUP),
                 new NamedFileSetImpl(Map.of()),
                 new NamedFileSetImpl(Map.of())));
 
@@ -63,7 +77,13 @@ final class ManifestStateCastingTest {
         Manifest.createInProgress(
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
-                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                new BackupDescriptorImpl(
+                    Optional.empty(),
+                    2345234L,
+                    3,
+                    "1.2.0-SNAPSHOT",
+                    Instant.now(),
+                    CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
 

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestStateTransitionTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/manifest/ManifestStateTransitionTest.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.Manifest;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +31,13 @@ final class ManifestStateTransitionTest {
         Manifest.createInProgress(
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
-                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                new BackupDescriptorImpl(
+                    Optional.empty(),
+                    2345234L,
+                    3,
+                    "1.2.0-SNAPSHOT",
+                    Instant.now(),
+                    CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
 
@@ -47,7 +55,13 @@ final class ManifestStateTransitionTest {
         Manifest.createInProgress(
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
-                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                new BackupDescriptorImpl(
+                    Optional.empty(),
+                    2345234L,
+                    3,
+                    "1.2.0-SNAPSHOT",
+                    Instant.now(),
+                    CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
 
@@ -70,7 +84,13 @@ final class ManifestStateTransitionTest {
         Manifest.createInProgress(
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
-                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                new BackupDescriptorImpl(
+                    Optional.empty(),
+                    2345234L,
+                    3,
+                    "1.2.0-SNAPSHOT",
+                    Instant.now(),
+                    CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
 
@@ -94,7 +114,13 @@ final class ManifestStateTransitionTest {
         Manifest.createInProgress(
             new BackupImpl(
                 new BackupIdentifierImpl(1, 2, 43),
-                new BackupDescriptorImpl(Optional.empty(), 2345234L, 3, "1.2.0-SNAPSHOT"),
+                new BackupDescriptorImpl(
+                    Optional.empty(),
+                    2345234L,
+                    3,
+                    "1.2.0-SNAPSHOT",
+                    Instant.now(),
+                    CheckpointType.MANUAL_BACKUP),
                 null,
                 null));
 

--- a/zeebe/backup-stores/s3/pom.xml
+++ b/zeebe/backup-stores/s3/pom.xml
@@ -164,6 +164,12 @@
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupUploadIT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupUploadIT.java
@@ -13,11 +13,13 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -126,7 +128,13 @@ final class BackupUploadIT {
 
     return new BackupImpl(
         new BackupIdentifierImpl(1, 2, 3),
-        new BackupDescriptorImpl(Optional.of("test-snapshot-id"), 4, 5, "test"),
+        new BackupDescriptorImpl(
+            Optional.of("test-snapshot-id"),
+            4,
+            5,
+            "test",
+            Instant.now(),
+            CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(largeNumberOfSegments),
         new NamedFileSetImpl(Map.of("snapshot-file-1", s1, "snapshot-file-2", s2)));
   }
@@ -147,7 +155,13 @@ final class BackupUploadIT {
 
     return new BackupImpl(
         new BackupIdentifierImpl(1, 2, 3),
-        new BackupDescriptorImpl(Optional.of("test-snapshot-id"), 4, 5, "test"),
+        new BackupDescriptorImpl(
+            Optional.of("test-snapshot-id"),
+            4,
+            5,
+            "test",
+            Instant.now(),
+            CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of("snapshot-file-1", s1, "snapshot-file-2", s2)),
         new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)));
   }

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CompressionIT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CompressionIT.java
@@ -14,10 +14,13 @@ import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.testkit.support.BackupAssert;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -123,7 +126,13 @@ final class CompressionIT {
 
     return new BackupImpl(
         new BackupIdentifierImpl(1, 2, 3),
-        new BackupDescriptorImpl(Optional.of("test-snapshot-id"), 4, 5, "test"),
+        new BackupDescriptorImpl(
+            Optional.of("test-snapshot-id"),
+            4,
+            5,
+            "test",
+            Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)),
         new NamedFileSetImpl(Map.of("snapshot-file-1", s1, "snapshot-file-2", s2)));
   }

--- a/zeebe/backup-stores/testkit/pom.xml
+++ b/zeebe/backup-stores/testkit/pom.xml
@@ -41,6 +41,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
+++ b/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
@@ -15,8 +15,11 @@ import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -45,7 +48,13 @@ public final class TestBackupProvider implements ArgumentsProvider {
 
     return new BackupImpl(
         new BackupIdentifierImpl(1, 2, 3),
-        new BackupDescriptorImpl(Optional.empty(), 4, 5, "test"),
+        new BackupDescriptorImpl(
+            Optional.empty(),
+            4,
+            5,
+            "test",
+            Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of()),
         new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)));
   }
@@ -70,7 +79,13 @@ public final class TestBackupProvider implements ArgumentsProvider {
 
     return new BackupImpl(
         id,
-        new BackupDescriptorImpl(Optional.of("test-snapshot-id"), 4, 5, "test"),
+        new BackupDescriptorImpl(
+            Optional.of("test-snapshot-id"),
+            4,
+            5,
+            "test",
+            Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of("snapshot-file-1", s1, "snapshot-file-2", s2)),
         new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)));
   }
@@ -83,7 +98,13 @@ public final class TestBackupProvider implements ArgumentsProvider {
 
     return new BackupImpl(
         id,
-        new BackupDescriptorImpl(Optional.empty(), 4, 5, "test"),
+        new BackupDescriptorImpl(
+            Optional.empty(),
+            4,
+            5,
+            "test",
+            Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of()),
         new NamedFileSetImpl(Map.of("segment-file-1", seg1)));
   }

--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -81,6 +81,16 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
@@ -47,7 +47,8 @@ public interface BackupDescriptor {
   String brokerVersion();
 
   /**
-   * @return the timestamp at which the related checkpoint was created
+   * @return the timestamp at which the related checkpoint was created can be null for backups
+   *     created before 8.9
    */
   Instant checkpointTimestamp();
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.time.Instant;
 import java.util.Optional;
 
 /**
@@ -43,4 +45,14 @@ public interface BackupDescriptor {
    * @return The version of the broker that took the backup.
    */
   String brokerVersion();
+
+  /**
+   * @return the timestamp at which the related checkpoint was created
+   */
+  Instant checkpointTimestamp();
+
+  /**
+   * @return the type of the checkpoint that triggered the backup
+   */
+  CheckpointType checkpointType();
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupDescriptorImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupDescriptorImpl.java
@@ -7,14 +7,23 @@
  */
 package io.camunda.zeebe.backup.common;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.io.IOException;
+import java.time.Instant;
 import java.util.Optional;
 
 public record BackupDescriptorImpl(
     Optional<String> snapshotId,
     long checkpointPosition,
     int numberOfPartitions,
-    String brokerVersion)
+    String brokerVersion,
+    Instant checkpointTimestamp,
+    @JsonDeserialize(using = CheckpointTypeDeserializer.class) CheckpointType checkpointType)
     implements BackupDescriptor {
 
   public static BackupDescriptorImpl from(final BackupDescriptor descriptor) {
@@ -22,6 +31,30 @@ public record BackupDescriptorImpl(
         descriptor.snapshotId(),
         descriptor.checkpointPosition(),
         descriptor.numberOfPartitions(),
-        descriptor.brokerVersion());
+        descriptor.brokerVersion(),
+        descriptor.checkpointTimestamp(),
+        descriptor.checkpointType());
+  }
+
+  /**
+   * CheckpointType backwards compatibility deserializer to handle missing fields and properly
+   * assign the {@link CheckpointType.MANUAL_BACKUP} value since checkpoints were previously
+   * directly associated with backups
+   */
+  static class CheckpointTypeDeserializer extends JsonDeserializer<CheckpointType> {
+
+    @Override
+    public CheckpointType deserialize(final JsonParser p, final DeserializationContext ctx)
+        throws IOException {
+      final String value = p.getText();
+      return value == null || value.isEmpty()
+          ? CheckpointType.MANUAL_BACKUP
+          : CheckpointType.valueOf(value);
+    }
+
+    @Override
+    public CheckpointType getNullValue(final DeserializationContext ctx) {
+      return CheckpointType.MANUAL_BACKUP;
+    }
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupDescriptorImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupDescriptorImpl.java
@@ -38,7 +38,7 @@ public record BackupDescriptorImpl(
 
   /**
    * CheckpointType backwards compatibility deserializer to handle missing fields and properly
-   * assign the {@link CheckpointType.MANUAL_BACKUP} value since checkpoints were previously
+   * assign the {@link CheckpointType#MANUAL_BACKUP} value since checkpoints were previously
    * directly associated with backups
    */
   static class CheckpointTypeDeserializer extends JsonDeserializer<CheckpointType> {
@@ -47,9 +47,7 @@ public record BackupDescriptorImpl(
     public CheckpointType deserialize(final JsonParser p, final DeserializationContext ctx)
         throws IOException {
       final String value = p.getText();
-      return value == null || value.isEmpty()
-          ? CheckpointType.MANUAL_BACKUP
-          : CheckpointType.valueOf(value);
+      return CheckpointType.valueOf(value);
     }
 
     @Override

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.backup.api.NamedFileSet;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -220,7 +222,12 @@ final class InProgressBackupImpl implements InProgressBackup {
 
     final var backupDescriptor =
         new BackupDescriptorImpl(
-            snapshotId, checkpointPosition, numberOfPartitions, VersionUtil.getVersion());
+            snapshotId,
+            checkpointPosition,
+            numberOfPartitions,
+            VersionUtil.getVersion(),
+            Instant.now(),
+            CheckpointType.MANUAL_BACKUP);
     return new BackupImpl(backupId, backupDescriptor, snapshotFileSet, segmentsFileSet);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.protocol.management.BackupRequestType;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
 import io.camunda.zeebe.protocol.management.BackupStatusResponseEncoder;
 import io.camunda.zeebe.protocol.record.ErrorCode;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
@@ -179,7 +180,14 @@ final class BackupApiRequestHandlerTest {
     final BackupStatus status =
         new BackupStatusImpl(
             new BackupIdentifierImpl(1, 1, checkpointId),
-            Optional.of(new BackupDescriptorImpl(Optional.of("s-id"), 100, 3, "test")),
+            Optional.of(
+                new BackupDescriptorImpl(
+                    Optional.of("s-id"),
+                    100,
+                    3,
+                    "test",
+                    Instant.now(),
+                    CheckpointType.MANUAL_BACKUP)),
             io.camunda.zeebe.backup.api.BackupStatusCode.COMPLETED,
             Optional.empty(),
             Optional.of(createdAt),
@@ -289,7 +297,14 @@ final class BackupApiRequestHandlerTest {
     final BackupStatus status =
         new BackupStatusImpl(
             new BackupIdentifierImpl(1, 1, 2),
-            Optional.of(new BackupDescriptorImpl(Optional.of("s-id"), 100, 3, "test")),
+            Optional.of(
+                new BackupDescriptorImpl(
+                    Optional.of("s-id"),
+                    100,
+                    3,
+                    "test",
+                    Instant.now(),
+                    CheckpointType.MANUAL_BACKUP)),
             io.camunda.zeebe.backup.api.BackupStatusCode.COMPLETED,
             Optional.empty(),
             Optional.of(createdAt),


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Extend BackupDescriptor to handle CheckpointType and CheckpointTimestamp
- Align descriptor related tests to include the new fields
  - Timestamp is currently supplied directly as `Instant.now` will be aligned where needed when performing the full alignment of the current backup solution with the new fields on a service level

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #40650
