### PR TITLE
ci: move leader balancing step from old to new benchmark workflow

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -339,12 +339,15 @@ jobs:
           ${{ inputs.load-test-load }}
       - name: Setup leader balancing
         run: |
-          kubectl create cronjob leader-balancer \
-          --namespace ${{ inputs.name }} \
-          --image=curlimages/curl:7.87.0 \
-          --schedule="*/10 * * * *" \
-          -- curl -L -v -X POST http://camunda:9600/actuator/rebalance \
-          || echo "Leader balancer cronjob already exists"
+          if ! kubectl get cronjob leader-balancer --namespace ${{ inputs.name }} &>/dev/null; then
+            kubectl create cronjob leader-balancer \
+              --namespace ${{ inputs.name }} \
+              --image=curlimages/curl:7.87.0 \
+              --schedule="*/10 * * * *" \
+              -- curl -L -v -X POST http://camunda:9600/actuator/rebalance
+          else
+            echo "Leader balancer cronjob already exists"
+          fi
       - name: Summarize deployment
         if: success()
         run: |

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -337,6 +337,14 @@ jobs:
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }}
           ${{ inputs.load-test-load }}
+      - name: Setup leader balancing
+        run: |
+          kubectl create cronjob leader-balancer \
+          --namespace ${{ inputs.name }} \
+          --image=curlimages/curl:7.87.0 \
+          --schedule="*/10 * * * *" \
+          -- curl -L -v -X POST http://camunda:9600/actuator/rebalance \
+          || echo "Leader balancer cronjob already exists"
       - name: Summarize deployment
         if: success()
         run: |

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -275,14 +275,6 @@ jobs:
           ${{ inputs.stable-vms && '-f load-tests/setup/default/values-stable.yaml' || '' }}
           ${{ inputs.realistic && '-f https://raw.githubusercontent.com/zeebe-io/benchmark-helm/main/charts/zeebe-benchmark/values-realistic-benchmark.yaml' || '' }}
           ${{ inputs.benchmark-load }}
-      - name: Setup leader balancing
-        run: |
-          kubectl create cronjob leader-balancer \
-          --namespace ${{ inputs.name }} \
-          --image=curlimages/curl:7.87.0 \
-          --schedule="*/10 * * * *" \
-          -- curl -L -v -X POST http://camunda:9600/actuator/rebalance \
-          || echo "Leader balancer cronjob already exists"
       - name: Label namespace
         run: >
           kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite


### PR DESCRIPTION
The old one already has this built-in in the helm chart.

Fixes a mistake made in https://github.com/camunda/camunda/pull/40660