### PR TITLE
Bugfix/38297 processes by deleted tenants

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionDefinitionDao.java
@@ -28,8 +28,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
@@ -111,35 +111,21 @@ public class OpensearchDecisionDefinitionDao
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<DecisionDefinition> query, final SearchRequest.Builder request) {
-    final DecisionDefinition filter = query.getFilter();
-
-    if (filter != null) {
-      final var queryTerms =
-          Stream.of(
-                  queryDSLWrapper.term(DecisionDefinition.ID, filter.getId()),
-                  queryDSLWrapper.term(DecisionDefinition.KEY, filter.getKey()),
-                  queryDSLWrapper.term(DecisionDefinition.DECISION_ID, filter.getDecisionId()),
-                  queryDSLWrapper.term(DecisionDefinition.TENANT_ID, filter.getTenantId()),
-                  queryDSLWrapper.term(DecisionDefinition.NAME, filter.getName()),
-                  queryDSLWrapper.term(DecisionDefinition.VERSION, filter.getVersion()),
-                  queryDSLWrapper.term(
-                      DecisionDefinition.DECISION_REQUIREMENTS_ID,
-                      filter.getDecisionRequirementsId()),
-                  queryDSLWrapper.term(
-                      DecisionDefinition.DECISION_REQUIREMENTS_KEY,
-                      filter.getDecisionRequirementsKey()),
-                  buildFilteringBy(
-                      filter.getDecisionRequirementsName(),
-                      filter.getDecisionRequirementsVersion()))
-              .filter(Objects::nonNull)
-              .collect(Collectors.toList());
-
-      if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
-      }
-    }
+  protected Stream<org.opensearch.client.opensearch._types.query_dsl.Query> collectFilterQueryTerms(
+      @NonNull final DecisionDefinition filter) {
+    return Stream.of(
+        queryDSLWrapper.term(DecisionDefinition.ID, filter.getId()),
+        queryDSLWrapper.term(DecisionDefinition.KEY, filter.getKey()),
+        queryDSLWrapper.term(DecisionDefinition.DECISION_ID, filter.getDecisionId()),
+        queryDSLWrapper.term(DecisionDefinition.TENANT_ID, filter.getTenantId()),
+        queryDSLWrapper.term(DecisionDefinition.NAME, filter.getName()),
+        queryDSLWrapper.term(DecisionDefinition.VERSION, filter.getVersion()),
+        queryDSLWrapper.term(
+            DecisionDefinition.DECISION_REQUIREMENTS_ID, filter.getDecisionRequirementsId()),
+        queryDSLWrapper.term(
+            DecisionDefinition.DECISION_REQUIREMENTS_KEY, filter.getDecisionRequirementsKey()),
+        buildFilteringBy(
+            filter.getDecisionRequirementsName(), filter.getDecisionRequirementsVersion()));
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionInstanceDao.java
@@ -21,12 +21,11 @@ import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
@@ -106,49 +105,34 @@ public class OpensearchDecisionInstanceDao
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<DecisionInstance> query, final SearchRequest.Builder request) {
-    final DecisionInstance filter = query.getFilter();
-
-    if (filter != null) {
-      final var queryTerms =
-          Stream.of(
-                  queryDSLWrapper.term(DecisionInstance.ID, filter.getId()),
-                  queryDSLWrapper.term(DecisionInstance.KEY, filter.getKey()),
-                  queryDSLWrapper.term(
-                      DecisionInstance.STATE,
-                      filter.getState() == null ? null : filter.getState().name()),
-                  queryDSLWrapper.matchDateQuery(
-                      DecisionInstance.EVALUATION_DATE,
-                      filter.getEvaluationDate(),
-                      dateTimeFormatter.getApiDateTimeFormatString()),
-                  queryDSLWrapper.or(
-                      queryDSLWrapper.term(
-                          DecisionInstance.EVALUATION_FAILURE_MESSAGE,
-                          filter.getEvaluationFailure()),
-                      queryDSLWrapper.term(
-                          DecisionInstance.EVALUATION_FAILURE, filter.getEvaluationFailure())),
-                  queryDSLWrapper.term(
-                      DecisionInstance.PROCESS_DEFINITION_KEY, filter.getProcessDefinitionKey()),
-                  queryDSLWrapper.term(
-                      DecisionInstance.PROCESS_INSTANCE_KEY, filter.getProcessInstanceKey()),
-                  queryDSLWrapper.term(DecisionInstance.DECISION_ID, filter.getDecisionId()),
-                  queryDSLWrapper.term(DecisionInstance.TENANT_ID, filter.getTenantId()),
-                  queryDSLWrapper.term(
-                      DecisionInstance.DECISION_DEFINITION_ID, filter.getDecisionDefinitionId()),
-                  queryDSLWrapper.term(DecisionInstance.DECISION_NAME, filter.getDecisionName()),
-                  queryDSLWrapper.term(
-                      DecisionInstance.DECISION_VERSION, filter.getDecisionVersion()),
-                  queryDSLWrapper.term(
-                      DecisionInstance.DECISION_TYPE,
-                      filter.getDecisionType() == null ? null : filter.getDecisionType().name()))
-              .filter(Objects::nonNull)
-              .collect(Collectors.toList());
-
-      if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
-      }
-    }
+  protected Stream<org.opensearch.client.opensearch._types.query_dsl.Query> collectFilterQueryTerms(
+      @NonNull final DecisionInstance filter) {
+    return Stream.of(
+        queryDSLWrapper.term(DecisionInstance.ID, filter.getId()),
+        queryDSLWrapper.term(DecisionInstance.KEY, filter.getKey()),
+        queryDSLWrapper.term(
+            DecisionInstance.STATE, filter.getState() == null ? null : filter.getState().name()),
+        queryDSLWrapper.matchDateQuery(
+            DecisionInstance.EVALUATION_DATE,
+            filter.getEvaluationDate(),
+            dateTimeFormatter.getApiDateTimeFormatString()),
+        queryDSLWrapper.or(
+            queryDSLWrapper.term(
+                DecisionInstance.EVALUATION_FAILURE_MESSAGE, filter.getEvaluationFailure()),
+            queryDSLWrapper.term(
+                DecisionInstance.EVALUATION_FAILURE, filter.getEvaluationFailure())),
+        queryDSLWrapper.term(
+            DecisionInstance.PROCESS_DEFINITION_KEY, filter.getProcessDefinitionKey()),
+        queryDSLWrapper.term(DecisionInstance.PROCESS_INSTANCE_KEY, filter.getProcessInstanceKey()),
+        queryDSLWrapper.term(DecisionInstance.DECISION_ID, filter.getDecisionId()),
+        queryDSLWrapper.term(DecisionInstance.TENANT_ID, filter.getTenantId()),
+        queryDSLWrapper.term(
+            DecisionInstance.DECISION_DEFINITION_ID, filter.getDecisionDefinitionId()),
+        queryDSLWrapper.term(DecisionInstance.DECISION_NAME, filter.getDecisionName()),
+        queryDSLWrapper.term(DecisionInstance.DECISION_VERSION, filter.getDecisionVersion()),
+        queryDSLWrapper.term(
+            DecisionInstance.DECISION_TYPE,
+            filter.getDecisionType() == null ? null : filter.getDecisionType().name()));
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionRequirementsDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionRequirementsDao.java
@@ -11,7 +11,6 @@ import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.webapp.api.v1.dao.DecisionRequirementsDao;
 import io.camunda.operate.webapp.api.v1.entities.DecisionRequirements;
-import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.api.v1.exceptions.APIException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
@@ -22,10 +21,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
@@ -122,29 +121,16 @@ public class OpensearchDecisionRequirementsDao
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<DecisionRequirements> query, final SearchRequest.Builder request) {
-    final DecisionRequirements filter = query.getFilter();
-    if (filter != null) {
-      final var queryTerms =
-          Stream.of(
-                  queryDSLWrapper.term(DecisionRequirements.ID, filter.getId()),
-                  queryDSLWrapper.term(DecisionRequirements.KEY, filter.getKey()),
-                  queryDSLWrapper.term(
-                      DecisionRequirements.DECISION_REQUIREMENTS_ID,
-                      filter.getDecisionRequirementsId()),
-                  queryDSLWrapper.term(DecisionRequirements.TENANT_ID, filter.getTenantId()),
-                  queryDSLWrapper.term(DecisionRequirements.NAME, filter.getName()),
-                  queryDSLWrapper.term(DecisionRequirements.VERSION, filter.getVersion()),
-                  queryDSLWrapper.term(
-                      DecisionRequirements.RESOURCE_NAME, filter.getResourceName()))
-              .filter(Objects::nonNull)
-              .collect(Collectors.toList());
-
-      if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
-      }
-    }
+  protected Stream<Query> collectFilterQueryTerms(@NonNull final DecisionRequirements filter) {
+    return Stream.of(
+        queryDSLWrapper.term(DecisionRequirements.ID, filter.getId()),
+        queryDSLWrapper.term(DecisionRequirements.KEY, filter.getKey()),
+        queryDSLWrapper.term(
+            DecisionRequirements.DECISION_REQUIREMENTS_ID, filter.getDecisionRequirementsId()),
+        queryDSLWrapper.term(DecisionRequirements.TENANT_ID, filter.getTenantId()),
+        queryDSLWrapper.term(DecisionRequirements.NAME, filter.getName()),
+        queryDSLWrapper.term(DecisionRequirements.VERSION, filter.getVersion()),
+        queryDSLWrapper.term(DecisionRequirements.RESOURCE_NAME, filter.getResourceName()));
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeInstanceDao.java
@@ -13,16 +13,13 @@ import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.webapp.api.v1.dao.FlowNodeInstanceDao;
 import io.camunda.operate.webapp.api.v1.entities.FlowNodeInstance;
-import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
@@ -85,39 +82,27 @@ public class OpensearchFlowNodeInstanceDao
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<FlowNodeInstance> query, final SearchRequest.Builder request) {
-    final FlowNodeInstance filter = query.getFilter();
-
-    if (filter != null) {
-      final var queryTerms =
-          Stream.of(
-                  queryDSLWrapper.term(FlowNodeInstance.KEY, filter.getKey()),
-                  queryDSLWrapper.term(
-                      FlowNodeInstance.PROCESS_INSTANCE_KEY, filter.getProcessInstanceKey()),
-                  queryDSLWrapper.term(
-                      FlowNodeInstance.PROCESS_DEFINITION_KEY, filter.getProcessDefinitionKey()),
-                  queryDSLWrapper.matchDateQuery(
-                      FlowNodeInstance.START_DATE,
-                      filter.getStartDate(),
-                      dateTimeFormatter.getApiDateTimeFormatString()),
-                  queryDSLWrapper.matchDateQuery(
-                      FlowNodeInstance.END_DATE,
-                      filter.getEndDate(),
-                      dateTimeFormatter.getApiDateTimeFormatString()),
-                  queryDSLWrapper.term(FlowNodeInstance.STATE, filter.getState()),
-                  queryDSLWrapper.term(FlowNodeInstance.TYPE, filter.getType()),
-                  queryDSLWrapper.term(FlowNodeInstance.FLOW_NODE_ID, filter.getFlowNodeId()),
-                  queryDSLWrapper.term(FlowNodeInstance.INCIDENT, filter.getIncident()),
-                  queryDSLWrapper.term(FlowNodeInstance.INCIDENT_KEY, filter.getIncidentKey()),
-                  queryDSLWrapper.term(FlowNodeInstance.TENANT_ID, filter.getTenantId()))
-              .filter(Objects::nonNull)
-              .collect(Collectors.toList());
-
-      if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
-      }
-    }
+  protected Stream<org.opensearch.client.opensearch._types.query_dsl.Query> collectFilterQueryTerms(
+      @NonNull final FlowNodeInstance filter) {
+    return Stream.of(
+        queryDSLWrapper.term(FlowNodeInstance.KEY, filter.getKey()),
+        queryDSLWrapper.term(FlowNodeInstance.PROCESS_INSTANCE_KEY, filter.getProcessInstanceKey()),
+        queryDSLWrapper.term(
+            FlowNodeInstance.PROCESS_DEFINITION_KEY, filter.getProcessDefinitionKey()),
+        queryDSLWrapper.matchDateQuery(
+            FlowNodeInstance.START_DATE,
+            filter.getStartDate(),
+            dateTimeFormatter.getApiDateTimeFormatString()),
+        queryDSLWrapper.matchDateQuery(
+            FlowNodeInstance.END_DATE,
+            filter.getEndDate(),
+            dateTimeFormatter.getApiDateTimeFormatString()),
+        queryDSLWrapper.term(FlowNodeInstance.STATE, filter.getState()),
+        queryDSLWrapper.term(FlowNodeInstance.TYPE, filter.getType()),
+        queryDSLWrapper.term(FlowNodeInstance.FLOW_NODE_ID, filter.getFlowNodeId()),
+        queryDSLWrapper.term(FlowNodeInstance.INCIDENT, filter.getIncident()),
+        queryDSLWrapper.term(FlowNodeInstance.INCIDENT_KEY, filter.getIncidentKey()),
+        queryDSLWrapper.term(FlowNodeInstance.TENANT_ID, filter.getTenantId()));
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchIncidentDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchIncidentDao.java
@@ -21,11 +21,9 @@ import io.camunda.operate.webapp.api.v1.exceptions.APIException;
 import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
@@ -90,32 +88,21 @@ public class OpensearchIncidentDao extends OpensearchKeyFilteringDao<Incident, O
   }
 
   @Override
