### PR TITLE
feat: Extract out legacy os exporter and unify StandaloneSchemaManager

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -895,7 +895,6 @@
           </ignoredNonTestScopedDependencies>
           <!-- dependencies only packaged but not explicitly used -->
           <usedDependencies>
-            <dependency>io.camunda:zeebe-opensearch-exporter</dependency>
 
             <!-- Needed for Spring Actuators, and REST API -->
             <dependency>org.springframework.boot:spring-boot-starter-web</dependency>

--- a/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
@@ -18,9 +18,15 @@ import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverrid
 import io.camunda.configuration.beans.LegacyBrokerBasedProperties;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration;
 import io.camunda.zeebe.exporter.ElasticsearchExporterSchemaManager;
+import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
+import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration;
+import io.camunda.zeebe.exporter.opensearch.OpensearchExporterSchemaManager;
 import java.io.IOException;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
@@ -75,7 +81,7 @@ public class StandaloneSchemaManager implements CommandLineRunner {
     MainSupport.putSystemPropertyIfAbsent(
         "spring.banner.location", "classpath:/assets/camunda_banner.txt");
 
-    LOG.info("Creating/updating Elasticsearch schema for Camunda ...");
+    LOG.info("Creating/updating schema for Camunda ...");
 
     MainSupport.createDefaultApplicationBuilder()
         .web(WebApplicationType.NONE)
@@ -93,6 +99,8 @@ public class StandaloneSchemaManager implements CommandLineRunner {
         .listeners(new ApplicationErrorListener())
         .run(args);
 
+    LOG.info("... finished creating/updating schema for Camunda");
+
     // Explicit exit needed because there are daemon threads (at least from the ES client) that are
     // blocking shutdown.
     System.exit(0);
@@ -100,15 +108,43 @@ public class StandaloneSchemaManager implements CommandLineRunner {
 
   @Override
   public void run(final String... args) throws Exception {
-    if (brokerProperties.getExporters().containsKey("elasticsearch")) {
-      final var elasticsearchConfig =
-          new ExporterConfiguration(
-                  "elasticsearch", brokerProperties.getExporters().get("elasticsearch").getArgs())
-              .instantiate(ElasticsearchExporterConfiguration.class);
-      new ElasticsearchExporterSchemaManager(elasticsearchConfig)
-          .createSchema(CURRENT_BROKER_VERSION.toString());
+    try {
+      getSchemaCreators()
+          .forEach(
+              schemaCreator -> {
+                schemaCreator.createSchema(CURRENT_BROKER_VERSION.toString());
+              });
+    } catch (final Exception e) {
+      LOG.error("Failed to create/update schema", e);
+      throw e;
     }
-    LOG.info("... finished creating/updating Elasticsearch schema for Camunda");
+  }
+
+  private List<SchemaCreator> getSchemaCreators() {
+    final SchemaManagerFactory schemaManagerFactory = getSchemaManagerFactory();
+    return brokerProperties.getExporters().entrySet().stream()
+        .map(entry -> schemaManagerFactory.create(entry.getKey(), entry.getValue()))
+        .toList();
+  }
+
+  private SchemaManagerFactory getSchemaManagerFactory() {
+    return (id, cfg) -> {
+      if (ElasticsearchExporter.class.getName().equals(cfg.getClassName())) {
+        final var config =
+            new ExporterConfiguration(id, cfg.getArgs())
+                .instantiate(ElasticsearchExporterConfiguration.class);
+        final var schemaManager = new ElasticsearchExporterSchemaManager(config);
+        return schemaManager::createSchema;
+      } else if (OpensearchExporter.class.getName().equals(cfg.getClassName())) {
+        final var config =
+            new ExporterConfiguration(id, cfg.getArgs())
+                .instantiate(OpensearchExporterConfiguration.class);
+        final var schemaManager = new OpensearchExporterSchemaManager(config);
+        return schemaManager::createSchema;
+      } else {
+        return brokerVersion -> {};
+      }
+    };
   }
 
   @EnableAutoConfiguration
@@ -118,4 +154,19 @@ public class StandaloneSchemaManager implements CommandLineRunner {
       basePackages = {"io.camunda.application.commons.search", "io.camunda.configuration"},
       nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
   public static class StandaloneSchemaManagerConfiguration {}
+
+  /*
+   * Since we don't have a common SchemaManager interface that we can put in a common project for
+   * Elasticsearch and OpenSearch exporters (yet), we use these functional interfaces to give at least
+   * a sense of abstraction.
+   */
+  @FunctionalInterface
+  private interface SchemaCreator {
+    void createSchema(String brokerVersion);
+  }
+
+  @FunctionalInterface
+  private interface SchemaManagerFactory {
+    SchemaCreator create(String exporterId, ExporterCfg exporterConfig);
+  }
 }

--- a/dist/src/main/java/io/camunda/application/initializers/StandaloneSchemaManagerInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/StandaloneSchemaManagerInitializer.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.application.initializers;
 
-import static io.camunda.configuration.SecondaryStorage.SecondaryStorageType.elasticsearch;
 import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import java.util.Objects;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 
@@ -25,9 +25,11 @@ public class StandaloneSchemaManagerInitializer
             .getEnvironment()
             .getProperty(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE);
 
-    if (elasticsearch != SecondaryStorageType.valueOf(databaseTypeProperty.toLowerCase())) {
+    final var storageType =
+        SecondaryStorageType.valueOf(Objects.requireNonNull(databaseTypeProperty).toLowerCase());
+    if (!storageType.isElasticSearch() && !storageType.isOpenSearch()) {
       throw new IllegalArgumentException(
-          "Cannot create schema for anything other than Elasticsearch with this script for now...");
+          "Cannot create schema for anything other than Elasticsearch and Opensearch with this script for now...");
     }
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
-import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -43,6 +42,7 @@ public class OpensearchExporter implements Exporter {
   private OpensearchClient client;
   private OpensearchRecordCounters recordCounters;
   private MeterRegistry meterRegistry;
+  private OpensearchExporterSchemaManager schemaManager;
 
   private long lastPosition = -1;
   private Set<String> indexTemplatesCreated;
@@ -76,6 +76,7 @@ public class OpensearchExporter implements Exporter {
               .orElse(new OpensearchRecordCounters());
 
       scheduleDelayedFlush();
+      schemaManager = new OpensearchExporterSchemaManager(client, configuration);
       log.info("Exporter opened");
     } catch (final Exception ex) {
       if (client != null) {
@@ -128,11 +129,7 @@ public class OpensearchExporter implements Exporter {
       lastPosition = record.getPosition();
       return;
     }
-
-    if (!indexTemplatesCreated.contains(record.getBrokerVersion())) {
-      createIndexTemplates(record.getBrokerVersion());
-      updateRetentionPolicyForExistingIndices();
-    }
+    schemaManager.createSchema(record.getBrokerVersion());
 
     final var recordSequence = recordCounters.getNextRecordSequence(record);
     final var isRecordIndexedToBatch = client.index(record, recordSequence);
@@ -246,195 +243,6 @@ public class OpensearchExporter implements Exporter {
       return exporterMetadataObjectMapper.readValue(metadata, OpensearchExporterMetadata.class);
     } catch (final IOException e) {
       throw new OpensearchExporterException("Failed to deserialize exporter metadata", e);
-    }
-  }
-
-  private void createIndexTemplates(final String version) {
-    if (configuration.retention.isEnabled()) {
-      createIndexStateManagementPolicy();
-    } else {
-      deleteIndexStateManagementPolicy();
-    }
-
-    final IndexConfiguration index = configuration.index;
-
-    if (index.createTemplate) {
-      createComponentTemplate();
-
-      if (index.deployment) {
-        createValueIndexTemplate(ValueType.DEPLOYMENT, version);
-      }
-      if (index.process) {
-        createValueIndexTemplate(ValueType.PROCESS, version);
-      }
-      if (index.error) {
-        createValueIndexTemplate(ValueType.ERROR, version);
-      }
-      if (index.incident) {
-        createValueIndexTemplate(ValueType.INCIDENT, version);
-      }
-      if (index.job) {
-        createValueIndexTemplate(ValueType.JOB, version);
-      }
-      if (index.jobBatch) {
-        createValueIndexTemplate(ValueType.JOB_BATCH, version);
-      }
-      if (index.message) {
-        createValueIndexTemplate(ValueType.MESSAGE, version);
-      }
-      if (index.messageBatch) {
-        createValueIndexTemplate(ValueType.MESSAGE_BATCH, version);
-      }
-      if (index.messageSubscription) {
-        createValueIndexTemplate(ValueType.MESSAGE_SUBSCRIPTION, version);
-      }
-      if (index.variable) {
-        createValueIndexTemplate(ValueType.VARIABLE, version);
-      }
-      if (index.variableDocument) {
-        createValueIndexTemplate(ValueType.VARIABLE_DOCUMENT, version);
-      }
-      if (index.processInstance) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE, version);
-      }
-      if (index.processInstanceBatch) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BATCH, version);
-      }
-      if (index.processInstanceCreation) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION, version);
-      }
-      if (index.processInstanceModification) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MODIFICATION, version);
-      }
-      if (index.processMessageSubscription) {
-        createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
-      }
-      if (index.adHocSubProcessInstruction) {
-        createValueIndexTemplate(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, version);
-      }
-      if (index.decisionRequirements) {
-        createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS, version);
-      }
-      if (index.decision) {
-        createValueIndexTemplate(ValueType.DECISION, version);
-      }
-      if (index.decisionEvaluation) {
-        createValueIndexTemplate(ValueType.DECISION_EVALUATION, version);
-      }
-      if (index.checkpoint) {
-        createValueIndexTemplate(ValueType.CHECKPOINT, version);
-      }
-      if (index.timer) {
-        createValueIndexTemplate(ValueType.TIMER, version);
-      }
-      if (index.messageStartEventSubscription) {
-        createValueIndexTemplate(ValueType.MESSAGE_START_EVENT_SUBSCRIPTION, version);
-      }
-      if (index.processEvent) {
-        createValueIndexTemplate(ValueType.PROCESS_EVENT, version);
-      }
-      if (index.deploymentDistribution) {
-        createValueIndexTemplate(ValueType.DEPLOYMENT_DISTRIBUTION, version);
-      }
-      if (index.escalation) {
-        createValueIndexTemplate(ValueType.ESCALATION, version);
-      }
-      if (index.signal) {
-        createValueIndexTemplate(ValueType.SIGNAL, version);
-      }
-      if (index.signalSubscription) {
-        createValueIndexTemplate(ValueType.SIGNAL_SUBSCRIPTION, version);
-      }
-      if (index.resourceDeletion) {
-        createValueIndexTemplate(ValueType.RESOURCE_DELETION, version);
-      }
-      if (index.commandDistribution) {
-        createValueIndexTemplate(ValueType.COMMAND_DISTRIBUTION, version);
-      }
-      if (index.form) {
-        createValueIndexTemplate(ValueType.FORM, version);
-      }
-      if (index.userTask) {
-        createValueIndexTemplate(ValueType.USER_TASK, version);
-      }
-      if (index.processInstanceMigration) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MIGRATION, version);
-      }
-      if (index.compensationSubscription) {
-        createValueIndexTemplate(ValueType.COMPENSATION_SUBSCRIPTION, version);
-      }
-      if (index.messageCorrelation) {
-        createValueIndexTemplate(ValueType.MESSAGE_CORRELATION, version);
-      }
-      if (index.asyncRequest) {
-        createValueIndexTemplate(ValueType.ASYNC_REQUEST, version);
-      }
-      if (index.runtimeInstruction) {
-        createValueIndexTemplate(ValueType.RUNTIME_INSTRUCTION, version);
-      }
-      if (index.clusterVariable) {
-        createValueIndexTemplate(ValueType.CLUSTER_VARIABLE, version);
-      }
-    }
-
-    indexTemplatesCreated.add(version);
-  }
-
-  private void createIndexStateManagementPolicy() {
-    final var policyOptional = client.getIndexStateManagementPolicy();
-
-    // Create the policy if it doesn't exist yet
-    if (policyOptional.isEmpty()) {
-      if (!client.createIndexStateManagementPolicy()) {
-        log.warn("Failed to acknowledge the creation of the Index State Management Policy");
-      }
-      return;
-    }
-
-    // Update the policy if it exists and is different from the configuration
-    final var policy = policyOptional.get();
-    if (!policy.equalsConfiguration(configuration)) {
-      if (!client.updateIndexStateManagementPolicy(policy.seqNo(), policy.primaryTerm())) {
-        log.warn("Failed to acknowledge the update of the Index State Management Policy");
-      }
-    }
-  }
-
-  private void deleteIndexStateManagementPolicy() {
-    final var policyOptional = client.getIndexStateManagementPolicy();
-    if (policyOptional.isEmpty()) {
-      return;
-    }
-
-    if (!client.deleteIndexStateManagementPolicy()) {
-      log.warn("Failed to acknowledge the deletion of the Index State Management Policy");
-    }
-  }
-
-  private void createComponentTemplate() {
-    if (!client.putComponentTemplate()) {
-      log.warn("Failed to acknowledge the creation or update of the component template");
-    }
-  }
-
-  private void createValueIndexTemplate(final ValueType valueType, final String version) {
-    if (!client.putIndexTemplate(valueType, version)) {
-      log.warn(
-          "Failed to acknowledge the creation or update of the index template for value type {}",
-          valueType);
-    }
-  }
-
-  private void updateRetentionPolicyForExistingIndices() {
-    final boolean successful;
-    if (configuration.retention.isEnabled()) {
-      successful = client.bulkAddISMPolicyToAllZeebeIndices();
-    } else {
-      successful = client.bulkRemoveISMPolicyToAllZeebeIndices();
-    }
-
-    if (!successful) {
-      log.warn("Failed to acknowledge the the update of retention policy for existing indices");
     }
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.IndexConfiguration;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.HashSet;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpensearchExporterSchemaManager {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OpensearchExporterSchemaManager.class.getPackageName());
+  private final OpensearchClient client;
+  private final OpensearchExporterConfiguration configuration;
+  private final Set<String> indexTemplatesCreated = new HashSet<>();
+
+  public OpensearchExporterSchemaManager(
+      final OpensearchClient client, final OpensearchExporterConfiguration configuration) {
+    this.client = client;
+    this.configuration = configuration;
+  }
+
+  public OpensearchExporterSchemaManager(final OpensearchExporterConfiguration configuration) {
+    this(new OpensearchClient(configuration, new SimpleMeterRegistry()), configuration);
+  }
+
+  public void createSchema(final String brokerVersion) {
+    if (!indexTemplatesCreated.contains(brokerVersion)) {
+      createIndexTemplates(brokerVersion);
+      updateRetentionPolicyForExistingIndices();
+    }
+  }
+
+  private void createIndexTemplates(final String version) {
+    if (configuration.retention.isEnabled()) {
+      createIndexStateManagementPolicy();
+    } else {
+      deleteIndexStateManagementPolicy();
+    }
+
+    final IndexConfiguration index = configuration.index;
+
+    if (index.createTemplate) {
+      createComponentTemplate();
+
+      if (index.deployment) {
+        createValueIndexTemplate(ValueType.DEPLOYMENT, version);
+      }
+      if (index.process) {
+        createValueIndexTemplate(ValueType.PROCESS, version);
+      }
+      if (index.error) {
+        createValueIndexTemplate(ValueType.ERROR, version);
+      }
+      if (index.incident) {
+        createValueIndexTemplate(ValueType.INCIDENT, version);
+      }
+      if (index.job) {
+        createValueIndexTemplate(ValueType.JOB, version);
+      }
+      if (index.jobBatch) {
+        createValueIndexTemplate(ValueType.JOB_BATCH, version);
+      }
+      if (index.message) {
+        createValueIndexTemplate(ValueType.MESSAGE, version);
+      }
+      if (index.messageBatch) {
+        createValueIndexTemplate(ValueType.MESSAGE_BATCH, version);
+      }
+      if (index.messageSubscription) {
+        createValueIndexTemplate(ValueType.MESSAGE_SUBSCRIPTION, version);
+      }
+      if (index.variable) {
+        createValueIndexTemplate(ValueType.VARIABLE, version);
+      }
+      if (index.variableDocument) {
+        createValueIndexTemplate(ValueType.VARIABLE_DOCUMENT, version);
+      }
+      if (index.processInstance) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE, version);
+      }
+      if (index.processInstanceBatch) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BATCH, version);
+      }
+      if (index.processInstanceCreation) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION, version);
+      }
+      if (index.processInstanceModification) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MODIFICATION, version);
+      }
+      if (index.processMessageSubscription) {
+        createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
+      }
+      if (index.adHocSubProcessInstruction) {
+        createValueIndexTemplate(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, version);
+      }
+      if (index.decisionRequirements) {
+        createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS, version);
+      }
+      if (index.decision) {
+        createValueIndexTemplate(ValueType.DECISION, version);
+      }
+      if (index.decisionEvaluation) {
+        createValueIndexTemplate(ValueType.DECISION_EVALUATION, version);
+      }
+      if (index.checkpoint) {
+        createValueIndexTemplate(ValueType.CHECKPOINT, version);
+      }
+      if (index.timer) {
+        createValueIndexTemplate(ValueType.TIMER, version);
+      }
+      if (index.messageStartEventSubscription) {
+        createValueIndexTemplate(ValueType.MESSAGE_START_EVENT_SUBSCRIPTION, version);
+      }
+      if (index.processEvent) {
+        createValueIndexTemplate(ValueType.PROCESS_EVENT, version);
+      }
+      if (index.deploymentDistribution) {
+        createValueIndexTemplate(ValueType.DEPLOYMENT_DISTRIBUTION, version);
+      }
+      if (index.escalation) {
+        createValueIndexTemplate(ValueType.ESCALATION, version);
+      }
+      if (index.signal) {
+        createValueIndexTemplate(ValueType.SIGNAL, version);
+      }
+      if (index.signalSubscription) {
+        createValueIndexTemplate(ValueType.SIGNAL_SUBSCRIPTION, version);
+      }
+      if (index.resourceDeletion) {
+        createValueIndexTemplate(ValueType.RESOURCE_DELETION, version);
+      }
+      if (index.commandDistribution) {
+        createValueIndexTemplate(ValueType.COMMAND_DISTRIBUTION, version);
+      }
+      if (index.form) {
+        createValueIndexTemplate(ValueType.FORM, version);
+      }
+      if (index.userTask) {
+        createValueIndexTemplate(ValueType.USER_TASK, version);
+      }
+      if (index.processInstanceMigration) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MIGRATION, version);
+      }
+      if (index.compensationSubscription) {
+        createValueIndexTemplate(ValueType.COMPENSATION_SUBSCRIPTION, version);
+      }
+      if (index.messageCorrelation) {
+        createValueIndexTemplate(ValueType.MESSAGE_CORRELATION, version);
+      }
+      if (index.asyncRequest) {
+        createValueIndexTemplate(ValueType.ASYNC_REQUEST, version);
+      }
+      if (index.runtimeInstruction) {
+        createValueIndexTemplate(ValueType.RUNTIME_INSTRUCTION, version);
+      }
+      if (index.clusterVariable) {
+        createValueIndexTemplate(ValueType.CLUSTER_VARIABLE, version);
+      }
+    }
+
+    indexTemplatesCreated.add(version);
+  }
+
+  private void createIndexStateManagementPolicy() {
+    final var policyOptional = client.getIndexStateManagementPolicy();
+
+    // Create the policy if it doesn't exist yet
+    if (policyOptional.isEmpty()) {
+      if (!client.createIndexStateManagementPolicy()) {
+        LOG.warn("Failed to acknowledge the creation of the Index State Management Policy");
+      }
+      return;
+    }
+
+    // Update the policy if it exists and is different from the configuration
+    final var policy = policyOptional.get();
+    if (!policy.equalsConfiguration(configuration)) {
+      if (!client.updateIndexStateManagementPolicy(policy.seqNo(), policy.primaryTerm())) {
+        LOG.warn("Failed to acknowledge the update of the Index State Management Policy");
+      }
+    }
+  }
+
+  private void deleteIndexStateManagementPolicy() {
+    final var policyOptional = client.getIndexStateManagementPolicy();
+    if (policyOptional.isEmpty()) {
+      return;
+    }
+
+    if (!client.deleteIndexStateManagementPolicy()) {
+      LOG.warn("Failed to acknowledge the deletion of the Index State Management Policy");
+    }
+  }
+
+  private void createComponentTemplate() {
+    if (!client.putComponentTemplate()) {
+      LOG.warn("Failed to acknowledge the creation or update of the component template");
+    }
+  }
+
+  private void createValueIndexTemplate(final ValueType valueType, final String version) {
+    if (!client.putIndexTemplate(valueType, version)) {
+      LOG.warn(
+          "Failed to acknowledge the creation or update of the index template for value type {}",
+          valueType);
+    }
+  }
+
+  private void updateRetentionPolicyForExistingIndices() {
+    final boolean successful;
+    if (configuration.retention.isEnabled()) {
+      successful = client.bulkAddISMPolicyToAllZeebeIndices();
+    } else {
+      successful = client.bulkRemoveISMPolicyToAllZeebeIndices();
+    }
+
+    if (!successful) {
+      LOG.warn("Failed to acknowledge the update of retention policy for existing indices");
+    }
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/SchemaManagerIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/SchemaManagerIT.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -58,8 +57,8 @@ public class SchemaManagerIT {
 
     // when
     // we create an 8.5 component template
-    osClient.putComponentTemplate();
-    osClient.putIndexTemplate(ValueType.PROCESS_INSTANCE);
+    final var schemaManager = new OpensearchExporterSchemaManager(osClient, CONFIG);
+    schemaManager.createSchema("8.5.0");
 
     // create the 8.6 component template
     final var upgradedVersion = "8.6.0";
@@ -67,14 +66,15 @@ public class SchemaManagerIT {
       mockedVersionUtil.when(VersionUtil::getVersion).thenReturn(upgradedVersion);
       mockedVersionUtil.when(VersionUtil::getVersionLowerCase).thenReturn(upgradedVersion);
 
-      osClient.putComponentTemplate();
-      osClient.putIndexTemplate(ValueType.PROCESS_INSTANCE);
+      // trigger schema manager for 8.6
+      final var schemaManager2 = new OpensearchExporterSchemaManager(osClient, CONFIG);
+      schemaManager2.createSchema(upgradedVersion);
     }
 
     // Use a new schema manager to mock 8.5 broker restart which then triggers schema manager.
     // 8.5 schema manager runs again and attempts to create old component template
-    osClient.putComponentTemplate();
-    osClient.putIndexTemplate(ValueType.PROCESS_INSTANCE);
+    final var schemaManager3 = new OpensearchExporterSchemaManager(osClient, CONFIG);
+    schemaManager3.createSchema("8.5.0");
 
     // then
     // 8.6.0 component template exists


### PR DESCRIPTION
## Description

This PR extracts schema management logic from `OpensearchExporter` to enable standalone schema creation for the OpenSearch exporter, mirroring the existing pattern used for Elasticsearch.

Previously, the standalone schema manager could only create Elasticsearch index templates by directly invoking `ElasticsearchExporterSchemaManager#createSchema`. This PR extends that capability to OpenSearch by:

1. Extracting `OpensearchExporterSchemaManager` from `OpensearchExporter`
2. Introducing functional interfaces (`SchemaCreator` and `SchemaManagerFactory`) to provide a common abstraction for both Elasticsearch and OpenSearch schema management
3. Updating `StandaloneSchemaManager` to detect and instantiate the appropriate schema manager based on exporter class type

## Changes

### New Components

- **`OpensearchExporterSchemaManager`**: Extracted schema management logic from `OpensearchExporter`, following the same pattern as `ElasticsearchExporterSchemaManager`
- **Functional interfaces** in `StandaloneSchemaManager`:
  - `SchemaCreator`: Represents schema creation operation
  - `SchemaManagerFactory`: Creates schema creators for configured exporters

### Modified Components

- **`StandaloneSchemaManager`**:
  - Replaced exporter ID filtering with exporter class detection
  - Added factory pattern to instantiate appropriate schema manager based on exporter type
  - Now supports both Elasticsearch and OpenSearch exporters
- **`OpensearchExporter`**: Refactored to use the new `OpensearchExporterSchemaManager`

### Test Coverage

- **`OpensearchExporterSchemaManagerTest`**: New test class validating schema manager functionality
- **`StandaloneSchemaManagerTest`**: Updated to test both Elasticsearch and OpenSearch schema creation paths
- **`OpensearchExporterTest`**: Updated to verify exporter still functions correctly with extracted schema manager

## Testing

- [ ] Verified standalone schema manager creates OpenSearch index templates
- [ ] Verified standalone schema manager still creates Elasticsearch index templates
- [ ] Confirmed exporter functionality remains unchanged

## Related Issues

Closes #39444 #39497