### PR TITLE
deps: ensure Optimize has only (transitive) dep to Jakarta annotations

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -103,6 +103,12 @@
       <groupId>io.camunda</groupId>
       <artifactId>identity-spring-boot-starter</artifactId>
       <version>${version.identity}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Spring -->


### PR DESCRIPTION
- fixes maven-dependency-plugin analysis

See https://camunda.slack.com/archives/C06UWQNCU7M/p1762796843724999?thread_ts=1762423545.431679&cid=C06UWQNCU7M for a problem description and reasoning why this solves the problem.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