-  protected void buildFiltering(final Query<Incident> query, final SearchRequest.Builder request) {
-    final Incident filter = query.getFilter();
-    if (filter != null) {
-      final var queryTerms =
-          Stream.of(
-                  queryDSLWrapper.term(Incident.KEY, filter.getKey()),
-                  queryDSLWrapper.term(
-                      Incident.PROCESS_DEFINITION_KEY, filter.getProcessDefinitionKey()),
-                  queryDSLWrapper.term(
-                      Incident.PROCESS_INSTANCE_KEY, filter.getProcessInstanceKey()),
-                  queryDSLWrapper.term(Incident.TYPE, filter.getType()),
-                  queryDSLWrapper.match(Incident.MESSAGE, filter.getMessage()),
-                  queryDSLWrapper.term(Incident.STATE, filter.getState()),
-                  queryDSLWrapper.term(Incident.JOB_KEY, filter.getJobKey()),
-                  queryDSLWrapper.term(Incident.TENANT_ID, filter.getTenantId()),
-                  queryDSLWrapper.matchDateQuery(
-                      Incident.CREATION_TIME,
-                      filter.getCreationTime(),
-                      dateTimeFormatter.getApiDateTimeFormatString()))
-              .filter(Objects::nonNull)
-              .collect(Collectors.toList());
-
-      if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
-      }
-    }
+  protected Stream<org.opensearch.client.opensearch._types.query_dsl.Query> collectFilterQueryTerms(
+      @NonNull final Incident filter) {
+    return Stream.of(
+        queryDSLWrapper.term(Incident.KEY, filter.getKey()),
+        queryDSLWrapper.term(Incident.PROCESS_DEFINITION_KEY, filter.getProcessDefinitionKey()),
+        queryDSLWrapper.term(Incident.PROCESS_INSTANCE_KEY, filter.getProcessInstanceKey()),
+        queryDSLWrapper.term(Incident.TYPE, filter.getType()),
+        queryDSLWrapper.match(Incident.MESSAGE, filter.getMessage()),
+        queryDSLWrapper.term(Incident.STATE, filter.getState()),
+        queryDSLWrapper.term(Incident.JOB_KEY, filter.getJobKey()),
+        queryDSLWrapper.term(Incident.TENANT_ID, filter.getTenantId()),
+        queryDSLWrapper.matchDateQuery(
+            Incident.CREATION_TIME,
+            filter.getCreationTime(),
+            dateTimeFormatter.getApiDateTimeFormatString()));
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
@@ -11,7 +11,6 @@ import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.webapp.api.v1.dao.ProcessDefinitionDao;
 import io.camunda.operate.webapp.api.v1.entities.ProcessDefinition;
-import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.api.v1.exceptions.APIException;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
@@ -19,11 +18,9 @@ import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
@@ -100,26 +97,15 @@ public class OpensearchProcessDefinitionDao
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<ProcessDefinition> query, final SearchRequest.Builder request) {
-    final ProcessDefinition filter = query.getFilter();
-    if (filter != null) {
-      final var queryTerms =
-          Stream.of(
-                  queryDSLWrapper.term(ProcessDefinition.NAME, filter.getName()),
-                  queryDSLWrapper.term(
-                      ProcessDefinition.BPMN_PROCESS_ID, filter.getBpmnProcessId()),
-                  queryDSLWrapper.term(ProcessDefinition.TENANT_ID, filter.getTenantId()),
-                  queryDSLWrapper.term(ProcessDefinition.VERSION, filter.getVersion()),
-                  queryDSLWrapper.term(ProcessDefinition.VERSION_TAG, filter.getVersionTag()),
-                  queryDSLWrapper.term(ProcessDefinition.KEY, filter.getKey()))
-              .filter(Objects::nonNull)
-              .collect(Collectors.toList());
-
-      if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
-      }
-    }
+  protected Stream<org.opensearch.client.opensearch._types.query_dsl.Query> collectFilterQueryTerms(
+      @NonNull final ProcessDefinition filter) {
+    return Stream.of(
+        queryDSLWrapper.term(ProcessDefinition.NAME, filter.getName()),
+        queryDSLWrapper.term(ProcessDefinition.BPMN_PROCESS_ID, filter.getBpmnProcessId()),
+        queryDSLWrapper.term(ProcessDefinition.TENANT_ID, filter.getTenantId()),
+        queryDSLWrapper.term(ProcessDefinition.VERSION, filter.getVersion()),
+        queryDSLWrapper.term(ProcessDefinition.VERSION_TAG, filter.getVersionTag()),
+        queryDSLWrapper.term(ProcessDefinition.KEY, filter.getKey()));
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDao.java
@@ -14,12 +14,16 @@ import io.camunda.operate.webapp.api.v1.entities.Results;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.springframework.lang.NonNull;
 
 /**
  * @param <T> - API model class
@@ -32,15 +36,16 @@ public abstract class OpensearchSearchableDao<T, R> {
   protected final RichOpenSearchClient richOpenSearchClient;
 
   public OpensearchSearchableDao(
-      OpensearchQueryDSLWrapper queryDSLWrapper,
-      OpensearchRequestDSLWrapper requestDSLWrapper,
-      RichOpenSearchClient richOpenSearchClient) {
+      final OpensearchQueryDSLWrapper queryDSLWrapper,
+      final OpensearchRequestDSLWrapper requestDSLWrapper,
+      final RichOpenSearchClient richOpenSearchClient) {
+
     this.queryDSLWrapper = queryDSLWrapper;
     this.requestDSLWrapper = requestDSLWrapper;
     this.richOpenSearchClient = richOpenSearchClient;
   }
 
-  public Results<T> search(Query<T> query) {
+  public Results<T> search(final Query<T> query) {
     final var request = buildSearchRequest(query);
 
     buildSorting(query, getUniqueSortKey(), request);
@@ -52,12 +57,12 @@ public abstract class OpensearchSearchableDao<T, R> {
           richOpenSearchClient.doc().search(request, getInternalDocumentModelClass()).hits();
 
       return formatHitsIntoResults(results);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new ServerException("Error in reading incidents", e);
     }
   }
 
-  protected SearchRequest.Builder buildSearchRequest(Query<T> query) {
+  protected SearchRequest.Builder buildSearchRequest(final Query<T> query) {
     return requestDSLWrapper
         .searchRequestBuilder(getIndexName())
         .query(queryDSLWrapper.withTenantCheck(queryDSLWrapper.matchAll()));
@@ -69,7 +74,8 @@ public abstract class OpensearchSearchableDao<T, R> {
 
   protected abstract String getIndexName();
 
-  protected void buildSorting(Query<T> query, String uniqueSortKey, SearchRequest.Builder request) {
+  protected void buildSorting(
+      final Query<T> query, final String uniqueSortKey, final SearchRequest.Builder request) {
     final List<Query.Sort> sorts = query.getSort();
     if (sorts != null) {
       sorts.forEach(
@@ -86,7 +92,7 @@ public abstract class OpensearchSearchableDao<T, R> {
     request.sort(queryDSLWrapper.sortOptions(uniqueSortKey, SortOrder.Asc));
   }
 
-  protected void buildPaging(Query<T> query, SearchRequest.Builder request) {
+  protected void buildPaging(final Query<T> query, final SearchRequest.Builder request) {
     final Object[] searchAfter = query.getSearchAfter();
     if (searchAfter != null) {
       request.searchAfter(CollectionUtil.toSafeListOfStrings(searchAfter));
@@ -94,9 +100,49 @@ public abstract class OpensearchSearchableDao<T, R> {
     request.size(query.getSize());
   }
 
-  protected abstract void buildFiltering(Query<T> query, SearchRequest.Builder request);
+  /**
+   * Builds a tenant-aware filter query based on the query terms provided by {@link
+   * #collectFilterQueryTerms(Object)} and {@link #collectRequiredFilterQueryTerms()}
+   */
+  @VisibleForTesting
+  protected void buildFiltering(final Query<T> query, final SearchRequest.Builder request) {
+    final var queryTerms =
+        Stream.concat(
+                collectRequiredFilterQueryTerms(),
+                Optional.ofNullable(query.getFilter())
+                    .map(this::collectFilterQueryTerms)
+                    .orElseGet(Stream::empty))
+            .filter(Objects::nonNull)
+            .toList();
 
-  protected Results<T> formatHitsIntoResults(HitsMetadata<R> results) {
+    if (!queryTerms.isEmpty()) {
+      request.query(queryDSLWrapper.withTenantCheck(queryDSLWrapper.and(queryTerms)));
+    }
+  }
+
+  /**
+   * Collect required query terms that must always be present.
+   *
+   * <p>You can use {@link #collectFilterQueryTerms(Object)} instead to build query terms based on
+   * an existing filter object. The two may be combined if you have query terms that always need to
+   * be present as well as query terms based on a filter object that may or may not exist.
+   */
+  protected Stream<org.opensearch.client.opensearch._types.query_dsl.Query>
+      collectRequiredFilterQueryTerms() {
+    return Stream.empty();
+  }
+
+  /**
+   * Collect query terms based on the query's filter object.
+   *
+   * <p>You can use {@link #collectRequiredFilterQueryTerms()} instead to build query terms that
+   * must always be present.The two may be combined if you have query terms that always need to be
+   * present as well as query terms based on a filter object that may or may not exist.
+   */
+  protected abstract Stream<org.opensearch.client.opensearch._types.query_dsl.Query>
+      collectFilterQueryTerms(@NonNull final T filter);
+
+  protected Results<T> formatHitsIntoResults(final HitsMetadata<R> results) {
     final List<Hit<R>> hits = results.hits();
 
     if (!hits.isEmpty()) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDao.java
@@ -14,7 +14,6 @@ import io.camunda.operate.webapp.api.v1.entities.Results;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
-import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -104,8 +103,7 @@ public abstract class OpensearchSearchableDao<T, R> {
    * Builds a tenant-aware filter query based on the query terms provided by {@link
    * #collectFilterQueryTerms(Object)} and {@link #collectRequiredFilterQueryTerms()}
    */
-  @VisibleForTesting
-  protected void buildFiltering(final Query<T> query, final SearchRequest.Builder request) {
+  void buildFiltering(final Query<T> query, final SearchRequest.Builder request) {
     final var queryTerms =
         Stream.concat(
                 collectRequiredFilterQueryTerms(),

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDao.java
@@ -119,7 +119,8 @@ public abstract class OpensearchSearchableDao<T, R> {
   }
 
   /**
-   * Collect required query terms that must always be present.
+   * Collect required query terms that must always be present and automatically applies a
+   * tenant-aware filter, if necessary.
    *
    * <p>You can use {@link #collectFilterQueryTerms(Object)} instead to build query terms based on
    * an existing filter object. The two may be combined if you have query terms that always need to

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSequenceFlowDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSequenceFlowDao.java
@@ -10,16 +10,14 @@ package io.camunda.operate.webapp.api.v1.dao.opensearch;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.webapp.api.v1.dao.SequenceFlowDao;
-import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.api.v1.entities.SequenceFlow;
 import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import io.camunda.webapps.schema.descriptors.template.SequenceFlowTemplate;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
@@ -54,25 +52,12 @@ public class OpensearchSequenceFlowDao extends OpensearchSearchableDao<SequenceF
   }
 
   @Override
-  protected void buildFiltering(
-      final Query<SequenceFlow> query, final SearchRequest.Builder request) {
-    final SequenceFlow filter = query.getFilter();
-
-    if (filter != null) {
-      final var queryTerms =
-          Stream.of(
-                  queryDSLWrapper.term(SequenceFlow.ID, filter.getId()),
-                  queryDSLWrapper.term(SequenceFlow.ACTIVITY_ID, filter.getActivityId()),
-                  queryDSLWrapper.term(SequenceFlow.TENANT_ID, filter.getTenantId()),
-                  queryDSLWrapper.term(
-                      SequenceFlow.PROCESS_INSTANCE_KEY, filter.getProcessInstanceKey()))
-              .filter(Objects::nonNull)
-              .collect(Collectors.toList());
-
-      if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
-      }
-    }
+  protected Stream<Query> collectFilterQueryTerms(@NonNull final SequenceFlow filter) {
+    return Stream.of(
+        queryDSLWrapper.term(SequenceFlow.ID, filter.getId()),
+        queryDSLWrapper.term(SequenceFlow.ACTIVITY_ID, filter.getActivityId()),
+        queryDSLWrapper.term(SequenceFlow.TENANT_ID, filter.getTenantId()),
+        queryDSLWrapper.term(SequenceFlow.PROCESS_INSTANCE_KEY, filter.getProcessInstanceKey()));
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchVariableDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchVariableDao.java
@@ -10,16 +10,14 @@ package io.camunda.operate.webapp.api.v1.dao.opensearch;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.webapp.api.v1.dao.VariableDao;
-import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.api.v1.entities.Variable;
 import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
@@ -54,27 +52,15 @@ public class OpensearchVariableDao extends OpensearchKeyFilteringDao<Variable, V
   }
 
   @Override
-  protected void buildFiltering(final Query<Variable> query, final SearchRequest.Builder request) {
-    final Variable filter = query.getFilter();
-
-    if (filter != null) {
-      final var queryTerms =
-          Stream.of(
-                  queryDSLWrapper.term(Variable.KEY, filter.getKey()),
-                  queryDSLWrapper.term(Variable.TENANT_ID, filter.getTenantId()),
-                  queryDSLWrapper.term(
-                      Variable.PROCESS_INSTANCE_KEY, filter.getProcessInstanceKey()),
-                  queryDSLWrapper.term(Variable.SCOPE_KEY, filter.getScopeKey()),
-                  queryDSLWrapper.term(Variable.NAME, filter.getName()),
-                  queryDSLWrapper.term(Variable.VALUE, filter.getValue()),
-                  queryDSLWrapper.term(Variable.TRUNCATED, filter.getTruncated()))
-              .filter(Objects::nonNull)
-              .collect(Collectors.toList());
-
-      if (!queryTerms.isEmpty()) {
-        request.query(queryDSLWrapper.and(queryTerms));
-      }
-    }
+  protected Stream<Query> collectFilterQueryTerms(@NonNull final Variable filter) {
+    return Stream.of(
+        queryDSLWrapper.term(Variable.KEY, filter.getKey()),
+        queryDSLWrapper.term(Variable.TENANT_ID, filter.getTenantId()),
+        queryDSLWrapper.term(Variable.PROCESS_INSTANCE_KEY, filter.getProcessInstanceKey()),
+        queryDSLWrapper.term(Variable.SCOPE_KEY, filter.getScopeKey()),
+        queryDSLWrapper.term(Variable.NAME, filter.getName()),
+        queryDSLWrapper.term(Variable.VALUE, filter.getValue()),
+        queryDSLWrapper.term(Variable.TRUNCATED, filter.getTruncated()));
   }
 
   @Override

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeInstanceDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchFlowNodeInstanceDaoTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -36,7 +37,8 @@ import org.opensearch.client.opensearch.core.SearchRequest;
 @ExtendWith(MockitoExtension.class)
 public class OpensearchFlowNodeInstanceDaoTest {
 
-  @Mock private OpensearchQueryDSLWrapper mockQueryWrapper;
+  @Mock(answer = Answers.RETURNS_MOCKS)
+  private OpensearchQueryDSLWrapper mockQueryWrapper;
 
   @Mock private OpensearchRequestDSLWrapper mockRequestWrapper;
 
@@ -152,6 +154,7 @@ public class OpensearchFlowNodeInstanceDaoTest {
     verify(mockQueryWrapper, times(1)).term(FlowNodeInstance.INCIDENT, filter.getIncident());
     verify(mockQueryWrapper, times(1)).term(FlowNodeInstance.INCIDENT_KEY, filter.getIncidentKey());
     verify(mockQueryWrapper, times(1)).term(FlowNodeInstance.TENANT_ID, filter.getTenantId());
+    verify(mockQueryWrapper, times(1)).withTenantCheck(any());
   }
 
   @Test
@@ -212,6 +215,7 @@ public class OpensearchFlowNodeInstanceDaoTest {
     // Verify the request was built with a tenant check, the index name, and permissive matching
     assertThat(results).containsExactlyElementsOf(validResults);
     verify(mockQueryWrapper, times(1)).term(underTest.getKeyFieldName(), 1L);
+    // Verify that we don't need to specify a tenantCheck for it to be included
     verify(mockQueryWrapper, times(1)).withTenantCheck(any());
     verify(mockRequestWrapper, times(1)).searchRequestBuilder(underTest.getIndexName());
   }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchKeyFilteringDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchKeyFilteringDaoTest.java
@@ -17,19 +17,20 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
-import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.api.v1.exceptions.ResourceNotFoundException;
 import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.SearchRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -84,8 +85,9 @@ public class OpensearchKeyFilteringDaoTest {
           }
 
           @Override
-          protected void buildFiltering(
-              final Query<Object> query, final SearchRequest.Builder request) {}
+          protected Stream<Query> collectFilterQueryTerms(final Object filter) {
+            return Stream.empty();
+          }
 
           @Override
           protected Object convertInternalToApiResult(final Object internalResult) {

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDaoTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.webapp.api.v1.dao.opensearch;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -68,5 +69,7 @@ public class OpensearchProcessDefinitionDaoTest {
     verify(wrapper, times(1))
         .term(ProcessDefinition.VERSION_TAG, processDefinition.getVersionTag());
     verify(wrapper, times(1)).term(ProcessDefinition.KEY, processDefinition.getKey());
+    // Verify that we don't need to specify a tenantCheck for it to be included
+    verify(wrapper, times(1)).withTenantCheck(any());
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessInstanceDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessInstanceDaoTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -35,7 +36,8 @@ import org.opensearch.client.opensearch.core.SearchRequest;
 @ExtendWith(MockitoExtension.class)
 public class OpensearchProcessInstanceDaoTest {
 
-  @Mock private OpensearchQueryDSLWrapper mockQueryWrapper;
+  @Mock(answer = Answers.RETURNS_MOCKS)
+  private OpensearchQueryDSLWrapper mockQueryWrapper;
 
   @Mock private OpensearchRequestDSLWrapper mockRequestWrapper;
 
@@ -137,6 +139,8 @@ public class OpensearchProcessInstanceDaoTest {
     // Verify that the join relation was still set
     verify(mockQueryWrapper, times(1))
         .term(ListViewTemplate.JOIN_RELATION, ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION);
+    // Verify that we don't need to specify a tenantCheck for it to be included
+    verify(mockQueryWrapper, times(1)).withTenantCheck(any());
   }
 
   @Test
@@ -150,6 +154,8 @@ public class OpensearchProcessInstanceDaoTest {
     // Verify that the join relation was still set
     verify(mockQueryWrapper, times(1))
         .term(ListViewTemplate.JOIN_RELATION, ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION);
+    // Verify that we don't need to specify a tenantCheck for it to be included
+    verify(mockQueryWrapper, times(1)).withTenantCheck(any());
   }
 
   @Test
@@ -201,5 +207,7 @@ public class OpensearchProcessInstanceDaoTest {
     // Verify that the join relation was still set
     verify(mockQueryWrapper, times(1))
         .term(ListViewTemplate.JOIN_RELATION, ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION);
+    // Verify that we don't need to specify a tenantCheck for it to be included
+    verify(mockQueryWrapper, times(1)).withTenantCheck(any());
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSearchableDaoTest.java
@@ -21,6 +21,7 @@ import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +33,7 @@ import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
 import org.opensearch.client.opensearch.core.search.TotalHits;
+import org.springframework.lang.NonNull;
 
 @ExtendWith(MockitoExtension.class)
 public class OpensearchSearchableDaoTest {
@@ -64,7 +66,10 @@ public class OpensearchSearchableDaoTest {
           }
 
           @Override
-          protected void buildFiltering(final Query query, final SearchRequest.Builder request) {}
+          protected Stream<org.opensearch.client.opensearch._types.query_dsl.Query>
+              collectFilterQueryTerms(@NonNull final Object filter) {
+            return Stream.empty();
+          }
 
           @Override
           protected Object convertInternalToApiResult(final Object internalResult) {

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSequenceFlowDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchSequenceFlowDaoTest.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.webapp.api.v1.dao.opensearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -22,6 +23,7 @@ import io.camunda.webapps.schema.descriptors.template.SequenceFlowTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,7 +32,8 @@ import org.opensearch.client.opensearch.core.SearchRequest;
 @ExtendWith(MockitoExtension.class)
 public class OpensearchSequenceFlowDaoTest {
 
-  @Mock private OpensearchQueryDSLWrapper mockQueryWrapper;
+  @Mock(answer = Answers.RETURNS_MOCKS)
+  private OpensearchQueryDSLWrapper mockQueryWrapper;
 
   @Mock private OpensearchRequestDSLWrapper mockRequestWrapper;
 
@@ -94,5 +97,7 @@ public class OpensearchSequenceFlowDaoTest {
     verify(mockQueryWrapper, times(1)).term(SequenceFlow.TENANT_ID, filter.getTenantId());
     verify(mockQueryWrapper, times(1))
         .term(SequenceFlow.PROCESS_INSTANCE_KEY, filter.getProcessInstanceKey());
+    // Verify that we don't need to specify a tenantCheck for it to be included
+    verify(mockQueryWrapper, times(1)).withTenantCheck(any());
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchVariableDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchVariableDaoTest.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.webapp.api.v1.dao.opensearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -22,6 +23,7 @@ import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,7 +32,8 @@ import org.opensearch.client.opensearch.core.SearchRequest;
 @ExtendWith(MockitoExtension.class)
 public class OpensearchVariableDaoTest {
 
-  @Mock private OpensearchQueryDSLWrapper mockQueryWrapper;
+  @Mock(answer = Answers.RETURNS_MOCKS)
+  private OpensearchQueryDSLWrapper mockQueryWrapper;
 
   @Mock private OpensearchRequestDSLWrapper mockRequestWrapper;
 
@@ -123,5 +126,7 @@ public class OpensearchVariableDaoTest {
     verify(mockQueryWrapper, times(1)).term(Variable.NAME, filter.getName());
     verify(mockQueryWrapper, times(1)).term(Variable.VALUE, filter.getValue());
     verify(mockQueryWrapper, times(1)).term(Variable.TRUNCATED, filter.getTruncated());
+    // Verify that we don't need to specify a tenantCheck for it to be included
+    verify(mockQueryWrapper, times(1)).withTenantCheck(any());
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1TenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateV1TenancyIT.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.operate;
+
+import static io.camunda.client.api.search.enums.PermissionType.DELETE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ;
+import static io.camunda.client.api.search.enums.PermissionType.READ_DECISION_DEFINITION;
+import static io.camunda.client.api.search.enums.PermissionType.READ_DECISION_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.ResourceType.DECISION_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.DECISION_REQUIREMENTS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestRestOperateClient;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.util.Either;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class OperateV1TenancyIT {
+
+  @MultiDbTestApplication
+  static final TestCamundaApplication STANDALONE_CAMUNDA =
+      new TestCamundaApplication()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  private static final List<Permissions> AUTHORIZED_PERMISSIONS =
+      List.of(
+          new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
+          new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*")),
+          new Permissions(PROCESS_DEFINITION, DELETE_PROCESS_INSTANCE, List.of("*")),
+          new Permissions(DECISION_DEFINITION, READ_DECISION_DEFINITION, List.of("*")),
+          new Permissions(DECISION_DEFINITION, READ_DECISION_INSTANCE, List.of("*")),
+          new Permissions(DECISION_REQUIREMENTS_DEFINITION, READ, List.of("*")));
+
+  private static final String ADMIN = "multiTenancyAdmin";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_TO_BE_DELETED = "tenantToBeDeleted";
+  private static final String PROCESS_ID = "service_tasks_v1";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, ADMIN, AUTHORIZED_PERMISSIONS);
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_TO_BE_DELETED);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_TO_BE_DELETED);
+
+    deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
+    startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
+
+    deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_TO_BE_DELETED);
+    startProcessInstance(adminClient, PROCESS_ID, TENANT_TO_BE_DELETED);
+    waitForProcessBeingExported(adminClient);
+  }
+
+  @Test
+  public void shouldNotReturnProcessesFromDeletedTenants(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) throws Exception {
+
+    try (final var operateClient = STANDALONE_CAMUNDA.newOperateClient(ADMIN, ADMIN)) {
+      // given
+      verifySearch(
+          operateClient,
+          processInstanceResult -> {
+            assertThat(processInstanceResult.total).isEqualTo(2);
+            assertThat(processInstanceResult.tenantIds)
+                .containsExactlyInAnyOrder(TENANT_A, TENANT_TO_BE_DELETED);
+          });
+
+      // when
+      deleteTenant(camundaClient, TENANT_TO_BE_DELETED);
+
+      // then
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(10))
+          .untilAsserted(
+              () -> {
+                verifySearch(
+                    operateClient,
+                    processInstanceResult -> {
+                      assertThat(processInstanceResult.total).isEqualTo(1);
+                      assertThat(processInstanceResult.tenantIds).containsExactly(TENANT_A);
+                    });
+              });
+    }
+  }
+
+  private void verifySearch(
+      final TestRestOperateClient client, final Consumer<ProcessInstanceResults> assertions)
+      throws Exception {
+    final HttpResponse<String> searchResponse =
+        client.sendV1SearchRequest("v1/process-instances", "{}");
+    final Either<Exception, Map> result = client.mapResult(searchResponse, Map.class);
+
+    assertThat(result.isRight()).isTrue();
+
+    final Map<String, Object> responseBody = result.get();
+
+    final var processInstanceResults =
+        new ProcessInstanceResults(
+            (int) responseBody.get("total"),
+            ((List<Map<String, Object>>) responseBody.get("items"))
+                .stream().map(r -> r.get("tenantId").toString()).collect(Collectors.toSet()));
+
+    assertions.accept(processInstanceResults);
+  }
+
+  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
+  }
+
+  private static void deleteTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newDeleteTenantCommand(tenant).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient camundaClient, final String username, final String tenant) {
+    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
+  }
+
+  private static void deployResource(
+      final CamundaClient camundaClient, final String resourceName, final String tenant) {
+    camundaClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void startProcessInstance(
+      final CamundaClient camundaClient, final String processId, final String tenant) {
+    camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .tenantId(tenant)
+        .send()
+        .join();
+  }
+
+  private static void waitForProcessBeingExported(final CamundaClient camundaClient) {
+    waitForProcessBeingExported(camundaClient, 2);
+  }
+
+  private static void waitForProcessBeingExported(
+      final CamundaClient camundaClient, final int expectedDefinitions) {
+    Awaitility.await("should receive data from secondary storage")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      camundaClient
+                          .newProcessInstanceSearchRequest()
+                          .filter(filter -> filter.processDefinitionId(fn -> fn.in(PROCESS_ID)))
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(expectedDefinitions);
+            });
+  }
+
+  private record ProcessInstanceResults(long total, Set<String> tenantIds) {}
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessInstanceTenancyIT.java
@@ -67,7 +67,51 @@ public class ProcessInstanceTenancyIT {
 
     deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);
     startProcessInstance(adminClient, PROCESS_ID, TENANT_B);
-    waitForProcessBeingExported(adminClient);
+    waitForProcessBeingExported(adminClient, 2);
+  }
+
+  @Test
+  public void shouldNotReturnProcessesFromDeletedTenants(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+
+    // given
+    final var tenantToBeDeleted = "toBeDeleted";
+    createTenant(camundaClient, tenantToBeDeleted);
+    assignUserToTenant(camundaClient, ADMIN, tenantToBeDeleted);
+
+    deployResource(camundaClient, "process/service_tasks_v1.bpmn", tenantToBeDeleted);
+    startProcessInstance(camundaClient, PROCESS_ID, tenantToBeDeleted);
+
+    waitForProcessBeingExported(camundaClient, 3);
+
+    final var beforeTenantDeletionResults =
+        camundaClient.newProcessInstanceSearchRequest().send().join();
+
+    assertThat(beforeTenantDeletionResults.items()).hasSize(3);
+    assertThat(
+            beforeTenantDeletionResults.items().stream()
+                .map(ProcessInstance::getTenantId)
+                .collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B, tenantToBeDeleted);
+
+    // when
+    deleteTenant(camundaClient, tenantToBeDeleted);
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () -> {
+              // then
+              final var afterTenantDeletionResults =
+                  camundaClient.newProcessInstanceSearchRequest().send().join();
+
+              assertThat(afterTenantDeletionResults.items()).hasSize(2);
+              assertThat(
+                      afterTenantDeletionResults.items().stream()
+                          .map(ProcessInstance::getTenantId)
+                          .collect(Collectors.toSet()))
+                  .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+            });
   }
 
   @Test
@@ -143,6 +187,10 @@ public class ProcessInstanceTenancyIT {
     camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
   }
 
+  private static void deleteTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newDeleteTenantCommand(tenant).send().join();
+  }
+
   private static void assignUserToTenant(
       final CamundaClient camundaClient, final String username, final String tenant) {
     camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
@@ -169,7 +217,8 @@ public class ProcessInstanceTenancyIT {
         .join();
   }
 
-  private static void waitForProcessBeingExported(final CamundaClient camundaClient) {
+  private static void waitForProcessBeingExported(
+      final CamundaClient camundaClient, final int expectedProcessDefinitions) {
     Awaitility.await("should receive data from secondary storage")
         .atMost(Duration.ofMinutes(1))
         .ignoreExceptions() // Ignore exceptions and continue retrying
@@ -182,7 +231,7 @@ public class ProcessInstanceTenancyIT {
                           .send()
                           .join()
                           .items())
-                  .hasSize(2);
+                  .hasSize(expectedProcessDefinitions);
             });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -36,6 +36,7 @@ import io.camunda.client.api.search.response.GroupUser;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.RoleUser;
 import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.response.Tenant;
 import io.camunda.client.impl.search.filter.DecisionDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionRequirementsFilterImpl;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -49,6 +50,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
 
 /**
@@ -167,12 +169,27 @@ public final class TestHelper {
     }
   }
 
+  public static void deleteTenant(final CamundaClient camundaClient, final String tenant) {
+    camundaClient.newDeleteTenantCommand(tenant).send().join();
+  }
+
   public static ProcessInstanceEvent startProcessInstance(
       final CamundaClient camundaClient, final String bpmnProcessId) {
     return camundaClient
         .newCreateInstanceCommand()
         .bpmnProcessId(bpmnProcessId)
         .latestVersion()
+        .send()
+        .join();
+  }
+
+  public static ProcessInstanceEvent startProcessInstanceForTenant(
+      final CamundaClient camundaClient, final String bpmnProcessId, final String tenant) {
+    return camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(bpmnProcessId)
+        .latestVersion()
+        .tenantId(tenant)
         .send()
         .join();
   }
@@ -593,6 +610,20 @@ public final class TestHelper {
                             .join()
                             .items())
                     .hasSize(expectedProcessInstances));
+  }
+
+  public static void waitForTenantDeletion(
+      final CamundaClient camundaClient, final String tenantToBeDeleted) {
+    Awaitility.await("should wait until tenant is deleted")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient.newTenantsSearchRequest().send().join().items().stream()
+                            .map(Tenant::getTenantId)
+                            .collect(Collectors.toSet()))
+                    .doesNotContain(tenantToBeDeleted));
   }
 
   public static void waitForProcessesToBeDeployed(


### PR DESCRIPTION
## Description

At the moment, processes from deleted tenants appear in search results on the /v1/process-instances/search endpoint when running with Opensearch. This is due to the OpenSearch DAOs overwriting the SearchRequest.query query without adding withTenantCheck. This PR fixes the mistake and structures the aggregation of the filter query so that such errors are less likely to happen in the future.

### Technical Details

The OpensearchSearchableDao initializes a search request with a tenant-aware match-all query. However, the `buildFiltering` -- and buildSorting and buildPaging -- give consumers unrestricted access to the SearchRequest. Specifically in `buildFiltering` it meant that derived classes defaulted to setting the `SearchResult.Builder.query()` property without ensuring that the query used a tenant-aware query check.

`buildFiltering` has been refactored so that it no longer allows consumers to set SearchRequest.Builder properties directly. Instead, they return a list of query terms which the OpensearchSearchableDao chains together with a tenant-aware query statement.

Ultimately a consumer can still overwrite the query property before a search by overriding the `search` method, for example. Further refactorings may be considered to try and tighten/restrict how a consumer can access the SearchRequest.

### Alternatives

I compared the `OpensearchSearchableDao` to ES' `ElasticsearchDao`. The latter provides a `tenantAwareClient` that adds a tenant-aware query every time a consumer uses the `search` method. Because OS uses a stateless `QueryDslWrapper`, that wasn't feasible to implement. I could imagine building a QueryBuilder of some kind which lets consumers build a query without that logic being orchestrated by the OpensearchSearchableDao, but that would have taken an undue amount of time, in my opinion.

Another option is to refactor the inheritance to composition, turning the specific Dao implementations like `OpensearchProcessDefinitionDao` into components that use a `OpensearchSearchableDao` instance and then defining an API with which they can create and execute searches against OS. That, too, would be a lot of work and deviate quite strongly from how the ES search is built.

### Resetting static contexts

One persistent bug I encountered along the way is that the test would pass in isolation, but fail when run after any other test. From what I could tell, `TestCamundaApplication` and `TestSpringApplication` have no static context, but crucially the `TenantCheckApplierHolder` is a singleton and its context is never reset. This resulted in test failures as soon as we tried testing multiTenancy which has a different `SecurityConfiguration` - all other tests succeeded because they had an identical test setup in that regard. I've included a workaround that clears the singleton value after every run, but I can't guarantee that this is the only singleton or static context in the code. We should consider creating a technical task that analyzes the code for further static contexts and resetting them in the test setup or removing them in favor of a non-global state solution.

## Checklist

- [ ] Enable backports for 8.7 and 8.8

## Related issues

closes #38297
