### PR TITLE
[Backport stable/8.8] ci: exclude testing/camunda-process-test-coverage-frontend from FOSSA

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -18,6 +18,7 @@ paths:
     - optimize
     - qa/c8-orchestration-cluster-e2e-test-suite
     - tasklist/qa/backup-restore-tests
+    - testing/camunda-process-test-coverage-frontend
 
 maven:
   scope-exclude:


### PR DESCRIPTION
# Description
Backport of #40749 to `stable/8.8`.

relates to 