### PR TITLE
ci: exclude testing/camunda-process-test-coverage-frontend from FOSSA

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -18,6 +18,7 @@ paths:
     - optimize
     - qa/c8-orchestration-cluster-e2e-test-suite
     - tasklist/qa/backup-restore-tests
+    - testing/camunda-process-test-coverage-frontend
 
 maven:
   scope-exclude:


### PR DESCRIPTION
## Description

This pull request makes a minor update to the `.fossa.yml` configuration file, adding a new project path for license scanning.

* Added `testing/camunda-process-test-coverage-frontend` to the `paths` section in `.fossa.yml` to ensure its dependencies are excluded in license compliance checks.

See this issue for more context: https://camunda.slack.com/archives/C071KP5BTHB/p1762765882203529

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
