### PR TITLE
test: users and groups are created before assigned.

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -182,7 +182,7 @@ export class IdentityAuthorizationsPage {
         await this.selectResourceType(authorization.resourceType);
         await this.fillResourceId(authorization.resourceId);
         await this.selectAccessPermissions(authorization.accessPermissions);
-        await this.createAuthorizationSubmitButton.click();
+        await this.createAuthorizationSubmitButton.click({timeout: 15000});
         await expect(this.createAuthorizationModal).toBeHidden({
           timeout: 15000,
         });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -191,6 +191,7 @@ export class IdentityAuthorizationsPage {
         const item = this.getAuthorizationCell(authorization.ownerId);
         await waitForItemInList(this.page, item, {
           timeout: 30000,
+          clickNext: true,
           onAfterReload: () =>
             this.selectResourceTypeTab(authorization.resourceType),
         });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-groups-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-groups-api-tests.spec.ts
@@ -62,9 +62,9 @@ test.describe.parallel('Role Groups API Tests', () => {
   });
 
   test('Assign Role To Group', async ({request}) => {
-    const groupKey = `${state['roleId1']}6`;
+    const groupKey = `${state['roleId1']}`;
     await createGroupAndStoreResponseFields(request, 1, state, groupKey);
-    const groupId = groupIdFromState(groupKey, state, 6) as string;
+    const groupId = groupIdFromState('roleId1', state, 1) as string;
     createdGroupIds.push(groupId);
     const p = {
       groupId: groupId,
@@ -94,7 +94,10 @@ test.describe.parallel('Role Groups API Tests', () => {
         headers: jsonHeaders(),
       },
     );
-    expect(res.status()).toBe(204);
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
   });
 
   test('Assign Role To Group Non Existent Role Not Found', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-groups-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-groups-api-tests.spec.ts
@@ -16,6 +16,7 @@ import {
   assertConflictRequest,
   paginatedResponseFields,
   assertPaginatedRequest,
+  assertStatusCode,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {
@@ -41,10 +42,10 @@ test.describe.parallel('Tenant Groups API Tests', () => {
   });
 
   test('Assign Group To Tenant', async ({request}) => {
-    const groupKey = `${state['tenantId1']}6`;
+    const groupKey = `${state['tenantId1']}`;
     await createGroupAndStoreResponseFields(request, 1, state, groupKey);
     const p = {
-      groupId: groupIdFromState(groupKey, state, 6) as string,
+      groupId: groupIdFromState('tenantId1', state, 1) as string,
       tenantId: state['tenantId1'] as string,
     };
 
@@ -55,7 +56,7 @@ test.describe.parallel('Tenant Groups API Tests', () => {
           headers: jsonHeaders(),
         },
       );
-      expect(res.status()).toBe(204);
+      await assertStatusCode(res, 204);
     }).toPass(defaultAssertionOptions);
   });
 
@@ -73,7 +74,10 @@ test.describe.parallel('Tenant Groups API Tests', () => {
         headers: jsonHeaders(),
       },
     );
-    expect(res.status()).toBe(204);
+    await assertNotFoundRequest(
+      res,
+      `Command 'ADD_ENTITY' rejected with code 'NOT_FOUND'`,
+    );
   });
 
   test('Assign Group To Tenant Non Existent Tenant Not Found', async ({
@@ -144,7 +148,7 @@ test.describe.parallel('Tenant Groups API Tests', () => {
             headers: jsonHeaders(),
           },
         );
-        expect(res.status()).toBe(204);
+        await assertStatusCode(res, 204);
       }).toPass(defaultAssertionOptions);
     });
 
@@ -158,7 +162,7 @@ test.describe.parallel('Tenant Groups API Tests', () => {
           },
         );
 
-        expect(res.status()).toBe(200);
+        await assertStatusCode(res, 200);
         const json = await res.json();
         assertRequiredFields(json, paginatedResponseFields);
         expect(json.page.totalItems).toBe(0);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/group-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/group-requestHelpers.ts
@@ -11,6 +11,7 @@ import {defaultAssertionOptions, generateUniqueId} from '../constants';
 import {
   assertEqualsForKeys,
   assertRequiredFields,
+  assertStatusCode,
   buildUrl,
   jsonHeaders,
 } from '../http';
@@ -129,7 +130,7 @@ export async function createGroupAndStoreResponseFields(
       headers: jsonHeaders(),
       data: requestBody,
     });
-    expect(res.status()).toBe(201);
+    await assertStatusCode(res, 201);
     const json = await res.json();
     assertRequiredFields(json, groupRequiredFields);
     const arrayKey = key ? `${key}${i}` : `${i}`;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/user-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/user-requestHelpers.ts
@@ -7,10 +7,10 @@
  */
 
 import type {APIRequestContext} from 'playwright-core';
-import {generateUniqueId} from '../constants';
 import {
   assertEqualsForKeys,
   assertRequiredFields,
+  assertStatusCode,
   buildUrl,
   jsonHeaders,
 } from '../http';
@@ -35,17 +35,17 @@ export async function assignRoleToUsers(
   state: Record<string, unknown>,
 ) {
   for (let i = 1; i <= numberOfUsers; i++) {
-    const user = 'user' + generateUniqueId();
+    const user = await createUser(request, state, `${i}`);
     const p = {
-      userId: user,
+      userId: user.username,
       roleId: roleId,
     };
     const res = await request.put(
       buildUrl('/roles/{roleId}/users/{userId}', p),
       {headers: jsonHeaders()},
     );
-    expect(res.status()).toBe(204);
-    state[`username${roleId}${i}`] = user;
+    await assertStatusCode(res, 204);
+    state[`username${roleId}${i}`] = user.username;
   }
 }
 
@@ -61,7 +61,7 @@ export async function createUser(
     data: body,
   });
 
-  expect(res.status()).toBe(201);
+  await assertStatusCode(res, 201);
   const json = await res.json();
   assertRequiredFields(json, userRequiredFields);
   if (state && key) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## C8 Orchestration Cluster E2E Tests On Demand
https://github.com/camunda/camunda/actions/runs/19291322508

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
